### PR TITLE
Fix the exception that the port is empty when using db shell

### DIFF
--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -71,6 +71,7 @@ def shell(args):
                 database = {url.database}
                 """
             ).strip()
+            print(content)
             f.write(content.encode())
             f.flush()
             execute_interactive(["mysql", f"--defaults-extra-file={f.name}"])
@@ -79,7 +80,7 @@ def shell(args):
     elif url.get_backend_name() == 'postgresql':
         env = os.environ.copy()
         env['PGHOST'] = url.host or ""
-        env['PGPORT'] = str(url.port or "")
+        env['PGPORT'] = str(url.port or "5432")
         env['PGUSER'] = url.username or ""
         # PostgreSQL does not allow the use of PGPASSFILE if the current user is root.
         env["PGPASSWORD"] = url.password or ""

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -71,7 +71,6 @@ def shell(args):
                 database = {url.database}
                 """
             ).strip()
-            print(content)
             f.write(content.encode())
             f.flush()
             execute_interactive(["mysql", f"--defaults-extra-file={f.name}"])

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -67,7 +67,7 @@ def shell(args):
                 host     = {url.host}
                 user     = {url.username}
                 password = {url.password or ""}
-                port     = {url.port or ""}
+                port     = {url.port or "3306"}
                 database = {url.database}
                 """
             ).strip()

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -110,27 +110,27 @@ class TestCliDb(unittest.TestCase):
             postgres_env,
         )
 
-        @mock.patch("airflow.cli.commands.db_command.execute_interactive")
-        @mock.patch(
-            "airflow.cli.commands.db_command.settings.engine.url",
-            make_url("postgresql+psycopg2://postgres:airflow@postgres/airflow"),
+    @mock.patch("airflow.cli.commands.db_command.execute_interactive")
+    @mock.patch(
+        "airflow.cli.commands.db_command.settings.engine.url",
+        make_url("postgresql+psycopg2://postgres:airflow@postgres/airflow"),
+    )
+    def test_cli_shell_postgres_without_port(self, mock_execute_interactive):
+        db_command.shell(self.parser.parse_args(['db', 'shell']))
+        mock_execute_interactive.assert_called_once_with(['psql'], env=mock.ANY)
+        _, kwargs = mock_execute_interactive.call_args
+        env = kwargs['env']
+        postgres_env = {k: v for k, v in env.items() if k.startswith('PG')}
+        self.assertEqual(
+            {
+                'PGDATABASE': 'airflow',
+                'PGHOST': 'postgres',
+                'PGPASSWORD': 'airflow',
+                'PGPORT': '5432',
+                'PGUSER': 'postgres',
+            },
+            postgres_env,
         )
-        def test_cli_shell_postgres_without_port(self, mock_execute_interactive):
-            db_command.shell(self.parser.parse_args(['db', 'shell']))
-            mock_execute_interactive.assert_called_once_with(['psql'], env=mock.ANY)
-            _, kwargs = mock_execute_interactive.call_args
-            env = kwargs['env']
-            postgres_env = {k: v for k, v in env.items() if k.startswith('PG')}
-            self.assertEqual(
-                {
-                    'PGDATABASE': 'airflow',
-                    'PGHOST': 'postgres',
-                    'PGPASSWORD': 'airflow',
-                    'PGPORT': '5432',
-                    'PGUSER': 'postgres',
-                },
-                postgres_env,
-            )
 
     @mock.patch(
         "airflow.cli.commands.db_command.settings.engine.url",

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -56,13 +56,28 @@ class TestCliDb(unittest.TestCase):
 
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")
     @mock.patch("airflow.cli.commands.db_command.NamedTemporaryFile")
-    @mock.patch("airflow.cli.commands.db_command.settings.engine.url", make_url("mysql://root@mysql:3306/airflow"))
+    @mock.patch(
+        "airflow.cli.commands.db_command.settings.engine.url", make_url("mysql://root@mysql:3306/airflow")
+    )
     def test_cli_shell_mysql(self, mock_tmp_file, mock_execute_interactive):
         mock_tmp_file.return_value.__enter__.return_value.name = "/tmp/name"
         db_command.shell(self.parser.parse_args(['db', 'shell']))
         mock_execute_interactive.assert_called_once_with(['mysql', '--defaults-extra-file=/tmp/name'])
         mock_tmp_file.return_value.__enter__.return_value.write.assert_called_once_with(
-            b'[client]\nhost     = mysql\nuser     = root\npassword = \nport     = 3306' b'\ndatabase = airflow'
+            b'[client]\nhost     = mysql\nuser     = root\npassword = \nport     = 3306'
+            b'\ndatabase = airflow'
+        )
+
+    @mock.patch("airflow.cli.commands.db_command.execute_interactive")
+    @mock.patch("airflow.cli.commands.db_command.NamedTemporaryFile")
+    @mock.patch("airflow.cli.commands.db_command.settings.engine.url", make_url("mysql://root@mysql/airflow"))
+    def test_cli_shell_mysql_without_port(self, mock_tmp_file, mock_execute_interactive):
+        mock_tmp_file.return_value.__enter__.return_value.name = "/tmp/name"
+        db_command.shell(self.parser.parse_args(['db', 'shell']))
+        mock_execute_interactive.assert_called_once_with(['mysql', '--defaults-extra-file=/tmp/name'])
+        mock_tmp_file.return_value.__enter__.return_value.write.assert_called_once_with(
+            b'[client]\nhost     = mysql\nuser     = root\npassword = \nport     = 3306'
+            b'\ndatabase = airflow'
         )
 
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")
@@ -76,7 +91,7 @@ class TestCliDb(unittest.TestCase):
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")
     @mock.patch(
         "airflow.cli.commands.db_command.settings.engine.url",
-        make_url("postgresql+psycopg2://postgres:airflow@postgres/airflow"),
+        make_url("postgresql+psycopg2://postgres:airflow@postgres:5432/airflow"),
     )
     def test_cli_shell_postgres(self, mock_execute_interactive):
         db_command.shell(self.parser.parse_args(['db', 'shell']))
@@ -89,11 +104,33 @@ class TestCliDb(unittest.TestCase):
                 'PGDATABASE': 'airflow',
                 'PGHOST': 'postgres',
                 'PGPASSWORD': 'airflow',
-                'PGPORT': '',
+                'PGPORT': '5432',
                 'PGUSER': 'postgres',
             },
             postgres_env,
         )
+
+        @mock.patch("airflow.cli.commands.db_command.execute_interactive")
+        @mock.patch(
+            "airflow.cli.commands.db_command.settings.engine.url",
+            make_url("postgresql+psycopg2://postgres:airflow@postgres/airflow"),
+        )
+        def test_cli_shell_postgres_without_port(self, mock_execute_interactive):
+            db_command.shell(self.parser.parse_args(['db', 'shell']))
+            mock_execute_interactive.assert_called_once_with(['psql'], env=mock.ANY)
+            _, kwargs = mock_execute_interactive.call_args
+            env = kwargs['env']
+            postgres_env = {k: v for k, v in env.items() if k.startswith('PG')}
+            self.assertEqual(
+                {
+                    'PGDATABASE': 'airflow',
+                    'PGHOST': 'postgres',
+                    'PGPASSWORD': 'airflow',
+                    'PGPORT': '5432',
+                    'PGUSER': 'postgres',
+                },
+                postgres_env,
+            )
 
     @mock.patch(
         "airflow.cli.commands.db_command.settings.engine.url",

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -56,13 +56,13 @@ class TestCliDb(unittest.TestCase):
 
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")
     @mock.patch("airflow.cli.commands.db_command.NamedTemporaryFile")
-    @mock.patch("airflow.cli.commands.db_command.settings.engine.url", make_url("mysql://root@mysql/airflow"))
+    @mock.patch("airflow.cli.commands.db_command.settings.engine.url", make_url("mysql://root@mysql:3306/airflow"))
     def test_cli_shell_mysql(self, mock_tmp_file, mock_execute_interactive):
         mock_tmp_file.return_value.__enter__.return_value.name = "/tmp/name"
         db_command.shell(self.parser.parse_args(['db', 'shell']))
         mock_execute_interactive.assert_called_once_with(['mysql', '--defaults-extra-file=/tmp/name'])
         mock_tmp_file.return_value.__enter__.return_value.write.assert_called_once_with(
-            b'[client]\nhost     = mysql\nuser     = root\npassword = \nport     = ' b'\ndatabase = airflow'
+            b'[client]\nhost     = mysql\nuser     = root\npassword = \nport     = 3306' b'\ndatabase = airflow'
         )
 
     @mock.patch("airflow.cli.commands.db_command.execute_interactive")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #12739

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Apache Airflow version: 2.0.0b3

Kubernetes version (if you are using kubernetes) (use kubectl version):

Environment:

Cloud provider or hardware configuration:
OS (e.g. from /etc/os-release): Debian GNU/Linux 10 (buster)
Kernel (e.g. uname -a): Linux ace72a077a8c 4.19.76-linuxkit #1 SMP Tue May 26 11:42:35 UTC 2020 x86_64 GNU/Linux
Install tools: ./breeze --backend mysql --integration redis --db-reset
Others:
What happened: Encountered an error "mysql: [ERROR] mysql: Empty value for'port' specified." using airflow db shell in breeze。 An error will be encountered when the port is not set in sql_alchemy_conn. Like the default value "mysql://root@mysql/airflow?charset=utf8mb4"

What you expected to happen: The default port should be used in db_command

How to reproduce it: use './breeze --backend mysql --integration redis --db-reset' ,and then run 'airflow db shell'

ISSUE: #12739

