### PR TITLE
Correct failure message in sql_sensor.py.

### DIFF
--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -109,7 +109,7 @@ class SqlSensor(BaseSensorOperator):
                 if self.failure(first_cell):
                     raise AirflowException(f"Failure criteria met. self.failure({first_cell}) returned True")
             else:
-                raise AirflowException(f"self.failure is present, but not callable -> {self.success}")
+                raise AirflowException(f"self.failure is present, but not callable -> {self.failure}")
         if self.success is not None:
             if callable(self.success):
                 return self.success(first_cell)

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -217,7 +217,9 @@ class TestSqlSensor(TestHiveEnvironment):
         mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
 
         mock_get_records.return_value = [[1]]
-        self.assertRaises(AirflowException, op.poke, None)
+        with self.assertRaises(AirflowException) as e:
+            op.poke(None)
+        self.assertEqual("self.failure is present, but not callable -> [1]", str(e.exception))
 
     @mock.patch('airflow.sensors.sql_sensor.BaseHook')
     def test_sql_sensor_postgres_poke_invalid_success(self, mock_hook):
@@ -232,7 +234,9 @@ class TestSqlSensor(TestHiveEnvironment):
         mock_get_records = mock_hook.get_connection.return_value.get_hook.return_value.get_records
 
         mock_get_records.return_value = [[1]]
-        self.assertRaises(AirflowException, op.poke, None)
+        with self.assertRaises(AirflowException) as e:
+            op.poke(None)
+        self.assertEqual("self.success is present, but not callable -> [1]", str(e.exception))
 
     @unittest.skipIf(
         'AIRFLOW_RUNALL_TESTS' not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set"


### PR DESCRIPTION
An `AirFlowException` in `sql_sensor.py` is formatting its message as a success instead of a failure. This PR resolves the issue by correcting the message to indicate a failure, and adjusting tests which should reach this message to also check the message itself instead of just checking whether this Exception occurred.

Resolves #10553