### PR TITLE
Ensure that the `prohibit_commit` guard only applies to _one_ session.

### DIFF
--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -217,11 +217,11 @@ class CommitProhibitorGuard:
         raise RuntimeError("UNEXPECTED COMMIT - THIS WILL BREAK HA LOCKS!")
 
     def __enter__(self):
-        event.listen(self.session.bind, 'commit', self._validate_commit)
+        event.listen(self.session, 'before_commit', self._validate_commit)
         return self
 
     def __exit__(self, *exc_info):
-        event.remove(self.session.bind, 'commit', self._validate_commit)
+        event.remove(self.session, 'before_commit', self._validate_commit)
 
     def commit(self):
         """


### PR DESCRIPTION
By listening on the engine's `commit` we were picking up _all_ session
commit calls, even from sessions other than the one passed to
`prohibit_commit`, which was not intended.

This changes it to listen to before_commit, which is session specific,
rather than engine "global" and also adds tests which were lacking
before hand.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).