### PR TITLE
Make airflow upgrade_check a command from a separate dist

### DIFF
--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -16,6 +16,8 @@
 # under the License.
 
 from __future__ import absolute_import
+import argparse
+import sys
 from typing import List
 
 from airflow.upgrade.formatters import BaseFormatter
@@ -36,3 +38,32 @@ def check_upgrade(formatter):
         formatter.on_next_rule_status(rule_status)
     formatter.end_checking(all_rule_statuses)
     return all_rule_statuses
+
+
+def register_arguments(subparser):
+    subparser.add_argument(
+        "-s", "--save",
+        help="Saves the result to the indicated file. The file format is determined by the file extension."
+    )
+    subparser.set_defaults(func=run)
+
+
+def run(args):
+    from airflow.upgrade.formatters import (ConsoleFormatter, JSONFormatter)
+    if args.save:
+        filename = args.save
+        if not filename.lower().endswith(".json"):
+            exit("Only JSON files are supported")
+        formatter = JSONFormatter(args.save)
+    else:
+        formatter = ConsoleFormatter()
+    all_problems = check_upgrade(formatter)
+    if all_problems:
+        sys.exit(1)
+
+
+def __main__():
+    parser = argparse.ArgumentParser()
+    register_arguments(parser)
+    args.parser.parse_args()
+    args.func(args)

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -65,5 +65,5 @@ def run(args):
 def __main__():
     parser = argparse.ArgumentParser()
     register_arguments(parser)
-    args.parser.parse_args()
+    args = parser.parse_args()
     args.func(args)

--- a/setup.py
+++ b/setup.py
@@ -652,7 +652,7 @@ def do_setup():
         long_description_content_type='text/markdown',
         license='Apache License 2.0',
         version=version,
-        packages=find_packages(exclude=['tests*']),
+        packages=find_packages(exclude=['tests*', 'airflow.upgrade*']),
         package_data={
             '': ['airflow/alembic.ini', "airflow/git_version", "*.ipynb",
                  "airflow/providers/cncf/kubernetes/example_dags/*.yaml"],

--- a/tests/upgrade/test_formattes.py
+++ b/tests/upgrade/test_formattes.py
@@ -46,9 +46,10 @@ class TestJSONFormatter:
             }
         ]
         parser = cli.CLIFactory.get_parser()
-        with NamedTemporaryFile("w+") as temp:
+        with NamedTemporaryFile("w+", suffix=".json") as temp:
             with pytest.raises(SystemExit):
-                cli.upgrade_check(parser.parse_args(['upgrade_check', '-s', temp.name]))
+                args = parser.parse_args(['upgrade_check', '-s', temp.name])
+                args.func(args)
             content = temp.read()
 
         assert json.loads(content) == expected


### PR DESCRIPTION
By doing it this way we can add new features to upgrade_check, such as
the adding a flag to make changes automatically, without having to
release a new version of Airflow.

I will next work on packaging up the existing checks in to a packageable format.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).