### PR TITLE
Remove explicit casting to List when sorted() is applied

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1836,7 +1836,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             )
         dag_runs = {dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs}
 
-        dates = sorted(list(dag_runs.keys()))
+        dates = sorted(dag_runs.keys())
         max_date = max(dates) if dates else None
         min_date = min(dates) if dates else None
 
@@ -2143,7 +2143,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
                 y=scale_time_units(cumulative_y[task_id], cum_y_unit),
             )
 
-        dates = sorted(list({ti.execution_date for ti in task_instances}))
+        dates = sorted({ti.execution_date for ti in task_instances})
         max_date = max([ti.execution_date for ti in task_instances]) if dates else None
 
         session.commit()
@@ -2215,7 +2215,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
                 chart.add_serie(name=task.task_id, x=x_points, y=y_points)
 
         tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
-        tries = sorted(list({ti.try_number for ti in tis}))
+        tries = sorted({ti.try_number for ti in tis})
         max_date = max([ti.execution_date for ti in tis]) if tries else None
         chart.create_y_axis('yAxis', format='.02f', custom_format=False, label='Tries')
         chart.axislist['yAxis']['axisLabelDistance'] = '-15'
@@ -2299,7 +2299,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             )
 
         tis = dag.get_task_instances(start_date=min_date, end_date=base_date)
-        dates = sorted(list({ti.execution_date for ti in tis}))
+        dates = sorted({ti.execution_date for ti in tis})
         max_date = max([ti.execution_date for ti in tis]) if dates else None
 
         session.commit()

--- a/tests/build_provider_packages_dependencies.py
+++ b/tests/build_provider_packages_dependencies.py
@@ -242,7 +242,7 @@ if __name__ == '__main__':
         print(f"Total: {len(errors)} errors.")
     unique_sorted_dependencies: Dict[str, List[str]] = {}
     for key in sorted(dependencies.keys()):
-        unique_sorted_dependencies[key] = sorted(list(set(dependencies[key])))
+        unique_sorted_dependencies[key] = sorted(set(dependencies[key]))
     if provider_dependencies_file_name:
         with open(provider_dependencies_file_name, "w") as providers_file:
             json.dump(unique_sorted_dependencies, providers_file, indent=2)


### PR DESCRIPTION
`sorted()` returns a sorted list.
`sorted(list(A))` is equivalent to `sorted(A)` no matter A is *Tuple*, *List*, or *Set*.

Ref: https://docs.python.org/3/library/functions.html#sorted

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
