### PR TITLE
add ability to import dags in a subfolder with a zip file

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -256,6 +256,15 @@
       type: integer
       example: ~
       default: "2"
+    - name: dagbag_import_tree_depth
+      description: |
+        For zip files, if dags are defined in a subfolder,
+        how deep will a DagFileProcessor look for a dag object.
+        0 means we only look at the root folder.
+      version_added: 2.0.0
+      type: integer
+      example: ~
+      default: "0"
     - name: dag_file_processor_timeout
       description: |
         How long before timing out a DagFileProcessor, which processes a dag file

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -156,6 +156,11 @@ dagbag_import_error_tracebacks = True
 # If tracebacks are shown, how many entries from the traceback should be shown
 dagbag_import_error_traceback_depth = 2
 
+# For zip files, if dags are defined in a subfolder,
+# how deep will a DagFileProcessor look for a dag object.
+# 0 means we only look at the root folder.
+dagbag_import_tree_depth = 0
+
 # How long before timing out a DagFileProcessor, which processes a dag file
 dag_file_processor_timeout = 50
 

--- a/tests/dags_zip/archive1/test_zip_nested/__init__.py
+++ b/tests/dags_zip/archive1/test_zip_nested/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,11 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import os
-
-from airflow.utils import timezone
-
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-TEST_DAGS_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags')
-TEST_DAGS_ZIP_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags_zip')

--- a/tests/dags_zip/archive1/test_zip_nested/custom_lib/__init__.py
+++ b/tests/dags_zip/archive1/test_zip_nested/custom_lib/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,11 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import os
-
-from airflow.utils import timezone
-
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-TEST_DAGS_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags')
-TEST_DAGS_ZIP_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags_zip')

--- a/tests/dags_zip/archive1/test_zip_nested/custom_lib/my_module.py
+++ b/tests/dags_zip/archive1/test_zip_nested/custom_lib/my_module.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,10 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
 
-from airflow.utils import timezone
-
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-TEST_DAGS_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags')
-TEST_DAGS_ZIP_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags_zip')
+def my_func(**context):
+    print(context['dag_run'])

--- a/tests/dags_zip/archive1/test_zip_nested/dag.py
+++ b/tests/dags_zip/archive1/test_zip_nested/dag.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,10 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
+from datetime import datetime
 
-from airflow.utils import timezone
+from airflow.models import DAG
+from airflow.operators.python import PythonOperator
 
-DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-TEST_DAGS_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags')
-TEST_DAGS_ZIP_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags_zip')
+from .custom_lib.my_module import my_func
+
+DEFAULT_DATE = datetime(2016, 1, 1)
+
+args = {
+    'owner': 'airflow',
+    'start_date': DEFAULT_DATE,
+}
+
+dag = DAG(dag_id='test_zip_nested', default_args=args)
+python_op = PythonOperator(task_id='python_task', python_callable=my_func, dag=dag)


### PR DESCRIPTION
At Nielsen our data scientists write complex models using Airflow dags. Most of their projects follow this structure:

```
model-xyz
├── __init__.py
├── config.yaml
├── dag
│   ├── __init__.py
│   ├── dag.py
│   └── lib
│       ├── __init__.py
               ...
│       └── my_module.py
├── job_request.yaml
└── tests
    ├── __init__.py
    └── test_lib
        ├── __init__.py
        ├── test.yaml
                 ...
        └── test_my_module.py
```

Each model has a dedicated team working on it, is its own git repo and is edited through an IDE. When editing the project, our users may use relative imports and they usually have a root dir (here "model-xyz"). They then use a cli tool to zip their projects and send them to the dag home of our Airflow instance. We would prefer not to change the project structure when zipping it. 

Before this PR, all dags must be defined at the root level in a zip file.

This PR allows us to parse dag objects nested inside sub-folders. It is backwards compatible with the default value and allows for more customization. Some airflow dag projects at Nielsen contain hundreds of python files including tests. 