### PR TITLE
Move config item 'worker_precheck' from section [core] to [celery]

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -321,13 +321,6 @@
       type: string
       example: ~
       default: "True"
-    - name: worker_precheck
-      description: |
-        Worker initialisation check to validate Metadata Database connection
-      version_added: 1.10.1
-      type: string
-      example: ~
-      default: "False"
     - name: dag_discovery_safe_mode
       description: |
         When discovering DAGs, ignore any files that don't contain the strings ``DAG`` and ``airflow``.
@@ -1512,6 +1505,13 @@
       type: int
       example: ~
       default: "3"
+    - name: worker_precheck
+      description: |
+        Worker initialisation check to validate Metadata Database connection
+      version_added: 1.10.1
+      type: string
+      example: ~
+      default: "False"
 - name: celery_broker_transport_options
   description: |
     This section is for specifying options which can be passed to the

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -188,9 +188,6 @@ killed_task_cleanup_time = 60
 # ``airflow dags trigger -c``, the key-value pairs will override the existing ones in params.
 dag_run_conf_overrides_params = True
 
-# Worker initialisation check to validate Metadata Database connection
-worker_precheck = False
-
 # When discovering DAGs, ignore any files that don't contain the strings ``DAG`` and ``airflow``.
 dag_discovery_safe_mode = True
 
@@ -749,6 +746,9 @@ task_adoption_timeout = 600
 # The Maximum number of retries for publishing task messages to the broker when failing
 # due to ``AirflowTaskTimeout`` error before giving up and marking Task as failed.
 task_publish_max_retries = 3
+
+# Worker initialisation check to validate Metadata Database connection
+worker_precheck = False
 
 [celery_broker_transport_options]
 

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -43,7 +43,6 @@ fernet_key = {FERNET_KEY}
 enable_xcom_pickling = False
 killed_task_cleanup_time = 5
 hostname_callable = socket.getfqdn
-worker_precheck = False
 default_task_retries = 0
 # This is a hack, too many tests assume DAGs are already in the DB. We need to fix those tests instead
 store_serialized_dags = False
@@ -99,6 +98,7 @@ flower_host = 0.0.0.0
 flower_port = 5555
 default_queue = default
 sync_parallelism = 0
+worker_precheck = False
 
 [scheduler]
 job_heartbeat_sec = 1

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -136,6 +136,7 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
     # When reading new option, the old option will be checked to see if it exists. If it does a
     # DeprecationWarning will be issued and the old option will be used instead
     deprecated_options = {
+        ('celery', 'worker_precheck'): ('core', 'worker_precheck'),
         ('logging', 'base_log_folder'): ('core', 'base_log_folder'),
         ('logging', 'remote_logging'): ('core', 'remote_logging'),
         ('logging', 'remote_log_conn_id'): ('core', 'remote_log_conn_id'),

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -325,7 +325,7 @@ def configure_adapters():
 
 def validate_session():
     """Validate ORM Session"""
-    worker_precheck = conf.getboolean('core', 'worker_precheck', fallback=False)
+    worker_precheck = conf.getboolean('celery', 'worker_precheck', fallback=False)
     if not worker_precheck:
         return True
     else:

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -42,7 +42,7 @@ class TestWorkerPrecheck(unittest.TestCase):
             celery_command.worker(Namespace(queues=1, concurrency=1))
         self.assertEqual(cm.exception.code, 1)
 
-    @conf_vars({('core', 'worker_precheck'): 'False'})
+    @conf_vars({('celery', 'worker_precheck'): 'False'})
     def test_worker_precheck_exception(self):
         """
         Test to check the behaviour of validate_session method
@@ -51,7 +51,7 @@ class TestWorkerPrecheck(unittest.TestCase):
         self.assertTrue(airflow.settings.validate_session())
 
     @mock.patch('sqlalchemy.orm.session.Session.execute')
-    @conf_vars({('core', 'worker_precheck'): 'True'})
+    @conf_vars({('celery', 'worker_precheck'): 'True'})
     def test_validate_session_dbapi_exception(self, mock_session):
         """
         Test to validate connection failure scenario on SELECT 1 query


### PR DESCRIPTION
This configuration is ONLY applicable for Celery Worker. So it should be in section `[celery]`, rather than `[core]`.

No logic change in this PR.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
