### PR TITLE
Deprecate importing Hooks from plugin-created module

### DIFF
--- a/airflow/hooks/__init__.py
+++ b/airflow/hooks/__init__.py
@@ -22,6 +22,8 @@ import os as _os
 import sys
 
 
+PY37 = sys.version_info >= (3, 7)
+
 # ------------------------------------------------------------------------
 #
 # #TODO #FIXME Airflow 2.0
@@ -77,6 +79,10 @@ def _integrate_plugins():
     from airflow.plugins_manager import hooks_modules
     for hooks_module in hooks_modules:
         sys.modules[hooks_module.__name__] = hooks_module
+
+        if not PY37:
+            from pep562 import Pep562
+            hooks_module = Pep562(hooks_module.__name__)
         globals()[hooks_module._name] = hooks_module
 
         ##########################################################

--- a/tests/plugins/test_plugins_manager_www.py
+++ b/tests/plugins/test_plugins_manager_www.py
@@ -22,7 +22,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import unittest
+import six
 from mock import MagicMock, PropertyMock
 
 from flask.blueprints import Blueprint
@@ -37,19 +37,39 @@ from airflow.www.app import create_app
 
 from tests.plugins.test_plugin import MockPluginA, MockPluginB, MockPluginC
 
+if six.PY2:
+    # Need `assertWarns` back-ported from unittest2
+    import unittest2 as unittest
+else:
+    import unittest
+
 
 class PluginsTest(unittest.TestCase):
-
     def test_operators(self):
-        from airflow.operators.test_plugin import PluginOperator
+        with self.assertWarnsRegex(
+            FutureWarning, r"'PluginOperator' from under 'airflow.operators.*'"
+        ):
+            from airflow.operators.test_plugin import PluginOperator
         self.assertTrue(issubclass(PluginOperator, BaseOperator))
 
+        with self.assertWarnsRegex(
+            FutureWarning, r"'PluginSensorOperator' from under 'airflow.operators.*'"
+        ):
+            from airflow.operators.test_plugin import PluginSensorOperator
+        self.assertTrue(issubclass(PluginSensorOperator, BaseSensorOperator))
+
     def test_sensors(self):
-        from airflow.sensors.test_plugin import PluginSensorOperator
+        with self.assertWarnsRegex(
+            FutureWarning, r"'PluginSensorOperator' from under 'airflow.sensors.*'"
+        ):
+            from airflow.sensors.test_plugin import PluginSensorOperator
         self.assertTrue(issubclass(PluginSensorOperator, BaseSensorOperator))
 
     def test_hooks(self):
-        from airflow.hooks.test_plugin import PluginHook
+        with self.assertWarnsRegex(
+            FutureWarning, r"'PluginHook' from under 'airflow.hooks.*'"
+        ):
+            from airflow.hooks.test_plugin import PluginHook
         self.assertTrue(issubclass(PluginHook, BaseHook))
 
     def test_executors(self):


### PR DESCRIPTION
Closes #9506


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).