### PR TITLE
Fix file permission issue when running git-sync in the KubernetesExecutor mode

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -53,7 +53,7 @@ spec:
 {{- end }}
 {{- if .Values.dags.gitSync.knownHosts }}
         - mountPath: /etc/git-secret/known_hosts
-          name: {{ .Values.dags.gitSync.knownHosts }}
+          name: git-sync-known-hosts
           subPath: known_hosts
 {{- end }}
 {{- if .Values.dags.gitSync.sshKeySecret }}
@@ -77,6 +77,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: {{ .Values.uid }}
+    fsGroup: {{ .Values.gid }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   affinity: {{ toYaml .Values.affinity | nindent 4 }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -256,3 +256,11 @@ class PodTemplateFileTest(unittest.TestCase):
                 docs[0],
             ),
         )
+
+    def test_should_add_fsgroup_to_the_pod_template(self):
+        docs = render_chart(
+            values={"gid": 5000},
+            show_only=["templates/pod-template-file.yaml"],
+        )
+
+        self.assertEqual(5000, jmespath.search("spec.securityContext.fsGroup", docs[0]))


### PR DESCRIPTION
…tor mode.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
When using git-sync in the Kubernetes, dag folder is empty because the ssh key file cannot be accessed by git-sync user.
This commit try to fix this by add securityContext.fsGroup parameter in the pod template.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
