### PR TITLE
Use sys.exit() instead of exit()

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_check_setup_installation.py
+++ b/scripts/ci/pre_commit/pre_commit_check_setup_installation.py
@@ -22,6 +22,7 @@ Checks if all the libraries in setup.py are listed in installation.rst file
 
 import os
 import re
+import sys
 from os.path import dirname
 from typing import Dict, List
 
@@ -92,7 +93,7 @@ if __name__ == '__main__':
             output_table += "| {:20} | {:^10} | {:^10} |\n".format(extras, "", "V")
 
     if output_table == "":
-        exit(0)
+        sys.exit(0)
 
     print(
         f"""
@@ -108,4 +109,4 @@ documented although not used.
     print(".{:_^22}.{:_^12}.{:_^12}.".format("NAME", "SETUP", "INSTALLATION"))
     print(output_table)
 
-    exit(1)
+    sys.exit(1)


### PR DESCRIPTION
The `exit` and `quit` functions are actually `site.Quitter` objects and are loaded, at interpreter start up, from site.py. However, if the interpreter is started with the `-S` flag, or a custom site.py is used then exit and quit may not be present. It is recommended to use `sys.exit()` which is built into the interpreter and is guaranteed to be present.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
