### PR TITLE
Output of installing remaining packages is shown also on success

### DIFF
--- a/scripts/in_container/run_prepare_provider_readme.sh
+++ b/scripts/in_container/run_prepare_provider_readme.sh
@@ -27,10 +27,11 @@ export PYTHONPATH="${AIRFLOW_SOURCES}"
 
 verify_suffix_versions_for_package_preparation
 
+# TODO: remove it when devel_all == devel_ci
 echo
 echo "Installing remaining packages from 'all' extras"
 echo
-pip install -e ".[devel_all]" >"${OUT_FILE_PRINTED_ON_ERROR}" 2>&1
+pip install -e ".[devel_all]"
 
 cd "${AIRFLOW_SOURCES}/provider_packages" || exit 1
 


### PR DESCRIPTION
Previously the output of instaling remaining packges when testing
provider imports was only shown on error. However it is useful
to know what's going on even if it clutters the log.

Note that this installation is only needed until we include
apache-beam in the installed packages on CI.

Related to #12703

This PR shows the output always .

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
