### PR TITLE
Fix backwards compatibility for affinity and node selector

### DIFF
--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -142,30 +142,15 @@ def convert_configmap(configmaps) -> k8s.V1EnvFromSource:
 
 
 def convert_affinity(affinity) -> k8s.V1Affinity:
-    """
-    Converts a dict into an k8s.V1Affinity
-
-    :param affinity:
-    :return:
-    """
+    """Converts a dict into an k8s.V1Affinity"""
     return _convert_from_dict(affinity, k8s.V1Affinity)
 
 
 def convert_node_selector(node_selector) -> k8s.V1NodeSelector:
-    """
-    Converts a dict into an k8s.V1NodeSelector
-
-    :param node_selector:
-    :return:
-    """
+    """Converts a dict into a k8s.V1NodeSelector"""
     return _convert_from_dict(node_selector, k8s.V1NodeSelector)
 
 
 def convert_toleration(toleration) -> k8s.V1Toleration:
-    """
-    Converts a dict into an k8s.V1Toleration
-
-    :param toleration:
-    :return:
-    """
+    """Converts a dict into an k8s.V1Toleration"""
     return _convert_from_dict(toleration, k8s.V1Toleration)

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -18,7 +18,7 @@
 
 from typing import List
 
-from kubernetes.client import models as k8s
+from kubernetes.client import ApiClient, models as k8s
 
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.backcompat.pod import Port, Resources
@@ -35,6 +35,16 @@ def _convert_kube_model_object(obj, old_class, new_class):
         return obj
     else:
         raise AirflowException(f"Expected {old_class} or {new_class}, got {type(obj)}")
+
+
+def _convert_from_dict(obj, new_class):
+    if isinstance(obj, new_class):
+        return obj
+    elif isinstance(obj, dict):
+        api_client = ApiClient()
+        return api_client._ApiClient__deserialize_model(obj, new_class)  # pylint: disable=W0212
+    else:
+        raise AirflowException(f"Expected dict or {new_class}, got {type(obj)}")
 
 
 def convert_volume(volume) -> k8s.V1Volume:
@@ -129,3 +139,33 @@ def convert_configmap(configmaps) -> k8s.V1EnvFromSource:
     :return:
     """
     return k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name=configmaps))
+
+
+def convert_affinity(affinity) -> k8s.V1Affinity:
+    """
+    Converts a dict into an k8s.V1Affinity
+
+    :param affinity:
+    :return:
+    """
+    return _convert_from_dict(affinity, k8s.V1Affinity)
+
+
+def convert_node_selector(node_selector) -> k8s.V1NodeSelector:
+    """
+    Converts a dict into an k8s.V1NodeSelector
+
+    :param node_selector:
+    :return:
+    """
+    return _convert_from_dict(node_selector, k8s.V1NodeSelector)
+
+
+def convert_toleration(toleration) -> k8s.V1Toleration:
+    """
+    Converts a dict into an k8s.V1Toleration
+
+    :param toleration:
+    :return:
+    """
+    return _convert_from_dict(toleration, k8s.V1Toleration)

--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -62,38 +62,37 @@ init_container = k8s.V1Container(
     args=["echo 10"],
 )
 
-affinity = {
-    'nodeAffinity': {
-        'preferredDuringSchedulingIgnoredDuringExecution': [
-            {
-                "weight": 1,
-                "preference": {"matchExpressions": {"key": "disktype", "operator": "In", "values": ["ssd"]}},
-            }
+affinity = k8s.V1Affinity(
+    node_affinity=k8s.V1NodeAffinity(
+        preferred_during_scheduling_ignored_during_execution=[
+            k8s.V1PreferredSchedulingTerm(
+                weight=1,
+                preference=k8s.V1NodeSelectorTerm(
+                    match_expressions=[
+                        k8s.V1NodeSelectorRequirement(key="disktype", operator="in", values=["ssd"])
+                    ]
+                ),
+            )
         ]
-    },
-    "podAffinity": {
-        "requiredDuringSchedulingIgnoredDuringExecution": [
-            {
-                "labelSelector": {
-                    "matchExpressions": [{"key": "security", "operator": "In", "values": ["S1"]}]
-                },
-                "topologyKey": "failure-domain.beta.kubernetes.io/zone",
-            }
+    ),
+    pod_affinity=k8s.V1PodAffinity(
+        required_during_scheduling_ignored_during_execution=[
+            k8s.V1WeightedPodAffinityTerm(
+                pod_affinity_term=k8s.V1PodAffinityTerm(
+                    label_selector=k8s.V1LabelSelector(
+                        match_expressions=[
+                            k8s.V1LabelSelectorRequirement(key="security", operator="In", values="S1")
+                        ]
+                    ),
+                    topology_key="failure-domain.beta.kubernetes.io/zone",
+                )
+            )
         ]
-    },
-    "podAntiAffinity": {
-        "requiredDuringSchedulingIgnoredDuringExecution": [
-            {
-                "labelSelector": {
-                    "matchExpressions": [{"key": "security", "operator": "In", "values": ["S2"]}]
-                },
-                "topologyKey": "kubernetes.io/hostname",
-            }
-        ]
-    },
-}
+    ),
+)
 
-tolerations = [{'key': "key", 'operator': 'Equal', 'value': 'value'}]
+tolerations = [k8s.V1Toleration(key="key", operator="Equal", value="value")]
+
 # [END howto_operator_k8s_cluster_resources]
 
 

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -19,7 +19,7 @@ import unittest
 from unittest import mock
 
 import pendulum
-from kubernetes.client import models as k8s
+from kubernetes.client import ApiClient, models as k8s
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, TaskInstance
@@ -227,3 +227,207 @@ class TestKubernetesPodOperator(unittest.TestCase):
         k.execute(context=context)
 
         assert not mock_client.return_value.read_namespaced_pod.called
+
+    def test_create_with_affinity(self):
+        name_base = 'test'
+
+        affinity = {
+            'nodeAffinity': {
+                'preferredDuringSchedulingIgnoredDuringExecution': [
+                    {
+                        "weight": 1,
+                        "preference": {
+                            "matchExpressions": [{"key": "disktype", "operator": "In", "values": ["ssd"]}]
+                        },
+                    }
+                ]
+            }
+        }
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name=name_base,
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            affinity=affinity,
+        )
+
+        result = k.create_pod_request_obj()
+        client = ApiClient()
+        self.assertEqual(type(result.spec.affinity), k8s.V1Affinity)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['affinity'], affinity)
+
+        k8s_api_affinity = k8s.V1Affinity(
+            node_affinity=k8s.V1NodeAffinity(
+                preferred_during_scheduling_ignored_during_execution=[
+                    k8s.V1PreferredSchedulingTerm(
+                        weight=1,
+                        preference=k8s.V1NodeSelectorTerm(
+                            match_expressions=[
+                                k8s.V1NodeSelectorRequirement(key="disktype", operator="In", values=["ssd"])
+                            ]
+                        ),
+                    )
+                ]
+            ),
+        )
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name=name_base,
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            affinity=k8s_api_affinity,
+        )
+
+        result = k.create_pod_request_obj()
+        self.assertEqual(type(result.spec.affinity), k8s.V1Affinity)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['affinity'], affinity)
+
+    def test_tolerations(self):
+        k8s_api_tolerations = [k8s.V1Toleration(key="key", operator="Equal", value="value")]
+
+        tolerations = [{'key': "key", 'operator': 'Equal', 'value': 'value'}]
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="name",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            tolerations=tolerations,
+        )
+
+        result = k.create_pod_request_obj()
+        client = ApiClient()
+        self.assertEqual(type(result.spec.tolerations[0]), k8s.V1Toleration)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['tolerations'], tolerations)
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="name",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            tolerations=k8s_api_tolerations,
+        )
+
+        result = k.create_pod_request_obj()
+        self.assertEqual(type(result.spec.tolerations[0]), k8s.V1Toleration)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['tolerations'], tolerations)
+
+    def test_node_selector(self):
+        k8s_api_node_selector = k8s.V1NodeSelector(
+            node_selector_terms=[
+                k8s.V1NodeSelectorTerm(
+                    match_expressions=[
+                        k8s.V1NodeSelectorRequirement(key="disktype", operator="In", values=["ssd"])
+                    ]
+                )
+            ]
+        )
+
+        node_selector = {
+            'nodeSelectorTerms': [
+                {'matchExpressions': [{'key': 'disktype', 'operator': 'In', 'values': ['ssd']}]}
+            ]
+        }
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="name",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            node_selector=k8s_api_node_selector,
+        )
+
+        result = k.create_pod_request_obj()
+        client = ApiClient()
+        self.assertEqual(type(result.spec.node_selector), k8s.V1NodeSelector)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['nodeSelector'], node_selector)
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="name",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            node_selector=k8s_api_node_selector,
+        )
+
+        result = k.create_pod_request_obj()
+        client = ApiClient()
+        self.assertEqual(type(result.spec.node_selector), k8s.V1NodeSelector)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['nodeSelector'], node_selector)
+
+        # repeat tests using deprecated parameter
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="name",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            node_selectors=node_selector,
+        )
+
+        result = k.create_pod_request_obj()
+        client = ApiClient()
+        self.assertEqual(type(result.spec.node_selector), k8s.V1NodeSelector)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['nodeSelector'], node_selector)
+
+        k = KubernetesPodOperator(
+            namespace='default',
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            arguments=["echo 10"],
+            labels={"foo": "bar"},
+            name="name",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+            cluster_context='default',
+            node_selectors=node_selector,
+        )
+
+        result = k.create_pod_request_obj()
+        client = ApiClient()
+        self.assertEqual(type(result.spec.node_selector), k8s.V1NodeSelector)
+        self.assertEqual(client.sanitize_for_serialization(result)['spec']['nodeSelector'], node_selector)


### PR DESCRIPTION
This PR ensures that node_selector, affinity, and tolerations are all
converted into k8s API objects before they are sent to the
pod_mutation_hook. this fixes an inconsistency that would force airflow
engineers to consider both cases when writing their pod_mutation_hook

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
