### PR TITLE
Clean-up airflow/kubernetes/kube_config.py

### DIFF
--- a/airflow/kubernetes/kube_config.py
+++ b/airflow/kubernetes/kube_config.py
@@ -15,10 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
-from typing import Union
 
-from airflow import settings
 from airflow.configuration import conf
+from airflow.settings import AIRFLOW_HOME
 
 
 class KubeConfig:  # pylint: disable=too-many-instance-attributes
@@ -30,8 +29,8 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
 
     def __init__(self):  # pylint: disable=too-many-statements
         configuration_dict = conf.as_dict(display_sensitive=True)
-        self.core_configuration = configuration_dict['core']
-        self.airflow_home = settings.AIRFLOW_HOME
+        self.core_configuration = configuration_dict[self.core_section]
+        self.airflow_home = AIRFLOW_HOME
         self.dags_folder = conf.get(self.core_section, 'dags_folder')
         self.parallelism = conf.getint(self.core_section, 'parallelism')
         self.pod_template_file = conf.get(self.kubernetes_section, 'pod_template_file', fallback=None)
@@ -76,12 +75,3 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
             self.delete_option_kwargs = json.loads(delete_option_kwargs)
         else:
             self.delete_option_kwargs = {}
-
-    # pod security context items should return integers
-    # and only return a blank string if contexts are not set.
-    def _get_security_context_val(self, scontext: str) -> Union[str, int]:
-        val = conf.get(self.kubernetes_section, scontext)
-        if not val:
-            return ""
-        else:
-            return int(val)


### PR DESCRIPTION
- Remove the stale internal method `_get_security_context_val`
  It was added in PR #5429, but to what I can see, it's not needed anymore.
- Avoid hard-coding when we can (we already have `core_section` specified, so can avoid using `'core'`)
- Narrow down what we import from `airflow.settings`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
