### PR TITLE
Collapse the importErrors pane by default

### DIFF
--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -53,13 +53,13 @@
       <div class="panel panel-default">
         <div class="panel-heading" id="errorHeading">
           <h4 class="panel-title">
-            <a id="alerts-accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#alerts" aria-expanded="false">
-              DAG Import Errors ({{ dag_import_errors|length }})
+            <a id="alerts-accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#alerts" aria-expanded="false" class="collapsed">
+              <span class="text-danger"><span class="material-icons" aria-hidden="true">error</span> DAG Import Errors ({{ dag_import_errors|length }})</span>
             </a>
           </h4>
         </div>
 
-        <div id="alerts" class="panel-collapse collapse in">
+        <div id="alerts" class="panel-collapse collapse">
           <div class="panel-body">
             {% for category, m in dag_import_errors %}
               <div class="alert alert-error dag-import-error">{{ m }}</div>


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Our Airflow Environment is shared by multiple teams and many users. On several occasions we've seen someone introduce an error in a couple hundred generated DAGs, which completely clobbers the web UI. 

My initial plan was to introduce a separate view for import errors, and allow users to disable the import errors on the main page via configuration. However, now that Airflow 2 makes this section of the page collapsible, I figured its easier to just make this section collapsed by default. This prevents one user's errors from affecting other users' experience.

Before:
![image](https://user-images.githubusercontent.com/16950874/101184034-3c172280-361e-11eb-8636-2b9fe153fd14.png)

After:
![image](https://user-images.githubusercontent.com/16950874/101217356-35ed6a00-364f-11eb-980b-fd3ee9219c69.png)


Happy to discuss, if you disagree with this change in default behaviour then feel free to close. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
