### PR TITLE
Avoid log spam & have more meaningful log when pull image in DockerOperator

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -289,6 +289,7 @@ class DockerOperator(BaseOperator):
             for output in self.cli.pull(self.image, stream=True, decode=True):
                 if isinstance(output, str):
                     self.log.info("%s", output)
+                    continue
                 if isinstance(output, dict) and 'status' in output:
                     if 'id' in output:
                         if latest_status.get(output['id']) != output['status']:

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -291,12 +291,15 @@ class DockerOperator(BaseOperator):
                     self.log.info("%s", output)
                     continue
                 if isinstance(output, dict) and 'status' in output:
-                    if 'id' in output:
-                        if latest_status.get(output['id']) != output['status']:
-                            self.log.info("%s: %s", output['id'], output['status'])
-                            latest_status[output['id']] = output['status']
-                    else:
-                        self.log.info("%s", output['status'])
+                    output_status = output["status"]
+                    if 'id' not in output:
+                        self.log.info("%s", output_status)
+                        continue
+
+                    output_id = output["id"]
+                    if latest_status.get(output_id) != output_status:
+                        self.log.info("%s: %s", output_id, output_status)
+                        latest_status[output_id] = output_status
 
         self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
         return self._run_image()

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -288,10 +288,13 @@ class DockerOperator(BaseOperator):
             for output in self.cli.pull(self.image, stream=True, decode=True):
                 if isinstance(output, str):
                     self.log.info("%s", output)
-                if isinstance(output, dict) and 'status' in output and 'id' in output:
-                    if latest_status.get(output['id']) != output['status']:
-                        self.log.info("%s: %s", output['id'], output['status'])
-                        latest_status[output['id']] = output['status']
+                if isinstance(output, dict) and 'status' in output:
+                    if 'id' in output:
+                        if latest_status.get(output['id']) != output['status']:
+                            self.log.info("%s: %s", output['id'], output['status'])
+                            latest_status[output['id']] = output['status']
+                    else:
+                        self.log.info("%s", output['status'])
 
         self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
         return self._run_image()

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -282,6 +282,7 @@ class DockerOperator(BaseOperator):
             raise Exception("The 'cli' should be initialized before!")
 
         # Pull the docker image if `force_pull` is set or image does not exist locally
+        # pylint: disable=too-many-nested-blocks
         if self.force_pull or not self.cli.images(name=self.image):
             self.log.info('Pulling docker image %s', self.image)
             latest_status = {}


### PR DESCRIPTION
Closes https://github.com/apache/airflow/issues/12576

- Fix the log spam issue reported in https://github.com/apache/airflow/issues/12576 . It's easy to validate the issue
```python
import docker
cli = docker.APIClient()
for x in cli.pull(self.image, stream=True, decode=True):
    print(x)
```

- The change in this PR actually also makes the log more meaningful. When we pull an image, normally there are a few layers, simply printing the `status` is not very meaningful. It's much better to print the `status` by `id`.


#### Sample output when we pull image using `docker.APIClient.pull(stream=True)`
![image](https://user-images.githubusercontent.com/11539188/100925266-1258e100-34e2-11eb-9930-3c31e25baaa0.png)



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
