### PR TITLE
Pass image_pull_policy when creating the container spec in the KubernetesPodOperator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -390,6 +390,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                         args=self.arguments,
                         env=self.env_vars,
                         env_from=self.env_from,
+                        image_pull_policy=self.image_pull_policy,
                     )
                 ],
                 image_pull_secrets=self.image_pull_secrets,


### PR DESCRIPTION
Address issue #11998 (not applying the image_pull_policy in the KubernetesPodOperator) by passing the image_pull_policy when creating the container description for the pod spec.

See https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Container.md for a description of the V1Container class. 

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
