### PR TITLE
Optimize json schema validation in providers_manager

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -38,7 +38,6 @@ log = logging.getLogger(__name__)
 def _create_validator():
     schema = json.loads(importlib_resources.read_text('airflow', 'provider.yaml.schema.json'))
     cls = jsonschema.validators.validator_for(schema)
-    cls.check_schema(schema)
     validator = cls(schema)
     return validator
 

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -21,7 +21,6 @@ import json
 import logging
 import pkgutil
 import traceback
-from typing import Dict
 
 import jsonschema
 import yaml
@@ -36,8 +35,12 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
-def _load_schema() -> Dict:
-    return json.loads(importlib_resources.read_text('airflow', 'provider.yaml.schema.json'))
+def _create_validator():
+    schema = json.loads(importlib_resources.read_text('airflow', 'provider.yaml.schema.json'))
+    cls = jsonschema.validators.validator_for(schema)
+    cls.check_schema(schema)
+    validator = cls(schema)
+    return validator
 
 
 class ProvidersManager:
@@ -50,7 +53,7 @@ class ProvidersManager:
         except ImportError as e:
             log.warning("No providers are present or error when importing them! :%s", e)
             return
-        self._schema = _load_schema()
+        self._validator = _create_validator()
         self.__find_all_providers(providers.__path__)
 
     def __find_all_providers(self, paths: str):
@@ -67,7 +70,7 @@ class ProvidersManager:
             try:
                 provider = importlib_resources.read_text(imported_module, 'provider.yaml')
                 provider_info = yaml.safe_load(provider)
-                jsonschema.validate(provider_info, schema=self._schema)
+                self._validator.validate(provider_info)
                 self._provider_directory[provider_info['package-name']] = provider_info
             except FileNotFoundError:
                 # This is OK - this is not a provider package


### PR DESCRIPTION
```
    :func:`validate` will first verify that the provided schema is
    itself valid, since not doing so can lead to less obvious error
    messages and fail in less obvious or consistent ways.

    If you know you have a valid schema already, especially if you
    intend to validate multiple instances with the same schema, you
    likely would prefer using the `IValidator.validate` method directly
    on a specific validator (e.g. ``Draft7Validator.validate``).
```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
