### PR TITLE
Remove unsupported arguments from Slack webhook

### DIFF
--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -32,7 +32,7 @@ class SlackWebhookHook(HttpHook):
     and webhook_token will be taken as endpoint, the relative path of the url.
 
     Each Slack webhook token can be pre-configured to use a specific channel, username and
-    icon. You can override these defaults in this hook.
+    icon.
 
     :param http_conn_id: connection that has Slack webhook token in the extra field
     :type http_conn_id: str
@@ -46,14 +46,6 @@ class SlackWebhookHook(HttpHook):
     :param blocks: The blocks to send on Slack. Should be a list of
         dictionaries representing Slack blocks.
     :type blocks: list
-    :param channel: The channel the message should be posted to
-    :type channel: str
-    :param username: The username to post to slack with
-    :type username: str
-    :param icon_emoji: The emoji to use as icon for the user posting to Slack
-    :type icon_emoji: str
-    :param icon_url: The icon image URL string to use in place of the default icon.
-    :type icon_url: str
     :param link_names: Whether or not to find and link channel and usernames in your
         message
     :type link_names: bool
@@ -69,10 +61,6 @@ class SlackWebhookHook(HttpHook):
         message="",
         attachments=None,
         blocks=None,
-        channel=None,
-        username=None,
-        icon_emoji=None,
-        icon_url=None,
         link_names=False,
         proxy=None,
         *args,
@@ -83,10 +71,6 @@ class SlackWebhookHook(HttpHook):
         self.message = message
         self.attachments = attachments
         self.blocks = blocks
-        self.channel = channel
-        self.username = username
-        self.icon_emoji = icon_emoji
-        self.icon_url = icon_url
         self.link_names = link_names
         self.proxy = proxy
 
@@ -133,14 +117,6 @@ class SlackWebhookHook(HttpHook):
         """
         cmd = {}
 
-        if self.channel:
-            cmd['channel'] = self.channel
-        if self.username:
-            cmd['username'] = self.username
-        if self.icon_emoji:
-            cmd['icon_emoji'] = self.icon_emoji
-        if self.icon_url:
-            cmd['icon_url'] = self.icon_url
         if self.link_names:
             cmd['link_names'] = 1
         if self.attachments:

--- a/airflow/providers/slack/operators/slack_webhook.py
+++ b/airflow/providers/slack/operators/slack_webhook.py
@@ -31,7 +31,7 @@ class SlackWebhookOperator(SimpleHttpOperator):
     and webhook_token will be taken as endpoint, the relative path of the url.
 
     Each Slack webhook token can be pre-configured to use a specific channel, username and
-    icon. You can override these defaults in this hook.
+    icon.
 
     :param http_conn_id: connection that has Slack webhook token in the extra field
     :type http_conn_id: str
@@ -45,14 +45,6 @@ class SlackWebhookOperator(SimpleHttpOperator):
     :param blocks: The blocks to send on Slack. Should be a list of
         dictionaries representing Slack blocks.
     :type blocks: list
-    :param channel: The channel the message should be posted to
-    :type channel: str
-    :param username: The username to post to slack with
-    :type username: str
-    :param icon_emoji: The emoji to use as icon for the user posting to Slack
-    :type icon_emoji: str
-    :param icon_url: The icon image URL string to use in place of the default icon.
-    :type icon_url: str
     :param link_names: Whether or not to find and link channel and usernames in your
         message
     :type link_names: bool
@@ -65,8 +57,6 @@ class SlackWebhookOperator(SimpleHttpOperator):
         'message',
         'attachments',
         'blocks',
-        'channel',
-        'username',
         'proxy',
     ]
 
@@ -80,10 +70,6 @@ class SlackWebhookOperator(SimpleHttpOperator):
         message: str = "",
         attachments: Optional[list] = None,
         blocks: Optional[list] = None,
-        channel: Optional[str] = None,
-        username: Optional[str] = None,
-        icon_emoji: Optional[str] = None,
-        icon_url: Optional[str] = None,
         link_names: bool = False,
         proxy: Optional[str] = None,
         **kwargs,
@@ -94,10 +80,6 @@ class SlackWebhookOperator(SimpleHttpOperator):
         self.message = message
         self.attachments = attachments
         self.blocks = blocks
-        self.channel = channel
-        self.username = username
-        self.icon_emoji = icon_emoji
-        self.icon_url = icon_url
         self.link_names = link_names
         self.proxy = proxy
         self.hook: Optional[SlackWebhookHook] = None
@@ -110,10 +92,6 @@ class SlackWebhookOperator(SimpleHttpOperator):
             self.message,
             self.attachments,
             self.blocks,
-            self.channel,
-            self.username,
-            self.icon_emoji,
-            self.icon_url,
             self.link_names,
             self.proxy,
         )

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -35,18 +35,10 @@ class TestSlackWebhookHook(unittest.TestCase):
         'message': 'Awesome message to put on Slack',
         'attachments': [{'fallback': 'Required plain-text summary'}],
         'blocks': [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': '*bold text*'}}],
-        'channel': '#general',
-        'username': 'SlackMcSlackFace',
-        'icon_emoji': ':hankey:',
-        'icon_url': 'https://airflow.apache.org/_images/pin_large.png',
         'link_names': True,
         'proxy': 'https://my-horrible-proxy.proxyist.com:8080',
     }
     expected_message_dict = {
-        'channel': _config['channel'],
-        'username': _config['username'],
-        'icon_emoji': _config['icon_emoji'],
-        'icon_url': _config['icon_url'],
         'link_names': 1,
         'attachments': _config['attachments'],
         'blocks': _config['blocks'],

--- a/tests/providers/slack/operators/test_slack_webhook.py
+++ b/tests/providers/slack/operators/test_slack_webhook.py
@@ -33,10 +33,6 @@ class TestSlackWebhookOperator(unittest.TestCase):
         'message': 'your message here',
         'attachments': [{'fallback': 'Required plain-text summary'}],
         'blocks': [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': '*bold text*'}}],
-        'channel': '#general',
-        'username': 'SlackMcSlackFace',
-        'icon_emoji': ':hankey',
-        'icon_url': 'https://airflow.apache.org/_images/pin_large.png',
         'link_names': True,
         'proxy': 'https://my-horrible-proxy.proxyist.com:8080',
     }
@@ -54,10 +50,6 @@ class TestSlackWebhookOperator(unittest.TestCase):
         assert self._config['message'] == operator.message
         assert self._config['attachments'] == operator.attachments
         assert self._config['blocks'] == operator.blocks
-        assert self._config['channel'] == operator.channel
-        assert self._config['username'] == operator.username
-        assert self._config['icon_emoji'] == operator.icon_emoji
-        assert self._config['icon_url'] == operator.icon_url
         assert self._config['link_names'] == operator.link_names
         assert self._config['proxy'] == operator.proxy
 
@@ -69,8 +61,6 @@ class TestSlackWebhookOperator(unittest.TestCase):
             'message',
             'attachments',
             'blocks',
-            'channel',
-            'username',
             'proxy',
         ]
 


### PR DESCRIPTION
We cannot override channel, username, and icon now. Plseas refer  https://api.slack.com/messaging/webhooks#advanced_message_formatting

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
