### PR TITLE
Fix: Don't display DAG Docs when None

### DIFF
--- a/airflow/www/templates/appbuilder/dag_docs.html
+++ b/airflow/www/templates/appbuilder/dag_docs.html
@@ -18,7 +18,7 @@
 #}
 
 {% macro dag_docs(doc_md) %}
-  {% if doc_md is defined %}
+  {% if doc_md is defined and doc_md is not none %}
     <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true" style="margin-top: 16px;">
       <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingOne">


### PR DESCRIPTION
Fixes a small bug introduced in #12330 (I'm new to Python/Flask)

The desired behavior is to not show the "DAG Docs" at all when (defined and) `None`. Renders nothing instead of this:

![image](https://user-images.githubusercontent.com/3267/99441917-94dc8080-28e6-11eb-88f1-ff9c840ef0b8.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
