### PR TITLE
Make import errors dropdown configurable for default value

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -587,6 +587,9 @@ update_fab_perms = True
 # `session_lifetime_minutes` of non-activity
 session_lifetime_minutes = 43200
 
+# give option to have import errors collapsed on dags view
+default_collapse_import_error = True
+
 [email]
 
 # Configuration email backend and whether to

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -59,7 +59,7 @@
           </h4>
         </div>
 
-        <div id="alerts" class="panel-collapse collapse in">
+        <div id="alerts" class="panel-collapse collapse {{'' if default_collapse_import_error else 'in'}}">
           <div class="panel-body">
             {% for category, m in dag_import_errors %}
               <div class="alert alert-error dag-import-error">{{ m }}</div>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -573,6 +573,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             status_count_active=status_count_active,
             status_count_paused=status_count_paused,
             tags_filter=arg_tags_filter,
+            default_collapse_import_error=conf.getboolean('webserver', 'default_collapse_import_error'),
         )
 
     @expose('/dag_stats', methods=['POST'])


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
This is a simple pr to introduce the option to have the import errors collapsed. I know some teams / orgs like to see the import errors front and center (makes sense) but for such large organizations with thousands of flows, it could be the noise generated from import errors taking up a lot of real estate here. This pr is to introduce an optional config to make it collapsing by default.

I pass in this config to the view, and use a bit of a statement to make this possible. I.e. to add the `in` property or not. If there are better ways to do this please chime in!
<img width="1680" alt="Screen Shot 2020-11-13 at 8 01 23 PM" src="https://user-images.githubusercontent.com/10408007/99139247-df5eb400-25eb-11eb-8754-31cdf9e8c97f.png">

