### PR TITLE
Allow to configure Flower's url_prefix

### DIFF
--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -112,6 +112,7 @@ spec:
                   key: basicAuth
             {{- end }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+          {{- include "custom_airflow_environment" . | indent 10 }}
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
When deploying with the Helm chart using an ingress for flower that has a path (`ingress.flower.path`) flower is currently unusable.
Flower by default assumes that it will be serving url starting on `/` and it must be told via [url_prefix][1] if it's actual url is not based directly on `/`. 
Currently there is no way (that I know of) to pass `url_prefix` to the Flower deployment/pod. 

This PR introduces a new helm chart value `flower.url_prefix` to allow for that. 


[1]: https://flower.readthedocs.io/en/latest/config.html#url-prefix



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
