### PR TITLE
Move setup properties out of setup.py in to setup.cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,7 +779,8 @@ jobs:
           cache-name: cache-kubernetes-tests-v7-master
         with:
           path: ".build/.kubernetes_venv*"
-          key: "venv-${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py') }}\
+          key: "venv-${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py')\
+-${{ hashFiles('setup.cfg') }}\
 -${{ needs.build-info.outputs.defaultPythonVersion }}"
       - name: "Cache bin folder with tools for kubernetes testing"
         uses: actions/cache@v2
@@ -788,6 +789,7 @@ jobs:
         with:
           path: ".build/bin"
           key: "bin-${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py') }}\
+-${{ hashFiles('setup.cfg') }}\
 -${{ needs.build-info.outputs.defaultPythonVersion }}\
 -${{ needs.build-info.outputs.defaultKindVersion }}\
 -${{ needs.build-info.outputs.defaultHelmVersion }}\

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -788,8 +788,7 @@ jobs:
           cache-name: cache-kubernetes-tests-v7-master
         with:
           path: ".build/bin"
-          key: "bin-${{ env.cache-name }}-${{ github.job }}-${{ hashFiles('setup.py') }}\
--${{ hashFiles('setup.cfg') }}\
+          key: "bin-${{ env.cache-name }}-${{ github.job }}\
 -${{ needs.build-info.outputs.defaultPythonVersion }}\
 -${{ needs.build-info.outputs.defaultKindVersion }}\
 -${{ needs.build-info.outputs.defaultHelmVersion }}\

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,9 +27,9 @@ Getting Airflow
 Airflow is published as ``apache-airflow`` package in PyPI. Installing it however might be sometimes tricky
 because Airflow is a bit of both a library and application. Libraries usually keep their dependencies open and
 applications usually pin them, but we should do neither and both at the same time. We decided to keep
-our dependencies as open as possible (in ``setup.cfg``) so users can install different version of libraries
-if needed. This means that from time to time plain ``pip install apache-airflow`` will not work or will
-produce unusable Airflow installation.
+our dependencies as open as possible (in ``setup.cfg`` and ``setup.py``) so users can install different
+version of libraries if needed. This means that from time to time plain ``pip install apache-airflow`` will
+not work or will produce unusable Airflow installation.
 
 In order to have repeatable installation, however, starting from **Airflow 1.10.10** and updated in
 **Airflow 1.10.12** we also keep a set of "known-to-be-working" constraint files in the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,7 +27,7 @@ Getting Airflow
 Airflow is published as ``apache-airflow`` package in PyPI. Installing it however might be sometimes tricky
 because Airflow is a bit of both a library and application. Libraries usually keep their dependencies open and
 applications usually pin them, but we should do neither and both at the same time. We decided to keep
-our dependencies as open as possible (in ``setup.py``) so users can install different version of libraries
+our dependencies as open as possible (in ``setup.cfg``) so users can install different version of libraries
 if needed. This means that from time to time plain ``pip install apache-airflow`` will not work or will
 produce unusable Airflow installation.
 

--- a/scripts/ci/pre_commit/pre_commit_check_order_setup.py
+++ b/scripts/ci/pre_commit/pre_commit_check_order_setup.py
@@ -103,21 +103,23 @@ def check_alias_dependent_group(setup_context: str) -> None:
         _check_list_sorted(src, f"Order of alias dependencies group: {dependent}")
 
 
-def check_install_and_setup_requires(setup_context: str) -> None:
+def check_install_and_setup_requires() -> None:
     """
     Test for an order of dependencies in function do_setup section
     install_requires and setup_requires in setup.py
     """
-    pattern_install_and_setup_requires = re.compile('(setup_requires) ?= ?\\[(.*?)\\]', re.DOTALL)
-    install_and_setup_requires = pattern_install_and_setup_requires.findall(setup_context)
 
-    for dependent_requires in install_and_setup_requires:
-        pattern_dependent = re.compile('\'(.*?)\'')
-        dependent = pattern_dependent.findall(dependent_requires[1])
-        pattern_dependent_version = re.compile('[~|><=;].*')
+    from setuptools.config import read_configuration
 
-        src = [pattern_dependent_version.sub('', p) for p in dependent]
-        _check_list_sorted(src, f"Order of dependencies in do_setup section: {dependent_requires[0]}")
+    path = abspath(os.path.join(dirname(__file__), os.pardir, os.pardir, os.pardir, 'setup.cfg'))
+    config = read_configuration(path)
+
+    pattern_dependent_version = re.compile('[~|><=;].*')
+
+    for key in ('install_requires', 'setup_requires'):
+        deps = config['options'][key]
+        dists = [pattern_dependent_version.sub('', p) for p in deps]
+        _check_list_sorted(dists, f"Order of dependencies in do_setup section: {key}")
 
 
 def check_extras_require(setup_context: str) -> None:
@@ -187,7 +189,7 @@ if __name__ == '__main__':
     check_main_dependent_group(setup_context_main)
     check_alias_dependent_group(setup_context_main)
     check_sub_dependent_group(setup_context_main)
-    check_install_and_setup_requires(setup_context_main)
+    check_install_and_setup_requires()
     check_extras_require(setup_context_main)
     check_provider_requirements(setup_context_main)
     check_extras_provider_packages(setup_context_main)

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,7 +81,7 @@ setup_requires =
 install_requires =
     alembic>=1.2, <2.0
     argcomplete~=1.10
-    attrs>=20.0, <21.0,
+    attrs>=20.0, <21.0
     cached_property~=1.5
     # cattrs >= 1.1.0 dropped support for Python 3.6
     cattrs>=1.0, <1.1.0;python_version<="3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,11 +68,70 @@ include_package_data = True
 python_requires = ~=3.6
 packages = find:
 setup_requires =
-      bowler
-      docutils
-      gitpython
-      setuptools
-      wheel
+    bowler
+    docutils
+    gitpython
+    setuptools
+    wheel
+#####################################################################################################
+# IMPORTANT NOTE!!!!!!!!!!!!!!!
+# IF you are removing dependencies from this list, please make sure that you also increase
+# DEPENDENCIES_EPOCH_NUMBER in the Dockerfile.ci
+#####################################################################################################
+install_requires =
+    alembic>=1.2, <2.0
+    argcomplete~=1.10
+    attrs>=20.0, <21.0,
+    cached_property~=1.5
+    # cattrs >= 1.1.0 dropped support for Python 3.6
+    cattrs>=1.0, <1.1.0;python_version<="3.6"
+    cattrs>=1.0, <2.0;python_version>"3.6"
+    colorlog==4.0.2
+    connexion[swagger-ui,flask]>=2.6.0,<3
+    croniter>=0.3.17, <0.4
+    cryptography>=0.9.3
+    dill>=0.2.2, <0.4
+    flask>=1.1.0, <2.0
+    flask-appbuilder~=3.1.1
+    flask-caching>=1.5.0, <2.0.0
+    flask-login>=0.3, <0.5
+    flask-swagger==0.2.13
+    flask-wtf>=0.14.3, <0.15
+    funcsigs>=1.0.0, <2.0.0
+    graphviz>=0.12
+    gunicorn>=19.5.0, <20.0
+    iso8601>=0.1.12
+    jinja2>=2.10.1, <2.12.0
+    json-merge-patch==0.2
+    jsonschema~=3.0
+    lazy_object_proxy~=1.3
+    lockfile>=0.12.2
+    markdown>=2.5.2, <4.0
+    markupsafe>=1.1.1, <2.0
+    marshmallow-oneofschema>=2.0.1
+    pandas>=0.17.1, <2.0
+    pendulum~=2.0
+    pep562~=1.0;python_version<"3.7"
+    psutil>=4.2.0, <6.0.0
+    pygments>=2.0.1, <3.0
+    python-daemon>=2.1.1
+    python-dateutil>=2.3, <3
+    python-nvd3~=0.15.0
+    python-slugify>=3.0.0,<5.0
+    requests>=2.20.0, <3
+    rich==9.2.0
+    setproctitle>=1.1.8, <2
+    sqlalchemy>=1.3.18, <2
+    sqlalchemy_jsonfield~=0.9
+    tabulate>=0.7.5, <0.9
+    tenacity~=6.2.0
+    termcolor>=1.1.0
+    thrift>=0.9.2
+    typing;python_version<"3.6"
+    typing-extensions>=3.7.4;python_version<"3.8"
+    tzlocal>=1.4,<2.0.0
+    unicodecsv>=0.14.1
+    werkzeug~=1.0, >=1.0.1
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,9 +134,6 @@ install_requires =
     werkzeug~=1.0, >=1.0.1
 
 [options.packages.find]
-exclude =
-    airflow.providers
-    airflow.providers.*
 include =
     airflow*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,12 +16,14 @@
 # under the License.
 
 [metadata]
-name = Airflow
-summary = Airflow is a system to programmatically author, schedule and monitor data pipelines.
-description-file = README.md
-author = Apache Airflow PMC
-author-email = dev@airflow.apache.org
-license = Apache License, Version 2.0
+name = apache-airflow
+summary = Programmatically author, schedule and monitor data pipelines
+author = Apache Software Foundation
+author_email = dev@airflow.apache.org
+url = http://airflow.apache.org/
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = Apache License 2.0
 license_files =
    LICENSE
    NOTICE
@@ -44,6 +46,52 @@ license_files =
    licenses/LICENSE-python-nvd3.txt
    licenses/LICENSE-python-slugify.txt
 # End of licences generated automatically
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Environment :: Web Environment
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Topic :: System :: Monitoring
+project_urls =
+    Documentation=https://airflow.apache.org/docs/
+    Bug Tracker=https://github.com/apache/airflow/issues
+    Source Code=https://github.com/apache/airflow
+
+[options]
+zip_safe = False
+include_package_data = True
+python_requires = ~=3.6
+packages = find:
+setup_requires =
+      bowler
+      docutils
+      gitpython
+      setuptools
+      wheel
+
+[options.packages.find]
+exclude =
+    airflow.providers
+    airflow.providers.*
+include =
+    airflow*
+
+[options.package_data]
+airflow=
+    py.typed
+    alembic.ini
+    git_version
+airflow.api.connextion.openaip=*.yaml
+airflow.serialization=*.json
+
+[options.entry_points]
+console_scripts=
+    airflow=airflow.__main__:main
 
 [bdist_wheel]
 python-tag=py3

--- a/setup.py
+++ b/setup.py
@@ -803,68 +803,6 @@ EXTRAS_REQUIREMENTS.update(
     }
 )
 
-#####################################################################################################
-# IMPORTANT NOTE!!!!!!!!!!!!!!!
-# IF you are removing dependencies from this list, please make sure that you also increase
-# DEPENDENCIES_EPOCH_NUMBER in the Dockerfile.ci
-#####################################################################################################
-INSTALL_REQUIREMENTS = [
-    'alembic>=1.2, <2.0',
-    'argcomplete~=1.10',
-    'attrs>=20.0, <21.0',
-    'cached_property~=1.5',
-    # cattrs >= 1.1.0 dropped support for Python 3.6
-    'cattrs>=1.0, <1.1.0;python_version<="3.6"',
-    'cattrs>=1.0, <2.0;python_version>"3.6"',
-    'colorlog==4.0.2',
-    'connexion[swagger-ui,flask]>=2.6.0,<3',
-    'croniter>=0.3.17, <0.4',
-    'cryptography>=0.9.3',
-    'dill>=0.2.2, <0.4',
-    'flask>=1.1.0, <2.0',
-    'flask-appbuilder~=3.1.1',
-    'flask-caching>=1.5.0, <2.0.0',
-    'flask-login>=0.3, <0.5',
-    'flask-swagger==0.2.13',
-    'flask-wtf>=0.14.3, <0.15',
-    'funcsigs>=1.0.0, <2.0.0',
-    'graphviz>=0.12',
-    'gunicorn>=19.5.0, <20.0',
-    'iso8601>=0.1.12',
-    'importlib_resources; python_version<"3.7"',
-    'jinja2>=2.10.1, <2.12.0',
-    'json-merge-patch==0.2',
-    'jsonschema~=3.0',
-    'lazy_object_proxy~=1.3',
-    'lockfile>=0.12.2',
-    'markdown>=2.5.2, <4.0',
-    'markupsafe>=1.1.1, <2.0',
-    'marshmallow-oneofschema>=2.0.1',
-    'pandas>=0.17.1, <2.0',
-    'pendulum~=2.0',
-    'pep562~=1.0;python_version<"3.7"',
-    'psutil>=4.2.0, <6.0.0',
-    'pygments>=2.0.1, <3.0',
-    'python-daemon>=2.1.1',
-    'python-dateutil>=2.3, <3',
-    'python-nvd3~=0.15.0',
-    'python-slugify>=3.0.0,<5.0',
-    'requests>=2.20.0, <3',
-    'rich==9.2.0',
-    'setproctitle>=1.1.8, <2',
-    'sqlalchemy>=1.3.18, <2',
-    'sqlalchemy_jsonfield~=0.9',
-    'tabulate>=0.7.5, <0.9',
-    'tenacity~=6.2.0',
-    'termcolor>=1.1.0',
-    'thrift>=0.9.2',
-    'typing;python_version<"3.6"',
-    'typing-extensions>=3.7.4;python_version<"3.8"',
-    'tzlocal>=1.4,<2.0.0',
-    'unicodecsv>=0.14.1',
-    'werkzeug~=1.0, >=1.0.1',
-]
-
 
 def get_provider_package_from_package_id(package_id: str):
     """
@@ -896,7 +834,6 @@ def do_setup():
         # Most values come from setup.cfg -- see
         # https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
         version=version,
-        install_requires=INSTALL_REQUIREMENTS,
         extras_require=EXTRAS_REQUIREMENTS,
         download_url=('https://archive.apache.org/dist/airflow/' + version),
         cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from os.path import dirname
 from textwrap import wrap
 from typing import Dict, Iterable, List
 
-from setuptools import Command, find_namespace_packages, find_packages, setup
+from setuptools import Command, find_namespace_packages, setup
 
 logger = logging.getLogger(__name__)
 
@@ -36,12 +36,6 @@ version = '2.0.0b2'
 PY3 = sys.version_info[0] == 3
 
 my_dir = dirname(__file__)
-
-try:
-    with open(os.path.join(my_dir, 'README.md'), encoding='utf-8') as f:
-        long_description = f.read()
-except FileNotFoundError:
-    long_description = ''
 
 
 def airflow_test_suite():
@@ -885,73 +879,25 @@ def get_provider_package_from_package_id(package_id: str):
 
 def do_setup():
     """Perform the Airflow package setup."""
-    install_providers_from_sources = os.getenv('INSTALL_PROVIDERS_FROM_SOURCES')
-    exclude_patterns = (
-        []
-        if install_providers_from_sources and install_providers_from_sources == 'true'
-        else ['airflow.providers', 'airflow.providers.*']
-    )
-    write_version()
-    if not install_providers_from_sources:
+    setup_kwargs = {}
+
+    if os.getenv('INSTALL_PROVIDERS_FROM_SOURCES') == 'true':
+        # Only specify this if we need this option, otherwise let default from
+        # setup.cfg control this (kwargs in setup() call take priority)
+        setup_kwargs['packages'] = find_namespace_packages(include=['airflow*'])
+    else:
         for key, value in EXTRAS_PROVIDERS_PACKAGES.items():
             EXTRAS_REQUIREMENTS[key].extend(
                 [get_provider_package_from_package_id(package_name) for package_name in value]
             )
-    packages_to_install = (
-        find_namespace_packages(include=['airflow*'], exclude=exclude_patterns)
-        if install_providers_from_sources
-        else find_packages(include=['airflow*'], exclude=exclude_patterns)
-    )
+
+    write_version()
     setup(
-        name='apache-airflow',
-        description='Programmatically author, schedule and monitor data pipelines',
-        long_description=long_description,
-        long_description_content_type='text/markdown',
-        license='Apache License 2.0',
+        # Most values come from setup.cfg -- see
+        # https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
         version=version,
-        packages=packages_to_install,
-        package_data={
-            'airflow': ['py.typed'],
-            '': [
-                'airflow/alembic.ini',
-                "airflow/git_version",
-                "*.ipynb",
-                "airflow/providers/cncf/kubernetes/example_dags/*.yaml",
-            ],
-            'airflow.api_connexion.openapi': ['*.yaml'],
-            'airflow.serialization': ["*.json"],
-        },
-        include_package_data=True,
-        zip_safe=False,
-        entry_points={
-            "console_scripts": [
-                "airflow = airflow.__main__:main",
-            ],
-        },
         install_requires=INSTALL_REQUIREMENTS,
-        setup_requires=[
-            'bowler',
-            'docutils',
-            'gitpython',
-            'setuptools',
-            'wheel',
-        ],
         extras_require=EXTRAS_REQUIREMENTS,
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Environment :: Console',
-            'Environment :: Web Environment',
-            'Intended Audience :: Developers',
-            'Intended Audience :: System Administrators',
-            'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.6',
-            'Programming Language :: Python :: 3.7',
-            'Programming Language :: Python :: 3.8',
-            'Topic :: System :: Monitoring',
-        ],
-        author='Apache Software Foundation',
-        author_email='dev@airflow.apache.org',
-        url='http://airflow.apache.org/',
         download_url=('https://archive.apache.org/dist/airflow/' + version),
         cmdclass={
             'extra_clean': CleanCommand,
@@ -959,12 +905,7 @@ def do_setup():
             'list_extras': ListExtras,
         },
         test_suite='setup.airflow_test_suite',
-        python_requires='~=3.6',
-        project_urls={
-            'Documentation': 'https://airflow.apache.org/docs/',
-            'Bug Tracker': 'https://github.com/apache/airflow/issues',
-            'Source Code': 'https://github.com/apache/airflow',
-        },
+        **setup_kwargs,
     )
 
 


### PR DESCRIPTION
I've moved all the ones that are "static" -- any form of dynamic or interpolated values are left in setup.py

If a value is passed as n kwrg to setup and in setup.cfg, the kwarg wins out.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).