### PR TITLE
PR to add 'files' to template-fields in EmailOperator class to make files a templated parameter.

### DIFF
--- a/airflow/operators/email.py
+++ b/airflow/operators/email.py
@@ -33,7 +33,7 @@ class EmailOperator(BaseOperator):
     :param html_content: content of the email, html markup
         is allowed. (templated)
     :type html_content: str
-    :param files: file names to attach in email
+    :param files: file names to attach in email (templated)
     :type files: list
     :param cc: list of recipients to be added in CC field
     :type cc: list or string (comma or semicolon delimited)
@@ -46,7 +46,7 @@ class EmailOperator(BaseOperator):
     :type mime_charset: str
     """
 
-    template_fields = ('to', 'subject', 'html_content')
+    template_fields = ('to', 'subject', 'html_content', 'files')
     template_fields_renderers = {"html_content": "html"}
     template_ext = ('.html',)
     ui_color = '#e6faf9'


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
