### PR TITLE
Fix - TestSchedulerJobQueriesCount::test_process_dags_queries_count

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3746,35 +3746,35 @@ class TestSchedulerJobQueriesCount(unittest.TestCase):
             # pylint: disable=bad-whitespace
             # expected, dag_count, task_count, start_ago, schedule_interval, shape
             # One DAG with one task per DAG file
-            ([10, 10, 10, 10], 1, 1, "1d", "None", "no_structure"),  # noqa
-            ([10, 10, 10, 10], 1, 1, "1d", "None", "linear"),  # noqa
-            ([22, 14, 14, 14], 1, 1, "1d", "@once", "no_structure"),  # noqa
-            ([22, 14, 14, 14], 1, 1, "1d", "@once", "linear"),  # noqa
-            ([22, 24, 27, 30], 1, 1, "1d", "30m", "no_structure"),  # noqa
-            ([22, 24, 27, 30], 1, 1, "1d", "30m", "linear"),  # noqa
-            ([22, 24, 27, 30], 1, 1, "1d", "30m", "binary_tree"),  # noqa
-            ([22, 24, 27, 30], 1, 1, "1d", "30m", "star"),  # noqa
-            ([22, 24, 27, 30], 1, 1, "1d", "30m", "grid"),  # noqa
+            ([8, 8, 8, 8], 1, 1, "1d", "None", "no_structure"),  # noqa
+            ([8, 8, 8, 8], 1, 1, "1d", "None", "linear"),  # noqa
+            ([20, 11, 11, 11], 1, 1, "1d", "@once", "no_structure"),  # noqa
+            ([20, 11, 11, 11], 1, 1, "1d", "@once", "linear"),  # noqa
+            ([20, 21, 23, 25], 1, 1, "1d", "30m", "no_structure"),  # noqa
+            ([20, 21, 23, 25], 1, 1, "1d", "30m", "linear"),  # noqa
+            ([20, 21, 23, 25], 1, 1, "1d", "30m", "binary_tree"),  # noqa
+            ([20, 21, 23, 25], 1, 1, "1d", "30m", "star"),  # noqa
+            ([20, 21, 23, 25], 1, 1, "1d", "30m", "grid"),  # noqa
             # One DAG with five tasks per DAG  file
-            ([10, 10, 10, 10], 1, 5, "1d", "None", "no_structure"),  # noqa
-            ([10, 10, 10, 10], 1, 5, "1d", "None", "linear"),  # noqa
-            ([22, 14, 14, 14], 1, 5, "1d", "@once", "no_structure"),  # noqa
-            ([23, 15, 15, 15], 1, 5, "1d", "@once", "linear"),  # noqa
-            ([22, 24, 27, 30], 1, 5, "1d", "30m", "no_structure"),  # noqa
-            ([23, 26, 30, 34], 1, 5, "1d", "30m", "linear"),  # noqa
-            ([23, 26, 30, 34], 1, 5, "1d", "30m", "binary_tree"),  # noqa
-            ([23, 26, 30, 34], 1, 5, "1d", "30m", "star"),  # noqa
-            ([23, 26, 30, 34], 1, 5, "1d", "30m", "grid"),  # noqa
+            ([8, 8, 8, 8], 1, 5, "1d", "None", "no_structure"),  # noqa
+            ([8, 8, 8, 8], 1, 5, "1d", "None", "linear"),  # noqa
+            ([20, 11, 11, 11], 1, 5, "1d", "@once", "no_structure"),  # noqa
+            ([21, 12, 12, 12], 1, 5, "1d", "@once", "linear"),  # noqa
+            ([20, 21, 23, 25], 1, 5, "1d", "30m", "no_structure"),  # noqa
+            ([21, 23, 26, 29], 1, 5, "1d", "30m", "linear"),  # noqa
+            ([21, 23, 26, 29], 1, 5, "1d", "30m", "binary_tree"),  # noqa
+            ([21, 23, 26, 29], 1, 5, "1d", "30m", "star"),  # noqa
+            ([21, 23, 26, 29], 1, 5, "1d", "30m", "grid"),  # noqa
             # 10 DAGs with 10 tasks per DAG file
-            ([10, 10, 10, 10], 10, 10, "1d", "None", "no_structure"),  # noqa
-            ([10, 10, 10, 10], 10, 10, "1d", "None", "linear"),  # noqa
-            ([85, 38, 38, 38], 10, 10, "1d", "@once", "no_structure"),  # noqa
-            ([95, 51, 51, 51], 10, 10, "1d", "@once", "linear"),  # noqa
-            ([85, 99, 99, 99], 10, 10, "1d", "30m", "no_structure"),  # noqa
-            ([95, 125, 125, 125], 10, 10, "1d", "30m", "linear"),  # noqa
-            ([95, 119, 119, 119], 10, 10, "1d", "30m", "binary_tree"),  # noqa
-            ([95, 119, 119, 119], 10, 10, "1d", "30m", "star"),  # noqa
-            ([95, 119, 119, 119], 10, 10, "1d", "30m", "grid"),  # noqa
+            ([8, 8, 8, 8], 10, 10, "1d", "None", "no_structure"),  # noqa
+            ([8, 8, 8, 8], 10, 10, "1d", "None", "linear"),  # noqa
+            ([83, 26, 26, 26], 10, 10, "1d", "@once", "no_structure"),  # noqa
+            ([93, 39, 39, 39], 10, 10, "1d", "@once", "linear"),  # noqa
+            ([83, 87, 87, 87], 10, 10, "1d", "30m", "no_structure"),  # noqa
+            ([93, 113, 113, 113], 10, 10, "1d", "30m", "linear"),  # noqa
+            ([93, 107, 107, 107], 10, 10, "1d", "30m", "binary_tree"),  # noqa
+            ([93, 107, 107, 107], 10, 10, "1d", "30m", "star"),  # noqa
+            ([93, 107, 107, 107], 10, 10, "1d", "30m", "grid"),  # noqa
             # pylint: enable=bad-whitespace
         ]
     )
@@ -3796,8 +3796,6 @@ class TestSchedulerJobQueriesCount(unittest.TestCase):
                 ('scheduler', 'use_job_schedule'): 'True',
                 ('core', 'store_serialized_dags'): 'True',
             }
-        ), mock.patch.object(
-            settings, 'STORE_SERIALIZED_DAGS', True
         ):
 
             dagbag = DagBag(dag_folder=ELASTIC_DAG_FILE, include_examples=False)


### PR DESCRIPTION
The first time this test was broken in the following commit.
406ed2925 Make Dag Serialization a hard requirement (#11335)
And the number of database queries has changed: Fortunately, it was optimization.
92e405e72 Call scheduler "book-keeping" operations less frequently. (#12139)

A few more tests look like they might be broken too:
https://github.com/apache/airflow/blob/92e405e72922cc569a2e41281df9d055c3a7855d/tests/jobs/test_scheduler_job.py#L1742
https://github.com/apache/airflow/blob/92e405e72922cc569a2e41281df9d055c3a7855d/tests/jobs/test_scheduler_job.py#L3712

Thanks to @potiuk  for creating the quarantine test list. This allowed me to see that the tests that had previously been only partially unstable. Now it was never successful.
https://github.com/apache/airflow/issues/10118

CC: @ashb @kaxil 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
