### PR TITLE
Fix indentation for affinities in helm chart

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -66,12 +66,9 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: {{ .Values.uid }}
-  nodeSelector:
-    {{ toYaml .Values.nodeSelector | indent 8 }}
-  affinity:
-    {{ toYaml .Values.affinity | indent 8 }}
-  tolerations:
-    {{ toYaml .Values.tolerations | indent 8 }}
+  nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
+  affinity: {{ toYaml .Values.affinity | nindent 4 }}
+  tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
   serviceAccountName: '{{ .Release.Name }}-worker'
   volumes:
   {{- if .Values.dags.persistence.enabled }}


### PR DESCRIPTION
This PR fixes a bug in the helm chart where custom affinities in
the pod_template_file cause the yaml to fail due to invalid spacing

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
