### PR TITLE
Sign release files with an apache.org key by default

### DIFF
--- a/dev/sign.sh
+++ b/dev/sign.sh
@@ -23,8 +23,12 @@ set -euo pipefail
 # you will still be required to type in your signing key password
 # or it needs to be available in your keychain
 
+# Which key to sign releases with? This can be a (partial) email address or a
+# key id. By default use any apache.org key
+SIGN_WITH="${SIGN_WITH:-apache.org}"
+
 for name in "${@}"
 do
-    gpg --armor --output "${name}.asc" --detach-sig "${name}"
+    gpg --armor --local-user "$SIGN_WITH" --output "${name}.asc" --detach-sig "${name}"
     gpg --print-md SHA512 "${name}" > "${name}.sha512"
 done


### PR DESCRIPTION
If you have more than a single private key in your GPG trust store, gpg
will use the first one, which for me is not right.

This changes the script to by default use any key with `apache.org` in
the name. This is a patch I've been carrying locally for about 8
releases now :D


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).