### PR TITLE
Remove deprecated BashTaskRunner

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -177,8 +177,7 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
     # about. Mapping of section -> setting -> { old, replace, by_version }
     deprecated_values = {
         'core': {
-            'task_runner': (re.compile(r'\ABashTaskRunner\Z'), r'StandardTaskRunner', '2.0'),
-            'hostname_callable': (re.compile(r':'), r'.', '2.0'),
+            'hostname_callable': (re.compile(r':'), r'.', '2.1'),
         },
         'webserver': {
             'navbar_color': (re.compile(r'\A#007A87\Z', re.IGNORECASE), '#fff', '2.1'),
@@ -187,7 +186,7 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
             'email_backend': (
                 re.compile(r'^airflow\.contrib\.utils\.sendgrid\.send_email$'),
                 r'airflow.providers.sendgrid.utils.emailer.send_email',
-                '2.0',
+                '2.1',
             ),
         },
     }

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -489,15 +489,13 @@ AIRFLOW_HOME = /root/airflow
             # lookup even if we remove this explicit fallback
             test_conf.deprecated_values = {
                 'core': {
-                    'task_runner': (re.compile(r'\ABashTaskRunner\Z'), r'StandardTaskRunner', '2.0'),
-                    'hostname_callable': (re.compile(r':'), r'.', '2.0'),
+                    'hostname_callable': (re.compile(r':'), r'.', '2.1'),
                 },
             }
             test_conf.read_dict(
                 {
                     'core': {
                         'executor': 'SequentialExecutor',
-                        'task_runner': 'BashTaskRunner',
                         'sql_alchemy_conn': 'sqlite://',
                         'hostname_callable': 'socket:getfqdn',
                     },
@@ -507,33 +505,21 @@ AIRFLOW_HOME = /root/airflow
 
         with self.assertWarns(FutureWarning):
             test_conf = make_config()
-            self.assertEqual(test_conf.get('core', 'task_runner'), 'StandardTaskRunner')
             self.assertEqual(test_conf.get('core', 'hostname_callable'), 'socket.getfqdn')
-
-        with self.assertWarns(FutureWarning):
-            with unittest.mock.patch.dict('os.environ', AIRFLOW__CORE__TASK_RUNNER='BashTaskRunner'):
-                test_conf = make_config()
-
-                self.assertEqual(test_conf.get('core', 'task_runner'), 'StandardTaskRunner')
 
         with self.assertWarns(FutureWarning):
             with unittest.mock.patch.dict('os.environ', AIRFLOW__CORE__HOSTNAME_CALLABLE='socket:getfqdn'):
                 test_conf = make_config()
-
                 self.assertEqual(test_conf.get('core', 'hostname_callable'), 'socket.getfqdn')
 
         with reset_warning_registry():
             with warnings.catch_warnings(record=True) as warning:
                 with unittest.mock.patch.dict(
                     'os.environ',
-                    AIRFLOW__CORE__TASK_RUNNER='NotBashTaskRunner',
                     AIRFLOW__CORE__HOSTNAME_CALLABLE='CarrierPigeon',
                 ):
                     test_conf = make_config()
-
-                    self.assertEqual(test_conf.get('core', 'task_runner'), 'NotBashTaskRunner')
                     self.assertEqual(test_conf.get('core', 'hostname_callable'), 'CarrierPigeon')
-
                     self.assertListEqual([], warning)
 
     def test_deprecated_funcs(self):


### PR DESCRIPTION
This commit:

- Remove support for BashTaskRunner, this task_runner was deprecated from
Airflow 1.10.3 (https://github.com/apache/airflow/blob/1.10.3/UPDATING.md#rename-of-bashtaskrunner-to-standardtaskrunner)

- Support deprecated `hostname_callable` & `email_backend` until 2.1 since it has not been deprecated in any released Airflow versions

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
