### PR TITLE
Add provide_file_and_upload to GCSHook

### DIFF
--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -318,6 +318,38 @@ class GCSHook(GoogleBaseHook):
             tmp_file.flush()
             yield tmp_file
 
+    @_fallback_object_url_to_object_name_and_bucket_name()
+    @contextmanager
+    def provide_file_and_upload(
+        self,
+        bucket_name: Optional[str] = None,
+        object_name: Optional[str] = None,
+        object_url: Optional[str] = None,  # pylint: disable=unused-argument
+    ):
+        """
+        Creates temporary file, returns a file handle and uploads the files content
+        on close.
+
+        You can use this method by passing the bucket_name and object_name parameters
+        or just object_url parameter.
+
+        :param bucket_name: The bucket to fetch from.
+        :type bucket_name: str
+        :param object_name: The object to fetch.
+        :type object_name: str
+        :param object_url: File reference url. Must start with "gs: //"
+        :type object_url: str
+        :return: File handler
+        """
+        if object_name is None:
+            raise ValueError("Object name can not be empty")
+
+        _, _, file_name = object_name.rpartition("/")
+        with NamedTemporaryFile(suffix=file_name) as tmp_file:
+            yield tmp_file
+            tmp_file.flush()
+            self.upload(bucket_name=bucket_name, object_name=object_name, filename=tmp_file.name)
+
     def upload(
         self,
         bucket_name: str,


### PR DESCRIPTION
This commit adds provide_file_and_upload context manager
which works similar to provide_file. Users using it can
avoid boilerplate code of creating temporary file and then
uploading its content to GCS.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
