### PR TITLE
K8s yaml templates not rendered by k8sexecutor

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -396,6 +396,7 @@ class PodGenerator:
                         name="base",
                         command=command,
                         image=image,
+                        env=[k8s.V1EnvVar(name="AIRFLOW_IS_K8S_EXECUTOR_POD", value="True")],
                     )
                 ]
             ),

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -51,7 +51,7 @@ class RenderedTaskInstanceFields(Base):
         self.ti = ti
         if render_templates:
             ti.render_templates()
-        if os.environ["AIRFLOW_IS_K8S_EXECUTOR_POD"]:
+        if os.environ.get("AIRFLOW_IS_K8S_EXECUTOR_POD", None):
             self.k8s_pod_yaml = ti.render_k8s_pod_yaml()
         self.rendered_fields = {
             field: serialize_template_field(getattr(self.task, field)) for field in self.task.template_fields

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -103,7 +103,7 @@ class RenderedTaskInstanceFields(Base):
             )
             .one_or_none()
         )
-        return result.k8s_pod_yaml if result else ti.render_k8s_pod_yaml()
+        return result.k8s_pod_yaml if result else None
 
     @provide_session
     def write(self, session: Session = None):

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1671,7 +1671,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         rendered_k8s_spec = RenderedTaskInstanceFields.get_k8s_pod_yaml(self)
         if not rendered_k8s_spec:
             try:
-                self.render_k8s_pod_yaml()
+                rendered_k8s_spec = self.render_k8s_pod_yaml()
             except (TemplateAssertionError, UndefinedError) as e:
                 raise AirflowException(f"Unable to render a k8s spec for this taskinstance: {e}") from e
         return rendered_k8s_spec

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -19,10 +19,8 @@
 function kind::get_kind_cluster_name() {
     # Name of the KinD cluster to connect to
     export KIND_CLUSTER_NAME=${KIND_CLUSTER_NAME:="airflow-python-${PYTHON_MAJOR_MINOR_VERSION}-${KUBERNETES_VERSION}"}
-    readonly KIND_CLUSTER_NAME
     # Name of the KinD cluster to connect to when referred to via kubectl
     export KUBECTL_CLUSTER_NAME=kind-${KIND_CLUSTER_NAME}
-    readonly KUBECTL_CLUSTER_NAME
     export KUBECONFIG="${BUILD_CACHE_DIR}/.kube/config"
     mkdir -pv "${BUILD_CACHE_DIR}/.kube/"
     touch "${KUBECONFIG}"

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -365,7 +365,6 @@ class TestPodGenerator(unittest.TestCase):
                         image='',
                         name='name',
                         command=['/bin/command2.sh', 'arg2'],
-                        env=[],
                         volume_mounts=[
                             k8s.V1VolumeMount(mount_path="/foo/", name="example-kubernetes-test-volume2")
                         ],

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -127,10 +127,6 @@ class TestPodGenerator(unittest.TestCase):
                                     secret_key_ref=k8s.V1SecretKeySelector(name='secret_b', key='source_b')
                                 ),
                             ),
-                            k8s.V1EnvVar(
-                                name="AIRFLOW_IS_K8S_EXECUTOR_POD",
-                                value='True',
-                            ),
                         ],
                         env_from=[
                             k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name='configmap_a')),
@@ -369,6 +365,7 @@ class TestPodGenerator(unittest.TestCase):
                         image='',
                         name='name',
                         command=['/bin/command2.sh', 'arg2'],
+                        env=[],
                         volume_mounts=[
                             k8s.V1VolumeMount(mount_path="/foo/", name="example-kubernetes-test-volume2")
                         ],
@@ -444,6 +441,12 @@ class TestPodGenerator(unittest.TestCase):
         expected.spec.containers[0].command = ['command']
         expected.spec.containers[0].image = 'airflow_image'
         expected.spec.containers[0].resources = {'limits': {'cpu': '1m', 'memory': '1G'}}
+        expected.spec.containers[0].env.append(
+            k8s.V1EnvVar(
+                name="AIRFLOW_IS_K8S_EXECUTOR_POD",
+                value='True',
+            )
+        )
         result_dict = self.k8s_client.sanitize_for_serialization(result)
         expected_dict = self.k8s_client.sanitize_for_serialization(self.expected)
 
@@ -477,6 +480,9 @@ class TestPodGenerator(unittest.TestCase):
         worker_config.metadata.labels['app'] = 'myapp'
         worker_config.metadata.name = 'pod_id-' + self.static_uuid.hex
         worker_config.metadata.namespace = 'namespace'
+        worker_config.spec.containers[0].env.append(
+            k8s.V1EnvVar(name="AIRFLOW_IS_K8S_EXECUTOR_POD", value='True')
+        )
         worker_config_result = self.k8s_client.sanitize_for_serialization(worker_config)
         self.assertEqual(worker_config_result, sanitized_result)
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -127,6 +127,10 @@ class TestPodGenerator(unittest.TestCase):
                                     secret_key_ref=k8s.V1SecretKeySelector(name='secret_b', key='source_b')
                                 ),
                             ),
+                            k8s.V1EnvVar(
+                                name="AIRFLOW_IS_K8S_EXECUTOR_POD",
+                                value='True',
+                            ),
                         ],
                         env_from=[
                             k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name='configmap_a')),

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -294,3 +294,12 @@ class TestRenderedTaskInstanceFields(unittest.TestCase):
             session.add(rtif)
 
         self.assertEqual(expected_pod_yaml, RTIF.get_k8s_pod_yaml(ti=ti))
+
+        # Test the else part of get_k8s_pod_yaml
+        # i.e. for the TIs that are not stored in RTIF table
+        # Fetching them will return None
+        with dag:
+            task_2 = BashOperator(task_id="test2", bash_command="echo hello")
+
+        ti2 = TI(task_2, EXECUTION_DATE)
+        self.assertIsNone(RTIF.get_k8s_pod_yaml(ti=ti2))

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1814,7 +1814,6 @@ class TestTaskInstance(unittest.TestCase):
         with create_session() as session:
             session.query(RenderedTaskInstanceFields).delete()
 
-    @patch("airflow.models.renderedtifields.IS_K8S_OR_K8SCELERY_EXECUTOR", new=True)
     def test_get_rendered_k8s_spec(self):
         with DAG('test_get_rendered_k8s_spec', start_date=DEFAULT_DATE):
             task = BashOperator(task_id='op1', bash_command="{{ task.task_id }}")

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1814,6 +1814,7 @@ class TestTaskInstance(unittest.TestCase):
         with create_session() as session:
             session.query(RenderedTaskInstanceFields).delete()
 
+    @mock.patch.dict(os.environ, {"AIRFLOW_IS_K8S_EXECUTOR_POD": "True"})
     def test_get_rendered_k8s_spec(self):
         with DAG('test_get_rendered_k8s_spec', start_date=DEFAULT_DATE):
             task = BashOperator(task_id='op1', bash_command="{{ task.task_id }}")
@@ -1853,6 +1854,7 @@ class TestTaskInstance(unittest.TestCase):
                         ],
                         'image': ':',
                         'name': 'base',
+                        'env': [{'name': 'AIRFLOW_IS_K8S_EXECUTOR_POD', 'value': 'True'}],
                     }
                 ]
             },


### PR DESCRIPTION
There is a bug in the yaml template rendering caused by the logic that
yaml templates are only generated when the current executor is the
k8sexecutor. This is a problem as the templates are generated by the
task pod, which is itself running a LocalExecutor. Also generates a
"base" template if this taskInstance has not run yet.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
