### PR TITLE
Change should_response to should_respond.

### DIFF
--- a/tests/api_connexion/endpoints/test_config_endpoint.py
+++ b/tests/api_connexion/endpoints/test_config_endpoint.py
@@ -60,7 +60,7 @@ class TestGetConfig:
         self.client = self.app.test_client()  # type:ignore
 
     @patch("airflow.api_connexion.endpoints.config_endpoint.conf.as_dict", return_value=MOCK_CONF)
-    def test_should_response_200_text_plain(self, mock_as_dict):
+    def test_should_respond_200_text_plain(self, mock_as_dict):
         response = self.client.get(
             "/api/v1/config", headers={'Accept': 'text/plain'}, environ_overrides={'REMOTE_USER': "test"}
         )
@@ -78,7 +78,7 @@ class TestGetConfig:
         assert expected == response.data.decode()
 
     @patch("airflow.api_connexion.endpoints.config_endpoint.conf.as_dict", return_value=MOCK_CONF)
-    def test_should_response_200_application_json(self, mock_as_dict):
+    def test_should_respond_200_application_json(self, mock_as_dict):
         response = self.client.get(
             "/api/v1/config",
             headers={'Accept': 'application/json'},
@@ -105,7 +105,7 @@ class TestGetConfig:
         assert expected == response.json
 
     @patch("airflow.api_connexion.endpoints.config_endpoint.conf.as_dict", return_value=MOCK_CONF)
-    def test_should_response_406(self, mock_as_dict):
+    def test_should_respond_406(self, mock_as_dict):
         response = self.client.get(
             "/api/v1/config",
             headers={'Accept': 'application/octet-stream'},

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -68,7 +68,7 @@ class TestConnectionEndpoint(unittest.TestCase):
 
 class TestDeleteConnection(TestConnectionEndpoint):
     @provide_session
-    def test_delete_should_response_204(self, session):
+    def test_delete_should_respond_204(self, session):
         connection_model = Connection(conn_id='test-connection', conn_type='test_type')
 
         session.add(connection_model)
@@ -82,7 +82,7 @@ class TestDeleteConnection(TestConnectionEndpoint):
         connection = session.query(Connection).all()
         assert len(connection) == 0
 
-    def test_delete_should_response_404(self):
+    def test_delete_should_respond_404(self):
         response = self.client.delete(
             "/api/v1/connections/test-connection", environ_overrides={'REMOTE_USER': "test"}
         )
@@ -111,7 +111,7 @@ class TestDeleteConnection(TestConnectionEndpoint):
 
 class TestGetConnection(TestConnectionEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         connection_model = Connection(
             conn_id='test-connection-id',
             conn_type='mysql',
@@ -140,7 +140,7 @@ class TestGetConnection(TestConnectionEndpoint):
             },
         )
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         response = self.client.get(
             "/api/v1/connections/invalid-connection", environ_overrides={'REMOTE_USER': "test"}
         )
@@ -163,7 +163,7 @@ class TestGetConnection(TestConnectionEndpoint):
 
 class TestGetConnections(TestConnectionEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         connection_model_1 = Connection(conn_id='test-connection-id-1', conn_type='test_type')
         connection_model_2 = Connection(conn_id='test-connection-id-2', conn_type='test_type')
         connections = [connection_model_1, connection_model_2]
@@ -303,7 +303,7 @@ class TestPatchConnection(TestConnectionEndpoint):
         ]
     )
     @provide_session
-    def test_patch_should_response_200(self, payload, session):
+    def test_patch_should_respond_200(self, payload, session):
         self._create_connection(session)
 
         response = self.client.patch(
@@ -312,7 +312,7 @@ class TestPatchConnection(TestConnectionEndpoint):
         assert response.status_code == 200
 
     @provide_session
-    def test_patch_should_response_200_with_update_mask(self, session):
+    def test_patch_should_respond_200_with_update_mask(self, session):
         self._create_connection(session)
         test_connection = "test-connection-id"
         payload = {
@@ -390,7 +390,7 @@ class TestPatchConnection(TestConnectionEndpoint):
         ]
     )
     @provide_session
-    def test_patch_should_response_400_for_invalid_fields_in_update_mask(
+    def test_patch_should_respond_400_for_invalid_fields_in_update_mask(
         self, payload, update_mask, error_message, session
     ):
         self._create_connection(session)
@@ -432,7 +432,7 @@ class TestPatchConnection(TestConnectionEndpoint):
         ]
     )
     @provide_session
-    def test_patch_should_response_400_for_invalid_update(self, payload, error_message, session):
+    def test_patch_should_respond_400_for_invalid_update(self, payload, error_message, session):
         self._create_connection(session)
         response = self.client.patch(
             "/api/v1/connections/test-connection-id", json=payload, environ_overrides={'REMOTE_USER': "test"}
@@ -440,7 +440,7 @@ class TestPatchConnection(TestConnectionEndpoint):
         assert response.status_code == 400
         self.assertIn(error_message, response.json['detail'])
 
-    def test_patch_should_response_404_not_found(self):
+    def test_patch_should_respond_404_not_found(self):
         payload = {"connection_id": "test-connection-id", "conn_type": "test-type", "port": 90}
         response = self.client.patch(
             "/api/v1/connections/test-connection-id", json=payload, environ_overrides={'REMOTE_USER': "test"}
@@ -470,7 +470,7 @@ class TestPatchConnection(TestConnectionEndpoint):
 
 class TestPostConnection(TestConnectionEndpoint):
     @provide_session
-    def test_post_should_response_200(self, session):
+    def test_post_should_respond_200(self, session):
         payload = {"connection_id": "test-connection-id", "conn_type": 'test_type'}
         response = self.client.post(
             "/api/v1/connections", json=payload, environ_overrides={'REMOTE_USER': "test"}
@@ -480,7 +480,7 @@ class TestPostConnection(TestConnectionEndpoint):
         assert len(connection) == 1
         self.assertEqual(connection[0].conn_id, 'test-connection-id')
 
-    def test_post_should_response_400_for_invalid_payload(self):
+    def test_post_should_respond_400_for_invalid_payload(self):
         payload = {
             "connection_id": "test-connection-id",
         }  # conn_type missing
@@ -498,7 +498,7 @@ class TestPostConnection(TestConnectionEndpoint):
             },
         )
 
-    def test_post_should_response_409_already_exist(self):
+    def test_post_should_respond_409_already_exist(self):
         payload = {"connection_id": "test-connection-id", "conn_type": 'test_type'}
         response = self.client.post(
             "/api/v1/connections", json=payload, environ_overrides={'REMOTE_USER': "test"}

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -101,7 +101,7 @@ class TestDagEndpoint(unittest.TestCase):
 
 
 class TestGetDag(TestDagEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         self._create_dag_models(1)
         response = self.client.get("/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
@@ -124,7 +124,7 @@ class TestGetDag(TestDagEndpoint):
         )
 
     @provide_session
-    def test_should_response_200_with_schedule_interval_none(self, session=None):
+    def test_should_respond_200_with_schedule_interval_none(self, session=None):
         dag_model = DagModel(
             dag_id="TEST_DAG_1",
             fileloc="/tmp/dag_1.py",
@@ -152,14 +152,14 @@ class TestGetDag(TestDagEndpoint):
             current_response,
         )
 
-    def test_should_response_200_with_granular_dag_access(self):
+    def test_should_respond_200_with_granular_dag_access(self):
         self._create_dag_models(1)
         response = self.client.get(
             "/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test_granular_permissions"}
         )
         assert response.status_code == 200
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         response = self.client.get("/api/v1/dags/INVALID_DAG", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 404
 
@@ -176,7 +176,7 @@ class TestGetDag(TestDagEndpoint):
         )
         assert response.status_code == 403
 
-    def test_should_response_403_with_granular_access_for_different_dag(self):
+    def test_should_respond_403_with_granular_access_for_different_dag(self):
         self._create_dag_models(3)
         response = self.client.get(
             "/api/v1/dags/TEST_DAG_2", environ_overrides={'REMOTE_USER': "test_granular_permissions"}
@@ -185,7 +185,7 @@ class TestGetDag(TestDagEndpoint):
 
 
 class TestGetDagDetails(TestDagEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         response = self.client.get(
             f"/api/v1/dags/{self.dag_id}/details", environ_overrides={'REMOTE_USER': "test"}
         )
@@ -215,7 +215,7 @@ class TestGetDagDetails(TestDagEndpoint):
         }
         assert response.json == expected
 
-    def test_should_response_200_serialized(self):
+    def test_should_respond_200_serialized(self):
         # Create empty app with empty dagbag to check if DAG is read from db
         with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
             app_serialized = app.create_app(testing=True)
@@ -286,7 +286,7 @@ class TestGetDagDetails(TestDagEndpoint):
 
 
 class TestGetDags(TestDagEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         self._create_dag_models(2)
 
         response = self.client.get("api/v1/dags", environ_overrides={'REMOTE_USER': "test"})
@@ -329,7 +329,7 @@ class TestGetDags(TestDagEndpoint):
             response.json,
         )
 
-    def test_should_response_200_with_granular_dag_access(self):
+    def test_should_respond_200_with_granular_dag_access(self):
         self._create_dag_models(3)
         response = self.client.get(
             "/api/v1/dags", environ_overrides={'REMOTE_USER': "test_granular_permissions"}
@@ -366,7 +366,7 @@ class TestGetDags(TestDagEndpoint):
             ("api/v1/dags?limit=2&offset=2", ["TEST_DAG_2", "TEST_DAG_3"]),
         ]
     )
-    def test_should_response_200_and_handle_pagination(self, url, expected_dag_ids):
+    def test_should_respond_200_and_handle_pagination(self, url, expected_dag_ids):
         self._create_dag_models(10)
 
         response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
@@ -378,7 +378,7 @@ class TestGetDags(TestDagEndpoint):
         self.assertEqual(expected_dag_ids, dag_ids)
         self.assertEqual(10, response.json["total_entries"])
 
-    def test_should_response_200_default_limit(self):
+    def test_should_respond_200_default_limit(self):
         self._create_dag_models(101)
 
         response = self.client.get("api/v1/dags", environ_overrides={'REMOTE_USER': "test"})
@@ -393,7 +393,7 @@ class TestGetDags(TestDagEndpoint):
 
         assert_401(response)
 
-    def test_should_response_403_unauthorized(self):
+    def test_should_respond_403_unauthorized(self):
         self._create_dag_models(1)
 
         response = self.client.get("api/v1/dags", environ_overrides={'REMOTE_USER': "test_no_permissions"})
@@ -402,7 +402,7 @@ class TestGetDags(TestDagEndpoint):
 
 
 class TestPatchDag(TestDagEndpoint):
-    def test_should_response_200_on_patch_is_paused(self):
+    def test_should_respond_200_on_patch_is_paused(self):
         dag_model = self._create_dag_model()
         response = self.client.patch(
             f"/api/v1/dags/{dag_model.dag_id}",
@@ -428,7 +428,7 @@ class TestPatchDag(TestDagEndpoint):
         }
         self.assertEqual(response.json, expected_response)
 
-    def test_should_response_200_on_patch_with_granular_dag_access(self):
+    def test_should_respond_200_on_patch_with_granular_dag_access(self):
         self._create_dag_models(1)
         response = self.client.patch(
             "/api/v1/dags/TEST_DAG_1",
@@ -439,7 +439,7 @@ class TestPatchDag(TestDagEndpoint):
         )
         assert response.status_code == 200
 
-    def test_should_response_400_on_invalid_request(self):
+    def test_should_respond_400_on_invalid_request(self):
         patch_body = {
             "is_paused": True,
             "schedule_interval": {
@@ -460,7 +460,7 @@ class TestPatchDag(TestDagEndpoint):
             },
         )
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         response = self.client.get("/api/v1/dags/INVALID_DAG", environ_overrides={'REMOTE_USER': "test"})
         self.assertEqual(response.status_code, 404)
 
@@ -483,7 +483,7 @@ class TestPatchDag(TestDagEndpoint):
 
         assert_401(response)
 
-    def test_should_response_200_with_update_mask(self):
+    def test_should_respond_200_with_update_mask(self):
         dag_model = self._create_dag_model()
         payload = {
             "is_paused": False,
@@ -528,7 +528,7 @@ class TestPatchDag(TestDagEndpoint):
             ),
         ]
     )
-    def test_should_response_400_for_invalid_fields_in_update_mask(self, payload, update_mask, error_message):
+    def test_should_respond_400_for_invalid_fields_in_update_mask(self, payload, update_mask, error_message):
         dag_model = self._create_dag_model()
 
         response = self.client.patch(
@@ -539,7 +539,7 @@ class TestPatchDag(TestDagEndpoint):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json['detail'], error_message)
 
-    def test_should_response_403_unauthorized(self):
+    def test_should_respond_403_unauthorized(self):
         dag_model = self._create_dag_model()
         response = self.client.patch(
             f"/api/v1/dags/{dag_model.dag_id}",

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -124,7 +124,7 @@ class TestDagRunEndpoint(unittest.TestCase):
 
 class TestDeleteDagRun(TestDagRunEndpoint):
     @provide_session
-    def test_should_response_204(self, session):
+    def test_should_respond_204(self, session):
         session.add_all(self._create_test_dag_run())
         session.commit()
         response = self.client.delete(
@@ -137,7 +137,7 @@ class TestDeleteDagRun(TestDagRunEndpoint):
         )
         self.assertEqual(response.status_code, 404)
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         response = self.client.delete(
             "api/v1/dags/INVALID_DAG_RUN/dagRuns/INVALID_DAG_RUN", environ_overrides={'REMOTE_USER': "test"}
         )
@@ -173,7 +173,7 @@ class TestDeleteDagRun(TestDagRunEndpoint):
 
 class TestGetDagRun(TestDagRunEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         dagrun_model = DagRun(
             dag_id="TEST_DAG_ID",
             run_id="TEST_DAG_RUN_ID",
@@ -202,7 +202,7 @@ class TestGetDagRun(TestDagRunEndpoint):
         }
         assert response.json == expected_response
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         response = self.client.get(
             "api/v1/dags/invalid-id/dagRuns/invalid-id", environ_overrides={'REMOTE_USER': "test"}
         )
@@ -235,7 +235,7 @@ class TestGetDagRun(TestDagRunEndpoint):
 
 class TestGetDagRuns(TestDagRunEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         self._create_test_dag_run()
         result = session.query(DagRun).all()
         assert len(result) == 2
@@ -780,7 +780,7 @@ class TestPostDagRun(TestDagRunEndpoint):
         ]
     )
     @provide_session
-    def test_should_response_200(self, name, request_json, session):
+    def test_should_respond_200(self, name, request_json, session):
         del name
         dag_instance = DagModel(dag_id="TEST_DAG_ID")
         session.add(dag_instance)

--- a/tests/api_connexion/endpoints/test_dag_source_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_source_endpoint.py
@@ -76,7 +76,7 @@ class TestGetSource(unittest.TestCase):
         return docstring
 
     @parameterized.expand([(True,), (False,)])
-    def test_should_response_200_text(self, store_dag_code):
+    def test_should_respond_200_text(self, store_dag_code):
         serializer = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
         with mock.patch("airflow.models.dag.settings.STORE_DAG_CODE", store_dag_code), mock.patch(
             "airflow.models.dagcode.STORE_DAG_CODE", store_dag_code
@@ -96,7 +96,7 @@ class TestGetSource(unittest.TestCase):
             self.assertEqual('text/plain', response.headers['Content-Type'])
 
     @parameterized.expand([(True,), (False,)])
-    def test_should_response_200_json(self, store_dag_code):
+    def test_should_respond_200_json(self, store_dag_code):
         serializer = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
         with mock.patch("airflow.models.dag.settings.STORE_DAG_CODE", store_dag_code), mock.patch(
             "airflow.models.dagcode.STORE_DAG_CODE", store_dag_code
@@ -116,7 +116,7 @@ class TestGetSource(unittest.TestCase):
             self.assertEqual('application/json', response.headers['Content-Type'])
 
     @parameterized.expand([(True,), (False,)])
-    def test_should_response_406(self, store_dag_code):
+    def test_should_respond_406(self, store_dag_code):
         serializer = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
         with mock.patch("airflow.models.dag.settings.STORE_DAG_CODE", store_dag_code), mock.patch(
             "airflow.models.dagcode.STORE_DAG_CODE", store_dag_code
@@ -133,7 +133,7 @@ class TestGetSource(unittest.TestCase):
             self.assertEqual(406, response.status_code)
 
     @parameterized.expand([(True,), (False,)])
-    def test_should_response_404(self, store_dag_code):
+    def test_should_respond_404(self, store_dag_code):
         with mock.patch("airflow.models.dag.settings.STORE_DAG_CODE", store_dag_code), mock.patch(
             "airflow.models.dagcode.STORE_DAG_CODE", store_dag_code
         ):

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -76,7 +76,7 @@ class TestEventLogEndpoint(unittest.TestCase):
 
 class TestGetEventLog(TestEventLogEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         log_model = Log(
             event='TEST_EVENT',
             task_instance=self._create_task_instance(),
@@ -103,7 +103,7 @@ class TestGetEventLog(TestEventLogEndpoint):
             },
         )
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         response = self.client.get("/api/v1/eventLogs/1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 404
         self.assertEqual(
@@ -135,7 +135,7 @@ class TestGetEventLog(TestEventLogEndpoint):
 
 class TestGetEventLogs(TestEventLogEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         log_model_1 = Log(
             event='TEST_EVENT_1',
             task_instance=self._create_task_instance(),

--- a/tests/api_connexion/endpoints/test_extra_link_endpoint.py
+++ b/tests/api_connexion/endpoints/test_extra_link_endpoint.py
@@ -125,7 +125,7 @@ class TestGetExtraLinks(unittest.TestCase):
             ),
         ]
     )
-    def test_should_response_404(self, name, url, expected_title, expected_detail):
+    def test_should_respond_404(self, name, url, expected_title, expected_detail):
         del name
         response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
 
@@ -148,7 +148,7 @@ class TestGetExtraLinks(unittest.TestCase):
         assert response.status_code == 403
 
     @mock_plugin_manager(plugins=[])
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         XCom.set(
             key="job_id",
             value="TEST_JOB_ID",
@@ -167,7 +167,7 @@ class TestGetExtraLinks(unittest.TestCase):
         )
 
     @mock_plugin_manager(plugins=[])
-    def test_should_response_200_missing_xcom(self):
+    def test_should_respond_200_missing_xcom(self):
         response = self.client.get(
             "/api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/taskInstances/TEST_SINGLE_QUERY/links",
             environ_overrides={'REMOTE_USER': "test"},
@@ -180,7 +180,7 @@ class TestGetExtraLinks(unittest.TestCase):
         )
 
     @mock_plugin_manager(plugins=[])
-    def test_should_response_200_multiple_links(self):
+    def test_should_respond_200_multiple_links(self):
         XCom.set(
             key="job_id",
             value=["TEST_JOB_ID_1", "TEST_JOB_ID_2"],
@@ -203,7 +203,7 @@ class TestGetExtraLinks(unittest.TestCase):
         )
 
     @mock_plugin_manager(plugins=[])
-    def test_should_response_200_multiple_links_missing_xcom(self):
+    def test_should_respond_200_multiple_links_missing_xcom(self):
         response = self.client.get(
             "/api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID/taskInstances/TEST_MULTIPLE_QUERY/links",
             environ_overrides={'REMOTE_USER': "test"},
@@ -215,7 +215,7 @@ class TestGetExtraLinks(unittest.TestCase):
             response.json,
         )
 
-    def test_should_response_200_support_plugins(self):
+    def test_should_respond_200_support_plugins(self):
         class GoogleLink(BaseOperatorLink):
             name = "Google"
 

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -153,7 +153,7 @@ class TestGetLog(unittest.TestCase):
         super().tearDown()
 
     @provide_session
-    def test_should_response_200_json(self, session):
+    def test_should_respond_200_json(self, session):
         self._create_dagrun(session)
         key = self.app.config["SECRET_KEY"]
         serializer = URLSafeSerializer(key)
@@ -176,7 +176,7 @@ class TestGetLog(unittest.TestCase):
         self.assertEqual(200, response.status_code)
 
     @provide_session
-    def test_should_response_200_text_plain(self, session):
+    def test_should_respond_200_text_plain(self, session):
         self._create_dagrun(session)
         key = self.app.config["SECRET_KEY"]
         serializer = URLSafeSerializer(key)

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -78,7 +78,7 @@ class TestTaskEndpoint(unittest.TestCase):
 
 
 class TestGetTask(TestTaskEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         expected = {
             "class_ref": {
                 "class_name": "DummyOperator",
@@ -112,7 +112,7 @@ class TestGetTask(TestTaskEndpoint):
         assert response.status_code == 200
         assert response.json == expected
 
-    def test_should_response_200_serialized(self):
+    def test_should_respond_200_serialized(self):
         # Create empty app with empty dagbag to check if DAG is read from db
         with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
             app_serialized = app.create_app(testing=True)
@@ -155,7 +155,7 @@ class TestGetTask(TestTaskEndpoint):
         assert response.status_code == 200
         assert response.json == expected
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         task_id = "xxxx_not_existing"
         response = self.client.get(
             f"/api/v1/dags/{self.dag_id}/tasks/{task_id}", environ_overrides={'REMOTE_USER': "test"}
@@ -175,7 +175,7 @@ class TestGetTask(TestTaskEndpoint):
 
 
 class TestGetTasks(TestTaskEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         expected = {
             "tasks": [
                 {
@@ -214,7 +214,7 @@ class TestGetTasks(TestTaskEndpoint):
         assert response.status_code == 200
         assert response.json == expected
 
-    def test_should_response_404(self):
+    def test_should_respond_404(self):
         dag_id = "xxxx_not_existing"
         response = self.client.get(f"/api/v1/dags/{dag_id}/tasks", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 404

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -136,7 +136,7 @@ class TestTaskInstanceEndpoint(unittest.TestCase):
 
 class TestGetTaskInstance(TestTaskInstanceEndpoint):
     @provide_session
-    def test_should_response_200(self, session):
+    def test_should_respond_200(self, session):
         self.create_task_instances(session)
         response = self.client.get(
             "/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/taskInstances/print_the_context",
@@ -170,7 +170,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
         )
 
     @provide_session
-    def test_should_response_200_task_instance_with_sla(self, session):
+    def test_should_respond_200_task_instance_with_sla(self, session):
         self.create_task_instances(session)
         session.query()
         sla_miss = SlaMiss(
@@ -400,7 +400,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
         ]
     )
     @provide_session
-    def test_should_response_200(self, _, task_instances, update_extras, url, expected_ti, session):
+    def test_should_respond_200(self, _, task_instances, update_extras, url, expected_ti, session):
         self.create_task_instances(
             session,
             update_extras=update_extras,
@@ -412,7 +412,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
         self.assertEqual(len(response.json["task_instances"]), expected_ti)
 
     @provide_session
-    def test_should_response_200_for_dag_id_filter(self, session):
+    def test_should_respond_200_for_dag_id_filter(self, session):
         self.create_task_instances(session)
         self.create_task_instances(session, dag_id="example_skip_dag")
         response = self.client.get(
@@ -541,7 +541,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         ]
     )
     @provide_session
-    def test_should_response_200(
+    def test_should_respond_200(
         self, _, task_instances, update_extras, single_dag_run, payload, expected_ti_count, session
     ):
         self.create_task_instances(
@@ -570,7 +570,7 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
         ],
     )
     @provide_session
-    def test_should_response_200_dag_ids_filter(self, _, payload, expected_ti, total_ti, session):
+    def test_should_respond_200_dag_ids_filter(self, _, payload, expected_ti, total_ti, session):
         self.create_task_instances(session)
         self.create_task_instances(session, dag_id="example_skip_dag")
         response = self.client.post(
@@ -738,7 +738,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         ]
     )
     @provide_session
-    def test_should_response_200(
+    def test_should_respond_200(
         self, _, main_dag, task_instances, request_dag, payload, expected_ti, session
     ):
         self.create_task_instances(
@@ -758,7 +758,7 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         self.assertEqual(len(response.json["task_instances"]), expected_ti)
 
     @provide_session
-    def test_should_response_200_with_reset_dag_run(self, session):
+    def test_should_respond_200_with_reset_dag_run(self, session):
         dag_id = "example_python_operator"
         payload = {
             "dry_run": False,

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -76,7 +76,7 @@ class TestDeleteVariable(TestVariableEndpoint):
         response = self.client.get("/api/v1/variables/delete_var1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 404
 
-    def test_should_response_404_if_key_does_not_exist(self):
+    def test_should_respond_404_if_key_does_not_exist(self):
         response = self.client.delete(
             "/api/v1/variables/NONEXIST_VARIABLE_KEY", environ_overrides={'REMOTE_USER': "test"}
         )
@@ -103,7 +103,7 @@ class TestDeleteVariable(TestVariableEndpoint):
 
 
 class TestGetVariable(TestVariableEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         expected_value = '{"foo": 1}'
         Variable.set("TEST_VARIABLE_KEY", expected_value)
         response = self.client.get(
@@ -112,7 +112,7 @@ class TestGetVariable(TestVariableEndpoint):
         assert response.status_code == 200
         assert response.json == {"key": "TEST_VARIABLE_KEY", "value": expected_value}
 
-    def test_should_response_404_if_not_found(self):
+    def test_should_respond_404_if_not_found(self):
         response = self.client.get(
             "/api/v1/variables/NONEXIST_VARIABLE_KEY", environ_overrides={'REMOTE_USER': "test"}
         )

--- a/tests/api_connexion/endpoints/test_version_endpoint.py
+++ b/tests/api_connexion/endpoints/test_version_endpoint.py
@@ -33,7 +33,7 @@ class TestGetHealthTest(unittest.TestCase):
     @mock.patch(
         "airflow.api_connexion.endpoints.version_endpoint.get_airflow_git_version", return_value="GIT_COMMIT"
     )
-    def test_should_response_200(self, mock_get_airflow_get_commit):
+    def test_should_respond_200(self, mock_get_airflow_get_commit):
         response = self.client.get("/api/v1/version")
 
         self.assertEqual(200, response.status_code)

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -90,7 +90,7 @@ class TestXComEndpoint(unittest.TestCase):
 
 
 class TestGetXComEntry(TestXComEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         dag_id = 'test-dag-id'
         task_id = 'test-task-id'
         execution_date = '2005-04-02T00:00:00+00:00'
@@ -167,7 +167,7 @@ class TestGetXComEntry(TestXComEndpoint):
 
 
 class TestGetXComEntries(TestXComEndpoint):
-    def test_should_response_200(self):
+    def test_should_respond_200(self):
         dag_id = 'test-dag-id'
         task_id = 'test-task-id'
         execution_date = '2005-04-02T00:00:00+00:00'
@@ -207,7 +207,7 @@ class TestGetXComEntries(TestXComEndpoint):
             },
         )
 
-    def test_should_response_200_with_tilde_and_access_to_all_dags(self):
+    def test_should_respond_200_with_tilde_and_access_to_all_dags(self):
         dag_id_1 = 'test-dag-id-1'
         task_id_1 = 'test-task-id-1'
         execution_date = '2005-04-02T00:00:00+00:00'
@@ -266,7 +266,7 @@ class TestGetXComEntries(TestXComEndpoint):
             },
         )
 
-    def test_should_response_200_with_tilde_and_granular_dag_access(self):
+    def test_should_respond_200_with_tilde_and_granular_dag_access(self):
         dag_id_1 = 'test-dag-id-1'
         task_id_1 = 'test-task-id-1'
         execution_date = '2005-04-02T00:00:00+00:00'


### PR DESCRIPTION
Currently the api_connexion tests are prefixed with `should_response`. This fixes the typo by changing the prefix to `should_respond`.