### PR TITLE
Enable Markdownlint rule MD014/commands-show-output

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -31,9 +31,6 @@ MD012: false
 # MD013 Line length
 MD013: false
 
-# MD014/commands-show-output
-MD014: false
-
 # MD024/no-duplicate-heading/no-duplicate-header
 MD024: false
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -185,7 +185,7 @@ password=<API Upload Token>
 Set proper permissions for the pypirc file:
 
 ```shell script
-$ chmod 600 ~/.pypirc
+chmod 600 ~/.pypirc
 ```
 
 - Install [twine](https://pypi.org/project/twine/) if you do not have it already (it can be done

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -538,7 +538,7 @@ At this point we release an official package:
 - Get a diff between the last version and the current version:
 
     ```shell script
-    $ git log 1.8.0..1.9.0 --pretty=oneline
+    git log 1.8.0..1.9.0 --pretty=oneline
     ```
 
 - Update CHANGELOG.md with the details, and commit it.


### PR DESCRIPTION
https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md014---dollar-signs-used-before-commands-without-showing-output

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
