### PR TITLE
Add upgrade check rule for unrecognized arguments to Operators

### DIFF
--- a/airflow/upgrade/rules/no_additional_args_in_operators.py
+++ b/airflow/upgrade/rules/no_additional_args_in_operators.py
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+import os
+import re
+import logging
+import warnings
+from airflow.utils.dag_processing import correct_maybe_zipped, list_py_file_paths
+from airflow import conf
+from airflow.models.dagbag import DagBag
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class NoAdditionalArgsInOperatorsRule(BaseRule):
+    title = "No additional argument allowed in BaseOperator."
+
+    description = """
+                Passing unrecognized arguments to operators is not allowed in Airflow 2.0 anymore,
+                and will cause an exception.
+                  """
+
+    def check(self, dags_folder=None):
+        if not dags_folder:
+            dags_folder = conf.get("core", "dags_folder")
+
+        logger = logging.root
+        old_level = logger.level
+        try:
+            logger.setLevel(logging.ERROR)
+            dagbag = DagBag(dag_folder=os.devnull, include_examples=False, store_serialized_dags=False)
+            dags_folder = correct_maybe_zipped(dags_folder)
+
+            # Each file in the DAG folder is parsed individually
+            for filepath in list_py_file_paths(dags_folder,
+                                               safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+                                               include_examples=False):
+                try:
+                    with warnings.catch_warnings(record=True) as captured_warnings:
+                        _ = dagbag.process_file(
+                            filepath,
+                            safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'))
+                except Exception:
+                    pass
+
+                for warning in captured_warnings:
+                    if warning.category == PendingDeprecationWarning \
+                            and str(warning.message).startswith("Invalid arguments were passed"):
+                        m = re.match(r'''
+                                    .* \(task_id:\ ([^\)]+)\) .* \n
+                                    \*args:\ (.*) \n
+                                     \*\*kwargs:\ (.*)
+                                    ''', str(warning.message), re.VERBOSE)
+
+                        yield "DAG file `{}` with task_id `{}` has unrecognized positional args `{}`" \
+                              "and keyword args " \
+                              "`{}`".format(filepath, m.group(1), m.group(2), m.group(3))
+        finally:
+            logger.setLevel(old_level)

--- a/airflow/upgrade/rules/no_additional_args_in_operators.py
+++ b/airflow/upgrade/rules/no_additional_args_in_operators.py
@@ -30,9 +30,9 @@ from airflow.upgrade.rules.base_rule import BaseRule
 class NoAdditionalArgsInOperatorsRule(BaseRule):
     title = "No additional argument allowed in BaseOperator."
 
-    description = """
-                Passing unrecognized arguments to operators is not allowed in Airflow 2.0 anymore,
-                and will cause an exception.
+    description = """\
+Passing unrecognized arguments to operators is not allowed in Airflow 2.0 anymore,
+and will cause an exception.
                   """
 
     def check(self, dags_folder=None):
@@ -59,7 +59,7 @@ class NoAdditionalArgsInOperatorsRule(BaseRule):
                     pass
 
                 for warning in captured_warnings:
-                    if warning.category == PendingDeprecationWarning \
+                    if warning.category in (DeprecationWarning, PendingDeprecationWarning) \
                             and str(warning.message).startswith("Invalid arguments were passed"):
                         m = re.match(r'''
                                     .* \(task_id:\ ([^\)]+)\) .* \n

--- a/tests/upgrade/rules/test_no_additional_args_operators.py
+++ b/tests/upgrade/rules/test_no_additional_args_operators.py
@@ -40,5 +40,5 @@ class TestNoAdditionalArgsInOperatorsRule(TestCase):
                 BashOperator(task_id='test', bash_command="true", extra_param=42)
                 '''))
             dag_file.flush()
-            msgs = rule.check(dags_folder=dag_file.name)
-            assert len(list(msgs)) == 1
+            msgs = list(rule.check(dags_folder=dag_file.name))
+            assert len(msgs) == 1

--- a/tests/upgrade/rules/test_no_additional_args_operators.py
+++ b/tests/upgrade/rules/test_no_additional_args_operators.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from tempfile import NamedTemporaryFile
+from unittest import TestCase
+import textwrap
+from airflow.upgrade.rules.no_additional_args_in_operators import NoAdditionalArgsInOperatorsRule
+from tests.test_utils.db import clear_db_connections
+
+
+class TestNoAdditionalArgsInOperatorsRule(TestCase):
+    def tearDown(self):
+        clear_db_connections()
+
+    def test_check(self):
+        rule = NoAdditionalArgsInOperatorsRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        with NamedTemporaryFile(mode='w', suffix='.py') as dag_file:
+            dag_file.write(
+                textwrap.dedent('''
+            from airflow import DAG
+            from airflow.utils.dates import days_ago
+            from airflow.operators.bash_operator import BashOperator
+
+            with DAG(dag_id="test", start_date=days_ago(0)):
+                BashOperator(task_id='test', bash_command="true", extra_param=42)
+                '''
+                                ))
+            dag_file.flush()
+            msgs = rule.check(dags_folder=dag_file.name)
+            assert list(msgs) != []

--- a/tests/upgrade/rules/test_no_additional_args_operators.py
+++ b/tests/upgrade/rules/test_no_additional_args_operators.py
@@ -36,7 +36,7 @@ class TestNoAdditionalArgsInOperatorsRule(TestCase):
             from airflow.utils.dates import days_ago
             from airflow.operators.bash_operator import BashOperator
 
-            with DAG(dag_id="test", start_date=days_ago(0)):
+            with DAG(dag_id="test_no_additional_args_operators", start_date=days_ago(0)):
                 BashOperator(task_id='test', bash_command="true", extra_param=42)
                 '''))
             dag_file.flush()

--- a/tests/upgrade/rules/test_no_additional_args_operators.py
+++ b/tests/upgrade/rules/test_no_additional_args_operators.py
@@ -16,13 +16,18 @@
 # under the License.
 
 
+import textwrap
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
-import textwrap
+
+import pytest
+
 from airflow.upgrade.rules.no_additional_args_in_operators import NoAdditionalArgsInOperatorsRule
 
 
 class TestNoAdditionalArgsInOperatorsRule(TestCase):
+
+    @pytest.mark.filterwarnings('always')
     def test_check(self):
         rule = NoAdditionalArgsInOperatorsRule()
 

--- a/tests/upgrade/rules/test_no_additional_args_operators.py
+++ b/tests/upgrade/rules/test_no_additional_args_operators.py
@@ -20,13 +20,9 @@ from tempfile import NamedTemporaryFile
 from unittest import TestCase
 import textwrap
 from airflow.upgrade.rules.no_additional_args_in_operators import NoAdditionalArgsInOperatorsRule
-from tests.test_utils.db import clear_db_connections
 
 
 class TestNoAdditionalArgsInOperatorsRule(TestCase):
-    def tearDown(self):
-        clear_db_connections()
-
     def test_check(self):
         rule = NoAdditionalArgsInOperatorsRule()
 
@@ -42,8 +38,7 @@ class TestNoAdditionalArgsInOperatorsRule(TestCase):
 
             with DAG(dag_id="test", start_date=days_ago(0)):
                 BashOperator(task_id='test', bash_command="true", extra_param=42)
-                '''
-                                ))
+                '''))
             dag_file.flush()
             msgs = rule.check(dags_folder=dag_file.name)
-            assert list(msgs) != []
+            assert len(list(msgs)) == 1


### PR DESCRIPTION
ease upgrade to Airflow 2.0

The NoAdditionalArgsInOperatorsRule class ensures that passing an
unrecognised arguments to operators causes an exception.

Passing unrecognised arguments is not allowed in Airflow 2.0

fixes #11042 


