### PR TITLE
Enable Markdownlint rule MD045/no alt text

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -61,8 +61,5 @@ MD040: false
 # MD041/first-line-heading/first-line-h1
 MD041: false
 
-# MD045/no-alt-text
-MD045: false
-
 # MD046/code-block-style
 MD046: false

--- a/README.md
+++ b/README.md
@@ -177,27 +177,27 @@ following the ASF Policy.
 
 - **DAGs**: Overview of all DAGs in your environment.
 
-  ![](/docs/img/dags.png)
+  ![DAGs](/docs/img/dags.png)
 
 - **Tree View**: Tree representation of a DAG that spans across time.
 
-  ![](/docs/img/tree.png)
+  ![Tree View](/docs/img/tree.png)
 
 - **Graph View**: Visualization of a DAG's dependencies and their current status for a specific run.
 
-  ![](/docs/img/graph.png)
+  ![Graph View](/docs/img/graph.png)
 
 - **Task Duration**: Total time spent on different tasks over time.
 
-  ![](/docs/img/duration.png)
+  ![Task Duration](/docs/img/duration.png)
 
 - **Gantt View**: Duration and overlap of a DAG.
 
-  ![](/docs/img/gantt.png)
+  ![Gantt View](/docs/img/gantt.png)
 
 - **Code View**:  Quick way to view source code of a DAG.
 
-  ![](/docs/img/code.png)
+  ![Code View](/docs/img/code.png)
 
 
 ## Contributing


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md045---images-should-have-alternate-text-alt-text

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
