### PR TITLE
Fix broken 'Blocked Highlight' feature in UI

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -359,7 +359,7 @@
         a = document.querySelector(`[data-dag-id="${this.dag_id}"]`);
         a.title = `${this.active_dag_run}/${this.max_active_runs} active dag runs`;
         if(this.active_dag_run >= this.max_active_runs) {
-          a.style.backgroundColor = 'red';
+          a.style.color = '#e43921';
         }
       });
     }

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -133,7 +133,7 @@
                 </td>
                 {# Column 5: Dag Schedule #}
                 <td>
-                  <a class="label label-default schedule" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
+                  <a class="label label-default schedule" href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}">
                     {{ dag.schedule_interval }}
                   </a>
                 </td>
@@ -356,12 +356,10 @@
 
     function blockedHandler(error, json) {
       $.each(json, function() {
-        $('.label.schedule.' + this.dag_id)
-        .attr('title', this.active_dag_run + '/' + this.max_active_runs + ' active dag runs')
-        .tooltip();
+        a = document.querySelector(`[data-dag-id="${this.dag_id}"]`);
+        a.title = `${this.active_dag_run}/${this.max_active_runs} active dag runs`;
         if(this.active_dag_run >= this.max_active_runs) {
-          $('.label.schedule.' + this.dag_id)
-          .css('background-color', 'red');
+          a.style.backgroundColor = 'red';
         }
       });
     }


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/12182

This "Blocked Highlight" feature helps highlight the DAGs whose # of active DagRuns is bigger than or equal to its max allowed. But this feature is broken in 2.0.0a2 and the latest releases of 1.10.x series.

## A bit more clarification

We will need the dag_id in the `class` so that code below can work as expected:

https://github.com/apache/airflow/blob/63ac07d9c735b1ccc8aa5fa974a260cc944cc539/airflow/www/templates/airflow/dags.html#L357-L367




<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
