### PR TITLE
Bugfix: Make doc_md field nullable and raise json for non-existing dag in dag detail endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -27,6 +27,7 @@ from airflow.api_connexion.schemas.dag_schema import (
     dag_schema,
     dags_collection_schema,
 )
+from airflow.exceptions import SerializedDagNotFound
 from airflow.models.dag import DagModel
 from airflow.security import permissions
 from airflow.utils.session import provide_session
@@ -47,8 +48,9 @@ def get_dag(dag_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 def get_dag_details(dag_id):
     """Get details of DAG."""
-    dag: DAG = current_app.dag_bag.get_dag(dag_id)
-    if not dag:
+    try:
+        dag: DAG = current_app.dag_bag.get_dag(dag_id)
+    except SerializedDagNotFound:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
     return dag_detail_schema.dump(dag)
 

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -52,6 +52,8 @@ def get_dag_details(dag_id):
         dag: DAG = current_app.dag_bag.get_dag(dag_id)
     except SerializedDagNotFound:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
+    if dag is None:
+        raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
     return dag_detail_schema.dump(dag)
 
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1898,6 +1898,7 @@ components:
             doc_md:
               type: string
               readOnly: true
+              nullable: true
             default_view:
               type: string
               readOnly: true


### PR DESCRIPTION
This PR fixes 2 of the 3 issues in #12121 
Issues fixed:
1. Calling this endpoint dags/{dag_id}/details returns an error due to doc_md field that's not nullable.

2. The dag details endpoint GET /dags/{dag_id}/details does not return a json if dag does not exist.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
