### PR TITLE
Add connection arguments in S3ToSnowflakeOperator

### DIFF
--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -36,16 +36,35 @@ class S3ToSnowflakeOperator(BaseOperator):
     :type s3_keys: list
     :param table: reference to a specific table in snowflake database
     :type table: str
-    :param stage: reference to a specific snowflake stage
+    :param warehouse: name of warehouse (will overwrite any warehouse
+    defined in the connection's extra JSON)
+    :type warehouse: str
+    :param schema: name of schema (will overwrite schema defined in
+        connection)
+    :type schema: str
+    :param stage: reference to a specific snowflake stage. If the stage's schema is not the same as the
+        table one, it must be specified
     :type stage: str
     :param file_format: reference to a specific file format
     :type file_format: str
-    :param schema: reference to a specific schema in snowflake database
-    :type schema: str
     :param columns_array: reference to a specific columns array in snowflake database
     :type columns_array: list
-    :param snowflake_conn_id: reference to a specific snowflake database
+    :param snowflake_conn_id: reference to a specific snowflake connection
     :type snowflake_conn_id: str
+    :param role: name of role (will overwrite any role defined in
+        connection's extra JSON)
+    :type role: str
+    :param authenticator: authenticator for Snowflake.
+        'snowflake' (default) to use the internal Snowflake authenticator
+        'externalbrowser' to authenticate using your web browser and
+        Okta, ADFS or any other SAML 2.0-compliant identify provider
+        (IdP) that has been defined for your account
+        'https://<your_okta_account_name>.okta.com' to authenticate
+        through native Okta.
+    :type authenticator: str
+    :param session_parameters: You can set session-level parameters at
+        the time you connect to Snowflake
+    :type session_parameters: dict
     """
 
     @apply_defaults
@@ -58,22 +77,38 @@ class S3ToSnowflakeOperator(BaseOperator):
         file_format: str,
         schema: str,  # TODO: shouldn't be required, rely on session/user defaults
         columns_array: Optional[list] = None,
+        warehouse: Optional[str] = None,
         autocommit: bool = True,
         snowflake_conn_id: str = 'snowflake_default',
+        role: Optional[str] = None,
+        authenticator: Optional[str] = None,
+        session_parameters: Optional[dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.s3_keys = s3_keys
         self.table = table
+        self.warehouse = warehouse
         self.stage = stage
         self.file_format = file_format
         self.schema = schema
         self.columns_array = columns_array
         self.autocommit = autocommit
         self.snowflake_conn_id = snowflake_conn_id
+        self.role = role
+        self.authenticator = authenticator
+        self.session_parameters = session_parameters
 
     def execute(self, context: Any) -> None:
-        snowflake_hook = SnowflakeHook(snowflake_conn_id=self.snowflake_conn_id)
+        snowflake_hook = SnowflakeHook(
+            snowflake_conn_id=self.snowflake_conn_id,
+            warehouse=self.warehouse,
+            database=self.database,
+            role=self.role,
+            schema=self.schema,
+            authenticator=self.authenticator,
+            session_parameters=self.session_parameters,
+        )
 
         # Snowflake won't accept list of files it has to be tuple only.
         # but in python tuple([1]) = (1,) => which is invalid for snowflake

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -103,7 +103,6 @@ class S3ToSnowflakeOperator(BaseOperator):
         snowflake_hook = SnowflakeHook(
             snowflake_conn_id=self.snowflake_conn_id,
             warehouse=self.warehouse,
-            database=self.database,
             role=self.role,
             schema=self.schema,
             authenticator=self.authenticator,

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -45,7 +45,7 @@ class S3ToSnowflakeOperator(BaseOperator):
     :param file_format: reference to a specific file format
     :type file_format: str
     :param warehouse: name of warehouse (will overwrite any warehouse
-    defined in the connection's extra JSON)
+        defined in the connection's extra JSON)
     :type warehouse: str
     :param database: reference to a specific database in Snowflake connection
     :type database: str

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -36,9 +36,6 @@ class S3ToSnowflakeOperator(BaseOperator):
     :type s3_keys: list
     :param table: reference to a specific table in snowflake database
     :type table: str
-    :param warehouse: name of warehouse (will overwrite any warehouse
-    defined in the connection's extra JSON)
-    :type warehouse: str
     :param schema: name of schema (will overwrite schema defined in
         connection)
     :type schema: str
@@ -47,6 +44,11 @@ class S3ToSnowflakeOperator(BaseOperator):
     :type stage: str
     :param file_format: reference to a specific file format
     :type file_format: str
+    :param warehouse: name of warehouse (will overwrite any warehouse
+    defined in the connection's extra JSON)
+    :type warehouse: str
+    :param database: reference to a specific database in Snowflake connection
+    :type database: str
     :param columns_array: reference to a specific columns array in snowflake database
     :type columns_array: list
     :param snowflake_conn_id: reference to a specific snowflake connection
@@ -78,6 +80,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         schema: str,  # TODO: shouldn't be required, rely on session/user defaults
         columns_array: Optional[list] = None,
         warehouse: Optional[str] = None,
+        database: Optional[str] = None,
         autocommit: bool = True,
         snowflake_conn_id: str = 'snowflake_default',
         role: Optional[str] = None,
@@ -89,6 +92,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         self.s3_keys = s3_keys
         self.table = table
         self.warehouse = warehouse
+        self.database = database
         self.stage = stage
         self.file_format = file_format
         self.schema = schema
@@ -103,6 +107,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         snowflake_hook = SnowflakeHook(
             snowflake_conn_id=self.snowflake_conn_id,
             warehouse=self.warehouse,
+            database=self.database,
             role=self.role,
             schema=self.schema,
             authenticator=self.authenticator,


### PR DESCRIPTION
Right now in this operator, if you want to use several warehouses, you have to create different connections, which is not ideal. With this change, you can specify the warehouse in each task, as well as other things related to the connection: role, authenticator, and session parameters.

As the change is very basic, it is based on the code of a preexisting one (SnowflakeOperator) and it doesn't break anything, I think no tests are necessary