### PR TITLE
Refine request check in api_connextion Pool endpoints

### DIFF
--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -99,9 +99,10 @@ def patch_pool(pool_name, session, update_mask=None):
         patch_body = _patch_body
 
     else:
-        for field in ["name", "slots"]:
-            if field not in request.json.keys():
-                raise BadRequest(detail=f"'{field}' is a required property")
+        required_fields = {"name", "slots"}
+        fields_diff = required_fields - set(request.json.keys())
+        if fields_diff:
+            raise BadRequest(detail=f"Missing required property(ies): {sorted(fields_diff)}")
 
     for key, value in patch_body.items():
         setattr(pool, key, value)
@@ -113,10 +114,10 @@ def patch_pool(pool_name, session, update_mask=None):
 @provide_session
 def post_pool(session):
     """Create a pool"""
-    required_fields = ["name", "slots"]  # Pool would require both fields in the post request
-    for field in required_fields:
-        if field not in request.json.keys():
-            raise BadRequest(detail=f"'{field}' is a required property")
+    required_fields = {"name", "slots"}  # Pool would require both fields in the post request
+    fields_diff = required_fields - set(request.json.keys())
+    if fields_diff:
+        raise BadRequest(detail=f"Missing required property(ies): {sorted(fields_diff)}")
 
     try:
         post_body = pool_schema.load(request.json, session=session)

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -293,12 +293,17 @@ class TestPostPool(TestBasePoolEndpoints):
             (
                 "for missing pool name",
                 {"slots": 3},
-                "'name' is a required property",
+                "Missing required property(ies): ['name']",
             ),
             (
                 "for missing slots",
                 {"name": "invalid_pool"},
-                "'slots' is a required property",
+                "Missing required property(ies): ['slots']",
+            ),
+            (
+                "for missing pool name AND slots",
+                {},
+                "Missing required property(ies): ['name', 'slots']",
             ),
             (
                 "for extra fields",
@@ -356,8 +361,9 @@ class TestPatchPool(TestBasePoolEndpoints):
     @parameterized.expand(
         [
             # Missing properties
-            ("'name' is a required property", {"slots": 3}),
-            ("'slots' is a required property", {"name": "test_pool_a"}),
+            ("Missing required property(ies): ['name']", {"slots": 3}),
+            ("Missing required property(ies): ['slots']", {"name": "test_pool_a"}),
+            ("Missing required property(ies): ['name', 'slots']", {}),
             # Extra properties
             (
                 "{'extra_field': ['Unknown field.']}",


### PR DESCRIPTION
Minor improve the request JSON key check in `PATCH` and `POST` endpoints for **Pool** in `/api_connextion`.

The main reasoning is:

If I miss *both* required properties (`name` and `slots`) in my request, I receive only one warning at one time.
That means I need to fix my error for twice, which is not necessary.

This commit helps check all missing properties in one shot.

(I'm not abstracting this into a util method/function because so far I only see two such usage in whole repo).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
