### PR TITLE
Update deprecated Apache Pinot Broker API

### DIFF
--- a/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/airflow/providers/apache/pinot/hooks/pinot.py
@@ -253,7 +253,7 @@ class PinotDbApiHook(DbApiHook):
     """
     Interact with Pinot Broker Query API
 
-    This hook uses standard-SQL endpoint since PQL endpoint is soon to be depricated.
+    This hook uses standard-SQL endpoint since PQL endpoint is soon to be deprecated.
     https://docs.pinot.apache.org/users/api/querying-pinot-using-standard-sql
     """
 

--- a/airflow/providers/apache/pinot/hooks/pinot.py
+++ b/airflow/providers/apache/pinot/hooks/pinot.py
@@ -250,7 +250,12 @@ class PinotAdminHook(BaseHook):
 
 
 class PinotDbApiHook(DbApiHook):
-    """Connect to pinot db (https://github.com/apache/incubator-pinot) to issue pql"""
+    """
+    Interact with Pinot Broker Query API
+
+    This hook uses standard-SQL endpoint since PQL endpoint is soon to be depricated.
+    https://docs.pinot.apache.org/users/api/querying-pinot-using-standard-sql
+    """
 
     conn_name_attr = 'pinot_broker_conn_id'
     default_conn_name = 'pinot_broker_default'
@@ -264,7 +269,7 @@ class PinotDbApiHook(DbApiHook):
         pinot_broker_conn = connect(
             host=conn.host,
             port=conn.port,
-            path=conn.extra_dejson.get('endpoint', '/pql'),
+            path=conn.extra_dejson.get('endpoint', '/query/sql'),
             scheme=conn.extra_dejson.get('schema', 'http'),
         )
         self.log.info('Get the connection to pinot broker on %s', conn.host)
@@ -274,14 +279,14 @@ class PinotDbApiHook(DbApiHook):
         """
         Get the connection uri for pinot broker.
 
-        e.g: http://localhost:9000/pql
+        e.g: http://localhost:9000/query/sql
         """
         conn = self.get_connection(getattr(self, self.conn_name_attr))
         host = conn.host
         if conn.port is not None:
             host += f':{conn.port}'
         conn_type = 'http' if not conn.conn_type else conn.conn_type
-        endpoint = conn.extra_dejson.get('endpoint', 'pql')
+        endpoint = conn.extra_dejson.get('endpoint', 'query/sql')
         return f'{conn_type}://{host}/{endpoint}'
 
     def get_records(self, sql: str, parameters: Optional[Union[Dict[str, Any], Iterable[Any]]] = None) -> Any:

--- a/tests/providers/apache/pinot/hooks/test_pinot.py
+++ b/tests/providers/apache/pinot/hooks/test_pinot.py
@@ -210,7 +210,7 @@ class TestPinotDbApiHook(unittest.TestCase):
         self.conn.host = 'host'
         self.conn.port = '1000'
         self.conn.conn_type = 'http'
-        self.conn.extra_dejson = {'endpoint': 'pql'}
+        self.conn.extra_dejson = {'endpoint': 'query/sql'}
         self.cur = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         self.conn.__enter__.return_value = self.cur
@@ -230,7 +230,7 @@ class TestPinotDbApiHook(unittest.TestCase):
         Test on getting a pinot connection uri
         """
         db_hook = self.db_hook()
-        self.assertEqual(db_hook.get_uri(), 'http://host:1000/pql')
+        self.assertEqual(db_hook.get_uri(), 'http://host:1000/query/sql')
 
     def test_get_conn(self):
         """
@@ -240,7 +240,7 @@ class TestPinotDbApiHook(unittest.TestCase):
         self.assertEqual(conn.host, 'host')
         self.assertEqual(conn.port, '1000')
         self.assertEqual(conn.conn_type, 'http')
-        self.assertEqual(conn.extra_dejson.get('endpoint'), 'pql')
+        self.assertEqual(conn.extra_dejson.get('endpoint'), 'query/sql')
 
     def test_get_records(self):
         statement = 'SQL'


### PR DESCRIPTION
This pull request updates the Apache Pinot hook to use up-to-date broker API.
By default, users should use the `standard-SQL` API endpoint since the PQL endpoint is soon to be depricated.

See more details about Apache Pinot Broker API here: https://docs.pinot.apache.org/users/api/querying-pinot-using-standard-sql
