### PR TITLE
Add 'headers' to template_fields in HttpSensor

### DIFF
--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -68,7 +68,7 @@ class HttpSensor(BaseSensorOperator):
         depends on the option that's being modified.
     """
 
-    template_fields = ('endpoint', 'request_params')
+    template_fields = ('endpoint', 'request_params', 'headers')
 
     @apply_defaults
     def __init__(


### PR DESCRIPTION
Adds `headers` to the `template_fields` member of the `HttpSensor` class to allow templating headers.

closes: #12796
