### PR TITLE
Fix Sample CLI commands for upgrading to 2.0

### DIFF
--- a/UPGRADING_TO_2.0.md
+++ b/UPGRADING_TO_2.0.md
@@ -919,23 +919,23 @@ airflow users remove-role --username jondoe --role Public
 
 #### Use exactly single character for short option style change in CLI
 
-For Airflow short option, use exactly one single character, New commands are available according to the following table:
+For Airflow short option, use exactly one single character. New commands are available according to the following table:
 
 | Old command                                          | New command                                         |
 | :----------------------------------------------------| :---------------------------------------------------|
 | ``airflow (dags\|tasks\|scheduler) [-sd, --subdir]`` | ``airflow (dags\|tasks\|scheduler) [-S, --subdir]`` |
-| ``airflow tasks test [-dr, --dry_run]``              | ``airflow tasks test [-n, --dry-run]``              |
-| ``airflow dags backfill [-dr, --dry_run]``           | ``airflow dags backfill [-n, --dry-run]``           |
-| ``airflow tasks clear [-dx, --dag_regex]``           | ``airflow tasks clear [-R, --dag-regex]``           |
+| ``airflow test [-dr, --dry_run]``                    | ``airflow tasks test [-n, --dry-run]``              |
+| ``airflow test [-tp, --task_params]``                | ``airflow tasks test [-t, --task-params]``          |
+| ``airflow test [-pm, --post_mortem]``                | ``airflow tasks test [-m, --post-mortem]``          |
+| ``airflow run [-int, --interactive]``                | ``airflow tasks run [-N, --interactive]``           |
+| ``airflow backfill [-dr, --dry_run]``                | ``airflow dags backfill [-n, --dry-run]``           |
+| ``airflow clear [-dx, --dag_regex]``                 | ``airflow tasks clear [-R, --dag-regex]``           |
 | ``airflow kerberos [-kt, --keytab]``                 | ``airflow kerberos [-k, --keytab]``                 |
-| ``airflow tasks run [-int, --interactive]``          | ``airflow tasks run [-N, --interactive]``           |
 | ``airflow webserver [-hn, --hostname]``              | ``airflow webserver [-H, --hostname]``              |
-| ``airflow celery worker [-cn, --celery_hostname]``   | ``airflow celery worker [-H, --celery-hostname]``   |
-| ``airflow celery flower [-hn, --hostname]``          | ``airflow celery flower [-H, --hostname]``          |
-| ``airflow celery flower [-fc, --flower_conf]``       | ``airflow celery flower [-c, --flower-conf]``       |
-| ``airflow celery flower [-ba, --basic_auth]``        | ``airflow celery flower [-A, --basic-auth]``        |
-| ``airflow celery flower [-tp, --task_params]``       | ``airflow celery flower [-t, --task-params]``       |
-| ``airflow celery flower [-pm, --post_mortem]``       | ``airflow celery flower [-m, --post-mortem]``       |
+| ``airflow worker [-cn, --celery_hostname]``          | ``airflow celery worker [-H, --celery-hostname]``   |
+| ``airflow flower [-hn, --hostname]``                 | ``airflow celery flower [-H, --hostname]``          |
+| ``airflow flower [-fc, --flower_conf]``              | ``airflow celery flower [-c, --flower-conf]``       |
+| ``airflow flower [-ba, --basic_auth]``               | ``airflow celery flower [-A, --basic-auth]``        |
 
 For Airflow long option, use [kebab-case](https://en.wikipedia.org/wiki/Letter_case) instead of [snake_case](https://en.wikipedia.org/wiki/Snake_case)
 

--- a/docs/security/flower.rst
+++ b/docs/security/flower.rst
@@ -36,7 +36,7 @@ command, or as a configuration item in your ``airflow.cfg``. For both cases, ple
 
 .. code-block:: bash
 
-    airflow flower --basic-auth=user1:password1,user2:password2
+    airflow celery flower --basic-auth=user1:password1,user2:password2
 
 .. code-block:: ini
 


### PR DESCRIPTION
The issue I found earlier (fixed in https://github.com/apache/airflow/pull/12347) reminded me to further check all the sample CLI commands. Turns out we have quite a few to fix.

In this PR, 

- Sample command for starting Celery Flower is fixed in `docs/security/flower.rst`
- A few errors in the table in section of "short option style change in CLI" are fixed, like
  - The commands in column `Old command` are in the new CLI style, which is wrong.
  - Some short options are used with wrong command, for example, `--task-params` and `--post-mortem` are applicable for `test`, instead of `flower`.



