### PR TITLE
KubernetesPodOperator: use randomized name to get the failure status

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -310,7 +310,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 self.log.info("creating pod with labels %s and launcher %s", labels, launcher)
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
             if final_state != State.SUCCESS:
-                status = self.client.read_namespaced_pod(self.name, self.namespace)
+                status = self.client.read_namespaced_pod(self.pod.metadata.name, self.namespace)
                 raise AirflowException(f'Pod returned a failure: {status}')
             return result
         except AirflowException as ex:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -311,7 +311,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 final_state, _, result = self.create_new_pod_for_operator(labels, launcher)
             if final_state != State.SUCCESS:
                 status = self.client.read_namespaced_pod(self.pod.metadata.name, self.namespace)
-                raise AirflowException(f'Pod returned a failure: {status}')
+                raise AirflowException(f'Pod {self.pod.metadata.name} returned a failure: {status}')
             return result
         except AirflowException as ex:
             raise AirflowException(f'Pod Launching failed: {ex}')

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -190,12 +190,14 @@ class TestKubernetesPodOperator(unittest.TestCase):
         read_namespaced_pod_mock = mock_client.return_value.read_namespaced_pod
         read_namespaced_pod_mock.return_value = failed_pod_status
 
-        with self.assertRaisesRegex(
-            AirflowException,
-            fr'Pod Launching failed: Pod {k.pod.metadata.name} returned a failure: {failed_pod_status}',
-        ):
+        with self.assertRaises(AirflowException) as cm:
             context = self.create_context(k)
             k.execute(context=context)
+
+        self.assertEqual(
+            str(cm.exception), 
+            f"Pod Launching failed: Pod {k.pod.metadata.name} returned a failure: {failed_pod_status}",
+        )
         assert mock_client.return_value.read_namespaced_pod.called
         self.assertEqual(read_namespaced_pod_mock.call_args[0][0], k.pod.metadata.name)
 

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -195,7 +195,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             k.execute(context=context)
 
         self.assertEqual(
-            str(cm.exception), 
+            str(cm.exception),
             f"Pod Launching failed: Pod {k.pod.metadata.name} returned a failure: {failed_pod_status}",
         )
         assert mock_client.return_value.read_namespaced_pod.called

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -164,3 +164,65 @@ class TestKubernetesPodOperator(unittest.TestCase):
 
         assert start_mock.call_args[0][0].metadata.name.startswith(name_base)
         assert start_mock.call_args[0][0].metadata.name != name_base
+
+    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    def test_describes_pod_on_failure(self, mock_client, monitor_mock, start_mock):
+        from airflow.utils.state import State
+
+        name_base = 'test'
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name=name_base,
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+        )
+        monitor_mock.return_value = (State.FAILED, None)
+        failed_pod_status = 'read_pod_namespaced_result'
+        read_namespaced_pod_mock = mock_client.return_value.read_namespaced_pod
+        read_namespaced_pod_mock.return_value = failed_pod_status
+
+        with self.assertRaises(AirflowException) as cm:
+            context = self.create_context(k)
+            k.execute(context=context)
+
+        self.assertEqual(
+            str(cm.exception), "Pod Launching failed: Pod returned a failure: " + failed_pod_status
+        )
+        assert mock_client.return_value.read_namespaced_pod.called
+        self.assertEqual(read_namespaced_pod_mock.call_args[0][0], k.pod.metadata.name)
+
+    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
+    def test_no_need_to_describe_pod_on_success(self, mock_client, monitor_mock, start_mock):
+        from airflow.utils.state import State
+
+        name_base = 'test'
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name=name_base,
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+        )
+        monitor_mock.return_value = (State.SUCCESS, None)
+
+        context = self.create_context(k)
+        k.execute(context=context)
+
+        assert not mock_client.return_value.read_namespaced_pod.called

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -190,13 +190,12 @@ class TestKubernetesPodOperator(unittest.TestCase):
         read_namespaced_pod_mock = mock_client.return_value.read_namespaced_pod
         read_namespaced_pod_mock.return_value = failed_pod_status
 
-        with self.assertRaises(AirflowException) as cm:
+        with self.assertRaisesRegex(
+            AirflowException,
+            fr'Pod Launching failed: Pod {k.pod.metadata.name} returned a failure: {failed_pod_status}',
+        ):
             context = self.create_context(k)
             k.execute(context=context)
-
-        self.assertEqual(
-            str(cm.exception), "Pod Launching failed: Pod returned a failure: " + failed_pod_status
-        )
         assert mock_client.return_value.read_namespaced_pod.called
         self.assertEqual(read_namespaced_pod_mock.call_args[0][0], k.pod.metadata.name)
 


### PR DESCRIPTION
This PR fixes the issue #12151, introduced by my commit here: #12117. It looks I didn't check the pod failure scenario, as none of my pods failed so far, sorry! :see_no_evil:

closes: #12151

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
