### PR TITLE
Enable v1-10-stable branch protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,6 +44,6 @@ github:
     master:
       required_pull_request_reviews:
         required_approving_review_count: 1
-#    v1-10-stable:
-#      required_pull_request_reviews:
-#        required_approving_review_count: 1
+    v1-10-stable:
+      required_pull_request_reviews:
+        required_approving_review_count: 1


### PR DESCRIPTION
I have sync'd v1-10-stable with v1-10-test. So we can enable branch protection again.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
