### PR TITLE
Don't use time.time() or timezone.utcnow() for duration calculations

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -774,6 +774,47 @@ If this function is designed to be called by "end-users" (i.e. DAG authors) then
       ...
       # You SHOULD not commit the session here. The wrapper will take care of commit()/rollback() if exception
 
+Don't use time() for duration calcuations
+-----------------------------------------
+
+If you wish to compute the time difference between two events with in the same process, use
+``time.monotonic()``, not ``time.time()`` nor ``timzeone.utcnow()``.
+
+If you are measuring duration for performance reasons, then ``time.perf_counter()`` should be used. (On many
+platforms, this uses the same underlying clock mechanism as monotonic, but ``perf_counter`` is guaranteed to be
+the highest accuracy clock on the system, monotonic is simply "guaranteed" to not go backwards.)
+
+If you wish to time how long a block of code takes, use ``Stats.timer()`` -- either with a metric name, which
+will be timed and submitted automatically:
+
+.. code-block:: python
+
+    from airflow.stats import Stats
+
+    ...
+
+    with Stats.timer("my_timer_metric"):
+        ...
+
+or to time but not send a metric:
+
+.. code-block:: python
+
+    from airflow.stats import Stats
+
+    ...
+
+    with Stats.timer() as timer:
+        ...
+
+    log.info("Code took %.3f seconds", timer.duration)
+
+For full docs on ``timer()`` check out `airflow/stats.py`_.
+
+If the start_date of a duration calculation needs to be stored in a database, then this has to be done using
+datetime objects. In all other cases, using datetime for duration calculation MUST be avoided as creating and
+diffing datetime operations are (comparatively) slow.
+
 Naming Conventions for provider packages
 ----------------------------------------
 

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -99,7 +99,7 @@ class GunicornMonitor(LoggingMixin):
 
         self._num_workers_running = 0
         self._num_ready_workers_running = 0
-        self._last_refresh_time = time.time() if worker_refresh_interval > 0 else None
+        self._last_refresh_time = time.monotonic() if worker_refresh_interval > 0 else None
         self._last_plugin_state = self._generate_plugin_state() if reload_on_plugin_change else None
         self._restart_on_next_plugin_check = False
 
@@ -149,9 +149,9 @@ class GunicornMonitor(LoggingMixin):
 
     def _wait_until_true(self, fn, timeout: int = 0) -> None:
         """Sleeps until fn is true"""
-        start_time = time.time()
+        start_time = time.monotonic()
         while not fn():
-            if 0 < timeout <= time.time() - start_time:
+            if 0 < timeout <= time.monotonic() - start_time:
                 raise AirflowWebServerTimeout(f"No response from gunicorn master within {timeout} seconds")
             sleep(0.1)
 
@@ -274,7 +274,7 @@ class GunicornMonitor(LoggingMixin):
         # If workers should be restarted periodically.
         if self.worker_refresh_interval > 0 and self._last_refresh_time:
             # and we refreshed the workers a long time ago, refresh the workers
-            last_refresh_diff = time.time() - self._last_refresh_time
+            last_refresh_diff = time.monotonic() - self._last_refresh_time
             if self.worker_refresh_interval < last_refresh_diff:
                 num_new_workers = self.worker_refresh_batch_size
                 self.log.debug(
@@ -284,7 +284,7 @@ class GunicornMonitor(LoggingMixin):
                     num_new_workers,
                 )
                 self._spawn_new_workers(num_new_workers)
-                self._last_refresh_time = time.time()
+                self._last_refresh_time = time.monotonic()
                 return
 
         # if we should check the directory with the plugin,
@@ -308,7 +308,7 @@ class GunicornMonitor(LoggingMixin):
                     num_workers_running,
                 )
                 self._restart_on_next_plugin_check = False
-                self._last_refresh_time = time.time()
+                self._last_refresh_time = time.monotonic()
                 self._reload_gunicorn()
 
 

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -23,7 +23,6 @@ import inspect
 import logging
 import os
 import sys
-import time
 import types
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
@@ -252,6 +251,8 @@ def ensure_plugins_loaded():
 
     Plugins are only loaded if they have not been previously loaded.
     """
+    from airflow.stats import Stats
+
     global plugins, registered_hooks  # pylint: disable=global-statement
 
     if plugins is not None:
@@ -263,24 +264,21 @@ def ensure_plugins_loaded():
 
     log.debug("Loading plugins")
 
-    start = time.monotonic()
+    with Stats.timer() as timer:
+        plugins = []
+        registered_hooks = []
 
-    plugins = []
-    registered_hooks = []
+        load_plugins_from_plugin_directory()
+        load_entrypoint_plugins()
 
-    load_plugins_from_plugin_directory()
-    load_entrypoint_plugins()
-
-    # We don't do anything with these for now, but we want to keep track of
-    # them so we can integrate them in to the UI's Connection screens
-    for plugin in plugins:
-        registered_hooks.extend(plugin.hooks)
-
-    end = time.monotonic()
+        # We don't do anything with these for now, but we want to keep track of
+        # them so we can integrate them in to the UI's Connection screens
+        for plugin in plugins:
+            registered_hooks.extend(plugin.hooks)
 
     num_loaded = len(plugins)
     if num_loaded > 0:
-        log.info("Loading %d plugin(s) took %.2f seconds", num_loaded, end - start)
+        log.info("Loading %d plugin(s) took %.2f seconds", num_loaded, timer.duration)
 
 
 def initialize_web_ui_plugins():

--- a/airflow/providers/amazon/aws/hooks/sagemaker.py
+++ b/airflow/providers/amazon/aws/hooks/sagemaker.py
@@ -615,9 +615,9 @@ class SageMakerHook(AwsBaseHook):  # pylint: disable=too-many-public-methods
 
         if state == LogState.JOB_COMPLETE:
             state = LogState.COMPLETE
-        elif time.time() - last_describe_job_call >= 30:
+        elif time.monotonic() - last_describe_job_call >= 30:
             description = self.describe_training_job(job_name)
-            last_describe_job_call = time.time()
+            last_describe_job_call = time.monotonic()
 
             if secondary_training_status_changed(description, last_description):
                 self.log.info(secondary_training_status_message(description, last_description))
@@ -815,7 +815,7 @@ class SageMakerHook(AwsBaseHook):  # pylint: disable=too-many-public-methods
         # Notes:
         # - The JOB_COMPLETE state forces us to do an extra pause and read any items that
         # got to Cloudwatch after the job was marked complete.
-        last_describe_job_call = time.time()
+        last_describe_job_call = time.monotonic()
         last_description = description
 
         while True:

--- a/airflow/providers/amazon/aws/sensors/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/sensors/sagemaker_training.py
@@ -59,7 +59,7 @@ class SageMakerTrainingSensor(SageMakerBaseSensor):
         job_already_completed = status not in self.non_terminal_states()
         self.state = LogState.TAILING if not job_already_completed else LogState.COMPLETE
         self.last_description = description
-        self.last_describe_job_call = time.time()
+        self.last_describe_job_call = time.monotonic()
         self.log_resource_inited = True
 
     def non_terminal_states(self):

--- a/airflow/providers/apache/kylin/operators/kylin_cube.py
+++ b/airflow/providers/apache/kylin/operators/kylin_cube.py
@@ -25,7 +25,6 @@ from kylinpy import kylinpy
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.kylin.hooks.kylin import KylinHook
-from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
 
 
@@ -169,7 +168,7 @@ class KylinCubeOperator(BaseOperator):
         }
         rsp_data = _hook.cube_run(self.cube, self.command.lower(), **kylinpy_params)
         if self.is_track_job and self.command.lower() in self.build_command:
-            started_at = timezone.utcnow()
+            started_at = time.monotonic()
             job_id = rsp_data.get("uuid")
             if job_id is None:
                 raise AirflowException("kylin job id is None")
@@ -177,7 +176,7 @@ class KylinCubeOperator(BaseOperator):
 
             job_status = None
             while job_status not in self.jobs_end_status:
-                if (timezone.utcnow() - started_at).total_seconds() > self.timeout:
+                if time.monotonic() - started_at > self.timeout:
                     raise AirflowException(f'kylin job {job_id} timeout')
                 time.sleep(self.interval)
 

--- a/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
+++ b/airflow/providers/google/cloud/hooks/cloud_storage_transfer_service.py
@@ -467,8 +467,8 @@ class CloudDataTransferServiceHook(GoogleBaseHook):
         elif isinstance(timeout, timedelta):
             timeout = timeout.total_seconds()
 
-        start_time = time.time()
-        while time.time() - start_time < timeout:
+        start_time = time.monotonic()
+        while time.monotonic() - start_time < timeout:
             request_filter = {FILTER_PROJECT_ID: job[PROJECT_ID], FILTER_JOB_NAMES: [job[NAME]]}
             operations = self.list_transfer_operations(request_filter=request_filter)
 

--- a/airflow/utils/orm_event_handlers.py
+++ b/airflow/utils/orm_event_handlers.py
@@ -66,11 +66,11 @@ def setup_event_handlers(engine):
 
         @event.listens_for(engine, "before_cursor_execute")
         def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-            conn.info.setdefault('query_start_time', []).append(time.time())
+            conn.info.setdefault('query_start_time', []).append(time.perf_counter())
 
         @event.listens_for(engine, "after_cursor_execute")
         def after_cursor_execute(conn, cursor, statement, parameters, context, executemany):
-            total = time.time() - conn.info['query_start_time'].pop()
+            total = time.perf_counter() - conn.info['query_start_time'].pop()
             file_name = [
                 f"'{f.name}':{f.filename}:{f.lineno}"
                 for f in traceback.extract_stack()

--- a/tests/providers/amazon/aws/hooks/test_sagemaker.py
+++ b/tests/providers/amazon/aws/hooks/test_sagemaker.py
@@ -492,7 +492,7 @@ class TestSageMakerHook(unittest.TestCase):
 
     @mock.patch.object(AwsLogsHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'get_conn')
-    @mock.patch.object(time, 'time')
+    @mock.patch.object(time, 'monotonic')
     def test_describe_training_job_with_logs_in_progress(self, mock_time, mock_client, mock_log_client):
         mock_session = mock.Mock()
         mock_log_session = mock.Mock()

--- a/tests/sensors/test_base_sensor.py
+++ b/tests/sensors/test_base_sensor.py
@@ -501,8 +501,12 @@ class TestBaseSensor(unittest.TestCase):
         sensor = self._make_sensor(return_value=None, poke_interval=5, timeout=60, exponential_backoff=False)
 
         started_at = timezone.utcnow() - timedelta(seconds=10)
-        self.assertEqual(sensor._get_next_poke_interval(started_at, 1), sensor.poke_interval)
-        self.assertEqual(sensor._get_next_poke_interval(started_at, 2), sensor.poke_interval)
+
+        def run_duration():
+            return (timezone.utcnow - started_at).total_seconds()
+
+        self.assertEqual(sensor._get_next_poke_interval(started_at, run_duration, 1), sensor.poke_interval)
+        self.assertEqual(sensor._get_next_poke_interval(started_at, run_duration, 2), sensor.poke_interval)
 
     def test_sensor_with_exponential_backoff_on(self):
 
@@ -512,10 +516,12 @@ class TestBaseSensor(unittest.TestCase):
             mock_utctime.return_value = DEFAULT_DATE
 
             started_at = timezone.utcnow() - timedelta(seconds=10)
-            print(started_at)
 
-            interval1 = sensor._get_next_poke_interval(started_at, 1)
-            interval2 = sensor._get_next_poke_interval(started_at, 2)
+            def run_duration():
+                return (timezone.utcnow - started_at).total_seconds()
+
+            interval1 = sensor._get_next_poke_interval(started_at, run_duration, 1)
+            interval2 = sensor._get_next_poke_interval(started_at, run_duration, 2)
 
             self.assertTrue(interval1 >= 0)
             self.assertTrue(interval1 <= sensor.poke_interval)


### PR DESCRIPTION
`time.time() - start`, or `timezone.utcnow() - start_dttm` will work
fine in 99% of cases, but it has one fatal flaw:

They both operate on system time, and that can go backwards.

While this might be surprising, it can happen -- usually due to clocks
being adjusted.

And while it is might seem rare, for long running processes it is more
common than we might expect. Most of these durations are harmless to get
wrong (just being logs) it is better to be safe than sorry.

Also the `utcnow()` style I have replaced will be much lighter weight -
creating a date time object is a comparatively expensive operation, and
computing a diff between two even more so, _especially_ when compared to
just subtracting two floats.

To make the "common" case easier of wanting to compute a duration for a
block, I have made `Stats.timer()` return an object that has a
`duration` field.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).