### PR TITLE
Fixes the sending of an empty list to BigQuery `list_rows`

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1296,9 +1296,13 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :return: list of rows
         """
         location = location or self.location
-        selected_fields = selected_fields or []
         if isinstance(selected_fields, str):
             selected_fields = selected_fields.split(",")
+
+        if selected_fields:
+            selected_fields = [SchemaField(n, "") for n in selected_fields]
+        else:
+            selected_fields = None
 
         table = self._resolve_table_reference(
             table_resource={},
@@ -1309,7 +1313,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         result = self.get_client(project_id=project_id, location=location).list_rows(
             table=Table.from_api_repr(table),
-            selected_fields=[SchemaField(n, "") for n in selected_fields],
+            selected_fields=selected_fields,
             max_results=max_results,
             page_token=page_token,
             start_index=start_index,

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -464,6 +464,27 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
 
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Table")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
+    def test_list_rows_with_empty_selected_fields(self, mock_client, mock_table):
+        self.hook.list_rows(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            max_results=10,
+            page_token="page123",
+            selected_fields=[],
+            start_index=5,
+            location=LOCATION,
+        )
+        mock_table.from_api_repr.assert_called_once_with({"tableReference": TABLE_REFERENCE_REPR})
+        mock_client.return_value.list_rows.assert_called_once_with(
+            table=mock_table.from_api_repr.return_value,
+            max_results=10,
+            page_token='page123',
+            selected_fields=None,
+            start_index=5,
+        )
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Table")
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
     def test_run_table_delete(self, mock_client, mock_table):
         source_project_dataset_table = f"{PROJECT_ID}.{DATASET_ID}.{TABLE_ID}"
         self.hook.run_table_delete(source_project_dataset_table, ignore_if_missing=False)


### PR DESCRIPTION
Ensures that only a non-empty list or `None` is passed to the BigQuery `list_rows` method.

Also adds a test to check that if `list_rows` is called with `[]` then `None` is submitted.

Closes: #12284 