### PR TITLE
Retry Publishing Task to Celery Broker

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -50,6 +50,12 @@ assists users migrating to a new version.
 
 ## Airflow Master
 
+### Default value for `[celery] operation_timeout` has changed to `1.0`
+
+From Airflow 2, by default Airflow will retry 3 times to publish task to Celery broker. This is controlled by
+`[celery] task_publish_max_retries`. Because of this we can now have a lower Operation timeout that raises
+`AirflowTaskTimeout`. This generally occurs during network blips or intermittent DNS issues.
+
 ### Adding Operators and Sensors via plugins is no longer supported
 
 Operators and Sensors should no longer be registered or imported via Airflow's plugin mechanism -- these types of classes are just treated as plain python classes by Airflow, so there is no need to register them with Airflow.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1412,7 +1412,7 @@
       version_added: 1.10.8
       type: float
       example: ~
-      default: "2.0"
+      default: "1.0"
     - name: task_track_started
       description: |
         Celery task will report its status as 'started' when the task is executed by a worker.
@@ -1430,6 +1430,14 @@
       type: int
       example: ~
       default: "600"
+    - name: task_publish_max_retries
+      description: |
+        The Maximum number of retries for publishing task messages to the broker when failing
+        due to ``AirflowTaskTimeout`` error before giving up and marking Task as failed.
+      version_added: 2.0.0
+      type: int
+      example: ~
+      default: "3"
 - name: celery_broker_transport_options
   description: |
     This section is for specifying options which can be passed to the

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -701,7 +701,7 @@ pool = prefork
 
 # The number of seconds to wait before timing out ``send_task_to_executor`` or
 # ``fetch_celery_task_state`` operations.
-operation_timeout = 2.0
+operation_timeout = 1.0
 
 # Celery task will report its status as 'started' when the task is executed by a worker.
 # This is used in Airflow to keep track of the running tasks and if a Scheduler is restarted
@@ -711,6 +711,10 @@ task_track_started = True
 # Time in seconds after which Adopted tasks are cleared by CeleryExecutor. This is helpful to clear
 # stalled tasks.
 task_adoption_timeout = 600
+
+# The Maximum number of retries for publishing task messages to the broker when failing
+# due to ``AirflowTaskTimeout`` error before giving up and marking Task as failed.
+task_publish_max_retries = 3
 
 [celery_broker_transport_options]
 

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -43,9 +43,10 @@ from setproctitle import setproctitle  # pylint: disable=no-name-in-module
 import airflow.settings as settings
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
 from airflow.configuration import conf
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, AirflowTaskTimeout
 from airflow.executors.base_executor import BaseExecutor, CommandType, EventBufferValueType
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstance, TaskInstanceKey
+from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
 from airflow.utils.state import State
@@ -59,7 +60,7 @@ CELERY_FETCH_ERR_MSG_HEADER = 'Error fetching Celery task state'
 
 CELERY_SEND_ERR_MSG_HEADER = 'Error sending Celery task'
 
-OPERATION_TIMEOUT = conf.getfloat('celery', 'operation_timeout', fallback=2.0)
+OPERATION_TIMEOUT = conf.getfloat('celery', 'operation_timeout', fallback=1.0)
 
 '''
 To start the celery worker, run the command:
@@ -220,6 +221,8 @@ class CeleryExecutor(BaseExecutor):
         self.task_adoption_timeout = datetime.timedelta(
             seconds=conf.getint('celery', 'task_adoption_timeout', fallback=600)
         )
+        self.task_publish_retries: Dict[TaskInstanceKey, int] = OrderedDict()
+        self.task_publish_max_retries = conf.getint('celery', 'task_publish_max_retries', fallback=3)
 
     def start(self) -> None:
         self.log.debug('Starting Celery Executor using %s processes for syncing', self._sync_parallelism)
@@ -246,7 +249,10 @@ class CeleryExecutor(BaseExecutor):
 
         for _ in range(min(open_slots, len(self.queued_tasks))):
             key, (command, _, queue, simple_ti) = sorted_queue.pop(0)
-            task_tuples_to_send.append((key, simple_ti, command, queue, execute_command))
+            task_tuple = (key, simple_ti, command, queue, execute_command)
+            task_tuples_to_send.append(task_tuple)
+            if key not in self.task_publish_retries:
+                self.task_publish_retries[key] = 1
 
         if task_tuples_to_send:
             self._process_tasks(task_tuples_to_send)
@@ -262,10 +268,26 @@ class CeleryExecutor(BaseExecutor):
         self.log.debug('Sent all tasks.')
 
         for key, _, result in key_and_async_results:
+            if isinstance(result, ExceptionWithTraceback) and isinstance(
+                result.exception, AirflowTaskTimeout
+            ):
+                if key in self.task_publish_retries and (
+                    self.task_publish_retries.get(key) <= self.task_publish_max_retries
+                ):
+                    Stats.incr("celery.task_timeout_error")
+                    self.log.info(
+                        "[Try %s of %s] Task Timeout Error for Task: (%s).",
+                        self.task_publish_retries[key],
+                        self.task_publish_max_retries,
+                        key,
+                    )
+                    self.task_publish_retries[key] += 1
+                    continue
             self.queued_tasks.pop(key)
+            self.task_publish_retries.pop(key)
             if isinstance(result, ExceptionWithTraceback):
                 self.log.error(  # pylint: disable=logging-not-lazy
-                    CELERY_SEND_ERR_MSG_HEADER + ":%s\n%s\n", result.exception, result.traceback
+                    CELERY_SEND_ERR_MSG_HEADER + ": %s\n%s\n", result.exception, result.traceback
                 )
                 self.event_buffer[key] = (State.FAILED, None)
             elif result is not None:
@@ -281,7 +303,7 @@ class CeleryExecutor(BaseExecutor):
                 # If the task runs _really quickly_ we may already have a result!
                 self.update_task_state(key, result.state, getattr(result, 'info', None))
 
-    def _send_tasks_to_celery(self, task_tuples_to_send):
+    def _send_tasks_to_celery(self, task_tuples_to_send: List[TaskInstanceInCelery]):
         if len(task_tuples_to_send) == 1 or self._sync_parallelism == 1:
             # One tuple, or max one process -> send it in the main thread.
             return list(map(send_task_to_executor, task_tuples_to_send))

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -45,6 +45,7 @@ from airflow.operators.bash import BashOperator
 from airflow.utils import timezone
 from airflow.utils.state import State
 from tests.test_utils import db
+from tests.test_utils.config import conf_vars
 
 
 def _prepare_test_bodies():
@@ -199,6 +200,72 @@ class TestCeleryExecutor(unittest.TestCase):
         self.assertEqual(0, len(executor.queued_tasks), "Task should no longer be queued")
         self.assertEqual(executor.event_buffer[('fail', 'fake_simple_ti', when, 0)][0], State.FAILED)
 
+    @pytest.mark.integration("redis")
+    @pytest.mark.integration("rabbitmq")
+    @pytest.mark.backend("mysql", "postgres")
+    @conf_vars({("celery", "operation_timeout"): "0.01"})
+    def test_retry_on_error_sending_task(self):
+        """Test that Airflow retries publishing tasks to Celery Broker atleast 3 times"""
+
+        def fake_execute_command(command):
+            print(command)
+
+        with _prepare_app(execute=fake_execute_command), self.assertLogs(celery_executor.log) as cm:
+            # fake_execute_command takes no arguments while execute_command takes 1,
+            # which will cause TypeError when calling task.apply_async()
+            executor = celery_executor.CeleryExecutor()
+            self.assertEqual(executor.task_publish_retries, {})
+            self.assertEqual(executor.task_publish_max_retries, 3, msg="Assert Default Max Retries is 3")
+
+            task = BashOperator(
+                task_id="test", bash_command="true", dag=DAG(dag_id='id'), start_date=datetime.now()
+            )
+            when = datetime.now()
+            value_tuple = (
+                'command',
+                1,
+                None,
+                SimpleTaskInstance(ti=TaskInstance(task=task, execution_date=datetime.now())),
+            )
+            key = ('fail', 'fake_simple_ti', when, 0)
+            executor.queued_tasks[key] = value_tuple
+
+            # Test that when heartbeat is called again, task is published again to Celery Queue
+            executor.heartbeat()
+            self.assertEqual(dict(executor.task_publish_retries), {key: 2})
+            self.assertEqual(1, len(executor.queued_tasks), "Task should remain in queue")
+            self.assertEqual(executor.event_buffer, {})
+            self.assertIn(
+                "INFO:airflow.executors.celery_executor.CeleryExecutor:"
+                f"[Try 1 of 3] Task Timeout Error for Task: ({key}).",
+                cm.output,
+            )
+
+            executor.heartbeat()
+            self.assertEqual(dict(executor.task_publish_retries), {key: 3})
+            self.assertEqual(1, len(executor.queued_tasks), "Task should remain in queue")
+            self.assertEqual(executor.event_buffer, {})
+            self.assertIn(
+                "INFO:airflow.executors.celery_executor.CeleryExecutor:"
+                f"[Try 2 of 3] Task Timeout Error for Task: ({key}).",
+                cm.output,
+            )
+
+            executor.heartbeat()
+            self.assertEqual(dict(executor.task_publish_retries), {key: 4})
+            self.assertEqual(1, len(executor.queued_tasks), "Task should remain in queue")
+            self.assertEqual(executor.event_buffer, {})
+            self.assertIn(
+                "INFO:airflow.executors.celery_executor.CeleryExecutor:"
+                f"[Try 3 of 3] Task Timeout Error for Task: ({key}).",
+                cm.output,
+            )
+
+            executor.heartbeat()
+            self.assertEqual(dict(executor.task_publish_retries), {})
+            self.assertEqual(0, len(executor.queued_tasks), "Task should no longer be in queue")
+            self.assertEqual(executor.event_buffer[('fail', 'fake_simple_ti', when, 0)][0], State.FAILED)
+
     @pytest.mark.quarantined
     @pytest.mark.backend("mysql", "postgres")
     def test_exception_propagation(self):
@@ -324,7 +391,7 @@ class TestCeleryExecutor(unittest.TestCase):
 
 
 def test_operation_timeout_config():
-    assert celery_executor.OPERATION_TIMEOUT == 2
+    assert celery_executor.OPERATION_TIMEOUT == 1
 
 
 class ClassWithCustomAttributes:


### PR DESCRIPTION
If for some reason (network blip, redis is down) if AirflowTaskTimeout is raised (controlled by `[celery] operation_timeout`) when publishing Task to the broker, Airflow will be default atleast retry 3 times to publish the messages controlled by `[celery] task_publish_max_retries`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
