### PR TITLE
Remove deprecated Elasticsearch Configs

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -137,13 +137,6 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
     # When reading new option, the old option will be checked to see if it exists. If it does a
     # DeprecationWarning will be issued and the old option will be used instead
     deprecated_options = {
-        ('elasticsearch', 'host'): ('elasticsearch', 'elasticsearch_host'),
-        ('elasticsearch', 'log_id_template'): ('elasticsearch', 'elasticsearch_log_id_template'),
-        ('elasticsearch', 'end_of_log_mark'): ('elasticsearch', 'elasticsearch_end_of_log_mark'),
-        ('elasticsearch', 'frontend'): ('elasticsearch', 'elasticsearch_frontend'),
-        ('elasticsearch', 'write_stdout'): ('elasticsearch', 'elasticsearch_write_stdout'),
-        ('elasticsearch', 'json_format'): ('elasticsearch', 'elasticsearch_json_format'),
-        ('elasticsearch', 'json_fields'): ('elasticsearch', 'elasticsearch_json_fields'),
         ('logging', 'base_log_folder'): ('core', 'base_log_folder'),
         ('logging', 'remote_logging'): ('core', 'remote_logging'),
         ('logging', 'remote_log_conn_id'): ('core', 'remote_log_conn_id'),


### PR DESCRIPTION
Since Airflow 1.10.4 we have removed `elasticsearch_` prefix from all
config items under `[elasticsearch]` section. It is time we remove them
from 2.0.

https://github.com/apache/airflow/blob/1.10.4/UPDATING.md#changes-in-writing-logs-to-elasticsearch

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
