### PR TITLE
Moved Contributors' Guide to CONTRIBUTING.rst file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,24 +39,26 @@ You can contribute to Airflow in various ways such as:
 - reporting bug
 - suggesting new features and Road Map items
 - submitting Pull Requests (PRs) for bug fixes and new features.
-- attending Airflow meets-up events near you:
+- speaking at Airflow meets-up events near you:
 
   - search for Airflow `Meetup <https://www.meetup.com/>`_
 
-- helping to answer questions on gitter, the dev email list, PRs, and Jiras.
+- helping to answer questions on Slack, engage in discussions on GitHub, reviewing GitHub issues and PRs.
 
 
-Best Ways of Engaging Yourself in the Community
+Best Ways of Engaging in the Community
 -----------------------------------------------
 
 There are several ways for members to connect meaningfully in the community.
 These include:
 
-- Sending an email to: `<dev@airflow.incubator.apache.org>`_
+- Subscribe to: `<dev@airflow.incubator.apache.org>`_
 
-  - This is the best way to get a Committer to answer a question.
+  - This mailing list is where Airflow development projects are discussed as well as voting for AIPs or Airflow releases.
 
-- Open a JIRA ticket when you discover a bug and propose a PR with a fix.
+  - Troubleshooting questions related to Airflow can asked on Slack or StackOverflow.
+
+- Open a GitHub issue when you discover a bug and propose a PR with a fix.
 
   - This is the only way to get PRs approved or to report bugs.
 
@@ -65,8 +67,8 @@ Is Your Company Using Airflow?
 ------------------------------
 
 If so, then add your company name (along with your Github handle) as links to the
-`README.md <https://github.com/apache/airflow/blob/master/README.md#who-uses-apache-airflow>`_
-and submit a PR (with associated JIRA). We will be happy to merge it.
+`README.md <https://github.com/apache/airflow/blob/master/INTHEWILD.md>`_
+and submit a PR. We will be happy to merge it.
 
 
 Get Mentoring Support

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,10 +56,6 @@ These include:
 
   - This is the best way to get a Committer to answer a question.
 
-- Asking a question on `<https://gitter.im/apache/incubator-airflow>`_
-
-  - This is the best way to get a quick response, but not from a committer.
-
 - Open a JIRA ticket when you discover a bug and propose a PR with a fix.
 
   - This is the only way to get PRs approved or to report bugs.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,8 +20,58 @@
 Contributions
 =============
 
-Contributions are welcome and are greatly appreciated! Every little bit helps,
+Contributions to Airflow are welcome and are greatly appreciated! Every little bit helps,
 and credit will always be given.
+
+We would like more people to use, contribute to, and help maintain Airflow. 
+These three goals align with the three main membership roles within our community: 
+users, contributors, and committers/maintainers.
+
+We would like to instill a sense of ownership and pride among the members of our community 
+by encouraging:
+
+- people to use Airflow 
+- users to contribute ro Airflow
+- contributors to become committers 
+
+You can contribute to Airflow in various ways such as:
+
+- reporting bug 
+- suggesting new features and Road Map items
+- submitting Pull Requests (PRs) for bug fixes and new features.
+- attending Airflow meets-up events near you:
+
+  - search for Airflow `Meetup <https://www.meetup.com/>`_ 
+
+- helping to answer questions on gitter, the dev email list, PRs, and Jiras.
+
+
+Best Ways of Engaging Yourself in the Community
+-----------------------------------------------
+
+There are several ways for members to connect meaningfully in the community.
+These include: 
+
+- Sending an email to: `<dev@airflow.incubator.apache.org>`_ 
+
+  - This is the best way to get a Committer to answer a question.
+
+- Asking a question on `<https://gitter.im/apache/incubator-airflow>` 
+
+  - This is the best way to get a quick response, but not from a committer.
+
+- Open a JIRA ticket when you discover a bug and propose a PR with a fix.
+
+  - This is the only way to get PRs approved or to report bugs.
+
+
+Is Your Company Using Airflow?
+------------------------------
+
+If so, then add your company name (along with your Github handle) as links to the 
+`README.md <https://github.com/apache/airflow/blob/master/README.md#who-uses-apache-airflow>`_ 
+and submit a PR (with associated JIRA). We will be happy to merge it.
+
 
 Get Mentoring Support
 ---------------------
@@ -56,8 +106,14 @@ implement it.
 Implement Features
 ------------------
 
-Look through the `GitHub issues labeled "kind:feature"
-<https://github.com/apache/airflow/labels/kind%3Afeature>`__ for features.
+To begin suggesting features and Road Map items:
+
+* First you have to subscribe to the Dev list by an email to `<dev-subscribe@airflow.incubator.apache.org>`_ 
+  - a bot will automatically add you to an allow-list which enables you to send emails to 
+  our Dev email list ( `<dev@airflow.incubator.apache.org>`_ )
+
+* Look through the `GitHub issues labeled "kind:feature"
+  <https://github.com/apache/airflow/labels/kind%3Afeature>`__ for features.
 
 Any unassigned feature request issue is open to whoever wants to implement it.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,25 +23,25 @@ Contributions
 Contributions to Airflow are welcome and are greatly appreciated! Every little bit helps,
 and credit will always be given.
 
-We would like more people to use, contribute to, and help maintain Airflow. 
-These three goals align with the three main membership roles within our community: 
+We would like more people to use, contribute to, and help maintain Airflow.
+These three goals align with the three main membership roles within our community:
 users, contributors, and committers/maintainers.
 
-We would like to instill a sense of ownership and pride among the members of our community 
+We would like to instill a sense of ownership and pride among the members of our community
 by encouraging:
 
-- people to use Airflow 
+- people to use Airflow
 - users to contribute ro Airflow
-- contributors to become committers 
+- contributors to become committers
 
 You can contribute to Airflow in various ways such as:
 
-- reporting bug 
+- reporting bug
 - suggesting new features and Road Map items
 - submitting Pull Requests (PRs) for bug fixes and new features.
 - attending Airflow meets-up events near you:
 
-  - search for Airflow `Meetup <https://www.meetup.com/>`_ 
+  - search for Airflow `Meetup <https://www.meetup.com/>`_
 
 - helping to answer questions on gitter, the dev email list, PRs, and Jiras.
 
@@ -50,13 +50,13 @@ Best Ways of Engaging Yourself in the Community
 -----------------------------------------------
 
 There are several ways for members to connect meaningfully in the community.
-These include: 
+These include:
 
-- Sending an email to: `<dev@airflow.incubator.apache.org>`_ 
+- Sending an email to: `<dev@airflow.incubator.apache.org>`_
 
   - This is the best way to get a Committer to answer a question.
 
-- Asking a question on `<https://gitter.im/apache/incubator-airflow>` 
+- Asking a question on `<https://gitter.im/apache/incubator-airflow>`_
 
   - This is the best way to get a quick response, but not from a committer.
 
@@ -68,8 +68,8 @@ These include:
 Is Your Company Using Airflow?
 ------------------------------
 
-If so, then add your company name (along with your Github handle) as links to the 
-`README.md <https://github.com/apache/airflow/blob/master/README.md#who-uses-apache-airflow>`_ 
+If so, then add your company name (along with your Github handle) as links to the
+`README.md <https://github.com/apache/airflow/blob/master/README.md#who-uses-apache-airflow>`_
 and submit a PR (with associated JIRA). We will be happy to merge it.
 
 
@@ -108,8 +108,8 @@ Implement Features
 
 To begin suggesting features and Road Map items:
 
-* First you have to subscribe to the Dev list by an email to `<dev-subscribe@airflow.incubator.apache.org>`_ 
-  - a bot will automatically add you to an allow-list which enables you to send emails to 
+* First you have to subscribe to the Dev list by an email to `<dev-subscribe@airflow.incubator.apache.org>`_
+  - a bot will automatically add you to an allow-list which enables you to send emails to
   our Dev email list ( `<dev@airflow.incubator.apache.org>`_ )
 
 * Look through the `GitHub issues labeled "kind:feature"


### PR DESCRIPTION
Fixed #10187

Moved the main content of Contributors' guide to CONTRIBUTING.rst file.

This is to eliminate duplication and unify Airflow's contributions
guidelines in CONTRIBUTING.rst file. The aim is to make CONTRIBUTING.rst
doc a single source of truth for all Airflow Contributors.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
