### PR TITLE
Add expandable groups in the docs build log

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -369,4 +369,7 @@ def main():
     )
 
 
-main()
+# main()
+del main
+from pprint import pprint
+print(os.environ)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -25,6 +25,7 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from glob import glob
+from pprint import pprint
 from subprocess import run
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Dict, List, Optional, Tuple
@@ -371,5 +372,5 @@ def main():
 
 # main()
 del main
-from pprint import pprint
-print(os.environ)
+pprint(os.environ)
+sys.exit(1)

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -25,7 +25,6 @@ import sys
 from collections import defaultdict
 from contextlib import contextmanager
 from glob import glob
-from pprint import pprint
 from subprocess import run
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Dict, List, Optional, Tuple
@@ -370,7 +369,4 @@ def main():
     )
 
 
-# main()
-del main
-pprint(os.environ)
-sys.exit(1)
+main()

--- a/scripts/ci/libraries/_runs.sh
+++ b/scripts/ci/libraries/_runs.sh
@@ -19,9 +19,10 @@
 # Docker command to build documentation
 function runs::run_docs() {
     docker run "${EXTRA_DOCKER_FLAGS[@]}" -t \
-            --entrypoint "/usr/local/bin/dumb-init"  \
-            "${AIRFLOW_CI_IMAGE}" \
-            "--" "/opt/airflow/scripts/in_container/run_docs_build.sh" "${@}"
+        -e "GITHUB_ACTIONS=${GITHUB_ACTIONS="false"}" \
+        --entrypoint "/usr/local/bin/dumb-init"  \
+        "${AIRFLOW_CI_IMAGE}" \
+        "--" "/opt/airflow/scripts/in_container/run_docs_build.sh" "${@}"
 }
 
 


### PR DESCRIPTION
I added documentation log grouping and it is now easier to find logs that applies to a specific package.
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#grouping-log-lines
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
