### PR TITLE
Improve www.security.get_accessible_dags() and webserver performance

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -261,6 +261,8 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         for role in user_query.roles:
             for permission in role.permissions:
                 resource = permission.view_menu.name
+                if resource == permissions.RESOURCE_DAG:
+                    return session.query(DagModel)
                 action = permission.permission.name
                 if action not in user_actions:
                     continue
@@ -269,9 +271,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
                     resources.add(resource[len(permissions.RESOURCE_DAG_PREFIX) :])
                 else:
                     resources.add(resource)
-
-        if permissions.RESOURCE_DAG in resources:
-            return session.query(DagModel)
 
         return session.query(DagModel).filter(DagModel.dag_id.in_(resources))
 

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -260,12 +260,13 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         resources = set()
         for role in user_query.roles:
             for permission in role.permissions:
-                resource = permission.view_menu.name
-                if resource == permissions.RESOURCE_DAG:
-                    return session.query(DagModel)
                 action = permission.permission.name
                 if action not in user_actions:
                     continue
+
+                resource = permission.view_menu.name
+                if resource == permissions.RESOURCE_DAG:
+                    return session.query(DagModel)
 
                 if resource.startswith(permissions.RESOURCE_DAG_PREFIX):
                     resources.add(resource[len(permissions.RESOURCE_DAG_PREFIX) :])


### PR DESCRIPTION
- The performance of `get_accessible_dags()` is improved simply by returning as early as possible

- All the changes made in `www.views.py` are based on the fact that the check against `permissions.RESOURCE_DAG` is already handled inside `get_accessible_dags()`, which is invoked by `get_accessible_dag_ids()` then. Comparing `permissions.RESOURCE_DAG` with the result of `get_accessible_dag_ids()` is not making sense. The lines inside these `IF`-clauses are either always executed or never executed (I believe these chunks were not cleaned-up after the relevant code changes in `get_accessible_dag_ids()` happened)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
