### PR TITLE
Fixes list of taskInstances without start_date, end_date and state fa…

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1724,14 +1724,17 @@ components:
         start_date:
           type: string
           format: datetime
+          nullable: true
         end_date:
           type: string
           format: datetime
+          nullable: true
         duration:
           type: number
           nullable: true
         state:
           $ref: '#/components/schemas/TaskState'
+          nullable: true
         try_number:
           type: integer
         max_tries:


### PR DESCRIPTION
Fixes a bug when calling `/api/v1//dags/~/dagRuns/~/taskInstances/list` with `dag_ids` as parameter. The behavior is now as described in the issue as expected. `start_date`, `end_date` and `state` are returned as null when None.

```
    {
      "dag_id": "latest_only",
      "duration": null,
      "end_date": null,
      "execution_date": "2020-11-18T16:35:37.935623+00:00",
      "executor_config": "{}",
      "hostname": "",
      "max_tries": 0,
      "operator": "DummyOperator",
      "pid": null,
      "pool": "default_pool",
      "pool_slots": 1,
      "priority_weight": 1,
      "queue": "default",
      "queued_when": null,
      "sla_miss": null,
      "start_date": null,
      "state": null,
      "task_id": "task1",
      "try_number": 0,
      "unixname": "root"
    }
```


closes: #12306 
