### PR TITLE
Add reference for SubDagOperator in docs

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -82,7 +82,7 @@ scope.
     my_function()
 
 Sometimes this can be put to good use. For example, a common pattern with
-``SubDagOperator`` is to define the subdag inside a function so that Airflow
+:class:`~airflow.operators.subdag_operator.SubDagOperator` is to define the subdag inside a function so that Airflow
 doesn't try to load it as a standalone DAG.
 
 .. _default-args:
@@ -946,7 +946,7 @@ This SubDAG can then be referenced in your main DAG file:
     :start-after: [START example_subdag_operator]
     :end-before: [END example_subdag_operator]
 
-You can zoom into a SubDagOperator from the graph view of the main DAG to show
+You can zoom into a :class:`~airflow.operators.subdag_operator.SubDagOperator` from the graph view of the main DAG to show
 the tasks contained within the SubDAG:
 
 .. image:: img/subdag_zoom.png
@@ -960,8 +960,8 @@ Some other tips when using SubDAGs:
 -  SubDAGs must have a schedule and be enabled. If the SubDAG's schedule is
    set to ``None`` or ``@once``, the SubDAG will succeed without having done
    anything
--  clearing a SubDagOperator also clears the state of the tasks within
--  marking success on a SubDagOperator does not affect the state of the tasks
+-  clearing a :class:`~airflow.operators.subdag_operator.SubDagOperator` also clears the state of the tasks within
+-  marking success on a :class:`~airflow.operators.subdag_operator.SubDagOperator` does not affect the state of the tasks
    within
 -  refrain from using ``depends_on_past=True`` in tasks within the SubDAG as
    this can be confusing
@@ -973,16 +973,16 @@ Some other tips when using SubDAGs:
 
 See ``airflow/example_dags`` for a demonstration.
 
-Note that airflow pool is not honored by SubDagOperator. Hence resources could be
-consumed by SubdagOperators.
+Note that airflow pool is not honored by :class:`~airflow.operators.subdag_operator.SubDagOperator`. Hence
+resources could be consumed by SubdagOperators.
 
 
 TaskGroup
 =========
 TaskGroup can be used to organize tasks into hierarchical groups in Graph View. It is
-useful for creating repeating patterns and cutting down visual clutter. Unlike SubDagOperator,
-TaskGroup is a UI grouping concept. Tasks in TaskGroups live on the same original DAG. They
-honor all the pool configurations.
+useful for creating repeating patterns and cutting down visual clutter. Unlike
+:class:`~airflow.operators.subdag_operator.SubDagOperator`, TaskGroup is a UI grouping concept.
+Tasks in TaskGroups live on the same original DAG. They honor all the pool configurations.
 
 Dependency relationships can be applied across all tasks in a TaskGroup with the ``>>`` and ``<<``
 operators. For example, the following code puts ``task1`` and ``task2`` in TaskGroup ``group1``


### PR DESCRIPTION
It would be better for users to have a link when they see SubDagOperator where they can read about it instead of just Class names

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
