### PR TITLE
Return nonzero exit codes on pool import errors.

### DIFF
--- a/tests/cli/commands/test_pool_command.py
+++ b/tests/cli/commands/test_pool_command.py
@@ -78,6 +78,25 @@ class TestCliPools(unittest.TestCase):
         pool_command.pool_delete(self.parser.parse_args(['pools', 'delete', 'foo']))
         self.assertEqual(self.session.query(Pool).count(), 1)
 
+    def test_pool_import_nonexistent(self):
+        with self.assertRaises(SystemExit):
+            pool_command.pool_import(self.parser.parse_args(['pools', 'import', 'nonexistent.json']))
+
+    def test_pool_import_invalid_json(self):
+        with open('pools_import_invalid.json', mode='w') as file:
+            file.write("not valid json")
+
+        with self.assertRaises(SystemExit):
+            pool_command.pool_import(self.parser.parse_args(['pools', 'import', 'pools_import_invalid.json']))
+
+    def test_pool_import_invalid_pools(self):
+        pool_config_input = {"foo": {"description": "foo_test"}}
+        with open('pools_import_invalid.json', mode='w') as file:
+            json.dump(pool_config_input, file)
+
+        with self.assertRaises(SystemExit):
+            pool_command.pool_import(self.parser.parse_args(['pools', 'import', 'pools_import_invalid.json']))
+
     def test_pool_import_export(self):
         # Create two pools first
         pool_config_input = {


### PR DESCRIPTION
The pool import command returns an exit code of zero in a few different
error cases. This causes problems for scripts that invoke the command,
since commands that actually failed will appear to have worked. This
patch returns a nonzero code if the pool file doesn't exist, if the file
isn't valid json, or if any of the pools in the file is invalid.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
