### PR TITLE
Remove the ability to add hooks to airflow.hooks namespace

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -68,7 +68,27 @@ from my_plugin import MyOperator
 
 The name under `airflow.operators.` was the plugin name, where as in the second example it is the python module name where the operator is defined.
 
-See http://airflow.apache.org/docs/stable/howto/custom-operator.html#define-an-operator-extra-link for more info.
+See http://airflow.apache.org/docs/stable/howto/custom-operator.html for more info.
+
+### Importing Hooks via plugins is no longer supported
+
+Importing hooks added in plugins via `airflow.hooks.<plugin_name>` is no longer supported, and hooks should just be imported as regular python modules.
+
+```
+from airflow.hooks.my_plugin import MyHook
+```
+
+You should instead import it as:
+
+```
+from my_plugin import MyHook
+```
+
+It is still possible (but not required) to "register" hooks in plugins. This is to allow future support for dynamically populating the Connections form in the UI.
+
+See http://airflow.apache.org/docs/stable/howto/custom-operator.html for more info.
+
+### Adding Operators and Sensors via plugins is no longer supported
 
 ### The default value for `[core] enable_xcom_pickling` has been changed to `False`
 

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -25,7 +25,6 @@ from airflow import plugins_manager
 PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP = [
     "plugins",
     "import_errors",
-    "hooks_modules",
     "macros_modules",
     "executors_modules",
     "flask_blueprints",
@@ -59,7 +58,7 @@ def dump_plugins(args):
     plugins_manager.log.setLevel(logging.DEBUG)
 
     plugins_manager.ensure_plugins_loaded()
-    plugins_manager.integrate_dag_plugins()
+    plugins_manager.integrate_macros_plugins()
     plugins_manager.integrate_executor_plugins()
     plugins_manager.initialize_extra_operators_links_plugins()
     plugins_manager.initialize_web_ui_plugins()

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -40,7 +40,6 @@ from airflow import settings
 from airflow.configuration import conf
 from airflow.dag.base_dag import BaseDagBag
 from airflow.exceptions import AirflowClusterPolicyViolation, AirflowDagCycleException, SerializedDagNotFound
-from airflow.plugins_manager import integrate_dag_plugins
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import test_cycle
@@ -236,8 +235,6 @@ class DagBag(BaseDagBag, LoggingMixin):
         Given a path to a python module or zip file, this method imports
         the module and look for dag objects within it.
         """
-        integrate_dag_plugins()
-
         # if the source file no longer exists in the DB or in the filesystem,
         # return an empty list
         # todo: raise exception?

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -55,6 +55,7 @@ from airflow.models.taskfail import TaskFail
 from airflow.models.taskreschedule import TaskReschedule
 from airflow.models.variable import Variable
 from airflow.models.xcom import XCOM_RETURN_KEY, XCom
+from airflow.plugins_manager import integrate_macros_plugins
 from airflow.sentry import Sentry
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
@@ -1469,6 +1470,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         """Return TI Context"""
         task = self.task
         from airflow import macros
+
+        integrate_macros_plugins()
 
         params = {}  # type: Dict[str, Any]
         run_id = ''

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2867,7 +2867,6 @@ class PluginView(AirflowBaseView):
     def list(self):
         """List loaded plugins."""
         plugins_manager.ensure_plugins_loaded()
-        plugins_manager.integrate_dag_plugins()
         plugins_manager.integrate_executor_plugins()
         plugins_manager.initialize_extra_operators_links_plugins()
         plugins_manager.initialize_web_ui_plugins()

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -24,8 +24,7 @@ Airflow has a simple plugin manager built-in that can integrate external
 features to its core by simply dropping files in your
 ``$AIRFLOW_HOME/plugins`` folder.
 
-The python modules in the ``plugins`` folder get imported,
-and **hooks**, **macros** and web **views**
+The python modules in the ``plugins`` folder get imported, and **macros** and web **views**
 get integrated to Airflow's main collections and become available for use.
 
 To troubleshoot issue with plugins, you can use ``airflow plugins`` command.
@@ -163,7 +162,7 @@ definitions in Airflow.
     from airflow.models.baseoperator import BaseOperatorLink
     from airflow.providers.amazon.aws.transfers.gcs_to_s3 import GCSToS3Operator
 
-    # Will show up under airflow.hooks.test_plugin.PluginHook
+    # Will show up in Connections screen in a future version
     class PluginHook(BaseHook):
         pass
 

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -30,6 +30,12 @@ get integrated to Airflow's main collections and become available for use.
 To troubleshoot issue with plugins, you can use ``airflow plugins`` command.
 This command dumps information about loaded plugins.
 
+.. versionchanged:: 2.0
+    Importing operators, sensors, hooks added in plugins via
+   ``airflow.{operators,sensors,hooks}.<plugin_name>`` is no longer supported, and these extensions should
+   just be imported as regular python modules. For more information, see: :doc:`/modules_management` and
+   :doc:`/howto/custom-operator`
+
 What for?
 ---------
 
@@ -265,9 +271,7 @@ will automatically load the registered plugins from the entrypoint list.
 .. note::
     Neither the entrypoint name (eg, ``my_plugin``) nor the name of the
     plugin class will contribute towards the module and class name of the plugin
-    itself. The structure is determined by
-    ``airflow.plugins_manager.AirflowPlugin.name`` and the class name of the plugin
-    component with the pattern ``airflow.{component}.{name}.{component_class_name}``.
+    itself.
 
 .. code-block:: python
 

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -117,10 +117,10 @@ class TestPluginsManager(unittest.TestCase):
         with mock_plugin_manager(plugins=[AirflowTestPropertyPlugin()]):
             from airflow import plugins_manager
 
-            plugins_manager.integrate_dag_plugins()
+            plugins_manager.ensure_plugins_loaded()
 
             self.assertIn('AirflowTestPropertyPlugin', str(plugins_manager.plugins))
-            self.assertIn("TestPropertyHook", str(plugins_manager.hooks_modules[0].__dict__))
+            self.assertIn("TestPropertyHook", str(plugins_manager.registered_hooks))
 
     def test_should_warning_about_incompatible_plugins(self):
         class AirflowAdminViewsPlugin(AirflowPlugin):


### PR DESCRIPTION
Hooks do not need to live under "airflow.hooks" namespace for them to
work -- so remove the ability to create them under there in plugins.

Using them as normal python imports is good enough!

We still allow them to be "registered" to support dynamically populating
the connections list in the UI (which won't be done for 2.0)

Closes #9507


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).