### PR TITLE
Reorder Migrations to make it 1.10.13 compatible

### DIFF
--- a/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
+++ b/airflow/migrations/versions/849da589634d_prefix_dag_permissions.py
@@ -19,7 +19,7 @@
 """Prefix DAG permissions.
 
 Revision ID: 849da589634d
-Revises: 03afc6b6f902
+Revises: 45ba3f1493b9
 Create Date: 2020-10-01 17:25:10.006322
 
 """
@@ -29,7 +29,7 @@ from airflow.www.app import cached_app
 
 # revision identifiers, used by Alembic.
 revision = '849da589634d'
-down_revision = '03afc6b6f902'
+down_revision = '45ba3f1493b9'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/92c57b58940d_add_fab_tables.py
+++ b/airflow/migrations/versions/92c57b58940d_add_fab_tables.py
@@ -19,7 +19,7 @@
 """Create FAB Tables
 
 Revision ID: 92c57b58940d
-Revises: 45ba3f1493b9
+Revises: da3f683c3a5a
 Create Date: 2020-11-13 19:27:10.161814
 
 """
@@ -30,7 +30,7 @@ from sqlalchemy.engine.reflection import Inspector
 
 # revision identifiers, used by Alembic.
 revision = '92c57b58940d'
-down_revision = '45ba3f1493b9'
+down_revision = 'da3f683c3a5a'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/e38be357a868_update_schema_for_smart_sensor.py
+++ b/airflow/migrations/versions/e38be357a868_update_schema_for_smart_sensor.py
@@ -19,7 +19,7 @@
 """Add sensor_instance table
 
 Revision ID: e38be357a868
-Revises: 939bb1e647c8
+Revises: 03afc6b6f902
 Create Date: 2019-06-07 04:03:17.003939
 
 """
@@ -30,7 +30,7 @@ from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
 revision = 'e38be357a868'
-down_revision = 'da3f683c3a5a'
+down_revision = '03afc6b6f902'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
This commits makes Airflow 2.0 migrations compatible with 1.10.13 so users can
easily upgrade from 1.10.13 to 2.0

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
