### PR TITLE
Fix wait-for-migrations command in helm chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -367,6 +367,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   - -c
   - |
         import airflow
+        import logging
         import os
         import time
 
@@ -399,7 +400,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
                     raise TimeoutError("There are still unapplied migrations after {} seconds.".format(ticker))
                 ticker += 1
                 time.sleep(1)
-                log.info('Waiting for migrations... %s second(s)', ticker)
+                logging.info('Waiting for migrations... %s second(s)', ticker)
 {{- end }}
 
 {{ define "registry_docker_config" -}}


### PR DESCRIPTION
If the migrations weren't yet applied this would fail with `NameError:
name 'log' is not defined`. (I guess no one really noticed as the
container would restart, and try again.)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).