### PR TITLE
Allow switching xcom_pickling to JSON/Pickle

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -247,7 +247,10 @@ class BaseXCom(Base, LoggingMixin):
         """Deserialize XCom value from str or pickle object"""
         enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
         if enable_pickling:
-            return pickle.loads(result.value)
+            try:
+                return pickle.loads(result.value)
+            except pickle.UnpicklingError:
+                return json.loads(result.value.decode('UTF-8'))
         try:
             return json.loads(result.value.decode('UTF-8'))
         except JSONDecodeError:

--- a/tests/models/test_xcom.py
+++ b/tests/models/test_xcom.py
@@ -179,6 +179,36 @@ class TestXCom(unittest.TestCase):
 
         self.assertEqual(ret_value, json_obj)
 
+    def test_xcom_deserialize_with_json_to_pickle_switch(self):
+        json_obj = {"key": "value"}
+        execution_date = timezone.utcnow()
+        key = "xcom_test3"
+        dag_id = "test_dag"
+        task_id = "test_task3"
+
+        with conf_vars({("core", "enable_xcom_pickling"): "False"}):
+            XCom.set(key=key, value=json_obj, dag_id=dag_id, task_id=task_id, execution_date=execution_date)
+
+        with conf_vars({("core", "enable_xcom_pickling"): "True"}):
+            ret_value = XCom.get_one(key=key, dag_id=dag_id, task_id=task_id, execution_date=execution_date)
+
+        self.assertEqual(ret_value, json_obj)
+
+    def test_xcom_deserialize_with_pickle_to_json_switch(self):
+        json_obj = {"key": "value"}
+        execution_date = timezone.utcnow()
+        key = "xcom_test3"
+        dag_id = "test_dag"
+        task_id = "test_task3"
+
+        with conf_vars({("core", "enable_xcom_pickling"): "True"}):
+            XCom.set(key=key, value=json_obj, dag_id=dag_id, task_id=task_id, execution_date=execution_date)
+
+        with conf_vars({("core", "enable_xcom_pickling"): "False"}):
+            ret_value = XCom.get_one(key=key, dag_id=dag_id, task_id=task_id, execution_date=execution_date)
+
+        self.assertEqual(ret_value, json_obj)
+
     @conf_vars({("core", "xcom_enable_pickling"): "False"})
     def test_xcom_disable_pickle_type_fail_on_non_json(self):
         class PickleRce:


### PR DESCRIPTION
Without this commit, the Webserver throws an error when
enabling xcom_pickling in the airflow_config by setting `enable_xcom_pickling = True`
(the default is `False`).

Example error:

```
>           return pickle.loads(result.value)
E           _pickle.UnpicklingError: invalid load key, '{'.

airflow/models/xcom.py:250: UnpicklingError
--------------------------------------------------
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
