### PR TITLE
Fix docs build on RTD

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -115,11 +115,6 @@ def clean_files() -> None:
     os.makedirs(_API_DIR, exist_ok=True)
     os.makedirs(_BUILD_DIR, exist_ok=True)
     print(f"Recreated content of the ${_BUILD_DIR} and ${_API_DIR} folders")
-    # Bugs in sphinx-autoapi using metaclasses prevent us from upgrading to 1.3
-    # which has implicit namespace support. Until that time, we make it look
-    # like a real package for building docs
-    with open(PROVIDER_INIT_FILE, "wt"):
-        pass
 
 
 def display_errors_summary() -> None:
@@ -727,21 +722,18 @@ Channel link: https://apache-airflow.slack.com/archives/CJ1LVREHX
 Invitation link: https://s.apache.org/airflow-slack\
 """
 
-try:
-    print_build_errors_and_exit("The documentation has errors. Fix them to build documentation.")
+print_build_errors_and_exit("The documentation has errors. Fix them to build documentation.")
 
-    if not args.docs_only:
-        check_spelling()
-        print_build_errors_and_exit("The documentation has spelling errors. Fix them to build documentation.")
+if not args.docs_only:
+    check_spelling()
+    print_build_errors_and_exit("The documentation has spelling errors. Fix them to build documentation.")
 
-    if not args.spellcheck_only:
-        build_sphinx_docs()
-        check_guide_links_in_operator_descriptions()
-        check_class_links_in_operators_and_hooks_ref()
-        check_guide_links_in_operators_and_hooks_ref()
-        check_enforce_code_block()
-        check_exampleinclude_for_example_dags()
-        check_google_guides()
-        print_build_errors_and_exit("The documentation has errors.")
-finally:
-    shutil.rmtree(PROVIDER_INIT_FILE, ignore_errors=True)
+if not args.spellcheck_only:
+    build_sphinx_docs()
+    check_guide_links_in_operator_descriptions()
+    check_class_links_in_operators_and_hooks_ref()
+    check_guide_links_in_operators_and_hooks_ref()
+    check_enforce_code_block()
+    check_exampleinclude_for_example_dags()
+    check_google_guides()
+    print_build_errors_and_exit("The documentation has errors.")

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -603,6 +603,7 @@ def check_spelling() -> None:
     :return:
     """
     extensions_to_use = [
+        'provider_init_hack',
         "sphinxarg.ext",
         "autoapi.extension",
         "sphinxcontrib.spelling",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,6 +78,7 @@ release = airflow.__version__
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'provider_init_hack',
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.viewcode',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -425,6 +425,7 @@ autoapi_ignore = [
     '*/airflow/kubernetes/kubernetes_request_factory/*',
     '*/_internal*',
     '*/node_modules/*',
+    '*/example_dags/*,',
     '*/migrations/*',
 ]
 # Keep the AutoAPI generated files on the filesystem after the run.

--- a/docs/exts/provider_init_hack.py
+++ b/docs/exts/provider_init_hack.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Bugs in sphinx-autoapi using metaclasses prevent us from upgrading to 1.3
+which has implicit namespace support. Until that time, we make it look
+like a real package for building docs
+"""
+import os
+import shutil
+
+from sphinx.application import Sphinx
+
+ROOT_PROJECT_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir)
+)
+
+PROVIDER_INIT_FILE = os.path.join(ROOT_PROJECT_DIR, "airflow", "providers", "__init__.py")
+
+
+def _create_init_py(app, config):
+    del app
+    del config
+    with open(PROVIDER_INIT_FILE, "wt"):
+        pass
+
+
+def _delete_init_py(app, exception):
+    del app
+    del exception
+    shutil.rmtree(PROVIDER_INIT_FILE, ignore_errors=True)
+
+
+def setup(app: Sphinx):
+    """
+    Sets the plugin up and returns configuration of the plugin.
+
+    :param app: application.
+    :return json description of the configuration that is needed by the plugin.
+    """
+    app.connect("config-inited", _create_init_py)
+    app.connect("build-finished", _delete_init_py)
+
+    return {"version": "builtin", "parallel_read_safe": True, "parallel_write_safe": True}

--- a/docs/exts/provider_init_hack.py
+++ b/docs/exts/provider_init_hack.py
@@ -21,7 +21,6 @@ which has implicit namespace support. Until that time, we make it look
 like a real package for building docs
 """
 import os
-import shutil
 
 from sphinx.application import Sphinx
 
@@ -42,7 +41,8 @@ def _create_init_py(app, config):
 def _delete_init_py(app, exception):
     del app
     del exception
-    shutil.rmtree(PROVIDER_INIT_FILE, ignore_errors=True)
+    if os.path.exists(PROVIDER_INIT_FILE):
+        os.remove(PROVIDER_INIT_FILE)
 
 
 def setup(app: Sphinx):


### PR DESCRIPTION
The docs/build_docs.py file is not used by RTD, so we need to use  sphinx extensions.  I tested this change locally, but didn't test it on RTD.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
