### PR TITLE
Remove XCom pickling

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -295,14 +295,6 @@
       type: string
       example: ~
       default: "False"
-    - name: enable_xcom_pickling
-      description: |
-        Whether to enable pickling for xcom (note that this is insecure and allows for
-        RCE exploits). This will be deprecated in Airflow 2.0 (be forced to False).
-      version_added: ~
-      type: string
-      example: ~
-      default: "True"
     - name: killed_task_cleanup_time
       description: |
         When a task is killed forcefully, this is the amount of time in seconds that

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -175,10 +175,6 @@ security =
 # values at runtime)
 unit_test_mode = False
 
-# Whether to enable pickling for xcom (note that this is insecure and allows for
-# RCE exploits). This will be deprecated in Airflow 2.0 (be forced to False).
-enable_xcom_pickling = True
-
 # When a task is killed forcefully, this is the amount of time in seconds that
 # it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED
 killed_task_cleanup_time = 60

--- a/airflow/providers/microsoft/winrm/operators/winrm.py
+++ b/airflow/providers/microsoft/winrm/operators/winrm.py
@@ -22,7 +22,6 @@ from typing import Optional, Union
 
 from winrm.exceptions import WinRMOperationTimeoutError
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
@@ -133,11 +132,7 @@ class WinRMOperator(BaseOperator):
 
         if return_code == 0:
             # returning output if do_xcom_push is set
-            enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
-            if enable_pickling:
-                return stdout_buffer
-            else:
-                return b64encode(b''.join(stdout_buffer)).decode('utf-8')
+            return b64encode(b''.join(stdout_buffer)).decode('utf-8')
         else:
             error_msg = "Error running cmd: {0}, return code: {1}, error: {2}".format(
                 self.command, return_code, b''.join(stderr_buffer).decode('utf-8')

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -20,7 +20,6 @@ from base64 import b64encode
 from select import select
 from typing import Optional, Union
 
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.ssh.hooks.ssh import SSHHook
@@ -157,12 +156,7 @@ class SSHOperator(BaseOperator):
 
                 exit_status = stdout.channel.recv_exit_status()
                 if exit_status == 0:
-                    enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
-                    if enable_pickling:
-                        return agg_stdout
-                    else:
-                        return b64encode(agg_stdout).decode('utf-8')
-
+                    return b64encode(agg_stdout).decode('utf-8')
                 else:
                     error_msg = agg_stderr.decode('utf-8')
                     raise AirflowException(

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from base64 import b64decode
 
 import boto3
 from moto import mock_s3
@@ -25,7 +26,6 @@ from airflow.providers.amazon.aws.transfers.s3_to_sftp import S3ToSFTPOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils import timezone
 from airflow.utils.timezone import datetime
-from tests.test_utils.config import conf_vars
 
 TASK_ID = 'test_s3_to_sftp'
 BUCKET = 'test-s3-bucket'
@@ -70,7 +70,6 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         self.s3_key = S3_KEY
 
     @mock_s3
-    @conf_vars({("core", "enable_xcom_pickling"): "True"})
     def test_s3_to_sftp_operation(self):
         # Setting
         test_remote_file_content = (
@@ -121,8 +120,8 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         ti3 = TaskInstance(task=check_file_task, execution_date=timezone.utcnow())
         ti3.run()
         self.assertEqual(
-            ti3.xcom_pull(task_ids='test_check_file', key='return_value').strip(),
-            test_remote_file_content.encode('utf-8'),
+            b64decode(ti3.xcom_pull(task_ids='test_check_file', key='return_value').strip()).decode('utf-8'),
+            test_remote_file_content,
         )
 
         # Clean up after finishing with test

--- a/tests/providers/amazon/aws/transfers/test_sftp_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_sftp_to_s3.py
@@ -28,7 +28,6 @@ from airflow.providers.ssh.hooks.ssh import SSHHook
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils import timezone
 from airflow.utils.timezone import datetime
-from tests.test_utils.config import conf_vars
 
 BUCKET = 'test-bucket'
 S3_KEY = 'test/test_1_file.csv'
@@ -69,7 +68,6 @@ class TestSFTPToS3Operator(unittest.TestCase):
         self.s3_key = S3_KEY
 
     @mock_s3
-    @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_sftp_to_s3_operation(self):
         # Setting
         test_remote_file_content = (


### PR DESCRIPTION
We have raised deprecation warning when using pickling for XCom
since Airflow 1.9.0 (Jan 2, 2018)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
