### PR TITLE
Added a second example for TaskFlow API

### DIFF
--- a/airflow/example_dags/tutorial_taskflow_api_pandas.py
+++ b/airflow/example_dags/tutorial_taskflow_api_pandas.py
@@ -1,0 +1,153 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=missing-function-docstring
+"""
+### TaskFlow API Example using Pandas
+
+This is a simple ETL data pipeline example which demonstrates the use of the
+TaskFlow API using three simple tasks for Extract, Transform, and Load, while
+using Pandas and loading data from files.
+
+"""
+# [START tutorial]
+# [START import_module]
+import pandas as pd
+
+# The DAG object; we'll need this to instantiate a DAG
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+from airflow.sensors.filesystem import FileSensor
+from airflow.utils.dates import days_ago
+
+# [END import_module]
+
+
+def generate_data_file():
+    tmp_data_file = open('/tmp/order_data.csv', 'w')
+    tmp_data_file.write('order_id,order_value\n')
+    tmp_data_file.write('"1001", 301.27\n')
+    tmp_data_file.write('"1002", 433.21\n')
+    tmp_data_file.write('"1003", 502.22\n')
+    tmp_data_file.close()
+
+
+# [START default_args]
+# These args will get passed on to each operator
+# You can override them on a per-task basis during operator initialization
+default_args = {
+    'owner': 'airflow',
+}
+# [END default_args]
+
+
+# [START instantiate_dag]
+with DAG(
+    'tutorial_taskflow_api_pandas',
+    default_args=default_args,
+    description='TaskFlow API ETL Pandas',
+    schedule_interval=None,
+    start_date=days_ago(2),
+    tags=['example'],
+) as dag:
+    # [END instantiate_dag]
+
+    # [START documentation]
+    dag.doc_md = __doc__
+    # [END documentation]
+
+    # [START extract]
+    @dag.task()
+    def extract():
+        """
+        #### Extract task
+        A simple Extract task to get data ready for the rest of the data
+        pipeline. In this case, data is read from a file.
+        """
+        order_data_file = '/tmp/order_data.csv'
+
+        order_data_df = pd.read_csv(order_data_file)
+
+        # convert to JSON so that it be returned using xcom
+        order_data_df_str = order_data_df.to_json(orient='split')
+        return order_data_df_str
+
+        # Altenatively, to directly return the pandas dataframe, set the
+        # xcom configuration in the airflow.cfg configuration file to use
+        # pickling instead of the default JSON
+        # enable_xcom_pickling = True
+        # Caution: Picking of xcom data is not the default due to security
+        # concerns. Please validate with your security team before changing
+        # this setting.
+        #
+        # return order_data_df
+
+    # [END extract]
+
+    # [START transform]
+    @dag.task(multiple_outputs=True)
+    def transform(order_data_df_str: str):
+        """
+        #### Transform task
+        A simple Transform task which takes in the order data and computes
+        the total order value.
+        """
+        order_data_df = pd.read_json(order_data_df_str, orient='split')
+
+        # Alterntively, if using pickling and directly returning a pandas
+        # dataframe, make sure to change the input signature to be a dataframe
+        # instead of a string and skip the above converstion from a string
+        # in JSON format to a pandas dataframe
+
+        total_series = order_data_df.sum(numeric_only=True)
+        total_order_value = total_series.get('order_value')
+
+        return {"total_order_value": total_order_value}
+
+    # [END transform]
+
+    # [START load]
+    @dag.task()
+    def load(total_order_value: float):
+        """
+        #### Load task
+        A simple Load task which takes in the result of the Transform task and
+        instead of saving it to end user review, just prints it out.
+        """
+
+        print("Total order value is: %.2f" % total_order_value)
+
+    # [END load]
+
+    # [START main_flow]
+
+    # in the example just generate the expected data file, so there are no
+    # external dependencies needed to get the data file
+    generate_data_file_task = PythonOperator(task_id='generate_data_file', python_callable=generate_data_file)
+
+    # in the real world, ETL processing typically starts with a data file
+    file_task = FileSensor(task_id='check_file', filepath='/tmp/order_data.csv')
+
+    order_data = extract()
+    order_summary = transform(order_data)
+    load(order_summary["total_order_value"])
+
+    generate_data_file_task >> file_task >> order_data
+    # [END main_flow]
+
+# [END tutorial]

--- a/airflow/example_dags/tutorial_xcom_pandas.py
+++ b/airflow/example_dags/tutorial_xcom_pandas.py
@@ -1,0 +1,149 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=missing-function-docstring
+"""
+### Custom Xcom back-end to support Pandas
+
+This is a simple example to illustrate an option to extend Xcoms for use
+with Pandas dataframes by storing Pandas within the local file system and
+passing them around between tasks.
+Clearly, this would only work on the same processing node, but this is
+intended to generalized to storage on S3, GCS, or equivalent shared volumes for
+distributed task execution.
+"""
+
+import dbm
+import json
+import os
+import pathlib
+import random
+import string
+from typing import Any
+
+import pandas as pd
+
+from airflow.models.xcom import BaseXCom
+
+CUSTOM_XCOM_DATA_DIR = 'tmp_xcom_data'
+
+
+class CustomXcomLocalForPandas(BaseXCom):
+    """Example Custom Xcom persistence class - extends base to support Pandas Dataframes."""
+
+    @staticmethod
+    def init_dir(xcom_data_path):
+        pathlib.Path(xcom_data_path).mkdir(parents=True, exist_ok=True)
+        print("Directory %s created" % xcom_data_path)
+
+        xcom_data_index = os.path.join(xcom_data_path, 'xcom_index')
+        return xcom_data_index
+
+    @staticmethod
+    def get_random_string():
+        random_result = ''.join(random.choices(string.ascii_uppercase + string.digits, k=32))
+        return random_result
+
+    @staticmethod
+    def write_value_file(filename, obj):
+        try:
+            if isinstance(obj, pd.DataFrame):
+                obj_type = 'dataframe'
+                obj_json = obj.to_json(orient="split")
+            else:
+                obj_type = 'native'
+                obj_json = json.dumps(obj)
+        except TypeError:
+            print("Could not serialize value into JSON")
+
+        print('Writing object of type: ' + obj_type)
+        try:
+            value_data_file = open(filename, 'w')
+            value_data_file.write(obj_json)
+            value_data_file.close()
+        except OSError:
+            print("Could not create file and write value")
+
+        return obj_type
+
+    @staticmethod
+    def read_value_file(filename, obj_type):
+        print('Reading object of type: ' + obj_type + ' from ' + filename)
+        try:
+            value_data_file = open(filename)
+            data = value_data_file.read()
+            value_data_file.close()
+        except OSError:
+            print("Could not open file and read value")
+
+        try:
+            if obj_type == 'dataframe':
+                value = pd.read_json(data, orient='split')
+                if isinstance(value, pd.DataFrame):
+                    print('Success in reading dataframe')
+                else:
+                    print('Failed in reading dataframe')
+                print(value)
+            else:
+                value = json.loads(data)
+        except TypeError:
+            print("Could not deserialize value from JSON")
+
+        return value
+
+    @staticmethod
+    def write_value(value):
+        xcom_data_path = os.path.join('/tmp', CUSTOM_XCOM_DATA_DIR)
+        xcom_data_index = CustomXcomLocalForPandas.init_dir(xcom_data_path)
+
+        key_str = CustomXcomLocalForPandas.get_random_string()
+        print('Storing object with key_str = ' + key_str + ', and value = ')
+        print(value)
+        object_type = CustomXcomLocalForPandas.write_value_file(os.path.join(xcom_data_path, key_str), value)
+
+        index_db = dbm.open(xcom_data_index, 'c')
+        index_db[key_str] = object_type
+        index_db.close()
+
+        return key_str
+
+    @staticmethod
+    def read_value(key_str_value):
+        xcom_data_path = os.path.join('/tmp', CUSTOM_XCOM_DATA_DIR)
+        xcom_data_index = CustomXcomLocalForPandas.init_dir(xcom_data_path)
+
+        read_db = dbm.open(xcom_data_index, 'r')
+
+        type_str = read_db.get(key_str_value).decode()
+        value = CustomXcomLocalForPandas.read_value_file(
+            os.path.join(xcom_data_path, key_str_value), type_str
+        )
+
+        read_db.close()
+        return value
+
+    @staticmethod
+    def serialize_value(value: Any):
+        key_str_value = CustomXcomLocalForPandas.write_value(value)
+        return key_str_value.encode('UTF-8')
+
+    @staticmethod
+    def deserialize_value(result) -> Any:
+        key_str_value = result.value.decode('UTF-8')
+        value = CustomXcomLocalForPandas.read_value(key_str_value)
+        return value


### PR DESCRIPTION
Added a second example DAG for the TaskFlow API, this time using Pandas dataframes and files to be more realistic. This also illustrates the mix of task dependencies between task decorators and sensors.

@kaxil @turbaszek @casassg @ashb 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
