### PR TITLE
Update DAG tag color to be neutral (and match DAGs index view)

### DIFF
--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -89,7 +89,7 @@
       <td>
         {% if tags is defined and tags %}
           {% for tag in tags | sort(attribute='name') %}
-            <a class="label label-success"
+            <a class="label label-info"
                href="/home?tags={{ tag.name }}"
                style="margin: 3px 6px 3px 0;"
                title="All DAGs tagged &ldquo;{{ tag.name }}&rdquo;"


### PR DESCRIPTION
The [DAG tag color was changed from green to blue](https://r.hmlt.in/2Nu0YLO4) recently on the DAGs index (home) view to avoid using a color (green) that typically communicates a status. This PR applies that change to the DAG Details view as well.

| Before | After |
|---|---|
| <img width="376" alt="Image 2020-11-19 at 3 12 12 PM" src="https://user-images.githubusercontent.com/3267/99719484-55df3400-2a7a-11eb-9166-fa8cb7db844b.png">  | <img width="397" alt="Image 2020-11-19 at 3 12 24 PM" src="https://user-images.githubusercontent.com/3267/99719471-537cda00-2a7a-11eb-88e1-d056a4590a47.png">  |

