### PR TITLE
Add info log message about duration taken to load plugins

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -23,6 +23,7 @@ import inspect
 import logging
 import os
 import sys
+import time
 import types
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
@@ -262,6 +263,8 @@ def ensure_plugins_loaded():
 
     log.debug("Loading plugins")
 
+    start = time.monotonic()
+
     plugins = []
     registered_hooks = []
 
@@ -272,6 +275,12 @@ def ensure_plugins_loaded():
     # them so we can integrate them in to the UI's Connection screens
     for plugin in plugins:
         registered_hooks.extend(plugin.hooks)
+
+    end = time.monotonic()
+
+    num_loaded = len(plugins)
+    if num_loaded > 0:
+        log.info("Loading %d plugin(s) took %.2f seconds", num_loaded, end - start)
 
 
 def initialize_web_ui_plugins():

--- a/airflow/utils/log/colored_log.py
+++ b/airflow/utils/log/colored_log.py
@@ -90,8 +90,9 @@ class CustomTTYColoredFormatter(TTYColoredFormatter):
 
     def format(self, record: LogRecord) -> str:
         try:
-            record = self._color_record_args(record)
-            record = self._color_record_traceback(record)
+            if self.stream.isatty():
+                record = self._color_record_args(record)
+                record = self._color_record_traceback(record)
             return super().format(record)
         except ValueError:  # I/O operation on closed file
             from logging import Formatter

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import getpass
+import logging
 import os
 import time
 import unittest
@@ -60,6 +61,9 @@ class TestStandardTaskRunner(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        airflow_logger = logging.getLogger('airflow')
+        airflow_logger.handlers = []
+        airflow_logger.propagate = True
         try:
             clear_db_runs()
         except Exception:  # noqa pylint: disable=broad-except


### PR DESCRIPTION
Loading plugins, particularly from setuptools entry points can be slow,
and since by default this happens per-task, it can slow down task
execution unexpectedly.

By having this log message users can know the source of the delay


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).