### PR TITLE
Order broken DAG messages in UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -536,7 +536,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
                 for name, in dagtags
             ]
 
-            import_errors = session.query(errors.ImportError).all()
+            import_errors = session.query(errors.ImportError).order_by(errors.ImportError.id).all()
 
         for import_error in import_errors:
             flash("Broken DAG: [{ie.filename}] {ie.stacktrace}".format(ie=import_error), "dag_import_error")


### PR DESCRIPTION
In case of existing issue, reference it using one of the following:

closes: https://github.com/apache/airflow/issues/9669

Minor update to ensure that Broken DAG messages are ordered when displayed in the UI. Since the ordering doesn't really matter, it just has to be consistent, I chose to order by the `id` column.