### PR TITLE
Remove store_serialized_dags from config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -335,15 +335,6 @@
       type: string
       example: ~
       default: "0"
-    - name: store_serialized_dags
-      description: |
-        Whether to serialise DAGs and persist them in DB.
-        If set to True, Webserver reads from DB instead of parsing DAG files
-        More details: https://airflow.apache.org/docs/stable/dag-serialization.html
-      version_added: 1.10.7
-      type: string
-      example: ~
-      default: "True"
     - name: min_serialized_dag_update_interval
       description: |
         Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -194,11 +194,6 @@ dag_discovery_safe_mode = True
 # The number of retries each task is going to have by default. Can be overridden at dag or task level.
 default_task_retries = 0
 
-# Whether to serialise DAGs and persist them in DB.
-# If set to True, Webserver reads from DB instead of parsing DAG files
-# More details: https://airflow.apache.org/docs/stable/dag-serialization.html
-store_serialized_dags = True
-
 # Updating serialized DAG can not be faster than a minimum interval to reduce database write rate.
 min_serialized_dag_update_interval = 30
 


### PR DESCRIPTION
The store_serialized_dags is no longer used in our code base as
both webserver and scheduler require serialization.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
