### PR TITLE
Reorder Database Migrations

### DIFF
--- a/airflow/migrations/versions/03afc6b6f902_increase_length_of_fab_ab_view_menu_.py
+++ b/airflow/migrations/versions/03afc6b6f902_increase_length_of_fab_ab_view_menu_.py
@@ -42,13 +42,6 @@ def upgrade():
     tables = inspector.get_table_names()
 
     if "ab_view_menu" in tables:
-        # Get Column and check if its length is already 250
-        get_ab_view_menu_name_column = [
-            col for col in inspector.get_columns('ab_view_menu') if col.get('name') == 'name'
-        ]
-        if get_ab_view_menu_name_column and get_ab_view_menu_name_column[0]['type'].length == 250:
-            # Do nothing if the left is already 250
-            return
         if conn.dialect.name == "sqlite":
             op.execute("PRAGMA foreign_keys=off")
             op.execute(
@@ -76,13 +69,6 @@ def downgrade():
     inspector = Inspector.from_engine(conn)
     tables = inspector.get_table_names()
     if "ab_view_menu" in tables:
-        # Get Column and check if its length is already 100
-        get_ab_view_menu_name_column = [
-            col for col in inspector.get_columns('ab_view_menu') if col.get('name') == 'name'
-        ]
-        if get_ab_view_menu_name_column and get_ab_view_menu_name_column[0]['type'].length == 100:
-            # Do nothing if the left is already 100
-            return
         if conn.dialect.name == "sqlite":
             op.execute("PRAGMA foreign_keys=off")
             op.execute(

--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -19,7 +19,7 @@
 """Resource based permissions.
 
 Revision ID: 2c6edca13270
-Revises: 364159666cbd
+Revises: 849da589634d
 Create Date: 2020-10-21 00:18:52.529438
 
 """
@@ -28,7 +28,7 @@ from airflow.www.app import create_app
 
 # revision identifiers, used by Alembic.
 revision = '2c6edca13270'
-down_revision = '364159666cbd'
+down_revision = '849da589634d'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
+++ b/airflow/migrations/versions/364159666cbd_add_job_id_to_dagrun_table.py
@@ -19,7 +19,7 @@
 """Add creating_job_id to DagRun table
 
 Revision ID: 364159666cbd
-Revises: 849da589634d
+Revises: 52d53670a240
 Create Date: 2020-10-10 09:08:07.332456
 
 """
@@ -29,7 +29,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '364159666cbd'
-down_revision = '849da589634d'
+down_revision = '52d53670a240'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/45ba3f1493b9_add_k8s_yaml_to_rendered_templates.py
+++ b/airflow/migrations/versions/45ba3f1493b9_add_k8s_yaml_to_rendered_templates.py
@@ -32,7 +32,7 @@ from airflow.settings import json
 
 # revision identifiers, used by Alembic.
 revision = '45ba3f1493b9'
-down_revision = '2c6edca13270'
+down_revision = '364159666cbd'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
+++ b/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
@@ -19,7 +19,7 @@
 """Prefix DAG permissions.
 
 Revision ID: 849da589634d
-Revises: 52d53670a240
+Revises: 03afc6b6f902
 Create Date: 2020-10-01 17:25:10.006322
 
 """
@@ -29,7 +29,7 @@ from airflow.www.app import cached_app
 
 # revision identifiers, used by Alembic.
 revision = '849da589634d'
-down_revision = '52d53670a240'
+down_revision = '03afc6b6f902'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/92c57b58940d_add_fab_tables.py
+++ b/airflow/migrations/versions/92c57b58940d_add_fab_tables.py
@@ -43,7 +43,7 @@ def upgrade():
     if "ab_permission" not in tables:
         op.create_table(
             'ab_permission',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
             sa.Column('name', sa.String(length=100), nullable=False),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('name'),
@@ -52,7 +52,7 @@ def upgrade():
     if "ab_view_menu" not in tables:
         op.create_table(
             'ab_view_menu',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
             sa.Column('name', sa.String(length=100), nullable=False),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('name'),
@@ -61,7 +61,7 @@ def upgrade():
     if "ab_role" not in tables:
         op.create_table(
             'ab_role',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
             sa.Column('name', sa.String(length=64), nullable=False),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('name'),
@@ -70,9 +70,9 @@ def upgrade():
     if "ab_permission_view" not in tables:
         op.create_table(
             'ab_permission_view',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
-            sa.Column('permission_id', sa.INTEGER(), nullable=True),
-            sa.Column('view_menu_id', sa.INTEGER(), nullable=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+            sa.Column('permission_id', sa.Integer(), nullable=True),
+            sa.Column('view_menu_id', sa.Integer(), nullable=True),
             sa.ForeignKeyConstraint(['permission_id'], ['ab_permission.id']),
             sa.ForeignKeyConstraint(['view_menu_id'], ['ab_view_menu.id']),
             sa.PrimaryKeyConstraint('id'),
@@ -82,9 +82,9 @@ def upgrade():
     if "ab_permission_view_role" not in tables:
         op.create_table(
             'ab_permission_view_role',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
-            sa.Column('permission_view_id', sa.INTEGER(), nullable=True),
-            sa.Column('role_id', sa.INTEGER(), nullable=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+            sa.Column('permission_view_id', sa.Integer(), nullable=True),
+            sa.Column('role_id', sa.Integer(), nullable=True),
             sa.ForeignKeyConstraint(['permission_view_id'], ['ab_permission_view.id']),
             sa.ForeignKeyConstraint(['role_id'], ['ab_role.id']),
             sa.PrimaryKeyConstraint('id'),
@@ -94,20 +94,20 @@ def upgrade():
     if "ab_user" not in tables:
         op.create_table(
             'ab_user',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
             sa.Column('first_name', sa.String(length=64), nullable=False),
             sa.Column('last_name', sa.String(length=64), nullable=False),
             sa.Column('username', sa.String(length=64), nullable=False),
             sa.Column('password', sa.String(length=256), nullable=True),
-            sa.Column('active', sa.BOOLEAN(), nullable=True),
+            sa.Column('active', sa.Boolean(), nullable=True),
             sa.Column('email', sa.String(length=64), nullable=False),
-            sa.Column('last_login', sa.DATETIME(), nullable=True),
-            sa.Column('login_count', sa.INTEGER(), nullable=True),
-            sa.Column('fail_login_count', sa.INTEGER(), nullable=True),
-            sa.Column('created_on', sa.DATETIME(), nullable=True),
-            sa.Column('changed_on', sa.DATETIME(), nullable=True),
-            sa.Column('created_by_fk', sa.INTEGER(), nullable=True),
-            sa.Column('changed_by_fk', sa.INTEGER(), nullable=True),
+            sa.Column('last_login', sa.DateTime(), nullable=True),
+            sa.Column('login_count', sa.Integer(), nullable=True),
+            sa.Column('fail_login_count', sa.Integer(), nullable=True),
+            sa.Column('created_on', sa.DateTime(), nullable=True),
+            sa.Column('changed_on', sa.DateTime(), nullable=True),
+            sa.Column('created_by_fk', sa.Integer(), nullable=True),
+            sa.Column('changed_by_fk', sa.Integer(), nullable=True),
             sa.ForeignKeyConstraint(['changed_by_fk'], ['ab_user.id']),
             sa.ForeignKeyConstraint(['created_by_fk'], ['ab_user.id']),
             sa.PrimaryKeyConstraint('id'),
@@ -118,9 +118,9 @@ def upgrade():
     if "ab_user_role" not in tables:
         op.create_table(
             'ab_user_role',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
-            sa.Column('user_id', sa.INTEGER(), nullable=True),
-            sa.Column('role_id', sa.INTEGER(), nullable=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
+            sa.Column('user_id', sa.Integer(), nullable=True),
+            sa.Column('role_id', sa.Integer(), nullable=True),
             sa.ForeignKeyConstraint(
                 ['role_id'],
                 ['ab_role.id'],
@@ -136,13 +136,13 @@ def upgrade():
     if "ab_register_user" not in tables:
         op.create_table(
             'ab_register_user',
-            sa.Column('id', sa.INTEGER(), nullable=False, primary_key=True),
+            sa.Column('id', sa.Integer(), nullable=False, primary_key=True),
             sa.Column('first_name', sa.String(length=64), nullable=False),
             sa.Column('last_name', sa.String(length=64), nullable=False),
             sa.Column('username', sa.String(length=64), nullable=False),
             sa.Column('password', sa.String(length=256), nullable=True),
             sa.Column('email', sa.String(length=64), nullable=False),
-            sa.Column('registration_date', sa.DATETIME(), nullable=True),
+            sa.Column('registration_date', sa.DateTime(), nullable=True),
             sa.Column('registration_hash', sa.String(length=256), nullable=True),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('username'),


### PR DESCRIPTION
Becase `2c6edca13270` (Resource based permissions) & `849da589634d` (Prefix DAG permissions)
were run before `92c57b58940d_add_fab_tables.py` and `03afc6b6f902_increase_length_of_fab_ab_view_menu_.py`,
the FAB tables were already created because those migrations imported `from airflow.www.app import create_app`
which calls the following lines that creates FAB tables:

https://github.com/dpgaspar/Flask-AppBuilder/blob/0e7f62418be0aea056302769ebac7d9bfa2bdd4e/flask_appbuilder/security/sqla/manager.py#L86-L97

https://github.com/apache/airflow/blob/02ef8e1cb37c6232db9e5bc32555cf114125eabb/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py#L19-L28

https://github.com/apache/airflow/blob/02ef8e1cb37c6232db9e5bc32555cf114125eabb/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py#L19-L27

**Previously**:

```
INFO  [alembic.runtime.migration] Running upgrade bef4f3d11e8b -> 98271e7606e2, Add scheduling_decision to DagRun and DAG
INFO  [alembic.runtime.migration] Running upgrade 98271e7606e2 -> 52d53670a240, fix_mssql_exec_date_rendered_task_instance_fields_for_MSSQL
INFO  [alembic.runtime.migration] Running upgrade 52d53670a240 -> 849da589634d, Prefix DAG permissions.
[2020-11-14 02:35:43,055] {manager.py:727} WARNING - No user yet created, use flask fab command to do it.
[2020-11-14 02:35:46,790] {migration.py:515} INFO - Running upgrade 849da589634d -> 364159666cbd, Add creating_job_id to DagRun table
[2020-11-14 02:35:46,794] {migration.py:515} INFO - Running upgrade 364159666cbd -> 2c6edca13270, Resource based permissions.
[2020-11-14 02:35:46,795] {app.py:87} INFO - User session lifetime is set to 43200 minutes.
[2020-11-14 02:35:46,806] {manager.py:727} WARNING - No user yet created, use flask fab command to do it.
[2020-11-14 02:35:48,221] {migration.py:515} INFO - Running upgrade 2c6edca13270 -> 45ba3f1493b9, add-k8s-yaml-to-rendered-templates
[2020-11-14 02:35:48,226] {migration.py:515} INFO - Running upgrade 45ba3f1493b9 -> 92c57b58940d, Create FAB Tables
[2020-11-14 02:35:48,227] {migration.py:515} INFO - Running upgrade 92c57b58940d -> 03afc6b6f902, Increase length of FAB ab_view_menu.name column
```

**Now**:

```
INFO  [alembic.runtime.migration] Running upgrade bef4f3d11e8b -> 98271e7606e2, Add scheduling_decision to DagRun and DAG
INFO  [alembic.runtime.migration] Running upgrade 98271e7606e2 -> 52d53670a240, fix_mssql_exec_date_rendered_task_instance_fields_for_MSSQL
INFO  [alembic.runtime.migration] Running upgrade 52d53670a240 -> 364159666cbd, Add creating_job_id to DagRun table
INFO  [alembic.runtime.migration] Running upgrade 364159666cbd -> 45ba3f1493b9, add-k8s-yaml-to-rendered-templates
INFO  [alembic.runtime.migration] Running upgrade 45ba3f1493b9 -> 92c57b58940d, Create FAB Tables
INFO  [alembic.runtime.migration] Running upgrade 92c57b58940d -> 03afc6b6f902, Increase length of FAB ab_view_menu.name column
INFO  [alembic.runtime.migration] Running upgrade 03afc6b6f902 -> 849da589634d, Prefix DAG permissions.
[2020-11-14 02:57:18,886] {manager.py:727} WARNING - No user yet created, use flask fab command to do it.
[2020-11-14 02:57:22,380] {migration.py:515} INFO - Running upgrade 849da589634d -> 2c6edca13270, Resource based permissions.
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
