### PR TITLE
Remove deprecated dagbag metrics

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -801,8 +801,6 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
                 Stats.gauge(f'dag_processing.last_run.seconds_ago.{file_name}', seconds_ago)
             if runtime:
                 Stats.timing(f'dag_processing.last_duration.{file_name}', runtime)
-                # TODO: Remove before Airflow 2.0
-                Stats.timing(f'dag_processing.last_runtime.{file_name}', runtime)
 
             rows.append((file_path, processor_pid, runtime, num_dags, num_errors, last_runtime, last_run))
 
@@ -1152,10 +1150,6 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         Stats.gauge(
             'dag_processing.import_errors', sum(stat.import_errors for stat in self._file_stats.values())
         )
-
-        # TODO: Remove before Airflow 2.0
-        Stats.gauge('collect_dags', parse_time)
-        Stats.gauge('dagbag_import_errors', sum(stat.import_errors for stat in self._file_stats.values()))
 
     # pylint: disable=missing-docstring
     @property


### PR DESCRIPTION
These were deprecated in 1.10.6 via #6157, so we should remove them
before 2.0 rolls around.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).