### PR TITLE
[AIRFLOW-12520] feat(gcs_to_bq): support schema in different bucket

### DIFF
--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery_system.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery_system.py
@@ -18,13 +18,27 @@
 
 import pytest
 
+from airflow.providers.google.cloud.example_dags.example_gcs_to_bigquery import SCHEMA_BUCKET, SOURCE_BUCKET
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_BIGQUERY_KEY
 from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
 
 
 @pytest.mark.backend("mysql", "postgres")
+@pytest.mark.system("google.cloud")
 @pytest.mark.credential_file(GCP_BIGQUERY_KEY)
 class TestGoogleCloudStorageToBigQueryExample(GoogleSystemTest):
     @provide_gcp_context(GCP_BIGQUERY_KEY)
+    def setUp(self):
+        super().setUp()
+        self.create_gcs_bucket(SOURCE_BUCKET)
+        self.create_gcs_bucket(SCHEMA_BUCKET)
+
+    @provide_gcp_context(GCP_BIGQUERY_KEY)
     def test_run_example_dag_gcs_to_bigquery_operator(self):
         self.run_dag('example_gcs_to_bigquery_operator', CLOUD_DAG_FOLDER)
+
+    @provide_gcp_context(GCP_BIGQUERY_KEY)
+    def tearDown(self):
+        self.delete_gcs_bucket(SOURCE_BUCKET)
+        self.delete_gcs_bucket(SCHEMA_BUCKET)
+        super().tearDown()


### PR DESCRIPTION
Draft of - Add possibility to specify different bucket when downloading schema file.

closes: https://github.com/apache/airflow/issues/12520
related: https://github.com/apache/airflow/issues/8280

# todo
- finish system tests