### PR TITLE
optional schema configuration of S3ToSnowflakeTransferOperator

### DIFF
--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -93,7 +93,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         if self.columns_array:
             columns = ','.join(self.columns_array)
             copy_query = (
-                f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}"
+                f"COPY INTO {self.schema}.{self.table}({columns}) {base_sql}"
                 if self.schema
                 else f"COPY INTO {self.table} ({columns}) {base_sql}"
             )

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -92,12 +92,18 @@ class S3ToSnowflakeOperator(BaseOperator):
 
         if self.columns_array:
             columns = ','.join(self.columns_array)
-            copy_query = f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}" if self.schema \
+            copy_query = (
+                f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}"
+                if self.schema
                 else f"COPY INTO {self.table} ({columns}) {base_sql}"
+            )
 
         else:
-            copy_query = f"COPY INTO {self.schema}.{self.table} {base_sql}" if self.schema \
+            copy_query = (
+                f"COPY INTO {self.schema}.{self.table} {base_sql}"
+                if self.schema
                 else f"COPY INTO {self.table} {base_sql}"
+            )
 
         self.log.info('Executing COPY command...')
         snowflake_hook.run(copy_query, self.autocommit)

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -88,12 +88,18 @@ class S3ToSnowflakeOperator(BaseOperator):
 
         if self.columns_array:
             columns = ','.join(self.columns_array)
-            copy_query = f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}" if self.schema \
+            copy_query = (
+                f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}"
+                if self.schema
                 else f"COPY INTO {self.table} ({columns}) {base_sql}"
+            )
 
         else:
-            copy_query = f"COPY INTO {self.schema}.{self.table} {base_sql}" if self.schema \
+            copy_query = (
+                f"COPY INTO {self.schema}.{self.table} {base_sql}"
+                if self.schema
                 else f"COPY INTO {self.table} {base_sql}"
+            )
 
         self.log.info('Executing COPY command...')
         snowflake_hook.run(copy_query, self.autocommit)

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -52,7 +52,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         table: str,
         stage: Any,
         file_format: str,
-        schema: str,  # TODO: shouldn't be required, rely on session/user defaults
+        schema: Optional[str] = None,
         columns_array: Optional[list] = None,
         autocommit: bool = True,
         snowflake_conn_id: str = 'snowflake_default',
@@ -87,17 +87,13 @@ class S3ToSnowflakeOperator(BaseOperator):
         )
 
         if self.columns_array:
-            copy_query = """
-                COPY INTO {schema}.{table}({columns}) {base_sql}
-            """.format(
-                schema=self.schema, table=self.table, columns=",".join(self.columns_array), base_sql=base_sql
-            )
+            columns = ','.join(self.columns_array)
+            copy_query = f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}" if self.schema \
+                else f"COPY INTO {self.table} ({columns}) {base_sql}"
+
         else:
-            copy_query = """
-                COPY INTO {schema}.{table} {base_sql}
-            """.format(
-                schema=self.schema, table=self.table, base_sql=base_sql
-            )
+            copy_query = f"COPY INTO {self.schema}.{self.table} {base_sql}" if self.schema \
+                else f"COPY INTO {self.table} {base_sql}"
 
         self.log.info('Executing COPY command...')
         snowflake_hook.run(copy_query, self.autocommit)


### PR DESCRIPTION
closing [12001](https://github.com/apache/airflow/issues/12001). 
schema can now be optionally passed, either via a parameter or via connection metadata