### PR TITLE
Don't wrap warrning messages when stderr is not a TTY

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import atexit
+import functools
 import json
 import logging
 import os
@@ -95,16 +96,23 @@ STATE_COLORS = {
 }
 
 
+@functools.lru_cache(maxsize=None)
+def _get_rich_console(file):
+    # Delay imports until we need it
+    import rich.console
+
+    return rich.console.Console(file=file)
+
+
 def custom_show_warning(message, category, filename, lineno, file=None, line=None):
     """Custom function to print rich and visible warnings"""
     # Delay imports until we need it
-    import rich
     from rich.markup import escape
 
     msg = f"[bold]{line}" if line else f"[bold][yellow]{filename}:{lineno}"
     msg += f" {category.__name__}[/bold]: {escape(str(message))}[/yellow]"
-    file = file or sys.stderr
-    rich.print(msg, file=file)
+    write_console = _get_rich_console(file or sys.stderr)
+    write_console.print(msg, soft_wrap=True)
 
 
 warnings.showwarning = custom_show_warning


### PR DESCRIPTION
If stderr is not a TTY, rich was hard-wrapping warning messages at 80 characters:

```
/home/ash/code/airflow/airflow/airflow/configuration.py:328 DeprecationWarning:
The remote_logging option in [core] has been moved to the remote_logging option
in [logging] - the old setting has been used, but please update your config.
```

After

```
/home/ash/code/airflow/airflow/airflow/configuration.py:328 DeprecationWarning: The remote_logging option in [core] has been moved to the remote_logging option in [logging] - the old setting has been used, but please update your config.
```

`rich.print()` doesn't take a `soft_wrap` option, so I had to create a `rich.console.Console` object -- and it seems best to cache those. (This is basically what `rich.print()` does internally).


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).