### PR TITLE
Add option in dag_runs api to filter out older runs.

### DIFF
--- a/airflow/api/common/experimental/get_dag_runs.py
+++ b/airflow/api/common/experimental/get_dag_runs.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """DAG runs APIs."""
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from flask import url_for
@@ -24,12 +25,15 @@ from airflow.api.common.experimental import check_and_get_dag
 from airflow.models import DagRun
 
 
-def get_dag_runs(dag_id: str, state: Optional[str] = None) -> List[Dict[str, Any]]:
+def get_dag_runs(dag_id: str, state: Optional[str] = None,
+                 execution_start_date: Optional[datetime] = None) -> List[Dict[str, Any]]:
     """
     Returns a list of Dag Runs for a specific DAG ID.
 
     :param dag_id: String identifier of a DAG
     :param state: queued|running|success...
+    :param execution_start_date: dag run that was executed from this date
+    :type execution_start_date: datetime.datetime
     :return: List of DAG runs of a DAG with requested state,
         or all runs if the state is not specified
     """
@@ -37,7 +41,7 @@ def get_dag_runs(dag_id: str, state: Optional[str] = None) -> List[Dict[str, Any
 
     dag_runs = []
     state = state.lower() if state else None
-    for run in DagRun.find(dag_id=dag_id, state=state):
+    for run in DagRun.find(dag_id=dag_id, state=state, execution_start_date=execution_start_date):
         dag_runs.append({
             'id': run.id,
             'run_id': run.run_id,

--- a/docs/rest-api-ref.rst
+++ b/docs/rest-api-ref.rst
@@ -61,6 +61,9 @@ Endpoints
 
   Returns a list of Dag Runs for a specific DAG ID.
 
+  **Optional query params:**
+  **state:** dag run state such as queued, running, success, etc
+  **execution_start_date:** start execution date string in YYYY-mm-DDTHH:MM:SS format to filter dag runs newer than specified execution_start_date
 
 .. http:get:: /api/experimental/dags/<string:dag_id>/dag_runs/<string:execution_date>
 


### PR DESCRIPTION
[/api/experimental/dags/{dag}/dag_runs](https://airflow.apache.org/docs/stable/rest-api-ref.html#get--api-experimental-dags--DAG_ID--dag_runs) takes a while to response if there are many dag runs.
Most users might be interested in the last N day runs so API should have a way to filter out older runs.

This change expose "execution_start_date" to API.

