### PR TITLE
Fix/Enhancement: Disable forms and communicate to user when no DAG Runs

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -667,7 +667,7 @@ class DAG(LoggingMixin):
             get_last_dagrun(
                 self.dag_id, session=session, include_externally_triggered=include_externally_triggered
             )
-            != None
+            is not None
         )
 
     @property

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -662,12 +662,12 @@ class DAG(LoggingMixin):
         )
 
     @provide_session
-    def has_no_dag_runs(self, session=None, include_externally_triggered=True) -> bool:
+    def has_dag_runs(self, session=None, include_externally_triggered=True) -> bool:
         return (
             get_last_dagrun(
                 self.dag_id, session=session, include_externally_triggered=include_externally_triggered
             )
-            == None
+            != None
         )
 
     @property

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -661,6 +661,15 @@ class DAG(LoggingMixin):
             self.dag_id, session=session, include_externally_triggered=include_externally_triggered
         )
 
+    @provide_session
+    def has_no_dag_runs(self, session=None, include_externally_triggered=True) -> bool:
+        return (
+            get_last_dagrun(
+                self.dag_id, session=session, include_externally_triggered=include_externally_triggered
+            )
+            == None
+        )
+
     @property
     def dag_id(self) -> str:
         return self._dag_id

--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -1889,6 +1889,7 @@ output {
 .form-control[readonly],
 fieldset[disabled] .form-control {
   cursor: not-allowed;
+  color: #cbcbcb;
   background-color: #eee;
   opacity: 1;
 }
@@ -2320,7 +2321,7 @@ select[multiple].form-group-lg .form-control {
 fieldset[disabled] .btn {
   cursor: not-allowed;
   pointer-events: none;
-  opacity: 0.65;
+  opacity: 0.5;
   -webkit-box-shadow: none;
   box-shadow: none;
 }

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -40,17 +40,18 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control") }}
+            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control") }}
+            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
-        <button type="submit" class="btn">Update</button>
+        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
+        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
   </div>

--- a/airflow/www/templates/airflow/chart.html
+++ b/airflow/www/templates/airflow/chart.html
@@ -40,18 +40,18 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.base_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.num_runs(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
-        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
-        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
+        <button type="submit" class="btn"{{' disabled' if not dag.has_dag_runs() else ''}}>Update</button>
+        {% if not dag.has_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
   </div>

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -39,18 +39,18 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.base_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.num_runs(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
-        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
-        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
+        <button type="submit" class="btn"{{' disabled' if not dag.has_dag_runs() else ''}}>Update</button>
+        {% if not dag.has_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
     <div class="col-md-2 text-right">

--- a/airflow/www/templates/airflow/duration_chart.html
+++ b/airflow/www/templates/airflow/duration_chart.html
@@ -39,17 +39,18 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control") }}
+            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control") }}
+            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
-        <button type="submit" class="btn">Update</button>
+        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
+        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
     <div class="col-md-2 text-right">

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -45,24 +45,25 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control") }}
+            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control") }}
+            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="execution_date">Run</label>
           <div class="input-group">
             <div class="input-group-addon">Run</div>
-            {{ form.execution_date(class_="form-control") }}
+            {{ form.execution_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
-        <button type="submit" class="btn">Update</button>
+        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
+        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
   </div>

--- a/airflow/www/templates/airflow/gantt.html
+++ b/airflow/www/templates/airflow/gantt.html
@@ -45,25 +45,25 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.base_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.num_runs(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="execution_date">Run</label>
           <div class="input-group">
             <div class="input-group-addon">Run</div>
-            {{ form.execution_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.execution_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
-        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
-        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
+        <button type="submit" class="btn"{{' disabled' if not dag.has_dag_runs() else ''}}>Update</button>
+        {% if not dag.has_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
   </div>

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -48,21 +48,21 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.base_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.num_runs(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="execution_date">Run</label>
           <div class="input-group">
             <div class="input-group-addon">Run</div>
-            {{ form.execution_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.execution_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
@@ -73,7 +73,7 @@
           </div>
         </div>
         <button type="submit" class="btn">Update</button>
-        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
+        {% if not dag.has_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
     <div class="col-md-2 text-right">

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -48,21 +48,21 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control") }}
+            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control") }}
+            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="execution_date">Run</label>
           <div class="input-group">
             <div class="input-group-addon">Run</div>
-            {{ form.execution_date(class_="form-control") }}
+            {{ form.execution_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
@@ -73,6 +73,7 @@
           </div>
         </div>
         <button type="submit" class="btn">Update</button>
+        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
     <div class="col-md-2 text-right">

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -46,17 +46,18 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control") }}
+            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control") }}
+            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
           </div>
         </div>
-        <button type="submit" class="btn">Update</button>
+        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
+        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
   </div>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -46,18 +46,18 @@
         <div class="form-group">
           <label class="sr-only" for="base_date">Base date</label>
           <div class="input-group">
-            {{ form.base_date(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.base_date(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
         <div class="form-group">
           <label class="sr-only" for="num_runs">Number of runs</label>
           <div class="input-group">
             <div class="input-group-addon">Runs</div>
-            {{ form.num_runs(class_="form-control", disabled=dag.has_no_dag_runs()) }}
+            {{ form.num_runs(class_="form-control", disabled=not(dag.has_dag_runs())) }}
           </div>
         </div>
-        <button type="submit" class="btn"{{' disabled' if dag.has_no_dag_runs() else ''}}>Update</button>
-        {% if dag.has_no_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
+        <button type="submit" class="btn"{{' disabled' if not dag.has_dag_runs() else ''}}>Update</button>
+        {% if not dag.has_dag_runs() %}<span class="text-warning" style="margin-left:16px;">No DAG runs yet.</span>{% endif %}
       </form>
     </div>
   </div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1981,7 +1981,12 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             'instances': [dag_runs.get(d) or {'execution_date': d.isoformat()} for d in dates],
         }
 
-        form = DateTimeWithNumRunsForm(data={'base_date': max_date, 'num_runs': num_runs})
+        form = DateTimeWithNumRunsForm(
+            data={
+                'base_date': max_date or timezone.utcnow(),
+                'num_runs': num_runs,
+            }
+        )
 
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None), css_class='dag-doc')
 
@@ -2204,7 +2209,12 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         session.commit()
 
-        form = DateTimeWithNumRunsForm(data={'base_date': max_date, 'num_runs': num_runs})
+        form = DateTimeWithNumRunsForm(
+            data={
+                'base_date': max_date or timezone.utcnow(),
+                'num_runs': num_runs,
+            }
+        )
         chart.buildcontent()
         cum_chart.buildcontent()
         s_index = cum_chart.htmlcontent.rfind('});')
@@ -2278,7 +2288,12 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         session.commit()
 
-        form = DateTimeWithNumRunsForm(data={'base_date': max_date, 'num_runs': num_runs})
+        form = DateTimeWithNumRunsForm(
+            data={
+                'base_date': max_date or timezone.utcnow(),
+                'num_runs': num_runs,
+            }
+        )
 
         chart.buildcontent()
 
@@ -2360,7 +2375,12 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         session.commit()
 
-        form = DateTimeWithNumRunsForm(data={'base_date': max_date, 'num_runs': num_runs})
+        form = DateTimeWithNumRunsForm(
+            data={
+                'base_date': max_date or timezone.utcnow(),
+                'num_runs': num_runs,
+            }
+        )
         chart.buildcontent()
         return self.render_template(
             'airflow/chart.html',


### PR DESCRIPTION
Resolves #10934

- Applies a consistent disabled state across the DAG Run selection forms when no DAG runs have yet occurred. 
- Some date inputs listed "Invalid date" or were blank. Now they will display today's date as a fallback. In the Tree view, submitting the form with "Invalid date" yielded an error. 

**Tree - Before:**

![image](https://user-images.githubusercontent.com/3267/98982946-1c448100-24ee-11eb-9499-c137f51c8079.png)

**Tree - After:**

![image](https://user-images.githubusercontent.com/3267/98982378-506b7200-24ed-11eb-8548-e7f784b0d85a.png)

-----

**Graph - Before:**

![image](https://user-images.githubusercontent.com/3267/98982985-2d8d8d80-24ee-11eb-91eb-f0bc9dea55da.png)

**Graph - After:**

![image](https://user-images.githubusercontent.com/3267/98982397-58c3ad00-24ed-11eb-9009-f21a34b49dde.png)
_Note: a slightly different treatment here as the layout update is still allowed._

-----

**Task Duration - Before:**

![image](https://user-images.githubusercontent.com/3267/98982604-a4765680-24ed-11eb-97d1-912307a0b878.png)

**Task Duration - After:**

![image](https://user-images.githubusercontent.com/3267/98982412-5feabb00-24ed-11eb-8629-ca6645cb02b0.png)

-----

**Task Tries - Before:**

![image](https://user-images.githubusercontent.com/3267/98982635-b0621880-24ed-11eb-84f1-3d2b4213e9c7.png)

**Task Tries - After:**

![image](https://user-images.githubusercontent.com/3267/98982438-6842f600-24ed-11eb-825a-0730355e5f26.png)

-----

**Landing Times - Before:**

![image](https://user-images.githubusercontent.com/3267/98982673-bd7f0780-24ed-11eb-933b-4b7c62ed1753.png)

**Landing Times - After:**

![image](https://user-images.githubusercontent.com/3267/98982461-7264f480-24ed-11eb-868d-db946e10f3ec.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
