### PR TITLE
Fix Connection.description migration for MySQL8

### DIFF
--- a/airflow/migrations/versions/64a7d6477aae_fix_description_field_in_connection_to_.py
+++ b/airflow/migrations/versions/64a7d6477aae_fix_description_field_in_connection_to_.py
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""fix description field in connection to be text
+
+Revision ID: 64a7d6477aae
+Revises: f5b5ec089444
+Create Date: 2020-11-25 08:56:11.866607
+
+"""
+
+import sqlalchemy as sa  # noqa
+from alembic import op  # noqa
+
+# revision identifiers, used by Alembic.
+revision = '64a7d6477aae'
+down_revision = '61ec73d9401f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Apply fix description field in connection to be text"""
+    conn = op.get_bind()  # pylint: disable=no-member
+    if conn.dialect.name == "sqlite":
+        # in sqlite TEXT and STRING column types are the same
+        return
+    if conn.dialect.name == "mysql":
+        op.alter_column(
+            'connection',
+            'description',
+            existing_type=sa.String(length=5000),
+            type_=sa.Text(length=5000),
+            existing_nullable=True,
+        )
+    else:
+        # postgres does not allow size modifier for text type
+        op.alter_column('connection', 'description', existing_type=sa.String(length=5000), type_=sa.Text())
+
+
+def downgrade():
+    """Unapply fix description field in connection to be text"""
+    conn = op.get_bind()  # pylint: disable=no-member
+    if conn.dialect.name == "sqlite":
+        # in sqlite TEXT and STRING column types are the same
+        return
+    if conn.dialect.name == "mysql":
+        op.alter_column(
+            'connection',
+            'description',
+            existing_type=sa.Text(5000),
+            type_=sa.String(length=5000),
+            existing_nullable=True,
+        )
+    else:
+        # postgres does not allow size modifier for text type
+        op.alter_column(
+            'connection',
+            'description',
+            existing_type=sa.Text(),
+            type_=sa.String(length=5000),
+            existing_nullable=True,
+        )

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -22,7 +22,7 @@ from json import JSONDecodeError
 from typing import Dict, List, Optional
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse
 
-from sqlalchemy import Boolean, Column, Integer, String
+from sqlalchemy import Boolean, Column, Integer, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import synonym
 
@@ -154,7 +154,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
     id = Column(Integer(), primary_key=True)
     conn_id = Column(String(ID_LEN), unique=True, nullable=False)
     conn_type = Column(String(500), nullable=False)
-    description = Column(String(5000))
+    description = Column(Text(5000))
     host = Column(String(500))
     schema = Column(String(500))
     login = Column(String(500))

--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -38,5 +38,7 @@ services:
       - mysql-db-volume:/var/lib/mysql
     ports:
       - "${MYSQL_HOST_PORT}:3306"
+    command: ['mysqld', '--character-set-server=utf8mb4',
+              '--collation-server=utf8mb4_unicode_ci']
 volumes:
   mysql-db-volume:


### PR DESCRIPTION
Based on #12596 so only the last commit counts.


We missed that when we added support
for differnet mysql versions in #7717 when we removed default
character set setting for the database server.

This change forces the default on database server to be
utf8mb4 - regardless if MySQL 5.7 or MySQL8 is used.
Utf8mb4 is default for MySQL8 but latin1 is default fo MySQL 5.7.

There was a suspected root cause of the problem:

https://dev.mysql.com/doc/refman/8.0/en/charset-connection.html
where mysql client falls back to the default collation if
the client8 is used with 5.7 database, but this should be
no problem if the default DB character set is forced to be
utf8mb4

This PR restores forcing the server-side encoding.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
