### PR TITLE
Add BaseOperatorMetaclassRule

### DIFF
--- a/airflow/upgrade/rules/custom_operator_metaclass_rule.py
+++ b/airflow/upgrade/rules/custom_operator_metaclass_rule.py
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.models.dagbag import DagBag
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.utils.db import provide_session
+
+
+def check_task_for_metaclasses(task):
+    class_type = type(task.__class__)
+    if class_type != type:
+        res = (
+            "Class {class_name} contained invalid custom metaclass "
+            "{metaclass_name}. Custom metaclasses for operators are not "
+            "allowed in Airflow 2.0. Please remove this custom metaclass.".format(
+                class_name=task.__class__, metaclass_name=class_type
+            )
+        )
+        return res
+    else:
+        return None
+
+
+class BaseOperatorMetaclassRule(BaseRule):
+    title = "Ensure users are not using custom metaclasses in custom operators"
+
+    description = """\
+In Airflow 2.0, we require that all custom operators use the BaseOperatorMeta metaclass.\
+To ensure this, we can no longer allow custom metaclasses in custom operators.
+    """
+
+    @provide_session
+    def check(self, session=None):
+        dagbag = DagBag(include_examples=True)
+        custom_metaclasses = []
+        for dag_id, dag in dagbag.dags.items():
+            for task in dag.tasks:
+                res = check_task_for_metaclasses(task)
+                if res:
+                    custom_metaclasses.append(res)
+
+        return custom_metaclasses

--- a/airflow/upgrade/rules/custom_operator_metaclass_rule.py
+++ b/airflow/upgrade/rules/custom_operator_metaclass_rule.py
@@ -48,11 +48,8 @@ To ensure this, we can no longer allow custom metaclasses in custom operators.
     @provide_session
     def check(self, session=None):
         dagbag = DagBag(include_examples=Flase)
-        custom_metaclass_error_messages = []
         for dag_id, dag in dagbag.dags.items():
             for task in dag.tasks:
                 res = check_task_for_metaclasses(task)
                 if res:
-                    custom_metaclass_error_messages.append(res)
-
-        return custom_metaclass_error_messages
+                    yield res

--- a/airflow/upgrade/rules/custom_operator_metaclass_rule.py
+++ b/airflow/upgrade/rules/custom_operator_metaclass_rule.py
@@ -47,7 +47,7 @@ To ensure this, we can no longer allow custom metaclasses in custom operators.
 
     @provide_session
     def check(self, session=None):
-        dagbag = DagBag(include_examples=Flase)
+        dagbag = DagBag(include_examples=False)
         for dag_id, dag in dagbag.dags.items():
             for task in dag.tasks:
                 res = check_task_for_metaclasses(task)

--- a/airflow/upgrade/rules/custom_operator_metaclass_rule.py
+++ b/airflow/upgrade/rules/custom_operator_metaclass_rule.py
@@ -47,7 +47,7 @@ To ensure this, we can no longer allow custom metaclasses in custom operators.
 
     @provide_session
     def check(self, session=None):
-        dagbag = DagBag(include_examples=True)
+        dagbag = DagBag(include_examples=Flase)
         custom_metaclass_error_messages = []
         for dag_id, dag in dagbag.dags.items():
             for task in dag.tasks:

--- a/airflow/upgrade/rules/custom_operator_metaclass_rule.py
+++ b/airflow/upgrade/rules/custom_operator_metaclass_rule.py
@@ -48,11 +48,11 @@ To ensure this, we can no longer allow custom metaclasses in custom operators.
     @provide_session
     def check(self, session=None):
         dagbag = DagBag(include_examples=True)
-        custom_metaclasses = []
+        custom_metaclass_error_messages = []
         for dag_id, dag in dagbag.dags.items():
             for task in dag.tasks:
                 res = check_task_for_metaclasses(task)
                 if res:
-                    custom_metaclasses.append(res)
+                    custom_metaclass_error_messages.append(res)
 
-        return custom_metaclasses
+        return custom_metaclass_error_messages

--- a/tests/upgrade/rules/test_custom_operator_metaclass_rule.py
+++ b/tests/upgrade/rules/test_custom_operator_metaclass_rule.py
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.models.baseoperator import BaseOperator
+from airflow.upgrade.rules.custom_operator_metaclass_rule import (
+    BaseOperatorMetaclassRule,
+    check_task_for_metaclasses,
+)
+from six import with_metaclass
+
+
+class MyMeta(type):
+    pass
+
+
+class MyMetaOperator(with_metaclass(MyMeta, BaseOperator)):
+    def execute(self, context):
+        pass
+
+
+class TestBaseOperatorMetaclassRule(TestCase):
+    def test_individual_task(self):
+        task = MyMetaOperator(task_id="foo")
+        res = check_task_for_metaclasses(task)
+        expected_error = (
+            "Class <class 'tests.upgrade.rules.test_custom_operator_metaclass_rule.MyMetaOperator'> "
+            "contained invalid custom metaclass <class "
+            "'tests.upgrade.rules.test_custom_operator_metaclass_rule.MyMeta'>. "
+            "Custom metaclasses for operators are not allowed in Airflow 2.0. "
+            "Please remove this custom metaclass."
+        )
+        self.assertEqual(expected_error, res)
+
+    def test_check(self):
+        rule = BaseOperatorMetaclassRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+        msgs = rule.check()
+        self.assertEqual(msgs, [])

--- a/tests/upgrade/rules/test_custom_operator_metaclass_rule.py
+++ b/tests/upgrade/rules/test_custom_operator_metaclass_rule.py
@@ -51,5 +51,5 @@ class TestBaseOperatorMetaclassRule(TestCase):
 
         assert isinstance(rule.description, str)
         assert isinstance(rule.title, str)
-        msgs = rule.check()
+        msgs = list(rule.check())
         self.assertEqual(msgs, [])


### PR DESCRIPTION
Adds an upgrade check rule that ensures that users are not using custom
metaclasses in their custom operators

Fixes https://github.com/apache/airflow/issues/11038
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
