### PR TITLE
Add success/failed sets to State class

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -428,9 +428,7 @@ class DagRun(Base, LoggingMixin):
         leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids]
 
         # if all roots finished and at least one failed, the run failed
-        if not unfinished_tasks and any(
-            leaf_ti.state in {State.FAILED, State.UPSTREAM_FAILED} for leaf_ti in leaf_tis
-        ):
+        if not unfinished_tasks and any(leaf_ti.state in State.failed_states for leaf_ti in leaf_tis):
             self.log.error('Marking run %s failed', self)
             self.set_state(State.FAILED)
             if execute_callbacks:
@@ -445,9 +443,7 @@ class DagRun(Base, LoggingMixin):
                 )
 
         # if all leafs succeeded and no unfinished tasks, the run succeeded
-        elif not unfinished_tasks and all(
-            leaf_ti.state in {State.SUCCESS, State.SKIPPED} for leaf_ti in leaf_tis
-        ):
+        elif not unfinished_tasks and all(leaf_ti.state in State.success_states for leaf_ti in leaf_tis):
             self.log.info('Marking run %s successful', self)
             self.set_state(State.SUCCESS)
             if execute_callbacks:

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -134,6 +134,16 @@ class State:
     a run or has not even started.
     """
 
+    failed_states = frozenset([FAILED, UPSTREAM_FAILED])
+    """
+    A list of states indicating that a task or dag is a failed state.
+    """
+
+    success_states = frozenset([SUCCESS, SKIPPED])
+    """
+    A list of states indicating that a task or dag is a success state.
+    """
+
 
 class PokeState:
     """Static class with poke states constants used in smart operator."""


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
This PR is mostly a refactor to make it easier in case any companies want to add addition states (i.e. in my case). The idea is that we keep a success/failure states set in the states filed that can be called by other parts (dagrun, taskinstance, etc.) to verify that indeed a state is within one of those lists rather than having to adjust the set its checking against in the code separately everywhere.
It's a small change. But simple unit test added as well.
