### PR TITLE
Fixes test that was not compatible with MySQL8

### DIFF
--- a/tests/operators/test_generic_transfer.py
+++ b/tests/operators/test_generic_transfer.py
@@ -55,12 +55,12 @@ class TestMySql(unittest.TestCase):
     )
     def test_mysql_to_mysql(self, client):
         with MySqlContext(client):
-            sql = "SELECT * FROM INFORMATION_SCHEMA.TABLES LIMIT 100;"
+            sql = "SELECT * FROM connection;"
             op = GenericTransfer(
                 task_id='test_m2m',
                 preoperator=[
                     "DROP TABLE IF EXISTS test_mysql_to_mysql",
-                    "CREATE TABLE IF NOT EXISTS test_mysql_to_mysql LIKE INFORMATION_SCHEMA.TABLES",
+                    "CREATE TABLE IF NOT EXISTS test_mysql_to_mysql LIKE connection",
                 ],
                 source_conn_id='airflow_db',
                 destination_conn_id='airflow_db',


### PR DESCRIPTION
In MySQL8 you cannot create table LIKE an INFORMATION_SCHEMA
table because they are not "real" tables and generic_transfer
tests failed on MySQL8 because of that.

This PR changes the test to use connection table instead as
a base for that test

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
