### PR TITLE
Install cattr on Python 3.7 - Fix docs build on RTD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -696,7 +696,7 @@ INSTALL_REQUIREMENTS = [
     'cached_property~=1.5',
     # cattrs >= 1.1.0 dropped support for Python 3.6
     'cattrs>=1.0, <1.1.0;python_version<="3.6"',
-    'cattrs>=1.0, <2.0;python_version>"3.7"',
+    'cattrs>=1.0, <2.0;python_version>"3.6"',
     'colorlog==4.0.2',
     'connexion[swagger-ui,flask]>=2.6.0,<3',
     'croniter>=0.3.17, <0.4',


### PR DESCRIPTION
I believe this library is still needed for Python 3.7, but the constraints currently preclude installing this library on this version of Python.
This causes a problem on RTD.
https://readthedocs.org/projects/airflow/builds/12243425/

Related: https://github.com/apache/airflow/pull/11969 CC: @kaxil 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
