### PR TITLE
Docstring fix for S3DeleteBucketOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -67,7 +67,7 @@ class S3DeleteBucketOperator(BaseOperator):
     """
     This operator deletes an S3 bucket
 
-    :param bucket_name: This is bucket name you want to create
+    :param bucket_name: This is bucket name you want to delete
     :type bucket_name: str
     :param force_delete: Forcibly delete all objects in the bucket before deleting the bucket
     :type force_delete: bool


### PR DESCRIPTION
The docstring of `S3DeleteBucketOperator` is inconsistent with what it actually does. Possibly a copy-paste error.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
