### PR TITLE
Add ORC source format support for BigQueryHook load jobs

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1662,6 +1662,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             "GOOGLE_SHEETS",
             "DATASTORE_BACKUP",
             "PARQUET",
+            "ORC",
         ]
         if source_format not in allowed_formats:
             raise ValueError(
@@ -1747,6 +1748,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
             'NEWLINE_DELIMITED_JSON': ['autodetect', 'ignoreUnknownValues'],
             'PARQUET': ['autodetect', 'ignoreUnknownValues'],
             'AVRO': ['useAvroLogicalTypes'],
+            'ORC': ['autodetect', 'ignoreUnknownValues'],
         }
 
         valid_configs = src_fmt_to_configs_mapping[source_format]

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -400,7 +400,9 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             "compatibility_val" in src_fmt_configs
         ), "_validate_src_fmt_configs should add backward_compatibility config"
 
-    @parameterized.expand([("AVRO",), ("PARQUET",), ("NEWLINE_DELIMITED_JSON",), ("DATASTORE_BACKUP",), ("ORC",)])
+    @parameterized.expand(
+        [("AVRO",), ("PARQUET",), ("NEWLINE_DELIMITED_JSON",), ("DATASTORE_BACKUP",), ("ORC",)]
+    )
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_with_non_csv_as_src_fmt(self, fmt, _):
 

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -400,7 +400,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             "compatibility_val" in src_fmt_configs
         ), "_validate_src_fmt_configs should add backward_compatibility config"
 
-    @parameterized.expand([("AVRO",), ("PARQUET",), ("NEWLINE_DELIMITED_JSON",), ("DATASTORE_BACKUP",)])
+    @parameterized.expand([("AVRO",), ("PARQUET",), ("NEWLINE_DELIMITED_JSON",), ("DATASTORE_BACKUP",), ("ORC",)])
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_with_non_csv_as_src_fmt(self, fmt, _):
 
@@ -673,7 +673,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         with self.assertRaisesRegex(
             Exception,
             r"JSON is not a valid source format. Please use one of the following types: \['CSV', "
-            r"'NEWLINE_DELIMITED_JSON', 'AVRO', 'GOOGLE_SHEETS', 'DATASTORE_BACKUP', 'PARQUET'\]",
+            r"'NEWLINE_DELIMITED_JSON', 'AVRO', 'GOOGLE_SHEETS', 'DATASTORE_BACKUP', 'PARQUET', 'ORC'\]",
         ):
             self.hook.run_load("test.test", "test_schema.json", ["test_data.json"], source_format="json")
 


### PR DESCRIPTION
Add the missing ORC format into the allowlist in BigQueryHook load jobs, in order to fully support all formats provided in BigQuery API.

Closes: #12556