### PR TITLE
Add job name and progress logs to gcp transfer hook.

### DIFF
--- a/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
@@ -18,7 +18,12 @@
 """This module contains a Google Cloud Transfer sensor."""
 from typing import Optional, Sequence, Set, Union
 
-from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import CloudDataTransferServiceHook
+from airflow.providers.google.cloud.hooks.cloud_storage_transfer_service import (
+    CloudDataTransferServiceHook,
+    COUNTERS,
+    METADATA,
+    NAME,
+)
 from airflow.sensors.base_sensor_operator import BaseSensorOperator
 from airflow.utils.decorators import apply_defaults
 
@@ -90,6 +95,9 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
         operations = hook.list_transfer_operations(
             request_filter={'project_id': self.project_id, 'job_names': [self.job_name]}
         )
+
+        for operation in operations:
+            self.log.info("Progress for operation %s: %s", operation[NAME], operation[METADATA][COUNTERS])
 
         check = CloudDataTransferServiceHook.operations_contain_expected_statuses(
             operations=operations, expected_statuses=self.expected_statuses

--- a/tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py
+++ b/tests/providers/google/cloud/sensors/test_cloud_storage_transfer_service.py
@@ -25,13 +25,27 @@ from airflow.providers.google.cloud.sensors.cloud_storage_transfer_service impor
     CloudDataTransferServiceJobStatusSensor,
 )
 
+TEST_NAME = "transferOperations/transferJobs-123-456"
+TEST_COUNTERS = {
+    "bytesFoundFromSource": 512,
+    "bytesCopiedToSink": 1024,
+}
+
 
 class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
     @mock.patch(
         'airflow.providers.google.cloud.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook'
     )
     def test_wait_for_status_success(self, mock_tool):
-        operations = [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}]
+        operations = [
+            {
+                'name': TEST_NAME,
+                'metadata': {
+                    'status': GcpTransferOperationStatus.SUCCESS,
+                    'counters': TEST_COUNTERS,
+                },
+            }
+        ]
         mock_tool.return_value.list_transfer_operations.return_value = operations
         mock_tool.operations_contain_expected_statuses.return_value = True
 
@@ -79,8 +93,24 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
     )
     def test_wait_for_status_after_retry(self, mock_tool):
         operations_set = [
-            [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}],
-            [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}],
+            [
+                {
+                    'name': TEST_NAME,
+                    'metadata': {
+                        'status': GcpTransferOperationStatus.SUCCESS,
+                        'counters': TEST_COUNTERS,
+                    },
+                },
+            ],
+            [
+                {
+                    'name': TEST_NAME,
+                    'metadata': {
+                        'status': GcpTransferOperationStatus.SUCCESS,
+                        'counters': TEST_COUNTERS,
+                    },
+                },
+            ],
         ]
 
         mock_tool.return_value.list_transfer_operations.side_effect = operations_set
@@ -124,7 +154,15 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor(unittest.TestCase):
         'airflow.providers.google.cloud.sensors.cloud_storage_transfer_service.CloudDataTransferServiceHook'
     )
     def test_wait_for_status_normalize_status(self, expected_status, received_status, mock_tool):
-        operations = [{'metadata': {'status': GcpTransferOperationStatus.SUCCESS}}]
+        operations = [
+            {
+                'name': TEST_NAME,
+                'metadata': {
+                    'status': GcpTransferOperationStatus.SUCCESS,
+                    'counters': TEST_COUNTERS,
+                },
+            }
+        ]
 
         mock_tool.return_value.list_transfer_operations.return_value = operations
         mock_tool.operations_contain_expected_statuses.side_effect = [False, True]


### PR DESCRIPTION
It's hard to get the progress of an ongoing gcp storage transfer job from the current logs. This patch logs the job name on job creation and the job progress while polling. For reference, the job progress dict looks like this: https://cloud.google.com/storage-transfer/docs/reference/rest/v1/transferOperations#TransferCounters.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
