### PR TITLE
Reject 'connections add' CLI request if URI provided is invalid

### DIFF
--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -648,9 +648,7 @@ class TestCliAddConnections(unittest.TestCase):
 
     def test_cli_connections_add_invalid_uri(self):
         # Attempt to add with invalid uri
-        with self.assertRaisesRegex(
-            SystemExit, r"The URI provided to --conn-uri is invalid: nonsense_uri"
-        ):
+        with self.assertRaisesRegex(SystemExit, r"The URI provided to --conn-uri is invalid: nonsense_uri"):
             connection_command.connections_add(
                 self.parser.parse_args(["connections", "add", "new1", "--conn-uri=%s" % "nonsense_uri"])
             )

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -646,6 +646,15 @@ class TestCliAddConnections(unittest.TestCase):
         ):
             connection_command.connections_add(self.parser.parse_args(["connections", "add", "new1"]))
 
+    def test_cli_connections_add_invalid_uri(self):
+        # Attempt to add with invalid uri
+        with self.assertRaisesRegex(
+            SystemExit, r"The URI provided to --conn-uri is invalid: nonsense_uri"
+        ):
+            connection_command.connections_add(
+                self.parser.parse_args(["connections", "add", "new1", "--conn-uri=%s" % "nonsense_uri"])
+            )
+
 
 class TestCliDeleteConnections(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/12369

- Reject the request is the URI is invalid
- The validity is decided by availability of both 'scheme' and 'netloc' in the parse result


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
