### PR TITLE
Restrict "build images" workflow to certain branches

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -20,7 +20,7 @@ name: "Build Images"
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["CI Build"]
-    branches: ['master', 'v1-10-test', 'v1-10-stable']
+    on: [pull_request]
     types: ['requested']
 env:
   MOUNT_LOCAL_SOURCES: "false"

--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -22,9 +22,9 @@ on:  # yamllint disable-line rule:truthy
     workflows: ["CI Build"]
     on:
       push:
-        branches: [ 'master', 'v1-10-test', 'v1-10-stable' ]
+        branches: ['master', 'v1-10-test', 'v1-10-stable']
       pull_request:
-        branches: [ 'master', 'v1-10-test', 'v1-10-stable' ]
+        branches: ['master', 'v1-10-test', 'v1-10-stable']
     types: ['requested']
 env:
   MOUNT_LOCAL_SOURCES: "false"

--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -20,11 +20,10 @@ name: "Build Images"
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["CI Build"]
-    on:
-      push:
-        branches: ['master', 'v1-10-test', 'v1-10-stable']
-      pull_request:
-        branches: ['master', 'v1-10-test', 'v1-10-stable']
+    push:
+      branches: ['master', 'v1-10-test', 'v1-10-stable']
+    pull_request:
+      branches: ['master', 'v1-10-test', 'v1-10-stable']
     types: ['requested']
 env:
   MOUNT_LOCAL_SOURCES: "false"

--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -20,7 +20,11 @@ name: "Build Images"
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["CI Build"]
-    on: [pull_request]
+    on:
+      push:
+        branches: [ 'master', 'v1-10-test', 'v1-10-stable' ]
+      pull_request:
+        branches: [ 'master', 'v1-10-test', 'v1-10-stable' ]
     types: ['requested']
 env:
   MOUNT_LOCAL_SOURCES: "false"

--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -20,6 +20,7 @@ name: "Build Images"
 on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["CI Build"]
+    branches: ['master', 'v1-10-test', 'v1-10-stable']
     types: ['requested']
 env:
   MOUNT_LOCAL_SOURCES: "false"


### PR DESCRIPTION
Currently, since we don't restrict it, on forks this runs the build step on all branches

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
