### PR TITLE
Fix pause/unpause toggle failed state when unsuccessful

### DIFF
--- a/airflow/www/static/css/switch.css
+++ b/airflow/www/static/css/switch.css
@@ -73,12 +73,20 @@
   box-shadow: 0 0 0 3px rgba(1, 124, 238, 0.4);
 }
 
-.switch-input:focus + .switch::before {
-  background-color: #fff;
-}
-
 .switch-input:not(:checked) + .switch:hover {
   background-color: #9e9e9c;
+}
+
+.switch-input:checked.switch-input--error + .switch {
+  background-color: #e43921;
+}
+
+.switch-input:not(:checked).switch-input--error + .switch {
+  background-color: #824840;
+}
+
+.switch-input:focus + .switch::before {
+  background-color: #fff;
 }
 
 .switch-input:not(:checked) + .switch:hover::before {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -45,7 +45,7 @@
         <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
       {% else %}
         <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
-          <input class="switch-input" id="pause_resume" dag_id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }} method="post">
+          <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }}>
           <span class="switch" aria-hidden="true"></span>
         </label>
         <span class="text-muted">DAG:</span> {{ dag.dag_id }}
@@ -596,23 +596,16 @@
     });
 
     $('#pause_resume').change(function() {
-      var dag_id = $(this).attr('dag_id');
       var $input = $(this);
-      var $buttons = $input.parent('.toggle').find('.btn');
-      $buttons.removeClass('btn-danger');
-      if ($input.prop('checked')) {
-        is_paused = 'true'
-      } else {
-        is_paused = 'false'
-      }
-      var url = '{{ url_for('Airflow.paused') }}' + '?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
+      var dagId = $input.data('dag-id');
+      var isPaused = $input.is(':checked');
+      var url = `{{ url_for('Airflow.paused') }}?is_paused=${isPaused}&dag_id=${encodeURIComponent(dagId)}`;
+      $input.removeClass('switch-input--error');
       $.post(url).fail(function() {
-        if (is_paused === 'true') {
-          $input.data('bs.toggle').off(true);
-        } else {
-          $input.data('bs.toggle').on(true);
-        }
-        $buttons.addClass('btn-danger');
+        setTimeout(() => {
+          $input.prop('checked', !isPaused);
+          $input.addClass('switch-input--error');
+        }, 500 );
       });
     });
   </script>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -104,7 +104,7 @@
                 {# Column 1: Turn dag on/off #}
                 <td style="padding-right:0;">
                   <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
-                    <input class="switch-input" id="toggle-{{ dag.dag_id }}" dag_id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }} method="post">
+                    <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }}>
                     <span class="switch" aria-hidden="true"></span>
                   </label>
                 </td>
@@ -302,27 +302,20 @@
 
     var encoded_dag_ids = new URLSearchParams();
 
-    $.each($('[id^=toggle]'), function(i, v) {
-      var $input = $(v);
-      var dag_id = $input.attr('dag_id');
-      encoded_dag_ids.append('dag_ids', dag_id);
+    $.each($('[id^=toggle]'), function() {
+      var $input = $(this);
+      var dagId = $input.data('dag-id');
+      encoded_dag_ids.append('dag_ids', dagId);
 
       $input.change(function() {
-        var $buttons = $input.parent('.toggle').find('.btn');
-        $buttons.removeClass('btn-danger');
-        if ($input.prop('checked')) {
-          is_paused = 'true'
-        } else {
-          is_paused = 'false'
-        }
-        var url = 'paused?is_paused=' + is_paused + '&dag_id=' + encodeURIComponent(dag_id);
+        var isPaused = $input.is(':checked');
+        var url = `{{ url_for('Airflow.paused') }}?is_paused=${isPaused}&dag_id=${encodeURIComponent(dagId)}`;
+        $input.removeClass('switch-input--error');
         $.post(url).fail(function() {
-          if (is_paused === 'true') {
-            $input.data('bs.toggle').off(true);
-          } else {
-            $input.data('bs.toggle').on(true);
-          }
-          $buttons.addClass('btn-danger');
+          setTimeout(() => {
+            $input.prop('checked', !isPaused);
+            $input.addClass('switch-input--error');
+          }, 500 );
         });
       });
     });


### PR DESCRIPTION
Fixes a regression that broke the failed toggle state originally added in #7669. The regression was introduced by my toggle overhaul in #11035 where I overlooked (wasn't aware of) this functionality.

Here's what this failed state looks like when request is unsuccessful:

![Screen Recording 2020-11-10 at 01 54 08 PM](https://user-images.githubusercontent.com/3267/98728275-4586d500-2367-11eb-83a8-ee73b49c99a8.gif)

This should be cherry-picked into 2.0.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
