### PR TITLE
Bugfix: Handle ParserError when dag is triggered with invalid execution_date

### DIFF
--- a/tests/api_connexion/schemas/test_dag_run_schema.py
+++ b/tests/api_connexion/schemas/test_dag_run_schema.py
@@ -19,6 +19,7 @@ import unittest
 from dateutil.parser import parse
 from parameterized import parameterized
 
+from airflow.api_connexion.exceptions import BadRequest
 from airflow.api_connexion.schemas.dag_run_schema import (
     DAGRunCollection,
     dagrun_collection_schema,
@@ -115,6 +116,12 @@ class TestDAGRunSchema(TestDAGRunBase):
             result,
             {"execution_date": result["execution_date"], "run_id": result["run_id"]},
         )
+
+    def test_invalid_execution_date_raises(self):
+        serialized_dagrun = {"execution_date": "mydate"}
+        with self.assertRaises(BadRequest) as e:
+            dagrun_schema.load(serialized_dagrun)
+        self.assertEqual(str(e.exception), "Incorrect datetime argument")
 
 
 class TestDagRunCollection(TestDAGRunBase):


### PR DESCRIPTION
Closes: #12616 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
