### PR TITLE
Update automated PR labels

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -47,7 +47,7 @@ labelPRBasedOnFilePath:
     - tests/providers/apache/*
     - tests/providers/apache/**/*
 
-  k8s:
+  area:kubernetes:
     - airflow/**/kubernetes_*.py
     - airflow/example_dags/example_kubernetes_executor.py
     - airflow/example_dags/example_kubernetes_executor_config.py
@@ -75,7 +75,7 @@ labelPRBasedOnFilePath:
     - tests/www/api/*
     - tests/www/api/**/*
 
-  area:dev:
+  area:dev-tools:
     - airflow/mypy/*
     - airflow/mypy/**/*
     - scripts/**/*
@@ -108,7 +108,7 @@ labelPRBasedOnFilePath:
     - airflow/www/.stylelintignore
     - airflow/www/.stylelintrc
 
-  area:docs:
+  kind:documentation:
     - docs/**/*
     - docs/*
 


### PR DESCRIPTION
Based on today's Issue triage community call, I have updated the following labels:

`k8s` -> `area:kubernetes`
`area:dev` -> `area:dev-tools`
`area:docs` -> `kind:documentation`

https://docs.google.com/document/d/1Fx46SoOnNLiqZKtrC-tOHj3zFlZfQwWuR2LRFXJnWqw/edit?usp=sharing

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
