### PR TITLE
Make warnings more visible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -240,6 +240,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     (MIT License) moment-strftime v0.5.0 (https://github.com/benjaminoakes/moment-strftime)
     (MIT License) python-slugify v4.0.0 (https://github.com/un33k/python-slugify)
     (MIT License) python-nvd3 v0.15.0 (https://github.com/areski/python-nvd3)
+    (MIT License) rich v9.2.0 (https://github.com/willmcgugan/rich)
     (MIT License) eonasdan-bootstrap-datetimepicker v4.17.37 (https://github.com/eonasdan/bootstrap-datetimepicker/)
 
 ========================================================================

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -20,9 +20,11 @@ import json
 import logging
 import os
 import sys
+import warnings
 from typing import Optional
 
 import pendulum
+import rich
 from sqlalchemy import create_engine, exc
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -91,6 +93,17 @@ STATE_COLORS = {
     "skipped": "pink",
     "scheduled": "tan",
 }
+
+
+def custom_show_warning(message, category, filename, lineno, file=None, line=None):
+    """Custom function to print rich and visible warnings"""
+    msg = f"[bold]{line}" if line else f"[bold][yellow]{filename}:{lineno}"
+    msg += f" {category.__name__}[/bold]: {message}[/yellow]"
+    file = file or sys.stderr
+    rich.print(msg, file=file)
+
+
+warnings.showwarning = custom_show_warning
 
 
 def policy(task):  # pylint: disable=unused-argument

--- a/setup.py
+++ b/setup.py
@@ -743,6 +743,7 @@ INSTALL_REQUIREMENTS = [
     'python-nvd3~=0.15.0',
     'python-slugify>=3.0.0,<5.0',
     'requests>=2.20.0, <3',
+    'rich>=9.2.0',
     'setproctitle>=1.1.8, <2',
     'sqlalchemy>=1.3.18, <2',
     'sqlalchemy_jsonfield~=0.9',

--- a/setup.py
+++ b/setup.py
@@ -743,7 +743,7 @@ INSTALL_REQUIREMENTS = [
     'python-nvd3~=0.15.0',
     'python-slugify>=3.0.0,<5.0',
     'requests>=2.20.0, <3',
-    'rich>=9.2.0',
+    'rich==9.2.0',
     'setproctitle>=1.1.8, <2',
     'sqlalchemy>=1.3.18, <2',
     'sqlalchemy_jsonfield~=0.9',


### PR DESCRIPTION
This PR proposes using custom `showwarning` function that provides users with better information about warnings using [rich](https://github.com/willmcgugan/rich) library to highlight the warning.

I think this makes harder to miss a warning especially the deprecation ones. I decided to use `rich` as it may be used in future for enhancing other outputs (see https://github.com/apache/airflow/pull/11259#issuecomment-703109966).

## Before

<img width="828" alt="Screenshot 2020-11-09 at 16 34 47" src="https://user-images.githubusercontent.com/9528307/98564802-1f046380-22ad-11eb-9996-65918858e468.png">

## After

<img width="828" alt="Screenshot 2020-11-09 at 16 34 22" src="https://user-images.githubusercontent.com/9528307/98564793-1ad84600-22ad-11eb-8832-e60976e2e33a.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
