### PR TITLE
Fix RTD docs build

### DIFF
--- a/docs/exts/providers_packages_ref.py
+++ b/docs/exts/providers_packages_ref.py
@@ -15,9 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from provider_yaml_utils import load_package_data  # pylint: disable=no-name-in-module
 from sphinx.application import Sphinx
-
-from docs.exts.provider_yaml_utils import load_package_data  # pylint: disable=no-name-in-module
 
 
 def _on_config_inited(app, config):


### PR DESCRIPTION
RTD documentation does not build.
https://readthedocs.org/projects/airflow/builds/12339456/
This import should work because we have the path to the `sys.path` variable added.
https://github.com/apache/airflow/blob/6889a333cff001727eb0a66e375544a28c9a5f03/docs/conf.py#L109
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
