### PR TITLE
Add connection form support to provider discovery

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -52,6 +52,12 @@ assists users migrating to a new version.
 
 ## Master
 
+### SparkJDBCHook default connection
+
+For SparkJDBCHook default connection was `spark-default`, and for SparkSubmitHook it was
+`spark_default`. Both hooks now use the `spark_default` which is a common pattern for the connection
+names used across all providers.
+
 ### Changes to output argument in commands
 
 From Airflow 2.0, We are replacing [tabulate](https://pypi.org/project/tabulate/) with [rich](https://github.com/willmcgugan/rich) to render commands output. Due to this change, the `--output` argument
@@ -99,7 +105,6 @@ The `all` extras were reduced to include only user-facing dependencies. This mea
 that this extra does not contain development dependencies. If you were relying on
 `all` extra then you should use now `devel_all` or figure out if you need development
 extras at all.
-
 
 ### `[scheduler] max_threads` config has been renamed to `[scheduler] parsing_processes`
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -69,6 +69,11 @@ if not settings.LAZY_LOAD_PLUGINS:
 
     plugins_manager.ensure_plugins_loaded()
 
+if not settings.LAZY_LOAD_PROVIDERS:
+    from airflow import providers_manager
+
+    providers_manager.ProvidersManager().initialize_providers_manager()
+
 
 # This is never executed, but tricks static analyzers (PyDev, PyCharm,
 # pylint, etc.) into knowing the types of these symbols, and what

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1152,12 +1152,6 @@ CONNECTIONS_COMMANDS = (
 )
 PROVIDERS_COMMANDS = (
     ActionCommand(
-        name='hooks',
-        help='List registered provider hooks',
-        func=lazy_load_command('airflow.cli.commands.provider_command.hooks_list'),
-        args=(ARG_OUTPUT,),
-    ),
-    ActionCommand(
         name='list',
         help='List installed providers',
         func=lazy_load_command('airflow.cli.commands.provider_command.providers_list'),
@@ -1173,6 +1167,24 @@ PROVIDERS_COMMANDS = (
         name='links',
         help='List extra links registered by the providers',
         func=lazy_load_command('airflow.cli.commands.provider_command.extra_links_list'),
+        args=(ARG_OUTPUT,),
+    ),
+    ActionCommand(
+        name='widgets',
+        help='Get information about registered connection form widgets',
+        func=lazy_load_command('airflow.cli.commands.provider_command.connection_form_widget_list'),
+        args=(ARG_OUTPUT,),
+    ),
+    ActionCommand(
+        name='hooks',
+        help='List registered provider hooks',
+        func=lazy_load_command('airflow.cli.commands.provider_command.hooks_list'),
+        args=(ARG_OUTPUT,),
+    ),
+    ActionCommand(
+        name='behaviours',
+        help='Get information about registered connection types with custom behaviours',
+        func=lazy_load_command('airflow.cli.commands.provider_command.connection_field_behaviours'),
         args=(ARG_OUTPUT,),
     ),
 )

--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -42,13 +42,13 @@ log = logging.getLogger(__name__)
 class Anonymizer(Protocol):
     """Anonymizer protocol."""
 
-    def process_path(self, value):
+    def process_path(self, value) -> str:
         """Remove pii from paths"""
 
-    def process_username(self, value):
+    def process_username(self, value) -> str:
         """Remove pii from username"""
 
-    def process_url(self, value):
+    def process_url(self, value) -> str:
         """Remove pii from URL"""
 
 

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -31,8 +31,8 @@ def provider_get(args):
     """Get a provider info."""
     providers = ProvidersManager().providers
     if args.provider_name in providers:
-        provider_version = providers[args.provider_name][0]
-        provider_info = providers[args.provider_name][1]
+        provider_version = providers[args.provider_name].version
+        provider_info = providers[args.provider_name].provider_info
         if args.full:
             provider_info["description"] = _remove_rst_syntax(provider_info["description"])
             AirflowConsole().print_as(
@@ -50,7 +50,7 @@ def provider_get(args):
 def providers_list(args):
     """Lists all providers at the command line"""
     AirflowConsole().print_as(
-        data=ProvidersManager().providers.values(),
+        data=list(ProvidersManager().providers.values()),
         output=args.output,
         mapper=lambda x: {
             "package_name": x[1]["package-name"],
@@ -64,16 +64,46 @@ def providers_list(args):
 def hooks_list(args):
     """Lists all hooks at the command line"""
     AirflowConsole().print_as(
-        data=ProvidersManager().hooks.items(),
+        data=list(ProvidersManager().hooks.items()),
         output=args.output,
         mapper=lambda x: {
             "connection_type": x[0],
-            "class": x[1][0],
-            "conn_attribute_name": x[1][1],
+            "class": x[1].connection_class,
+            "conn_id_attribute_name": x[1].connection_id_attribute_name,
+            'package_name': x[1].package_name,
+            'hook_name': x[1].hook_name,
         },
     )
 
 
+@suppress_logs_and_warning()
+def connection_form_widget_list(args):
+    """Lists all custom connection form fields at the command line"""
+    AirflowConsole().print_as(
+        data=list(ProvidersManager().connection_form_widgets.items()),
+        output=args.output,
+        mapper=lambda x: {
+            "connection_parameter_name": x[0],
+            "class": x[1].connection_class,
+            'package_name': x[1].package_name,
+            'field_type': x[1].field.field_class.__name__,
+        },
+    )
+
+
+@suppress_logs_and_warning()
+def connection_field_behaviours(args):
+    """Lists field behaviours"""
+    AirflowConsole().print_as(
+        data=list(ProvidersManager().field_behaviours.keys()),
+        output=args.output,
+        mapper=lambda x: {
+            "field_behaviours": x,
+        },
+    )
+
+
+@suppress_logs_and_warning()
 def extra_links_list(args):
     """Lists all extra links at the command line"""
     AirflowConsole().print_as(

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -394,6 +394,15 @@
       type: boolean
       example: ~
       default: "True"
+    - name: lazy_discover_providers
+      description: |
+        By default Airflow providers are lazily-discovered (discovery and imports happen only when required).
+        Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
+        loaded from module.
+      version_added: 2.0.0
+      type: boolean
+      example: ~
+      default: "True"
     - name: max_db_retries
       description: |
         Number of times the code should be retried in case of DB Operational Errors.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -225,6 +225,11 @@ xcom_backend = airflow.models.xcom.BaseXCom
 # if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
 lazy_load_plugins = True
 
+# By default Airflow providers are lazily-discovered (discovery and imports happen only when required).
+# Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
+# loaded from module.
+lazy_discover_providers = True
+
 # Number of times the code should be retried in case of DB Operational Errors.
 # Not all transactions will be retried as it can cause undesired state.
 # Currently it is only used in ``DagFileProcessor.process_file`` to retry ``dagbag.sync_to_db``.

--- a/airflow/customized_form_field_behaviours.schema.json
+++ b/airflow/customized_form_field_behaviours.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "hidden_fields": {
+      "description": "List of hidden fields for for the hook.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "relabeling": {
+      "type": "object",
+      "description": "Keeps information about re-labeling of field names.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "placeholders": {
+      "type": "object",
+      "description": "Placeholders that are used to fill the values",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "hidden_fields",
+    "relabeling"
+  ]
+}

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -18,9 +18,10 @@
 """Base class for all hooks"""
 import logging
 import warnings
-from typing import Any, List
+from typing import Any, Dict, List
 
 from airflow.models.connection import Connection
+from airflow.typing_compat import Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = logging.getLogger(__name__)
@@ -90,3 +91,82 @@ class BaseHook(LoggingMixin):
     def get_conn(self) -> Any:
         """Returns connection for the hook."""
         raise NotImplementedError()
+
+
+class DiscoverableHook(Protocol):
+    """
+    Interface that providers *can* implement to be discovered by ProvidersManager.
+
+    It is not used by any of the Hooks, but simply methods and class fields described here are
+    implemented by those Hooks. Each method is optional -- only implement the ones you need.
+
+    The conn_name_attr, default_conn_name, conn_type should be implemented by those
+    Hooks that want to be automatically mapped from the connection_type -> Hook when get_hook method
+    is called with connection_type.
+
+    Additionally hook_name should be set when you want the hook to have a custom name in the UI selection
+    Name. If not specified, conn_name will be used.
+
+    The "get_ui_field_behaviour" and "get_connection_form_widgets" are optional - override them if you want
+    to customize the Connection Form screen. You can add extra widgets to parse your extra fields via the
+    get_connection_form_widgets method as well as hide or relabel the fields or pre-fill
+    them with placeholders via get_ui_field_behaviour method.
+
+    Note that the "get_ui_field_behaviour" and "get_connection_form_widgets" need to be set by each class
+    in the class hierarchy in order to apply widget customizations.
+
+    For example, even if you want to use the fields from your parent class, you must explicitly
+    have a method on *your* class:
+
+    .. code-block:: python
+
+        @classmethod
+        def get_ui_field_behaviour(cls):
+            return super().get_ui_field_behaviour()
+
+    You also need to add the Hook class name to list 'hook_class_names' in provider.yaml in case you
+    build an internal provider or to return it in dictionary returned by provider_info entrypoint in the
+    package you prepare.
+
+    You can see some examples in airflow/providers/jdbc/hooks/jdbc.py.
+
+    """
+
+    conn_name_attr: str
+    default_conn_name: str
+    conn_type: str
+    hook_name: str
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """
+        Returns dictionary of widgets to be added for the hook to handle extra values.
+
+        If you have class hierarchy, usually the widgets needed by your class are already
+        added by the base class, so there is no need to implement this method. It might
+        actually result in warning in the logs if you try to add widgets that have already
+        been added by the base class.
+
+        Note that values of Dict should be of wtforms.Field type. It's not added here
+        for the efficiency of imports.
+
+        """
+        ...
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """
+        Returns dictionary describing customizations to implement in javascript handling the
+        connection form. Should be compliant with airflow/customized_form_field_behaviours.schema.json'
+
+
+        If you change conn_type in a derived class, you should also
+        implement this method and return field customizations appropriate to your Hook. This
+        is because the child hook will have usually different conn_type and the customizations
+        are per connection type.
+
+        .. seealso::
+            :class:`~airflow.providers.google.cloud.hooks.compute_ssh.ComputeSSH` as an example
+
+        """
+        ...

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -328,9 +328,14 @@ class AwsBaseHook(BaseHook):
     :type config: Optional[botocore.client.Config]
     """
 
+    conn_name_attr = 'aws_conn_id'
+    default_conn_name = 'aws_default'
+    conn_type = 'aws'
+    hook_name = 'Amazon Web Services'
+
     def __init__(
         self,
-        aws_conn_id: Optional[str] = "aws_default",
+        aws_conn_id: Optional[str] = default_conn_name,
         verify: Union[bool, str, None] = None,
         region_name: Optional[str] = None,
         client_type: Optional[str] = None,

--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -33,7 +33,12 @@ class EmrHook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
-    def __init__(self, emr_conn_id: Optional[str] = None, *args, **kwargs) -> None:
+    conn_name_attr = 'emr_conn_id'
+    default_conn_name = 'emr_default'
+    conn_type = 'emr'
+    hook_name = 'Elastic MapReduce'
+
+    def __init__(self, emr_conn_id: Optional[str] = default_conn_name, *args, **kwargs) -> None:
         self.emr_conn_id = emr_conn_id
         kwargs["client_type"] = "emr"
         super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -103,6 +103,9 @@ class S3Hook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
+    conn_type = 's3'
+    hook_name = 'S3'
+
     def __init__(self, *args, **kwargs) -> None:
         kwargs['client_type'] = 's3'
 

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -322,3 +322,8 @@ transfers:
   - source-integration-name: SSH File Transfer Protocol (SFTP)
     target-integration-name: Amazon Simple Storage Service (S3)
     python-module: airflow.providers.amazon.aws.transfers.sftp_to_s3
+
+hook-class-names:
+  - airflow.providers.amazon.aws.hooks.s3.S3Hook
+  - airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook
+  - airflow.providers.amazon.aws.hooks.emr.EmrHook

--- a/airflow/providers/apache/cassandra/hooks/cassandra.py
+++ b/airflow/providers/apache/cassandra/hooks/cassandra.py
@@ -86,6 +86,7 @@ class CassandraHook(BaseHook, LoggingMixin):
     conn_name_attr = 'cassandra_conn_id'
     default_conn_name = 'cassandra_default'
     conn_type = 'cassandra'
+    hook_name = 'Cassandra'
 
     def __init__(self, cassandra_conn_id: str = default_conn_name):
         super().__init__()

--- a/airflow/providers/apache/hdfs/hooks/hdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/hdfs.py
@@ -46,6 +46,11 @@ class HDFSHook(BaseHook):
     :type autoconfig: bool
     """
 
+    conn_name_attr = 'hdfs_conn_id'
+    default_conn_name = 'hdfs_default'
+    conn_type = 'hdfs'
+    hook_name = 'HDFS'
+
     def __init__(
         self, hdfs_conn_id: str = 'hdfs_default', proxy_user: Optional[str] = None, autoconfig: bool = False
     ):

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -48,3 +48,6 @@ hooks:
   - integration-name: WebHDFS
     python-modules:
       - airflow.providers.apache.hdfs.hooks.webhdfs
+
+hook-class-names:
+  - airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -81,6 +81,7 @@ class HiveCliHook(BaseHook):
     conn_name_attr = 'hive_cli_conn_id'
     default_conn_name = 'hive_cli_default'
     conn_type = 'hive_cli'
+    hook_name = 'Hive Client Wrapper'
 
     def __init__(
         self,
@@ -474,7 +475,12 @@ class HiveMetastoreHook(BaseHook):
     # java short max val
     MAX_PART_COUNT = 32767
 
-    def __init__(self, metastore_conn_id: str = 'metastore_default') -> None:
+    conn_name_attr = 'metastore_conn_id'
+    default_conn_name = 'metastore_default'
+    conn_type = 'hive_metastore'
+    hook_name = 'Hive Metastore Thrift'
+
+    def __init__(self, metastore_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = metastore_conn_id
         self.metastore = self.get_metastore_client()
@@ -814,6 +820,7 @@ class HiveServer2Hook(DbApiHook):
     conn_name_attr = 'hiveserver2_conn_id'
     default_conn_name = 'hiveserver2_default'
     conn_type = 'hiveserver2'
+    hook_name = 'Hive Server 2 Thrift'
     supports_autocommit = False
 
     def get_conn(self, schema: Optional[str] = None) -> Any:

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -70,3 +70,4 @@ transfers:
 hook-class-names:
   - airflow.providers.apache.hive.hooks.hive.HiveCliHook
   - airflow.providers.apache.hive.hooks.hive.HiveServer2Hook
+  - airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook

--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -64,7 +64,12 @@ class LivyHook(HttpHook, LoggingMixin):
 
     _def_headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
 
-    def __init__(self, livy_conn_id: str = 'livy_default') -> None:
+    conn_name_attr = 'livy_conn_id'
+    default_conn_name = 'livy_default'
+    conn_type = 'livy'
+    hook_name = 'Apache Livy'
+
+    def __init__(self, livy_conn_id: str = default_conn_name) -> None:
         super().__init__(http_conn_id=livy_conn_id)
 
     def get_conn(self, headers: Optional[Dict[str, Any]] = None) -> Any:

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -42,3 +42,6 @@ hooks:
   - integration-name: Apache Livy
     python-modules:
       - airflow.providers.apache.livy.hooks.livy
+
+hook-class-names:
+  - airflow.providers.apache.livy.hooks.livy.LivyHook

--- a/airflow/providers/apache/pig/hooks/pig.py
+++ b/airflow/providers/apache/pig/hooks/pig.py
@@ -36,6 +36,7 @@ class PigCliHook(BaseHook):
     conn_name_attr = 'pig_cli_conn_id'
     default_conn_name = 'pig_cli_default'
     conn_type = 'pig_cli'
+    hook_name = 'Pig Client Wrapper'
 
     def __init__(self, pig_cli_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/apache/spark/hooks/spark_jdbc.py
+++ b/airflow/providers/apache/spark/hooks/spark_jdbc.py
@@ -112,11 +112,16 @@ class SparkJDBCHook(SparkSubmitHook):
                                       types.
     """
 
+    conn_name_attr = 'spark_conn_id'
+    default_conn_name = 'spark_default'
+    conn_type = 'spark_jdbc'
+    hook_name = 'Spark JDBC'
+
     # pylint: disable=too-many-arguments,too-many-locals
     def __init__(
         self,
         spark_app_name: str = 'airflow-spark-jdbc',
-        spark_conn_id: str = 'spark-default',
+        spark_conn_id: str = default_conn_name,
         spark_conf: Optional[Dict[str, Any]] = None,
         spark_py_files: Optional[str] = None,
         spark_files: Optional[str] = None,

--- a/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -56,12 +56,17 @@ class SparkSqlHook(BaseHook):
     :type yarn_queue: str
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'spark_sql_default'
+    conn_type = 'spark_sql'
+    hook_name = 'Spark SQL'
+
     # pylint: disable=too-many-arguments
     def __init__(
         self,
         sql: str,
         conf: Optional[str] = None,
-        conn_id: str = 'spark_sql_default',
+        conn_id: str = default_conn_name,
         total_executor_cores: Optional[int] = None,
         executor_cores: Optional[int] = None,
         executor_memory: Optional[str] = None,

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -104,6 +104,19 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :type spark_binary: str
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'spark_default'
+    conn_type = 'spark'
+    hook_name = 'Spark'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'login', 'password'],
+            "relabeling": {},
+        }
+
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(
         self,

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -44,3 +44,8 @@ hooks:
       - airflow.providers.apache.spark.hooks.spark_jdbc_script
       - airflow.providers.apache.spark.hooks.spark_sql
       - airflow.providers.apache.spark.hooks.spark_submit
+
+hook-class-names:
+  - airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook
+  - airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook
+  - airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook

--- a/airflow/providers/apache/sqoop/hooks/sqoop.py
+++ b/airflow/providers/apache/sqoop/hooks/sqoop.py
@@ -52,9 +52,14 @@ class SqoopHook(BaseHook):
     :type properties: dict
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'sqoop_default'
+    conn_type = 'sqoop'
+    hook_name = 'Sqoop'
+
     def __init__(
         self,
-        conn_id: str = 'sqoop_default',
+        conn_id: str = default_conn_name,
         verbose: bool = False,
         num_mappers: Optional[int] = None,
         hcatalog_database: Optional[str] = None,

--- a/airflow/providers/apache/sqoop/provider.yaml
+++ b/airflow/providers/apache/sqoop/provider.yaml
@@ -37,3 +37,6 @@ hooks:
   - integration-name: Apache Sqoop
     python-modules:
       - airflow.providers.apache.sqoop.hooks.sqoop
+
+hook-class-names:
+  - airflow.providers.apache.sqoop.hooks.sqoop.SqoopHook

--- a/airflow/providers/cloudant/hooks/cloudant.py
+++ b/airflow/providers/cloudant/hooks/cloudant.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Hook for Cloudant"""
+from typing import Dict
+
 from cloudant import cloudant
 
 from airflow.exceptions import AirflowException
@@ -35,6 +37,15 @@ class CloudantHook(BaseHook):
     conn_name_attr = 'cloudant_conn_id'
     default_conn_name = 'cloudant_default'
     conn_type = 'cloudant'
+    hook_name = 'Cloudant'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['port', 'extra'],
+            "relabeling": {'host': 'Account', 'login': 'Username (or API Key)', 'schema': 'Database'},
+        }
 
     def __init__(self, cloudant_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import tempfile
-from typing import Any, Generator, Optional, Tuple, Union
+from typing import Any, Dict, Generator, Optional, Tuple, Union
 
 import yaml
 from cached_property import cached_property
@@ -57,6 +57,35 @@ class KubernetesHook(BaseHook):
     conn_name_attr = 'kubernetes_conn_id'
     default_conn_name = 'kubernetes_default'
     conn_type = 'kubernetes'
+    hook_name = 'Kubernetes Cluster Connection'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import BooleanField, StringField
+
+        return {
+            "extra__kubernetes__in_cluster": BooleanField(lazy_gettext('In cluster configuration')),
+            "extra__kubernetes__kube_config_path": StringField(
+                lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()
+            ),
+            "extra__kubernetes__kube_config": StringField(
+                lazy_gettext('Kube config (JSON format)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__kubernetes__namespace": StringField(
+                lazy_gettext('Namespace'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
 
     def __init__(
         self, conn_id: str = default_conn_name, client_configuration: Optional[client.Configuration] = None

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -103,9 +103,14 @@ class DatabricksHook(BaseHook):  # noqa
     :type retry_delay: float
     """
 
+    conn_name_attr = 'databricks_conn_id'
+    default_conn_name = 'databricks_default'
+    conn_type = 'databricks'
+    hook_name = 'Databricks'
+
     def __init__(
         self,
-        databricks_conn_id: str = 'databricks_default',
+        databricks_conn_id: str = default_conn_name,
         timeout_seconds: int = 180,
         retry_limit: int = 3,
         retry_delay: float = 1.0,

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: Databricks
     python-modules:
       - airflow.providers.databricks.hooks.databricks
+
+hook-class-names:
+  - airflow.providers.databricks.hooks.databricks.DatabricksHook

--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -30,6 +30,7 @@ class ElasticsearchHook(DbApiHook):
     conn_name_attr = 'elasticsearch_conn_id'
     default_conn_name = 'elasticsearch_default'
     conn_type = 'elasticsearch'
+    hook_name = 'Elasticsearch'
 
     def __init__(self, schema: str = "http", connection: Optional[AirflowConnection] = None, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -39,6 +39,7 @@ class ExasolHook(DbApiHook):
     conn_name_attr = 'exasol_conn_id'
     default_conn_name = 'exasol_default'
     conn_type = 'exasol'
+    hook_name = 'Exasol'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/facebook/ads/hooks/ads.py
+++ b/airflow/providers/facebook/ads/hooks/ads.py
@@ -55,9 +55,14 @@ class FacebookAdsReportingHook(BaseHook):
 
     """
 
+    conn_name_attr = 'facebook_conn_id'
+    default_conn_name = 'facebook_default'
+    conn_type = 'facebook_social'
+    hook_name = 'Facebook Ads'
+
     def __init__(
         self,
-        facebook_conn_id: str = "facebook_default",
+        facebook_conn_id: str = default_conn_name,
         api_version: str = "v6.0",
     ) -> None:
         super().__init__()

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -32,3 +32,6 @@ hooks:
   - integration-name: Facebook Ads
     python-modules:
       - airflow.providers.facebook.ads.hooks.ads
+
+hook-class-names:
+  - airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -34,7 +34,12 @@ class FTPHook(BaseHook):
     connection as ``{"passive": "true"}``.
     """
 
-    def __init__(self, ftp_conn_id: str = 'ftp_default') -> None:
+    conn_name_attr = 'ftp_conn_id'
+    default_conn_name = 'ftp_default'
+    conn_type = 'ftp'
+    hook_name = 'FTP'
+
+    def __init__(self, ftp_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.ftp_conn_id = ftp_conn_id
         self.conn: Optional[ftplib.FTP] = None

--- a/airflow/providers/ftp/provider.yaml
+++ b/airflow/providers/ftp/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: File Transfer Protocol (FTP)
     python-modules:
       - airflow.providers.ftp.hooks.ftp
+
+hook-class-names:
+  - airflow.providers.ftp.hooks.ftp.FTPHook

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -70,10 +70,11 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     conn_name_attr = 'gcp_conn_id'
     default_conn_name = 'google_cloud_default'
     conn_type = 'google_cloud_platform'
+    hook_name = 'Google Cloud'
 
     def __init__(
         self,
-        gcp_conn_id: str = 'google_cloud_default',
+        gcp_conn_id: str = default_conn_name,
         delegate_to: Optional[str] = None,
         use_legacy_sql: bool = True,
         location: Optional[str] = None,

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -76,10 +76,15 @@ class CloudSQLHook(GoogleBaseHook):
     keyword arguments rather than positional.
     """
 
+    conn_name_attr = 'gcp_conn_id'
+    default_conn_name = 'google_cloud_default'
+    conn_type = 'gcpcloudsql'
+    hook_name = 'Google Cloud SQL'
+
     def __init__(
         self,
         api_version: str,
-        gcp_conn_id: str = "google_cloud_default",
+        gcp_conn_id: str = default_conn_name,
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
     ) -> None:
@@ -662,7 +667,7 @@ class CloudSQLDatabaseHook(BaseHook):  # noqa
     # pylint: disable=too-many-instance-attributes
     """
     Serves DB connection configuration for Google Cloud SQL (Connections
-    of *gcpcloudsql://* type).
+    of *gcpcloudsqldb://* type).
 
     The hook is a "meta" one. It does not perform an actual connection.
     It is there to retrieve all the parameters configured in gcpcloudsql:// connection,
@@ -709,10 +714,10 @@ class CloudSQLDatabaseHook(BaseHook):  # noqa
            in the connection URL
     :type default_gcp_project_id: str
     """
-
     conn_name_attr = 'gcp_cloudsql_conn_id'
     default_conn_name = 'google_cloud_sql_default'
-    conn_type = 'gcpcloudsql'
+    conn_type = 'gcpcloudsqldb'
+    hook_name = 'Google Cloud SQL Database'
 
     _conn = None  # type: Optional[Any]
 

--- a/airflow/providers/google/cloud/hooks/compute_ssh.py
+++ b/airflow/providers/google/cloud/hooks/compute_ssh.py
@@ -17,7 +17,7 @@
 import shlex
 import time
 from io import StringIO
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import paramiko
 from cached_property import cached_property
@@ -92,6 +92,14 @@ class ComputeEngineSSHHook(SSHHook):
     conn_name_attr = 'gcp_conn_id'
     default_conn_name = 'google_cloud_default'
     conn_type = 'gcpssh'
+    hook_name = 'Google Cloud SSH'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/airflow/providers/google/cloud/hooks/dataprep.py
+++ b/airflow/providers/google/cloud/hooks/dataprep.py
@@ -40,6 +40,7 @@ class GoogleDataprepHook(BaseHook):
     conn_name_attr = 'dataprep_conn_id'
     default_conn_name = 'dataprep_default'
     conn_type = 'dataprep'
+    hook_name = 'Google Dataprep'
 
     def __init__(self, dataprep_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -156,6 +156,48 @@ class GoogleBaseHook(BaseHook):
     :type impersonation_chain: Union[str, Sequence[str]]
     """
 
+    conn_name_attr = 'gcp_conn_id'
+    default_conn_name = 'google_cloud_default'
+    conn_type = 'google_cloud_platform'
+    hook_name = 'Google Cloud'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import IntegerField, PasswordField, StringField
+        from wtforms.validators import NumberRange
+
+        return {
+            "extra__google_cloud_platform__project": StringField(
+                lazy_gettext('Project Id'), widget=BS3TextFieldWidget()
+            ),
+            "extra__google_cloud_platform__key_path": StringField(
+                lazy_gettext('Keyfile Path'), widget=BS3TextFieldWidget()
+            ),
+            "extra__google_cloud_platform__keyfile_dict": PasswordField(
+                lazy_gettext('Keyfile JSON'), widget=BS3PasswordFieldWidget()
+            ),
+            "extra__google_cloud_platform__scope": StringField(
+                lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__google_cloud_platform__num_retries": IntegerField(
+                lazy_gettext('Number of Retries'),
+                validators=[NumberRange(min=0)],
+                widget=BS3TextFieldWidget(),
+                default=5,
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
+
     def __init__(
         self,
         gcp_conn_id: str = 'google_cloud_default',

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -633,9 +633,11 @@ transfers:
 
 hook-class-names:
   - airflow.providers.google.cloud.hooks.dataprep.GoogleDataprepHook
+  - airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLHook
   - airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook
   - airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineSSHHook
   - airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
+  - airflow.providers.google.common.hooks.base_google.GoogleBaseHook
 
 extra-links:
   - airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink

--- a/airflow/providers/grpc/hooks/grpc.py
+++ b/airflow/providers/grpc/hooks/grpc.py
@@ -16,7 +16,7 @@
 # under the License.
 
 """GRPC Hook"""
-from typing import Callable, Generator, List, Optional
+from typing import Any, Callable, Dict, Generator, List, Optional
 
 import grpc
 from google import auth as google_auth
@@ -50,6 +50,26 @@ class GrpcHook(BaseHook):
     conn_name_attr = 'grpc_conn_id'
     default_conn_name = 'grpc_default'
     conn_type = 'grpc'
+    hook_name = 'GRPC Connection'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__grpc__auth_type": StringField(
+                lazy_gettext('Grpc Auth Type'), widget=BS3TextFieldWidget()
+            ),
+            "extra__grpc__credential_pem_file": StringField(
+                lazy_gettext('Credential Keyfile Path'), widget=BS3TextFieldWidget()
+            ),
+            "extra__grpc__scopes": StringField(
+                lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()
+            ),
+        }
 
     def __init__(
         self,

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -110,9 +110,14 @@ class VaultHook(BaseHook):
 
     """
 
+    conn_name_attr = 'vault_conn_id'
+    default_conn_name = 'imap_default'
+    conn_type = 'vault'
+    hook_name = 'Hashicorp Vault'
+
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        vault_conn_id: str,
+        vault_conn_id: str = default_conn_name,
         auth_type: Optional[str] = None,
         auth_mount_point: Optional[str] = None,
         kv_engine_version: Optional[int] = None,

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -32,3 +32,6 @@ hooks:
   - integration-name: Hashicorp Vault
     python-modules:
       - airflow.providers.hashicorp.hooks.vault
+
+hook-class-names:
+  - airflow.providers.hashicorp.hooks.vault.VaultHook

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -39,10 +39,15 @@ class HttpHook(BaseHook):
     :type auth_type: AuthBase of python requests lib
     """
 
+    conn_name_attr = 'http_conn_id'
+    default_conn_name = 'http_default'
+    conn_type = 'http'
+    hook_name = 'HTTP'
+
     def __init__(
         self,
         method: str = 'POST',
-        http_conn_id: str = 'http_default',
+        http_conn_id: str = default_conn_name,
         auth_type: Any = HTTPBasicAuth,
     ) -> None:
         super().__init__()

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -44,3 +44,6 @@ hooks:
   - integration-name: Hypertext Transfer Protocol (HTTP)
     python-modules:
       - airflow.providers.http.hooks.http
+
+hook-class-names:
+  - airflow.providers.http.hooks.http.HttpHook

--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -45,6 +45,7 @@ class ImapHook(BaseHook):
     conn_name_attr = 'imap_conn_id'
     default_conn_name = 'imap_default'
     conn_type = 'imap'
+    hook_name = 'IMAP'
 
     def __init__(self, imap_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import jaydebeapi
 
@@ -36,7 +36,30 @@ class JdbcHook(DbApiHook):
     conn_name_attr = 'jdbc_conn_id'
     default_conn_name = 'jdbc_default'
     conn_type = 'jdbc'
+    hook_name = 'JDBC Connection'
     supports_autocommit = True
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__jdbc__drv_path": StringField(lazy_gettext('Driver Path'), widget=BS3TextFieldWidget()),
+            "extra__jdbc__drv_clsname": StringField(
+                lazy_gettext('Driver Class'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['port', 'schema', 'extra'],
+            "relabeling": {'host': 'Connection URL'},
+        }
 
     def get_conn(self) -> jaydebeapi.Connection:
         conn: Connection = self.get_connection(getattr(self, self.conn_name_attr))

--- a/airflow/providers/jenkins/hooks/jenkins.py
+++ b/airflow/providers/jenkins/hooks/jenkins.py
@@ -27,7 +27,12 @@ from airflow.hooks.base_hook import BaseHook
 class JenkinsHook(BaseHook):
     """Hook to manage connection to jenkins server"""
 
-    def __init__(self, conn_id: str = 'jenkins_default') -> None:
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'jenkins_default'
+    conn_type = 'jenkins'
+    hook_name = 'Jenkins'
+
+    def __init__(self, conn_id: str = default_conn_name) -> None:
         super().__init__()
         connection = self.get_connection(conn_id)
         self.connection = connection

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -36,3 +36,6 @@ hooks:
   - integration-name: Jenkins
     python-modules:
       - airflow.providers.jenkins.hooks.jenkins
+
+hook-class-names:
+  - airflow.providers.jenkins.hooks.jenkins.JenkinsHook

--- a/airflow/providers/jira/hooks/jira.py
+++ b/airflow/providers/jira/hooks/jira.py
@@ -36,6 +36,7 @@ class JiraHook(BaseHook):
     default_conn_name = 'jira_default'
     conn_type = "jira"
     conn_name_attr = "jira_conn_id"
+    hook_name = "JIRA"
 
     def __init__(self, jira_conn_id: str = default_conn_name, proxies: Optional[Any] = None) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -78,7 +78,12 @@ class AzureDataExplorerHook(BaseHook):
     :type azure_data_explorer_conn_id: str
     """
 
-    def __init__(self, azure_data_explorer_conn_id: str = 'azure_data_explorer_default') -> None:
+    conn_name_attr = 'azure_data_explorer_conn_id'
+    default_conn_name = 'azure_data_explorer_default'
+    conn_type = 'azure_data_explorer'
+    hook_name = 'Azure Data Explorer'
+
+    def __init__(self, azure_data_explorer_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = azure_data_explorer_conn_id
         self.connection = self.get_conn()

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -40,6 +40,7 @@ class AzureBatchHook(BaseHook):
     conn_name_attr = 'azure_batch_conn_id'
     default_conn_name = 'azure_batch_default'
     conn_type = 'azure_batch'
+    hook_name = 'Azure Batch Service'
 
     def __init__(self, azure_batch_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -41,7 +41,12 @@ class AzureContainerInstanceHook(AzureBaseHook):
     :type conn_id: str
     """
 
-    def __init__(self, conn_id: str = 'azure_default') -> None:
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'azure_default'
+    conn_type = 'azure_container_instances'
+    hook_name = 'Azure Container Instance'
+
+    def __init__(self, conn_id: str = default_conn_name) -> None:
         super().__init__(sdk_client=ContainerInstanceManagementClient, conn_id=conn_id)
         self.connection = self.get_conn()
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -48,6 +48,7 @@ class AzureCosmosDBHook(BaseHook):
     conn_name_attr = 'azure_cosmos_conn_id'
     default_conn_name = 'azure_cosmos_default'
     conn_type = 'azure_cosmos'
+    hook_name = 'Azure CosmosDB'
 
     def __init__(self, azure_cosmos_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -46,6 +46,7 @@ class AzureDataLakeHook(BaseHook):
     conn_name_attr = 'azure_data_lake_conn_id'
     default_conn_name = 'azure_data_lake_default'
     conn_type = 'azure_data_lake'
+    hook_name = 'Azure Data Lake'
 
     def __init__(self, azure_data_lake_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -33,6 +33,11 @@ class AzureBaseHook(BaseHook):
     :param conn_id: The azure connection id which refers to the information to connect to the service.
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'azure_default'
+    conn_type = 'azure'
+    hook_name = 'Azure'
+
     def __init__(self, sdk_client: Any, conn_id: str = 'azure_default'):
         self.sdk_client = sdk_client
         self.conn_id = conn_id

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -57,6 +57,7 @@ class WasbHook(BaseHook):
     conn_name_attr = 'wasb_conn_id'
     default_conn_name = 'wasb_default'
     conn_type = 'wasb'
+    hook_name = 'Azure Blob Storage'
 
     def __init__(self, wasb_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -126,7 +126,10 @@ transfers:
     python-module: airflow.providers.microsoft.azure.transfers.azure_blob_to_gcs
 
 hook-class-names:
+  - airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook
+  - airflow.providers.microsoft.azure.hooks.adx.AzureDataExplorerHook
   - airflow.providers.microsoft.azure.hooks.azure_batch.AzureBatchHook
   - airflow.providers.microsoft.azure.hooks.azure_cosmos.AzureCosmosDBHook
   - airflow.providers.microsoft.azure.hooks.azure_data_lake.AzureDataLakeHook
+  - airflow.providers.microsoft.azure.hooks.azure_container_instance.AzureContainerInstanceHook
   - airflow.providers.microsoft.azure.hooks.wasb.WasbHook

--- a/airflow/providers/microsoft/mssql/hooks/mssql.py
+++ b/airflow/providers/microsoft/mssql/hooks/mssql.py
@@ -28,6 +28,7 @@ class MsSqlHook(DbApiHook):
     conn_name_attr = 'mssql_conn_id'
     default_conn_name = 'mssql_default'
     conn_type = 'mssql'
+    hook_name = 'Microsoft SQL Server'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -43,6 +43,7 @@ class MongoHook(BaseHook):
     conn_name_attr = 'conn_id'
     default_conn_name = 'mongo_default'
     conn_type = 'mongo'
+    hook_name = 'MongoDB'
 
     def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
 

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -42,6 +42,7 @@ class MySqlHook(DbApiHook):
     conn_name_attr = 'mysql_conn_id'
     default_conn_name = 'mysql_default'
     conn_type = 'mysql'
+    hook_name = 'MySQL'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -36,6 +36,7 @@ class OdbcHook(DbApiHook):
     conn_name_attr = 'odbc_conn_id'
     default_conn_name = 'odbc_default'
     conn_type = 'odbc'
+    hook_name = 'ODBC'
     supports_autocommit = True
 
     def __init__(

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -31,6 +31,8 @@ class OracleHook(DbApiHook):
     conn_name_attr = 'oracle_conn_id'
     default_conn_name = 'oracle_default'
     conn_type = 'oracle'
+    hook_name = 'Oracle'
+
     supports_autocommit = False
 
     # pylint: disable=c-extension-no-member

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -58,6 +58,7 @@ class PostgresHook(DbApiHook):
     conn_name_attr = 'postgres_conn_id'
     default_conn_name = 'postgres_default'
     conn_type = 'postgres'
+    hook_name = 'Postgres'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -56,6 +56,7 @@ class PrestoHook(DbApiHook):
     conn_name_attr = 'presto_conn_id'
     default_conn_name = 'presto_default'
     conn_type = 'presto'
+    hook_name = 'Presto'
 
     def get_conn(self) -> Connection:
         """Returns a connection object"""

--- a/airflow/providers/qubole/hooks/qubole.py
+++ b/airflow/providers/qubole/hooks/qubole.py
@@ -109,9 +109,26 @@ COMMAND_ARGS, HYPHEN_ARGS = build_command_args()
 class QuboleHook(BaseHook):
     """Hook for Qubole communication"""
 
+    conn_name_attr = 'qubole_conn_id'
+    default_conn_name = 'qubole_default'
+    conn_type = 'qubole'
+    hook_name = 'Qubole'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['login', 'schema', 'port', 'extra'],
+            "relabeling": {
+                'host': 'API Endpoint',
+                'password': 'Auth Token',
+            },
+            "placeholders": {'host': 'https://<env>.qubole.com/api'},
+        }
+
     def __init__(self, *args, **kwargs) -> None:  # pylint: disable=unused-argument
         super().__init__()
-        conn = self.get_connection(kwargs['qubole_conn_id'])
+        conn = self.get_connection(kwargs.get('qubole_conn_id', self.default_conn_name))
         Qubole.configure(api_token=conn.password, api_url=conn.host)
         self.task_id = kwargs['task_id']
         self.dag_id = kwargs['dag'].dag_id

--- a/airflow/providers/qubole/provider.yaml
+++ b/airflow/providers/qubole/provider.yaml
@@ -46,5 +46,8 @@ hooks:
       - airflow.providers.qubole.hooks.qubole
       - airflow.providers.qubole.hooks.qubole_check
 
+hook-class-names:
+  - airflow.providers.qubole.hooks.qubole.QuboleHook
+
 extra-links:
   - airflow.providers.qubole.operators.qubole.QDSLink

--- a/airflow/providers/redis/hooks/redis.py
+++ b/airflow/providers/redis/hooks/redis.py
@@ -34,6 +34,7 @@ class RedisHook(BaseHook):
     conn_name_attr = 'redis_conn_id'
     default_conn_name = 'redis_default'
     conn_type = 'redis'
+    hook_name = 'Redis'
 
     def __init__(self, redis_conn_id: str = default_conn_name) -> None:
         """

--- a/airflow/providers/salesforce/hooks/tableau.py
+++ b/airflow/providers/salesforce/hooks/tableau.py
@@ -54,6 +54,7 @@ class TableauHook(BaseHook):
     conn_name_attr = 'tableau_conn_id'
     default_conn_name = 'tableau_default'
     conn_type = 'tableau'
+    hook_name = 'Tableau'
 
     def __init__(self, site_id: Optional[str] = None, tableau_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -26,7 +26,12 @@ from airflow.hooks.base_hook import BaseHook
 class SambaHook(BaseHook):
     """Allows for interaction with an samba server."""
 
-    def __init__(self, samba_conn_id: str) -> None:
+    conn_name_attr = 'samba_conn_id'
+    default_conn_name = 'samba_default'
+    conn_type = 'samba'
+    hook_name = 'Samba'
+
+    def __init__(self, samba_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn = self.get_connection(samba_conn_id)
 

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -33,3 +33,6 @@ hooks:
   - integration-name: Samba
     python-modules:
       - airflow.providers.samba.hooks.samba
+
+hook-class-names:
+  - airflow.providers.samba.hooks.samba.SambaHook

--- a/airflow/providers/segment/hooks/segment.py
+++ b/airflow/providers/segment/hooks/segment.py
@@ -53,6 +53,11 @@ class SegmentHook(BaseHook):
         `{"write_key":"YOUR_SECURITY_TOKEN"}`
     """
 
+    conn_name_attr = 'segment_conn_id'
+    default_conn_name = 'segment_default'
+    conn_type = 'segment'
+    hook_name = 'Segment'
+
     def __init__(
         self, segment_conn_id: str = 'segment_default', segment_debug_mode: bool = False, *args, **kwargs
     ) -> None:

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: Segment
     python-modules:
       - airflow.providers.segment.hooks.segment
+
+hook-class-names:
+  - airflow.providers.segment.hooks.segment.SegmentHook

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -45,6 +45,20 @@ class SFTPHook(SSHHook):
     Errors that may occur throughout but should be handled downstream.
     """
 
+    conn_name_attr = 'ftp_conn_id'
+    default_conn_name = 'sftp_default'
+    conn_type = 'sftp'
+    hook_name = 'SFTP'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        return {
+            "hidden_fields": ['schema'],
+            "relabeling": {
+                'login': 'Username',
+            },
+        }
+
     def __init__(self, ftp_conn_id: str = 'sftp_default', *args, **kwargs) -> None:
         kwargs['ssh_conn_id'] = ftp_conn_id
         super().__init__(*args, **kwargs)

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -43,3 +43,6 @@ hooks:
   - integration-name: SSH File Transfer Protocol (SFTP)
     python-modules:
       - airflow.providers.sftp.hooks.sftp
+
+hook-class-names:
+  - airflow.providers.sftp.hooks.sftp.SFTPHook

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -36,6 +36,7 @@ class SnowflakeHook(DbApiHook):
     conn_name_attr = 'snowflake_conn_id'
     default_conn_name = 'snowflake_default'
     conn_type = 'snowflake'
+    hook_name = 'Snowflake'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -27,6 +27,7 @@ class SqliteHook(DbApiHook):
     conn_name_attr = 'sqlite_conn_id'
     default_conn_name = 'sqlite_default'
     conn_type = 'sqlite'
+    hook_name = 'Sqlite'
 
     def get_conn(self) -> sqlite3.dbapi2.Connection:
         """Returns a sqlite connection object"""

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -20,7 +20,7 @@ import getpass
 import os
 import warnings
 from io import StringIO
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import paramiko
 from paramiko.config import SSH_PORT
@@ -56,6 +56,21 @@ class SSHHook(BaseHook):
         keepalive_interval seconds
     :type keepalive_interval: int
     """
+
+    conn_name_attr = 'ssh_conn_id'
+    default_conn_name = 'ssh_default'
+    conn_type = 'ssh'
+    hook_name = 'SSH'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema'],
+            "relabeling": {
+                'login': 'Username',
+            },
+        }
 
     def __init__(
         self,

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: Secure Shell (SSH)
     python-modules:
       - airflow.providers.ssh.hooks.ssh
+
+hook-class-names:
+  - airflow.providers.ssh.hooks.ssh.SSHHook

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -28,6 +28,7 @@ class VerticaHook(DbApiHook):
     conn_name_attr = 'vertica_conn_id'
     default_conn_name = 'vertica_default'
     conn_type = 'vertica'
+    hook_name = 'Vertica'
     supports_autocommit = True
 
     def get_conn(self) -> connect:

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -47,3 +47,6 @@ hooks:
   - integration-name: Yandex.Cloud Dataproc
     python-modules:
       - airflow.providers.yandex.hooks.yandexcloud_dataproc
+
+hook-class-names:
+  - airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -494,6 +494,11 @@ USE_JOB_SCHEDULE = conf.getboolean('scheduler', 'use_job_schedule', fallback=Tru
 # if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
 LAZY_LOAD_PLUGINS = conf.getboolean('core', 'lazy_load_plugins', fallback=True)
 
+# By default Airflow providers are lazily-discovered (discovery and imports happen only when required).
+# Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
+# loaded from module.
+LAZY_LOAD_PROVIDERS = conf.getboolean('core', 'lazy_discover_providers', fallback=True)
+
 # Determines if the executor utilizes Kubernetes
 IS_K8S_OR_K8SCELERY_EXECUTOR = conf.get('core', 'EXECUTOR') in {
     executor_constants.KUBERNETES_EXECUTOR,

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -39,6 +39,7 @@ from airflow.www.extensions.init_views import (
     init_api_connexion,
     init_api_experimental,
     init_appbuilder_views,
+    init_connection_form,
     init_error_handlers,
     init_flash_views,
     init_plugins,
@@ -114,6 +115,7 @@ def create_app(config=None, testing=False, app_name="Airflow"):
         init_appbuilder_views(flask_app)
         init_appbuilder_links(flask_app)
         init_plugins(flask_app)
+        init_connection_form()
         init_error_handlers(flask_app)
         init_api_connexion(flask_app)
         init_api_experimental(flask_app)
@@ -123,7 +125,6 @@ def create_app(config=None, testing=False, app_name="Airflow"):
         init_jinja_globals(flask_app)
         init_xframe_protection(flask_app)
         init_permanent_session(flask_app)
-
     return flask_app
 
 

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -24,6 +24,7 @@ from flask import Flask, request
 
 from airflow.api_connexion.exceptions import common_error_handler
 from airflow.security import permissions
+from airflow.www.views import lazy_add_provider_discovered_options_to_connection_form
 
 log = logging.getLogger(__name__)
 
@@ -123,6 +124,11 @@ def init_plugins(app):
     for blue_print in plugins_manager.flask_blueprints:
         log.debug("Adding blueprint %s:%s", blue_print["name"], blue_print["blueprint"].import_name)
         app.register_blueprint(blue_print["blueprint"])
+
+
+def init_connection_form():
+    """Initializes connection form"""
+    lazy_add_provider_discovered_options_to_connection_form()
 
 
 def init_error_handlers(app: Flask):

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -18,7 +18,6 @@
 
 import json
 from datetime import datetime as dt
-from operator import itemgetter
 
 import pendulum
 from flask_appbuilder.fieldwidgets import (
@@ -40,7 +39,7 @@ from wtforms.fields import (
     StringField,
     TextAreaField,
 )
-from wtforms.validators import InputRequired, NumberRange, Optional
+from wtforms.validators import InputRequired, Optional
 
 from airflow.configuration import conf
 from airflow.utils import timezone
@@ -210,75 +209,10 @@ class TaskInstanceEditForm(DynamicForm):
     )
 
 
-_connection_types = [
-    ('docker', 'Docker Registry'),
-    ('elasticsearch', 'Elasticsearch'),
-    ('exasol', 'Exasol'),
-    ('facebook_social', 'Facebook Social'),
-    ('fs', 'File (path)'),
-    ('ftp', 'FTP'),
-    ('google_cloud_platform', 'Google Cloud'),
-    ('hdfs', 'HDFS'),
-    ('http', 'HTTP'),
-    ('pig_cli', 'Pig Client Wrapper'),
-    ('hive_cli', 'Hive Client Wrapper'),
-    ('hive_metastore', 'Hive Metastore Thrift'),
-    ('hiveserver2', 'Hive Server 2 Thrift'),
-    ('jdbc', 'JDBC Connection'),
-    ('odbc', 'ODBC Connection'),
-    ('jenkins', 'Jenkins'),
-    ('mysql', 'MySQL'),
-    ('postgres', 'Postgres'),
-    ('oracle', 'Oracle'),
-    ('vertica', 'Vertica'),
-    ('presto', 'Presto'),
-    ('s3', 'S3'),
-    ('samba', 'Samba'),
-    ('sqlite', 'Sqlite'),
-    ('ssh', 'SSH'),
-    ('cloudant', 'IBM Cloudant'),
-    ('mssql', 'Microsoft SQL Server'),
-    ('mesos_framework-id', 'Mesos Framework ID'),
-    ('jira', 'JIRA'),
-    ('redis', 'Redis'),
-    ('wasb', 'Azure Blob Storage'),
-    ('databricks', 'Databricks'),
-    ('aws', 'Amazon Web Services'),
-    ('emr', 'Elastic MapReduce'),
-    ('snowflake', 'Snowflake'),
-    ('segment', 'Segment'),
-    ('sqoop', 'Sqoop'),
-    ('azure_batch', 'Azure Batch Service'),
-    ('azure_data_lake', 'Azure Data Lake'),
-    ('azure_container_instances', 'Azure Container Instances'),
-    ('azure_cosmos', 'Azure CosmosDB'),
-    ('azure_data_explorer', 'Azure Data Explorer'),
-    ('cassandra', 'Cassandra'),
-    ('qubole', 'Qubole'),
-    ('mongo', 'MongoDB'),
-    ('gcpcloudsql', 'Google Cloud SQL'),
-    ('grpc', 'GRPC Connection'),
-    ('yandexcloud', 'Yandex Cloud'),
-    ('livy', 'Apache Livy'),
-    ('tableau', 'Tableau'),
-    ('kubernetes', 'Kubernetes Cluster Connection'),
-    ('spark', 'Spark'),
-    ('imap', 'IMAP'),
-    ('vault', 'Hashicorp Vault'),
-    ('azure', 'Azure'),
-]
-
-
 class ConnectionForm(DynamicForm):
     """Form for editing and adding Connection"""
 
     conn_id = StringField(lazy_gettext('Conn Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
-    conn_type = SelectField(
-        lazy_gettext('Conn Type'),
-        choices=sorted(_connection_types, key=itemgetter(1)),  # pylint: disable=protected-access
-        widget=Select2Widget(),
-        validators=[InputRequired()],
-    )
     description = StringField(lazy_gettext('Description'), widget=BS3TextAreaFieldWidget())
     host = StringField(lazy_gettext('Host'), widget=BS3TextFieldWidget())
     schema = StringField(lazy_gettext('Schema'), widget=BS3TextFieldWidget())
@@ -286,72 +220,3 @@ class ConnectionForm(DynamicForm):
     password = PasswordField(lazy_gettext('Password'), widget=BS3PasswordFieldWidget())
     port = IntegerField(lazy_gettext('Port'), validators=[Optional()], widget=BS3TextFieldWidget())
     extra = TextAreaField(lazy_gettext('Extra'), widget=BS3TextAreaFieldWidget())
-
-    # Used to customized the form, the forms elements get rendered
-    # and results are stored in the extra field as json. All of these
-    # need to be prefixed with extra__ and then the conn_type ___ as in
-    # extra__{conn_type}__name. You can also hide form elements and rename
-    # others from the connection_form.js file
-    extra__jdbc__drv_path = StringField(lazy_gettext('Driver Path'), widget=BS3TextFieldWidget())
-    extra__jdbc__drv_clsname = StringField(lazy_gettext('Driver Class'), widget=BS3TextFieldWidget())
-    extra__google_cloud_platform__project = StringField(
-        lazy_gettext('Project Id'), widget=BS3TextFieldWidget()
-    )
-    extra__google_cloud_platform__key_path = StringField(
-        lazy_gettext('Keyfile Path'), widget=BS3TextFieldWidget()
-    )
-    extra__google_cloud_platform__keyfile_dict = PasswordField(
-        lazy_gettext('Keyfile JSON'), widget=BS3PasswordFieldWidget()
-    )
-    extra__google_cloud_platform__scope = StringField(
-        lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()
-    )
-    extra__google_cloud_platform__num_retries = IntegerField(
-        lazy_gettext('Number of Retries'),
-        validators=[NumberRange(min=0)],
-        widget=BS3TextFieldWidget(),
-        default=5,
-    )
-    extra__grpc__auth_type = StringField(lazy_gettext('Grpc Auth Type'), widget=BS3TextFieldWidget())
-    extra__grpc__credential_pem_file = StringField(
-        lazy_gettext('Credential Keyfile Path'), widget=BS3TextFieldWidget()
-    )
-    extra__grpc__scopes = StringField(lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget())
-    extra__yandexcloud__service_account_json = PasswordField(
-        lazy_gettext('Service account auth JSON'),
-        widget=BS3PasswordFieldWidget(),
-        description='Service account auth JSON. Looks like '
-        '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
-        'Will be used instead of OAuth token and SA JSON file path field if specified.',
-    )
-    extra__yandexcloud__service_account_json_path = StringField(
-        lazy_gettext('Service account auth JSON file path'),
-        widget=BS3TextFieldWidget(),
-        description='Service account auth JSON file path. File content looks like '
-        '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
-        'Will be used instead of OAuth token if specified.',
-    )
-    extra__yandexcloud__oauth = PasswordField(
-        lazy_gettext('OAuth Token'),
-        widget=BS3PasswordFieldWidget(),
-        description='User account OAuth token. Either this or service account JSON must be specified.',
-    )
-    extra__yandexcloud__folder_id = StringField(
-        lazy_gettext('Default folder ID'),
-        widget=BS3TextFieldWidget(),
-        description='Optional. This folder will be used to create all new clusters and nodes by default',
-    )
-    extra__yandexcloud__public_ssh_key = StringField(
-        lazy_gettext('Public SSH key'),
-        widget=BS3TextFieldWidget(),
-        description='Optional. This key will be placed to all created Compute nodes'
-        'to let you have a root shell there',
-    )
-    extra__kubernetes__in_cluster = BooleanField(lazy_gettext('In cluster configuration'))
-    extra__kubernetes__kube_config_path = StringField(
-        lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()
-    )
-    extra__kubernetes__kube_config = StringField(
-        lazy_gettext('Kube config (JSON format)'), widget=BS3TextFieldWidget()
-    )
-    extra__kubernetes__namespace = StringField(lazy_gettext('Namespace'), widget=BS3TextFieldWidget())

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -20,60 +20,11 @@
  * Created by janomar on 23/07/15.
  */
 
+function decode(str) {
+  return new DOMParser().parseFromString(str, "text/html").documentElement.textContent
+}
+
 $(document).ready(function () {
-  var config = {
-    jdbc: {
-      hidden_fields: ['port', 'schema', 'extra'],
-      relabeling: {'host': 'Connection URL'},
-    },
-    google_cloud_platform: {
-      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
-      relabeling: {},
-    },
-    cloudant: {
-      hidden_fields: ['port', 'extra'],
-      relabeling: {
-        'host': 'Account',
-        'login': 'Username (or API Key)',
-        'schema': 'Database'
-      }
-    },
-    docker: {
-      hidden_fields: ['port', 'schema'],
-      relabeling: {
-        'host': 'Registry URL',
-        'login': 'Username',
-      },
-    },
-    qubole: {
-      hidden_fields: ['login', 'schema', 'port', 'extra'],
-      relabeling: {
-        'host': 'API Endpoint',
-        'password': 'Auth Token',
-      },
-      placeholders: {
-        'host': 'https://<env>.qubole.com/api'
-      }
-    },
-    kubernetes: {
-      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
-      relabeling: {},
-    },
-    ssh: {
-      hidden_fields: ['schema'],
-      relabeling: {
-        'login': 'Username',
-      }
-    },
-    yandexcloud: {
-      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
-      relabeling: {},
-    },
-    spark: {
-      hidden_fields: ['schema', 'login', 'password'],
-      relabeling: {},
-    },
-  };
 
   function connTypeChange(connectionType) {
     $(".hide").removeClass("hide");
@@ -87,7 +38,7 @@ $(document).ready(function () {
       $(this).text($(this).attr("orig_text"));
     });
     $(".form-control").each(function(){$(this).attr('placeholder', '')});
-
+    let config = JSON.parse(decode($("#field_behaviours").text()))
     if (config[connectionType] != undefined) {
       $.each(config[connectionType].hidden_fields, function (i, field) {
         $("#" + field).parent().parent().addClass('hide')

--- a/airflow/www/templates/airflow/conn_create.html
+++ b/airflow/www/templates/airflow/conn_create.html
@@ -22,4 +22,5 @@
 {% block tail %}
   {{ super() }}
   <script src="{{ url_for_asset('connectionForm.js') }}"></script>
+  <script id="field_behaviours" type="text/json">{{ widgets["add"].field_behaviours }}</script>
 {% endblock %}

--- a/airflow/www/templates/airflow/conn_edit.html
+++ b/airflow/www/templates/airflow/conn_edit.html
@@ -22,4 +22,5 @@
 {% block tail %}
   {{ super() }}
   <script src="{{ url_for_asset(filename='connectionForm.js') }}"></script>
+  <script id="field_behaviours" type="text/json">{{ widgets["edit"].field_behaviours }}</script>
 {% endblock %}

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -591,6 +591,7 @@ ctor
 cubeName
 customDataImportUids
 customizable
+customizations
 cx
 dabf
 dagBag
@@ -1377,6 +1378,7 @@ workgroup
 workgroups
 wsman
 wtf
+wtforms
 www
 xcom
 xcomarg

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,9 @@ airflow=
     py.typed
     alembic.ini
     git_version
+    customized_form_field_behaviours.schema.json
+    provider.yaml.schema.json
+
 airflow.api.connextion.openaip=*.yaml
 airflow.serialization=*.json
 

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -84,25 +84,39 @@ ALL_PROVIDERS = [
 ]
 
 CONNECTIONS_LIST = [
+    'aws',
+    'azure',
     'azure_batch',
+    'azure_container_instances',
     'azure_cosmos',
+    'azure_data_explorer',
     'azure_data_lake',
     'cassandra',
     'cloudant',
+    'databricks',
     'dataprep',
     'docker',
     'elasticsearch',
+    'emr',
     'exasol',
+    'facebook_social',
+    'ftp',
     'gcpcloudsql',
+    'gcpcloudsqldb',
     'gcpssh',
     'google_cloud_platform',
     'grpc',
+    'hdfs',
     'hive_cli',
+    'hive_metastore',
     'hiveserver2',
+    'http',
     'imap',
     'jdbc',
+    'jenkins',
     'jira',
     'kubernetes',
+    'livy',
     'mongo',
     'mssql',
     'mysql',
@@ -111,12 +125,60 @@ CONNECTIONS_LIST = [
     'pig_cli',
     'postgres',
     'presto',
+    'qubole',
     'redis',
+    's3',
+    'samba',
+    'segment',
+    'sftp',
     'snowflake',
+    'spark',
+    'spark_jdbc',
+    'spark_sql',
     'sqlite',
+    'sqoop',
+    'ssh',
     'tableau',
+    'vault',
     'vertica',
     'wasb',
+    'yandexcloud',
+]
+
+CONNECTION_FORM_WIDGETS = [
+    'extra__google_cloud_platform__key_path',
+    'extra__google_cloud_platform__keyfile_dict',
+    'extra__google_cloud_platform__num_retries',
+    'extra__google_cloud_platform__project',
+    'extra__google_cloud_platform__scope',
+    'extra__grpc__auth_type',
+    'extra__grpc__credential_pem_file',
+    'extra__grpc__scopes',
+    'extra__jdbc__drv_clsname',
+    'extra__jdbc__drv_path',
+    'extra__kubernetes__in_cluster',
+    'extra__kubernetes__kube_config',
+    'extra__kubernetes__kube_config_path',
+    'extra__kubernetes__namespace',
+    'extra__yandexcloud__folder_id',
+    'extra__yandexcloud__oauth',
+    'extra__yandexcloud__public_ssh_key',
+    'extra__yandexcloud__service_account_json',
+    'extra__yandexcloud__service_account_json_path',
+]
+
+CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
+    'cloudant',
+    'docker',
+    'gcpssh',
+    'google_cloud_platform',
+    'jdbc',
+    'kubernetes',
+    'qubole',
+    'sftp',
+    'spark',
+    'ssh',
+    'yandexcloud',
 ]
 
 EXTRA_LINKS = [
@@ -137,13 +199,22 @@ class TestProviderManager(unittest.TestCase):
             version = provider_manager.providers[provider][0]
             self.assertRegex(version, r'[0-9]*\.[0-9]*\.[0-9]*.*')
             self.assertEqual(package_name, provider)
-
         self.assertEqual(ALL_PROVIDERS, provider_list)
 
     def test_hooks(self):
         provider_manager = ProvidersManager()
         connections_list = list(provider_manager.hooks.keys())
         self.assertEqual(CONNECTIONS_LIST, connections_list)
+
+    def test_connection_form_widgets(self):
+        provider_manager = ProvidersManager()
+        connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
+        self.assertEqual(CONNECTION_FORM_WIDGETS, connections_form_widgets)
+
+    def test_field_behaviours(self):
+        provider_manager = ProvidersManager()
+        connections_with_field_behaviours = list(provider_manager.field_behaviours.keys())
+        self.assertEqual(CONNECTIONS_WITH_FIELD_BEHAVIOURS, connections_with_field_behaviours)
 
     def test_extra_links(self):
         provider_manager = ProvidersManager()

--- a/tests/providers/presto/hooks/test_presto.py
+++ b/tests/providers/presto/hooks/test_presto.py
@@ -217,6 +217,23 @@ class TestPrestoHookIntegration(unittest.TestCase):
         records = hook.get_records(sql)
         self.assertEqual([['Customer#000000001'], ['Customer#000000002'], ['Customer#000000003']], records)
 
+    @pytest.mark.xfail(
+        condition=True,
+        reason="""
+This test will fail when full suite of tests are run, because of Snowflake monkeypatching urllib3
+library as described in https://github.com/snowflakedb/snowflake-connector-python/issues/324
+the offending code is here:
+https://github.com/snowflakedb/snowflake-connector-python/blob/133d6215f7920d304c5f2d466bae38127c1b836d/src/snowflake/connector/network.py#L89-L92
+
+This test however runs fine when run in total isolation. We could move it to Heisentests, but then we would
+have to enable integrations there and make sure no snowflake gets imported.
+
+In the future Snowflake plans to get rid of the MonkeyPatching.
+
+Issue to keep track of it: https://github.com/apache/airflow/issues/12881
+
+""",
+    )
     @pytest.mark.integration("presto")
     @pytest.mark.integration("kerberos")
     def test_should_record_records_with_kerberos_auth(self):

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -266,6 +266,14 @@ class TestSSHHook(unittest.TestCase):
             (_, stdout, _) = client.exec_command('ls')  # pylint: disable=no-member
             self.assertIsNotNone(stdout.read())
 
+    def test_ssh_connection_no_connection_id(self):
+        hook = SSHHook(remote_host='localhost')
+        self.assertIsNone(hook.ssh_conn_id)
+        with hook.get_conn() as client:
+            # Note - Pylint will fail with no-member here due to https://github.com/PyCQA/pylint/issues/1437
+            (_, stdout, _) = client.exec_command('ls')  # pylint: disable=no-member
+            self.assertIsNotNone(stdout.read())
+
     def test_ssh_connection_old_cm(self):
         with SSHHook(ssh_conn_id='ssh_default') as hook:
             client = hook.get_conn()


### PR DESCRIPTION
Add support for dynamic connection form fields per provider

Connection form behaviour depends on the connection type. Since we've
separated providers into separate packages, the connection form should
be extendable by each provider. This PR implements both:

  * extra fields added by provider
  * configurable behaviour per provider

This PR will be followed by separate documentation on how to write your
provider.

Also this change triggers (in tests only) the snowflake annoyance
described in #12881 so we had to xfail presto test where monkeypatching
of snowflake causes the test to fail.

Part of #11429


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
