### PR TITLE
Fix Connection.description migration for MySQL8

### DIFF
--- a/airflow/migrations/versions/64a7d6477aae_fix_description_field_in_connection_to_.py
+++ b/airflow/migrations/versions/64a7d6477aae_fix_description_field_in_connection_to_.py
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""fix description field in connection to be text
+
+Revision ID: 64a7d6477aae
+Revises: f5b5ec089444
+Create Date: 2020-11-25 08:56:11.866607
+
+"""
+
+import sqlalchemy as sa  # noqa
+from alembic import op  # noqa
+
+# revision identifiers, used by Alembic.
+revision = '64a7d6477aae'
+down_revision = '61ec73d9401f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply fix description field in connection to be text"""
+    conn = op.get_bind()  # pylint: disable=no-member
+    if conn.dialect.name == "sqlite":
+        # in sqlite TEXT and STRING column types are the same
+        return
+    if conn.dialect.name == "mysql":
+        op.alter_column(
+            'connection',
+            'description',
+            existing_type=sa.String(length=5000),
+            type_=sa.Text(length=5000),
+            existing_nullable=True,
+        )
+    else:
+        # postgres does not allow size modifier for text type
+        op.alter_column('connection', 'description', existing_type=sa.String(length=5000), type_=sa.Text())
+
+
+def downgrade():
+    """Unapply fix description field in connection to be text"""
+    conn = op.get_bind()  # pylint: disable=no-member
+    if conn.dialect.name == "sqlite":
+        # in sqlite TEXT and STRING column types are the same
+        return
+    if conn.dialect.name == "mysql":
+        op.alter_column(
+            'connection',
+            'description',
+            existing_type=sa.Text(5000),
+            type_=sa.String(length=5000),
+            existing_nullable=True,
+        )
+    else:
+        # postgres does not allow size modifier for text type
+        op.alter_column(
+            'connection',
+            'description',
+            existing_type=sa.Text(),
+            type_=sa.String(length=5000),
+            existing_nullable=True,
+        )

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -22,7 +22,7 @@ from json import JSONDecodeError
 from typing import Dict, List, Optional
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse
 
-from sqlalchemy import Boolean, Column, Integer, String
+from sqlalchemy import Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import synonym
 
@@ -154,7 +154,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
     id = Column(Integer(), primary_key=True)
     conn_id = Column(String(ID_LEN), unique=True, nullable=False)
     conn_type = Column(String(500), nullable=False)
-    description = Column(String(5000))
+    description = Column(Text(5000))
     host = Column(String(500))
     schema = Column(String(500))
     login = Column(String(500))


### PR DESCRIPTION
Due to a bug in Breeze initialization code, we were always running
against Postgres 9.6 and MySQL 5.7, even when the matrix selected
something else.
    
(We were overwriting the POSTGRES_VERSION and MYSQL_VERSION environment
variables in initialization code)
    
There was a connected problem that hidden the utf8mb4 problem as we
migrated to MySQL client 8, where utf8mb4 in mysql client 8
was silently falling back to latin 1 on database creation time
and we have not detected that.
    
We also fix uf8mb4 migration problem that was hidden due to those
missing tests.

Fixes https://github.com/apache/airflow/issues/12588

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
