### PR TITLE
Add example dag and system tests for azure wasb and fileshare

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_file_to_wasb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_file_to_wasb.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from airflow.models import DAG
+from airflow.providers.microsoft.azure.operators.wasb_delete_blob import WasbDeleteBlobOperator
+from airflow.providers.microsoft.azure.transfers.file_to_wasb import FileToWasbOperator
+from airflow.utils.dates import days_ago
+
+PATH_TO_UPLOAD_FILE = os.environ.get('AZURE_PATH_TO_UPLOAD_FILE', 'example-text.txt')
+
+with DAG("example_file_to_wasb", schedule_interval="@once", start_date=days_ago(2)) as dag:
+    upload = FileToWasbOperator(
+        task_id="upload_file", file_path=PATH_TO_UPLOAD_FILE, container_name="mycontainer", blob_name='myblob'
+    )
+    delete = WasbDeleteBlobOperator(task_id="delete_file", container_name="mycontainer", blob_name="myblob")
+    upload >> delete

--- a/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.models import DAG
+from airflow.operators.python import PythonOperator
+from airflow.providers.microsoft.azure.hooks.azure_fileshare import AzureFileShareHook
+from airflow.utils.dates import days_ago
+
+NAME = 'myfileshare'
+DIRECTORY = "mydirectory"
+
+
+def create_fileshare():
+    """Create a fileshare with directory"""
+    hook = AzureFileShareHook()
+    hook.create_share(NAME)
+    hook.create_directory(share_name=NAME, directory_name=DIRECTORY)
+    exists = hook.check_for_directory(share_name=NAME, directory_name=DIRECTORY)
+    if not exists:
+        raise Exception
+
+
+def delete_fileshare():
+    """Delete a fileshare"""
+    hook = AzureFileShareHook()
+    hook.delete_share(NAME)
+
+
+with DAG("example_fileshare", schedule_interval="@once", start_date=days_ago(2)) as dag:
+    create = PythonOperator(task_id="create-share", python_callable=create_fileshare)
+    delete = PythonOperator(task_id="delete-share", python_callable=delete_fileshare)
+
+    create >> delete

--- a/tests/providers/microsoft/azure/hooks/test_fileshare_system.py
+++ b/tests/providers/microsoft/azure/hooks/test_fileshare_system.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import pytest
+
+from tests.test_utils.azure_system_helpers import (
+    AZURE_DAG_FOLDER,
+    AzureSystemTest,
+    provide_wasb_default_connection,
+)
+
+CREDENTIALS_DIR = os.environ.get('CREDENTIALS_DIR', '/files/airflow-breeze-config/keys')
+WASB_DEFAULT_KEY = 'wasb_key.json'
+CREDENTIALS_PATH = os.path.join(CREDENTIALS_DIR, WASB_DEFAULT_KEY)
+
+
+@pytest.mark.backend('postgres', 'mysql')
+@pytest.mark.credential_file(WASB_DEFAULT_KEY)
+class FileshareSystem(AzureSystemTest):
+    @provide_wasb_default_connection(CREDENTIALS_PATH)
+    def test_run_example_fileshare(self):
+        self.run_dag('example_fileshare', AZURE_DAG_FOLDER)

--- a/tests/providers/microsoft/azure/transfers/test_file_to_wasb_system.py
+++ b/tests/providers/microsoft/azure/transfers/test_file_to_wasb_system.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import pytest
+
+from airflow.providers.microsoft.azure.example_dags.example_file_to_wasb import PATH_TO_UPLOAD_FILE
+from tests.test_utils.azure_system_helpers import (
+    AZURE_DAG_FOLDER,
+    AzureSystemTest,
+    provide_wasb_default_connection,
+)
+
+CREDENTIALS_DIR = os.environ.get('CREDENTIALS_DIR', '/files/airflow-breeze-config/keys')
+WASB_DEFAULT_KEY = 'wasb_key.json'
+CREDENTIALS_PATH = os.path.join(CREDENTIALS_DIR, WASB_DEFAULT_KEY)
+
+
+@pytest.mark.backend('postgres', 'mysql')
+@pytest.mark.credential_file(WASB_DEFAULT_KEY)
+class FileToWasbSystem(AzureSystemTest):
+    def setUp(self):
+        super().setUp()
+        with open(PATH_TO_UPLOAD_FILE, 'w+') as file:
+            file.writelines(['example test files'])
+
+    def tearDown(self):
+        os.remove(PATH_TO_UPLOAD_FILE)
+        super().tearDown()
+
+    @provide_wasb_default_connection(CREDENTIALS_PATH)
+    def test_run_example_file_to_wasb(self):
+        self.run_dag('example_file_to_wasb', AZURE_DAG_FOLDER)


### PR DESCRIPTION
This PR adds example dag and system tests for azure wasb and fileshare.

It will help us validate the upgrade for azure wasb and fileshare in #12188 

cc: @potiuk @mik-laj 
Please, I'm not sure where to put the system test for fileshare, I added it to hooks tests. Let me know if I should change the location

To test this, create a json file named `wasb_key.json` in `/files/airflow-breeze-config/keys`. Fill it with `connection` fields: e.g

```{"login":"account_name", "password": "account_key"}```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
