### PR TITLE
Fix connection upgrade rules so they run with SQLite backend:

### DIFF
--- a/airflow/upgrade/rules/conn_id_is_unique.py
+++ b/airflow/upgrade/rules/conn_id_is_unique.py
@@ -41,5 +41,5 @@ duplicate values in conn_id column.
             .having(func.count() > 1)
         return (
             'Connection.conn_id={} is not unique.'.format(conn_id)
-            for conn_id in invalid_connections
+            for conn_id in invalid_connections.all()
         )

--- a/airflow/upgrade/rules/conn_type_is_not_nullable.py
+++ b/airflow/upgrade/rules/conn_type_is_not_nullable.py
@@ -42,5 +42,5 @@ If you made any modifications to the table directly, make sure you don't have nu
             'Connection<id={}", conn_id={}> have empty conn_type field.'.format(
                 conn.id, conn.conn_id
             )
-            for conn in invalid_connections
+            for conn in invalid_connections.all()
         )


### PR DESCRIPTION
When testing out the ugprade check command on 1.10 with the default
SQLite backend I got the following error:

```
[2020-11-20 12:10:28,248] {base.py:1372} ERROR - Error closing cursor
Traceback (most recent call last):
  File "/home/ash/.virtualenvs/airflow-1-10/lib/python3.7/site-packages/sqlalchemy/engine/result.py", line 1284, in fetchall
    l = self.process_rows(self._fetchall_impl())
  File "/home/ash/.virtualenvs/airflow-1-10/lib/python3.7/site-packages/sqlalchemy/engine/result.py", line 1230, in _fetchall_impl
    return self.cursor.fetchall()
sqlite3.ProgrammingError: Cannot operate on a closed database.
```

This was caused because the `@provide_session` decorator closed the
connection when the function returned, and since we were using a
generator expression, we hadn't yet fetched all the rows.

This changes it so the rows are fetched before returning.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).