### PR TITLE
Fix heisentest by ignoring the basepath

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -119,10 +119,11 @@ def find_path_from_directory(
         for file in files:  # type: ignore
             if file == ignore_file_name:
                 continue
-            file_path = os.path.join(root, str(file))
-            if any(re.findall(p, file_path) for p in patterns):
+            abs_file_path = os.path.join(root, str(file))
+            rel_file_path = os.path.join(os.path.relpath(root, str(base_dir_path)), str(file))
+            if any(p.search(rel_file_path) for p in patterns):
                 continue
-            yield str(file_path)
+            yield str(abs_file_path)
 
 
 def list_py_file_paths(directory: str,

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1534,7 +1534,7 @@ A ``.airflowignore`` file specifies the directories or files in ``DAG_FOLDER``
 or ``PLUGINS_FOLDER`` that Airflow should intentionally ignore.
 Each line in ``.airflowignore`` specifies a regular expression pattern,
 and directories or files whose names (not DAG id) match any of the patterns
-would be ignored (under the hood,``re.findall()`` is used to match the pattern).
+would be ignored (under the hood,``Pattern.search()`` is used to match the pattern).
 Overall it works like a ``.gitignore`` file.
 Use the ``#`` character to indicate a comment; all characters
 on a line following a ``#`` will be ignored.

--- a/tests/plugins/test_plugin_ignore.py
+++ b/tests/plugins/test_plugin_ignore.py
@@ -23,8 +23,6 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
-import pytest
-
 from airflow import settings
 from airflow.utils.file import find_path_from_directory
 
@@ -38,10 +36,11 @@ class TestIgnorePluginFile(unittest.TestCase):
         """
         Make tmp folder and files that should be ignored. And set base path.
         """
-        self.test_dir = tempfile.mkdtemp()
+        # Temp dir name includes an ignored token "not", but it shouldn't matter since it's in the base path.
+        self.test_dir = tempfile.mkdtemp(prefix="onotole")
         self.test_file = os.path.join(self.test_dir, 'test_file.txt')
         self.plugin_folder_path = os.path.join(self.test_dir, 'test_ignore')
-        os.mkdir(os.path.join(self.test_dir, "test_ignore"))
+        os.mkdir(self.plugin_folder_path)
         os.mkdir(os.path.join(self.plugin_folder_path, "subdir1"))
         os.mkdir(os.path.join(self.plugin_folder_path, "subdir2"))
         files_content = [
@@ -67,8 +66,6 @@ class TestIgnorePluginFile(unittest.TestCase):
         """
         shutil.rmtree(self.test_dir)
 
-    # See the issue: https://github.com/apache/airflow/issues/10988
-    @pytest.mark.heisentests
     def test_find_not_should_ignore_path(self):
         """
         Test that the .airflowignore work and whether the file is properly ignored.


### PR DESCRIPTION
**Problem:**
The issue #10988 suspects that there's a dependency on side-effects from other tests.
However, the test itself seems pretty hermetic, creating a new randomly-named temp directory every time.
My guess is that there is a case where the randomly-generated name contains one of the ignored tokens.
For example, probability of a random 8-character name containing `"not"` is roughly `6 / 37^3` ~ 0.01%.
In this case, all files will be wrongfully ignored because we use the absolute path to perform the pattern matching.

**Solution:**
Use the relative path to perform the pattern matching. Also, look for the first match only (no need for `re.findall()`).

**Validation:**
The modified test intentionally includes ignored token `"not"` in the name of the base path. With this modification, the test fails 100% of the time, unless the suggested fix in `find_path_from_directory()` is applied.

Closes: #10988