### PR TITLE
The Pyarrow limitation in install_requires is not needed.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ install_requires =
     funcsigs>=1.0.0, <2.0.0
     graphviz>=0.12
     gunicorn>=19.5.0, <20.0
-    importlib_resources;python_version<"3.7"
+    importlib_resources~=1.4
     iso8601>=0.1.12
     itsdangerous>=1.1.0
     jinja2>=2.10.1, <2.12.0
@@ -115,7 +115,6 @@ install_requires =
     pendulum~=2.0
     pep562~=1.0;python_version<"3.7"
     psutil>=4.2.0, <6.0.0
-    pyarrow<0.18.0,>=0.17.0  # Required to keep snowflake happy
     pygments>=2.0.1, <3.0
     python-daemon>=2.1.1
     python-dateutil>=2.3, <3


### PR DESCRIPTION
It was added to make snowflake happy, but it is not needed as
package requirement in fact and google provider complains when
the version of pyarrow is too low.

Also when PyArrow limitation is removed, we have to limit
the importlib_resources library back.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
