### PR TITLE
Remove Unnecessary comprehension

### DIFF
--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -301,9 +301,7 @@ def remap_permissions():
         if not appbuilder.sm.find_permission(old_perm_name):
             continue
         view_menus = appbuilder.sm.get_all_view_menu()
-        if not any(
-            appbuilder.sm.find_permission_view_menu(old_perm_name, view.name) for view in view_menus
-        ):
+        if not any(appbuilder.sm.find_permission_view_menu(old_perm_name, view.name) for view in view_menus):
             appbuilder.sm.del_permission(old_perm_name)
 
 

--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -302,7 +302,7 @@ def remap_permissions():
             continue
         view_menus = appbuilder.sm.get_all_view_menu()
         if not any(
-            [appbuilder.sm.find_permission_view_menu(old_perm_name, view.name) for view in view_menus]
+            appbuilder.sm.find_permission_view_menu(old_perm_name, view.name) for view in view_menus
         ):
             appbuilder.sm.del_permission(old_perm_name)
 

--- a/dev/import_all_classes.py
+++ b/dev/import_all_classes.py
@@ -57,7 +57,7 @@ def import_all_classes(
     def onerror(_):
         nonlocal tracebacks
         exception_string = traceback.format_exc()
-        if any([provider_prefix in exception_string for provider_prefix in provider_prefixes]):
+        if any(provider_prefix in exception_string for provider_prefix in provider_prefixes):
             tracebacks.append(exception_string)
 
     for modinfo in pkgutil.walk_packages(path=paths, prefix=prefix, onerror=onerror):


### PR DESCRIPTION
The inbuilt functions all() and any() in python support
short-circuiting (evaluation stops as soon as the overall return value
of the function is known), but this behaviour is lost if you use
comprehension. This affects performance.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
