### PR TITLE
Fix sed command on MacOS

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_sync_version.sh
+++ b/scripts/ci/pre_commit/pre_commit_sync_version.sh
@@ -25,4 +25,5 @@ set -x
 AIRFLOW_VERSION_STRING=$(grep "version =" "${AIRFLOW_SOURCES}/airflow/version.py")
 readonly AIRFLOW_VERSION_STRING
 
-sed "s/version =.*$/${AIRFLOW_VERSION_STRING}/" -i "${AIRFLOW_SOURCES}/setup.py"
+sed -i".out" -e "s/version =.*$/${AIRFLOW_VERSION_STRING}/" "${AIRFLOW_SOURCES}/setup.py"
+rm setup.py.out


### PR DESCRIPTION
Fixes the following error on MacOS:
```
+ sed 's/version =.*$/version = '\''2.0.0b3'\''/' -i /Users/turbaszek/code/airflow/setup.py
sed: -i: No such file or directory
```
based on:
https://github.com/kedacore/keda/pull/1071/files

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
