### PR TITLE
Add link to docs index to table of contents

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,7 @@ Content
 .. toctree::
     :maxdepth: 4
 
+    Home <self>
     project
     license
     start


### PR DESCRIPTION
Without this, it's not obvious how to get back to the main page.

This adds the new "Home" TOC item:
![image](https://user-images.githubusercontent.com/34150/100131474-fcad4100-2e7b-11eb-9fe9-44456e830787.png)

As asked for in https://github.com/apache/airflow/pull/12589#issuecomment-733116361
