### PR TITLE
allow to set airflow session cookie name

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -79,6 +79,7 @@ def create_app(config=None, testing=False, app_name="Airflow"):
     flask_app.config['SESSION_COOKIE_HTTPONLY'] = True
     flask_app.config['SESSION_COOKIE_SECURE'] = conf.getboolean('webserver', 'COOKIE_SECURE')
     flask_app.config['SESSION_COOKIE_SAMESITE'] = conf.get('webserver', 'COOKIE_SAMESITE')
+    flask_app.config['SESSION_COOKIE_NAME'] = conf.get('webserver', 'COOKIE_NAME')
 
     if config:
         flask_app.config.from_mapping(config)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


---
Hi,
This PR allows to set airflow session cookie name instead of using flask default name `session`.
https://flask.palletsprojects.com/en/1.0.x/config/#SESSION_COOKIE_NAME

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
