### PR TITLE
Fixes import of BaseOperator in dinging

### DIFF
--- a/airflow/providers/dingding/operators/dingding.py
+++ b/airflow/providers/dingding/operators/dingding.py
@@ -17,7 +17,8 @@
 # under the License.
 from typing import Union, Optional, List
 
-from airflow.operators.bash import BaseOperator
+from airflow.models import BaseOperator
+
 from airflow.providers.dingding.hooks.dingding import DingdingHook
 from airflow.utils.decorators import apply_defaults
 

--- a/provider_packages/refactor_provider_packages.py
+++ b/provider_packages/refactor_provider_packages.py
@@ -97,13 +97,17 @@ class RefactorBackportPackages:
 
         .. code-block:: diff
 
-            --- ./airflow/providers/google/cloud/operators/kubernetes_engine.py
-            +++ ./airflow/providers/google/cloud/operators/kubernetes_engine.py
-            @@ -179,86 +179,3 @@
-            -
-            -class GKEStartPodOperator(KubernetesPodOperator):
-            -
-            - ...
+            --- ./airflow/providers/qubole/example_dags/example_qubole.py
+            +++ ./airflow/providers/qubole/example_dags/example_qubole.py
+            @@ -22,7 +22,7 @@
+
+             from airflow import DAG
+             from airflow.operators.dummy_operator import DummyOperator
+            -from airflow.operators.python import BranchPythonOperator, PythonOperator
+            +from airflow.operators.python_operator import BranchPythonOperator, PythonOperator
+             from airflow.providers.qubole.operators.qubole import QuboleOperator
+             from airflow.providers.qubole.sensors.qubole import QuboleFileSensor, QubolePartitionSensor
+             from airflow.utils.dates import days_ago
 
         :param class_name: name to remove
         """
@@ -124,7 +128,7 @@ class RefactorBackportPackages:
              # specific language governing permissions and limitations
              # under the License.
 
-            -from airflow.operators.bash import BaseOperator
+            -from airflow.operators.baseoperator import BaseOperator
             +from airflow.operators.bash_operator import BaseOperator
              from airflow.providers.dingding.hooks.dingding import DingdingHook
              from airflow.utils.decorators import apply_defaults


### PR DESCRIPTION
The import was wrongly importing BaseOperator from bash_operator.

Now it correctly imports it from models.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
