### PR TITLE
Fix dag serialization crash caused by preset DagContext

### DIFF
--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -449,12 +449,10 @@ class TestStringifiedDAGs(unittest.TestCase):
         self.assertEqual(simple_task.start_date, expected_task_start_date)
 
     def test_deserialization_with_dag_context(self):
-        dag = DAG(dag_id='simple_dag', start_date=datetime(2019, 8, 1, tzinfo=timezone.utc))
-        DagContext.push_context_managed_dag(dag)
-        BaseOperator(task_id='simple_task')
-        # should not raise RuntimeError: dictionary changed size during iteration
-        SerializedDAG.to_dict(dag)
-        DagContext.pop_context_managed_dag()
+        with DAG(dag_id='simple_dag', start_date=datetime(2019, 8, 1, tzinfo=timezone.utc)) as dag:
+            BaseOperator(task_id='simple_task')
+            # should not raise RuntimeError: dictionary changed size during iteration
+            SerializedDAG.to_dict(dag)
 
     @parameterized.expand(
         [

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -36,7 +36,6 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.models import DAG, Connection, DagBag, TaskInstance
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
-from airflow.models.dag import DagContext
 from airflow.operators.bash import BashOperator
 from airflow.security import permissions
 from airflow.serialization.json_schema import load_dag_schema_dict


### PR DESCRIPTION
DagContext should not cause any side effect for `BaseOperator.get_serialized_fields`. This prevents serialization crash caused from use of `DagContext.push_context_managed_dag` in DAG definition.