### PR TITLE
Fix test in PR 12663

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -570,10 +570,10 @@ class SchedulerJobTest(unittest.TestCase):
         ti_to_schedule = []
         scheduler_job._process_task_instances(dag, task_instances_list=ti_to_schedule)
 
-        assert ti_to_schedule == [
+        assert sorted(ti_to_schedule) == sorted([
             (dag.dag_id, dag_task1.task_id, DEFAULT_DATE, TRY_NUMBER),
             (dag.dag_id, dag_task2.task_id, DEFAULT_DATE, TRY_NUMBER),
-        ]
+        ])
 
     def test_find_executable_task_instances_concurrency(self):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_concurrency'


### PR DESCRIPTION
The order of the two TI keys in `test_process_task_instances_depends_on_past()` (https://github.com/apache/airflow/pull/12663) is not guaranteed,
in such a case, directly assert two lists (both with two elements) will cause 'random' failure

This PR addresses this issue.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
