### PR TITLE
Improve Kubernetes docs, add Helm section, closes #10523

### DIFF
--- a/docs/apache-airflow/kubernetes.rst
+++ b/docs/apache-airflow/kubernetes.rst
@@ -20,31 +20,64 @@
 Kubernetes
 ----------
 
+Apache Airflow aims to be a very Kubernetes-friendly project, and many users run Airflow
+from within a Kubernetes cluster in order to take advantage of Kubernetes autoscaling
+features.
+
+
+Helm Chart
+^^^^^^^^^^
+
+Deploying your Airflow cluster to Kubernetes, even when using CeleryExecutor, is
+recommended due to the increased stability and autoscaling options that Kubernetes provides.
+
+The community is working on an
+`offical Helm chart https://github.com/apache/airflow/tree/master/chart`_ for Airflow
+which will be released with Airflow 2.1. The chart has
+`KEDA integration https://github.com/apache/airflow/tree/master/chart#autoscaling-with-keda`_
+which allows you to autoscale your Celery workers. More information is available
+`in this blog post https://www.astronomer.io/blog/the-keda-autoscaler`_.
+
+Other Helm charts in the wild:
+
+* https://github.com/airflow-helm/charts
+* https://bitnami.com/stack/apache-airflow/helm
+* https://github.com/astronomer/airflow-chart
+
+
 Kubernetes Executor
 ^^^^^^^^^^^^^^^^^^^
 
-The :doc:`Kubernetes Executor <executor/kubernetes>` allows you to run all the Airflow tasks on
-Kubernetes as separate Pods.
+The :doc:`Kubernetes Executor <executor/kubernetes>` allows you to run all the Airflow
+tasks on Kubernetes as separate Pods.
+
 
 KubernetesPodOperator
 ^^^^^^^^^^^^^^^^^^^^^
 
-The :ref:`KubernetesPodOperator <howto/operator:KubernetesPodOperator>` allows you to create
-Pods on Kubernetes.
+The :ref:`KubernetesPodOperator <howto/operator:KubernetesPodOperator>` allows you to
+create Pods on Kubernetes.
+
 
 Pod Mutation Hook
 ^^^^^^^^^^^^^^^^^
 
-The Airflow local settings file (``airflow_local_settings.py``) can define a ``pod_mutation_hook`` function
-that has the ability to mutate pod objects before sending them to the Kubernetes client
-for scheduling. It receives a single argument as a reference to pod objects, and
-is expected to alter its attributes.
+The Airflow local settings file (``airflow_local_settings.py``) can define a
+``pod_mutation_hook`` function that has the ability to mutate pod objects before sending
+them to the Kubernetes client for scheduling. It receives a single argument as a
+reference to pod objects, and is expected to alter its attributes.
 
 This could be used, for instance, to add sidecar or init containers
 to every worker pod launched by KubernetesExecutor or KubernetesPodOperator.
-
 
 .. code-block:: python
 
     def pod_mutation_hook(pod: Pod):
       pod.annotations['airflow.apache.org/launched-by'] = 'Tests'
+
+
+Airflow on K8s Operator
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Google donated a `Kubernetes Operator for Airflow
+https://github.com/apache/airflow-on-k8s-operator`_ which is still an alpha product.

--- a/docs/apache-airflow/kubernetes.rst
+++ b/docs/apache-airflow/kubernetes.rst
@@ -21,17 +21,15 @@ Kubernetes
 ----------
 
 Apache Airflow aims to be a very Kubernetes-friendly project, and many users run Airflow
-from within a Kubernetes cluster in order to take advantage of Kubernetes autoscaling
-features.
+from within a Kubernetes cluster in order to take advantage of the increased stability
+and autoscaling options that Kubernetes provides.
 
 
 Helm Chart
 ^^^^^^^^^^
 
-Deploying your Airflow cluster to Kubernetes, even when using CeleryExecutor, is
-recommended due to the increased stability and autoscaling options that Kubernetes provides.
-
-The community is working on an
+`Helm https://helm.sh/`_ provides a simple mechanism to deploy software to a
+Kubernetes cluster, and the community is working on an
 `offical Helm chart https://github.com/apache/airflow/tree/master/chart`_ for Airflow
 which will be released with Airflow 2.1. The chart has
 `KEDA integration https://github.com/apache/airflow/tree/master/chart#autoscaling-with-keda`_


### PR DESCRIPTION
I'd like for us to have a great Kubernetes page in Airflow docs. This is a small commit towards that goal - and also should help address the confusion in #10523 by clearly delineating that we're working on an official chart, however there are other charts in the wild that the community uses.

We can continue to improve this in subsequent commits.