### PR TITLE
BugFix: Improve support for special characters in DbApiHook.get_uri

### DIFF
--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -18,6 +18,7 @@
 from contextlib import closing
 from datetime import datetime
 from typing import Any, Optional
+from urllib.parse import quote_plus
 
 from sqlalchemy import create_engine
 
@@ -78,7 +79,7 @@ class DbApiHook(BaseHook):
         conn = self.get_connection(getattr(self, self.conn_name_attr))
         login = ''
         if conn.login:
-            login = '{conn.login}:{conn.password}@'.format(conn=conn)
+            login = f'{quote_plus(conn.login)}:{quote_plus(conn.password)}@'
         host = conn.host
         if conn.port is not None:
             host += f':{conn.port}'

--- a/tests/hooks/test_dbapi_hook.py
+++ b/tests/hooks/test_dbapi_hook.py
@@ -165,6 +165,19 @@ class TestDbApiHook(unittest.TestCase):
         )
         self.assertEqual("conn_type://login:password@host:1/", self.db_hook.get_uri())
 
+    def test_get_uri_special_characters(self):
+        self.db_hook.get_connection = mock.MagicMock(
+            return_value=Connection(
+                conn_type="conn_type",
+                host="host",
+                login="logi#! n",
+                password="pass*! word",
+                schema="schema",
+                port=1,
+            )
+        )
+        self.assertEqual("conn_type://logi%23%21+n:pass%2A%21+word@host:1/schema", self.db_hook.get_uri())
+
     def test_run_log(self):
         statement = 'SQL'
         self.db_hook.run(statement)


### PR DESCRIPTION
Closes [#12722](https://github.com/apache/airflow/issues/12722) raised by @NadimYounes

- Uses urllib.parse.quote_plus to urlencode the password since SQLAlchemy requires a valid URI to create an engine.

- Adds test case that checks for encoding of password.
