### PR TITLE
Simplify using XComArg in jinja template string

### DIFF
--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -87,7 +87,8 @@ class XComArg(TaskMixin):
             xcom_pull_kwargs.append(f"key='{self.key}'")
 
         xcom_pull_kwargs = ", ".join(xcom_pull_kwargs)
-        xcom_pull = f"task_instance.xcom_pull({xcom_pull_kwargs})"
+        # {{{{ are required for escape {{ in f-string
+        xcom_pull = f"{{{{ task_instance.xcom_pull({xcom_pull_kwargs}) }}}}"
         return xcom_pull
 
     @property

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -62,11 +62,14 @@ class TestXComArgBuild:
         assert actual.key == "test_key"
         # Asserting the overridden __eq__ method
         assert actual == XComArg(python_op, "test_key")
+        expected_str = (
+            "{{ task_instance.xcom_pull(task_ids='test_xcom_op', "
+            "dag_id='test_xcom_dag', key='test_key') }}"
+        )
+        assert str(actual) == expected_str
         assert (
-            str(actual) == "task_instance.xcom_pull("
-            "task_ids=\'test_xcom_op\', "
-            "dag_id=\'test_xcom_dag\', "
-            "key=\'test_key\')"
+            f"echo {actual}" == "echo {{ task_instance.xcom_pull(task_ids='test_xcom_op', "
+            "dag_id='test_xcom_dag', key='test_key') }}"
         )
 
     def test_xcom_key_is_empty_str(self):
@@ -74,8 +77,8 @@ class TestXComArgBuild:
         actual = XComArg(python_op, key="")
         assert actual.key == ""
         assert (
-            str(actual) == "task_instance.xcom_pull(task_ids='test_xcom_op', "
-            "dag_id='test_xcom_dag', key='')"
+            str(actual) == "{{ task_instance.xcom_pull(task_ids='test_xcom_op', "
+            "dag_id='test_xcom_dag', key='') }}"
         )
 
     def test_set_downstream(self):


### PR DESCRIPTION
This changes XComArg string representation from 'task_instance.pull(...)'
to '{{ task_instance.xcom_pull(...) }}' so users can use XComArgs with
f-string (and other) in simpler way. Instead of doing
f'echo {{{{ {op.output} }}}}' they can simply do f'echo {op.output}'.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
