### PR TITLE
Fix typo in migrations: RESOURCE_DAGS to RESOURCE_DAG.

### DIFF
--- a/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
+++ b/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
@@ -43,14 +43,14 @@ def upgrade():  # noqa: D103
 def downgrade():  # noqa: D103
     permissions = ['can_read', 'can_edit']
     vms = cached_app().appbuilder.sm.get_all_view_menu()
-    view_menus = [vm for vm in vms if (vm.name == permissions.RESOURCE_DAGS or vm.name.startswith('DAG:'))]
+    view_menus = [vm for vm in vms if (vm.name == permissions.RESOURCE_DAG or vm.name.startswith('DAG:'))]
     convert_permissions(permissions, view_menus, downgrade_action, downgrade_dag_id)
 
 
 def upgrade_dag_id(dag_id):
     """Adds the 'DAG:' prefix to a DAG view if appropriate."""
     if dag_id == 'all_dags':
-        return permissions.RESOURCE_DAGS
+        return permissions.RESOURCE_DAG
     if dag_id.startswith("DAG:"):
         return dag_id
     return f"DAG:{dag_id}"
@@ -58,7 +58,7 @@ def upgrade_dag_id(dag_id):
 
 def downgrade_dag_id(dag_id):
     """Removes the 'DAG:' prefix from a DAG view name to return the DAG id."""
-    if dag_id == permissions.RESOURCE_DAGS:
+    if dag_id == permissions.RESOURCE_DAG:
         return 'all_dags'
     if dag_id.startswith("DAG:"):
         return dag_id[len("DAG:") :]


### PR DESCRIPTION
DB Migrations on existing DBs are failing bc the DAG prefix migration step references `permissions.RESOURCE_DAGS`, which is no longer used. this uses the new name.