### PR TITLE
Allow Connection Edit View to handle entries with NULL 'extra'

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2818,7 +2818,11 @@ class ConnectionModelView(AirflowModelView):
     def prefill_form(self, form, pk):
         """Prefill the form."""
         try:
-            extra_dictionary = json.loads(form.data.get('extra', '{}'))
+            extra = form.data.get('extra')
+            if extra is None:
+                extra_dictionary = {}
+            else:
+                extra_dictionary = json.loads(extra)
         except JSONDecodeError:
             extra_dictionary = {}
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -62,6 +62,7 @@ from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
 from airflow.www import app as application
+from airflow.www.views import ConnectionModelView
 from tests.test_utils import fab_utils
 from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.config import conf_vars
@@ -241,6 +242,13 @@ class TestConnectionModelView(TestBase):
     def test_create_connection(self):
         resp = self.client.post('/connection/add', data=self.connection, follow_redirects=True)
         self.check_content_in_response('Added Row', resp)
+
+    def test_prefill_form_null_extra(self):
+        mock_form = mock.Mock()
+        mock_form.data = {"conn_id": "test", "extra": None}
+
+        cmv = ConnectionModelView()
+        cmv.prefill_form(form=mock_form, pk=1)
 
 
 class TestVariableModelView(TestBase):


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/12148  , a bug I observe in 2.0.0a2.

The root-cause is simple:
if the connection data is `{..., "extra": None}` (which is common), then `form.data.get('extra', '{}')` would return `None` rather than `'{}'`, which causes error given `json.loads()` does not accept `None`.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


related: https://github.com/apache/airflow/issues/12148

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
