### PR TITLE
Disable XCom pickling by default

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -50,7 +50,15 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
-### The default `[webserver] cookie_samesite` has been changed to `Lax`
+### The default value for `[core] enable_xcom_pickling` has been changed to `False`
+
+The pickle type for XCom messages has been replaced to JSON by default to prevent RCE attacks.
+Note that JSON serialization is stricter than pickling, so for example if you want to pass
+raw bytes through XCom you must encode them using an encoding like ``base64``.
+If you understand the risk and still want to use [pickling](https://docs.python.org/3/library/pickle.html),
+set `enable_xcom_pickling = False` in your Airflow config's `core` section.
+
+### The default value for `[webserver] cookie_samesite` has been changed to `Lax`
 
 As [recommended](https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOKIE_SAMESITE) by Flask, the
 `[webserver] cookie_samesite` has bee changed to `Lax` from `None`.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -298,11 +298,12 @@
     - name: enable_xcom_pickling
       description: |
         Whether to enable pickling for xcom (note that this is insecure and allows for
-        RCE exploits). This will be deprecated in Airflow 2.0 (be forced to False).
+        RCE exploits).
       version_added: ~
       type: string
       example: ~
-      default: "True"
+      default: "False"
+      see_also: "https://docs.python.org/3/library/pickle.html#comparison-with-json"
     - name: killed_task_cleanup_time
       description: |
         When a task is killed forcefully, this is the amount of time in seconds that

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -176,8 +176,8 @@ security =
 unit_test_mode = False
 
 # Whether to enable pickling for xcom (note that this is insecure and allows for
-# RCE exploits). This will be deprecated in Airflow 2.0 (be forced to False).
-enable_xcom_pickling = True
+# RCE exploits).
+enable_xcom_pickling = False
 
 # When a task is killed forcefully, this is the amount of time in seconds that
 # it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -56,10 +56,6 @@ class BaseXCom(Base, LoggingMixin):
     task_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
     dag_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
 
-    """
-    TODO: "pickling" has been deprecated and JSON is preferred.
-          "pickling" will be removed in Airflow 2.0.
-    """
     @reconstructor
     def init_on_load(self):
         """
@@ -92,8 +88,6 @@ class BaseXCom(Base, LoggingMixin):
             session=None):
         """
         Store an XCom value.
-        TODO: "pickling" has been deprecated and JSON is preferred.
-        "pickling" will be removed in Airflow 2.0.
 
         :return: None
         """
@@ -245,8 +239,6 @@ class BaseXCom(Base, LoggingMixin):
     @staticmethod
     def serialize_value(value: Any):
         """Serialize Xcom value to str or pickled object"""
-        # TODO: "pickling" has been deprecated and JSON is preferred.
-        # "pickling" will be removed in Airflow 2.0.
         if conf.getboolean('core', 'enable_xcom_pickling'):
             return pickle.dumps(value)
         try:
@@ -261,12 +253,9 @@ class BaseXCom(Base, LoggingMixin):
     @staticmethod
     def deserialize_value(result) -> Any:
         """Deserialize Xcom value from str or pickle object"""
-        # TODO: "pickling" has been deprecated and JSON is preferred.
-        # "pickling" will be removed in Airflow 2.0.
         enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
         if enable_pickling:
             return pickle.loads(result.value)
-
         try:
             return json.loads(result.value.decode('UTF-8'))
         except JSONDecodeError:


### PR DESCRIPTION
We have a note in UPDATING.md that we would change this default and even remove pickling for XCom
since Airflow 1.9.0 (Jan 2, 2018).

closes https://github.com/apache/airflow/issues/9606

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
