### PR TITLE
limit table of content at the main Airflow doc page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ unit of work and continuity.
 Content
 -------
 .. toctree::
-    :maxdepth: 4
+    :maxdepth: 1
 
     project
     license


### PR DESCRIPTION
Limiting "apache-airflow" documentation main page

closes: #12554 
