### PR TITLE
Treat AirflowSensorTimeout as immediate failure without retrying

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -82,6 +82,10 @@ but identifies logs based on labels.  For this reason, we decided to delete this
 If you need to read logs, you can use `airflow.utils.log.log_reader.TaskLogReader` class, which does not have
 the above restrictions.
 
+### If a sensor times out, it will not retry
+
+Previously, a sensor is retried when it times out until the number of ``retries`` are exhausted. So the effective timeout of a sensor is ``timeout * (retries + 1)``. This behaviour is now changed. A sensor will immediately fail without retrying if ``timeout`` is reached. If it's desirable to let the sensor continue running for longer time, set a larger ``timeout`` instead.
+
 ### Default Task Pools Slots can be set using ``[core] default_pool_task_slot_count``
 
 By default tasks are running in `default_pool`. `default_pool` is initialized with `128` slots and user can change the
@@ -317,10 +321,6 @@ It is still possible (but not required) to "register" hooks in plugins. This is 
 See https://airflow.apache.org/docs/apache-airflow/stable/howto/custom-operator.html for more info.
 
 ### Adding Operators and Sensors via plugins is no longer supported
-
-### If a sensor times out, it will not retry
-
-Previously, a sensor is retried when it times out until the number of ``retries`` are exhausted. So the effective timeout of a sensor is ``timeout * (retries + 1)``. This behaviour is now changed. A sensor will immediately fail without retrying if ``timeout`` is reached. If it's desirable to let the sensor continue running for longer time, set a larger ``timeout`` instead.
 
 ### The default value for `[core] enable_xcom_pickling` has been changed to `False`
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -319,6 +319,7 @@ See https://airflow.apache.org/docs/apache-airflow/stable/howto/custom-operator.
 ### Adding Operators and Sensors via plugins is no longer supported
 
 ### If a sensor times out, it will not retry
+
 Previously, a sensor is retried when it times out until the number of ``retries`` are exhausted. So the effective timeout of a sensor is ``timeout * (retries + 1)``. This behaviour is now changed. A sensor will immediately fail without retrying if ``timeout`` is reached. If it's desirable to let the sensor continue running for longer time, set a larger ``timeout`` instead.
 
 ### The default value for `[core] enable_xcom_pickling` has been changed to `False`

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -318,6 +318,9 @@ See https://airflow.apache.org/docs/apache-airflow/stable/howto/custom-operator.
 
 ### Adding Operators and Sensors via plugins is no longer supported
 
+### If a sensor times out, it will not retry
+Previously, a sensor is retried when it times out until the number of ``retries`` are exhausted. So the effective timeout of a sensor is ``timeout * (retries + 1)``. This behaviour is now changed. A sensor will immediately fail without retrying if ``timeout`` is reached. If it's desirable to let the sensor continue running for longer time, set a larger ``timeout`` instead.
+
 ### The default value for `[core] enable_xcom_pickling` has been changed to `False`
 
 The pickle type for XCom messages has been replaced to JSON by default to prevent RCE attacks.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -47,7 +47,9 @@ from airflow.exceptions import (
     AirflowFailException,
     AirflowRescheduleException,
     AirflowSensorTimeout,
-    AirflowSkipException, AirflowSmartSensorException, AirflowTaskTimeout,
+    AirflowSkipException,
+    AirflowSmartSensorException,
+    AirflowTaskTimeout,
 )
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
 from airflow.models.log import Log

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1155,6 +1155,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             self._handle_reschedule(actual_start_date, reschedule_exception, test_mode)
             return
         except (AirflowFailException, AirflowSensorTimeout) as e:
+            # If AirflowFailException is raised, task should not retry.
+            # If a sensor in reschedule mode reaches timeout, task should not retry.
             self.refresh_from_db()
             self.handle_failure(e, test_mode, force_fail=True, error_file=error_file)
             raise

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -46,9 +46,8 @@ from airflow.exceptions import (
     AirflowException,
     AirflowFailException,
     AirflowRescheduleException,
-    AirflowSkipException,
-    AirflowSmartSensorException,
-    AirflowTaskTimeout,
+    AirflowSensorTimeout,
+    AirflowSkipException, AirflowSmartSensorException, AirflowTaskTimeout,
 )
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
 from airflow.models.log import Log
@@ -1153,7 +1152,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             self.refresh_from_db()
             self._handle_reschedule(actual_start_date, reschedule_exception, test_mode)
             return
-        except AirflowFailException as e:
+        except (AirflowFailException, AirflowSensorTimeout) as e:
             self.refresh_from_db()
             self.handle_failure(e, test_mode, force_fail=True, error_file=error_file)
             raise

--- a/airflow/models/taskreschedule.py
+++ b/airflow/models/taskreschedule.py
@@ -60,7 +60,7 @@ class TaskReschedule(Base):
 
     @staticmethod
     @provide_session
-    def query_for_task_instance(task_instance, descending=False, session=None):
+    def query_for_task_instance(task_instance, descending=False, session=None, try_number=None):
         """
         Returns query for task reschedules for a given the task instance.
 
@@ -70,13 +70,19 @@ class TaskReschedule(Base):
         :type task_instance: airflow.models.TaskInstance
         :param descending: If True then records are returned in descending order
         :type descending: bool
+        :param try_number: Look for TaskReschedule of the given try_number. Default is None which
+            looks for the same try_number of the given task_instance.
+        :type try_number: int
         """
+        if try_number is None:
+            try_number = task_instance.try_number
+
         TR = TaskReschedule
         qry = session.query(TR).filter(
             TR.dag_id == task_instance.dag_id,
             TR.task_id == task_instance.task_id,
             TR.execution_date == task_instance.execution_date,
-            TR.try_number == task_instance.try_number,
+            TR.try_number == try_number,
         )
         if descending:
             return qry.order_by(desc(TR.id))
@@ -85,7 +91,7 @@ class TaskReschedule(Base):
 
     @staticmethod
     @provide_session
-    def find_for_task_instance(task_instance, session=None):
+    def find_for_task_instance(task_instance, session=None, try_number=None):
         """
         Returns all task reschedules for the task instance and try number,
         in ascending order.
@@ -94,5 +100,10 @@ class TaskReschedule(Base):
         :type session: sqlalchemy.orm.session.Session
         :param task_instance: the task instance to find task reschedules for
         :type task_instance: airflow.models.TaskInstance
+        :param try_number: Look for TaskReschedule of the given try_number. Default is None which
+            looks for the same try_number of the given task_instance.
+        :type try_number: int
         """
-        return TaskReschedule.query_for_task_instance(task_instance, session=session).all()
+        return TaskReschedule.query_for_task_instance(
+            task_instance, session=session, try_number=try_number
+        ).all()

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -199,11 +199,14 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
 
         if self.reschedule:
 
-            # If reschedule, use first start date of current try
-            task_reschedules = TaskReschedule.find_for_task_instance(context['ti'])
+            # If reschedule, use the start date of the first try (first try can be either the very
+            # first execution of the task, or the first execution after the task was cleared.)
+            first_try_number = context['ti'].max_tries - self.retries + 1
+            task_reschedules = TaskReschedule.find_for_task_instance(
+                context['ti'], try_number=first_try_number
+            )
             if task_reschedules:
                 started_at = task_reschedules[0].start_date
-                try_number = len(task_reschedules) + 1
             else:
                 started_at = timezone.utcnow()
 

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -225,10 +225,8 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
 
         while not self.poke(context):
             if run_duration() > self.timeout:
-                # If sensor is in soft fail mode but will be retried then
-                # give it a chance and fail with timeout.
-                # This gives the ability to set up non-blocking AND soft-fail sensors.
-                if self.soft_fail and not context['ti'].is_eligible_to_retry():
+                # If sensor is in soft fail mode but times out raise AirflowSkipException.
+                if self.soft_fail:
                     raise AirflowSkipException(f"Snap. Time is OUT. DAG id: {log_dag_id}")
                 else:
                     raise AirflowSensorTimeout(f"Snap. Time is OUT. DAG id: {log_dag_id}")

--- a/docs/apache-airflow/concepts/tasks.rst
+++ b/docs/apache-airflow/concepts/tasks.rst
@@ -108,7 +108,38 @@ There may also be instances of the *same task*, but for different values of ``ex
 Timeouts
 --------
 
-If you want a task to have a maximum runtime, set its ``execution_timeout`` attribute to a ``datetime.timedelta`` value that is the maximum permissible runtime. If it runs longer than this, Airflow will kick in and fail the task with a timeout exception.
+If you want a task to have a maximum runtime, set its ``execution_timeout`` attribute to a ``datetime.timedelta`` value
+that is the maximum permissible runtime. This applies to all Airflow tasks, including sensors. ``execution_timeout`` controls the
+maximum time allowed for every execution. If ``execution_timeout`` is breached, the task times out and
+``AirflowTaskTimeout`` is raised.
+
+In addition, sensors have a ``timeout`` parameter. This only matters for sensors in ``reschedule`` mode. ``timeout`` controls the maximum
+time allowed for the sensor to succeed. If ``timeout`` is breached, ``AirflowSensorTimeout`` will be raised and the sensor fails immediately
+without retrying.
+
+The following ``SFTPSensor`` example illustrates this. The ``sensor`` is in ``reschedule`` mode, meaning it
+is periodically executed and rescheduled until it succeeds.
+
+- Each time the sensor pokes the SFTP server, it is allowed to take maximum 60 seconds as defined by ``execution_time``.
+- If it takes the sensor more than 60 seconds to poke the SFTP server, ``AirflowTaskTimeout`` will be raised.
+  The sensor is allowed to retry when this happens. It can retry up to 2 times as defined by ``retries``.
+- From the start of the first execution, till it eventually succeeds (i.e. after the file 'root/test' appears),
+  the sensor is allowed maximum 3600 seconds as defined by ``timeout``. In other words, if the file
+  does not appear on the SFTP server within 3600 seconds, the sensor will raise ``AirflowSensorTimeout``.
+  It will not retry when this error is raised.
+- If the sensor fails due to other reasons such as network outages during the 3600 seconds interval,
+  it can retry up to 2 times as defined by ``retries``. Retrying does not reset the ``timeout``. It will
+  still have up to 3600 seconds in total for it to succeed.
+
+.. code-block:: python
+    sensor = SFTPSensor(
+        task_id="sensor",
+        path='/root/test',
+        execution_timeout=timedelta(seconds=60),
+        timeout=3600,
+        retries=2,
+        mode="reschedule",
+    )
 
 If you merely want to be notified if a task runs over but still let it run to completion, you want :ref:`concepts:slas` instead.
 

--- a/docs/apache-airflow/concepts/tasks.rst
+++ b/docs/apache-airflow/concepts/tasks.rst
@@ -132,6 +132,7 @@ is periodically executed and rescheduled until it succeeds.
   still have up to 3600 seconds in total for it to succeed.
 
 .. code-block:: python
+
     sensor = SFTPSensor(
         task_id="sensor",
         path='/root/test',

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -32,7 +32,12 @@ from parameterized import param, parameterized
 from sqlalchemy.orm.session import Session
 
 from airflow import models, settings
-from airflow.exceptions import AirflowException, AirflowFailException, AirflowSensorTimeout, AirflowSkipException
+from airflow.exceptions import (
+    AirflowException,
+    AirflowFailException,
+    AirflowSensorTimeout,
+    AirflowSkipException,
+)
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import (
     DAG,

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2149,7 +2149,6 @@ def test_sensor_timeout(mode, retries):
     """
     Test that AirflowSensorTimeout does not cause sensor to retry.
     """
-    from unittest import mock
 
     def timeout():
         raise AirflowSensorTimeout

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -32,7 +32,7 @@ from parameterized import param, parameterized
 from sqlalchemy.orm.session import Session
 
 from airflow import models, settings
-from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowSensorTimeout, AirflowSkipException
 from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.models import (
     DAG,
@@ -2136,3 +2136,35 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
         # Verify that ti.operator field renders correctly "with" Serialization
         ser_ti = TI(task=deserialized_op, execution_date=datetime.datetime.now())
         assert ser_ti.operator == "DummyOperator"
+
+
+@pytest.mark.parametrize("mode", ["poke", "reschedule"])
+@pytest.mark.parametrize("retries", [0, 1])
+def test_sensor_timeout(mode, retries):
+    """
+    Test that AirflowSensorTimeout does not cause sensor to retry.
+    """
+    from unittest import mock
+
+    def timeout():
+        raise AirflowSensorTimeout
+
+    dag = models.DAG(dag_id=f'test_sensor_timeout_{mode}_{retries}')
+    mock_on_failure = mock.MagicMock()
+    task = PythonSensor(
+        task_id='test_raise_sensor_timeout',
+        dag=dag,
+        python_callable=timeout,
+        owner='airflow',
+        start_date=timezone.datetime(2016, 2, 1, 0, 0, 0),
+        on_failure_callback=mock_on_failure,
+        retries=retries,
+        mode=mode,
+    )
+    ti = TI(task=task, execution_date=timezone.utcnow())
+
+    with pytest.raises(AirflowSensorTimeout):
+        ti.run()
+
+    assert mock_on_failure.called
+    assert ti.state == State.FAILED

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -508,6 +508,151 @@ class TestBaseSensor(unittest.TestCase):
             assert interval2 >= sensor.poke_interval
             assert interval2 > interval1
 
+    def test_reschedule_and_retry_fail(self):
+        """
+        poke_interval=5
+        timeout=10
+        retries=2
+        retry_delay=timedelta(seconds=3)
+
+        Actual behaviour:
+        00:00 False, try_number=1, max_retries=2
+        00:05 RuntimeError
+        00:08 False, try_number=2, max_retries=2
+        00:13 False, try_number=2, max_retries=2
+        00:18 AirflowSensorTimeout, try_number=2, max_retries=2
+
+        Expected behaviour:
+        00:00 False, try_number=1, max_retries=2
+        00:05 RuntimeError
+        00:08 False, try_number=2, max_retries=2
+        00:13 AirflowSensorTimeout, try_number=2, max_retries=2
+
+        Expected behaviour with clear:
+        00:00 False, try_number=1, max_retries=2
+        00:05 RuntimeError
+        00:08 False, try_number=2, max_retries=2
+        00:13 AirflowSensorTimeout, try_number=2, max_retries=2
+        00:18 Clear (deleted reschedules)
+        00:18 False, try_number=2, max_retries=3
+        00:23 False, try_number=2, max_retries=3
+        00:25 False, try_number=2, max_retries=3
+        00:30 AirflowSensorTimeout, try_number=2, max_retries=3
+        """
+        sensor = self._make_sensor(
+            return_value=None,
+            poke_interval=5,
+            timeout=10,
+            retries=2,
+            retry_delay=timedelta(seconds=3),
+            mode='reschedule',
+        )
+
+        sensor.poke = Mock(side_effect=[False, RuntimeError, False, False, False, False, False, False])
+        dr = self._make_dag_run()
+
+        # first poke returns False and task is re-scheduled
+        date1 = timezone.utcnow()
+        with freeze_time(date1):
+            self._run(sensor)
+        tis = dr.get_task_instances()
+        self.assertEqual(len(tis), 2)
+        for ti in tis:
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
+                # verify one row in task_reschedule table
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                self.assertEqual(len(task_reschedules), 1)
+                self.assertEqual(task_reschedules[0].start_date, date1)
+                self.assertEqual(
+                    task_reschedules[0].reschedule_date, date1 + timedelta(seconds=sensor.poke_interval)
+                )
+                self.assertEqual(task_reschedules[0].try_number, 1)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
+
+        # second poke raises RuntimeError and task instance retries
+        date2 = date1 + timedelta(seconds=sensor.poke_interval)
+        with freeze_time(date2):
+            with self.assertRaises(RuntimeError):
+                self._run(sensor)
+        tis = dr.get_task_instances()
+        self.assertEqual(len(tis), 2)
+        for ti in tis:
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.UP_FOR_RETRY)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
+
+        # third poke returns False and task is rescheduled again
+        date3 = date2 + timedelta(seconds=sensor.poke_interval) + sensor.retry_delay
+        with freeze_time(date3):
+            self._run(sensor)
+        tis = dr.get_task_instances()
+        self.assertEqual(len(tis), 2)
+        for ti in tis:
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
+                # verify one row in task_reschedule table
+                task_reschedules = TaskReschedule.find_for_task_instance(ti)
+                self.assertEqual(len(task_reschedules), 1)
+                self.assertEqual(task_reschedules[0].start_date, date3)
+                self.assertEqual(
+                    task_reschedules[0].reschedule_date, date3 + timedelta(seconds=sensor.poke_interval)
+                )
+                self.assertEqual(task_reschedules[0].try_number, 2)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
+
+        # fourth poke times out and raises AirflowSensorTimeout
+        date4 = date3 + timedelta(seconds=sensor.poke_interval)
+        with freeze_time(date4):
+            with self.assertRaises(AirflowSensorTimeout):
+                self._run(sensor)
+        tis = dr.get_task_instances()
+        self.assertEqual(len(tis), 2)
+        for ti in tis:
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.FAILED)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
+
+        # Clear the failed sensor
+        sensor.clear()
+
+        date5 = date4 + timedelta(seconds=20)
+
+        with freeze_time(date5):
+            self._run(sensor)
+
+        for ti in tis:
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.UP_FOR_RESCHEDULE)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
+
+        date6 = date5 + timedelta(seconds=sensor.poke_interval)
+
+        with freeze_time(date6):
+            self._run(sensor)
+
+        date7 = date6 + timedelta(seconds=sensor.poke_interval)
+
+        with freeze_time(date7):
+            self._run(sensor)
+
+        date8 = date8 + timedelta(seconds=sensor.poke_interval)
+
+        with freeze_time(date8):
+            with self.assertRaises(AirflowSensorTimeout):
+                self._run(sensor)
+
+        for ti in tis:
+            if ti.task_id == SENSOR_OP:
+                self.assertEqual(ti.state, State.FAILED)
+            if ti.task_id == DUMMY_OP:
+                self.assertEqual(ti.state, State.NONE)
+
 
 @poke_mode_only
 class DummyPokeOnlySensor(BaseSensorOperator):


### PR DESCRIPTION
## Expected behaviour
For a sensor like this, the intention of the DAG author is usually to fail the sensor if it's still not done after ten minutes. However, if the sensor fails prematurely due to other unexpected reasons (such as network outage), retry at most twice.

```python
sensor = PythonSensor(
    task_id='sensor',
    python_callable=python_callable,
    timeout=60 * 10,
    retries=2,
    mode="reschedule",
)
```

## Actual behaviour
The actual current behaviour of Airflow is to retry when the sensor times out. So the effective timeout of the sensor becomes 60 * 10 * (retries + 1) = 30min. This often causes confusion. It also makes it impossible to achieve the expected behaviour no matter how the author configures the sensor.

## Fix
This PR fixes this issue. `AirflowSensorTimeout` is now treated as immediate failure. This achieves the expected behaviour. The sensor will fail if timeout is reached. If someone really wants the previous behaviour, he can always increase the timeout. I.e instead of failing and retrying every ten minutes three times, just set the timeout to 30min.