### PR TITLE
Fix plugin macros not being exposed through airflow.macros

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -364,7 +364,8 @@ class PythonVirtualenvOperator(PythonOperator):
     string_args). In addition, one can pass stuff through op_args and op_kwargs, and one
     can use a return value.
     Note that if your virtualenv runs in a different Python major version than Airflow,
-    you cannot use return values, op_args, or op_kwargs. You can use string_args though.
+    you cannot use return values, op_args, op_kwargs, or use any macros that are being provided to
+    Airflow through plugins. You can use string_args though.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -431,7 +431,7 @@ class PythonVirtualenvOperator(PythonOperator):
         'prev_execution_date_success',
         'prev_start_date_success',
     }
-    AIRFLOW_SERIALIZABLE_CONTEXT_KEYS = {'conf', 'dag', 'dag_run', 'task'}
+    AIRFLOW_SERIALIZABLE_CONTEXT_KEYS = {'macros', 'conf', 'dag', 'dag_run', 'task'}
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -431,7 +431,7 @@ class PythonVirtualenvOperator(PythonOperator):
         'prev_execution_date_success',
         'prev_start_date_success',
     }
-    AIRFLOW_SERIALIZABLE_CONTEXT_KEYS = {'macros', 'conf', 'dag', 'dag_run', 'task'}
+    AIRFLOW_SERIALIZABLE_CONTEXT_KEYS = {'conf', 'dag', 'dag_run', 'task'}
 
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -420,9 +420,7 @@ def integrate_macros_plugins() -> None:
 
         if macros_module:
             macros_modules.append(macros_module)
-            # pylint: disable=no-member
-            sys.modules[macros_module.__name__] = macros_module
+            sys.modules[macros_module.__name__] = macros_module  # pylint: disable=no-member
             # Register the newly created module on airflow.macros such that it
             # can be accessed when rendering templates.
-            setattr(macros, macros_module.__name__.split('.')[-1], macros_module)
-            # pylint: enable=no-member
+            setattr(macros, plugin.name, macros_module)

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -398,6 +398,7 @@ def integrate_macros_plugins() -> None:
     global plugins
     global macros_modules
     # pylint: enable=global-statement
+    from airflow import macros
 
     if macros_modules is not None:
         return
@@ -419,4 +420,9 @@ def integrate_macros_plugins() -> None:
 
         if macros_module:
             macros_modules.append(macros_module)
-            sys.modules[macros_module.__name__] = macros_module  # pylint: disable=no-member
+            # pylint: disable=no-member
+            sys.modules[macros_module.__name__] = macros_module
+            # Register the newly created module on airflow.macros such that it
+            # can be accessed when rendering templates.
+            setattr(macros, macros_module.__name__.split('.')[-1], macros_module)
+            # pylint: enable=no-member

--- a/airflow/utils/python_virtualenv_script.jinja2
+++ b/airflow/utils/python_virtualenv_script.jinja2
@@ -23,7 +23,7 @@ import sys
 # Check whether Airflow is available in the environment.
 # If it is, we'll want to ensure that we integrate any macros that are being provided
 # by plugins prior to unpickling the task context.
-if int(sys.version[0]) >= 3:
+if sys.version_info.major >= 3 and sys.version_info.minor >= 6:
     try:
         from airflow.plugins_manager import integrate_macros_plugins
         integrate_macros_plugins()

--- a/airflow/utils/python_virtualenv_script.jinja2
+++ b/airflow/utils/python_virtualenv_script.jinja2
@@ -20,6 +20,18 @@
 import {{ pickling_library }}
 import sys
 
+# Check whether Airflow is available in the environment.
+# If it is, we'll want to ensure that we integrate any macros that are being provided
+# by plugins prior to unpickling the task context.
+if int(sys.version[0]) >= 3:
+    try:
+        from airflow.plugins_manager import integrate_macros_plugins
+        integrate_macros_plugins()
+    except ImportError:
+        # Airflow is not available in this environment, therefore we won't
+        # be able to integrate any plugin macros.
+        pass
+
 # Read args
 {% if op_args or op_kwargs %}
 with open(sys.argv[1], "rb") as file:

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1266,6 +1266,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             prev_execution_date_success,
             prev_start_date_success,
             # airflow-specific
+            macros,
             conf,
             dag,
             dag_run,

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1266,7 +1266,6 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             prev_execution_date_success,
             prev_start_date_success,
             # airflow-specific
-            macros,
             conf,
             dag,
             dag_run,

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import importlib
 import logging
 import unittest
 from unittest import mock
@@ -212,6 +213,34 @@ class TestPluginsManager:
             assert "my_fake_module not found" in received_logs
             assert "Failed to import plugin test-entrypoint" in received_logs
             assert ("test.plugins.test_plugins_manager", "my_fake_module not found") in import_errors.items()
+
+    def test_registering_plugin_macros(self):
+        """
+        Tests whether macros that originate from plugins are being registered correctly.
+        """
+        from airflow import macros
+        from airflow.plugins_manager import integrate_macros_plugins
+
+        def custom_macro():
+            return 'foo'
+
+        class MacroPlugin(AirflowPlugin):
+            name = 'macro_plugin'
+            macros = [custom_macro]
+
+        with mock_plugin_manager(plugins=[MacroPlugin()]):
+            # Ensure the macros for the plugin have been integrated.
+            integrate_macros_plugins()
+            # Test whether the modules have been created as expected.
+            plugin_macros = importlib.import_module(f"airflow.macros.{MacroPlugin.name}")
+            for macro in MacroPlugin.macros:
+                # Verify that the macros added by the plugin are being set correctly
+                # on the plugin's macro module.
+                assert hasattr(plugin_macros, macro.__name__)
+            # Verify that the symbol table in airflow.macros has been updated with an entry for
+            # this plugin, this is necessary in order to allow the plugin's macros to be used when
+            # rendering templates.
+            assert hasattr(macros, MacroPlugin.name)
 
 
 class TestPluginsDirectorySource(unittest.TestCase):


### PR DESCRIPTION
This PR fixes an issue where macros that are being provided through plugins can not be used at template time because they are not accessible through the `airflow.macros` module.

This PR consists out of two commits. In the first commit I add a test-case that reproduces the issue as outlined in #12785, and the second commit introduces the fix which fixes the issue and allows the test-case to pass.

Fixes: #12785 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
