### PR TITLE
Add missing `@apply_defaults` to BigQueryInsertJobOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2001,6 +2001,7 @@ class BigQueryInsertJobOperator(BaseOperator):
     template_fields_renderers = {"configuration": "json"}
     ui_color = BigQueryUIColors.QUERY.value
 
+    @apply_defaults
     def __init__(
         self,
         configuration: Dict[str, Any],


### PR DESCRIPTION
Applies a missing `@apply_defaults` decorator to `BigQeueryInsertJobOperator`.
