### PR TITLE
Fix webserver ingress annotations

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -28,7 +28,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
-- Kubernetes 1.12+ cluster
+- Kubernetes 1.14+ cluster
 - Helm 2.11+ or Helm 3.0+
 - PV provisioner support in the underlying infrastructure
 

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -29,10 +29,12 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-  {{- with .Values.ingress.web.annotations }}
+{{- if .Values.ingress.web.annotations }}
   annotations:
-  {{ toYaml . | indent 4 }}
-  {{- end }}
+{{- with .Values.ingress.web.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end}}
 spec:
   {{- if .Values.ingress.web.tls.enabled }}
   tls:
@@ -49,15 +51,19 @@ spec:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
           {{- end }}
-          - path: {{ .Values.ingress.web.path }}
-            backend:
+          - backend:
               serviceName: {{ .Release.Name }}-webserver
               servicePort: airflow-ui
+{{- if .Values.ingress.web.path }}
+            path: {{ .Values.ingress.web.path }}
+{{- end }}
           {{- range .Values.ingress.web.succeedingPaths }}
           - path: {{ .path }}
             backend:
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
           {{- end }}
+{{- if .Values.ingress.web.host }}
       host: {{ .Values.ingress.web.host }}
+{{- end }}
 {{- end }}

--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -29,7 +29,7 @@ from kubernetes.client.api_client import ApiClient
 
 api_client = ApiClient()
 
-BASE_URL_SPEC = "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.12.9"
+BASE_URL_SPEC = "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0"
 
 
 @lru_cache(maxsize=None)

--- a/chart/tests/test_ingress_web.py
+++ b/chart/tests/test_ingress_web.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import jmespath
+
+from tests.helm_template_generator import render_chart
+
+
+class IngressWebTest(unittest.TestCase):
+    def test_should_pass_validation_with_just_ingress_enabled(self):
+        render_chart(
+            values={"ingress": {"enabled": True}},
+            show_only=["templates/webserver/webserver-ingress.yaml"],
+        )  # checks that no validation exception is raised
+
+    def test_should_allow_more_than_one_annotation(self):
+        docs = render_chart(
+            values={"ingress": {"enabled": True, "web": {"annotations": {"aa": "bb", "cc": "dd"}}}},
+            show_only=["templates/webserver/webserver-ingress.yaml"],
+        )
+        self.assertEqual({"aa": "bb", "cc": "dd"}, jmespath.search("metadata.annotations", docs[0]))


### PR DESCRIPTION
The indentation under web.annotation was wrong (6 leading spaces
on first line, 4 on the next) leading to

    Error converting YAMl to JSON: yaml: line 32: did not find expected key

when more that 1 annotation was provided.

@potiuk 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
