### PR TITLE
Fix broken example_kubernetes DAG

### DIFF
--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -78,6 +78,7 @@ affinity = k8s.V1Affinity(
     pod_affinity=k8s.V1PodAffinity(
         required_during_scheduling_ignored_during_execution=[
             k8s.V1WeightedPodAffinityTerm(
+                weight=1,
                 pod_affinity_term=k8s.V1PodAffinityTerm(
                     label_selector=k8s.V1LabelSelector(
                         match_expressions=[
@@ -85,7 +86,7 @@ affinity = k8s.V1Affinity(
                         ]
                     ),
                     topology_key="failure-domain.beta.kubernetes.io/zone",
-                )
+                ),
             )
         ]
     ),


### PR DESCRIPTION
Fixes import of example_kubernetes DAG that was making tests fail.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
