### PR TITLE
Bugfix: REST API Variables update endpoint returns 204 No Content

### DIFF
--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -85,7 +85,7 @@ def patch_variable(variable_key: str, update_mask: Optional[List[str]] = None) -
             raise BadRequest("No field to update")
 
     Variable.set(data["key"], data["val"])
-    return Response(status=204)
+    return variable_schema.dump(data)
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -203,8 +203,7 @@ class TestPatchVariable(TestVariableEndpoint):
             },
             environ_overrides={'REMOTE_USER': "test"},
         )
-        assert response.status_code == 204
-        response = self.client.get("/api/v1/variables/var1", environ_overrides={'REMOTE_USER': "test"})
+        assert response.status_code == 200
         assert response.json == {
             "key": "var1",
             "value": "updated",


### PR DESCRIPTION
Currently updating a variable using the REST API returns status code 204 as a response instead of 200 as documented.
This PR fixes it and ensures a JSON is returned as documented.

cc: @mik-laj 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
