### PR TITLE
Enable SparkSqlHook to use supplied connections

### DIFF
--- a/airflow/providers/apache/spark/operators/spark_sql.py
+++ b/airflow/providers/apache/spark/operators/spark_sql.py
@@ -47,7 +47,9 @@ class SparkSqlOperator(BaseOperator):
     :type executor_memory: str
     :param keytab: Full path to the file that contains the keytab
     :type keytab: str
-    :param master: spark://host:port, mesos://host:port, yarn, or local
+    :param master: (Deprecated) spark://host:port, mesos://host:port, yarn, or local
+        This parameter has been deprecated. Master and connection parameters (such as YARN queue)
+        are determined by the conn_id parameter.
     :type master: str
     :param name: Name of the job
     :type name: str
@@ -56,6 +58,8 @@ class SparkSqlOperator(BaseOperator):
     :param verbose: Whether to pass the verbose flag to spark-sql
     :type verbose: bool
     :param yarn_queue: The YARN queue to submit to (Default: "default")
+        This parameter has been deprecated. Master and connection parameters (such as YARN queue)
+        are determined by the conn_id parameter.
     :type yarn_queue: str
     """
 

--- a/docs/apache-airflow-providers-apache-spark/connections/spark.rst
+++ b/docs/apache-airflow-providers-apache-spark/connections/spark.rst
@@ -23,7 +23,7 @@ The Apache Spark connection type enables connection to Apache Spark.
 Default Connection IDs
 ----------------------
 
-Spark Submit and Spark JDBC hooks and operators use ``spark_default`` by default, Spark SQL hooks and operators point to ``spark_sql_default`` by default, but don't use it.
+Spark Submit and Spark JDBC hooks and operators use ``spark_default`` by default, Spark SQL hooks and operators point to ``spark_sql_default`` by default.
 
 Configuring the Connection
 --------------------------

--- a/docs/apache-airflow-providers-apache-spark/operators.rst
+++ b/docs/apache-airflow-providers-apache-spark/operators.rst
@@ -26,9 +26,7 @@ Apache Spark Operators
 Prerequisite
 ------------
 
-To use ``SparkJDBCOperator`` and ``SparkSubmitOperator``, you must configure a :doc:`Spark Connection <connections/spark>`. For ``SparkJDBCOperator``, you must also configure a :doc:`JDBC connection <apache-airflow-providers-jdbc:connections/jdbc>`.
-
-``SparkSqlOperator`` gets all the configurations from operator parameters.
+To use ``SparkJDBCOperator``, ``SparkSubmitOperator``, and ``SparkSqlOperator``, you must configure a :doc:`Spark Connection <connections/spark>`. For ``SparkJDBCOperator``, you must also configure a :doc:`JDBC connection <apache-airflow-providers-jdbc:connections/jdbc>`.
 
 .. _howto/operator:SparkJDBCOperator:
 
@@ -63,6 +61,7 @@ SparkSqlOperator
 
 Launches applications on a Apache Spark server, it requires that the ``spark-sql`` script is in the PATH.
 The operator will run the SQL query on Spark Hive metastore service, the ``sql`` parameter can be templated and be a ``.sql`` or ``.hql`` file.
+There are two deprecated parameters, ``master`` and ``yarn_queue``, which were originally used to provide configuration; configuration is now determined through the supplied connection ID.
 
 For parameter definition take a look at :class:`~airflow.providers.apache.spark.operators.spark_sql.SparkSqlOperator`.
 


### PR DESCRIPTION
In case of existing issue, reference it using one of the following:

closes: https://github.com/apache/airflow/issues/8713

Minor update to the logic in `SparkSqlHook` to follow same behavior of `SparkSubmitHook` by determining master and connection parameters through connection ID.