### PR TITLE
SlackWebhookHook use password instead of extra

### DIFF
--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -109,13 +109,17 @@ class SlackWebhookHook(HttpHook):
             if getattr(conn, 'password', None):
                 return conn.password
             else:
-                warnings.warn(
-                    "'webhook_token' in 'extra' is deprecated. Please use 'password' field",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
                 extra = conn.extra_dejson
-                return extra.get('webhook_token', '')
+                web_token = extra.get('webhook_token', '')
+
+                if web_token:
+                    warnings.warn(
+                        "'webhook_token' in 'extra' is deprecated. Please use 'password' field",
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+
+                return web_token
         else:
             raise AirflowException('Cannot get token: No valid Slack webhook token nor conn_id supplied')
 

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -17,6 +17,8 @@
 # under the License.
 #
 import json
+import warnings
+
 from typing import Optional
 
 from airflow.exceptions import AirflowException
@@ -104,8 +106,18 @@ class SlackWebhookHook(HttpHook):
             return token
         elif http_conn_id:
             conn = self.get_connection(http_conn_id)
-            extra = conn.extra_dejson
-            return extra.get('webhook_token', '')
+
+            if getattr(conn, 'password', None):
+                return conn.password
+            else:
+
+                warnings.warn(
+                    "'webhook_token' in 'extra' is deprecated. Please use 'password' field",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                extra = conn.extra_dejson
+                return extra.get('webhook_token', '')
         else:
             raise AirflowException('Cannot get token: No valid Slack webhook token nor conn_id supplied')
 

--- a/airflow/providers/slack/hooks/slack_webhook.py
+++ b/airflow/providers/slack/hooks/slack_webhook.py
@@ -18,7 +18,6 @@
 #
 import json
 import warnings
-
 from typing import Optional
 
 from airflow.exceptions import AirflowException
@@ -110,7 +109,6 @@ class SlackWebhookHook(HttpHook):
             if getattr(conn, 'password', None):
                 return conn.password
             else:
-
                 warnings.warn(
                     "'webhook_token' in 'extra' is deprecated. Please use 'password' field",
                     DeprecationWarning,

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -96,7 +96,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         self.assertEqual(webhook_token, manual_token)
 
     def test_get_token_conn_id(self):
-        # GivenSlackWebhookHook
+        # Given
         conn_id = 'slack-webhook-default'
         hook = SlackWebhookHook(http_conn_id=conn_id)
         expected_webhook_token = 'your_token_here'
@@ -108,7 +108,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         self.assertEqual(webhook_token, expected_webhook_token)
 
     def test_get_token_conn_id_password(self):
-        # GivenSlackWebhookHook
+        # Given
         conn_id = 'slack-webhook-with-password'
         hook = SlackWebhookHook(http_conn_id=conn_id)
         expected_webhook_token = 'your_token_here'

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -76,6 +76,13 @@ class TestSlackWebhookHook(unittest.TestCase):
                 conn_id='slack-webhook-host', conn_type='http', host='https://hooks.slack.com/services/T000/'
             )
         )
+        db.merge_conn(
+            Connection(
+                conn_id='slack-webhook-with-password',
+                conn_type='http',
+                password='your_token_here',
+            )
+        )
 
     def test_get_token_manual_token(self):
         # Given
@@ -89,8 +96,20 @@ class TestSlackWebhookHook(unittest.TestCase):
         self.assertEqual(webhook_token, manual_token)
 
     def test_get_token_conn_id(self):
-        # Given
+        # GivenSlackWebhookHook
         conn_id = 'slack-webhook-default'
+        hook = SlackWebhookHook(http_conn_id=conn_id)
+        expected_webhook_token = 'your_token_here'
+
+        # When
+        webhook_token = hook._get_token(None, conn_id)
+
+        # Then
+        self.assertEqual(webhook_token, expected_webhook_token)
+
+    def test_get_token_conn_id_password(self):
+        # GivenSlackWebhookHook
+        conn_id = 'slack-webhook-with-password'
         hook = SlackWebhookHook(http_conn_id=conn_id)
         expected_webhook_token = 'your_token_here'
 


### PR DESCRIPTION
SlackWebhookHook use password and add deprecation warning for extra.

closes: #12214
