### PR TITLE
Adds extra check while the selective checks are run

### DIFF
--- a/.github/workflows/label_when_reviewed_workflow_run.yml
+++ b/.github/workflows/label_when_reviewed_workflow_run.yml
@@ -35,6 +35,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
+      - name: Initiate Selective Build check
+        uses: LouisBrunner/checks-action@9f02872da71b6f558c6a6f190f925dde5e4d8798  # v1.1.0
+        id: selective-build-check
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: "Selective build check"
+          status: "in_progress"
+          sha: ${{ steps.source-run-info.outputs.sourceHeadSha }}
+          details_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: >
+            {"summary":
+            "Checking selective status of the build in
+            [the run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            "}
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
       - name: >
@@ -125,3 +139,18 @@ jobs:
           pullRequestNumber: ${{ steps.source-run-info.outputs.pullRequestNumber }}
           require_committers_approval: 'true'
           comment: "The PR is ready to be merged. No tests are needed!"
+      - name: Update Selective Build check
+        uses: LouisBrunner/checks-action@9f02872da71b6f558c6a6f190f925dde5e4d8798  # v1.1.0
+        if: always()
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          check_id: ${{ steps.selective-build-check.outputs.check_id }}
+          status: "completed"
+          sha: ${{ steps.source-run-info.outputs.sourceHeadSha }}
+          conclusion: ${{ job.status }}
+          details_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          output: >
+            {"summary":
+            "Checking selective status of the build completed in
+            [the run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            "}


### PR DESCRIPTION
The selective checks are run in "workflow_run" because
they need to be able to set label and make comments, however
status of those checks are not displayed in GitHub and in
cases of small PRs the "merge" button might be green before
the status complete.

This PR adds additional check that is always completed after
the "worfklow_run" finishes it's job. This will prevent
accidental merges before the check completes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
