### PR TITLE
Move metrics configuration to new section - metrics

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -311,6 +311,20 @@ The following configurations have been moved from `[core]` to the new `[logging]
 * `dag_processor_manager_log_location`
 * `task_log_reader`
 
+#### Metrics configuration has been moved to new section
+
+The following configurations have been moved from `[scheduler]` to the new `[metrics]` section.
+
+- `statsd_on`
+- `statsd_host`
+- `statsd_port`
+- `statsd_prefix`
+- `statsd_allow_list`
+- `stat_name_handler`
+- `statsd_datadog_enabled`
+- `statsd_datadog_tags`
+- `statsd_custom_client_path`
+
 #### Changes to Elasticsearch logging provider
 
 When JSON output to stdout is enabled, log lines will now contain the `log_id` & `offset` fields, this should make reading task logs from elasticsearch on the webserver work out of the box. Example configuration:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -579,11 +579,11 @@
       default: ""
 - name: metrics
   description: |
-    Statsd (https://github.com/etsy/statsd) integration settings.
+    StatsD (https://github.com/etsy/statsd) integration settings.
   options:
     - name: statsd_on
       description: |
-        Enables sending statsD metrics.
+        Enables sending metrics to StatsD.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -577,6 +577,78 @@
       type: string
       example: "connexion,sqlalchemy"
       default: ""
+- name: metrics
+  description: |
+    Statsd (https://github.com/etsy/statsd) integration settings.
+  options:
+    - name: statsd_on
+      description: |
+        Enables sending statsD metrics.
+      version_added: ~
+      type: string
+      example: ~
+      default: "False"
+    - name: statsd_host
+      description: ~
+      version_added: ~
+      type: string
+      example: ~
+      default: "localhost"
+    - name: statsd_port
+      description: ~
+      version_added: ~
+      type: string
+      example: ~
+      default: "8125"
+    - name: statsd_prefix
+      description: ~
+      version_added: ~
+      type: string
+      example: ~
+      default: "airflow"
+    - name: statsd_allow_list
+      description: |
+        If you want to avoid send all the available metrics to StatsD,
+        you can configure an allow list of prefixes to send only the metrics that
+        start with the elements of the list (e.g: scheduler,executor,dagrun)
+      version_added: 1.10.6
+      type: string
+      example: ~
+      default: ""
+    - name: stat_name_handler
+      description: |
+        A function that validate the statsd stat name, apply changes to the stat name if necessary and return
+        the transformed stat name.
+
+        The function should have the following signature:
+        def func_name(stat_name: str) -> str:
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
+    - name: statsd_datadog_enabled
+      description: |
+        To enable datadog integration to send airflow metrics.
+      version_added: ~
+      type: string
+      example: ~
+      default: "False"
+    - name: statsd_datadog_tags
+      description: |
+        List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
+      version_added: ~
+      type: string
+      example: ~
+      default: ""
+    - name: statsd_custom_client_path
+      description: |
+        If you want to utilise your own custom Statsd client set the relevant
+        module path below.
+        Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
+      version_added: ~
+      type: string
+      example: ~
+      default: ~
 - name: secrets
   description: ~
   options:
@@ -1635,74 +1707,6 @@
       example: ~
       version_added: 2.0.0
       type: boolean
-      default: ~
-    - name: statsd_on
-      description: |
-        Statsd (https://github.com/etsy/statsd) integration settings
-      version_added: ~
-      type: string
-      example: ~
-      default: "False"
-    - name: statsd_host
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "localhost"
-    - name: statsd_port
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "8125"
-    - name: statsd_prefix
-      description: ~
-      version_added: ~
-      type: string
-      example: ~
-      default: "airflow"
-    - name: statsd_allow_list
-      description: |
-        If you want to avoid send all the available metrics to StatsD,
-        you can configure an allow list of prefixes to send only the metrics that
-        start with the elements of the list (e.g: scheduler,executor,dagrun)
-      version_added: 1.10.6
-      type: string
-      example: ~
-      default: ""
-    - name: stat_name_handler
-      description: |
-        A function that validate the statsd stat name, apply changes to the stat name if necessary and return
-        the transformed stat name.
-
-        The function should have the following signature:
-        def func_name(stat_name: str) -> str:
-      version_added: ~
-      type: string
-      example: ~
-      default: ""
-    - name: statsd_datadog_enabled
-      description: |
-        To enable datadog integration to send airflow metrics.
-      version_added: ~
-      type: string
-      example: ~
-      default: "False"
-    - name: statsd_datadog_tags
-      description: |
-        List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
-      version_added: ~
-      type: string
-      example: ~
-      default: ""
-    - name: statsd_custom_client_path
-      description: |
-        If you want to utilise your own custom Statsd client set the relevant
-        module path below.
-        Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
-      version_added: ~
-      type: string
-      example: ~
       default: ~
     - name: max_threads
       description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -608,9 +608,9 @@
       default: "airflow"
     - name: statsd_allow_list
       description: |
-        If you want to avoid send all the available metrics to StatsD,
-        you can configure an allow list of prefixes to send only the metrics that
-        start with the elements of the list (e.g: scheduler,executor,dagrun)
+        If you want to avoid sending all the available metrics to StatsD,
+        you can configure an allow list of prefixes (comma separated) to send only the metrics that
+        start with the elements of the list (e.g: "scheduler,executor,dagrun")
       version_added: 1.10.6
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -323,9 +323,9 @@ statsd_host = localhost
 statsd_port = 8125
 statsd_prefix = airflow
 
-# If you want to avoid send all the available metrics to StatsD,
-# you can configure an allow list of prefixes to send only the metrics that
-# start with the elements of the list (e.g: scheduler,executor,dagrun)
+# If you want to avoid sending all the available metrics to StatsD,
+# you can configure an allow list of prefixes (comma separated) to send only the metrics that
+# start with the elements of the list (e.g: "scheduler,executor,dagrun")
 statsd_allow_list =
 
 # A function that validate the statsd stat name, apply changes to the stat name if necessary and return

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -314,6 +314,38 @@ task_log_reader = task
 # Example: extra_loggers = connexion,sqlalchemy
 extra_loggers =
 
+[metrics]
+
+# Statsd (https://github.com/etsy/statsd) integration settings.
+# Enables sending statsD metrics.
+statsd_on = False
+statsd_host = localhost
+statsd_port = 8125
+statsd_prefix = airflow
+
+# If you want to avoid send all the available metrics to StatsD,
+# you can configure an allow list of prefixes to send only the metrics that
+# start with the elements of the list (e.g: scheduler,executor,dagrun)
+statsd_allow_list =
+
+# A function that validate the statsd stat name, apply changes to the stat name if necessary and return
+# the transformed stat name.
+#
+# The function should have the following signature:
+# def func_name(stat_name: str) -> str:
+stat_name_handler =
+
+# To enable datadog integration to send airflow metrics.
+statsd_datadog_enabled = False
+
+# List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
+statsd_datadog_tags =
+
+# If you want to utilise your own custom Statsd client set the relevant
+# module path below.
+# Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
+# statsd_custom_client_path =
+
 [secrets]
 # Full class name of secrets backend to enable (will precede env vars and metastore in search path)
 # Example: backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
@@ -821,35 +853,6 @@ use_row_level_locking = True
 #
 # Default: True
 # schedule_after_task_execution =
-
-# Statsd (https://github.com/etsy/statsd) integration settings
-statsd_on = False
-statsd_host = localhost
-statsd_port = 8125
-statsd_prefix = airflow
-
-# If you want to avoid send all the available metrics to StatsD,
-# you can configure an allow list of prefixes to send only the metrics that
-# start with the elements of the list (e.g: scheduler,executor,dagrun)
-statsd_allow_list =
-
-# A function that validate the statsd stat name, apply changes to the stat name if necessary and return
-# the transformed stat name.
-#
-# The function should have the following signature:
-# def func_name(stat_name: str) -> str:
-stat_name_handler =
-
-# To enable datadog integration to send airflow metrics.
-statsd_datadog_enabled = False
-
-# List of datadog tags attached to all metrics(e.g: key1:value1,key2:value2)
-statsd_datadog_tags =
-
-# If you want to utilise your own custom Statsd client set the relevant
-# module path below.
-# Note: The module path must exist on your PYTHONPATH for Airflow to pick it up
-# statsd_custom_client_path =
 
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -316,8 +316,8 @@ extra_loggers =
 
 [metrics]
 
-# Statsd (https://github.com/etsy/statsd) integration settings.
-# Enables sending statsD metrics.
+# StatsD (https://github.com/etsy/statsd) integration settings.
+# Enables sending metrics to StatsD.
 statsd_on = False
 statsd_host = localhost
 statsd_port = 8125

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -162,6 +162,15 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
         ('logging', 'log_processor_filename_template'): ('core', 'log_processor_filename_template'),
         ('logging', 'dag_processor_manager_log_location'): ('core', 'dag_processor_manager_log_location'),
         ('logging', 'task_log_reader'): ('core', 'task_log_reader'),
+        ('metrics', 'statsd_on'): ('scheduler', 'statsd_on'),
+        ('metrics', 'statsd_host'): ('scheduler', 'statsd_host'),
+        ('metrics', 'statsd_port'): ('scheduler', 'statsd_port'),
+        ('metrics', 'statsd_prefix'): ('scheduler', 'statsd_prefix'),
+        ('metrics', 'statsd_allow_list'): ('scheduler', 'statsd_allow_list'),
+        ('metrics', 'stat_name_handler'): ('scheduler', 'stat_name_handler'),
+        ('metrics', 'statsd_datadog_enabled'): ('scheduler', 'statsd_datadog_enabled'),
+        ('metrics', 'statsd_datadog_tags'): ('scheduler', 'statsd_datadog_tags'),
+        ('metrics', 'statsd_custom_client_path'): ('scheduler', 'statsd_custom_client_path'),
     }
 
     # A mapping of old default values that we want to change and warn the user

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -310,7 +310,7 @@ class _Stats(type):
         # and previously it would crash with None is callable if it was called without it.
         from statsd import StatsClient
 
-        stats_class = conf.getimport('metrics', 'statsd_custom_client_path')
+        stats_class = conf.getimport('metrics', 'statsd_custom_client_path', fallback=None)
 
         if stats_class:
             if not issubclass(stats_class, StatsClient):

--- a/airflow/stats.py
+++ b/airflow/stats.py
@@ -150,7 +150,7 @@ def stat_name_default_handler(stat_name, max_length=250) -> str:
 
 def get_current_handler_stat_name_func() -> Callable[[str], str]:
     """Get Stat Name Handler from airflow.cfg"""
-    return conf.getimport('scheduler', 'stat_name_handler') or stat_name_default_handler
+    return conf.getimport('metrics', 'stat_name_handler') or stat_name_default_handler
 
 
 T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
@@ -292,10 +292,10 @@ class _Stats(type):
         super().__init__(cls)
         if cls.__class__.instance is None:
             try:
-                is_datadog_enabled_defined = conf.has_option('scheduler', 'statsd_datadog_enabled')
-                if is_datadog_enabled_defined and conf.getboolean('scheduler', 'statsd_datadog_enabled'):
+                is_datadog_enabled_defined = conf.has_option('metrics', 'statsd_datadog_enabled')
+                if is_datadog_enabled_defined and conf.getboolean('metrics', 'statsd_datadog_enabled'):
                     cls.__class__.instance = cls.get_dogstatsd_logger()
-                elif conf.getboolean('scheduler', 'statsd_on'):
+                elif conf.getboolean('metrics', 'statsd_on'):
                     cls.__class__.instance = cls.get_statsd_logger()
                 else:
                     cls.__class__.instance = DummyStatsLogger()
@@ -310,9 +310,9 @@ class _Stats(type):
         # and previously it would crash with None is callable if it was called without it.
         from statsd import StatsClient
 
-        if conf.has_option('scheduler', 'statsd_custom_client_path'):
-            stats_class = conf.getimport('scheduler', 'statsd_custom_client_path')
+        stats_class = conf.getimport('metrics', 'statsd_custom_client_path')
 
+        if stats_class:
             if not issubclass(stats_class, StatsClient):
                 raise AirflowConfigException(
                     "Your custom Statsd client must extend the statsd.StatsClient in order to ensure "
@@ -325,11 +325,11 @@ class _Stats(type):
             stats_class = StatsClient
 
         statsd = stats_class(
-            host=conf.get('scheduler', 'statsd_host'),
-            port=conf.getint('scheduler', 'statsd_port'),
-            prefix=conf.get('scheduler', 'statsd_prefix'),
+            host=conf.get('metrics', 'statsd_host'),
+            port=conf.getint('metrics', 'statsd_port'),
+            prefix=conf.get('metrics', 'statsd_prefix'),
         )
-        allow_list_validator = AllowListValidator(conf.get('scheduler', 'statsd_allow_list', fallback=None))
+        allow_list_validator = AllowListValidator(conf.get('metrics', 'statsd_allow_list', fallback=None))
         return SafeStatsdLogger(statsd, allow_list_validator)
 
     @classmethod
@@ -338,12 +338,12 @@ class _Stats(type):
         from datadog import DogStatsd
 
         dogstatsd = DogStatsd(
-            host=conf.get('scheduler', 'statsd_host'),
-            port=conf.getint('scheduler', 'statsd_port'),
-            namespace=conf.get('scheduler', 'statsd_prefix'),
+            host=conf.get('metrics', 'statsd_host'),
+            port=conf.getint('metrics', 'statsd_port'),
+            namespace=conf.get('metrics', 'statsd_prefix'),
             constant_tags=cls.get_constant_tags(),
         )
-        dogstatsd_allow_list = conf.get('scheduler', 'statsd_allow_list', fallback=None)
+        dogstatsd_allow_list = conf.get('metrics', 'statsd_allow_list', fallback=None)
         allow_list_validator = AllowListValidator(dogstatsd_allow_list)
         return SafeDogStatsdLogger(dogstatsd, allow_list_validator)
 
@@ -351,7 +351,7 @@ class _Stats(type):
     def get_constant_tags(cls):
         """Get constant DataDog tags to add to all stats"""
         tags = []
-        tags_in_string = conf.get('scheduler', 'statsd_datadog_tags', fallback=None)
+        tags_in_string = conf.get('metrics', 'statsd_datadog_tags', fallback=None)
         if tags_in_string is None or tags_in_string == '':
             return tags
         else:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -600,6 +600,11 @@ config:
     auth_backend: airflow.api.auth.backend.deny_all
   logging:
     logging_level: DEBUG
+  metrics:
+    statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
+    statsd_port: 9125
+    statsd_prefix: airflow
+    statsd_host: '{{ printf "%s-statsd" .Release.Name }}'
   webserver:
     enable_proxy_fix: 'True'
     expose_config: 'True'
@@ -610,6 +615,7 @@ config:
 
   scheduler:
     scheduler_heartbeat_sec: 5
+    # For Airflow 1.10, backward compatibility
     statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
     statsd_port: 9125
     statsd_prefix: airflow

--- a/docs/configurations-ref.rst
+++ b/docs/configurations-ref.rst
@@ -33,6 +33,8 @@ can set in ``airflow.cfg`` file or using environment variables.
 
     {% for section in configs %}
 
+    .. _config:{{ section["name"] }}:
+
     [{{ section["name"] }}]
     {{ "=" * (section["name"]|length + 2) }}
 

--- a/docs/logging-monitoring/metrics.rst
+++ b/docs/logging-monitoring/metrics.rst
@@ -35,7 +35,7 @@ Add the following lines to your configuration file e.g. ``airflow.cfg``
 
 .. code-block:: ini
 
-    [scheduler]
+    [metrics]
     statsd_on = True
     statsd_host = localhost
     statsd_port = 8125
@@ -46,7 +46,7 @@ the metrics that start with the elements of the list:
 
 .. code-block:: ini
 
-    [scheduler]
+    [metrics]
     statsd_allow_list = scheduler,executor,dagrun
 
 If you want to redirect metrics to different name, you can configure ``stat_name_handler`` option
@@ -60,14 +60,19 @@ to the stat name if necessary and return the transformed stat name. The function
 
 If you want to use a custom Statsd client outwith the default one provided by Airflow the following key must be added
 to the configuration file alongside the module path of your custom Statsd client. This module must be available on
-your PYTHONPATH.
+your :envvar:`PYTHONPATH`.
 
 .. code-block:: ini
 
-    [scheduler]
+    [metrics]
     statsd_custom_client_path = x.y.customclient
 
 See :doc:`../modules_management` for details on how Python and Airflow manage modules.
+
+.. note::
+
+    For a detailed listing of configuration options regarding metrics,
+    see the configuration reference documentation - :ref:`config:metrics`.
 
 Counters
 --------

--- a/tests/core/test_config_templates.py
+++ b/tests/core/test_config_templates.py
@@ -27,6 +27,7 @@ CONFIG_TEMPLATES_FOLDER = os.path.join(AIRFLOW_MAIN_FOLDER, "airflow", "config_t
 DEFAULT_AIRFLOW_SECTIONS = [
     'core',
     "logging",
+    "metrics",
     'secrets',
     'cli',
     'debug',

--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -85,14 +85,14 @@ class TestStats(unittest.TestCase):
         self.stats.incr('test/$tats')
         self.statsd_client.assert_not_called()
 
-    @conf_vars({('scheduler', 'statsd_on'): 'True'})
+    @conf_vars({('metrics', 'statsd_on'): 'True'})
     @mock.patch("statsd.StatsClient")
     def test_does_send_stats_using_statsd(self, mock_statsd):
         importlib.reload(airflow.stats)
         airflow.stats.Stats.incr("dummy_key")
         mock_statsd.return_value.incr.assert_called_once_with('dummy_key', 1, 1)
 
-    @conf_vars({('scheduler', 'statsd_on'): 'True'})
+    @conf_vars({('metrics', 'statsd_on'): 'True'})
     @mock.patch("datadog.DogStatsd")
     def test_does_not_send_stats_using_dogstatsd(self, mock_dogstatsd):
         importlib.reload(airflow.stats)
@@ -101,8 +101,8 @@ class TestStats(unittest.TestCase):
 
     @conf_vars(
         {
-            ("scheduler", "statsd_on"): "True",
-            ("scheduler", "statsd_custom_client_path"): "tests.core.test_stats.CustomStatsd",
+            ("metrics", "statsd_on"): "True",
+            ("metrics", "statsd_custom_client_path"): "tests.core.test_stats.CustomStatsd",
         }
     )
     def test_load_custom_statsd_client(self):
@@ -111,8 +111,8 @@ class TestStats(unittest.TestCase):
 
     @conf_vars(
         {
-            ("scheduler", "statsd_on"): "True",
-            ("scheduler", "statsd_custom_client_path"): "tests.core.test_stats.CustomStatsd",
+            ("metrics", "statsd_on"): "True",
+            ("metrics", "statsd_custom_client_path"): "tests.core.test_stats.CustomStatsd",
         }
     )
     def test_does_use_custom_statsd_client(self):
@@ -122,8 +122,8 @@ class TestStats(unittest.TestCase):
 
     @conf_vars(
         {
-            ("scheduler", "statsd_on"): "True",
-            ("scheduler", "statsd_custom_client_path"): "tests.core.test_stats.InvalidCustomStatsd",
+            ("metrics", "statsd_on"): "True",
+            ("metrics", "statsd_custom_client_path"): "tests.core.test_stats.InvalidCustomStatsd",
         }
     )
     def test_load_invalid_custom_stats_client(self):
@@ -164,7 +164,7 @@ class TestDogStats(unittest.TestCase):
         self.dogstatsd.incr('test/$tats')
         self.dogstatsd_client.assert_not_called()
 
-    @conf_vars({('scheduler', 'statsd_datadog_enabled'): 'True'})
+    @conf_vars({('metrics', 'statsd_datadog_enabled'): 'True'})
     @mock.patch("datadog.DogStatsd")
     def test_does_send_stats_using_dogstatsd_when_dogstatsd_on(self, mock_dogstatsd):
         importlib.reload(airflow.stats)
@@ -173,7 +173,7 @@ class TestDogStats(unittest.TestCase):
             metric='dummy_key', sample_rate=1, tags=[], value=1
         )
 
-    @conf_vars({('scheduler', 'statsd_datadog_enabled'): 'True'})
+    @conf_vars({('metrics', 'statsd_datadog_enabled'): 'True'})
     @mock.patch("datadog.DogStatsd")
     def test_does_send_stats_using_dogstatsd_with_tags(self, mock_dogstatsd):
         importlib.reload(airflow.stats)
@@ -182,7 +182,7 @@ class TestDogStats(unittest.TestCase):
             metric='dummy_key', sample_rate=1, tags=['key1:value1', 'key2:value2'], value=1
         )
 
-    @conf_vars({('scheduler', 'statsd_on'): 'True', ('scheduler', 'statsd_datadog_enabled'): 'True'})
+    @conf_vars({('metrics', 'statsd_on'): 'True', ('metrics', 'statsd_datadog_enabled'): 'True'})
     @mock.patch("datadog.DogStatsd")
     def test_does_send_stats_using_dogstatsd_when_statsd_and_dogstatsd_both_on(self, mock_dogstatsd):
         importlib.reload(airflow.stats)
@@ -191,7 +191,7 @@ class TestDogStats(unittest.TestCase):
             metric='dummy_key', sample_rate=1, tags=[], value=1
         )
 
-    @conf_vars({('scheduler', 'statsd_on'): 'True', ('scheduler', 'statsd_datadog_enabled'): 'True'})
+    @conf_vars({('metrics', 'statsd_on'): 'True', ('metrics', 'statsd_datadog_enabled'): 'True'})
     @mock.patch("statsd.StatsClient")
     def test_does_not_send_stats_using_statsd_when_statsd_and_dogstatsd_both_on(self, mock_statsd):
         importlib.reload(airflow.stats)
@@ -254,8 +254,8 @@ def always_valid(stat_name):
 class TestCustomStatsName(unittest.TestCase):
     @conf_vars(
         {
-            ('scheduler', 'statsd_on'): 'True',
-            ('scheduler', 'stat_name_handler'): 'tests.core.test_stats.always_invalid',
+            ('metrics', 'statsd_on'): 'True',
+            ('metrics', 'stat_name_handler'): 'tests.core.test_stats.always_invalid',
         }
     )
     @mock.patch("statsd.StatsClient")
@@ -266,8 +266,8 @@ class TestCustomStatsName(unittest.TestCase):
 
     @conf_vars(
         {
-            ('scheduler', 'statsd_datadog_enabled'): 'True',
-            ('scheduler', 'stat_name_handler'): 'tests.core.test_stats.always_invalid',
+            ('metrics', 'statsd_datadog_enabled'): 'True',
+            ('metrics', 'stat_name_handler'): 'tests.core.test_stats.always_invalid',
         }
     )
     @mock.patch("datadog.DogStatsd")
@@ -278,8 +278,8 @@ class TestCustomStatsName(unittest.TestCase):
 
     @conf_vars(
         {
-            ('scheduler', 'statsd_on'): 'True',
-            ('scheduler', 'stat_name_handler'): 'tests.core.test_stats.always_valid',
+            ('metrics', 'statsd_on'): 'True',
+            ('metrics', 'stat_name_handler'): 'tests.core.test_stats.always_valid',
         }
     )
     @mock.patch("statsd.StatsClient")
@@ -290,8 +290,8 @@ class TestCustomStatsName(unittest.TestCase):
 
     @conf_vars(
         {
-            ('scheduler', 'statsd_datadog_enabled'): 'True',
-            ('scheduler', 'stat_name_handler'): 'tests.core.test_stats.always_valid',
+            ('metrics', 'statsd_datadog_enabled'): 'True',
+            ('metrics', 'stat_name_handler'): 'tests.core.test_stats.always_valid',
         }
     )
     @mock.patch("datadog.DogStatsd")


### PR DESCRIPTION
These options are very related, so it's a good idea to move them to the new section. Especially since these options are mistakenly in the `[scheduler]` section, when the metrics are also used by other components, e.g. workers.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
