### PR TITLE
Fix chart network policies definion and compliance

### DIFF
--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -29,10 +29,10 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{- with .Values.ingress.flower.annotations }}
   annotations:
-    {{- range $key, $value := .Values.ingress.flower.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+  {{ toYaml . | indent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.flower.tls.enabled }}
   tls:

--- a/chart/templates/flower/flower-networkpolicy.yaml
+++ b/chart/templates/flower/flower-networkpolicy.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Flower NetworkPolicy
 #################################
-{{- if (and .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- if and .Values.networkPolicies.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -39,13 +39,13 @@ spec:
       component: flower
       release: {{ .Release.Name }}
   policyTypes:
-  - Ingress
-  ingress:
-  - from:
+    - Ingress
 {{- if .Values.flower.extraNetworkPolicies }}
-{{ toYaml .Values.flower.extraNetworkPolicies | indent 4 }}
+  ingress:
+    - from:
+{{ toYaml .Values.flower.extraNetworkPolicies | indent 6 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ports.flowerUI }}
 {{- end }}
-    ports:
-    - protocol: TCP
-      port: {{ .Values.ports.flowerUI }}
 {{- end }}

--- a/chart/templates/webserver/webserver-networkpolicy.yaml
+++ b/chart/templates/webserver/webserver-networkpolicy.yaml
@@ -39,13 +39,13 @@ spec:
       component: webserver
       release: {{ .Release.Name }}
   policyTypes:
-  - Ingress
-  ingress:
-  - from:
+    - Ingress
 {{- if .Values.webserver.extraNetworkPolicies }}
-{{ toYaml .Values.webserver.extraNetworkPolicies | indent 4 }}
+  ingress:
+    - from:
+{{ toYaml .Values.webserver.extraNetworkPolicies | indent 6 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.ports.airflowUI }}
 {{- end }}
-    ports:
-    - protocol: TCP
-      port: {{ .Values.ports.airflowUI }}
 {{- end }}

--- a/chart/templates/workers/worker-networkpolicy.yaml
+++ b/chart/templates/workers/worker-networkpolicy.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Worker NetworkPolicy
 #################################
-{{- if (and .Values.networkPolicies.enabled ( or (eq .Values.executor "CeleryExecutor"))  (eq .Values.executor "CeleryKubernetesExecutor")) }}
+{{- if and .Values.networkPolicies.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -86,6 +86,31 @@ class TestBaseChartTest(unittest.TestCase):
         self.assertNotIn(('Job', 'TEST-BASIC-create-user'), list_of_kind_names_tuples)
         self.assertEqual(OBJECT_COUNT_IN_BASIC_DEPLOYMENT - 1, len(k8s_objects))
 
+    def test_network_policies_are_valid(self):
+        k8s_objects = render_chart(
+            "TEST-BASIC",
+            {
+                "networkPolicies": {"enabled": True},
+                "executor": "CeleryExecutor",
+                "pgbouncer": {"enabled": True},
+            },
+        )
+        kind_names_tuples = {
+            (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
+        }
+
+        expected_kind_names = [
+            ('NetworkPolicy', 'TEST-BASIC-redis-policy'),
+            ('NetworkPolicy', 'TEST-BASIC-flower-policy'),
+            ('NetworkPolicy', 'TEST-BASIC-pgbouncer-policy'),
+            ('NetworkPolicy', 'TEST-BASIC-scheduler-policy'),
+            ('NetworkPolicy', 'TEST-BASIC-statsd-policy'),
+            ('NetworkPolicy', 'TEST-BASIC-webserver-policy'),
+            ('NetworkPolicy', 'TEST-BASIC-worker-policy'),
+        ]
+        for kind_name in expected_kind_names:
+            self.assertIn(kind_name, kind_names_tuples)
+
     def test_chart_is_consistent_with_official_airflow_image(self):
         def get_k8s_objs_with_image(obj: Union[List[Any], Dict[str, Any]]) -> List[Dict[str, Any]]:
             """


### PR DESCRIPTION
Hello @mik-laj,

While I was adding support for an external redis to the chart I had issues with your latest changes regarding schema validation.

Here are the fixes.

Followup to #12003:
* Some network policies & ingress are not valid
  against the jsonschema (empty values mostly)
* Some network policies conditionnal definitions
  were incorrect

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
