### PR TITLE
Check K8S event reason in executor after Pod run

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -182,6 +182,23 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             % (raw_object['reason'], raw_object['code'], raw_object['message'])
         )
 
+    @staticmethod
+    def is_container_state_bad(container_state) -> bool:
+        """Returns True if the state of the container is not recoverable"""
+        container_waiting = container_state.get('waiting')
+        if not container_waiting:
+            return False
+
+        reason = container_waiting.get('reason')
+        if not reason:
+            return False
+
+        bad_waiting_reasons = {'ImagePullBackOff'}
+        if 'Failed' in reason or reason in bad_waiting_reasons:
+            return True
+
+        return False
+
     def process_status(
         self,
         pod_id: str,
@@ -193,11 +210,15 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
     ) -> None:
         """Process status response"""
         if status == 'Pending':
+            container_statuses = event.get('raw_object', {}).get('status', {}).get('containerStatuses', [])
             if event['type'] == 'DELETED':
                 self.log.info('Event: Failed to start pod %s, will reschedule', pod_id)
                 self.watcher_queue.put(
                     (pod_id, namespace, State.UP_FOR_RESCHEDULE, annotations, resource_version)
                 )
+            elif container_statuses and self.is_container_state_bad(container_statuses[0]['state']):
+                self.log.error('Container state and reason are not acceptable. Event is: %s', event)
+                self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
             else:
                 self.log.info('Event: %s Pending', pod_id)
         elif status == 'Failed':


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When Airflow attempts to create a Pod with the KubernetesExecutor, it has a possibility of failing due to certain resources being unavailable for that Pod. Volumes, Images resources etc. Although Kubernetes has a `restartPolicy` which is set to `never` when Airflow creates Pods, this restartPolicy only comes into effect when the container is running. Kubernetes has separate restart policies for different reasons a pod might not start. 

Airflow users on Kubernetes <= 1.15 can encounter [this error](https://github.com/kubernetes/kubernetes/issues/79398) where pods that fail with reason `FailedCreatePodSandBox` will not attempt to retry due to a bug. In Airflow this manifests itself as an indefinitely queuing pod.  In later Kubernetes versions this has been resolved.

The issue is Kubernetes doesn't [give granular enough restart configuration](https://github.com/kubernetes/kubernetes/issues/88193#issuecomment-659858179), So there is a mismatch between Airflow controlling restarts and Kubernetes controlling restarts. In order for Airflow to be the only thing restarting, it must be ensured that before marking something as FAILED in Airflow for a retry, that the resource has been removed in Kubernetes so that Kubernetes does not retry.

---
**^ Add meaningful description above**

related: #12264

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
