### PR TITLE
Prevent unused scrollbars from appearing in FF on Linux

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -442,5 +442,5 @@ label[for="timezone-other"],
 
 .task-instance-modal-column {
   margin-top: 8px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }


### PR DESCRIPTION
Prevents these scrollbars from appearing in Firefox on Linux (wasn't an issue on macOS)

![image](https://user-images.githubusercontent.com/3267/101085662-c0fe2f80-357d-11eb-9c1c-983baebdfef2.png)
