### PR TITLE
GCP Secrets Optional Lookup

### DIFF
--- a/docs/security/secrets/secrets-backend/aws-secrets-manaager-backend.rst
+++ b/docs/security/secrets/secrets-backend/aws-secrets-manaager-backend.rst
@@ -32,6 +32,21 @@ Here is a sample configuration:
 To authenticate you can either supply a profile name to reference aws profile, e.g. defined in ``~/.aws/config`` or set
 environment variables like ``AWS_ACCESS_KEY_ID``, ``AWS_SECRET_ACCESS_KEY``.
 
+Optional lookup
+"""""""""""""""
+
+Optionally connections, variables, or config may be looked up exclusive of each other or in any combination.
+This will prevent requests being sent to AWS Secrets Manager for the excluded type.
+
+If you want to look up some and not others in AWS Secrets Manager you may do so by setting the relevant ``*_prefix`` parameter of the ones to be excluded as ``null``.
+
+For example, if you want to set parameter ``connections_prefix`` to ``"airflow/connections"`` and not look up variables, your configuration file should look like this:
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
+    backend_kwargs = {"connections_prefix": "airflow/connections", "variables_prefix": null, "profile_name": "default"}
 
 Storing and Retrieving Connections
 """"""""""""""""""""""""""""""""""

--- a/docs/security/secrets/secrets-backend/aws-ssm-parameter-store-secrets-backend.rst
+++ b/docs/security/secrets/secrets-backend/aws-ssm-parameter-store-secrets-backend.rst
@@ -31,6 +31,22 @@ Here is a sample configuration:
     backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
     backend_kwargs = {"connections_prefix": "/airflow/connections", "variables_prefix": "/airflow/variables", "profile_name": "default"}
 
+Optional lookup
+"""""""""""""""
+
+Optionally connections, variables, or config may be looked up exclusive of each other or in any combination.
+This will prevent requests being sent to AWS SSM Parameter Store for the excluded type.
+
+If you want to look up some and not others in AWS SSM Parameter Store you may do so by setting the relevant ``*_prefix`` parameter of the ones to be excluded as ``null``.
+
+For example, if you want to set parameter ``connections_prefix`` to ``"/airflow/connections"`` and not look up variables, your configuration file should look like this:
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend
+    backend_kwargs = {"connections_prefix": "/airflow/connections", "variables_prefix": null, "profile_name": "default"}
+
 Storing and Retrieving Connections
 """"""""""""""""""""""""""""""""""
 

--- a/docs/security/secrets/secrets-backend/azure-key-vault-secrets-backend.rst
+++ b/docs/security/secrets/secrets-backend/azure-key-vault-secrets-backend.rst
@@ -34,6 +34,21 @@ Here is a sample configuration:
 For client authentication, the ``DefaultAzureCredential`` from the Azure Python SDK is used as credential provider,
 which supports service principal, managed identity and user credentials.
 
+Optional lookup
+"""""""""""""""
+
+Optionally connections, variables, or config may be looked up exclusive of each other or in any combination.
+This will prevent requests being sent to Azure Key Vault for the excluded type.
+
+If you want to look up some and not others in Azure Key Vault you may do so by setting the relevant ``*_prefix`` parameter of the ones to be excluded as ``null``.
+
+For example, if you want to set parameter ``connections_prefix`` to ``"airflow-connections"`` and not look up variables, your configuration file should look like this:
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.microsoft.azure.secrets.azure_key_vault.AzureKeyVaultBackend
+    backend_kwargs = {"connections_prefix": "airflow-connections", "variables_prefix": null, "vault_url": "https://example-akv-resource-name.vault.azure.net/"}
 
 Storing and Retrieving Connections
 """"""""""""""""""""""""""""""""""

--- a/docs/security/secrets/secrets-backend/google-cloud-secret-manager-backend.rst
+++ b/docs/security/secrets/secrets-backend/google-cloud-secret-manager-backend.rst
@@ -87,6 +87,22 @@ For example, if you want to set parameter ``connections_prefix`` to ``"airflow-t
     backend = airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
     backend_kwargs = {"connections_prefix": "airflow-tenant-primary", "variables_prefix": "airflow-tenant-primary"}
 
+Optional lookup
+"""""""""""""""
+
+Optionally connections, variables, or config may be looked up exclusive of each other or in any combination.
+This will prevent requests being sent to GCP Secrets Manager for the excluded type.
+
+If you want to look up some and not others in GCP Secrets Manager you may do so by setting the relevant ``*_prefix`` parameter of the ones to be excluded as ``null``.
+
+For example, if you want to set parameter ``connections_prefix`` to ``"airflow-tenant-primary"`` and not look up variables, your configuration file should look like this:
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.google.cloud.secrets.secret_manager.CloudSecretManagerBackend
+    backend_kwargs = {"connections_prefix": "airflow-tenant-primary", "variables_prefix": null}
+
 Set-up credentials
 """"""""""""""""""
 

--- a/docs/security/secrets/secrets-backend/hashicorp-vault-secrets-backend.rst
+++ b/docs/security/secrets/secrets-backend/hashicorp-vault-secrets-backend.rst
@@ -44,6 +44,21 @@ key to ``backend_kwargs``:
 
     export VAULT_ADDR="http://127.0.0.1:8200"
 
+Optional lookup
+"""""""""""""""
+
+Optionally connections, variables, or config may be looked up exclusive of each other or in any combination.
+This will prevent requests being sent to Vault for the excluded type.
+
+If you want to look up some and not others in Vault you may do so by setting the relevant ``*_path`` parameter of the ones to be excluded as ``null``.
+
+For example, if you want to set parameter ``connections_path`` to ``"airflow-connections"`` and not look up variables, your configuration file should look like this:
+
+.. code-block:: ini
+
+    [secrets]
+    backend = airflow.providers.hashicorp.secrets.vault.VaultBackend
+    backend_kwargs = {"connections_path": "airflow-connections", "variables_path": null, "mount_point": "airflow", "url": "http://127.0.0.1:8200"}
 
 Storing and Retrieving Connections
 """"""""""""""""""""""""""""""""""

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -206,3 +206,44 @@ class TestCloudSecretManagerBackend(TestCase):
                 log_output.output[0],
                 f"Google Cloud API Call Error \\(NotFound\\): Secret ID {secret_id} not found",
             )
+
+    @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
+    @mock.patch(CLIENT_MODULE_NAME + ".SecretManagerServiceClient")
+    def test_connections_prefix_none_value(self, mock_client_callable, mock_get_creds):
+        mock_get_creds.return_value = CREDENTIALS, PROJECT_ID
+        mock_client = mock.MagicMock()
+        mock_client_callable.return_value = mock_client
+
+        with mock.patch(MODULE_NAME + '.CloudSecretManagerBackend._get_secret') as mock_get_secret:
+            with mock.patch(MODULE_NAME + '.CloudSecretManagerBackend._is_valid_prefix_and_sep') as mock_is_valid_prefix_sep:
+                secrets_manager_backend = CloudSecretManagerBackend(connections_prefix=None)
+
+                mock_is_valid_prefix_sep.assert_not_called()
+                self.assertIsNone(secrets_manager_backend.get_conn_uri(conn_id=CONN_ID))
+                mock_get_secret.assert_not_called()
+
+    @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
+    @mock.patch(CLIENT_MODULE_NAME + ".SecretManagerServiceClient")
+    def test_variables_prefix_none_value(self, mock_client_callable, mock_get_creds):
+        mock_get_creds.return_value = CREDENTIALS, PROJECT_ID
+        mock_client = mock.MagicMock()
+        mock_client_callable.return_value = mock_client
+
+        with mock.patch(MODULE_NAME + '.CloudSecretManagerBackend._get_secret') as mock_get_secret:
+            secrets_manager_backend = CloudSecretManagerBackend(variables_prefix=None)
+
+            self.assertIsNone(secrets_manager_backend.get_variable(VAR_KEY))
+            mock_get_secret.assert_not_called()
+
+    @mock.patch(MODULE_NAME + ".get_credentials_and_project_id")
+    @mock.patch(CLIENT_MODULE_NAME + ".SecretManagerServiceClient")
+    def test_config_prefix_none_value(self, mock_client_callable, mock_get_creds):
+        mock_get_creds.return_value = CREDENTIALS, PROJECT_ID
+        mock_client = mock.MagicMock()
+        mock_client_callable.return_value = mock_client
+
+        with mock.patch(MODULE_NAME + '.CloudSecretManagerBackend._get_secret') as mock_get_secret:
+            secrets_manager_backend = CloudSecretManagerBackend(config_prefix=None)
+
+            self.assertIsNone(secrets_manager_backend.get_config(CONFIG_KEY))
+            mock_get_secret.assert_not_called()

--- a/tests/providers/google/cloud/secrets/test_secret_manager.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager.py
@@ -215,7 +215,9 @@ class TestCloudSecretManagerBackend(TestCase):
         mock_client_callable.return_value = mock_client
 
         with mock.patch(MODULE_NAME + '.CloudSecretManagerBackend._get_secret') as mock_get_secret:
-            with mock.patch(MODULE_NAME + '.CloudSecretManagerBackend._is_valid_prefix_and_sep') as mock_is_valid_prefix_sep:
+            with mock.patch(
+                MODULE_NAME + '.CloudSecretManagerBackend._is_valid_prefix_and_sep'
+            ) as mock_is_valid_prefix_sep:
                 secrets_manager_backend = CloudSecretManagerBackend(connections_prefix=None)
 
                 mock_is_valid_prefix_sep.assert_not_called()

--- a/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
+++ b/tests/providers/microsoft/azure/secrets/test_azure_key_vault.py
@@ -114,7 +114,7 @@ class TestAzureKeyVaultBackend(TestCase):
 
         backend = AzureKeyVaultBackend(**kwargs)
         self.assertIsNone(backend.get_conn_uri('test_mysql'))
-        mock_get_secret._get_secret.assert_not_called()
+        mock_get_secret.assert_not_called()
 
     @mock.patch('airflow.providers.microsoft.azure.secrets.azure_key_vault.AzureKeyVaultBackend._get_secret')
     def test_variable_prefix_none_value(self, mock_get_secret):
@@ -127,7 +127,7 @@ class TestAzureKeyVaultBackend(TestCase):
 
         backend = AzureKeyVaultBackend(**kwargs)
         self.assertIsNone(backend.get_variable('hello'))
-        mock_get_secret._get_secret.assert_not_called()
+        mock_get_secret.assert_not_called()
 
     @mock.patch('airflow.providers.microsoft.azure.secrets.azure_key_vault.AzureKeyVaultBackend._get_secret')
     def test_config_prefix_none_value(self, mock_get_secret):
@@ -140,4 +140,4 @@ class TestAzureKeyVaultBackend(TestCase):
 
         backend = AzureKeyVaultBackend(**kwargs)
         self.assertIsNone(backend.get_config('test_mysql'))
-        mock_get_secret._get_secret.assert_not_called()
+        mock_get_secret.assert_not_called()


### PR DESCRIPTION
Optional lookup for connections, variables, and config for GCP Secrets Backend.

Also cleaned up something in the tests for Azure optional lookup, and thought I'd just include it here.

This is a followup to these PRs.
#11736 - Vault
#12143 - AWS
#12174 - Azure
