### PR TITLE
Bugfix: Add file_token field to dag schema

### DIFF
--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -66,7 +66,7 @@ class DAGSchema(SQLAlchemySchema):
     @staticmethod
     def get_token(obj: DagModel):
         """Return file token"""
-        serializer = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
+        serializer = URLSafeSerializer(conf.get('webserver', 'secret_key'))
         return serializer.dumps(obj.fileloc)
 
 

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -17,10 +17,12 @@
 
 from typing import List, NamedTuple
 
+from itsdangerous import URLSafeSerializer
 from marshmallow import Schema, fields
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.schemas.common_schema import ScheduleIntervalSchema, TimeDeltaSchema, TimezoneField
+from airflow.configuration import conf
 from airflow.models.dag import DagModel, DagTag
 
 
@@ -48,6 +50,7 @@ class DAGSchema(SQLAlchemySchema):
     is_paused = auto_field()
     is_subdag = auto_field(dump_only=True)
     fileloc = auto_field(dump_only=True)
+    file_token = fields.Method("get_token", dump_only=True)
     owners = fields.Method("get_owners", dump_only=True)
     description = auto_field(dump_only=True)
     schedule_interval = fields.Nested(ScheduleIntervalSchema)
@@ -59,6 +62,12 @@ class DAGSchema(SQLAlchemySchema):
         if not getattr(obj, 'owners', None):
             return []
         return obj.owners.split(",")
+
+    @staticmethod
+    def get_token(obj: DagModel):
+        """Return file token"""
+        serializer = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
+        return serializer.dumps(obj.fileloc)
 
 
 class DAGDetailSchema(DAGSchema):

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,6 +101,7 @@ install_requires =
     graphviz>=0.12
     gunicorn>=19.5.0, <20.0
     iso8601>=0.1.12
+    itsdangerous>=1.1.0
     jinja2>=2.10.1, <2.12.0
     json-merge-patch==0.2
     jsonschema~=3.0

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -34,7 +34,7 @@ from tests.test_utils.api_connexion_utils import assert_401, create_user, delete
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
 
-SERIALIZER = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
+SERIALIZER = URLSafeSerializer(conf.get('webserver', 'secret_key'))
 FILE_TOKEN = SERIALIZER.dumps(__file__)
 
 
@@ -111,17 +111,17 @@ class TestDagEndpoint(unittest.TestCase):
 
 
 class TestGetDag(TestDagEndpoint):
+    @conf_vars({("webserver", "secret_key"): "mysecret"})
     def test_should_respond_200(self):
         self._create_dag_models(1)
         response = self.client.get("/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
-        file_token = SERIALIZER.dumps("/tmp/dag_1.py")
         self.assertEqual(
             {
                 "dag_id": "TEST_DAG_1",
                 "description": None,
                 "fileloc": "/tmp/dag_1.py",
-                "file_token": file_token,
+                "file_token": 'Ii90bXAvZGFnXzEucHki.EnmIdPaUPo26lHQClbWMbDFD1Pk',
                 "is_paused": False,
                 "is_subdag": False,
                 "owners": [],
@@ -132,6 +132,7 @@ class TestGetDag(TestDagEndpoint):
             response.json,
         )
 
+    @conf_vars({("webserver", "secret_key"): "mysecret"})
     @provide_session
     def test_should_respond_200_with_schedule_interval_none(self, session=None):
         dag_model = DagModel(
@@ -143,13 +144,12 @@ class TestGetDag(TestDagEndpoint):
         session.commit()
         response = self.client.get("/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
-        file_token = SERIALIZER.dumps("/tmp/dag_1.py")
         self.assertEqual(
             {
                 "dag_id": "TEST_DAG_1",
                 "description": None,
                 "fileloc": "/tmp/dag_1.py",
-                "file_token": file_token,
+                "file_token": 'Ii90bXAvZGFnXzEucHki.EnmIdPaUPo26lHQClbWMbDFD1Pk',
                 "is_paused": False,
                 "is_subdag": False,
                 "owners": [],

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -18,10 +18,12 @@ import os
 import unittest
 from datetime import datetime
 
+from itsdangerous import URLSafeSerializer
 from parameterized import parameterized
 
 from airflow import DAG
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
+from airflow.configuration import conf
 from airflow.models import DagBag, DagModel
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.dummy_operator import DummyOperator
@@ -31,6 +33,9 @@ from airflow.www import app
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
+
+SERIALIZER = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
+FILE_TOKEN = SERIALIZER.dumps(__file__)
 
 
 class TestDagEndpoint(unittest.TestCase):
@@ -110,14 +115,13 @@ class TestGetDag(TestDagEndpoint):
         self._create_dag_models(1)
         response = self.client.get("/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
-
-        current_response = response.json
-        current_response["fileloc"] = "/tmp/test-dag.py"
+        file_token = SERIALIZER.dumps("/tmp/dag_1.py")
         self.assertEqual(
             {
                 "dag_id": "TEST_DAG_1",
                 "description": None,
-                "fileloc": "/tmp/test-dag.py",
+                "fileloc": "/tmp/dag_1.py",
+                "file_token": file_token,
                 "is_paused": False,
                 "is_subdag": False,
                 "owners": [],
@@ -125,7 +129,7 @@ class TestGetDag(TestDagEndpoint):
                 "schedule_interval": {"__type": "CronExpression", "value": "2 2 * * *"},
                 "tags": [],
             },
-            current_response,
+            response.json,
         )
 
     @provide_session
@@ -139,14 +143,13 @@ class TestGetDag(TestDagEndpoint):
         session.commit()
         response = self.client.get("/api/v1/dags/TEST_DAG_1", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
-
-        current_response = response.json
-        current_response["fileloc"] = "/tmp/test-dag.py"
+        file_token = SERIALIZER.dumps("/tmp/dag_1.py")
         self.assertEqual(
             {
                 "dag_id": "TEST_DAG_1",
                 "description": None,
-                "fileloc": "/tmp/test-dag.py",
+                "fileloc": "/tmp/dag_1.py",
+                "file_token": file_token,
                 "is_paused": False,
                 "is_subdag": False,
                 "owners": [],
@@ -154,7 +157,7 @@ class TestGetDag(TestDagEndpoint):
                 "schedule_interval": None,
                 "tags": [],
             },
-            current_response,
+            response.json,
         )
 
     def test_should_respond_200_with_granular_dag_access(self):
@@ -204,6 +207,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "description": None,
             "doc_md": "details",
             "fileloc": __file__,
+            "file_token": FILE_TOKEN,
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
@@ -234,6 +238,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "description": None,
             "doc_md": None,
             "fileloc": __file__,
+            "file_token": FILE_TOKEN,
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
@@ -269,6 +274,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "description": None,
             "doc_md": "details",
             "fileloc": __file__,
+            "file_token": FILE_TOKEN,
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
@@ -303,6 +309,7 @@ class TestGetDagDetails(TestDagEndpoint):
             'description': None,
             'doc_md': 'details',
             'fileloc': __file__,
+            "file_token": FILE_TOKEN,
             'is_paused': None,
             'is_subdag': False,
             'orientation': 'LR',
@@ -340,7 +347,8 @@ class TestGetDags(TestDagEndpoint):
         self._create_dag_models(2)
 
         response = self.client.get("api/v1/dags", environ_overrides={'REMOTE_USER': "test"})
-
+        file_token = SERIALIZER.dumps("/tmp/dag_1.py")
+        file_token2 = SERIALIZER.dumps("/tmp/dag_2.py")
         assert response.status_code == 200
         self.assertEqual(
             {
@@ -349,6 +357,7 @@ class TestGetDags(TestDagEndpoint):
                         "dag_id": "TEST_DAG_1",
                         "description": None,
                         "fileloc": "/tmp/dag_1.py",
+                        "file_token": file_token,
                         "is_paused": False,
                         "is_subdag": False,
                         "owners": [],
@@ -363,6 +372,7 @@ class TestGetDags(TestDagEndpoint):
                         "dag_id": "TEST_DAG_2",
                         "description": None,
                         "fileloc": "/tmp/dag_2.py",
+                        "file_token": file_token2,
                         "is_paused": False,
                         "is_subdag": False,
                         "owners": [],
@@ -452,6 +462,9 @@ class TestGetDags(TestDagEndpoint):
 
 
 class TestPatchDag(TestDagEndpoint):
+
+    file_token = SERIALIZER.dumps("/tmp/dag_1.py")
+
     def test_should_respond_200_on_patch_is_paused(self):
         dag_model = self._create_dag_model()
         response = self.client.patch(
@@ -462,10 +475,12 @@ class TestPatchDag(TestDagEndpoint):
             environ_overrides={'REMOTE_USER': "test"},
         )
         self.assertEqual(response.status_code, 200)
+
         expected_response = {
             "dag_id": "TEST_DAG_1",
             "description": None,
             "fileloc": "/tmp/dag_1.py",
+            "file_token": self.file_token,
             "is_paused": False,
             "is_subdag": False,
             "owners": [],
@@ -543,11 +558,13 @@ class TestPatchDag(TestDagEndpoint):
             json=payload,
             environ_overrides={'REMOTE_USER': "test"},
         )
+
         self.assertEqual(response.status_code, 200)
         expected_response = {
             "dag_id": "TEST_DAG_1",
             "description": None,
             "fileloc": "/tmp/dag_1.py",
+            "file_token": self.file_token,
             "is_paused": False,
             "is_subdag": False,
             "owners": [],

--- a/tests/api_connexion/schemas/test_dag_schema.py
+++ b/tests/api_connexion/schemas/test_dag_schema.py
@@ -18,6 +18,8 @@
 import unittest
 from datetime import datetime
 
+from itsdangerous import URLSafeSerializer
+
 from airflow import DAG
 from airflow.api_connexion.schemas.dag_schema import (
     DAGCollection,
@@ -25,7 +27,10 @@ from airflow.api_connexion.schemas.dag_schema import (
     DAGDetailSchema,
     DAGSchema,
 )
+from airflow.configuration import conf
 from airflow.models import DagModel, DagTag
+
+SERIALIZER = URLSafeSerializer(conf.get('webserver', 'SECRET_KEY'))
 
 
 class TestDagSchema(unittest.TestCase):
@@ -47,6 +52,7 @@ class TestDagSchema(unittest.TestCase):
                 "dag_id": "test_dag_id",
                 "description": "The description",
                 "fileloc": "/root/airflow/dags/my_dag.py",
+                "file_token": SERIALIZER.dumps("/root/airflow/dags/my_dag.py"),
                 "is_paused": True,
                 "is_subdag": False,
                 "owners": ["airflow1", "airflow2"],
@@ -71,6 +77,7 @@ class TestDAGCollectionSchema(unittest.TestCase):
                         "dag_id": "test_dag_id_a",
                         "description": None,
                         "fileloc": "/tmp/a.py",
+                        "file_token": SERIALIZER.dumps("/tmp/a.py"),
                         "is_paused": None,
                         "is_subdag": None,
                         "owners": [],
@@ -82,6 +89,7 @@ class TestDAGCollectionSchema(unittest.TestCase):
                         "dag_id": "test_dag_id_b",
                         "description": None,
                         "fileloc": "/tmp/a.py",
+                        "file_token": SERIALIZER.dumps("/tmp/a.py"),
                         "is_paused": None,
                         "is_subdag": None,
                         "owners": [],
@@ -115,6 +123,7 @@ class TestDAGDetailSchema:
             'description': None,
             'doc_md': 'docs',
             'fileloc': __file__,
+            "file_token": SERIALIZER.dumps(__file__),
             'is_paused': None,
             'is_subdag': False,
             'orientation': 'LR',


### PR DESCRIPTION
Closes: #12121 
This PR adds file_token to dag schema so we can be able to get dag source through API. Resolves the last problem(no 3) in #12121

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
