### PR TITLE
Fix failing test on Py3.8

### DIFF
--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -3299,7 +3299,7 @@ class TestDecorators(TestBase):
         )
 
 
-class TestHelperFunctions(unittest.TestCase):
+class TestHelperFunctions(TestBase):
     @parameterized.expand(
         [
             ("", "/home"),
@@ -3316,8 +3316,7 @@ class TestHelperFunctions(unittest.TestCase):
         ]
     )
     @mock.patch("airflow.www.views.url_for")
-    @mock.patch("airflow.www.views.request")
-    def test_get_safe_url(self, test_url, expected_url, mock_req, mock_url_for):
-        mock_req.host = 'localhost:8080'
+    def test_get_safe_url(self, test_url, expected_url, mock_url_for):
         mock_url_for.return_value = "/home"
-        self.assertEqual(get_safe_url(test_url), expected_url)
+        with self.app.test_request_context(base_url="http://localhost:8080"):
+            self.assertEqual(get_safe_url(test_url), expected_url)


### PR DESCRIPTION
The tests passed on https://github.com/apache/airflow/pull/12459 as it only ran tests for Py3.6.

When it was merged to master, tests failed on Py3.8. This commit should fix all failing tests on Py3.8

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
