### PR TITLE
Wait option for dagrun operator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -162,6 +162,6 @@ class TriggerDagRunOperator(BaseOperator):
                 state = dag_run.state
                 if state in self.failed_states:
                     raise AirflowException(f"{self.trigger_dag_id} failed with failed states {state}")
-                elif state in self.allowed_states:
+                if state in self.allowed_states:
                     self.log.info("%s finished with allowed state %s", self.trigger_dag_id, state)
                     return

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -58,9 +58,10 @@ class TriggerDagRunOperator(BaseOperator):
         When reset_dag_run=False and dag run exists, DagRunAlreadyExists will be raised.
         When reset_dag_run=True and dag run exists, existing dag run will be cleared to rerun.
     :type reset_dag_run: bool
-    :param wait_for_completion: Whether or not wait for dag run completion.
+    :param wait_for_completion: Whether or not wait for dag run completion. (default: False)
     :type wait_for_completion: bool
-    :param poke_interval: Poke internal to check dag run status when wait_for_completion=True.
+    :param poke_interval: Poke interval to check dag run status when wait_for_completion=True.
+        (default: 60)
     :type poke_interval: int
     :param allowed_states: list of allowed states, default is ``['success']``
     :type allowed_states: list
@@ -155,6 +156,8 @@ class TriggerDagRunOperator(BaseOperator):
                     dag_run.execution_date,
                     self.allowed_states,
                 )
+                time.sleep(self.poke_interval)
+
                 dag_run.refresh_from_db()
                 state = dag_run.state
                 if state in self.failed_states:
@@ -162,5 +165,3 @@ class TriggerDagRunOperator(BaseOperator):
                 elif state in self.allowed_states:
                     self.log.info("%s finished with allowed state %s", self.trigger_dag_id, state)
                     return
-
-                time.sleep(self.poke_interval)

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -17,14 +17,19 @@
 # under the License.
 
 import datetime
-from typing import Dict, Optional, Union
+import time
+from typing import Dict, List, Optional, Union
+
+from sqlalchemy import func
 
 from airflow.api.common.experimental.trigger_dag import trigger_dag
-from airflow.exceptions import DagNotFound, DagRunAlreadyExists
+from airflow.exceptions import AirflowException, DagNotFound, DagRunAlreadyExists
 from airflow.models import BaseOperator, BaseOperatorLink, DagBag, DagModel, DagRun
 from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.helpers import build_airflow_url_with_query
+from airflow.utils.session import provide_session
+from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 
@@ -56,6 +61,14 @@ class TriggerDagRunOperator(BaseOperator):
         When reset_dag_run=False and dag run exists, DagRunAlreadyExists will be raised.
         When reset_dag_run=True and dag run exists, existing dag run will be cleared to rerun.
     :type reset_dag_run: bool
+    :param wait_for_completion: Whether or not wait for dag run completion.
+    :type wait_for_completion: bool
+    :param poke_interval: Poke internal to check dag run status when wait_for_completion=True.
+    :type poke_interval: int
+    :param allowed_states: list of allowed states, default is ``['success']``
+    :type allowed_states: list
+    :param failed_states: list of failed or dis-allowed states, default is ``None``
+    :type failed_states: list
     """
 
     template_fields = ("trigger_dag_id", "execution_date", "conf")
@@ -74,12 +87,20 @@ class TriggerDagRunOperator(BaseOperator):
         conf: Optional[Dict] = None,
         execution_date: Optional[Union[str, datetime.datetime]] = None,
         reset_dag_run: bool = False,
+        wait_for_completion: bool = False,
+        poke_interval: int = 60,
+        allowed_states: Optional[List] = None,
+        failed_states: Optional[List] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.trigger_dag_id = trigger_dag_id
         self.conf = conf
         self.reset_dag_run = reset_dag_run
+        self.wait_for_completion = wait_for_completion
+        self.poke_interval = poke_interval
+        self.allowed_states = allowed_states or [State.SUCCESS]
+        self.failed_states = failed_states or [State.FAILED]
 
         if not isinstance(execution_date, (str, datetime.datetime, type(None))):
             raise TypeError(
@@ -89,7 +110,8 @@ class TriggerDagRunOperator(BaseOperator):
 
         self.execution_date: Optional[datetime.datetime] = execution_date  # type: ignore
 
-    def execute(self, context: Dict):
+    @provide_session
+    def execute(self, context: Dict, session=None):
         if isinstance(self.execution_date, datetime.datetime):
             execution_date = self.execution_date
         elif isinstance(self.execution_date, str):
@@ -120,10 +142,56 @@ class TriggerDagRunOperator(BaseOperator):
                 if dag_model is None:
                     raise DagNotFound(f"Dag id {self.trigger_dag_id} not found in DagModel")
 
-                dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
+                dag_bag = DagBag(
+                    dag_folder=dag_model.fileloc,
+                    read_dags_from_db=True
+                )
 
                 dag = dag_bag.get_dag(self.trigger_dag_id)
 
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
             else:
                 raise e
+
+        if self.wait_for_completion:
+            # wait for dag to complete
+            while True:
+                dttm = context['execution_date']
+
+                dttm_filter = dttm if isinstance(dttm, list) else [dttm]
+                serialized_dttm_filter = ','.join(
+                    [datetime.isoformat() for datetime in dttm_filter])
+
+                self.log.info(
+                    'Waiting for %s on %s to become one of %s... ',
+                    self.trigger_dag_id, serialized_dttm_filter, self.allowed_states
+                )
+
+                DR = DagRun
+
+                # get failed count
+                failed_count = session.query(func.count()).filter(
+                    DR.dag_id == self.trigger_dag_id,
+                    DR.state.in_(self.failed_states),   # pylint: disable=no-member
+                    DR.execution_date.in_(dttm_filter),
+                ).scalar()
+                # if triggered dag run failed and that is not in allowed_states,
+                # make this triggering dag fail.
+                if failed_count:
+                    raise AirflowException(
+                        f"{self.trigger_dag_id} failed with failed states {self.failed_states}")
+
+                # get expected state count
+                count = session.query(func.count()).filter(
+                    DR.dag_id == self.trigger_dag_id,
+                    DR.state.in_(self.allowed_states),  # pylint: disable=no-member
+                    DR.execution_date.in_(dttm_filter),
+                ).scalar()
+
+                session.commit()
+                if count == len(dttm_filter):
+                    self.log.info("%s finished with allowed stats %s",
+                                  self.trigger_dag_id, self.allowed_states)
+                    return
+
+                time.sleep(self.poke_interval)


### PR DESCRIPTION
Current dag run operator trigger dag run and exit without checking the triggered dag run status.
If user want to check the status, user needs to use External Task sensor to check.
If trigger dag fail and want to rerun it, user has to rerun from previous task which is the one with dag run operator.

This code change add wait_for_completion so that same task trigger a dag run and wait for the status.
We have been using this updated operator and works great.