### PR TITLE
Remove redundant parenthesis

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1504,7 +1504,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
             response = self.render_template(
                 'airflow/confirm.html',
-                message=("Here's the list of task instances you are about to clear:"),
+                message="Here's the list of task instances you are about to clear:",
                 details=details,
             )
 
@@ -1773,7 +1773,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         response = self.render_template(
             "airflow/confirm.html",
-            message=(f"Here's the list of task instances you are about to mark as {state}:"),
+            message=f"Here's the list of task instances you are about to mark as {state}:",
             details=details,
         )
 


### PR DESCRIPTION

Example:
```diff
- ("Here's the list of task instances you are about to clear:"),
+ "Here's the list of task instances you are about to clear:",
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
