### PR TITLE
Remove providers imports from core examples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -297,7 +297,7 @@ repos:
       - id: no-providers-in-core-examples
         language: pygrep
         name: No providers imports in core example DAGs
-        description: The core example DAGs have to no dependencies other than core Airflow
+        description: The core example DAGs have no dependencies other than core Airflow
         entry: "^\\s*from airflow.providers.*"
         pass_filenames: true
         files: ^airflow/example_dags/.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -298,7 +298,7 @@ repos:
         language: pygrep
         name: No providers imports in core example DAGs
         description: The core example DAGs have no dependencies other than core Airflow
-        entry: "^\\s*from airflow.providers.*"
+        entry: "^\\s*from airflow\\.providers.*"
         pass_filenames: true
         files: ^airflow/example_dags/.*\.py$
       - id: no-relative-imports

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -294,6 +294,13 @@ repos:
         entry: "\\|\\s*safe"
         files: \.html$
         pass_filenames: true
+      - id: no-providers-in-core-examples
+        language: pygrep
+        name: No providers imports in core example DAGs
+        description: The core example DAGs have to no dependencies other than core Airflow
+        entry: "^\\s*from airflow.providers.*"
+        pass_filenames: true
+        files: ^airflow/example_dags/.*\.py$
       - id: no-relative-imports
         language: pygrep
         name: No relative imports
@@ -394,12 +401,6 @@ repos:
         pass_filenames: false
         require_serial: true
         additional_dependencies: ['pyyaml']
-      - id: pre-commit-descriptions
-        name: Check if pre-commits are described
-        entry: ./scripts/ci/pre_commit/pre_commit_check_pre_commits.sh
-        language: system
-        files: ^.pre-commit-config.yaml$|^STATIC_CODE_CHECKS.rst|^breeze-complete$
-        require_serial: true
       - id: sort-in-the-wild
         name: Sort INTHEWILD.md alphabetically
         entry: ./scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2007,11 +2007,12 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  dont-use-safe-filter end-of-file-fixer fix-encoding-pragma flake8 forbid-tabs
                  helm-lint incorrect-use-of-LoggingMixin insert-license isort language-matters
                  lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
-                 no-relative-imports pre-commit-descriptions provide-create-sessions
-                 providers-init-file pydevd pydocstyle pylint pylint-tests python-no-log-warn
-                 pyupgrade restrict-start_date rst-backticks setup-order setup-installation
-                 shellcheck sort-in-the-wild stylelint trailing-whitespace update-breeze-file
-                 update-extras update-local-yml-file update-setup-cfg-file version-sync yamllint
+                 no-providers-in-core-examples no-relative-imports pre-commit-descriptions
+                 provide-create-sessions providers-init-file pydevd pydocstyle pylint pylint-tests
+                 python-no-log-warn pyupgrade restrict-start_date rst-backticks setup-order
+                 setup-installation shellcheck sort-in-the-wild stylelint trailing-whitespace
+                 update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
+                 version-sync yamllint
 
         You can pass extra arguments including options to to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -88,6 +88,8 @@ require Breeze Docker images to be installed locally:
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``dont-use-safe-filter``              Don't use safe in templates.
 ----------------------------------- ---------------------------------------------------------------- ------------
+``no-providers-in-core-examples``     Don't use providers imports in core example DAGs
+----------------------------------- ---------------------------------------------------------------- ------------
 ``no-relative-imports``               Use absolute imports, not relative
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``end-of-file-fixer``                 Makes sure that there is an empty line at the end.

--- a/airflow/operators/email.py
+++ b/airflow/operators/email.py
@@ -47,6 +47,7 @@ class EmailOperator(BaseOperator):
     """
 
     template_fields = ('to', 'subject', 'html_content')
+    template_fields_renderers = {"html_content": "html"}
     template_ext = ('.html',)
     ui_color = '#e6faf9'
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -69,6 +69,7 @@ class PythonOperator(BaseOperator):
     """
 
     template_fields = ('templates_dict', 'op_args', 'op_kwargs')
+    template_fields_renderers = {"templates_dict": "json", "op_args": "py", "op_kwargs": "py"}
     ui_color = '#ffefeb'
 
     # since we won't mutate the arguments, we should just do the shallow copy
@@ -145,6 +146,8 @@ class _PythonDecoratedOperator(BaseOperator):
     """
 
     template_fields = ('op_args', 'op_kwargs')
+    template_fields_renderers = {"op_args": "py", "op_kwargs": "py"}
+
     ui_color = PythonOperator.ui_color
 
     # since we won't mutate the arguments, we should just do the shallow copy

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -336,6 +336,7 @@ def get_attr_renderer():
         'bash': lambda x: render(x, lexers.BashLexer),
         'bash_command': lambda x: render(x, lexers.BashLexer),
         'hql': lambda x: render(x, lexers.SqlLexer),
+        'html': lambda x: render(x, lexers.HtmlLexer),
         'sql': lambda x: render(x, lexers.SqlLexer),
         'doc': lambda x: render(x, lexers.TextLexer),
         'doc_json': lambda x: render(x, lexers.JsonLexer),

--- a/breeze-complete
+++ b/breeze-complete
@@ -103,6 +103,7 @@ mermaid
 mixed-line-ending
 mypy
 mypy-helm
+no-providers-in-core-examples
 no-relative-imports
 pre-commit-descriptions
 provide-create-sessions


### PR DESCRIPTION
Core example DAGs should not depend on any non-core dependency
like providers packages.

I also added a pre-commit check to avoid regression:
```
➜ pre-commit run no-providers-in-core-examples --all-files
No providers imports in core example DAGs................................Failed
- hook id: no-providers-in-core-examples
- exit code: 1

airflow/example_dags/example_dag_decorator.py:25:from airflow.providers.http.operators.http import SimpleHttpOperator
```

closes: #12247

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
