### PR TITLE
Doc Fix around Secret/Connection/Variable

### DIFF
--- a/airflow/secrets/base_secrets.py
+++ b/airflow/secrets/base_secrets.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 
 
 class BaseSecretsBackend(ABC):
-    """Abstract base class to retrieve secrets given a conn_id and construct a Connection object"""
+    """Abstract base class to retrieve Connection object given a conn_id or Variable given a key"""
 
     def __init__(self, **kwargs):
         pass
@@ -68,9 +68,10 @@ class BaseSecretsBackend(ABC):
 
     def get_variable(self, key: str) -> Optional[str]:
         """
-        Return value for Airflow Connection
+        Return value for Airflow Variable
 
         :param key: Variable Key
+        :type key: str
         :return: Variable Value
         """
         raise NotImplementedError()

--- a/airflow/secrets/environment_variables.py
+++ b/airflow/secrets/environment_variables.py
@@ -27,7 +27,7 @@ VAR_ENV_PREFIX = "AIRFLOW_VAR_"
 
 
 class EnvironmentVariablesBackend(BaseSecretsBackend):
-    """Retrieves Connection object from environment variable."""
+    """Retrieves Connection object and Variable from environment variable."""
 
     # pylint: disable=missing-docstring
     def get_conn_uri(self, conn_id: str) -> Optional[str]:
@@ -39,6 +39,7 @@ class EnvironmentVariablesBackend(BaseSecretsBackend):
         Get Airflow Variable from Environment Variable
 
         :param key: Variable Key
+        :type key: str
         :return: Variable Value
         """
         return os.environ.get(VAR_ENV_PREFIX + key.upper())

--- a/airflow/secrets/metastore.py
+++ b/airflow/secrets/metastore.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 
 
 class MetastoreBackend(BaseSecretsBackend):
-    """Retrieves Connection object from airflow metastore database."""
+    """Retrieves Connection object and Variable from airflow metastore database."""
 
     # pylint: disable=missing-docstring
     @provide_session
@@ -44,6 +44,7 @@ class MetastoreBackend(BaseSecretsBackend):
         Get Airflow Variable from Metadata DB
 
         :param key: Variable Key
+        :type key: str
         :return: Variable Value
         """
         from airflow.models.variable import Variable

--- a/docs/howto/connection/index.rst
+++ b/docs/howto/connection/index.rst
@@ -179,6 +179,8 @@ So if your connection id is ``my_prod_db`` then the variable name should be ``AI
 
     Single underscores surround ``CONN``.  This is in contrast with the way ``airflow.cfg``
     parameters are stored, where double underscores surround the config section name.
+    Connections set using Environment Variables would not appear in the Airflow UI but you will
+    be able to use them in your DAG file.
 
 The value of this environment variable must use airflow's URI format for connections.  See the section
 :ref:`Generating a Connection URI <generating_connection_uri>` for more details.

--- a/docs/howto/variable.rst
+++ b/docs/howto/variable.rst
@@ -61,7 +61,7 @@ You can use them in your DAGs as:
     Single underscores surround ``VAR``.  This is in contrast with the way ``airflow.cfg``
     parameters are stored, where double underscores surround the config section name.
     Variables set using Environment Variables would not appear in the Airflow UI but you will
-    be able to use it in your DAG file.
+    be able to use them in your DAG file.
 
 Securing Variables
 ------------------


### PR DESCRIPTION
Documentation fixes/improvements:

- For Variables set by Environment Variable, it was highlighted that it may not appear in the web UI. But this was not highlighted for Connections set by Environment Variable. This PR adds this note (in `docs/howto/connection/index.rst`).

- Fix wrong docstring of `airflow.secrets.base_secrets.BaseSecretsBackend.get_variable()`.

- The Secret Backends don't properly mentioning `Variables` in the docstrings (all the focus was put on `Connections` only). This PR addresses this.

- Other a few minor changes.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
