### PR TITLE
Switches to "cancel-all-duplicates' mode of cancelling.

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -66,12 +66,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
       - name: "Cancel duplicated 'CI Build' runs"
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cancelMode: duplicates
+          cancelMode: allDuplicates
           sourceRunId: ${{ github.event.workflow_run.id }}
-          notifyPRCancel: true
       - name: "Output BUILD_IMAGES"
         id: build-images
         run: |
@@ -84,7 +83,7 @@ jobs:
         # in GitHub Actions, we have to use Job names to match Event/Repo/Branch from the
         # build-info step there to find the duplicates ¯\_(ツ)_/¯.
 
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         with:
           cancelMode: namedJobs
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -102,7 +101,7 @@ jobs:
         # can cancel all the matching "Build Images" workflow runs in the two following steps.
         # Yeah. Adding to the complexity ¯\_(ツ)_/¯.
 
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         id: cancel-failed
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -136,18 +135,18 @@ jobs:
         # it to cancel any jobs that have matching names containing Source Run Id:
         # followed by one of the run ids. Yes I know it's super complex ¯\_(ツ)_/¯.
         if: env.BUILD_IMAGES == 'true' && steps.source-run-info-failed.outputs.cancelledRuns != '[]'
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         with:
           cancelMode: namedJobs
           token: ${{ secrets.GITHUB_TOKEN }}
           notifyPRCancel: true
           jobNameRegexps: ${{ steps.extract-cancelled-failed-runs.outputs.matching-regexp }}
       - name: "Cancel duplicated 'CodeQL' runs"
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         id: cancel
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          cancelMode: duplicates
+          cancelMode: allDuplicates
           workflowFileName: 'codeql-analysis.yml'
       - name: "Set Docker Cache Directive"
         id: cache-directive
@@ -364,7 +363,7 @@ jobs:
     needs: [build-images]
     steps:
       - name: "Canceling the 'CI Build' source workflow in case of failure!"
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cancelMode: self
@@ -379,7 +378,7 @@ jobs:
     needs: [build-images]
     steps:
       - name: "Canceling the 'CI Build' source workflow in case of failure!"
-        uses: potiuk/cancel-workflow-runs@c8448eb1e435664b3731ea1ead2efa0d1bb83b5b  # v4_0
+        uses: potiuk/cancel-workflow-runs@99869d37d982384d18c79539b67df94f17557cbe  # v4_1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cancelMode: self


### PR DESCRIPTION
The cancel-workflow-runs action in version 4.1 got the capability
of cancelling not only duplicates of own run (including future,
queued duplicates) but also cancelling all duplicates from all
running worklfows - regardless if they were triggered by my own
PR or some other PRs. This will be even more helpful with handling
the queues and optimising our builds, because in case ANY of
the build image workflows starts to run, it will cancel ALL
duplicates immediately.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
