### PR TITLE
Fix setup.py to install the right provider for mysql

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -712,7 +712,7 @@ EXTRAS_PROVIDERS_PACKAGES: Dict[str, Iterable[str]] = {
     "microsoft.winrm": ["microsoft.winrm"],
     'mongo': ["mongo"],
     'mssql': ["microsoft.mssql"],  # TODO: remove this in Airflow 2.1
-    'mysql': ["microsoft.mssql"],
+    'mysql': ["mysql"],
     'odbc': ["odbc"],
     'oracle': ["oracle"],
     'pagerduty': ["pagerduty"],


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently, `pip install -e .[mysql]` installs the mssql provider instead of mysql. This PR fixes it.

```
$ pip install --upgrade -e .[mysql]
$ pip list
Package                                  Version   Location
---------------------------------------- --------- --------------------------
alembic                                  1.4.3
apache-airflow                           2.0.0b3   /home/sekikn/repos/airflow
apache-airflow-providers-microsoft-mssql 1.0.0b2
apispec                                  3.3.2

(snip)
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
