### PR TITLE
Call scheduler "book-keeping" operations less frequently.

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1500,6 +1500,14 @@
       type: string
       example: ~
       default: "5"
+    - name: clean_tis_without_dagrun
+      description: |
+        How often (in seconds) to check and tidy up 'running' TaskInstancess
+        that no longer have a matching DagRun
+      version_added: 2.0.0
+      type: float
+      example: ~
+      default: "15.0"
     - name: scheduler_heartbeat_sec
       description: |
         The scheduler constantly tries to trigger new tasks (look at the
@@ -1545,6 +1553,13 @@
       type: string
       example: ~
       default: "30"
+    - name: pool_metrics_interval
+      description: |
+        How often (in seconds) should pool usage stats be sent to statsd (if statsd_on is enabled)
+      version_added: 2.0.0
+      type: float
+      example: ~
+      default: "5.0"
     - name: scheduler_health_check_threshold
       description: |
         If the last scheduler heartbeat happened more than scheduler_health_check_threshold
@@ -1554,6 +1569,13 @@
       type: string
       example: ~
       default: "30"
+    - name: orphaned_tasks_check_interval
+      description: |
+        How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs
+      version_added: 2.0.0
+      type: float
+      example: ~
+      default: "300.0"
     - name: child_process_log_directory
       description: ~
       version_added: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -749,6 +749,10 @@ tls_key =
 # listen (in seconds).
 job_heartbeat_sec = 5
 
+# How often (in seconds) to check and tidy up 'running' TaskInstancess
+# that no longer have a matching DagRun
+clean_tis_without_dagrun = 15.0
+
 # The scheduler constantly tries to trigger new tasks (look at the
 # scheduler section in the docs for more information). This defines
 # how often the scheduler should run (in seconds).
@@ -770,10 +774,16 @@ dag_dir_list_interval = 300
 # How often should stats be printed to the logs. Setting to 0 will disable printing stats
 print_stats_interval = 30
 
+# How often (in seconds) should pool usage stats be sent to statsd (if statsd_on is enabled)
+pool_metrics_interval = 5.0
+
 # If the last scheduler heartbeat happened more than scheduler_health_check_threshold
 # ago (in seconds), scheduler is considered unhealthy.
 # This is used by the health check in the "/health" endpoint
 scheduler_health_check_threshold = 30
+
+# How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs
+orphaned_tasks_check_interval = 300.0
 child_process_log_directory = {AIRFLOW_HOME}/logs/scheduler
 
 # Local task jobs periodically heartbeat to the DB. If the job has


### PR DESCRIPTION
This change makes it so that certain operations in the scheduler are
called on a regular interval, instead of only once at start up, or every
time around the loop:

- adopt_or_reset_orphaned_tasks (detecting SchedulerJobs that died) was
  previously only called on start up.
- _clean_tis_without_dagrun was previously called every time around the
  scheduling loop, but this isn't so needed to be done every time as
  this is a relatively rare cleanup operation
- _emit_pool_metrics doesn't need to be called _every_ time around the
  loop, once every 5 seconds is enough.

This uses the built in ["sched" module][sched] to handle the "timers".

[sched]: https://docs.python.org/3/library/sched.html


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).