### PR TITLE
Added `files` to templated fields of `EmailOperator`

### DIFF
--- a/airflow/operators/email.py
+++ b/airflow/operators/email.py
@@ -33,7 +33,7 @@ class EmailOperator(BaseOperator):
     :param html_content: content of the email, html markup
         is allowed. (templated)
     :type html_content: str
-    :param files: file names to attach in email
+    :param files: file names to attach in email (templated)
     :type files: list
     :param cc: list of recipients to be added in CC field
     :type cc: list or string (comma or semicolon delimited)

--- a/airflow/operators/email.py
+++ b/airflow/operators/email.py
@@ -46,7 +46,7 @@ class EmailOperator(BaseOperator):
     :type mime_charset: str
     """
 
-    template_fields = ('to', 'subject', 'html_content')
+    template_fields = ('to', 'subject', 'html_content', 'files')
     template_fields_renderers = {"html_content": "html"}
     template_ext = ('.html',)
     ui_color = '#e6faf9'

--- a/tests/operators/test_email.py
+++ b/tests/operators/test_email.py
@@ -59,4 +59,5 @@ class TestEmailOperator(unittest.TestCase):
         with conf_vars({('email', 'email_backend'): 'tests.operators.test_email.send_email_test'}):
             self._run_as_operator()
         assert send_email_test.call_count == 1
-        assert send_email_test.call_args[1]['files'][0] == '/tmp/Report-A-2016-01-01.csv' #pylint: disable=unsubscriptable-object
+        resulting_files = send_email_test.call_args[1]['files']  # pylint: disable=unsubscriptable-object
+        assert resulting_files[0] == '/tmp/Report-A-2016-01-01.csv'

--- a/tests/operators/test_email.py
+++ b/tests/operators/test_email.py
@@ -59,4 +59,4 @@ class TestEmailOperator(unittest.TestCase):
         with conf_vars({('email', 'email_backend'): 'tests.operators.test_email.send_email_test'}):
             self._run_as_operator()
         assert send_email_test.call_count == 1
-        assert send_email_test.call_args[1]['files'][0] == '/tmp/Report-A-2016-01-01.csv'
+        assert send_email_test.call_args[1]['files'][0] == '/tmp/Report-A-2016-01-01.csv' #pylint: disable=unsubscriptable-object

--- a/tests/operators/test_email.py
+++ b/tests/operators/test_email.py
@@ -50,6 +50,7 @@ class TestEmailOperator(unittest.TestCase):
             html_content='The quick brown fox jumps over the lazy dog',
             task_id='task',
             dag=self.dag,
+            files=["/tmp/Report-A-{{ execution_date.strftime('%Y-%m-%d') }}.csv"],
             **kwargs,
         )
         task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
@@ -58,3 +59,4 @@ class TestEmailOperator(unittest.TestCase):
         with conf_vars({('email', 'email_backend'): 'tests.operators.test_email.send_email_test'}):
             self._run_as_operator()
         assert send_email_test.call_count == 1
+        assert send_email_test.call_args[1]['files'][0] == '/tmp/Report-A-2016-01-01.csv'


### PR DESCRIPTION
This adds `files` to the templated fields of `EmailOperator`, and adds an associated assertion to its tests.
Enables you to do the following:
```
EmailOperator(
        ....
        files=[
            "/tmp/Report-A-{{ execution_date.strftime('%Y-%m-%d') }}.csv",
            "/tmp/Reportt-B-{{ execution_date.strftime('%Y-%m-%d') }}.csv"
        ]
```

closes: #12028 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
