### PR TITLE
Include data files in (backport) provider packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,6 +189,7 @@ log.txt*
 
 # Provider-related ignores
 /provider_packages/CHANGELOG.txt
+/provider_packages/MANIFEST.in
 /airflow/providers/__init__.py
 
 # Local .terraform directories

--- a/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
+++ b/dev/provider_packages/MANIFEST_TEMPLATE.in.jinja2
@@ -16,6 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+{% if PROVIDER_PACKAGE_ID == 'amazon' %}
+include airflow/providers/amazon/aws/hooks/batch_waiters.json
+{% elif PROVIDER_PACKAGE_ID == 'cncf.kubernetes' %}
+include airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_spark_pi.yaml
+{% elif PROVIDER_PACKAGE_ID == 'google' %}
+include airflow/providers/google/cloud/example_dags/*.yaml
+include airflow/providers/google/cloud/example_dags/*.sql
+{% elif PROVIDER_PACKAGE_ID == 'papermill' %}
+include airflow/providers/papermill/example_dags/*.ipynb
+{% endif %}
+
 include NOTICE
 include LICENSE
 include CHANGELOG.txt

--- a/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -59,7 +59,21 @@ def do_setup(version_suffix_for_pypi=''):
         packages=find_namespace_packages(
             include=['airflow.providers.{{ PROVIDER_PACKAGE_ID }}',
                      'airflow.providers.{{ PROVIDER_PACKAGE_ID }}.*']),
+        package_data={ '': [
+{% if PROVIDER_PACKAGE_ID == 'amazon' %}
+          "*.json",
+{% elif PROVIDER_PACKAGE_ID == 'cncf.kubernetes' %}
+          "*.yaml",
+{% elif PROVIDER_PACKAGE_ID == 'google' %}
+          "*.yaml",
+          "*.sql",
+{% elif PROVIDER_PACKAGE_ID == 'papermill' %}
+          "*.ipynb",
+{% endif %}
+            ],
+        },
         zip_safe=False,
+        include_package_data=True,
         install_requires={{ INSTALL_REQUIREMENTS }},
         setup_requires={{ SETUP_REQUIREMENTS }},
         extras_require={{ EXTRAS_REQUIREMENTS }},

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -1220,6 +1220,7 @@ def update_generated_files_for_package(
     if update_setup:
         prepare_setup_py_file(context)
         prepare_setup_cfg_file(context)
+        prepare_manifest_in_file(context)
 
     bad = bad + sum([len(entity_summary.wrong_entities) for entity_summary in entity_summaries.values()])
     if bad != 0:
@@ -1316,6 +1317,19 @@ def prepare_setup_cfg_file(context):
     )
     with open(setup_file_path, "wt") as setup_file:
         setup_file.write(setup_content)
+
+
+def prepare_manifest_in_file(context):
+    target = os.path.abspath(os.path.join(get_target_folder(), "MANIFEST.in"))
+    content = render_template(
+        template_name="MANIFEST",
+        context=context,
+        extension='.in',
+        autoescape=False,
+        keep_trailing_newline=True,
+    )
+    with open(target, "wt") as fh:
+        fh.write(content)
 
 
 def update_release_notes_for_packages(


### PR DESCRIPTION
This isn't the most stable long-term solution but this works for now
where we've only got 4 dists the need this

Tested with this:


```
~/code/airflow/airflow data-files-in-providers*
airflow ❯ for tgz in dist/*.tar.gz; do echo $tgz; tar -tzf $tgz | egrep '\.yaml|\.json|\.sql|\.ipynb'; done
dist/apache-airflow-providers-amazon-0.0.2a1.tar.gz
apache-airflow-providers-amazon-0.0.2a1/airflow/providers/amazon/aws/hooks/batch_waiters.json
dist/apache-airflow-providers-cncf-kubernetes-0.0.2a1.tar.gz
apache-airflow-providers-cncf-kubernetes-0.0.2a1/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_spark_pi.yaml
dist/apache-airflow-providers-google-0.0.2a1.tar.gz
apache-airflow-providers-google-0.0.2a1/airflow/providers/google/cloud/example_dags/example_bigquery_query.sql
apache-airflow-providers-google-0.0.2a1/airflow/providers/google/cloud/example_dags/example_cloud_build.yaml
apache-airflow-providers-google-0.0.2a1/airflow/providers/google/cloud/example_dags/example_spanner.sql
dist/apache-airflow-providers-papermill-0.0.2a1.tar.gz
apache-airflow-providers-papermill-0.0.2a1/airflow/providers/papermill/example_dags/input_notebook.ipynb

~/code/airflow/airflow data-files-in-providers*
airflow ❯ for whl in dist/*.whl; do echo $whl; unzip -l $whl | egrep '\.yaml|\.json|\.sql|\.ipynb'; done
dist/apache_airflow_providers_amazon-0.0.2a1-py3-none-any.whl
     2511  2020-11-06 15:14   airflow/providers/amazon/aws/hooks/batch_waiters.json
dist/apache_airflow_providers_cncf_kubernetes-0.0.2a1-py3-none-any.whl
     1707  2020-11-06 15:14   airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes_spark_pi.yaml
dist/apache_airflow_providers_google-0.0.2a1-py3-none-any.whl
      816  2020-11-06 15:14   airflow/providers/google/cloud/example_dags/example_bigquery_query.sql
      860  2020-11-06 15:14   airflow/providers/google/cloud/example_dags/example_cloud_build.yaml
      879  2020-11-06 15:14   airflow/providers/google/cloud/example_dags/example_spanner.sql
dist/apache_airflow_providers_papermill-0.0.2a1-py3-none-any.whl
     2933  2020-11-06 15:14   airflow/providers/papermill/example_dags/input_notebook.ipynb
```

Closes #12197

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).