### PR TITLE
Replace pkg_resources with importlib.metadata to avoid VersionConflict errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,6 +100,7 @@ install_requires =
     funcsigs>=1.0.0, <2.0.0
     graphviz>=0.12
     gunicorn>=19.5.0, <20.0
+    importlib_metadata~=1.7 # We could work with 3.1, but argparse needs <2
     importlib_resources~=1.4
     iso8601>=0.1.12
     itsdangerous>=1.1.0

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -52,7 +52,7 @@ from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
-from airflow.plugins_manager import AirflowPlugin, EntryPointSource, PluginsDirectorySource
+from airflow.plugins_manager import AirflowPlugin, EntryPointSource
 from airflow.security import permissions
 from airflow.ti_deps.dependencies_states import QUEUEABLE_STATES, RUNNABLE_STATES
 from airflow.utils import dates, timezone
@@ -67,6 +67,7 @@ from tests.test_utils import fab_utils
 from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_runs
+from tests.test_utils.mock_plugins import mock_plugin_manager
 
 
 class TemplateWithContext(NamedTuple):
@@ -337,10 +338,6 @@ class PluginOperator(BaseOperator):
     pass
 
 
-class EntrypointPlugin(AirflowPlugin):
-    name = 'test-entrypoint-testpluginview'
-
-
 class TestPluginView(TestBase):
     def test_should_list_plugins_on_page_with_details(self):
         resp = self.client.get('/plugin')
@@ -349,43 +346,20 @@ class TestPluginView(TestBase):
         self.check_content_in_response("source", resp)
         self.check_content_in_response("<em>$PLUGINS_FOLDER/</em>test_plugin.py", resp)
 
-    @mock.patch('airflow.plugins_manager.pkg_resources.iter_entry_points')
-    def test_should_list_entrypoint_plugins_on_page_with_details(self, mock_ep_plugins):
-        from airflow.plugins_manager import load_entrypoint_plugins
+    def test_should_list_entrypoint_plugins_on_page_with_details(self):
 
-        mock_entrypoint = mock.Mock()
-        mock_entrypoint.name = 'test-entrypoint-testpluginview'
-        mock_entrypoint.module_name = 'module_name_testpluginview'
-        mock_entrypoint.dist = 'test-entrypoint-testpluginview==1.0.0'
-        mock_entrypoint.load.return_value = EntrypointPlugin
-        mock_ep_plugins.return_value = [mock_entrypoint]
-
-        load_entrypoint_plugins()
-        resp = self.client.get('/plugin')
+        mock_plugin = AirflowPlugin()
+        mock_plugin.name = "test_plugin"
+        mock_plugin.source = EntryPointSource(
+            mock.Mock(), mock.Mock(version='1.0.0', metadata={'name': 'test-entrypoint-testpluginview'})
+        )
+        with mock_plugin_manager(plugins=[mock_plugin]):
+            resp = self.client.get('/plugin')
 
         self.check_content_in_response("test_plugin", resp)
         self.check_content_in_response("Airflow Plugins", resp)
         self.check_content_in_response("source", resp)
         self.check_content_in_response("<em>test-entrypoint-testpluginview==1.0.0:</em> <Mock id=", resp)
-
-
-class TestPluginsDirectorySource(unittest.TestCase):
-    def test_should_provide_correct_attribute_values(self):
-        source = PluginsDirectorySource("./test_views.py")
-        self.assertEqual("$PLUGINS_FOLDER/../../test_views.py", str(source))
-        self.assertEqual("<em>$PLUGINS_FOLDER/</em>../../test_views.py", source.__html__())
-        self.assertEqual("../../test_views.py", source.path)
-
-
-class TestEntryPointSource(unittest.TestCase):
-    def test_should_provide_correct_attribute_values(self):
-        mock_entrypoint = mock.Mock()
-        mock_entrypoint.dist = 'test-entrypoint-dist==1.0.0'
-        source = EntryPointSource(mock_entrypoint)
-        self.assertEqual("test-entrypoint-dist==1.0.0", source.dist)
-        self.assertEqual(str(mock_entrypoint), source.entrypoint)
-        self.assertEqual("test-entrypoint-dist==1.0.0: " + str(mock_entrypoint), str(source))
-        self.assertEqual("<em>test-entrypoint-dist==1.0.0:</em> " + str(mock_entrypoint), source.__html__())
 
 
 class TestPoolModelView(TestBase):


### PR DESCRIPTION
Using `pkg_resources.iter_entry_points` validates the version
constraints, and if any fail it will throw an Exception for that
entrypoint.

This sounds nice, but is a huge mis-feature.

So instead of that, switch to using importlib.metadata (well, it's
backport importlib_metadata) that just gives us the entrypoints - no
other verification of requirements is performed.

This has two advantages:

1. providers and plugins load much more reliably.
2. it's faster too

Closes #12692


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).