### PR TITLE
Use different deserialization method in XCom init_on_load

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -63,7 +63,7 @@ class BaseXCom(Base, LoggingMixin):
         i.e automatically deserialize Xcom value when loading from DB.
         """
         try:
-            self.value = XCom.deserialize_value(self)
+            self.value = XCom.orm_deserialize_value(self)
         except (UnicodeEncodeError, ValueError):
             # For backward-compatibility.
             # Preventing errors in webserver
@@ -258,6 +258,17 @@ class BaseXCom(Base, LoggingMixin):
                 "support for XCOM in your airflow config."
             )
             raise
+
+    @staticmethod
+    def orm_deserialize_value(result) -> Any:
+        """
+        Deserialize method which is used to reconstruct ORM XCom object.
+
+        This method should be overridden in custom XCom backends to avoid
+        unnecessary request or other resource consuming operations when
+        creating XCom orm model
+        """
+        return BaseXCom.deserialize_value(result)
 
 
 def resolve_xcom_backend():

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -265,7 +265,8 @@ class BaseXCom(Base, LoggingMixin):
 
         This method should be overridden in custom XCom backends to avoid
         unnecessary request or other resource consuming operations when
-        creating XCom orm model
+        creating XCom orm model. This is used when viewing XCom listing
+        in the webserver, for example.
         """
         return BaseXCom.deserialize_value(self)
 

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -63,7 +63,7 @@ class BaseXCom(Base, LoggingMixin):
         i.e automatically deserialize Xcom value when loading from DB.
         """
         try:
-            self.value = XCom.orm_deserialize_value(self)
+            self.value = self.orm_deserialize_value(self)
         except (UnicodeEncodeError, ValueError):
             # For backward-compatibility.
             # Preventing errors in webserver

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -235,16 +235,16 @@ class BaseXCom(Base, LoggingMixin):
             return json.dumps(value).encode('UTF-8')
         except (ValueError, TypeError):
             log.error(
-                "Could not serialize the XCOM value into JSON. "
+                "Could not serialize the XCom value into JSON. "
                 "If you are using pickles instead of JSON "
-                "for XCOM, then you need to enable pickle "
-                "support for XCOM in your airflow config."
+                "for XCom, then you need to enable pickle "
+                "support for XCom in your airflow config."
             )
             raise
 
     @staticmethod
-    def deserialize_value(result) -> Any:
-        """Deserialize Xcom value from str or pickle object"""
+    def deserialize_value(result: "XCom") -> Any:
+        """Deserialize XCom value from str or pickle object"""
         enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
         if enable_pickling:
             return pickle.loads(result.value)
@@ -252,10 +252,10 @@ class BaseXCom(Base, LoggingMixin):
             return json.loads(result.value.decode('UTF-8'))
         except JSONDecodeError:
             log.error(
-                "Could not deserialize the XCOM value from JSON. "
+                "Could not deserialize the XCom value from JSON. "
                 "If you are using pickles instead of JSON "
-                "for XCOM, then you need to enable pickle "
-                "support for XCOM in your airflow config."
+                "for XCom, then you need to enable pickle "
+                "support for XCom in your airflow config."
             )
             raise
 

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -63,7 +63,7 @@ class BaseXCom(Base, LoggingMixin):
         i.e automatically deserialize Xcom value when loading from DB.
         """
         try:
-            self.value = self.orm_deserialize_value(self)
+            self.value = self.orm_deserialize_value()
         except (UnicodeEncodeError, ValueError):
             # For backward-compatibility.
             # Preventing errors in webserver
@@ -259,8 +259,7 @@ class BaseXCom(Base, LoggingMixin):
             )
             raise
 
-    @staticmethod
-    def orm_deserialize_value(result) -> Any:
+    def orm_deserialize_value(self) -> Any:
         """
         Deserialize method which is used to reconstruct ORM XCom object.
 
@@ -268,7 +267,7 @@ class BaseXCom(Base, LoggingMixin):
         unnecessary request or other resource consuming operations when
         creating XCom orm model
         """
-        return BaseXCom.deserialize_value(result)
+        return BaseXCom.deserialize_value(self)
 
 
 def resolve_xcom_backend():

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -805,7 +805,7 @@ methods.
 
 It is also possible to override the ``orm_deserialize_value`` method which is used for deserialization when
 recreating ORM XCom object. By default this method will use ``BaseXCom.orm_deserialize_value`` which returns
-the value stored in Airflow metadatabase. In this way Airflow is avoiding unnecessary requests that may occur
+the value stored in Airflow database. In this way Airflow is avoiding unnecessary requests that may occur
 in custom ``deserialize`` methods of custom XCom backend.
 
 See :doc:`modules_management` for details on how Python and Airflow manage modules.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -804,9 +804,10 @@ deserialization mechanism the custom class should override ``serialize_value`` a
 methods.
 
 It is also possible to override the ``orm_deserialize_value`` method which is used for deserialization when
-recreating ORM XCom object. By default this method will use ``BaseXCom.orm_deserialize_value`` which returns
-the value stored in Airflow database. In this way Airflow is avoiding unnecessary requests that may occur
-in custom ``deserialize`` methods of custom XCom backend.
+recreating ORM XCom object. This happens everytime we query the XCom table, for example when we want to populate
+XCom list view in webserver. By default Airflow will use ``BaseXCom.orm_deserialize_value`` method which returns the
+value stored in Airflow database. In this way Airflow is avoiding unnecessary requests that may occur in custom
+``deserialize`` methods of custom XCom backend.
 
 See :doc:`modules_management` for details on how Python and Airflow manage modules.
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -804,7 +804,7 @@ deserialization mechanism the custom class should override ``serialize_value`` a
 methods.
 
 It is also possible to override the ``orm_deserialize_value`` method which is used for deserialization when
-recreating ORM XCom object. This happens everytime we query the XCom table, for example when we want to populate
+recreating ORM XCom object. This happens every time we query the XCom table, for example when we want to populate
 XCom list view in webserver. By default Airflow will use ``BaseXCom.orm_deserialize_value`` method which returns the
 value stored in Airflow database. In this way Airflow is avoiding unnecessary requests that may occur in custom
 ``deserialize`` methods of custom XCom backend.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -803,6 +803,11 @@ to a class that is subclass of :class:`~airflow.models.xcom.BaseXCom`. To alter 
 deserialization mechanism the custom class should override ``serialize_value`` and ``deserialize_value``
 methods.
 
+It is also possible to override the ``orm_deserialize_value`` method which is used for deserialization when
+recreating ORM XCom object. By default this method will use ``BaseXCom.orm_deserialize_value`` which returns
+the value stored in Airflow metadatabase. In this way Airflow is avoiding unnecessary requests that may occur
+in custom ``deserialize`` methods of custom XCom backend.
+
 See :doc:`modules_management` for details on how Python and Airflow manage modules.
 
 .. _concepts:variables:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -805,9 +805,9 @@ methods.
 
 It is also possible to override the ``orm_deserialize_value`` method which is used for deserialization when
 recreating ORM XCom object. This happens every time we query the XCom table, for example when we want to populate
-XCom list view in webserver. By default Airflow will use ``BaseXCom.orm_deserialize_value`` method which returns the
-value stored in Airflow database. In this way Airflow is avoiding unnecessary requests that may occur in custom
-``deserialize`` methods of custom XCom backend.
+XCom list view in webserver. If your XCom backend performs expensive operations, or has large values that aren't
+useful to show in such a view, override this method to provide an alternative representation. By default Airflow will
+use ``BaseXCom.orm_deserialize_value`` method which returns the value stored in Airflow database.
 
 See :doc:`modules_management` for details on how Python and Airflow manage modules.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -995,6 +995,7 @@ openfaas
 oper
 optimise
 ora
+orm
 orchestrator
 orgtbl
 os

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -16,6 +16,7 @@
 # under the License.
 import os
 import unittest
+from unittest import mock
 
 from airflow import settings
 from airflow.configuration import conf
@@ -212,3 +213,18 @@ class TestXCom(unittest.TestCase):
 
         for result in results:
             self.assertEqual(result.value, json_obj)
+
+    @mock.patch("airflow.models.xcom.BaseXCom.orm_deserialize_value")
+    def test_xcom_init_on_load_uses_orm_deserialize_value(self, mock_orm_deserialize):
+        # pylint: disable=unexpected-keyword-arg
+        instance = BaseXCom(
+            key="key",
+            value="value",
+            timestamp=timezone.utcnow(),
+            execution_date=timezone.utcnow(),
+            task_id="task_id",
+            dag_id="dag_id",
+        )
+        # pylint: enable=unexpected-keyword-arg
+        instance.init_on_load()
+        mock_orm_deserialize.assert_called_once_with(instance)

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -214,7 +214,7 @@ class TestXCom(unittest.TestCase):
         for result in results:
             self.assertEqual(result.value, json_obj)
 
-    @mock.patch("airflow.models.xcom.BaseXCom.orm_deserialize_value")
+    @mock.patch("airflow.models.xcom.XCom.orm_deserialize_value")
     def test_xcom_init_on_load_uses_orm_deserialize_value(self, mock_orm_deserialize):
         # pylint: disable=unexpected-keyword-arg
         instance = BaseXCom(
@@ -227,4 +227,4 @@ class TestXCom(unittest.TestCase):
         )
         # pylint: enable=unexpected-keyword-arg
         instance.init_on_load()
-        mock_orm_deserialize.assert_called_once_with(instance)
+        mock_orm_deserialize.assert_called_once_with()


### PR DESCRIPTION
The init_on_load method used deserialize_value method which
in case of custom XCom backends may perform requests to external
services (for example downloading file from buckets).

This is problematic because wherever we query XCom the resuest would be
send (for example when listing XCom in webui). This PR proposes implementing
orm_deserialize_value which allows overriding this behavior. By default
we use BaseXCom.deserialize_value.

closes: #12315

I'm testing this with the following backend:
```py
class GCSXComBackend(BaseXCom):
    PREFIX = "xcom_gs://"
    BUCKET_NAME = "airflow-xcom-backend"

    @staticmethod
    def serialize_value(value: Any):
        if isinstance(value, pd.DataFrame):
            hook = GCSHook()
            with NamedTemporaryFile("w+") as f:
                object_name = "data_" + f.name.replace("/", "_")
                value.to_csv(f.name)
                f.flush()
                hook.upload(
                    bucket_name=GCSXComBackend.BUCKET_NAME,
                    object_name=object_name,
                    filename=f.name
                )
            value = GCSXComBackend.PREFIX + object_name
        return BaseXCom.serialize_value(value)

    @staticmethod
    def deserialize_value(result) -> Any:
        result = BaseXCom.deserialize_value(result)
        if isinstance(result, str) and result.startswith(GCSXComBackend.PREFIX):
            object_name = result.replace(GCSXComBackend.PREFIX, "")
            with GCSHook().provide_file(
                bucket_name=GCSXComBackend.BUCKET_NAME,
                object_name=object_name,
            ) as f:
                f.flush()
                result = pd.read_csv(f.name)
        return result
```

And that's what I see in XCom table:
<img width="1673" alt="Screenshot 2020-11-12 at 22 18 56" src="https://user-images.githubusercontent.com/9528307/98997809-6bfa6b00-2535-11eb-90b3-2b57985a4e66.png">

In logs I can see that the data is uploaded and downloaded as expected.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
