### PR TITLE
Fix incorrect .airflowignore behavior with multiple nested directories

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -114,7 +114,7 @@ def find_path_from_directory(
                 os.path.join(os.path.relpath(root, str(base_dir_path)), subdir)) for p in patterns)
         ]
 
-        patterns_by_dir = {os.path.join(root, sd): patterns.copy() for sd in dirs}
+        patterns_by_dir.update({os.path.join(root, sd): patterns.copy() for sd in dirs})
 
         for file in files:  # type: ignore
             if file == ignore_file_name:

--- a/tests/plugins/test_plugin_ignore.py
+++ b/tests/plugins/test_plugin_ignore.py
@@ -44,6 +44,7 @@ class TestIgnorePluginFile(unittest.TestCase):
         os.mkdir(os.path.join(self.test_dir, "test_ignore"))
         os.mkdir(os.path.join(self.plugin_folder_path, "subdir1"))
         os.mkdir(os.path.join(self.plugin_folder_path, "subdir2"))
+        os.mkdir(os.path.join(self.plugin_folder_path, "subdir3"))
         files_content = [
             ["test_load.py", "#Should not be ignored file"],
             ["test_notload.py", 'raise Exception("This file should have been ignored!")'],
@@ -53,6 +54,7 @@ class TestIgnorePluginFile(unittest.TestCase):
             ["test_notload_sub.py", 'raise Exception("This file should have been ignored!")'],
             ["subdir1/test_noneload_sub1.py", 'raise Exception("This file should have been ignored!")'],
             ["subdir2/test_shouldignore.py", 'raise Exception("This file should have been ignored!")'],
+            ["subdir3/test_notload_sub3.py", 'raise Exception("This file should have been ignored!")'],
         ]
         for file_path, content in files_content:
             with open(os.path.join(self.plugin_folder_path, file_path), "w") as f:


### PR DESCRIPTION
**Problem:**
In `find_path_from_directory()`, the `patterns_by_dir` map is incorrectly emptied and reset with patterns from the current directory, effectively forgetting about the patterns added earlier, for directories not yet processed. The modified testcase demonstrates the issue.

**Solution:**
Instead of resetting the map, update it with the new entries. An entry for a directory is added only once, namely when its immediate parent directory is processed, therefore we never overwrite any key in the map.

**Note:**
The test is currently marked as `heisentest`; PR #11993 unmarks it. I imagine that PR should go first, and this PR should be rebased after that.