### PR TITLE
Fix: Deprecated config force_log_out_after was not used

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -369,7 +369,7 @@ def get_session_lifetime_config():
     session_lifetime_minutes = conf.get('webserver', 'session_lifetime_minutes', fallback=None)
     session_lifetime_days = conf.get('webserver', 'session_lifetime_days', fallback=None)
     uses_deprecated_lifetime_configs = session_lifetime_days or conf.get(
-        'webserver', 'force_logout_after', fallback=None
+        'webserver', 'force_log_out_after', fallback=None
     )
 
     minutes_per_day = 24 * 60
@@ -378,7 +378,7 @@ def get_session_lifetime_config():
         warnings.warn(
             '`session_lifetime_days` option from `[webserver]` section has been '
             'renamed to `session_lifetime_minutes`. The new option allows to configure '
-            'session lifetime in minutes. The `force_logout_after` option has been removed '
+            'session lifetime in minutes. The `force_log_out_after` option has been removed '
             'from `[webserver]` section. Please update your configuration.',
             category=DeprecationWarning,
         )


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/12642

Config in 1.10.12: https://airflow.readthedocs.io/en/1.10.12/configurations-ref.html#force-log-out-after

`force_logout_after` should be `force_log_out_after` in the code
section https://github.com/apache/airflow/blob/master/airflow/settings.py#L372-L381.

As `force_log_out_after` is actually used and written in
https://github.com/apache/airflow/blob/c5700a56bb3b9a5b872bda0fe0d3de82b0128bdf/UPDATING.md#unify-user-session-lifetime-configuration.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
