### PR TITLE
Remove redundant asserts in tests/www/test_views.py

### DIFF
--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -810,7 +810,6 @@ class TestAirflowBaseViews(TestBase):
             data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
             follow_redirects=True,
         )
-        self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
         self.assertIn('example_subdag_operator', stats)
@@ -1977,7 +1976,6 @@ class TestDagACLView(TestBase):
             data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
             follow_redirects=True,
         )
-        self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
         self.assertIn('example_subdag_operator', stats)
@@ -2049,7 +2047,6 @@ class TestDagACLView(TestBase):
             data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
             follow_redirects=True,
         )
-        self.assertEqual(resp.status_code, 200)
         stats = json.loads(resp.data.decode('utf-8'))
         self.assertIn('example_bash_operator', stats)
         self.assertIn('example_subdag_operator', stats)
@@ -2353,7 +2350,6 @@ class TestDagACLView(TestBase):
             data={'dag_ids': ['example_subdag_operator', 'example_bash_operator']},
             follow_redirects=True,
         )
-        self.assertEqual(resp.status_code, 200)
         blocked_dags = {blocked['dag_id'] for blocked in json.loads(resp.data.decode('utf-8'))}
         self.assertIn('example_bash_operator', blocked_dags)
         self.assertIn('example_subdag_operator', blocked_dags)


### PR DESCRIPTION
Methods `check_content_not_in_response`/`check_content_in_response` already take care of status code check (by default asserts against 200).

https://github.com/apache/airflow/blob/3ff7e0743a1156efe1d6aaf7b8f82136d0bba08f/tests/www/test_views.py#L202-L204

So we don't need to explicitly assert for status code if we check response using `check_content_not_in_response`/`check_content_in_response`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

