### PR TITLE
Fix line breaks in CeleryKubernetesExecutor docs

### DIFF
--- a/docs/executor/celery_kubernetes.rst
+++ b/docs/executor/celery_kubernetes.rst
@@ -38,7 +38,7 @@ it requires setting up ``CeleryExecutor`` and ``KubernetesExecutor``.
 We recommend considering ``CeleryKubernetesExecutor`` when your use case meets:
 
 1. The number of tasks needed to be scheduled at the peak exceeds the scale that your kubernetes cluster
-    can comfortably handle
+   can comfortably handle
 
 2. A relative small portion of your tasks requires runtime isolation.
 


### PR DESCRIPTION
The problem is visible here:
https://airflow.readthedocs.io/en/latest/executor/celery_kubernetes.html

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
