### PR TITLE
Add DBApiHook check for 2.0 migration

### DIFF
--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -70,7 +70,11 @@ class DbApiRule(BaseRule):
         subclasses = BaseHook.__subclasses__()
         incorrect_implementations = []
         for s in subclasses:
-            if "airflow.hooks" in s.__module__ or 'airflow.contrib.hooks.grpc_hook' in s.__module__:
+            if (
+                "airflow.hooks" in s.__module__
+                or "airflow.contrib.hooks.grpc_hook" in s.__module__
+                or "tests.plugins.test_plugin.PluginHook" in str(s)
+            ):
                 pass
             else:
                 pandas_df = check_get_pandas_df(s)

--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.hooks.base_hook import BaseHook
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.exceptions import AirflowException
+
+
+def check_get_pandas_df(cls):
+    try:
+        cls.get_pandas_df(None, "fake SQL")
+        return return_error_string(cls, "get_pandas_df")
+    except NotImplementedError:
+        pass
+    except Exception as e:
+        raise AirflowException(
+            "the following hook incorrectly implements %s. error: %s", cls, e
+        )
+
+
+def check_run(cls):
+    try:
+        cls.run(None, "fake SQL")
+        return return_error_string(cls, "run")
+    except NotImplementedError:
+        pass
+    except Exception as e:
+        raise AirflowException(
+            "the following hook incorrectly implements run %s. error: %s", cls, e
+        )
+
+
+def check_get_records(cls):
+    try:
+        cls.get_records(None, "fake SQL")
+        return return_error_string(cls, "get_records")
+    except NotImplementedError:
+        pass
+    except Exception as e:
+        raise AirflowException(
+            "the following hook incorrectly implements run %s. error: %s", cls, e
+        )
+
+
+def return_error_string(cls, method):
+    return (
+        "Class {} incorrectly implements the function {} while inheriting from BaseHook. "
+        "Please make this class inherit from airflow.hooks.db_api_hook.DbApiHook instead".format(
+            cls, method
+        )
+    )
+
+
+class DbApiRule(BaseRule):
+    def check(self):
+        subclasses = BaseHook.__subclasses__()
+        incorrect_implementations = []
+        for s in subclasses:
+            if "airflow.hooks" in s.__module__:
+                pass
+            else:
+                pandas_df = check_get_pandas_df(s)
+                if pandas_df:
+                    incorrect_implementations.append(pandas_df)
+                run = check_run(s)
+                if run:
+                    incorrect_implementations.append(run)
+                get_records = check_get_records(s)
+                if get_records:
+                    incorrect_implementations.append(get_records)
+        return incorrect_implementations

--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -70,7 +70,7 @@ class DbApiRule(BaseRule):
         subclasses = BaseHook.__subclasses__()
         incorrect_implementations = []
         for s in subclasses:
-            if "airflow.hooks" in s.__module__:
+            if "airflow.hooks" in s.__module__ or 'airflow.contrib.hooks.grpc_hook' in s.__module__:
                 pass
             else:
                 pandas_df = check_get_pandas_df(s)

--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -66,6 +66,12 @@ def return_error_string(cls, method):
 
 
 class DbApiRule(BaseRule):
+    title = "Hooks that run DB functions must inherit from DBApiHook"
+
+    description = (
+        "Hooks that run DB functions must inherit from DBApiHook instead of BaseHook"
+    )
+
     def check(self):
         subclasses = BaseHook.__subclasses__()
         incorrect_implementations = []

--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -66,7 +66,9 @@ def return_error_string(cls, method):
 
 
 def get_all_non_dbapi_children():
-    basehook_children = [child for child in BaseHook.__subclasses__() if child.__name__ != "DbApiHook"]
+    basehook_children = [
+        child for child in BaseHook.__subclasses__() if child.__name__ != "DbApiHook"
+    ]
     res = basehook_children[:]
     while basehook_children:
         next_generation = []

--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -17,7 +17,6 @@
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.upgrade.rules.base_rule import BaseRule
-from airflow.exceptions import AirflowException
 
 
 def check_get_pandas_df(cls):
@@ -26,10 +25,8 @@ def check_get_pandas_df(cls):
         return return_error_string(cls, "get_pandas_df")
     except NotImplementedError:
         pass
-    except Exception as e:
-        raise AirflowException(
-            "the following hook incorrectly implements %s. error: %s", cls, e
-        )
+    except Exception:
+        return return_error_string(cls, "get_pandas_df")
 
 
 def check_run(cls):
@@ -38,10 +35,8 @@ def check_run(cls):
         return return_error_string(cls, "run")
     except NotImplementedError:
         pass
-    except Exception as e:
-        raise AirflowException(
-            "the following hook incorrectly implements run %s. error: %s", cls, e
-        )
+    except Exception:
+        return return_error_string(cls, "run")
 
 
 def check_get_records(cls):
@@ -50,10 +45,8 @@ def check_get_records(cls):
         return return_error_string(cls, "get_records")
     except NotImplementedError:
         pass
-    except Exception as e:
-        raise AirflowException(
-            "the following hook incorrectly implements run %s. error: %s", cls, e
-        )
+    except Exception:
+        return return_error_string(cls, "get_records")
 
 
 def return_error_string(cls, method):

--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -79,7 +79,7 @@ class DbApiRule(BaseRule):
             if (
                 "airflow.hooks" in s.__module__
                 or "airflow.contrib.hooks.grpc_hook" in s.__module__
-                or "tests.plugins.test_plugin.PluginHook" in str(s)
+                or ".PluginHook" in str(s)
             ):
                 pass
             else:

--- a/tests/upgrade/rules/test_db_api_functions.py
+++ b/tests/upgrade/rules/test_db_api_functions.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.dbapi_hook import DbApiHook
+from airflow.upgrade.rules.db_api_functions import DbApiRule
+
+
+class MyHook(BaseHook):
+    def get_records(self, sql):
+        pass
+
+    def run(self, sql):
+        pass
+
+    def get_pandas_df(self, sql):
+        pass
+
+    def get_conn(self):
+        pass
+
+
+class ProperDbApiHook(DbApiHook):
+
+    def bulk_dump(self, table, tmp_file):
+        pass
+
+    def bulk_load(self, table, tmp_file):
+        pass
+
+    def get_records(self, sql, *kwargs):
+        pass
+
+    def run(self, sql, *kwargs):
+        pass
+
+    def get_pandas_df(self, sql, *kwargs):
+        pass
+
+
+class TestSqlHookCheck(TestCase):
+    def test_fails_on_incorrect_hook(self):
+        db_api_rule_failures = DbApiRule().check()
+        self.assertEqual(len(db_api_rule_failures), 3)
+        proper_db_api_hook_failures = \
+            [failure for failure in db_api_rule_failures if "ProperDbApiHook" in failure]
+        self.assertEqual(len(proper_db_api_hook_failures), 0)

--- a/tests/upgrade/rules/test_db_api_functions.py
+++ b/tests/upgrade/rules/test_db_api_functions.py
@@ -22,9 +22,6 @@ from airflow.upgrade.rules.db_api_functions import DbApiRule
 
 
 class MyHook(BaseHook):
-    def get_records(self, sql):
-        pass
-
     def run(self, sql):
         pass
 
@@ -32,6 +29,15 @@ class MyHook(BaseHook):
         pass
 
     def get_conn(self):
+        pass
+
+
+class GrandChildHook(MyHook):
+    def __init__(self, foo, bar):
+        self.foo = foo
+        self.bar = bar
+
+    def get_records(self, sql):
         pass
 
 
@@ -56,7 +62,10 @@ class ProperDbApiHook(DbApiHook):
 class TestSqlHookCheck(TestCase):
     def test_fails_on_incorrect_hook(self):
         db_api_rule_failures = DbApiRule().check()
-        self.assertEqual(len(db_api_rule_failures), 3)
+        myhook_errors = [d for d in db_api_rule_failures if "MyHook" in d]
+        grandchild_errors = [d for d in db_api_rule_failures if "GrandChild" in d]
+        self.assertEqual(len(myhook_errors), 2)
+        self.assertEqual(len(grandchild_errors), 3)
         proper_db_api_hook_failures = \
             [failure for failure in db_api_rule_failures if "ProperDbApiHook" in failure]
         self.assertEqual(len(proper_db_api_hook_failures), 0)

--- a/tests/upgrade/rules/test_db_api_functions.py
+++ b/tests/upgrade/rules/test_db_api_functions.py
@@ -42,7 +42,6 @@ class GrandChildHook(MyHook):
 
 
 class ProperDbApiHook(DbApiHook):
-
     def bulk_dump(self, table, tmp_file):
         pass
 
@@ -66,6 +65,7 @@ class TestSqlHookCheck(TestCase):
         grandchild_errors = [d for d in db_api_rule_failures if "GrandChild" in d]
         self.assertEqual(len(myhook_errors), 2)
         self.assertEqual(len(grandchild_errors), 3)
-        proper_db_api_hook_failures = \
-            [failure for failure in db_api_rule_failures if "ProperDbApiHook" in failure]
+        proper_db_api_hook_failures = [
+            failure for failure in db_api_rule_failures if "ProperDbApiHook" in failure
+        ]
         self.assertEqual(len(proper_db_api_hook_failures), 0)


### PR DESCRIPTION
Adds a check that ensures that any hook that uses the
run, get_pandas_df or get_records functions does not import from the
base_hook

addresses https://github.com/apache/airflow/issues/11039
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
