### PR TITLE
Silence DagBag INFO logs during upgrade check

### DIFF
--- a/airflow/upgrade/rules/undefined_jinja_varaibles.py
+++ b/airflow/upgrade/rules/undefined_jinja_varaibles.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 
+import logging
 import re
 
 import jinja2
@@ -131,8 +132,14 @@ The user should do either of the following to fix this -
 
     def check(self, dagbag=None):
         if not dagbag:
-            dag_folder = conf.get("core", "dags_folder")
-            dagbag = DagBag(dag_folder)
+            logger = logging.root
+            old_level = logger.level
+            try:
+                logger.setLevel(logging.ERROR)
+                dag_folder = conf.get("core", "dags_folder")
+                dagbag = DagBag(dag_folder)
+            finally:
+                logger.setLevel(old_level)
         dags = dagbag.dags
         messages = []
         for dag_id, dag in dags.items():


### PR DESCRIPTION
By default, the logs would appear in the middle of the status stream,
which makes it slightly harder to parse the output.

Before:

```
============================================= STATUS =============================================

Legacy UI is deprecated by default......................................................SUCCESS
Users must set a kubernetes.pod_template_file value.....................................FAIL
Changes in import paths of hooks, operators, sensors and others.........................FAIL
Remove airflow.AirflowMacroPlugin class.................................................SUCCESS
[2020-11-20 14:26:04,083] {__init__.py:50} INFO - Using executor SequentialExecutor
[2020-11-20 14:26:04,083] {dagbag.py:417} INFO - Filling up the DagBag from /home/ash/airflow/dags
Jinja Template Variables cannot be undefined............................................SUCCESS
```

After:

```
============================================= STATUS =============================================

Legacy UI is deprecated by default......................................................SUCCESS
Users must set a kubernetes.pod_template_file value.....................................FAIL
Changes in import paths of hooks, operators, sensors and others.........................FAIL
Remove airflow.AirflowMacroPlugin class.................................................SUCCESS
Jinja Template Variables cannot be undefined............................................SUCCESS
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).