### PR TITLE
Implements canceling of future duplicate runs (but the latest)

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -21,7 +21,7 @@ on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["CI Build"]
     types: ['requested']
-
+##
 env:
   MOUNT_LOCAL_SOURCES: "false"
   MOUNT_FILES: "true"
@@ -67,7 +67,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
       - name: "Cancel duplicated 'CI Build' runs"
-        uses: potiuk/cancel-workflow-runs@0acb1c01f6740dfbca6eab6e21a5b5066e8bafb3  # v3_3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cancelMode: duplicates
@@ -85,7 +85,7 @@ jobs:
         # in GitHub Actions, we have to use Job names to match Event/Repo/Branch from the
         # build-info step there to find the duplicates ¯\_(ツ)_/¯.
 
-        uses: potiuk/cancel-workflow-runs@0acb1c01f6740dfbca6eab6e21a5b5066e8bafb3  # v3_3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         with:
           cancelMode: namedJobs
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -94,9 +94,7 @@ jobs:
             [".*Event: ${{ steps.source-run-info.outputs.sourceEvent }}
             Repo: ${{ steps.source-run-info.outputs.sourceHeadRepo }}
             Branch: ${{ steps.source-run-info.outputs.sourceHeadBranch }}.*"]
-        if: >
-          env.BUILD_IMAGES == 'true' && steps.source-run-info.outputs.sourceEvent != 'schedule'
-          && steps.source-run-info.outputs.sourceEvent != 'push'
+        if: env.BUILD_IMAGES == 'true'
       - name: "Cancel all 'CI Build' runs where some jobs failed"
 
         # We find any of the "CI Build" workflow runs, where any of the important jobs
@@ -105,7 +103,7 @@ jobs:
         # can cancel all the matching "Build Images" workflow runs in the two following steps.
         # Yeah. Adding to the complexity ¯\_(ツ)_/¯.
 
-        uses: potiuk/cancel-workflow-runs@0acb1c01f6740dfbca6eab6e21a5b5066e8bafb3  # v3_3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         id: cancel-failed
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -139,14 +137,14 @@ jobs:
         # it to cancel any jobs that have matching names containing Source Run Id:
         # followed by one of the run ids. Yes I know it's super complex ¯\_(ツ)_/¯.
         if: env.BUILD_IMAGES == 'true' && steps.source-run-info-failed.outputs.cancelledRuns != '[]'
-        uses: potiuk/cancel-workflow-runs@0acb1c01f6740dfbca6eab6e21a5b5066e8bafb3  # v3_3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         with:
           cancelMode: namedJobs
           token: ${{ secrets.GITHUB_TOKEN }}
           notifyPRCancel: true
           jobNameRegexps: ${{ steps.extract-cancelled-failed-runs.outputs.matching-regexp }}
       - name: "Cancel duplicated 'CodeQL' runs"
-        uses: potiuk/cancel-workflow-runs@0acb1c01f6740dfbca6eab6e21a5b5066e8bafb3  # v3_3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         id: cancel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -367,7 +365,7 @@ jobs:
     needs: [build-images]
     steps:
       - name: "Canceling the 'CI Build' source workflow in case of failure!"
-        uses: potiuk/cancel-workflow-runs@cancel_message  # v3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cancelMode: self
@@ -382,7 +380,7 @@ jobs:
     needs: [build-images]
     steps:
       - name: "Canceling the 'CI Build' source workflow in case of failure!"
-        uses: potiuk/cancel-workflow-runs@0acb1c01f6740dfbca6eab6e21a5b5066e8bafb3  # v3_3
+        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cancelMode: self

--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -21,7 +21,6 @@ on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["CI Build"]
     types: ['requested']
-##
 env:
   MOUNT_LOCAL_SOURCES: "false"
   MOUNT_FILES: "true"


### PR DESCRIPTION
Previous version of the cancel-workflow-runs action implemented
canceling of only past duplicates, but when there are queues
involved, some future "cancel-workflow-runs" might be in a queue
for  long time. This change has the effect that cancel-workflow-runs
for duplicates will also allow future runs of the same branch/repo
sparing only the most recent run - no matter if the duplicates
were older than my own run.

This should handle the case where we have queues blocking the
"cancel-workflow-runs" from running.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
