### PR TITLE
Improve breeze help messages

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2029,6 +2029,10 @@ This is the current syntax for  `./breeze <./breeze>`_:
         'breeze static-check mypy -- --files tests/core.py'
         'breeze static-check mypy -- --all-files'
 
+        To check all files that differ between you current branch and master run:
+
+        'breeze static-check all -- --from-ref $(git merge-base master HEAD) --to-ref HEAD'
+
         You can see all the options by adding --help EXTRA_ARG:
 
         'breeze static-check mypy -- --help'

--- a/breeze
+++ b/breeze
@@ -247,6 +247,8 @@ function breeze::initialize_virtualenv() {
             echo
             if [[ ${OSTYPE} == "darwin"* ]]; then
                 echo "  brew install sqlite mysql postgresql openssl"
+                echo "  export LDFLAGS=\"-L/usr/local/opt/openssl/lib\""
+                echo "  export CPPFLAGS=\"-I/usr/local/opt/openssl/include\""
             else
                 echo "  sudo apt install build-essentials python3.6-dev python3.7-dev python3.8-dev python-dev openssl \\"
                 echo "              sqlite sqlite-dev default-libmysqlclient-dev libmysqld-dev postgresql"
@@ -1862,6 +1864,10 @@ ${FORMATTED_STATIC_CHECKS}
       '${CMDNAME} static-check mypy' or
       '${CMDNAME} static-check mypy -- --files tests/core.py'
       '${CMDNAME} static-check mypy -- --all-files'
+
+      To check all files that differ between you current branch and master run:
+
+      '${CMDNAME} static-check all -- --from-ref \$(git merge-base master HEAD) --to-ref HEAD'
 
       You can see all the options by adding --help EXTRA_ARG:
 


### PR DESCRIPTION
* **initialize-local-virtualenv**: on the event of failure it recomends to change `LDFLAGS` and `CPPFLAGS`  to that it pick up the ssl library from the location where `brew` installs it.
* **static-check --help**: now includes an example on how to run the checks for all files changed by your current branch.
