### PR TITLE
Compile static assets when running setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -907,6 +907,7 @@ def do_setup():
         test_suite='setup.airflow_test_suite',
         **setup_kwargs,
     )
+    subprocess.check_call('./airflow/www/compile_assets.sh')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If Airflow is installed but static assets aren't compiled, the web UI will load but it won't work properly. One result is that CSRF tokens won't be added to POST requests, causing them to fail.

Addresses https://github.com/apache/airflow/issues/12262