### PR TITLE
Widen importlib-* backport deps, add python_version limits.

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -26,7 +26,12 @@ import sys
 import types
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
-import importlib_metadata
+try:
+    # Python 3.8 and up
+    from importlib import metadata as importlib_metadata
+except ImportError:
+    # Use the backport
+    import importlib_metadata
 
 from airflow import settings
 from airflow.utils.entry_points import entry_points_with_dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,8 +100,8 @@ install_requires =
     funcsigs>=1.0.0, <2.0.0
     graphviz>=0.12
     gunicorn>=19.5.0, <20.0
-    importlib_metadata~=1.7 # We could work with 3.1, but argparse needs <2
-    importlib_resources~=1.4
+    importlib_metadata>=1.5,<4;python_version<="3.7"
+    importlib_resources>=1.4,<4;python_version<="3.6"
     iso8601>=0.1.12
     itsdangerous>=1.1.0
     jinja2>=2.10.1, <2.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -101,7 +101,7 @@ install_requires =
     graphviz>=0.12
     gunicorn>=19.5.0, <20.0
     importlib_metadata>=1.5,<4;python_version<="3.7"
-    importlib_resources>=1.4,<4;python_version<="3.6"
+    importlib_resources~=1.4;python_version<="3.6"
     iso8601>=0.1.12
     itsdangerous>=1.1.0
     jinja2>=2.10.1, <2.12.0

--- a/setup.py
+++ b/setup.py
@@ -469,7 +469,6 @@ devel = [
     'freezegun',
     'github3.py',
     'gitpython',
-    'importlib-resources~=1.4',
     'ipdb',
     'jira',
     'mongomock',


### PR DESCRIPTION
Later versions either add small features not used in Airflow, packaging updates and bug fixes or perf improvements. Moreover, newer Python releases already include the functionality needed.

It's generally a better idea to be permissive in dependency versions to prevent
accidentally limiting what other packages can be used with Airflow.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
