### PR TITLE
Sync FAB Permissions for all base views

### DIFF
--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -27,6 +27,8 @@ def sync_perm(args):
     appbuilder = cached_app().appbuilder  # pylint: disable=no-member
     print('Updating permission, view-menu for all existing roles')
     appbuilder.sm.sync_roles()
+    # Add missing permissions for all the Base Views
+    appbuilder.add_permissions(update_perms=True)
     print('Updating permission on all DAG views')
     dags = DagBag(read_dags_from_db=True).dags.values()
     for dag in dags:

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -59,6 +59,7 @@ class TestCliSyncPerm(unittest.TestCase):
             'no_access_control',
             None,
         )
+        appbuilder.add_permissions.assert_called_once_with(update_perms=True)
 
     def expect_dagbag_contains(self, dags, dagbag_mock):
         dagbag = mock.Mock()


### PR DESCRIPTION
If a user has set `[webserver] update_fab_perms = False` and runs `airflow sync-perm` command to sync all permissions, they will receive the following error:

```
webserver_1  | [2020-11-07 15:13:07,431] {decorators.py:113} WARNING - Access is Denied for: can_index on: Airflow
```

and if the user was created before and some perms were sync'd a user won't be able to find Security Menu & Configurations View.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
