### PR TITLE
[AIRFLOW-5115] Bugfix for S3KeySensor failing to accept template_fields

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -69,22 +69,7 @@ class S3KeySensor(BaseSensorOperator):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        # Parse
-        if bucket_name is None:
-            parsed_url = urlparse(bucket_key)
-            if parsed_url.netloc == '':
-                raise AirflowException('Please provide a bucket_name')
-            else:
-                bucket_name = parsed_url.netloc
-                bucket_key = parsed_url.path.lstrip('/')
-        else:
-            parsed_url = urlparse(bucket_key)
-            if parsed_url.scheme != '' or parsed_url.netloc != '':
-                raise AirflowException(
-                    'If bucket_name is provided, bucket_key'
-                    + ' should be relative path from root'
-                    + ' level, rather than a full s3:// url'
-                )
+
         self.bucket_name = bucket_name
         self.bucket_key = bucket_key
         self.wildcard_match = wildcard_match
@@ -93,6 +78,24 @@ class S3KeySensor(BaseSensorOperator):
         self.hook: Optional[S3Hook] = None
 
     def poke(self, context):
+
+        if self.bucket_name is None:
+            parsed_url = urlparse(self.bucket_key)
+            if parsed_url.netloc == '':
+                raise AirflowException(
+                    'If key is a relative path from root,' + ' please provide a bucket_name'
+                )
+            self.bucket_name = parsed_url.netloc
+            self.bucket_key = parsed_url.path.lstrip('/')
+        else:
+            parsed_url = urlparse(self.bucket_key)
+            if parsed_url.scheme != '' or parsed_url.netloc != '':
+                raise AirflowException(
+                    'If bucket_name is provided, bucket_key'
+                    + ' should be relative path from root'
+                    + ' level, rather than a full s3:// url'
+                )
+
         self.log.info('Poking for key : s3://%s/%s', self.bucket_name, self.bucket_key)
         if self.wildcard_match:
             return self.get_hook().check_for_wildcard_key(self.bucket_key, self.bucket_name)

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -82,9 +82,7 @@ class S3KeySensor(BaseSensorOperator):
         if self.bucket_name is None:
             parsed_url = urlparse(self.bucket_key)
             if parsed_url.netloc == '':
-                raise AirflowException(
-                    'If key is a relative path from root,' + ' please provide a bucket_name'
-                )
+                raise AirflowException('If key is a relative path from root, please provide a bucket_name')
             self.bucket_name = parsed_url.netloc
             self.bucket_key = parsed_url.path.lstrip('/')
         else:

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -26,6 +26,8 @@ from airflow.providers.amazon.aws.sensors.s3_key import S3KeySensor
 
 
 class TestS3KeySensor(unittest.TestCase):
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
     def test_bucket_name_none_and_bucket_key_as_relative_path(self):
         """
         Test if exception is raised when bucket_name is None
@@ -36,6 +38,7 @@ class TestS3KeySensor(unittest.TestCase):
         with self.assertRaises(AirflowException):
             op.poke(None)
 
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
     def test_bucket_name_provided_and_bucket_key_is_s3_url(self):
         """
         Test if exception is raised when bucket_name is provided
@@ -54,6 +57,7 @@ class TestS3KeySensor(unittest.TestCase):
             ['key', 'bucket', 'key', 'bucket'],
         ]
     )
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
     def test_parse_bucket_key(self, key, bucket, parsed_key, parsed_bucket):
         op = S3KeySensor(
             task_id='s3_key_sensor',

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -26,7 +26,6 @@ from airflow.providers.amazon.aws.sensors.s3_key import S3KeySensor
 
 
 class TestS3KeySensor(unittest.TestCase):
-
     @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
     def test_bucket_name_none_and_bucket_key_as_relative_path(self):
         """

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -26,7 +26,6 @@ from airflow.providers.amazon.aws.sensors.s3_key import S3KeySensor
 
 
 class TestS3KeySensor(unittest.TestCase):
-    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
     def test_bucket_name_none_and_bucket_key_as_relative_path(self):
         """
         Test if exception is raised when bucket_name is None
@@ -37,7 +36,6 @@ class TestS3KeySensor(unittest.TestCase):
         with self.assertRaises(AirflowException):
             op.poke(None)
 
-    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
     def test_bucket_name_provided_and_bucket_key_is_s3_url(self):
         """
         Test if exception is raised when bucket_name is provided
@@ -57,7 +55,9 @@ class TestS3KeySensor(unittest.TestCase):
         ]
     )
     @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
-    def test_parse_bucket_key(self, key, bucket, parsed_key, parsed_bucket):
+    def test_parse_bucket_key(self, key, bucket, parsed_key, parsed_bucket, mock_hook):
+        mock_hook.return_value.check_for_key.return_value = False
+
         op = S3KeySensor(
             task_id='s3_key_sensor',
             bucket_key=key,

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -32,8 +32,9 @@ class TestS3KeySensor(unittest.TestCase):
         and bucket_key is provided as relative path rather than s3:// url.
         :return:
         """
+        op = S3KeySensor(task_id='s3_key_sensor', bucket_key="file_in_bucket")
         with self.assertRaises(AirflowException):
-            S3KeySensor(task_id='s3_key_sensor', bucket_key="file_in_bucket")
+            op.poke(None)
 
     def test_bucket_name_provided_and_bucket_key_is_s3_url(self):
         """
@@ -41,10 +42,11 @@ class TestS3KeySensor(unittest.TestCase):
         while bucket_key is provided as a full s3:// url.
         :return:
         """
+        op = S3KeySensor(
+            task_id='s3_key_sensor', bucket_key="s3://test_bucket/file", bucket_name='test_bucket'
+        )
         with self.assertRaises(AirflowException):
-            S3KeySensor(
-                task_id='s3_key_sensor', bucket_key="s3://test_bucket/file", bucket_name='test_bucket'
-            )
+            op.poke(None)
 
     @parameterized.expand(
         [
@@ -58,6 +60,9 @@ class TestS3KeySensor(unittest.TestCase):
             bucket_key=key,
             bucket_name=bucket,
         )
+
+        op.poke(None)
+
         self.assertEqual(op.bucket_key, parsed_key)
         self.assertEqual(op.bucket_name, parsed_bucket)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixes a bug in the `S3KeySensor` that prevents the use of Jinja-templated strings as arguments to `bucket_key` and `bucket_name` by performing a URL parsing validation in the constructor (_before_ the template gets rendered).

This PR simply moves this validation downstream to the `poke` method. This unblocks users from using Jinja-templated fields in args to the operator.

To the best of my knowledge there is no corresponding issue in Github but I have linked the Jira issue.

closes: https://issues.apache.org/jira/browse/AIRFLOW-5115

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
