### PR TITLE
Add kubernetes to requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ install_requires =
     colorlog==4.0.2
     connexion[swagger-ui,flask]>=2.6.0,<3
     croniter>=0.3.17, <0.4
-    cryptography>=0.9.3
+    cryptography>=2.0.0
     dill>=0.2.2, <0.4
     flask>=1.1.0, <2.0
     flask-appbuilder~=3.1.1
@@ -107,6 +107,7 @@ install_requires =
     jinja2>=2.10.1, <2.12.0
     json-merge-patch==0.2
     jsonschema~=3.0
+    kubernetes>=3.0.0, <12.0.0
     lazy-object-proxy<1.5.0  # Required to keep pip-check happy with astroid
     lockfile>=0.12.2
     markdown>=2.5.2, <4.0


### PR DESCRIPTION
With a clean venv, only run 
```shell
pip install apache-airflow[postgres]==2.0.0b3
```
you will get :

**Fix the ModuleNotFoundError: No module named 'kubernetes'** _from_ **example_dags/example_kubernetes_executor_config.py**


![Screenshot from 2020-11-29 16-39-38](https://user-images.githubusercontent.com/10202690/100546615-9ef56c00-3262-11eb-9c49-1e68849318c0.png)
