### PR TITLE
Add wait_for_completion option to dag run operator.

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -17,14 +17,19 @@
 # under the License.
 
 import datetime
-from typing import Dict, Optional, Union
+import time
+from typing import Dict, List, Optional, Union
 from urllib.parse import quote
 
+from sqlalchemy import func
+
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.exceptions import DagNotFound, DagRunAlreadyExists
+from airflow.exceptions import AirflowException, DagNotFound, DagRunAlreadyExists
 from airflow.models import BaseOperator, BaseOperatorLink, DagBag, DagModel, DagRun
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
+from airflow.utils.session import provide_session
+from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 
@@ -55,6 +60,14 @@ class TriggerDagRunOperator(BaseOperator):
         When reset_dag_run=False and dag run exists, DagRunAlreadyExists will be raised.
         When reset_dag_run=True and dag run exists, existing dag run will be cleared to rerun.
     :type reset_dag_run: bool
+    :param wait_for_completion: Whether or not wait for dag run completion.
+    :type wait_for_completion: bool
+    :param poke_interval: Poke internal to check dag run status when wait_for_completion=True.
+    :type poke_interval: int
+    :param allowed_states: list of allowed states, default is ``['success']``
+    :type allowed_states: list
+    :param failed_states: list of failed or dis-allowed states, default is ``None``
+    :type failed_states: list
     """
 
     template_fields = ("trigger_dag_id", "execution_date", "conf")
@@ -73,12 +86,20 @@ class TriggerDagRunOperator(BaseOperator):
         conf: Optional[Dict] = None,
         execution_date: Optional[Union[str, datetime.datetime]] = None,
         reset_dag_run: bool = False,
+        wait_for_completion: bool = False,
+        poke_interval: int = 60,
+        allowed_states: Optional[List] = None,
+        failed_states: Optional[List] = None,
         **kwargs
     ) -> None:
         super().__init__(**kwargs)
         self.trigger_dag_id = trigger_dag_id
         self.conf = conf
         self.reset_dag_run = reset_dag_run
+        self.wait_for_completion = wait_for_completion
+        self.poke_interval = poke_interval
+        self.allowed_states = allowed_states or [State.SUCCESS]
+        self.failed_states = failed_states or [State.FAILED]
 
         if not isinstance(execution_date, (str, datetime.datetime, type(None))):
             raise TypeError(
@@ -88,7 +109,8 @@ class TriggerDagRunOperator(BaseOperator):
 
         self.execution_date: Optional[datetime.datetime] = execution_date  # type: ignore
 
-    def execute(self, context: Dict):
+    @provide_session
+    def execute(self, context: Dict, session=None):
         if isinstance(self.execution_date, datetime.datetime):
             execution_date = self.execution_date
         elif isinstance(self.execution_date, str):
@@ -129,3 +151,46 @@ class TriggerDagRunOperator(BaseOperator):
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
             else:
                 raise e
+
+        if self.wait_for_completion:
+            # wait for dag to complete
+            while True:
+                dttm = context['execution_date']
+
+                dttm_filter = dttm if isinstance(dttm, list) else [dttm]
+                serialized_dttm_filter = ','.join(
+                    [datetime.isoformat() for datetime in dttm_filter])
+
+                self.log.info(
+                    'Waiting for %s on %s to become one of %s... ',
+                    self.trigger_dag_id, serialized_dttm_filter, self.allowed_states
+                )
+
+                DR = DagRun
+
+                # get failed count
+                failed_count = session.query(func.count()).filter(
+                    DR.dag_id == self.trigger_dag_id,
+                    DR.state.in_(self.failed_states),   # pylint: disable=no-member
+                    DR.execution_date.in_(dttm_filter),
+                ).scalar()
+                # if triggered dag run failed and that is not in allowed_states,
+                # make this triggering dag fail.
+                if failed_count:
+                    raise AirflowException(
+                        f"{self.trigger_dag_id} failed with failed states {self.failed_states}")
+
+                # get expected state count
+                count = session.query(func.count()).filter(
+                    DR.dag_id == self.trigger_dag_id,
+                    DR.state.in_(self.allowed_states),  # pylint: disable=no-member
+                    DR.execution_date.in_(dttm_filter),
+                ).scalar()
+
+                session.commit()
+                if count == len(dttm_filter):
+                    self.log.info("%s finished with allowed stats %s",
+                                  self.trigger_dag_id, self.allowed_states)
+                    return
+
+                time.sleep(self.poke_interval)

--- a/tests/operators/test_dagrun_operator.py
+++ b/tests/operators/test_dagrun_operator.py
@@ -21,12 +21,13 @@ import tempfile
 from datetime import datetime
 from unittest import TestCase
 
-from airflow.exceptions import DagRunAlreadyExists
+from airflow.exceptions import AirflowException, DagRunAlreadyExists
 from airflow.models import DAG, DagBag, DagModel, DagRun, Log, TaskInstance
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.utils import timezone
 from airflow.utils.session import create_session
+from airflow.utils.state import State
 
 DEFAULT_DATE = datetime(2019, 1, 1, tzinfo=timezone.utc)
 TEST_DAG_ID = "testdag"
@@ -174,3 +175,32 @@ class TestDagRunOperator(TestCase):
             dagruns = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
             self.assertEqual(len(dagruns), 1)
             self.assertTrue(dagruns[0].external_trigger)
+
+    def test_trigger_dagrun_with_wait_for_completion_true(self):
+        """Test TriggerDagRunOperator with wait_for_completion."""
+        execution_date = DEFAULT_DATE
+        task = TriggerDagRunOperator(task_id="test_task",
+                                     trigger_dag_id=TRIGGERED_DAG_ID,
+                                     execution_date=execution_date,
+                                     wait_for_completion=True,
+                                     poke_interval=10,
+                                     allowed_states=[State.RUNNING],
+                                     dag=self.dag)
+        task.run(start_date=execution_date, end_date=execution_date)
+
+        with create_session() as session:
+            dagruns = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).all()
+            self.assertEqual(len(dagruns), 1)
+
+    def test_trigger_dagrun_with_wait_for_completion_true_fail(self):
+        """Test TriggerDagRunOperator with wait_for_completion but triggered dag fails."""
+        execution_date = DEFAULT_DATE
+        task = TriggerDagRunOperator(task_id="test_task",
+                                     trigger_dag_id=TRIGGERED_DAG_ID,
+                                     execution_date=execution_date,
+                                     wait_for_completion=True,
+                                     poke_interval=10,
+                                     failed_states=[State.RUNNING],
+                                     dag=self.dag)
+        with self.assertRaises(AirflowException):
+            task.run(start_date=execution_date, end_date=execution_date)


### PR DESCRIPTION
Current dag run operator trigger dag run and exit without checking the triggered dag run status.
If user want to check the status, user needs to use External Task sensor to check.
If trigger dag fail and want to rerun it, user has to rerun from previous task which is the one with dag run operator.

This code change add wait_for_completion so that same task trigger a dag run and wait for the status.
We have been using this updated operator and works great.