### PR TITLE
Bugfix: Handle naive datetimes in REST API

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -218,8 +218,10 @@ def post_dag_run(dag_id, session):
     """Trigger a DAG."""
     if not session.query(DagModel).filter(DagModel.dag_id == dag_id).first():
         raise NotFound(title="DAG not found", detail=f"DAG with dag_id: '{dag_id}' not found")
-
-    post_body = dagrun_schema.load(request.json, session=session)
+    try:
+        post_body = dagrun_schema.load(request.json, session=session)
+    except ValidationError as err:
+        raise BadRequest(detail=str(err))
     dagrun_instance = (
         session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.run_id == post_body["run_id"]).first()
     )

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -24,6 +24,12 @@ from airflow.configuration import conf
 from airflow.utils import timezone
 
 
+def validate_istimezone(value):
+    """Validates that a datetime is not naive"""
+    if not value.tzinfo:
+        raise BadRequest("Invalid datetime format", detail="Naive datetime is disallowed")
+
+
 def format_datetime(value: str):
     """
     Datetime format parser for args since connexion doesn't parse datetimes

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -22,6 +22,7 @@ from marshmallow import fields, pre_load
 from marshmallow.schema import Schema
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
+from airflow.api_connexion.parameters import validate_istimezone
 from airflow.api_connexion.schemas.enum_schemas import DagStateField
 from airflow.models.dagrun import DagRun
 from airflow.utils import timezone
@@ -53,7 +54,7 @@ class DAGRunSchema(SQLAlchemySchema):
 
     run_id = auto_field(data_key='dag_run_id')
     dag_id = auto_field(dump_only=True)
-    execution_date = auto_field()
+    execution_date = auto_field(validate=validate_istimezone)
     start_date = auto_field(dump_only=True)
     end_date = auto_field(dump_only=True)
     state = DagStateField(dump_only=True)
@@ -98,12 +99,12 @@ class DagRunsBatchFormSchema(Schema):
     page_offset = fields.Int(missing=0, min=0)
     page_limit = fields.Int(missing=100, min=1)
     dag_ids = fields.List(fields.Str(), missing=None)
-    execution_date_gte = fields.DateTime(missing=None)
-    execution_date_lte = fields.DateTime(missing=None)
-    start_date_gte = fields.DateTime(missing=None)
-    start_date_lte = fields.DateTime(missing=None)
-    end_date_gte = fields.DateTime(missing=None)
-    end_date_lte = fields.DateTime(missing=None)
+    execution_date_gte = fields.DateTime(missing=None, validate=validate_istimezone)
+    execution_date_lte = fields.DateTime(missing=None, validate=validate_istimezone)
+    start_date_gte = fields.DateTime(missing=None, validate=validate_istimezone)
+    start_date_lte = fields.DateTime(missing=None, validate=validate_istimezone)
+    end_date_gte = fields.DateTime(missing=None, validate=validate_istimezone)
+    end_date_lte = fields.DateTime(missing=None, validate=validate_istimezone)
 
 
 dagrun_schema = DAGRunSchema()

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -20,6 +20,7 @@ from typing import List, NamedTuple, Optional, Tuple
 from marshmallow import Schema, ValidationError, fields, validate, validates_schema
 from marshmallow.utils import get_value
 
+from airflow.api_connexion.parameters import validate_istimezone
 from airflow.api_connexion.schemas.enum_schemas import TaskInstanceStateField
 from airflow.api_connexion.schemas.sla_miss_schema import SlaMissSchema
 from airflow.models import SlaMiss, TaskInstance
@@ -31,9 +32,9 @@ class TaskInstanceSchema(Schema):
 
     task_id = fields.Str()
     dag_id = fields.Str()
-    execution_date = fields.DateTime()
-    start_date = fields.DateTime()
-    end_date = fields.DateTime()
+    execution_date = fields.DateTime(validate=validate_istimezone)
+    start_date = fields.DateTime(validate=validate_istimezone)
+    end_date = fields.DateTime(validate=validate_istimezone)
     duration = fields.Float()
     state = TaskInstanceStateField()
     _try_number = fields.Int(data_key="try_number")
@@ -80,12 +81,12 @@ class TaskInstanceBatchFormSchema(Schema):
     page_offset = fields.Int(missing=0, min=0)
     page_limit = fields.Int(missing=100, min=1)
     dag_ids = fields.List(fields.Str(), missing=None)
-    execution_date_gte = fields.DateTime(missing=None)
-    execution_date_lte = fields.DateTime(missing=None)
-    start_date_gte = fields.DateTime(missing=None)
-    start_date_lte = fields.DateTime(missing=None)
-    end_date_gte = fields.DateTime(missing=None)
-    end_date_lte = fields.DateTime(missing=None)
+    execution_date_gte = fields.DateTime(missing=None, validate=validate_istimezone)
+    execution_date_lte = fields.DateTime(missing=None, validate=validate_istimezone)
+    start_date_gte = fields.DateTime(missing=None, validate=validate_istimezone)
+    start_date_lte = fields.DateTime(missing=None, validate=validate_istimezone)
+    end_date_gte = fields.DateTime(missing=None, validate=validate_istimezone)
+    end_date_lte = fields.DateTime(missing=None, validate=validate_istimezone)
     duration_gte = fields.Int(missing=None)
     duration_lte = fields.Int(missing=None)
     state = fields.List(fields.Str(), missing=None)
@@ -97,8 +98,8 @@ class ClearTaskInstanceFormSchema(Schema):
     """Schema for handling the request of clearing task instance of a Dag"""
 
     dry_run = fields.Boolean(default=True)
-    start_date = fields.DateTime(missing=None)
-    end_date = fields.DateTime(missing=None)
+    start_date = fields.DateTime(missing=None, validate=validate_istimezone)
+    end_date = fields.DateTime(missing=None, validate=validate_istimezone)
     only_failed = fields.Boolean(missing=True)
     only_running = fields.Boolean(missing=False)
     include_subdags = fields.Boolean(missing=False)
@@ -120,7 +121,7 @@ class SetTaskInstanceStateFormSchema(Schema):
 
     dry_run = fields.Boolean(default=True)
     task_id = fields.Str(required=True)
-    execution_date = fields.DateTime(required=True)
+    execution_date = fields.DateTime(required=True, validate=validate_istimezone)
     include_upstream = fields.Boolean(required=True)
     include_downstream = fields.Boolean(required=True)
     include_future = fields.Boolean(required=True)

--- a/tests/api_connexion/test_parameters.py
+++ b/tests/api_connexion/test_parameters.py
@@ -22,9 +22,29 @@ from pendulum import DateTime
 from pendulum.tz.timezone import Timezone
 
 from airflow.api_connexion.exceptions import BadRequest
-from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
+from airflow.api_connexion.parameters import (
+    check_limit,
+    format_datetime,
+    format_parameters,
+    validate_istimezone,
+)
 from airflow.utils import timezone
 from tests.test_utils.config import conf_vars
+
+
+class TestValidateIsTimezone(unittest.TestCase):
+    def setUp(self) -> None:
+        from datetime import datetime
+
+        self.naive = datetime.now()
+        self.timezoned = datetime.now(tz=timezone.utc)
+
+    def test_gives_400_for_naive(self):
+        with self.assertRaises(BadRequest):
+            validate_istimezone(self.naive)
+
+    def test_timezone_passes(self):
+        assert validate_istimezone(self.timezoned) is None
 
 
 class TestDateTimeParser(unittest.TestCase):


### PR DESCRIPTION
Close: #12201

Triggering a dag run with naive datetime returns an HTML page instead of json.
Also Invalid datetime returns an HTML page.
Same issue when making requests against Dagruns batch endpoint, Taskinstances batch, set and clear endpoints.

This PR fixes it

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
