### PR TITLE
Fix docstrings for Kubernetes Backcompat module

### DIFF
--- a/airflow/providers/cncf/kubernetes/backcompat/volume.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/volume.py
@@ -36,9 +36,8 @@ class Volume:
 
         :param name: the name of the volume mount
         :type name: str
-        :param configs: dictionary of any features needed for volume.
-        We purposely keep this vague since there are multiple volume types with changing
-        configs.
+        :param configs: dictionary of any features needed for volume. We purposely keep this
+            vague since there are multiple volume types with changing configs.
         :type configs: dict
         """
         self.name = name
@@ -48,7 +47,7 @@ class Volume:
         """
         Converts to k8s object.
 
-        :return Volume Mount k8s object
+        :return: Volume Mount k8s object
         """
         resp = k8s.V1Volume(name=self.name)
         for k, v in self.configs.items():

--- a/airflow/providers/cncf/kubernetes/backcompat/volume_mount.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/volume_mount.py
@@ -55,7 +55,7 @@ class VolumeMount:
         """
         Converts to k8s object.
 
-        :return Volume Mount k8s object
+        :return: Volume Mount k8s object
         """
         return k8s.V1VolumeMount(
             name=self.name, mount_path=self.mount_path, sub_path=self.sub_path, read_only=self.read_only


### PR DESCRIPTION
This were missed in https://github.com/apache/airflow/pull/12384

Docs: https://airflow.readthedocs.io/en/latest/_api/airflow/providers/cncf/kubernetes/backcompat/volume_mount/index.html

![image](https://user-images.githubusercontent.com/8811558/99464369-e1987980-292f-11eb-8080-d7cdc57e1b88.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
