### PR TITLE
Add setup.cfg for apache-airflow-upgrade-check

### DIFF
--- a/airflow/upgrade/setup.cfg
+++ b/airflow/upgrade/setup.cfg
@@ -59,3 +59,6 @@ zip_safe = no
 include =
   airflow.upgrade
   airflow.upgrade.*
+
+[bdist_wheel]
+universal=1

--- a/airflow/upgrade/setup.cfg
+++ b/airflow/upgrade/setup.cfg
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[metadata]
+version=1.0.0
+name = apache-airflow-upgrade-check
+description = Check for compatibility between Airflow versions
+long_description = file: airflow/upgrade/README.md
+long_description_content_type = text/markdown
+url = https://airflow.apache.org
+author = Apache Airflow PMC
+author-email = dev@airflow.apache.org
+license = Apache License 2.0
+license_files =
+   LICENSE
+   NOTICE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+keywords = airflow, upgrade
+project_urls =
+    Source Code=https://github.com/apache/airflow
+    Bug Tracker=https://github.com/apache/airflow/issues
+    Documentation=https://airflow.apache.org/docs/
+
+[options]
+packages = find:
+install_requires =
+    apache-airflow>=1.10.13,<3
+    importlib-metadata~=2.0; python_version<"3.8"
+    packaging
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+setup_requires =
+    setuptools>=40.0
+    wheel
+zip_safe = no
+
+[options.packages.find]
+include =
+  airflow.upgrade
+  airflow.upgrade.*

--- a/setup.py
+++ b/setup.py
@@ -426,12 +426,14 @@ devel = [
     'flaky',
     'freezegun',
     'gitpython',
+    'importlib-metadata~=2.0; python_version<"3.8"',
     'ipdb',
     'jira',
     'mock;python_version<"3.3"',
     'mongomock',
     'moto==1.3.14',  # TODO - fix Datasync issues to get higher version of moto:
                      #        See: https://github.com/apache/airflow/issues/10985
+    'packaging',
     'parameterized',
     'paramiko',
     'pre-commit',
@@ -445,7 +447,7 @@ devel = [
     'pywinrm',
     'qds-sdk>=1.9.6',
     'requests_mock',
-    'yamllint'
+    'yamllint',
 ]
 ############################################################################################################
 # IMPORTANT NOTE!!!!!!!!!!!!!!!


### PR DESCRIPTION
Nothing currently uses this setup.cfg from this folder -- automation for that will follow shortly. But this is what we need to create a release for this subpackage.

Now that there is a place list deps for upgrade-check I have moved `packaging` and `importlib_meta` to test_requires of the main dist.



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).