### PR TITLE
Fix: Render label as html instead of text

### DIFF
--- a/airflow/www/static/js/base.js
+++ b/airflow/www/static/js/base.js
@@ -146,7 +146,7 @@ function initializeUITimezone() {
   changDisplayedTimezone(selectedTz || Airflow.defaultUITimezone);
 
   if (Airflow.serverTimezone !== 'UTC') {
-    $('#timezone-server a').text(`${formatTimezone(Airflow.serverTimezone)} <span class="label label-primary">Server</span>`);
+    $('#timezone-server a').html(`${formatTimezone(Airflow.serverTimezone)} <span class="label label-primary">Server</span>`);
     $('#timezone-server').show();
   }
 


### PR DESCRIPTION
Resolves #12344 

Small bug introduced in #11195.

| Before | After |
|---|---|
| <img width="382" alt="Image 2020-11-18 at 9 40 11 AM" src="https://user-images.githubusercontent.com/3267/99545025-f3efd300-2982-11eb-9d49-aa97e8ba2ff4.png">  |  <img width="200" alt="Image 2020-11-18 at 9 41 05 AM" src="https://user-images.githubusercontent.com/3267/99544996-eb979800-2982-11eb-984b-25608ab899db.png"> |
