### PR TITLE
Drop random.choice() in BaseHook.get_connection()

### DIFF
--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -17,7 +17,6 @@
 # under the License.
 """Base class for all hooks"""
 import logging
-import random
 from typing import Any, List
 
 from airflow.models.connection import Connection
@@ -38,7 +37,7 @@ class BaseHook(LoggingMixin):
     @classmethod
     def get_connections(cls, conn_id: str) -> List[Connection]:
         """
-        Get all connections as an iterable.
+        Get all connections as an iterable, given the connection id.
 
         :param conn_id: connection id
         :return: array of connections
@@ -48,12 +47,12 @@ class BaseHook(LoggingMixin):
     @classmethod
     def get_connection(cls, conn_id: str) -> Connection:
         """
-        Get random connection selected from all connections configured with this connection id.
+        Get connection, given connection id.
 
         :param conn_id: connection id
         :return: connection
         """
-        conn = random.choice(cls.get_connections(conn_id))
+        conn = cls.get_connections(conn_id)[0]
         if conn.host:
             log.info(
                 "Using connection to: id: %s. Host: %s, Port: %s, Schema: %s, Login: %s, Password: %s, "


### PR DESCRIPTION
https://github.com/apache/airflow/pull/9067 made `conn_id` unique, and this is effective from 2.0.*. Due to this change, `BaseHook.get_connections()` will return a List of length 1, or raise Exception.

In such a case, we should simply always get the only element from the output, and drop `random.choice()` in `BaseHook.get_connection()`, which was only applicable for the earlier setting (multiple connections is allowed for single `conn_id`, which is no longer true).

### A Side Question

After https://github.com/apache/airflow/pull/9067 is rolled out, I would question if we still need `hook.get_connections()` (note NOT `get_connection()`). This needs change in bigger scope and may be a breaking change for many users. So I'm not addressing/touching it in this PR.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
