### PR TITLE
Housekeeping: Remove 'dirty_ids' in www/views.py

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3265,9 +3265,6 @@ class DagRunModelView(AirflowModelView):
         """Multiple delete."""
         self.datamodel.delete_all(items)
         self.update_redirect()
-        dirty_ids = []
-        for item in items:
-            dirty_ids.append(item.dag_id)
         return redirect(self.get_redirect())
 
     @action('set_running', "Set state to 'running'", '', single=False)
@@ -3276,11 +3273,9 @@ class DagRunModelView(AirflowModelView):
         """Set state to running."""
         try:
             count = 0
-            dirty_ids = []
             for dr in (
                 session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all()
             ):  # noqa pylint: disable=no-member
-                dirty_ids.append(dr.dag_id)
                 count += 1
                 dr.start_date = timezone.utcnow()
                 dr.state = State.RUNNING
@@ -3302,12 +3297,10 @@ class DagRunModelView(AirflowModelView):
         """Set state to failed."""
         try:
             count = 0
-            dirty_ids = []
             altered_tis = []
             for dr in (
                 session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all()
             ):  # noqa pylint: disable=no-member
-                dirty_ids.append(dr.dag_id)
                 count += 1
                 altered_tis += set_dag_run_state_to_failed(
                     current_app.dag_bag.get_dag(dr.dag_id), dr.execution_date, commit=True, session=session
@@ -3332,12 +3325,10 @@ class DagRunModelView(AirflowModelView):
         """Set state to success."""
         try:
             count = 0
-            dirty_ids = []
             altered_tis = []
             for dr in (
                 session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all()
             ):  # noqa pylint: disable=no-member
-                dirty_ids.append(dr.dag_id)
                 count += 1
                 altered_tis += set_dag_run_state_to_success(
                     current_app.dag_bag.get_dag(dr.dag_id), dr.execution_date, commit=True, session=session


### PR DESCRIPTION
This is a (another😉) clean-up/housekeeping change.

Usage of `dirty_ids` is no longer applicable since PR https://github.com/apache/airflow/pull/4378, back in Dec 2018.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
