### PR TITLE
Clean noqa labels wrongly handled by black linter

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -288,7 +288,7 @@ def dag_link(attr):
     dag_id = attr.get('dag_id')
     execution_date = attr.get('execution_date')
     url = url_for('Airflow.graph', dag_id=dag_id, execution_date=execution_date)
-    return Markup('<a href="{}">{}</a>').format(url, dag_id)  # noqa  # noqa
+    return Markup('<a href="{}">{}</a>').format(url, dag_id)  # noqa
 
 
 def dag_run_link(attr):
@@ -297,7 +297,7 @@ def dag_run_link(attr):
     run_id = attr.get('run_id')
     execution_date = attr.get('execution_date')
     url = url_for('Airflow.graph', dag_id=dag_id, run_id=run_id, execution_date=execution_date)
-    return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)  # noqa  # noqa
+    return Markup('<a href="{url}">{run_id}</a>').format(url=url, run_id=run_id)  # noqa
 
 
 def pygment_html_render(s, lexer=lexers.TextLexer):  # noqa pylint: disable=no-member

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -493,7 +493,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             if arg_search_query:
                 dags_query = dags_query.filter(
                     DagModel.dag_id.ilike('%' + arg_search_query + '%')
-                    | DagModel.owners.ilike('%' + arg_search_query + '%')  # noqa  # noqa
+                    | DagModel.owners.ilike('%' + arg_search_query + '%')  # noqa
                 )
 
             if arg_tags_filter:


### PR DESCRIPTION
In some cases, two continuous lines have `#  noqa` lable, and Black simply duplicate the `# noqa` label when it combines the lines (in PR https://github.com/apache/airflow/pull/9550).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
