### PR TITLE
adding quick description for singularity container operator

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -257,7 +257,7 @@ Here's the list of the subpackages and what they enable:
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+
 | samba               | ``pip install 'apache-airflow[samba]'``             | :class:`airflow.providers.apache.hive.transfers.hive_to_samba.HiveToSambaOperator` |
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+
-| singularity         | ``pip install 'apache-airflow[singularity]'``       |                                                                                    |
+| singularity         | ``pip install 'apache-airflow[singularity]'``       | Singularity container operator                                                     |
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+
 | statsd              | ``pip install 'apache-airflow[statsd]'``            | Needed by StatsD metrics                                                           |
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+


### PR DESCRIPTION
This doesn't close the issue, but checks off the box in #12042 to add a description for the Singularity container operator. I mirrored the Docker description to just cleanly state it's for Singularity. I can also confirm that the software is listed in the correct section.

Signed-off-by: vsoch <vsochat@stanford.edu>