### PR TITLE
Update init instructions

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -153,7 +153,7 @@ run tasks:
 
 .. code-block:: bash
 
-    airflow db init
+    airflow initdb  
 
 Docker image
 ''''''''''''


### PR DESCRIPTION
There is no ``airflow db init``. Instead it should be ``airflow initdb``.
