### PR TITLE
Fix FAB table views overflow

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -427,3 +427,8 @@ label[for="timezone-other"],
 .btn-group {
   display: inline-flex;
 }
+
+/* Override FAB table views where table width extends beyond parent containers */
+.panel-body .panel-group + div {
+  overflow-x: scroll;
+}


### PR DESCRIPTION
Resolves #12030.

This could potentially be better resolved in FAB itself, but the issue is caused by the context of Airflow's tables having a large number of columns (very wide). This solution is similar to #11958 where the body will scroll horizontal instead of breaking the layout.

| Before | After |
|---|---|
| ![Screen Recording 2020-11-02 at 11 27 22 AM](https://user-images.githubusercontent.com/3267/97892755-6c596180-1cfe-11eb-8826-093772eef229.gif)  |  ![Screen Recording 2020-11-02 at 11 26 14 AM](https://user-images.githubusercontent.com/3267/97892779-73806f80-1cfe-11eb-8c92-5ed6e58edd90.gif) |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
