### PR TITLE
Add possibility to configure upgrade_check command

### DIFF
--- a/airflow/upgrade/README.md
+++ b/airflow/upgrade/README.md
@@ -80,3 +80,23 @@ This will generate a pod using your aiflow.cfg settings
 
 ...
 ```
+
+Additionally you can use "upgrade config" to:
+- specify rules you would like to ignore
+- extend the check using custom rules
+
+For example:
+```
+airflow upgrade_check --config=/files/upgrade.yaml
+```
+the configuration file should be a proper yaml file similar to this one:
+```yaml
+ignored_rules:
+  - LegacyUIDeprecated
+  - ConnTypeIsNotNullableRule
+  - PodTemplateFileRule
+
+custom_rules:
+  - path.to.upgrade_module.VeryCustomCheckClass
+  - path.to.upgrade_module.VeryCustomCheckClass2
+```

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 import argparse
+import logging
 import sys
 from typing import List
 
@@ -28,11 +29,11 @@ from airflow.upgrade.rules.base_rule import BaseRule
 ALL_RULES = [cls() for cls in get_rules()]  # type: List[BaseRule]
 
 
-def check_upgrade(formatter):
-    # type: (BaseFormatter) -> List[RuleStatus]
-    formatter.start_checking(ALL_RULES)
+def check_upgrade(formatter, rules):
+    # type: (BaseFormatter, List[BaseRule]) -> List[RuleStatus]
+    formatter.start_checking(rules)
     all_rule_statuses = []  # List[RuleStatus]
-    for rule in ALL_RULES:
+    for rule in rules:
         rule_status = RuleStatus.from_rule(rule)
         all_rule_statuses.append(rule_status)
         formatter.on_next_rule_status(rule_status)
@@ -45,11 +46,22 @@ def register_arguments(subparser):
         "-s", "--save",
         help="Saves the result to the indicated file. The file format is determined by the file extension."
     )
+    subparser.add_argument(
+        "-i", "--ignore",
+        help="Ignore a rule. Can be used multiple times.",
+        action='append',
+    )
+    subparser.add_argument(
+        "-c", "--config",
+        help="Path to upgrade check config yaml file.",
+    )
     subparser.set_defaults(func=run)
 
 
 def run(args):
     from airflow.upgrade.formatters import (ConsoleFormatter, JSONFormatter)
+    from airflow.upgrade.config import UpgradeConfig
+
     if args.save:
         filename = args.save
         if not filename.lower().endswith(".json"):
@@ -57,7 +69,21 @@ def run(args):
         formatter = JSONFormatter(args.save)
     else:
         formatter = ConsoleFormatter()
-    all_problems = check_upgrade(formatter)
+
+    if args.ignore:
+        rules = [r for r in ALL_RULES if r.__class__.__name__ not in args.ignore]
+    else:
+        rules = ALL_RULES
+
+    if args.config:
+        print("Using config file from:", args.config)
+        upgrade_config = UpgradeConfig.read(path=args.config)
+        rules = upgrade_config.register_custom_rules(rules)
+        rules = upgrade_config.remove_ignored_rules(rules)
+
+    logging.disable(logging.WARNING)
+
+    all_problems = check_upgrade(formatter, rules)
     if all_problems:
         sys.exit(1)
 

--- a/airflow/upgrade/config.py
+++ b/airflow/upgrade/config.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+import yaml
+
+from airflow.utils.module_loading import import_string
+
+
+class UpgradeConfig(object):
+    def __init__(self, raw_config):
+        self._raw_config = raw_config
+
+    def remove_ignored_rules(self, rules):
+        rules_to_ignore = self._raw_config.get("ignored_rules")
+        if not rules_to_ignore:
+            return rules
+        return [r for r in rules if r.__class__.__name__ not in rules_to_ignore]
+
+    def register_custom_rules(self, rules):
+        custom_rules = self._raw_config.get("custom_rules")
+        if not custom_rules:
+            return rules
+        for custom_rule in custom_rules:
+            rule = import_string(custom_rule)
+            rules.append(rule())
+        return rules
+
+    @classmethod
+    def read(cls, path):
+        with open(path) as f:
+            raw_config = yaml.safe_load(f)
+        return cls(raw_config)

--- a/airflow/upgrade/rules/undefined_jinja_varaibles.py
+++ b/airflow/upgrade/rules/undefined_jinja_varaibles.py
@@ -17,7 +17,6 @@
 
 from __future__ import absolute_import
 
-import logging
 import re
 
 import jinja2
@@ -132,14 +131,8 @@ The user should do either of the following to fix this -
 
     def check(self, dagbag=None):
         if not dagbag:
-            logger = logging.root
-            old_level = logger.level
-            try:
-                logger.setLevel(logging.ERROR)
-                dag_folder = conf.get("core", "dags_folder")
-                dagbag = DagBag(dag_folder)
-            finally:
-                logger.setLevel(old_level)
+            dag_folder = conf.get("core", "dags_folder")
+            dagbag = DagBag(dag_folder)
         dags = dagbag.dags
         messages = []
         for dag_id, dag in dags.items():

--- a/tests/upgrade/rules/test_undefined_jinja_varaibles.py
+++ b/tests/upgrade/rules/test_undefined_jinja_varaibles.py
@@ -19,6 +19,7 @@ from tempfile import mkdtemp
 from unittest import TestCase
 
 import jinja2
+import pytest
 
 from airflow import DAG
 from airflow.models import DagBag
@@ -155,6 +156,7 @@ class TestUndefinedJinjaVariablesRule(TestCase):
 
         assert len(messages) == 0
 
+    @pytest.mark.quarantined
     def test_invalid_check(self):
         dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
         dagbag.dags[self.invalid_dag.dag_id] = self.invalid_dag

--- a/tests/upgrade/test_config.py
+++ b/tests/upgrade/test_config.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tempfile
+from unittest import mock
+
+import pytest
+
+from airflow.upgrade.config import UpgradeConfig
+
+dummy_config = """\
+ignored_rules:
+- MockRule1
+- MockRule2
+custom_rules:
+- custom.rule.one
+"""
+
+
+class MockRule1(object):
+    pass
+
+
+class MockRule2(object):
+    pass
+
+
+class MockRule3(object):
+    pass
+
+
+@pytest.fixture(scope="class")
+def config():
+    with tempfile.NamedTemporaryFile("w+") as f:
+        f.write(dummy_config)
+        f.flush()
+        yield UpgradeConfig.read(f.name)
+
+
+class TestUpgradeConfig:
+    def test_read(self, config):
+        assert "ignored_rules" in config._raw_config
+        assert "custom_rules" in config._raw_config
+
+        assert len(config._raw_config["ignored_rules"]) == 2
+        assert len(config._raw_config["custom_rules"]) == 1
+
+    def test_ignore(self, config):
+        rules = [MockRule1(), MockRule2(), MockRule3()]
+        assert config.remove_ignored_rules(rules) == [rules[-1]]
+
+    @mock.patch("airflow.upgrade.config.import_string")
+    def test_register_custom_rules(self, mock_import, config):
+        rules = [MockRule1, MockRule2]
+        mock_import.return_value = MockRule3
+        rules = config.register_custom_rules(rules)
+        mock_import.assert_called_once_with("custom.rule.one")
+        assert len(rules) == 3
+        assert isinstance(rules[-1], MockRule3)

--- a/tests/upgrade/test_formattes.py
+++ b/tests/upgrade/test_formattes.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import json
 from tempfile import NamedTemporaryFile
 from tests.compat import mock
@@ -37,7 +36,8 @@ class MockRule(BaseRule):
 
 class TestJSONFormatter:
     @mock.patch("airflow.upgrade.checker.ALL_RULES", [MockRule()])
-    def test_output(self):
+    @mock.patch("airflow.upgrade.checker.logging.disable")  # mock to avoid side effects
+    def test_output(self, _):
         expected = [
             {
                 "rule": MockRule.__name__,


### PR DESCRIPTION
In some cases users may want to suppress some checks. This commit
adds possibility to specify simple yaml file where users can
specify ignored checks and module path to custom checks.

I also disable logging to avoid output between lines of check.

Before:
```
root@5d103907dca8:/opt/airflow# airflow upgrade_check -i LegacyUIDeprecated -i ConnTypeIsNotNullableRule -i TaskHandlersMovedRule -i VersionCheckRule -i MesosExecutorRemovedRule

====================================================================================================== STATUS ======================================================================================================

Remove airflow.AirflowMacroPlugin class...................................................................................................................................................................SUCCESS
Chain between DAG and operator not allowed................................................................................................................................................................SUCCESS
Connection.conn_id is not unique..........................................................................................................................................................................SUCCESS
[2020-11-27 14:09:31,544] {__init__.py:50} INFO - Using executor LocalExecutor
[2020-11-27 14:09:31,546] {dagbag.py:417} INFO - Filling up the DagBag from /root
Ensure users are not using custom metaclasses in custom operators.........................................................................................................................................SUCCESS
Fernet is enabled by default..............................................................................................................................................................................SUCCESS
GCP service account key deprecation.......................................................................................................................................................................SUCCESS
Changes in import paths of hooks, operators, sensors and others...........................................................................................................................................SUCCESS
Logging configuration has been moved to new section.......................................................................................................................................................SUCCESS
Users must set a kubernetes.pod_template_file value.......................................................................................................................................................FAIL
SendGrid email uses old airflow.contrib module............................................................................................................................................................SUCCESS
Jinja Template Variables cannot be undefined..............................................................................................................................................................SUCCESS
Found 1 problem.
```

After:
```
root@5d103907dca8:/opt/airflow# airflow upgrade_check -i LegacyUIDeprecated -i ConnTypeIsNotNullableRule -i TaskHandlersMovedRule -i VersionCheckRule -i MesosExecutorRemovedRule

====================================================================================================== STATUS ======================================================================================================

Remove airflow.AirflowMacroPlugin class...................................................................................................................................................................SUCCESS
Chain between DAG and operator not allowed................................................................................................................................................................SUCCESS
Connection.conn_id is not unique..........................................................................................................................................................................SUCCESS
Ensure users are not using custom metaclasses in custom operators.........................................................................................................................................SUCCESS
Fernet is enabled by default..............................................................................................................................................................................SUCCESS
GCP service account key deprecation.......................................................................................................................................................................SUCCESS
Changes in import paths of hooks, operators, sensors and others...........................................................................................................................................SUCCESS
Logging configuration has been moved to new section.......................................................................................................................................................SUCCESS
Users must set a kubernetes.pod_template_file value.......................................................................................................................................................FAIL
SendGrid email uses old airflow.contrib module............................................................................................................................................................SUCCESS
Jinja Template Variables cannot be undefined..............................................................................................................................................................SUCCESS
Found 1 problem.
```

And using custom rules:
```
root@5d103907dca8:/opt/airflow# airflow upgrade_check -i TaskHandlersMovedRule -i VersionCheckRule -i MesosExecutorRemovedRule --config=/files/upgrade.yaml
Using config file from: /files/upgrade.yaml

====================================================================================================== STATUS ======================================================================================================

Remove airflow.AirflowMacroPlugin class...................................................................................................................................................................SUCCESS
Chain between DAG and operator not allowed................................................................................................................................................................SUCCESS
Connection.conn_id is not unique..........................................................................................................................................................................SUCCESS
Ensure users are not using custom metaclasses in custom operators.........................................................................................................................................SUCCESS
Fernet is enabled by default..............................................................................................................................................................................SUCCESS
GCP service account key deprecation.......................................................................................................................................................................SUCCESS
Changes in import paths of hooks, operators, sensors and others...........................................................................................................................................SUCCESS
Logging configuration has been moved to new section.......................................................................................................................................................SUCCESS
SendGrid email uses old airflow.contrib module............................................................................................................................................................SUCCESS
Jinja Template Variables cannot be undefined..............................................................................................................................................................SUCCESS
A custom rule.............................................................................................................................................................................................SUCCESS
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
