### PR TITLE
Allow using _CMD / _SECRET to set `[webserver] secret_key` config

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -130,6 +130,7 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
         ('atlas', 'password'),
         ('smtp', 'smtp_password'),
         ('kubernetes', 'git_password'),
+        ('webserver', 'secret_key'),
     }
 
     # A mapping of (new option -> old option). where option is a tuple of section name and key.

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -70,6 +70,7 @@ The following config options support this ``_cmd`` and ``_secret`` version:
 * ``password`` in ``[atlas]`` section
 * ``smtp_password`` in ``[smtp]`` section
 * ``git_password`` in ``[kubernetes]`` section
+* ``secret_key`` in ``[webserver]`` section
 
 The ``_cmd`` config options can also be set using a corresponding environment variable
 the same way the usual config options can. For example:

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -561,17 +561,19 @@ notacommand = OK
         config_parser = AirflowConfigParser()
         self.assertEqual(
             sorted(config_parser.sensitive_config_values),
-            {
-                ('core', 'sql_alchemy_conn'),
-                ('core', 'fernet_key'),
-                ('celery', 'broker_url'),
-                ('celery', 'flower_basic_auth'),
-                ('celery', 'result_backend'),
-                ('atlas', 'password'),
-                ('smtp', 'smtp_password'),
-                ('kubernetes', 'git_password'),
-                ('webserver', 'secret_key'),
-            },
+            sorted(
+                {
+                    ('core', 'sql_alchemy_conn'),
+                    ('core', 'fernet_key'),
+                    ('celery', 'broker_url'),
+                    ('celery', 'flower_basic_auth'),
+                    ('celery', 'result_backend'),
+                    ('atlas', 'password'),
+                    ('smtp', 'smtp_password'),
+                    ('kubernetes', 'git_password'),
+                    ('webserver', 'secret_key'),
+                }
+            ),
         )
 
     def test_parameterized_config_gen(self):

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -571,7 +571,7 @@ notacommand = OK
                 ('smtp', 'smtp_password'),
                 ('kubernetes', 'git_password'),
                 ('webserver', 'secret_key'),
-            }
+            },
         )
 
     def test_parameterized_config_gen(self):

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -560,7 +560,7 @@ notacommand = OK
     def test_sensitive_config_values(self):
         config_parser = AirflowConfigParser()
         self.assertEqual(
-            config_parser.sensitive_config_values,
+            sorted(config_parser.sensitive_config_values),
             {
                 ('core', 'sql_alchemy_conn'),
                 ('core', 'fernet_key'),

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -557,6 +557,23 @@ notacommand = OK
             # the environment variable's echo command
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'notacommand'), 'OK')
 
+    def test_sensitive_config_values(self):
+        config_parser = AirflowConfigParser()
+        self.assertEqual(
+            config_parser.sensitive_config_values,
+            {
+                ('core', 'sql_alchemy_conn'),
+                ('core', 'fernet_key'),
+                ('celery', 'broker_url'),
+                ('celery', 'flower_basic_auth'),
+                ('celery', 'result_backend'),
+                ('atlas', 'password'),
+                ('smtp', 'smtp_password'),
+                ('kubernetes', 'git_password'),
+                ('webserver', 'secret_key'),
+            }
+        )
+
     def test_parameterized_config_gen(self):
 
         cfg = parameterized_config(DEFAULT_CONFIG)

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -557,25 +557,6 @@ notacommand = OK
             # the environment variable's echo command
             self.assertEqual(test_cmdenv_conf.get('testcmdenv', 'notacommand'), 'OK')
 
-    def test_sensitive_config_values(self):
-        config_parser = AirflowConfigParser()
-        self.assertEqual(
-            sorted(config_parser.sensitive_config_values),
-            sorted(
-                {
-                    ('core', 'sql_alchemy_conn'),
-                    ('core', 'fernet_key'),
-                    ('celery', 'broker_url'),
-                    ('celery', 'flower_basic_auth'),
-                    ('celery', 'result_backend'),
-                    ('atlas', 'password'),
-                    ('smtp', 'smtp_password'),
-                    ('kubernetes', 'git_password'),
-                    ('webserver', 'secret_key'),
-                }
-            ),
-        )
-
     def test_parameterized_config_gen(self):
 
         cfg = parameterized_config(DEFAULT_CONFIG)


### PR DESCRIPTION
`[webserver] secret_key` is also a secret like Fernet key. Allowing
it to be set via _CMD or _SECRET allows uers to use external secret store for it.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
