### PR TITLE
Fix: Conditionally update button URL only when it is present

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -425,11 +425,13 @@
         execution_date: execution_date,
       });
 
-      updateButtonUrl(buttons.rendered_k8s, {
-        dag_id: dag_id,
-        task_id: task_id,
-        execution_date: execution_date,
-      });
+      if (buttons.rendered_k8s) {
+        updateButtonUrl(buttons.rendered_k8s, {
+          dag_id: dag_id,
+          task_id: task_id,
+          execution_date: execution_date,
+        });
+      }
 
       updateButtonUrl(buttons.ti, {
         flt1_dag_id_equals: dag_id,


### PR DESCRIPTION
Resolves #12254

A bug introduced in #11815. The function that updates the button URLs was failing when trying to update the "K8s Pod Spec" which is conditionally displayed (`if k8s_or_k8scelery_executor`). This fix adds a check to confirm the button exists before attempting.

This should be cherry-picked into 2.0

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
