### PR TITLE
Add .airflowignore to example dags

### DIFF
--- a/airflow/example_dags/.airflowignore
+++ b/airflow/example_dags/.airflowignore
@@ -1,0 +1,2 @@
+example_kubernetes_executor.py
+example_kubernetes_executor_config.py

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3191,6 +3191,8 @@ class TestSchedulerJob(unittest.TestCase):
 
         ignored_files = {
             'helper.py',
+            'example_kubernetes_executor.py',
+            'example_kubernetes_executor_config.py',
         }
         example_dag_folder = airflow.example_dags.__path__[0]
         for root, _, files in os.walk(example_dag_folder):  # pylint: disable=too-many-nested-blocks


### PR DESCRIPTION
Kubernetes is not required for running Airflow. If users will have
load_examples=True then they will see warning as described in #12705.

This is the simplest possible solution I can think of. The examples should render in docs (if used) and are not listed in DAGs:
```
DAG ID                                   Filepath                                                                      Owner
example_bash_operator                    /opt/airflow/airflow/example_dags/example_bash_operator.py                    airflow
example_branch_dop_operator_v3           /opt/airflow/airflow/example_dags/example_branch_python_dop_operator_3.py     airflow
example_branch_operator                  /opt/airflow/airflow/example_dags/example_branch_operator.py                  airflow
example_complex                          /opt/airflow/airflow/example_dags/example_complex.py                          airflow
example_dag_decorator                    /opt/airflow/airflow/example_dags/example_dag_decorator.py                    airflow
example_external_task_marker_child       /opt/airflow/airflow/example_dags/example_external_task_marker_dag.py         airflow
example_external_task_marker_parent      /opt/airflow/airflow/example_dags/example_external_task_marker_dag.py         airflow
example_nested_branch_dag                /opt/airflow/airflow/example_dags/example_nested_branch_dag.py                airflow
example_passing_params_via_test_command  /opt/airflow/airflow/example_dags/example_passing_params_via_test_command.py  airflow
example_python_operator                  /opt/airflow/airflow/example_dags/example_python_operator.py                  airflow
example_short_circuit_operator           /opt/airflow/airflow/example_dags/example_short_circuit_operator.py           airflow
example_skip_dag                         /opt/airflow/airflow/example_dags/example_skip_dag.py                         airflow
example_subdag_operator                  /opt/airflow/airflow/example_dags/example_subdag_operator.py                  airflow
example_subdag_operator.section-1        /opt/airflow/airflow/example_dags/example_subdag_operator.py                  airflow
example_subdag_operator.section-2        /opt/airflow/airflow/example_dags/example_subdag_operator.py                  airflow
example_task_group                       /opt/airflow/airflow/example_dags/example_task_group.py                       airflow
example_trigger_controller_dag           /opt/airflow/airflow/example_dags/example_trigger_controller_dag.py           airflow
example_trigger_target_dag               /opt/airflow/airflow/example_dags/example_trigger_target_dag.py               airflow
example_xcom                             /opt/airflow/airflow/example_dags/example_xcom.py                             airflow
example_xcom_args                        /opt/airflow/airflow/example_dags/example_xcomargs.py                         airflow
example_xcom_args_with_operators         /opt/airflow/airflow/example_dags/example_xcomargs.py                         airflow
latest_only                              /opt/airflow/airflow/example_dags/example_latest_only.py                      airflow
latest_only_with_trigger                 /opt/airflow/airflow/example_dags/example_latest_only_with_trigger.py         airflow
test_utils                               /opt/airflow/airflow/example_dags/test_utils.py                               airflow
tutorial                                 /opt/airflow/airflow/example_dags/tutorial.py                                 airflow
tutorial_etl_dag                         /opt/airflow/airflow/example_dags/tutorial_etl_dag.py                         airflow
tutorial_taskflow_api_etl_dag            /opt/airflow/airflow/example_dags/tutorial_taskflow_api_etl.py                airflow
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
