### PR TITLE
Fix doc for hiding sensitive variables in Variable View

### DIFF
--- a/docs/ui.rst
+++ b/docs/ui.rst
@@ -77,14 +77,15 @@ Variable View
 The variable view allows you to list, create, edit or delete the key-value pair
 of a variable used during jobs. Value of a variable will be hidden if the key contains
 any words in ('password', 'secret', 'passwd', 'authorization', 'api_key', 'apikey', 'access_token')
-by default, but can be configured to show in clear-text.
+by default, but can be configured to show in clear-text (by configuration option
+``hide_sensitive_variable_fields``).
 
-It's also can be configured to extend this list by using the following configurations option:
+Users can also extend this list by using the following configurations option:
 
 .. code-block:: ini
 
     [admin]
-    hide_sensitive_variable_fields = comma_separated_sensitive_variable_fields_list
+    sensitive_variable_fields = comma_separated_sensitive_variable_fields_list
 
 ------------
 


### PR DESCRIPTION
The original documentation is:
- incomplete: usage of `hide_sensitive_variable_fields` is not clear.
- incorrect: it should be `sensitive_variable_fields` deciding how to extend the list, rather than `hide_sensitive_variable_fields` 

According to:
https://github.com/apache/airflow/blob/ded3dbbff0c8e4fabcee62a677394dec0db1aa45/airflow/config_templates/default_airflow.cfg#L892-L897

In addition, fix minor grammar error.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
