### PR TITLE
Fix: "invalid date" for running task

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -25,14 +25,8 @@ import { defaultFormat, formatDateTime } from './datetime-utils';
 
 function makeDateTimeHTML(start, end) {
   // check task ended or not
-  if (end && end instanceof moment) {
-    return (
-      `Started: ${start.format(defaultFormat)} <br> Ended: ${end.format(defaultFormat)} <br>`
-    );
-  }
-  return (
-    `Started: ${start.format(defaultFormat)} <br> Ended: Not ended yet <br>`
-  );
+  const isEnded = end && end instanceof moment && end.isValid();
+  return `Started: ${start.format(defaultFormat)}<br>Ended: ${isEnded ? end.format(defaultFormat) : 'Not ended yet'}<br>`;
 }
 
 function generateTooltipDateTimes(startDate, endDate, dagTZ) {


### PR DESCRIPTION
"Invalid date" date was displaying in the tooltip's "Ended" value for tasks currently running (not ended yet). I added the `isValid()` to confirm the Moment object is a valid one before displaying. Removed some redundancy within the function as well.

| Before | After |
|---|---|
| <img width="315" alt="Image 2020-11-19 at 2 53 19 PM" src="https://user-images.githubusercontent.com/3267/99717173-0f3c0a80-2a77-11eb-947e-a7ca6dc99570.png">  |  <img width="319" alt="Image 2020-11-19 at 2 52 26 PM" src="https://user-images.githubusercontent.com/3267/99717179-1105ce00-2a77-11eb-9ab1-c61ab8ddb5ea.png"> |



