### PR TITLE
Refactor airflow plugins command

### DIFF
--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -14,12 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import inspect
+from typing import Any, List, Optional, Union
 
-import logging
-import shutil
-from pprint import pprint
+from rich.console import Console
 
 from airflow import plugins_manager
+from airflow.cli.simple_table import SimpleTable
+from airflow.configuration import conf
+from airflow.plugins_manager import PluginsDirectorySource
 
 # list to maintain the order of items.
 PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP = [
@@ -48,38 +51,57 @@ PLUGINS_ATTRIBUTES_TO_DUMP = [
 ]
 
 
-def _header(text, fillchar):
-    terminal_size_size = shutil.get_terminal_size((80, 20))
-    print(f" {text} ".center(terminal_size_size.columns, fillchar))
+def _get_name(class_like_object) -> str:
+    if isinstance(class_like_object, (str, PluginsDirectorySource)):
+        return str(class_like_object)
+    if inspect.isclass(class_like_object):
+        return class_like_object.__name__
+    return class_like_object.__class__.__name__
+
+
+def _join_plugins_names(value: Union[List[Any], Any]) -> str:
+    value = value if isinstance(value, list) else [value]
+    return ",".join(_get_name(v) for v in value)
 
 
 def dump_plugins(args):
     """Dump plugins information"""
-    plugins_manager.log.setLevel(logging.DEBUG)
-
     plugins_manager.ensure_plugins_loaded()
     plugins_manager.integrate_macros_plugins()
     plugins_manager.integrate_executor_plugins()
     plugins_manager.initialize_extra_operators_links_plugins()
     plugins_manager.initialize_web_ui_plugins()
-
-    _header("PLUGINS MANGER:", "#")
-
-    for attr_name in PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP:
-        attr_value = getattr(plugins_manager, attr_name)
-        print(f"{attr_name} = ", end='')
-        pprint(attr_value)
-    print()
-
-    _header("PLUGINS:", "#")
     if not plugins_manager.plugins:
         print("No plugins loaded")
-    else:
-        print(f"Loaded {len(plugins_manager.plugins)} plugins")
-        for plugin_no, plugin in enumerate(plugins_manager.plugins, 1):
-            _header(f"{plugin_no}. {plugin.name}", "=")
-            for attr_name in PLUGINS_ATTRIBUTES_TO_DUMP:
-                attr_value = getattr(plugin, attr_name)
-                print(f"{attr_name} = ", end='')
-                pprint(attr_value)
-            print()
+        return
+
+    console = Console()
+    console.print("[bold yellow]SUMMARY:[/bold yellow]")
+    console.print(
+        f"[bold green]Plugins directory[/bold green]: {conf.get('core', 'plugins_folder')}\n", highlight=False
+    )
+    console.print(
+        f"[bold green]Loaded plugins[/bold green]: {len(plugins_manager.plugins)}\n", highlight=False
+    )
+
+    for attr_name in PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP:
+        attr_value: Optional[List[Any]] = getattr(plugins_manager, attr_name)
+        if not attr_value:
+            continue
+        table = SimpleTable(title=attr_name.capitalize().replace("_", " "))
+        table.add_column(width=100)
+        for item in attr_value:  # pylint: disable=not-an-iterable
+            table.add_row(
+                f"- {_get_name(item)}",
+            )
+        console.print(table)
+
+    console.print("[bold yellow]DETAILED INFO:[/bold yellow]")
+    for plugin in plugins_manager.plugins:
+        table = SimpleTable(title=plugin.name)
+        for attr_name in PLUGINS_ATTRIBUTES_TO_DUMP:
+            value = getattr(plugin, attr_name)
+            if not value:
+                continue
+            table.add_row(attr_name.capitalize().replace("_", " "), _join_plugins_names(value))
+        console.print(table)

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -28,6 +28,7 @@ class SimpleTable(Table):
         self.pad_edge = kwargs.get("pad_edge", False)
         self.box = kwargs.get("box", ASCII_DOUBLE_HEAD)
         self.show_header = kwargs.get("show_header", False)
+        self.header_style = kwargs.get("header_style", "bold green")
         self.title_style = kwargs.get("title_style", "bold green")
         self.title_justify = kwargs.get("title_justify", "left")
         self.caption = kwargs.get("caption", " ")

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -28,7 +28,6 @@ class SimpleTable(Table):
         self.pad_edge = kwargs.get("pad_edge", False)
         self.box = kwargs.get("box", ASCII_DOUBLE_HEAD)
         self.show_header = kwargs.get("show_header", False)
-        self.header_style = kwargs.get("header_style", "bold green")
         self.title_style = kwargs.get("title_style", "bold green")
         self.title_justify = kwargs.get("title_justify", "left")
         self.caption = kwargs.get("caption", " ")


### PR DESCRIPTION
This commit refactors plugins command to make it more
user-friendly, structured and easier to read.

Before:
<img width="700" alt="Screenshot 2020-11-29 at 01 05 52" src="https://user-images.githubusercontent.com/9528307/100528602-12ee3080-31df-11eb-91b1-eaa24d8eb5f1.png">

After
<img width="700" alt="Screenshot 2020-11-29 at 01 23 23" src="https://user-images.githubusercontent.com/9528307/100528845-7aa57b00-31e1-11eb-966f-c1fb7aeb031b.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
