### PR TITLE
Make AzureKeyVaultBackend backwards-compatible

### DIFF
--- a/airflow/contrib/secrets/azure_key_vault.py
+++ b/airflow/contrib/secrets/azure_key_vault.py
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use `airflow.providers.microsoft.azure.secrets.azure_key_vault`."""
+
+import warnings
+
+# pylint: disable=unused-import
+from airflow.providers.microsoft.azure.secrets.azure_key_vault import AzureKeyVaultBackend  # noqa
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.microsoft.azure.secrets.azure_key_vault`.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
This module was released in 1.10.13. This commit just makes
it backwards-compatible

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
