### PR TITLE
Properly mocks UUID objects

### DIFF
--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -24,6 +24,7 @@ import unittest
 from typing import Any, Dict
 from unittest import mock
 from unittest.mock import MagicMock
+from uuid import UUID
 
 from parameterized import parameterized
 
@@ -40,8 +41,9 @@ from airflow.providers.google.cloud.hooks.dataflow import (
 
 TASK_ID = 'test-dataflow-operator'
 JOB_NAME = 'test-dataflow-pipeline'
-MOCK_UUID = '12345678'
-UNIQUE_JOB_NAME = f'test-dataflow-pipeline-{MOCK_UUID}'
+MOCK_UUID = UUID('cf4a56d2-8101-4217-b027-2af6216feb48')
+MOCK_UUID_PREFIX = str(MOCK_UUID)[:8]
+UNIQUE_JOB_NAME = f'test-dataflow-pipeline-{MOCK_UUID_PREFIX}'
 TEST_TEMPLATE = 'gs://dataflow-templates/wordcount/template_file'
 PARAMETERS = {
     'inputFile': 'gs://dataflow-samples/shakespeare/kinglear.txt',
@@ -216,7 +218,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--labels=foo=bar',
             '--staging_location=gs://test/staging',
-            f'--job_name={JOB_NAME}-{MOCK_UUID}',
+            f'--job_name={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -250,7 +252,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--labels=foo=bar',
             '--staging_location=gs://test/staging',
-            f'--job_name={JOB_NAME}-{MOCK_UUID}',
+            f'--job_name={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -283,7 +285,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--labels=foo=bar',
             '--staging_location=gs://test/staging',
-            f'--job_name={JOB_NAME}-{MOCK_UUID}',
+            f'--job_name={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -320,7 +322,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--labels=foo=bar',
             '--staging_location=gs://test/staging',
-            f'--job_name={JOB_NAME}-{MOCK_UUID}',
+            f'--job_name={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -368,7 +370,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--labels=foo=bar',
             '--staging_location=gs://test/staging',
-            f'--job_name={JOB_NAME}-{MOCK_UUID}',
+            f'--job_name={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -418,7 +420,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--labels=foo=bar',
             '--staging_location=gs://test/staging',
-            f'--job_name={JOB_NAME}-{MOCK_UUID}',
+            f'--job_name={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -467,7 +469,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--stagingLocation=gs://test/staging',
             '--labels={"foo":"bar"}',
-            f'--jobName={JOB_NAME}-{MOCK_UUID}',
+            f'--jobName={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(
             sorted(expected_cmd),
@@ -504,7 +506,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--stagingLocation=gs://test/staging',
             '--labels={"foo":"bar"}',
-            f'--jobName={JOB_NAME}-{MOCK_UUID}',
+            f'--jobName={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -537,7 +539,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--stagingLocation=gs://test/staging',
             '--labels={"foo":"bar"}',
-            f'--jobName={JOB_NAME}-{MOCK_UUID}',
+            f'--jobName={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(
             sorted(expected_cmd),
@@ -573,7 +575,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--stagingLocation=gs://test/staging',
             '--labels={"foo":"bar"}',
-            f'--jobName={JOB_NAME}-{MOCK_UUID}',
+            f'--jobName={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(
             sorted(expected_cmd),
@@ -604,7 +606,7 @@ class TestDataflowHook(unittest.TestCase):
             '--project=test',
             '--stagingLocation=gs://test/staging',
             '--labels={"foo":"bar"}',
-            f'--jobName={JOB_NAME}-{MOCK_UUID}',
+            f'--jobName={JOB_NAME}-{MOCK_UUID_PREFIX}',
         ]
         self.assertListEqual(sorted(mock_dataflow.call_args[1]["cmd"]), sorted(expected_cmd))
 
@@ -612,8 +614,8 @@ class TestDataflowHook(unittest.TestCase):
         [
             (JOB_NAME, JOB_NAME, False),
             ('test-example', 'test_example', False),
-            ('test-dataflow-pipeline-12345678', JOB_NAME, True),
-            ('test-example-12345678', 'test_example', True),
+            (f'test-dataflow-pipeline-{MOCK_UUID_PREFIX}', JOB_NAME, True),
+            (f'test-example-{MOCK_UUID_PREFIX}', 'test_example', True),
             ('df-job-1', 'df-job-1', False),
             ('df-job', 'df-job', False),
             ('dfjob', 'dfjob', False),
@@ -674,7 +676,7 @@ class TestDataflowTemplateHook(unittest.TestCase):
 
         launch_method.assert_called_once_with(
             body={
-                'jobName': 'test-dataflow-pipeline-12345678',
+                'jobName': f'test-dataflow-pipeline-{MOCK_UUID_PREFIX}',
                 'parameters': PARAMETERS,
                 'environment': variables,
             },
@@ -686,7 +688,7 @@ class TestDataflowTemplateHook(unittest.TestCase):
         mock_controller.assert_called_once_with(
             dataflow=mock_conn.return_value,
             job_id='test-job-id',
-            name='test-dataflow-pipeline-12345678',
+            name=f'test-dataflow-pipeline-{MOCK_UUID_PREFIX}',
             num_retries=5,
             poll_sleep=10,
             project_number=TEST_PROJECT,
@@ -809,7 +811,7 @@ class TestDataflowTemplateHook(unittest.TestCase):
             dataflow=mock_conn.return_value,
             job_id=TEST_JOB_ID,
             location=DEFAULT_DATAFLOW_LOCATION,
-            name=f'test-dataflow-pipeline-{MOCK_UUID}',
+            name=f'test-dataflow-pipeline-{MOCK_UUID_PREFIX}',
             num_retries=5,
             poll_sleep=10,
             project_number=TEST_PROJECT,
@@ -857,7 +859,7 @@ class TestDataflowTemplateHook(unittest.TestCase):
             dataflow=mock_conn.return_value,
             job_id=TEST_JOB_ID,
             location=DEFAULT_DATAFLOW_LOCATION,
-            name=f'test-dataflow-pipeline-{MOCK_UUID}',
+            name=f'test-dataflow-pipeline-{MOCK_UUID_PREFIX}',
             num_retries=5,
             poll_sleep=10,
             project_number=TEST_PROJECT,

--- a/tests/providers/google/cloud/hooks/test_pubsub.py
+++ b/tests/providers/google/cloud/hooks/test_pubsub.py
@@ -19,6 +19,7 @@
 import unittest
 from typing import List
 from unittest import mock
+from uuid import UUID
 
 from google.api_core.exceptions import AlreadyExists, GoogleAPICallError
 from google.cloud.exceptions import NotFound
@@ -37,7 +38,7 @@ EMPTY_CONTENT = b''
 TEST_PROJECT = 'test-project'
 TEST_TOPIC = 'test-topic'
 TEST_SUBSCRIPTION = 'test-subscription'
-TEST_UUID = 'abc123-xzy789'
+TEST_UUID = UUID('cf4a56d2-8101-4217-b027-2af6216feb48')
 TEST_MESSAGES = [
     {'data': b'Hello, World!', 'attributes': {'type': 'greeting'}},
     {'data': b'Knock, knock'},


### PR DESCRIPTION
The uuid methods return UUID objects not strings and there is
a certain expectation about those - like hex property for example

We had a few cases where those uuid method's return values have
been mocked with strings and it caused a problem - for example
with migration to latest sentry library which used this very
hex method from the uuid4() return value.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
