### PR TITLE
Show all Providers in Docs

### DIFF
--- a/docs/exts/providers_packages_ref.py
+++ b/docs/exts/providers_packages_ref.py
@@ -42,7 +42,7 @@ def _filepath_to_module(filepath: str):
 def _load_package_data():
     schema = _load_schema()
     result = []
-    for provider_yaml_path in sorted(glob(f"{ROOT_DIR}/airflow/providers/**/provider.yaml")):
+    for provider_yaml_path in sorted(glob(f"{ROOT_DIR}/airflow/providers/**/provider.yaml", recursive=True)):
         with open(provider_yaml_path) as yaml_file:
             provider = yaml.safe_load(yaml_file)
         provider['python-module'] = _filepath_to_module(os.path.dirname(provider_yaml_path))


### PR DESCRIPTION
Before in https://airflow.readthedocs.io/en/latest/provider-packages-ref.html, the apache.spark and other nested providers were ignored


![image](https://user-images.githubusercontent.com/8811558/99138801-4bacd800-262b-11eb-945e-104c8a07650e.png)

```python
In [1]: from glob import glob
   ...:

In [2]: sorted(glob(f"airflow/providers/**/provider.yaml"))
Out[2]:
['airflow/providers/amazon/provider.yaml',
 'airflow/providers/celery/provider.yaml',
 'airflow/providers/cloudant/provider.yaml',
 'airflow/providers/databricks/provider.yaml',
 'airflow/providers/datadog/provider.yaml',
 'airflow/providers/dingding/provider.yaml',
 'airflow/providers/discord/provider.yaml',
 'airflow/providers/docker/provider.yaml',
 'airflow/providers/elasticsearch/provider.yaml',
 'airflow/providers/exasol/provider.yaml',
 'airflow/providers/facebook/provider.yaml',
 'airflow/providers/ftp/provider.yaml',
 'airflow/providers/google/provider.yaml',
 'airflow/providers/grpc/provider.yaml',
 'airflow/providers/hashicorp/provider.yaml',
 'airflow/providers/http/provider.yaml',
 'airflow/providers/imap/provider.yaml',
 'airflow/providers/jdbc/provider.yaml',
 'airflow/providers/jenkins/provider.yaml',
 'airflow/providers/jira/provider.yaml',
 'airflow/providers/mongo/provider.yaml',
 'airflow/providers/mysql/provider.yaml',
 'airflow/providers/odbc/provider.yaml',
 'airflow/providers/openfaas/provider.yaml',
 'airflow/providers/opsgenie/provider.yaml',
 'airflow/providers/oracle/provider.yaml',
 'airflow/providers/pagerduty/provider.yaml',
 'airflow/providers/papermill/provider.yaml',
 'airflow/providers/plexus/provider.yaml',
 'airflow/providers/postgres/provider.yaml',
 'airflow/providers/presto/provider.yaml',
 'airflow/providers/qubole/provider.yaml',
 'airflow/providers/redis/provider.yaml',
 'airflow/providers/salesforce/provider.yaml',
 'airflow/providers/samba/provider.yaml',
 'airflow/providers/segment/provider.yaml',
 'airflow/providers/sendgrid/provider.yaml',
 'airflow/providers/sftp/provider.yaml',
 'airflow/providers/singularity/provider.yaml',
 'airflow/providers/slack/provider.yaml',
 'airflow/providers/snowflake/provider.yaml',
 'airflow/providers/sqlite/provider.yaml',
 'airflow/providers/ssh/provider.yaml',
 'airflow/providers/vertica/provider.yaml',
 'airflow/providers/yandex/provider.yaml',
 'airflow/providers/zendesk/provider.yaml']
```

Now:

```python
In [4]: sorted(glob(f"airflow/providers/**/provider.yaml", recursive=True))
Out[4]:
['airflow/providers/amazon/provider.yaml',
 'airflow/providers/apache/cassandra/provider.yaml',
 'airflow/providers/apache/druid/provider.yaml',
 'airflow/providers/apache/hdfs/provider.yaml',
 'airflow/providers/apache/hive/provider.yaml',
 'airflow/providers/apache/kylin/provider.yaml',
 'airflow/providers/apache/livy/provider.yaml',
 'airflow/providers/apache/pig/provider.yaml',
 'airflow/providers/apache/pinot/provider.yaml',
 'airflow/providers/apache/spark/provider.yaml',
 'airflow/providers/apache/sqoop/provider.yaml',
 'airflow/providers/celery/provider.yaml',
 'airflow/providers/cloudant/provider.yaml',
 'airflow/providers/cncf/kubernetes/provider.yaml',
 'airflow/providers/databricks/provider.yaml',
 'airflow/providers/datadog/provider.yaml',
 'airflow/providers/dingding/provider.yaml',
 'airflow/providers/discord/provider.yaml',
 'airflow/providers/docker/provider.yaml',
 'airflow/providers/elasticsearch/provider.yaml',
 'airflow/providers/exasol/provider.yaml',
 'airflow/providers/facebook/provider.yaml',
 'airflow/providers/ftp/provider.yaml',
 'airflow/providers/google/provider.yaml',
 'airflow/providers/grpc/provider.yaml',
 'airflow/providers/hashicorp/provider.yaml',
 'airflow/providers/http/provider.yaml',
 'airflow/providers/imap/provider.yaml',
 'airflow/providers/jdbc/provider.yaml',
 'airflow/providers/jenkins/provider.yaml',
 'airflow/providers/jira/provider.yaml',
 'airflow/providers/microsoft/azure/provider.yaml',
 'airflow/providers/microsoft/mssql/provider.yaml',
 'airflow/providers/microsoft/winrm/provider.yaml',
 'airflow/providers/mongo/provider.yaml',
 'airflow/providers/mysql/provider.yaml',
 'airflow/providers/odbc/provider.yaml',
 'airflow/providers/openfaas/provider.yaml',
 'airflow/providers/opsgenie/provider.yaml',
 'airflow/providers/oracle/provider.yaml',
 'airflow/providers/pagerduty/provider.yaml',
 'airflow/providers/papermill/provider.yaml',
 'airflow/providers/plexus/provider.yaml',
 'airflow/providers/postgres/provider.yaml',
 'airflow/providers/presto/provider.yaml',
 'airflow/providers/qubole/provider.yaml',
 'airflow/providers/redis/provider.yaml',
 'airflow/providers/salesforce/provider.yaml',
 'airflow/providers/samba/provider.yaml',
 'airflow/providers/segment/provider.yaml',
 'airflow/providers/sendgrid/provider.yaml',
 'airflow/providers/sftp/provider.yaml',
 'airflow/providers/singularity/provider.yaml',
 'airflow/providers/slack/provider.yaml',
 'airflow/providers/snowflake/provider.yaml',
 'airflow/providers/sqlite/provider.yaml',
 'airflow/providers/ssh/provider.yaml',
 'airflow/providers/vertica/provider.yaml',
 'airflow/providers/yandex/provider.yaml',
 'airflow/providers/zendesk/provider.yaml']
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
