### PR TITLE
fix db migration downgrade actions

### DIFF
--- a/airflow/migrations/versions/3c20cacc0044_add_dagrun_run_type.py
+++ b/airflow/migrations/versions/3c20cacc0044_add_dagrun_run_type.py
@@ -101,4 +101,4 @@ def upgrade():
 
 def downgrade():
     """Unapply Add DagRun run_type"""
-    op.drop_column("run_type")
+    op.drop_column("dag_run", "run_type")

--- a/airflow/migrations/versions/bbf4a7ad0465_remove_id_column_from_xcom.py
+++ b/airflow/migrations/versions/bbf4a7ad0465_remove_id_column_from_xcom.py
@@ -53,5 +53,4 @@ def downgrade():
     with op.batch_alter_table('xcom') as bop:
         bop.drop_constraint('pk_xcom', type_='primary')
         bop.add_column(Column('id', Integer, primary_key=True))
-        bop.create_primary_key('pk_xcom', ['id'])
         bop.create_index('idx_xcom_dag_task_date', ['dag_id', 'task_id', 'key', 'execution_date'])

--- a/airflow/migrations/versions/bef4f3d11e8b_drop_kuberesourceversion_and_.py
+++ b/airflow/migrations/versions/bef4f3d11e8b_drop_kuberesourceversion_and_.py
@@ -64,7 +64,7 @@ def _add_worker_uuid_table():
     elif conn.dialect.name not in {"mssql"}:
         columns_and_constraints.append(sa.CheckConstraint("one_row_id", name="kube_worker_one_row_id"))
 
-    table = op.create_table(WORKER_RESOURCEVERSION_TABLE, *columns_and_constraints)
+    table = op.create_table(WORKER_UUID_TABLE, *columns_and_constraints)
 
     op.bulk_insert(table, [{"worker_uuid": ""}])
 


### PR DESCRIPTION
couple DB migration downgrade methods are not working, causing crashes during schema rollback. perhaps we should setup automation in CI to test both upgrade and downgrade for new alembic version files.