### PR TITLE
Ensure that tasks set to up_for_retry have an end date

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -633,10 +633,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         current_time = timezone.utcnow()
         self.log.debug("Setting task state for %s to %s", self, state)
         self.state = state
-        self.start_date = current_time
-        if self.state in State.finished:
-            self.end_date = current_time
-            self.duration = 0
+        self.start_date = self.start_date or current_time
+        if self.state in State.finished or self.state == State.UP_FOR_RETRY:
+            self.end_date = self.end_date or current_time
+            self.duration = (self.end_date - self.start_date).total_seconds()
         session.merge(self)
 
     @property

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1977,6 +1977,20 @@ class TestTaskInstance(unittest.TestCase):
                 task_instance_b.run()
                 self.validate_ti_states(dag_run, second_run_state, error_message)
 
+    def test_set_state_up_for_retry(self):
+        dag = DAG('dag', start_date=DEFAULT_DATE)
+        op1 = DummyOperator(task_id='op_1', owner='test', dag=dag)
+
+        ti = TI(task=op1, execution_date=timezone.utcnow(), state=State.RUNNING)
+        start_date = timezone.utcnow()
+        ti.start_date = start_date
+
+        ti.set_state(State.UP_FOR_RETRY)
+        assert ti.state == State.UP_FOR_RETRY
+        assert ti.start_date == start_date, "Start date should have been left alone"
+        assert ti.start_date < ti.end_date
+        assert ti.duration > 0
+
 
 @pytest.mark.parametrize("pool_override", [None, "test_pool2"])
 def test_refresh_from_task(pool_override):


### PR DESCRIPTION
If a task is "manually" set to up_for_retry (via the UI for instance) it
might not have an end date, and much of the logic about computing
retries assumes that it does.
    
Without this, manually setting a running task to up_for_retry will make
the make it impossible to view the TaskInstance details page (as it
tries to print the is_premature property), and also the NotInRetryPeriod
TIDep fails - both with an exception:
    
> File "airflow/models/taskinstance.py", line 882, in next_retry_datetime
>   return self.end_date + delay
> TypeError: unsupported operand type(s) for +: 'NoneType' and 'datetime.timedelta'
