### PR TITLE
`airflow info` fix for python 3.8+

### DIFF
--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -28,9 +28,9 @@ from urllib.parse import urlsplit, urlunsplit
 
 import requests
 import tenacity
-from typing_extensions import Protocol
 
 from airflow import configuration
+from airflow.typing_compat import Protocol
 from airflow.version import version as airflow_version
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
`airflow info` of Airflow 2.0 (alpha2) doesn't work on python3.8, throwing issue like #9508. This small PR fixes the import.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
