### PR TITLE
Mount airflow.cfg to pod_template_file

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -40,6 +40,16 @@ spec:
       volumeMounts:
         - mountPath: {{ template "airflow_logs" . }}
           name: airflow-logs
+        - name: config
+          mountPath: {{ template "airflow_config_path" . }}
+          subPath: airflow.cfg
+          readOnly: true
+{{- if .Values.scheduler.airflowLocalSettings }}
+        - name: config
+          mountPath: {{ template "airflow_local_setting_path" . }}
+          subPath: airflow_local_settings.py
+          readOnly: true
+{{- end }}
 {{- if .Values.dags.gitSync.knownHosts }}
         - mountPath: /etc/git-secret/known_hosts
           name: {{ .Values.dags.gitSync.knownHosts }}

--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -102,7 +102,4 @@ spec:
 {{- end }}
   - configMap:
       name: {{ include "airflow_config" . }}
-    name: airflow-config
-  - configMap:
-      name: {{ include "airflow_config" . }}
-    name: airflow-local-settings
+    name: config

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -185,6 +185,27 @@ class PodTemplateFileTest(unittest.TestCase):
         self.assertEqual("dummy_image:latest", jmespath.search("spec.containers[0].image", docs[0]))
         self.assertEqual("base", jmespath.search("spec.containers[0].name", docs[0]))
 
+    def test_mount_airflow_cfg(self):
+        docs = render_chart(
+            values={},
+            show_only=["templates/pod-template-file.yaml"],
+        )
+
+        self.assertRegex(docs[0]["kind"], "Pod")
+        self.assertDictEqual(
+            {'configMap': {'name': 'RELEASE-NAME-airflow-config'}, 'name': 'airflow-config'},
+            jmespath.search("spec.volumes[1]", docs[0]),
+        )
+        self.assertDictEqual(
+            {
+                'name': 'config',
+                'mountPath': '/opt/airflow/airflow.cfg',
+                'subPath': 'airflow.cfg',
+                'readOnly': True,
+            },
+            jmespath.search("spec.containers[0].volumeMounts[1]", docs[0]),
+        )
+
     def test_should_create_valid_affinity_and_node_selector(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
k8sexecutor workers were launching without an airflow.cfg,
this was preventing logs from being sent to distributed logging systems.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
