### PR TITLE
Revert "Add link to docs index to table of contents (#12594)"

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,6 @@ unit of work and continuity.
 .. toctree::
     :hidden:
 
-    Home <self>
     project
     license
     start


### PR DESCRIPTION
This reverts commit 91af0ddf76855737a3c32456ce1cfeddde82b44e.

Currently, the sidebar of our doc site is broken: http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/index.html

![image](https://user-images.githubusercontent.com/8811558/100177634-5d636a80-2eca-11eb-8c54-d27c9807fc91.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
