### PR TITLE
Fix S3ToSnowflakeOperator docstring

### DIFF
--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -32,8 +32,8 @@ class S3ToSnowflakeOperator(BaseOperator):
     :type s3_keys: list
     :param table: reference to a specific table in snowflake database
     :type table: str
-    :param s3_bucket: reference to a specific S3 bucket
-    :type s3_bucket: str
+    :param stage: reference to a specific snowflake stage
+    :type stage: str
     :param file_format: reference to a specific file format
     :type file_format: str
     :param schema: reference to a specific schema in snowflake database


### PR DESCRIPTION
There's a parameter called s3_bucket in its docstring,
but it doesn't exist actually. The stage parameter exists instead.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
