### PR TITLE
UI Fix: spacing between table and pagination

### DIFF
--- a/airflow/www/static/css/dags.css
+++ b/airflow/www/static/css/dags.css
@@ -18,6 +18,7 @@
  */
 
 .dags-table-wrap {
+  margin-bottom: 16px;
   border-radius: 4px 4px 0 0;
   background-color: #f0f0f0;
 }


### PR DESCRIPTION
Fixes a tiny regression (I caused) where there wasn't spacing between the DAGs table and the pagination below.

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/3267/98442160-10f9eb80-20d1-11eb-833e-4d7bb3f95df4.png)  |  ![image](https://user-images.githubusercontent.com/3267/98442156-07708380-20d1-11eb-8d9c-f33ab17ee1ff.png) |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
