### PR TITLE
Don't include provider datafiles in the apache-airflow sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,10 +32,5 @@ global-exclude __pycache__  *.pyc
 include airflow/alembic.ini
 include airflow/api_connexion/openapi/v1.yaml
 include airflow/git_version
-include airflow/providers/amazon/aws/hooks/batch_waiters.json
-include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_operator_spark_pi.yaml
-include airflow/providers/google/cloud/example_dags/example_bigquery_query.sql
-include airflow/providers/google/cloud/example_dags/example_cloud_build.yaml
-include airflow/providers/google/cloud/example_dags/example_spanner.sql
 include airflow/serialization/schema.json
 include airflow/utils/python_virtualenv_script.jinja2


### PR DESCRIPTION
We shouldn't include these in the main sdist now we've split providers
to separate distributions.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).