### PR TITLE
Add Apache Beam operators

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -647,7 +647,7 @@ apache.hive                amazon,microsoft.mssql,mysql,presto,samba,vertica
 apache.livy                http
 dingding                   http
 discord                    http
-google                     amazon,apache.cassandra,cncf.kubernetes,facebook,microsoft.azure,microsoft.mssql,mysql,oracle,postgres,presto,salesforce,sftp,ssh
+google                     amazon,apache.beam,apache.cassandra,cncf.kubernetes,facebook,microsoft.azure,microsoft.mssql,mysql,oracle,postgres,presto,salesforce,sftp,ssh
 hashicorp                  google
 microsoft.azure            google,oracle
 microsoft.mssql            odbc

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -641,6 +641,7 @@ Here is the list of packages and their extras:
 Package                    Extras
 ========================== ===========================
 amazon                     apache.hive,exasol,ftp,google,imap,mongo,mysql,postgres,ssh
+apache.beam                google
 apache.druid               apache.hive
 apache.hive                amazon,microsoft.mssql,mysql,presto,samba,vertica
 apache.livy                http

--- a/airflow/providers/apache/beam/BACKPORT_PROVIDER_README.md
+++ b/airflow/providers/apache/beam/BACKPORT_PROVIDER_README.md
@@ -1,0 +1,101 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+
+# Package apache-airflow-backport-providers-apache-beam
+
+Release:
+
+**Table of contents**
+
+- [Backport package](#backport-package)
+- [Installation](#installation)
+- [PIP requirements](#pip-requirements)
+- [Cross provider package dependencies](#cross-provider-package-dependencies)
+- [Provider class summary](#provider-classes-summary)
+    - [Operators](#operators)
+        - [Moved operators](#moved-operators)
+    - [Transfer operators](#transfer-operators)
+        - [Moved transfer operators](#moved-transfer-operators)
+    - [Hooks](#hooks)
+        - [Moved hooks](#moved-hooks)
+- [Releases](#releases)
+    - [Release](#release)
+
+## Backport package
+
+This is a backport providers package for `apache.beam` provider. All classes for this provider package
+are in `airflow.providers.apache.beam` python package.
+
+**Only Python 3.6+ is supported for this backport package.**
+
+While Airflow 1.10.* continues to support Python 2.7+ - you need to upgrade python to 3.6+ if you
+want to use this backport package.
+
+
+
+## Installation
+
+You can install this package on top of an existing airflow 1.10.* installation via
+`pip install apache-airflow-backport-providers-apache-beam`
+
+## PIP requirements
+
+
+## Cross provider package dependencies
+
+Those are dependencies that might be needed in order to use all the features of the package.
+You need to install the specified backport providers package in order to use them.
+
+You can install such cross-provider dependencies when installing from PyPI. For example:
+
+```bash
+pip install apache-airflow-backport-providers-apache-beam[google]
+```
+
+| Dependent package                                                                                                   | Extra  |
+|:--------------------------------------------------------------------------------------------------------------------|:-------|
+| [apache-airflow-backport-providers-google](https://github.com/apache/airflow/tree/master/airflow/providers/google/) | google |
+
+# Provider classes summary
+
+In Airflow 2.0, all operators, transfers, hooks, sensors, secrets for the `apache.beam` provider
+are in the `airflow.providers.apache.beam` package. You can read more about the naming conventions used
+in [Naming conventions for provider packages](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#naming-conventions-for-provider-packages)
+
+
+## Operators
+
+### Moved operators
+
+## Transfer operators
+
+### Moved transfer operators
+
+## Hooks
+
+### Moved hooks
+
+
+## Releases
+
+### Release
+
+| Commit                                                                                         | Committed   | Subject                                                      |
+|:-----------------------------------------------------------------------------------------------|:------------|:-------------------------------------------------------------|

--- a/airflow/providers/apache/beam/BACKPORT_PROVIDER_README.md
+++ b/airflow/providers/apache/beam/BACKPORT_PROVIDER_README.md
@@ -49,14 +49,10 @@ While Airflow 1.10.* continues to support Python 2.7+ - you need to upgrade pyth
 want to use this backport package.
 
 
-
 ## Installation
 
 You can install this package on top of an existing airflow 1.10.* installation via
 `pip install apache-airflow-backport-providers-apache-beam`
-
-## PIP requirements
-
 
 ## Cross provider package dependencies
 
@@ -66,12 +62,13 @@ You need to install the specified backport providers package in order to use the
 You can install such cross-provider dependencies when installing from PyPI. For example:
 
 ```bash
-pip install apache-airflow-backport-providers-apache-beam[google]
+pip install apache-airflow-beckport-providers-apache-beam[google]
 ```
 
-| Dependent package                                                                                                   | Extra  |
-|:--------------------------------------------------------------------------------------------------------------------|:-------|
-| [apache-airflow-backport-providers-google](https://github.com/apache/airflow/tree/master/airflow/providers/google/) | google |
+| Dependent package                                                                                         | Extra       |
+|:----------------------------------------------------------------------------------------------------------|:------------|
+| [apache-airflow-providers-apache-google](https://pypi.org/project/apache-airflow-providers-apache-google) | google      |
+
 
 # Provider classes summary
 
@@ -82,20 +79,21 @@ in [Naming conventions for provider packages](https://github.com/apache/airflow/
 
 ## Operators
 
-### Moved operators
+### New operators
 
-## Transfer operators
+| New Airflow 2.0 operators: `airflow.providers.apache.beam` package                                                                                                                 |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| [operators.beam.BeamRunJavaPipelineOperator](https://github.com/apache/airflow/blob/master/airflow/providers/apache/beam/operators/beam.py)    |
+| [operators.beam.BeamRunPythonPipelineOperator](https://github.com/apache/airflow/blob/master/airflow/providers/apache/beam/operators/beam.py)  |
 
-### Moved transfer operators
 
 ## Hooks
 
-### Moved hooks
+### New hooks
+
+| New Airflow 2.0 hooks: `airflow.providers.apache.beam` package                                                   |
+|:-----------------------------------------------------------------------------------------------------------------|
+| [hooks.beam.BeamHook](https://github.com/apache/airflow/blob/master/airflow/providers/apache/beam/hooks/beam.py) |
 
 
 ## Releases
-
-### Release
-
-| Commit                                                                                         | Committed   | Subject                                                      |
-|:-----------------------------------------------------------------------------------------------|:------------|:-------------------------------------------------------------|

--- a/airflow/providers/apache/beam/CHANGELOG.rst
+++ b/airflow/providers/apache/beam/CHANGELOG.rst
@@ -1,0 +1,25 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Changelog
+---------
+
+1.0.0
+.....
+
+Initial version of the provider.

--- a/airflow/providers/apache/beam/README.md
+++ b/airflow/providers/apache/beam/README.md
@@ -34,26 +34,38 @@ Release: 0.0.1
     - [Hooks](#hooks)
 - [Releases](#releases)
 
-
 ## Provider package
 
 This is a provider package for `apache.beam` provider. All classes for this provider package
 are in `airflow.providers.apache.beam` python package.
 
-
 ## Installation
+
+NOTE!
+
+On November 2020, new version of PIP (20.3) has been released with a new, 2020 resolver. This resolver
+does not yet work with Apache Airflow and might lead to errors in installation - depends on your choice
+of extras. In order to install Airflow you need to either downgrade pip to version 20.2.4
+`pip install --upgrade pip==20.2.4` or, in case you use Pip 20.3, you need to add option
+`--use-deprecated legacy-resolver` to your pip install command.
 
 You can install this package on top of an existing airflow 2.* installation via
 `pip install apache-airflow-providers-apache-beam`
-
-
-## PIP requirements
-
 
 ## Cross provider package dependencies
 
 Those are dependencies that might be needed in order to use all the features of the package.
 You need to install the specified backport providers package in order to use them.
+
+You can install such cross-provider dependencies when installing from PyPI. For example:
+
+```bash
+pip install apache-airflow-providers-apache-beam[google]
+```
+
+| Dependent package                                                                           | Extra       |
+|:--------------------------------------------------------------------------------------------|:------------|
+| [apache-airflow-providers-google](https://pypi.org/project/apache-airflow-providers-google) | google      |
 
 
 # Provider classes summary
@@ -65,11 +77,21 @@ in [Naming conventions for provider packages](https://github.com/apache/airflow/
 
 ## Operators
 
+### New operators
 
-## Transfer operators
+| New Airflow 2.0 operators: `airflow.providers.apache.beam` package                                                                                                                 |
+|:-----------------------------------------------------------------------------------------------------------------------------------------------|
+| [operators.beam.BeamRunJavaPipelineOperator](https://github.com/apache/airflow/blob/master/airflow/providers/apache/beam/operators/beam.py)    |
+| [operators.beam.BeamRunPythonPipelineOperator](https://github.com/apache/airflow/blob/master/airflow/providers/apache/beam/operators/beam.py)  |
 
 
 ## Hooks
+
+### New hooks
+
+| New Airflow 2.0 hooks: `airflow.providers.apache.beam` package                                                   |
+|:-----------------------------------------------------------------------------------------------------------------|
+| [hooks.beam.BeamHook](https://github.com/apache/airflow/blob/master/airflow/providers/apache/beam/hooks/beam.py) |
 
 
 ## Releases

--- a/airflow/providers/apache/beam/README.md
+++ b/airflow/providers/apache/beam/README.md
@@ -1,0 +1,75 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+
+
+# Package apache-airflow-providers-apache-beam
+
+Release: 0.0.1
+
+**Table of contents**
+
+- [Provider package](#provider-package)
+- [Installation](#installation)
+- [PIP requirements](#pip-requirements)
+- [Cross provider package dependencies](#cross-provider-package-dependencies)
+- [Provider class summary](#provider-classes-summary)
+    - [Operators](#operators)
+    - [Transfer operators](#transfer-operators)
+    - [Hooks](#hooks)
+- [Releases](#releases)
+
+
+## Provider package
+
+This is a provider package for `apache.beam` provider. All classes for this provider package
+are in `airflow.providers.apache.beam` python package.
+
+
+## Installation
+
+You can install this package on top of an existing airflow 2.* installation via
+`pip install apache-airflow-providers-apache-beam`
+
+
+## PIP requirements
+
+
+## Cross provider package dependencies
+
+Those are dependencies that might be needed in order to use all the features of the package.
+You need to install the specified backport providers package in order to use them.
+
+
+# Provider classes summary
+
+In Airflow 2.0, all operators, transfers, hooks, sensors, secrets for the `apache.beam` provider
+are in the `airflow.providers.apache.beam` package. You can read more about the naming conventions used
+in [Naming conventions for provider packages](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#naming-conventions-for-provider-packages)
+
+
+## Operators
+
+
+## Transfer operators
+
+
+## Hooks
+
+
+## Releases

--- a/airflow/providers/apache/beam/__init__.py
+++ b/airflow/providers/apache/beam/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/apache/beam/example_dags/__init__.py
+++ b/airflow/providers/apache/beam/example_dags/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/apache/beam/example_dags/example_beam.py
+++ b/airflow/providers/apache/beam/example_dags/example_beam.py
@@ -1,0 +1,260 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG for Apache Beam operators
+"""
+import os
+from urllib.parse import urlparse
+
+from airflow import models
+from airflow.providers.apache.beam.operators.beam import (
+    BeamRunJavaPipelineOperator,
+    BeamRunPythonPipelineOperator,
+)
+from airflow.providers.google.cloud.transfers.gcs_to_local import GCSToLocalFilesystemOperator
+from airflow.utils.dates import days_ago
+
+GCS_INPUT = os.environ.get('APACHE_BEAM_PYTHON', 'gs://apache-beam-samples/shakespeare/kinglear.txt')
+GCS_TMP = os.environ.get('APACHE_BEAM_GCS_TMP', 'gs://test-dataflow-example/temp/')
+GCS_STAGING = os.environ.get('APACHE_BEAM_GCS_STAGING', 'gs://test-dataflow-example/staging/')
+GCS_OUTPUT = os.environ.get('APACHE_BEAM_GCS_OUTPUT', 'gs://test-dataflow-example/output')
+GCS_PYTHON = os.environ.get('APACHE_BEAM_PYTHON', 'gs://test-dataflow-example/wordcount_debugging.py')
+
+GCS_JAR_DIRECT_RUNNER = os.environ.get(
+    'APACHE_BEAM_DIRECT_RUNNER_JAR',
+    'gs://test-dataflow-example/tests/dataflow-templates-bundled-java=11-beam-v2.25.0-DirectRunner.jar',
+)
+GCS_JAR_DATAFLOW_RUNNER = os.environ.get(
+    'APACHE_BEAM_DATAFLOW_RUNNER_JAR', 'gs://test-dataflow-example/word-count-beam-bundled-0.1.jar'
+)
+GCS_JAR_SPARK_RUNNER = os.environ.get(
+    'APACHE_BEAM_SPARK_RUNNER_JAR',
+    'gs://test-dataflow-example/tests/dataflow-templates-bundled-java=11-beam-v2.25.0-SparkRunner.jar',
+)
+GCS_JAR_FLINK_RUNNER = os.environ.get(
+    'APACHE_BEAM_FLINK_RUNNER_JAR',
+    'gs://test-dataflow-example/tests/dataflow-templates-bundled-java=11-beam-v2.25.0-FlinkRunner.jar',
+)
+
+GCS_JAR_DIRECT_RUNNER_PARTS = urlparse(GCS_JAR_DIRECT_RUNNER)
+GCS_JAR_DIRECT_RUNNER_BUCKET_NAME = GCS_JAR_DIRECT_RUNNER_PARTS.netloc
+GCS_JAR_DIRECT_RUNNER_OBJECT_NAME = GCS_JAR_DIRECT_RUNNER_PARTS.path[1:]
+GCS_JAR_DATAFLOW_RUNNER_PARTS = urlparse(GCS_JAR_DATAFLOW_RUNNER)
+GCS_JAR_DATAFLOW_RUNNER_BUCKET_NAME = GCS_JAR_DATAFLOW_RUNNER_PARTS.netloc
+GCS_JAR_DATAFLOW_RUNNER_OBJECT_NAME = GCS_JAR_DATAFLOW_RUNNER_PARTS.path[1:]
+GCS_JAR_SPARK_RUNNER_PARTS = urlparse(GCS_JAR_SPARK_RUNNER)
+GCS_JAR_SPARK_RUNNER_BUCKET_NAME = GCS_JAR_SPARK_RUNNER_PARTS.netloc
+GCS_JAR_SPARK_RUNNER_OBJECT_NAME = GCS_JAR_SPARK_RUNNER_PARTS.path[1:]
+GCS_JAR_FLINK_RUNNER_PARTS = urlparse(GCS_JAR_FLINK_RUNNER)
+GCS_JAR_FLINK_RUNNER_BUCKET_NAME = GCS_JAR_FLINK_RUNNER_PARTS.netloc
+GCS_JAR_FLINK_RUNNER_OBJECT_NAME = GCS_JAR_FLINK_RUNNER_PARTS.path[1:]
+
+
+default_args = {
+    'default_pipeline_options': {
+        'output': '/tmp/example_beam',
+    },
+    "trigger_rule": "all_done",
+}
+
+
+with models.DAG(
+    "example_beam_native_java_direct_runner",
+    schedule_interval=None,  # Override to match your needs
+    start_date=days_ago(1),
+    tags=['example'],
+) as dag_native_java_direct_runner:
+
+    jar_to_local_direct_runner = GCSToLocalFilesystemOperator(
+        task_id="jar_to_local_direct_runner",
+        bucket=GCS_JAR_DIRECT_RUNNER_BUCKET_NAME,
+        object_name=GCS_JAR_DIRECT_RUNNER_OBJECT_NAME,
+        filename="/tmp/beam_wordcount_direct_runner_{{ ds_nodash }}.jar",
+    )
+
+    start_java_job_direct_runner = BeamRunJavaPipelineOperator(
+        task_id="start_java_job_direct_runner",
+        runner="DirectRunner",
+        jar="/tmp/beam_wordcount_direct_runner_{{ ds_nodash }}.jar",
+        job_name='{{task.task_id}}',
+        pipeline_options={
+            'output': '/tmp/start_java_job_direct_runner',
+            'inputFile': GCS_INPUT,
+        },
+        job_class='org.apache.beam.examples.WordCount',
+    )
+
+    jar_to_local_direct_runner >> start_java_job_direct_runner
+
+with models.DAG(
+    "example_beam_native_java_dataflow_runner",
+    schedule_interval=None,  # Override to match your needs
+    start_date=days_ago(1),
+    tags=['example'],
+) as dag_native_java_dataflow_runner:
+
+    jar_to_local_dataflow_runner = GCSToLocalFilesystemOperator(
+        task_id="jar_to_local_dataflow_runner",
+        bucket=GCS_JAR_DATAFLOW_RUNNER_BUCKET_NAME,
+        object_name=GCS_JAR_DATAFLOW_RUNNER_OBJECT_NAME,
+        filename="/tmp/beam_wordcount_dataflow_runner_{{ ds_nodash }}.jar",
+    )
+
+    start_java_job_dataflow = BeamRunJavaPipelineOperator(
+        task_id="start_java_job_dataflow",
+        runner="DataflowRunner",
+        jar="/tmp/beam_wordcount_dataflow_runner_{{ ds_nodash }}.jar",
+        job_name='{{task.task_id}}',
+        pipeline_options={
+            'tempLocation': GCS_TMP,
+            'stagingLocation': GCS_STAGING,
+            'output': GCS_OUTPUT,
+        },
+        job_class='org.apache.beam.examples.WordCount',
+    )
+
+    jar_to_local_dataflow_runner >> start_java_job_dataflow
+
+with models.DAG(
+    "example_beam_native_java_spark_runner",
+    schedule_interval=None,  # Override to match your needs
+    start_date=days_ago(1),
+    tags=['example'],
+) as dag_native_java_spark_runner:
+
+    jar_to_local_spark_runner = GCSToLocalFilesystemOperator(
+        task_id="jar_to_local_spark_runner",
+        bucket=GCS_JAR_SPARK_RUNNER_BUCKET_NAME,
+        object_name=GCS_JAR_SPARK_RUNNER_OBJECT_NAME,
+        filename="/tmp/beam_wordcount_spark_runner_{{ ds_nodash }}.jar",
+    )
+
+    start_java_job_spark_runner = BeamRunJavaPipelineOperator(
+        task_id="start_java_job_spark_runner",
+        runner="SparkRunner",
+        jar="/tmp/beam_wordcount_spark_runner_{{ ds_nodash }}.jar",
+        job_name='{{task.task_id}}',
+        pipeline_options={
+            'output': '/tmp/start_java_job_spark_runner',
+            'inputFile': GCS_INPUT,
+        },
+        job_class='org.apache.beam.examples.WordCount',
+    )
+
+    jar_to_local_spark_runner >> start_java_job_spark_runner
+
+with models.DAG(
+    "example_beam_native_java_flink_runner",
+    schedule_interval=None,  # Override to match your needs
+    start_date=days_ago(1),
+    tags=['example'],
+) as dag_native_java_flink_runner:
+
+    jar_to_local_flink_runner = GCSToLocalFilesystemOperator(
+        task_id="jar_to_local_flink_runner",
+        bucket=GCS_JAR_FLINK_RUNNER_BUCKET_NAME,
+        object_name=GCS_JAR_FLINK_RUNNER_OBJECT_NAME,
+        filename="/tmp/beam_wordcount_flink_runner_{{ ds_nodash }}.jar",
+    )
+
+    start_java_job_flink_runner = BeamRunJavaPipelineOperator(
+        task_id="start_java_job_flink_runner",
+        runner="FlinkRunner",
+        jar="/tmp/beam_wordcount_flink_runner_{{ ds_nodash }}.jar",
+        job_name='{{task.task_id}}',
+        pipeline_options={
+            'output': '/tmp/start_java_job_flink_runner',
+            'inputFile': GCS_INPUT,
+        },
+        job_class='org.apache.beam.examples.WordCount',
+    )
+
+    jar_to_local_flink_runner >> start_java_job_flink_runner
+
+
+with models.DAG(
+    "example_beam_native_python",
+    default_args=default_args,
+    start_date=days_ago(1),
+    schedule_interval=None,  # Override to match your needs
+    tags=['example'],
+) as dag_native_python:
+
+    start_python_job_local_direct_runner = BeamRunPythonPipelineOperator(
+        task_id="start_python_job_local_direct_runner",
+        py_file='apache_beam.examples.wordcount',
+        py_options=['-m'],
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
+    )
+
+    start_python_job_direct_runner = BeamRunPythonPipelineOperator(
+        task_id="start_python_job_direct_runner",
+        py_file=GCS_PYTHON,
+        py_options=[],
+        pipeline_options={"output": GCS_OUTPUT},
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
+    )
+
+    start_python_job_dataflow_runner = BeamRunPythonPipelineOperator(
+        task_id="start_python_job_dataflow_runner",
+        runner="DataflowRunner",
+        py_file=GCS_PYTHON,
+        pipeline_options={
+            'tempLocation': GCS_TMP,
+            'stagingLocation': GCS_STAGING,
+            'output': GCS_OUTPUT,
+        },
+        py_options=[],
+        job_name='{{task.task_id}}',
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
+    )
+
+    start_python_job_local_spark_runner = BeamRunPythonPipelineOperator(
+        task_id="start_python_job_local_spark_runner",
+        py_file='apache_beam.examples.wordcount',
+        runner="SparkRunner",
+        py_options=['-m'],
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
+    )
+
+    start_python_job_local_flink_runner = BeamRunPythonPipelineOperator(
+        task_id="start_python_job_local_flink_runner",
+        py_file='apache_beam.examples.wordcount',
+        runner="FlinkRunner",
+        py_options=['-m'],
+        pipeline_options={
+            'output': '/tmp/start_python_job_local_flink_runner',
+        },
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
+    )
+
+    [
+        start_python_job_local_direct_runner,
+        start_python_job_direct_runner,
+    ] >> start_python_job_local_flink_runner >> start_python_job_local_spark_runner

--- a/airflow/providers/apache/beam/example_dags/example_beam.py
+++ b/airflow/providers/apache/beam/example_dags/example_beam.py
@@ -88,6 +88,7 @@ with models.DAG(
     tags=['example'],
 ) as dag_native_java_direct_runner:
 
+    # [START howto_operator_start_java_direct_runner_pipeline]
     jar_to_local_direct_runner = GCSToLocalFilesystemOperator(
         task_id="jar_to_local_direct_runner",
         bucket=GCS_JAR_DIRECT_RUNNER_BUCKET_NAME,
@@ -106,6 +107,7 @@ with models.DAG(
     )
 
     jar_to_local_direct_runner >> start_java_pipeline_direct_runner
+    # [END howto_operator_start_java_direct_runner_pipeline]
 
 with models.DAG(
     "example_beam_native_java_dataflow_runner",
@@ -113,7 +115,7 @@ with models.DAG(
     start_date=days_ago(1),
     tags=['example'],
 ) as dag_native_java_dataflow_runner:
-
+    # [START howto_operator_start_java_dataflow_runner_pipeline]
     jar_to_local_dataflow_runner = GCSToLocalFilesystemOperator(
         task_id="jar_to_local_dataflow_runner",
         bucket=GCS_JAR_DATAFLOW_RUNNER_BUCKET_NAME,
@@ -135,6 +137,7 @@ with models.DAG(
     )
 
     jar_to_local_dataflow_runner >> start_java_pipeline_dataflow
+    # [END howto_operator_start_java_dataflow_runner_pipeline]
 
 with models.DAG(
     "example_beam_native_java_spark_runner",
@@ -199,6 +202,7 @@ with models.DAG(
     tags=['example'],
 ) as dag_native_python:
 
+    # [START howto_operator_start_python_direct_runner_pipeline_local_file]
     start_python_pipeline_local_direct_runner = BeamRunPythonPipelineOperator(
         task_id="start_python_pipeline_local_direct_runner",
         py_file='apache_beam.examples.wordcount',
@@ -207,7 +211,9 @@ with models.DAG(
         py_interpreter='python3',
         py_system_site_packages=False,
     )
+    # [END howto_operator_start_python_direct_runner_pipeline_local_file]
 
+    # [START howto_operator_start_python_direct_runner_pipeline_gcs_file]
     start_python_pipeline_direct_runner = BeamRunPythonPipelineOperator(
         task_id="start_python_pipeline_direct_runner",
         py_file=GCS_PYTHON,
@@ -217,7 +223,9 @@ with models.DAG(
         py_interpreter='python3',
         py_system_site_packages=False,
     )
+    # [END howto_operator_start_python_direct_runner_pipeline_gcs_file]
 
+    # [START howto_operator_start_python_dataflow_runner_pipeline_gcs_file]
     start_python_pipeline_dataflow_runner = BeamRunPythonPipelineOperator(
         task_id="start_python_pipeline_dataflow_runner",
         runner="DataflowRunner",
@@ -235,6 +243,7 @@ with models.DAG(
             job_name='{{task.task_id}}', project_id=GCP_PROJECT_ID, location="us-central1"
         ),
     )
+    # [END howto_operator_start_python_dataflow_runner_pipeline_gcs_file]
 
     start_python_pipeline_local_spark_runner = BeamRunPythonPipelineOperator(
         task_id="start_python_pipeline_local_spark_runner",
@@ -272,6 +281,7 @@ with models.DAG(
     schedule_interval=None,  # Override to match your needs
     tags=['example'],
 ) as dag_native_python_dataflow_async:
+    # [START howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]
     start_python_job_dataflow_runner_async = BeamRunPythonPipelineOperator(
         task_id="start_python_job_dataflow_runner_async",
         runner="DataflowRunner",
@@ -302,3 +312,4 @@ with models.DAG(
     )
 
     start_python_job_dataflow_runner_async >> wait_for_python_job_dataflow_runner_async_done
+    # [END howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]

--- a/airflow/providers/apache/beam/hooks/__init__.py
+++ b/airflow/providers/apache/beam/hooks/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/apache/beam/hooks/beam.py
+++ b/airflow/providers/apache/beam/hooks/beam.py
@@ -1,0 +1,235 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains a Apache Beam Hook."""
+import json
+import select
+import shlex
+import subprocess
+import textwrap
+from tempfile import TemporaryDirectory
+from typing import List, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.hooks.base_hook import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.python_virtualenv import prepare_virtualenv
+
+
+class _BeamRunner(LoggingMixin):
+    def __init__(
+        self,
+        cmd: List[str],
+    ) -> None:
+        super().__init__()
+        self.log.info("Running command: %s", " ".join(shlex.quote(c) for c in cmd))
+        self._proc = subprocess.Popen(
+            cmd,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+        )
+
+    def _process_fd(self, fd):
+        """
+        Prints output to logs.
+
+        :param fd: File descriptor.
+        """
+        if fd == self._proc.stderr:
+            while True:
+                line = self._proc.stderr.readline().decode()
+                if not line:
+                    return
+                self.log.warning(line.rstrip("\n"))
+
+        if fd == self._proc.stdout:
+            while True:
+                line = self._proc.stdout.readline().decode()
+                if not line:
+                    return
+                self.log.info(line.rstrip("\n"))
+
+        raise Exception("No data in stderr or in stdout.")
+
+    def wait_for_done(self) -> None:
+        """Waits for Apache Beam pipeline to complete."""
+        self.log.info("Start waiting for Apache Beam process to complete.")
+        reads = [self._proc.stderr, self._proc.stdout]
+        while True:
+            # Wait for at least one available fd.
+            readable_fds, _, _ = select.select(reads, [], [], 5)
+            if readable_fds is None:
+                self.log.info("Waiting for Apache Beam process to complete.")
+                continue
+
+            for readable_fd in readable_fds:
+                self._process_fd(readable_fd)
+
+            if self._proc.poll() is not None:
+                break
+
+        # Corner case: check if more output was created between the last read and the process termination
+        for readable_fd in reads:
+            self._process_fd(readable_fd)
+
+        self.log.info("Process exited with return code: %s", self._proc.returncode)
+
+        if self._proc.returncode != 0:
+            raise Exception(f"Apache Beam process failed with return code {self._proc.returncode}")
+
+
+class BeamHook(BaseHook):
+    """
+    Hook for Apache Beam.
+
+    All the methods in the hook where project_id is used must be called with
+    keyword arguments rather than positional.
+    """
+
+    def __init__(
+        self,
+        runner: str,
+    ) -> None:
+        self.runner = runner
+        super().__init__()
+
+    def _start_pipeline(
+        self,
+        variables: dict,
+        command_prefix: List[str],
+    ) -> None:
+        cmd = command_prefix + [
+            f"--runner={self.runner}",
+        ]
+        if variables:
+            cmd.extend(self._options_to_args(variables))
+        _BeamRunner(cmd=cmd).wait_for_done()
+
+    @staticmethod
+    def _options_to_args(variables: dict) -> List[str]:
+        if not variables:
+            return []
+        # The logic of this method should be compatible with Apache Beam:
+        # https://github.com/apache/beam/blob/b56740f0e8cd80c2873412847d0b336837429fb9/sdks/python/
+        # apache_beam/options/pipeline_options.py#L230-L251
+        args: List[str] = []
+        for attr, value in variables.items():
+            if value is None or (isinstance(value, bool) and value):
+                args.append(f"--{attr}")
+            elif isinstance(value, list):
+                args.extend([f"--{attr}={v}" for v in value])
+            else:
+                args.append(f"--{attr}={value}")
+        return args
+
+    def start_python_pipeline(  # pylint: disable=too-many-arguments
+        self,
+        variables: dict,
+        py_file: str,
+        py_options: List[str],
+        py_interpreter: str = "python3",
+        py_requirements: Optional[List[str]] = None,
+        py_system_site_packages: bool = False,
+    ):
+        """
+        Starts Apache Beam python pipeline.
+
+        :param variables: Variables passed to the pipeline.
+        :type variables: Dict
+        :param py_options: Additional options.
+        :type py_options: List[str]
+        :param py_interpreter: Python version of the Apache Beam pipeline.
+            If None, this defaults to the python3.
+            To track python versions supported by beam and related
+            issues check: https://issues.apache.org/jira/browse/BEAM-1251
+        :param py_requirements: Additional python package(s) to install.
+            If a value is passed to this parameter, a new virtual environment has been created with
+            additional packages installed.
+
+            You could also install the apache-beam package if it is not installed on your system or you want
+            to use a different version.
+        :type py_requirements: List[str]
+        :param py_system_site_packages: Whether to include system_site_packages in your virtualenv.
+            See virtualenv documentation for more information.
+
+            This option is only relevant if the ``py_requirements`` parameter is not None.
+        :type py_interpreter: str
+        """
+        if "labels" in variables:
+            variables["labels"] = [f"{key}={value}" for key, value in variables["labels"].items()]
+
+        if py_requirements is not None:
+            if not py_requirements and not py_system_site_packages:
+                warning_invalid_environment = textwrap.dedent(
+                    """\
+                    Invalid method invocation. You have disabled inclusion of system packages and empty list
+                    required for installation, so it is not possible to create a valid virtual environment.
+                    In the virtual environment, apache-beam package must be installed for your job to be \
+                    executed. To fix this problem:
+                    * install apache-beam on the system, then set parameter py_system_site_packages to True,
+                    * add apache-beam to the list of required packages in parameter py_requirements.
+                    """
+                )
+                raise AirflowException(warning_invalid_environment)
+
+            with TemporaryDirectory(prefix="apache-beam-venv") as tmp_dir:
+                py_interpreter = prepare_virtualenv(
+                    venv_directory=tmp_dir,
+                    python_bin=py_interpreter,
+                    system_site_packages=py_system_site_packages,
+                    requirements=py_requirements,
+                )
+                command_prefix = [py_interpreter] + py_options + [py_file]
+
+                self._start_pipeline(
+                    variables=variables,
+                    command_prefix=command_prefix,
+                )
+        else:
+            command_prefix = [py_interpreter] + py_options + [py_file]
+
+            self._start_pipeline(
+                variables=variables,
+                command_prefix=command_prefix,
+            )
+
+    def start_java_pipeline(
+        self,
+        variables: dict,
+        jar: str,
+        job_class: Optional[str] = None,
+    ) -> None:
+        """
+        Starts Apache Beam Java pipeline.
+
+        :param variables: Variables passed to the job.
+        :type variables: dict
+        :param jar: Name of the jar for the pipeline
+        :type job_class: str
+        :param job_class: Name of the java class for the pipeline.
+        :type job_class: str
+        """
+        if "labels" in variables:
+            variables["labels"] = json.dumps(variables["labels"], separators=(",", ":"))
+
+        command_prefix = ["java", "-cp", jar, job_class] if job_class else ["java", "-jar", jar]
+        self._start_pipeline(
+            variables=variables,
+            command_prefix=command_prefix,
+        )

--- a/airflow/providers/apache/beam/hooks/beam.py
+++ b/airflow/providers/apache/beam/hooks/beam.py
@@ -111,14 +111,11 @@ class BeamCommandRunner(LoggingMixin):
         if fd not in (self._proc.stdout, self._proc.stderr):
             raise Exception("No data in stderr or in stdout.")
 
-        func_proc, func_log = (
-            (self._proc.stderr, self.log.warning)
-            if fd == self._proc.stderr
-            else (self._proc.stdout, self.log.info)
-        )
+        fd_to_log = {self._proc.stderr: self.log.warning, self._proc.stdout: self.log.info}
+        func_log = fd_to_log[fd]
 
         while True:
-            line = func_proc.readline().decode()
+            line = fd.readline().decode()
             if not line:
                 return
             if self.process_line_callback:

--- a/airflow/providers/apache/beam/operators/__init__.py
+++ b/airflow/providers/apache/beam/operators/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -1,0 +1,407 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""This module contains Apache Beam operators."""
+import copy
+import re
+from contextlib import ExitStack
+from typing import List, Optional
+
+from airflow.models import BaseOperator
+from airflow.providers.apache.beam.hooks.beam import BeamHook
+from airflow.providers.google.cloud.hooks.dataflow import DataflowHook
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.utils.decorators import apply_defaults
+from airflow.version import version
+
+
+class BeamRunPythonPipelineOperator(BaseOperator):
+    """
+    Launching Apache Beam pipelines written in Python. Note that both
+    ``default_pipeline_options`` and ``pipeline_options`` will be merged to specify pipeline
+    execution parameter, and ``default_pipeline_options`` is expected to save
+    high-level options, for instances, project and zone information, which
+    apply to all beam operators in the DAG.
+
+    .. code-block:: python
+
+        default_args = {
+            'default_pipeline_options':
+                {
+                    'labels': 'example-label'
+                }
+        }
+
+        with models.DAG(
+            "example_beam_native_python",
+            default_args=default_args,
+            start_date=days_ago(1),
+            schedule_interval=None,
+            tags=['example'],
+        ) as dag_native_python:
+
+            start_python_job_local_direct_runner = BeamRunPythonPipelineOperator(
+                task_id="start_python_job_local_direct_runner",
+                runner="DirectRunner",
+                py_file='apache_beam.examples.wordcount',
+                py_options=['-m'],
+                py_requirements=['apache-beam[gcp]==2.21.0'],
+                py_interpreter='python3',
+                py_system_site_packages=False,
+            )
+
+    .. seealso::
+        For more detail on Apache Beam have a look at the reference:
+        https://beam.apache.org/documentation/
+
+    :param py_file: Reference to the python Apache Beam pipeline file.py, e.g.,
+        /some/local/file/path/to/your/python/pipeline/file. (templated)
+    :type py_file: str
+    :param runner: Runner on which pipeline will be run. By default "DirectRunner" is being used.
+        See:
+        https://beam.apache.org/documentation/runners/capability-matrix/
+        If you use Dataflow runner check dedicated operator:
+        :class:`~providers.google.cloud.operators.dataflow.DataflowCreatePythonJobOperator`
+    :type runner: str
+    :param py_options: Additional python options, e.g., ["-m", "-v"].
+    :type py_options: list[str]
+    :param default_pipeline_options: Map of default pipeline options.
+    :type default_pipeline_options: dict
+    :param pipeline_options: Map of pipeline options.The key must be a dictionary.
+        The value can contain different types:
+
+        * If the value is None, the single option - ``--key`` (without value) will be added.
+        * If the value is False, this option will be skipped
+        * If the value is True, the single option - ``--key`` (without value) will be added.
+        * If the value is list, the many options will be added for each key.
+          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key-B`` options
+          will be left
+        * Other value types will be replaced with the Python textual representation.
+
+        When defining labels (``labels`` option), you can also provide a dictionary.
+    :type pipeline_options: dict
+    :param py_interpreter: Python version of the beam pipeline.
+        If None, this defaults to the python3.
+        To track python versions supported by beam and related
+        issues check: https://issues.apache.org/jira/browse/BEAM-1251
+    :type py_interpreter: str
+    :param py_requirements: Additional python package(s) to install.
+        If a value is passed to this parameter, a new virtual environment has been created with
+        additional packages installed.
+
+        You could also install the apache_beam package if it is not installed on your system or you want
+        to use a different version.
+    :type py_requirements: List[str]
+    :param py_system_site_packages: Whether to include system_site_packages in your virtualenv.
+        See virtualenv documentation for more information.
+
+        This option is only relevant if the ``py_requirements`` parameter is not None.
+    :param project_id: (DataflowRunner) Optional,
+        the Google Cloud project ID in which to start a job.
+        If set to None or missing, the default project_id from the Google Cloud connection is used.
+    :type project_id: str
+    :param gcp_conn_id: (DataflowRunner) Optional.
+        The connection ID to use connecting to Google Cloud.
+    :type gcp_conn_id: str
+    :param job_name: (DataflowRunner) Optional.
+        The 'job_name' to use when executing the DataFlow job (templated).
+        This ends up being set in the pipeline options, so any entry
+        with key ``'jobName'`` or ``'job_name'`` in ``options`` will be overwritten.
+    :type job_name: str
+    :param delegate_to: (DataflowRunner) Optional.
+        The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    template_fields = ["py_file", "runner", "pipeline_options", "default_pipeline_options", "job_name"]
+
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        py_file: str,
+        runner: str = "DirectRunner",
+        default_pipeline_options: Optional[dict] = None,
+        pipeline_options: Optional[dict] = None,
+        py_interpreter: str = "python3",
+        py_options: Optional[List[str]] = None,
+        py_requirements: Optional[List[str]] = None,
+        py_system_site_packages: bool = False,
+        gcp_conn_id: str = "google_cloud_default",
+        project_id: Optional[str] = None,
+        job_name: str = "{{task.task_id}}",
+        delegate_to: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.py_file = py_file
+        self.runner = runner
+        self.py_options = py_options or []
+        self.default_pipeline_options = default_pipeline_options or {}
+        self.pipeline_options = pipeline_options or {}
+        self.pipeline_options.setdefault("labels", {}).update(
+            {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
+        )
+        self.py_interpreter = py_interpreter
+        self.py_requirements = py_requirements
+        self.py_system_site_packages = py_system_site_packages
+        self.gcp_conn_id = gcp_conn_id
+        self.job_name = job_name
+        self.project_id = project_id
+        self.job_id = None
+        self.delegate_to = delegate_to
+        self.hook: Optional[DataflowHook] = None
+
+    def execute(self, context):
+        """Execute the Apache Beam Pipeline."""
+        pipeline_options = self.default_pipeline_options.copy()
+        pipeline_options.update(self.pipeline_options)
+        # Convert argument names from lowerCamelCase to snake case.
+        camel_to_snake = lambda name: re.sub(r"[A-Z]", lambda x: "_" + x.group(0).lower(), name)
+        formatted_pipeline_options = {camel_to_snake(key): pipeline_options[key] for key in pipeline_options}
+
+        with ExitStack() as exit_stack:
+            if self.py_file.lower().startswith("gs://"):
+                gcs_hook = GCSHook(self.gcp_conn_id, self.delegate_to)
+                tmp_gcs_file = exit_stack.enter_context(  # pylint: disable=no-member
+                    gcs_hook.provide_file(object_url=self.py_file)
+                )
+                self.py_file = tmp_gcs_file.name
+
+            if self.runner == "DataflowRunner":
+                self.log.warning(
+                    "For more advanced option of DataflowRunner use: "
+                    "providers.google.cloud.operators.dataflow.DataflowCreatePythonJobOperator"
+                )
+                self.hook = DataflowHook(
+                    gcp_conn_id=self.gcp_conn_id,
+                )
+
+                def set_current_job_id(job_id):
+                    self.job_id = job_id
+
+                self.hook.start_python_dataflow(
+                    project_id=self.project_id,
+                    job_name=self.job_name,
+                    variables=formatted_pipeline_options,
+                    dataflow=self.py_file,
+                    py_options=self.py_options,
+                    py_interpreter=self.py_interpreter,
+                    py_requirements=self.py_requirements,
+                    py_system_site_packages=self.py_system_site_packages,
+                    on_new_job_id_callback=set_current_job_id,
+                )
+            else:
+                self.hook = BeamHook(runner=self.runner)
+                self.hook.start_python_pipeline(
+                    variables=formatted_pipeline_options,
+                    py_file=self.py_file,
+                    py_options=self.py_options,
+                    py_interpreter=self.py_interpreter,
+                    py_requirements=self.py_requirements,
+                    py_system_site_packages=self.py_system_site_packages,
+                )
+
+    def on_kill(self) -> None:
+        self.log.info("On kill.")
+        if self.runner == "DataflowRunner" and self.job_id:
+            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)
+
+
+# pylint: disable=too-many-instance-attributes
+class BeamRunJavaPipelineOperator(BaseOperator):
+    """
+    Launching Apache Beam pipelines written in Java.
+
+    Note that both
+    ``default_pipeline_options`` and ``pipeline_options`` will be merged to specify pipeline
+    execution parameter, and ``default_pipeline_options`` is expected to save
+    high-level pipeline_options, for instances, project and zone information, which
+    apply to all Apache Beam operators in the DAG.
+
+    It's a good practice to define parameters in the default_args of the dag
+    like the project, zone and staging location.
+
+    .. code-block:: python
+
+       default_args = {
+            'default_pipeline_options':
+                {
+                    'labels': 'example-label'
+                }
+        }
+
+    You need to pass the path to your jar file as a file reference with the ``jar``
+    parameter, the jar needs to be a self executing jar (see documentation here:
+    https://beam.apache.org/documentation/runners/dataflow/#self-executing-jar).
+    Use ``pipeline_options`` to pass on pipeline_options to your job.
+
+    .. code-block:: python
+
+       t1 = BeamRunJavaPipelineOperator(
+           task_id='start_java_job_spark_runner',
+           jar='{{var.value.spark_runner_jar_base}}pipeline/build/libs/pipeline-example-1.0.jar',
+           pipeline_options={
+               'output': '/tmp/start_java_job_spark_runner',
+               'inputFile': 'gs://apache-beam-samples/shakespeare/kinglear.txt,
+           },
+           dag=my-dag)
+
+    .. seealso::
+        For more detail on Apache Beam have a look at the reference:
+        https://beam.apache.org/documentation/
+
+    :param jar: The reference to a self executing Apache Beam jar (templated).
+    :type jar: str
+    :param runner: Runner on which pipeline will be run. By default "DirectRunner" is being used.
+        See:
+        https://beam.apache.org/documentation/runners/capability-matrix/
+        If you use Dataflow runner check dedicated operator:
+        :class:`~providers.google.cloud.operators.dataflow.DataflowCreateJavaJobOperator`
+    :type runner: str
+    :param job_class: The name of the Apache Beam pipeline class to be executed, it
+        is often not the main class configured in the pipeline jar file.
+    :type job_class: str
+    :param default_pipeline_options: Map of default job pipeline_options.
+    :type default_pipeline_options: dict
+    :param pipeline_options: Map of job specific pipeline_options.The key must be a dictionary.
+        The value can contain different types:
+
+        * If the value is None, the single option - ``--key`` (without value) will be added.
+        * If the value is False, this option will be skipped
+        * If the value is True, the single option - ``--key`` (without value) will be added.
+        * If the value is list, the many pipeline_options will be added for each key.
+          If the value is ``['A', 'B']`` and the key is ``key`` then the ``--key=A --key-B`` pipeline_options
+          will be left
+        * Other value types will be replaced with the Python textual representation.
+
+        When defining labels (``labels`` option), you can also provide a dictionary.
+    :type pipeline_options: dict
+    :param job_name: (DataflowRunner) The 'jobName' to use when executing the DataFlow job
+        (templated). This ends up being set in the pipeline pipeline_options, so any entry
+        with key ``'jobName'`` in ``pipeline_options`` will be overwritten.
+    :type job_name: str
+    :param project_id: (DataflowRunner) Optional, the Google Cloud project ID in which to start a job.
+        If set to None or missing, the default project_id from the Google Cloud connection is used.
+    :type project_id: str
+    :param gcp_conn_id: (DataflowRunner) The connection ID to use connecting to Google Cloud.
+    :type gcp_conn_id: str
+    :param delegate_to: (DataflowRunner) The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    """
+
+    template_fields = ["jar", "runner", "job_class", "pipeline_options", "job_name"]
+    ui_color = "#0273d4"
+
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        jar: str,
+        runner: str = "DirectRunner",
+        job_class: Optional[str] = None,
+        default_pipeline_options: Optional[dict] = None,
+        pipeline_options: Optional[dict] = None,
+        job_name: str = "{{task.task_id}}",
+        project_id: Optional[str] = None,
+        gcp_conn_id: str = "google_cloud_default",
+        delegate_to: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+
+        self.jar = jar
+        self.runner = runner
+        self.default_pipeline_options = default_pipeline_options or {}
+        self.pipeline_options = pipeline_options or {}
+        self.job_class = job_class
+        self.gcp_conn_id = gcp_conn_id
+        self.project_id = project_id
+        self.job_name = job_name
+        self.delegate_to = delegate_to
+        self.job_id = None
+        self.hook = None
+
+    def execute(self, context):
+        """Execute the Apache Beam Pipeline."""
+        pipeline_options = copy.copy(self.default_pipeline_options)
+        pipeline_options.update(self.pipeline_options)
+
+        with ExitStack() as exit_stack:
+            if self.jar.lower().startswith("gs://"):
+                gcs_hook = GCSHook(self.gcp_conn_id, self.delegate_to)
+                tmp_gcs_file = exit_stack.enter_context(  # pylint: disable=no-member
+                    gcs_hook.provide_file(object_url=self.jar)
+                )
+                self.jar = tmp_gcs_file.name
+
+            if self.runner == "DataflowRunner":
+                pipeline_options.setdefault("labels", {}).update(
+                    {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
+                )
+
+                self.log.warning(
+                    "For more advanced option of DataflowRunner use: "
+                    "providers.google.cloud.operators.dataflow.DataflowCreateJavaJobOperator"
+                )
+                self.hook = DataflowHook(
+                    gcp_conn_id=self.gcp_conn_id,
+                    delegate_to=self.delegate_to,
+                )
+
+                is_running = self.hook.is_job_dataflow_running(  # type: ignore[attr-defined]
+                    name=self.job_name,
+                    variables=pipeline_options,
+                    project_id=self.project_id,
+                )
+                while is_running:
+                    is_running = self.hook.is_job_dataflow_running(  # type: ignore[attr-defined]
+                        name=self.job_name,
+                        variables=pipeline_options,
+                        project_id=self.project_id,
+                    )
+
+                if not is_running:
+
+                    def set_current_job_id(job_id):
+                        self.job_id = job_id
+
+                    self.hook.start_java_dataflow(  # type: ignore[attr-defined]
+                        job_name=self.job_name,
+                        variables=pipeline_options,
+                        jar=self.jar,
+                        job_class=self.job_class,
+                        on_new_job_id_callback=set_current_job_id,
+                        project_id=self.project_id,
+                    )
+            else:
+                self.hook = BeamHook(runner=self.runner)
+                self.hook.start_java_pipeline(  # type: ignore[attr-defined]
+                    variables=pipeline_options,
+                    jar=self.jar,
+                    job_class=self.job_class,
+                )
+
+    def on_kill(self) -> None:
+        self.log.info("On kill.")
+        if self.runner == "DataflowRunner" and self.job_id:
+            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)

--- a/airflow/providers/apache/beam/operators/beam.py
+++ b/airflow/providers/apache/beam/operators/beam.py
@@ -40,32 +40,9 @@ class BeamRunPythonPipelineOperator(BaseOperator):
     high-level options, for instances, project and zone information, which
     apply to all beam operators in the DAG.
 
-    .. code-block:: python
-
-        default_args = {
-            'default_pipeline_options':
-                {
-                    'labels': 'example-label'
-                }
-        }
-
-        with models.DAG(
-            "example_beam_native_python",
-            default_args=default_args,
-            start_date=days_ago(1),
-            schedule_interval=None,
-            tags=['example'],
-        ) as dag_native_python:
-
-            start_python_job_local_direct_runner = BeamRunPythonPipelineOperator(
-                task_id="start_python_job_local_direct_runner",
-                runner="DirectRunner",
-                py_file='apache_beam.examples.wordcount',
-                py_options=['-m'],
-                py_requirements=['apache-beam[gcp]==2.21.0'],
-                py_interpreter='python3',
-                py_system_site_packages=False,
-            )
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BeamRunPythonPipelineOperator`
 
     .. seealso::
         For more detail on Apache Beam have a look at the reference:
@@ -266,37 +243,18 @@ class BeamRunJavaPipelineOperator(BaseOperator):
     high-level pipeline_options, for instances, project and zone information, which
     apply to all Apache Beam operators in the DAG.
 
-    It's a good practice to define parameters in the default_args of the dag
-    like the project, zone and staging location.
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BeamRunJavaPipelineOperator`
 
-    .. code-block:: python
-
-       default_args = {
-            'default_pipeline_options':
-                {
-                    'labels': 'example-label'
-                }
-        }
+    .. seealso::
+        For more detail on Apache Beam have a look at the reference:
+        https://beam.apache.org/documentation/
 
     You need to pass the path to your jar file as a file reference with the ``jar``
     parameter, the jar needs to be a self executing jar (see documentation here:
     https://beam.apache.org/documentation/runners/dataflow/#self-executing-jar).
     Use ``pipeline_options`` to pass on pipeline_options to your job.
-
-    .. code-block:: python
-
-       t1 = BeamRunJavaPipelineOperator(
-           task_id='start_java_job_spark_runner',
-           jar='{{var.value.spark_runner_jar_base}}pipeline/build/libs/pipeline-example-1.0.jar',
-           pipeline_options={
-               'output': '/tmp/start_java_job_spark_runner',
-               'inputFile': 'gs://apache-beam-samples/shakespeare/kinglear.txt,
-           },
-           dag=my-dag)
-
-    .. seealso::
-        For more detail on Apache Beam have a look at the reference:
-        https://beam.apache.org/documentation/
 
     :param jar: The reference to a self executing Apache Beam jar (templated).
     :type jar: str

--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -27,6 +27,8 @@ versions:
 integrations:
   - integration-name: Apache Beam
     external-doc-url: https://beam.apache.org/
+    how-to-guide:
+      - /docs/apache-airflow-providers-apache-beam/operators.rst
     tags: [apache]
 
 operators:
@@ -38,3 +40,6 @@ hooks:
   - integration-name: Apache Beam
     python-modules:
       - airflow.providers.apache.beam.hooks.beam
+
+hook-class-names:
+  - airflow.providers.apache.beam.hooks.beam.BeamHook

--- a/airflow/providers/apache/beam/provider.yaml
+++ b/airflow/providers/apache/beam/provider.yaml
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+---
+package-name: apache-airflow-providers-apache-beam
+name: Apache Beam
+description: |
+    `Apache Beam <https://beam.apache.org/>`__.
+
+versions:
+  - 0.0.1
+
+integrations:
+  - integration-name: Apache Beam
+    external-doc-url: https://beam.apache.org/
+    tags: [apache]
+
+operators:
+  - integration-name: Apache Beam
+    python-modules:
+      - airflow.providers.apache.beam.operators.beam
+
+hooks:
+  - integration-name: Apache Beam
+    python-modules:
+      - airflow.providers.apache.beam.hooks.beam

--- a/airflow/providers/dependencies.json
+++ b/airflow/providers/dependencies.json
@@ -35,6 +35,7 @@
   ],
   "google": [
     "amazon",
+    "apache.beam",
     "apache.cassandra",
     "cncf.kubernetes",
     "facebook",

--- a/airflow/providers/dependencies.json
+++ b/airflow/providers/dependencies.json
@@ -10,6 +10,9 @@
     "postgres",
     "ssh"
   ],
+  "apache.beam": [
+    "google"
+  ],
   "apache.druid": [
     "apache.hive"
   ],

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -176,6 +176,9 @@ class DataflowCreateJavaJobOperator(BaseOperator):
     Start a Java Cloud DataFlow batch job. The parameters of the operation
     will be passed to the job.
 
+    This class is deprecated.
+    Please use `providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator`.
+
     **Example**: ::
 
         default_args = {
@@ -935,6 +938,9 @@ class DataflowCreatePythonJobOperator(BaseOperator):
     execution parameter, and dataflow_default_options is expected to save
     high-level options, for instances, project and zone information, which
     apply to all dataflow operators in the DAG.
+
+    This class is deprecated.
+    Please use `providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator`.
 
     .. seealso::
         For more detail on job submission have a look at the reference:

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -16,15 +16,20 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains Google Dataflow operators."""
-
 import copy
 import re
+import warnings
 from contextlib import ExitStack
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Union
 
 from airflow.models import BaseOperator
-from airflow.providers.google.cloud.hooks.dataflow import DEFAULT_DATAFLOW_LOCATION, DataflowHook
+from airflow.providers.apache.beam.hooks.beam import BeamHook, BeamRunnerType
+from airflow.providers.google.cloud.hooks.dataflow import (
+    DEFAULT_DATAFLOW_LOCATION,
+    DataflowHook,
+    process_line_and_extract_dataflow_job_id_callback,
+)
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
 from airflow.utils.decorators import apply_defaults
 from airflow.version import version
@@ -41,6 +46,128 @@ class CheckJobRunning(Enum):
     IgnoreJob = 1
     FinishIfRunning = 2
     WaitForRun = 3
+
+
+class DataflowConfiguration:
+    """Dataflow configuration that can be passed to
+    :py:class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` and
+    :py:class:`~airflow.providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator`.
+
+    :param job_name: The 'jobName' to use when executing the DataFlow job
+        (templated). This ends up being set in the pipeline options, so any entry
+        with key ``'jobName'`` or  ``'job_name'``in ``options`` will be overwritten.
+    :type job_name: str
+    :param append_job_name: True if unique suffix has to be appended to job name.
+    :type append_job_name: bool
+    :param project_id: Optional, the Google Cloud project ID in which to start a job.
+        If set to None or missing, the default project_id from the Google Cloud connection is used.
+    :type project_id: str
+    :param location: Job location.
+    :type location: str
+    :param gcp_conn_id: The connection ID to use connecting to Google Cloud.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param poll_sleep: The time in seconds to sleep between polling Google
+        Cloud Platform for the dataflow job status while the job is in the
+        JOB_STATE_RUNNING state.
+    :type poll_sleep: int
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+    :param drain_pipeline: Optional, set to True if want to stop streaming job by draining it
+        instead of canceling during during killing task instance. See:
+        https://cloud.google.com/dataflow/docs/guides/stopping-a-pipeline
+    :type drain_pipeline: bool
+    :param cancel_timeout: How long (in seconds) operator should wait for the pipeline to be
+        successfully cancelled when task is being killed.
+    :type cancel_timeout: Optional[int]
+    :param wait_until_finished: (Optional)
+        If True, wait for the end of pipeline execution before exiting.
+        If False, only submits job.
+        If None, default behavior.
+
+        The default behavior depends on the type of pipeline:
+
+        * for the streaming pipeline, wait for jobs to start,
+        * for the batch pipeline, wait for the jobs to complete.
+
+        .. warning::
+
+            You cannot call ``PipelineResult.wait_until_finish`` method in your pipeline code for the operator
+            to work properly. i. e. you must use asynchronous execution. Otherwise, your pipeline will
+            always wait until finished. For more information, look at:
+            `Asynchronous execution
+            <https://cloud.google.com/dataflow/docs/guides/specifying-exec-params#python_10>`__
+
+        The process of starting the Dataflow job in Airflow consists of two steps:
+
+        * running a subprocess and reading the stderr/stderr log for the job id.
+        * loop waiting for the end of the job ID from the previous step.
+          This loop checks the status of the job.
+
+        Step two is started just after step one has finished, so if you have wait_until_finished in your
+        pipeline code, step two will not start until the process stops. When this process stops,
+        steps two will run, but it will only execute one iteration as the job will be in a terminal state.
+
+        If you in your pipeline do not call the wait_for_pipeline method but pass wait_until_finish=True
+        to the operator, the second loop will wait for the job's terminal state.
+
+        If you in your pipeline do not call the wait_for_pipeline method, and pass wait_until_finish=False
+        to the operator, the second loop will check once is job not in terminal state and exit the loop.
+    :type wait_until_finished: Optional[bool]
+    :param multiple_jobs: If pipeline creates multiple jobs then monitor all jobs. Supported only by
+        :py:class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator`
+    :type multiple_jobs: boolean
+    :param check_if_running: Before running job, validate that a previous run is not in process.
+        IgnoreJob = do not check if running.
+        FinishIfRunning = if job is running finish with nothing.
+        WaitForRun = wait until job finished and the run job.
+        Supported only by:
+        :py:class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator`
+    :type check_if_running: CheckJobRunning
+    """
+
+    template_fields = ["job_name", "location"]
+
+    def __init__(
+        self,
+        *,
+        job_name: Optional[str] = "{{task.task_id}}",
+        append_job_name: bool = True,
+        project_id: Optional[str] = None,
+        location: Optional[str] = DEFAULT_DATAFLOW_LOCATION,
+        gcp_conn_id: str = "google_cloud_default",
+        delegate_to: Optional[str] = None,
+        poll_sleep: int = 10,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        drain_pipeline: bool = False,
+        cancel_timeout: Optional[int] = 5 * 60,
+        wait_until_finished: Optional[bool] = None,
+        multiple_jobs: Optional[bool] = None,
+        check_if_running: CheckJobRunning = CheckJobRunning.WaitForRun,
+    ) -> None:
+        self.job_name = job_name
+        self.append_job_name = append_job_name
+        self.project_id = project_id
+        self.location = location
+        self.gcp_conn_id = gcp_conn_id
+        self.delegate_to = delegate_to
+        self.poll_sleep = poll_sleep
+        self.impersonation_chain = impersonation_chain
+        self.drain_pipeline = drain_pipeline
+        self.cancel_timeout = cancel_timeout
+        self.wait_until_finished = wait_until_finished
+        self.multiple_jobs = multiple_jobs
+        self.check_if_running = check_if_running
 
 
 # pylint: disable=too-many-instance-attributes
@@ -239,6 +366,14 @@ class DataflowCreateJavaJobOperator(BaseOperator):
         wait_until_finished: Optional[bool] = None,
         **kwargs,
     ) -> None:
+        # TODO: Remove one day
+        warnings.warn(
+            "The `{cls}` operator is deprecated, please use "
+            "`providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` instead."
+            "".format(cls=self.__class__.__name__),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**kwargs)
 
         dataflow_default_options = dataflow_default_options or {}
@@ -261,62 +396,83 @@ class DataflowCreateJavaJobOperator(BaseOperator):
         self.cancel_timeout = cancel_timeout
         self.wait_until_finished = wait_until_finished
         self.job_id = None
-        self.hook = None
+        self.beam_hook: Optional[BeamHook] = None
+        self.dataflow_hook: Optional[DataflowHook] = None
 
     def execute(self, context):
-        self.hook = DataflowHook(
+        """Execute the Apache Beam Pipeline."""
+        self.beam_hook = BeamHook(runner=BeamRunnerType.DataflowRunner)
+        self.dataflow_hook = DataflowHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
             poll_sleep=self.poll_sleep,
             cancel_timeout=self.cancel_timeout,
             wait_until_finished=self.wait_until_finished,
         )
-        dataflow_options = copy.copy(self.dataflow_default_options)
-        dataflow_options.update(self.options)
-        is_running = False
-        if self.check_if_running != CheckJobRunning.IgnoreJob:
-            is_running = self.hook.is_job_dataflow_running(  # type: ignore[attr-defined]
-                name=self.job_name,
-                variables=dataflow_options,
-                project_id=self.project_id,
-                location=self.location,
-            )
-            while is_running and self.check_if_running == CheckJobRunning.WaitForRun:
-                is_running = self.hook.is_job_dataflow_running(  # type: ignore[attr-defined]
-                    name=self.job_name,
-                    variables=dataflow_options,
-                    project_id=self.project_id,
-                    location=self.location,
-                )
+        job_name = self.dataflow_hook.build_dataflow_job_name(job_name=self.job_name)
+        pipeline_options = copy.deepcopy(self.dataflow_default_options)
 
-        if not is_running:
-            with ExitStack() as exit_stack:
-                if self.jar.lower().startswith("gs://"):
-                    gcs_hook = GCSHook(self.gcp_conn_id, self.delegate_to)
-                    tmp_gcs_file = exit_stack.enter_context(  # pylint: disable=no-member
-                        gcs_hook.provide_file(object_url=self.jar)
+        pipeline_options["jobName"] = self.job_name
+        pipeline_options["project"] = self.project_id or self.dataflow_hook.project_id
+        pipeline_options["region"] = self.location
+        pipeline_options.update(self.options)
+        pipeline_options.setdefault("labels", {}).update(
+            {"airflow-version": "v" + version.replace(".", "-").replace("+", "-")}
+        )
+        pipeline_options.update(self.options)
+
+        def set_current_job_id(job_id):
+            self.job_id = job_id
+
+        process_line_callback = process_line_and_extract_dataflow_job_id_callback(
+            on_new_job_id_callback=set_current_job_id
+        )
+
+        with ExitStack() as exit_stack:
+            if self.jar.lower().startswith("gs://"):
+                gcs_hook = GCSHook(self.gcp_conn_id, self.delegate_to)
+                tmp_gcs_file = exit_stack.enter_context(  # pylint: disable=no-member
+                    gcs_hook.provide_file(object_url=self.jar)
+                )
+                self.jar = tmp_gcs_file.name
+
+                is_running = False
+                if self.check_if_running != CheckJobRunning.IgnoreJob:
+                    is_running = (
+                        self.dataflow_hook.is_job_dataflow_running(  # pylint: disable=no-value-for-parameter
+                            name=self.job_name,
+                            variables=pipeline_options,
+                        )
                     )
-                    self.jar = tmp_gcs_file.name
+                    while is_running and self.check_if_running == CheckJobRunning.WaitForRun:
+                        # pylint: disable=no-value-for-parameter
+                        is_running = self.dataflow_hook.is_job_dataflow_running(
+                            name=self.job_name,
+                            variables=pipeline_options,
+                        )
+                if not is_running:
+                    pipeline_options["jobName"] = job_name
+                    self.beam_hook.start_java_pipeline(
+                        variables=pipeline_options,
+                        jar=self.jar,
+                        job_class=self.job_class,
+                        process_line_callback=process_line_callback,
+                    )
+                    self.dataflow_hook.wait_for_done(  # pylint: disable=no-value-for-parameter
+                        job_name=job_name,
+                        location=self.location,
+                        job_id=self.job_id,
+                        multiple_jobs=self.multiple_jobs,
+                    )
 
-                def set_current_job_id(job_id):
-                    self.job_id = job_id
-
-                self.hook.start_java_dataflow(  # type: ignore[attr-defined]
-                    job_name=self.job_name,
-                    variables=dataflow_options,
-                    jar=self.jar,
-                    job_class=self.job_class,
-                    append_job_name=True,
-                    multiple_jobs=self.multiple_jobs,
-                    on_new_job_id_callback=set_current_job_id,
-                    project_id=self.project_id,
-                    location=self.location,
-                )
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
         if self.job_id:
-            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)
+            self.dataflow_hook.cancel_job(
+                job_id=self.job_id, project_id=self.project_id or self.dataflow_hook.project_id
+            )
 
 
 # pylint: disable=too-many-instance-attributes
@@ -910,7 +1066,14 @@ class DataflowCreatePythonJobOperator(BaseOperator):
         wait_until_finished: Optional[bool] = None,
         **kwargs,
     ) -> None:
-
+        # TODO: Remove one day
+        warnings.warn(
+            "The `{cls}` operator is deprecated, please use "
+            "`providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator` instead."
+            "".format(cls=self.__class__.__name__),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**kwargs)
 
         self.py_file = py_file
@@ -933,10 +1096,40 @@ class DataflowCreatePythonJobOperator(BaseOperator):
         self.cancel_timeout = cancel_timeout
         self.wait_until_finished = wait_until_finished
         self.job_id = None
-        self.hook: Optional[DataflowHook] = None
+        self.beam_hook: Optional[BeamHook] = None
+        self.dataflow_hook: Optional[DataflowHook] = None
 
     def execute(self, context):
         """Execute the python dataflow job."""
+        self.beam_hook = BeamHook(runner=BeamRunnerType.DataflowRunner)
+        self.dataflow_hook = DataflowHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            poll_sleep=self.poll_sleep,
+            impersonation_chain=None,
+            drain_pipeline=self.drain_pipeline,
+            cancel_timeout=self.cancel_timeout,
+            wait_until_finished=self.wait_until_finished,
+        )
+
+        job_name = self.dataflow_hook.build_dataflow_job_name(job_name=self.job_name)
+        pipeline_options = self.dataflow_default_options.copy()
+        pipeline_options["job_name"] = job_name
+        pipeline_options["project"] = self.project_id or self.dataflow_hook.project_id
+        pipeline_options["region"] = self.location
+        pipeline_options.update(self.options)
+
+        # Convert argument names from lowerCamelCase to snake case.
+        camel_to_snake = lambda name: re.sub(r"[A-Z]", lambda x: "_" + x.group(0).lower(), name)
+        formatted_pipeline_options = {camel_to_snake(key): pipeline_options[key] for key in pipeline_options}
+
+        def set_current_job_id(job_id):
+            self.job_id = job_id
+
+        process_line_callback = process_line_and_extract_dataflow_job_id_callback(
+            on_new_job_id_callback=set_current_job_id
+        )
+
         with ExitStack() as exit_stack:
             if self.py_file.lower().startswith("gs://"):
                 gcs_hook = GCSHook(self.gcp_conn_id, self.delegate_to)
@@ -945,38 +1138,28 @@ class DataflowCreatePythonJobOperator(BaseOperator):
                 )
                 self.py_file = tmp_gcs_file.name
 
-            self.hook = DataflowHook(
-                gcp_conn_id=self.gcp_conn_id,
-                delegate_to=self.delegate_to,
-                poll_sleep=self.poll_sleep,
-                drain_pipeline=self.drain_pipeline,
-                cancel_timeout=self.cancel_timeout,
-                wait_until_finished=self.wait_until_finished,
-            )
-            dataflow_options = self.dataflow_default_options.copy()
-            dataflow_options.update(self.options)
-            # Convert argument names from lowerCamelCase to snake case.
-            camel_to_snake = lambda name: re.sub(r"[A-Z]", lambda x: "_" + x.group(0).lower(), name)
-            formatted_options = {camel_to_snake(key): dataflow_options[key] for key in dataflow_options}
-
-            def set_current_job_id(job_id):
-                self.job_id = job_id
-
-            self.hook.start_python_dataflow(  # type: ignore[attr-defined]
-                job_name=self.job_name,
-                variables=formatted_options,
-                dataflow=self.py_file,
+            self.beam_hook.start_python_pipeline(
+                variables=formatted_pipeline_options,
+                py_file=self.py_file,
                 py_options=self.py_options,
                 py_interpreter=self.py_interpreter,
                 py_requirements=self.py_requirements,
                 py_system_site_packages=self.py_system_site_packages,
-                on_new_job_id_callback=set_current_job_id,
-                project_id=self.project_id,
-                location=self.location,
+                process_line_callback=process_line_callback,
             )
-            return {"job_id": self.job_id}
+
+            self.dataflow_hook.wait_for_done(  # pylint: disable=no-value-for-parameter
+                job_name=job_name,
+                location=self.location,
+                job_id=self.job_id,
+                multiple_jobs=False,
+            )
+
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
         if self.job_id:
-            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)
+            self.dataflow_hook.cancel_job(
+                job_id=self.job_id, project_id=self.project_id or self.dataflow_hook.project_id
+            )

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -790,8 +790,10 @@ def convert_git_changes_to_table(
                 f"`{message_without_backticks}`" if markdown else f"``{message_without_backticks}``",
             )
         )
-    table = tabulate(table_data, headers=headers, tablefmt="pipe" if markdown else "rst")
     header = ""
+    if not table_data:
+        return header
+    table = tabulate(table_data, headers=headers, tablefmt="pipe" if markdown else "rst")
     if not markdown:
         header += f"\n\n{print_version}\n" + "." * len(print_version) + "\n\n"
         release_date = table_data[0][1]

--- a/docs/apache-airflow-providers-apache-beam/index.rst
+++ b/docs/apache-airflow-providers-apache-beam/index.rst
@@ -26,3 +26,5 @@ Content
     :caption: References
 
     Python API <_api/airflow/providers/apache/beam/index>
+    PyPI Repository <https://pypi.org/project/apache-airflow-providers-apache-beam/>
+    Example DAGs <https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags>

--- a/docs/apache-airflow-providers-apache-beam/index.rst
+++ b/docs/apache-airflow-providers-apache-beam/index.rst
@@ -1,0 +1,28 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+``apache-airflow-providers-apache-beam``
+========================================
+
+Content
+-------
+
+.. toctree::
+    :maxdepth: 1
+    :caption: References
+
+    Python API <_api/airflow/providers/apache/beam/index>

--- a/docs/apache-airflow-providers-apache-beam/index.rst
+++ b/docs/apache-airflow-providers-apache-beam/index.rst
@@ -28,3 +28,9 @@ Content
     Python API <_api/airflow/providers/apache/beam/index>
     PyPI Repository <https://pypi.org/project/apache-airflow-providers-apache-beam/>
     Example DAGs <https://github.com/apache/airflow/tree/master/airflow/providers/apache/beam/example_dags>
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Guides
+
+    Operators <operators>

--- a/docs/apache-airflow-providers-apache-beam/operators.rst
+++ b/docs/apache-airflow-providers-apache-beam/operators.rst
@@ -1,0 +1,116 @@
+
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Apache Beam Operators
+=====================
+
+`Apache Beam <https://beam.apache.org/>`__ is an open source, unified model for defining both batch and
+streaming data-parallel processing pipelines. Using one of the open source Beam SDKs, you build a program
+that defines the pipeline. The pipeline is then executed by one of Beam’s supported distributed processing
+back-ends, which include Apache Flink, Apache Spark, and Google Cloud Dataflow.
+
+
+.. _howto/operator:BeamRunPythonPipelineOperator:
+
+Run Python Pipelines in Apache Beam
+===================================
+
+The ``py_file`` argument must be specified for
+:class:`~airflow.providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator`
+as it contains the pipeline to be executed by Beam. The Python file can be available on GCS that Airflow
+has the ability to download or available on the local filesystem (provide the absolute path to it).
+
+The ``py_interpreter`` argument specifies the Python version to be used when executing the pipeline, the default
+is ``python3`. If your Airflow instance is running on Python 2 - specify ``python2`` and ensure your ``py_file`` is
+in Python 2. For best results, use Python 3.
+
+If ``py_requirements`` argument is specified a temporary Python virtual environment with specified requirements will be created
+and within it pipeline will run.
+
+The ``py_system_site_packages`` argument specifies whether or not all the Python packages from your Airflow instance,
+will be accessible within virtual environment (if ``py_requirements`` argument is specified),
+recommend avoiding unless the Dataflow job requires it.
+
+Python Pipelines with DirectRunner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_python_direct_runner_pipeline_local_file]
+    :end-before: [END howto_operator_start_python_direct_runner_pipeline_local_file]
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_python_direct_runner_pipeline_gcs_file]
+    :end-before: [END howto_operator_start_python_direct_runner_pipeline_gcs_file]
+
+Python Pipelines with DataflowRunner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_python_dataflow_runner_pipeline_gcs_file]
+    :end-before: [END howto_operator_start_python_dataflow_runner_pipeline_gcs_file]
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]
+    :end-before: [END howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]
+
+.. _howto/operator:BeamRunJavaPipelineOperator:
+
+Run Java Pipelines in Apache Beam
+=================================
+
+For Java pipeline the ``jar`` argument must be specified for
+:class:`~airflow.providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator`
+as it contains the pipeline to be executed by Apache Beam. The JAR can be available on GCS that Airflow
+has the ability to download or available on the local filesystem (provide the absolute path to it).
+
+Java Pipelines with DirectRunner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_java_direct_runner_pipeline]
+    :end-before: [END howto_operator_start_java_direct_runner_pipeline
+
+Java Pipelines with DataflowRunner
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. exampleinclude:: /../../airflow/providers/apache/beam/example_dags/example_beam.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_start_java_dataflow_runner_pipeline]
+    :end-before: [END howto_operator_start_java_dataflow_runner_pipeline
+
+Reference
+^^^^^^^^^
+
+For further information, look at:
+
+* `Apache Beam Documentation <https://beam.apache.org/documentation/>`__
+* `Google Cloud API Documentation <https://cloud.google.com/dataflow/docs/apis>`__
+* `Product Documentation <https://cloud.google.com/dataflow/docs/>`__
+* `Dataflow Monitoring Interface <https://cloud.google.com/dataflow/docs/guides/using-monitoring-intf/>`__
+* `Dataflow Command-line Interface <https://cloud.google.com/dataflow/docs/guides/using-command-line-intf/>`__

--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -50,7 +50,7 @@ Those are extras that add dependencies needed for integration with other Apache 
 +=====================+=====================================================+======================================================================+===========+
 | apache.atlas        | ``pip install 'apache-airflow[apache.atlas]'``      | Apache Atlas to use Data Lineage feature                             |           |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------+-----------+
-| apache.beam         | ``pip install 'apache-airflow[apache.beam]'``       | Apache Beam operators & hooks                                        |           |
+| apache.beam         | ``pip install 'apache-airflow[apache.beam]'``       | Apache Beam operators & hooks                                        |     *     |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------+-----------+
 | apache.cassandra    | ``pip install 'apache-airflow[apache.cassandra]'``  | Cassandra related operators & hooks                                  |     *     |
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------+-----------+

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -141,6 +141,7 @@ Fileshares
 Filesystem
 Firehose
 Firestore
+Flink
 FluentD
 Fokko
 Formaturas
@@ -324,6 +325,7 @@ Seki
 Sendgrid
 Siddharth
 SlackHook
+Spark
 SparkPi
 SparkR
 SparkSQL

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -95,7 +95,7 @@ function discover_all_provider_packages() {
     # Columns is to force it wider, so it doesn't wrap at 80 characters
     COLUMNS=180 airflow providers list
 
-    local expected_number_of_providers=62
+    local expected_number_of_providers=63
     local actual_number_of_providers
     actual_providers=$(airflow providers list --output yaml | grep package_name)
     actual_number_of_providers=$(wc -l <<<"$actual_providers")

--- a/setup.py
+++ b/setup.py
@@ -522,7 +522,7 @@ devel_hadoop = devel_minreq + hdfs + hive + kerberos + presto + webhdfs
 # Dict of all providers which are part of the Apache Airflow repository together with their requirements
 PROVIDERS_REQUIREMENTS: Dict[str, List[str]] = {
     'amazon': amazon,
-    'apache.beam': google,
+    'apache.beam': apache_beam,
     'apache.cassandra': cassandra,
     'apache.druid': druid,
     'apache.hdfs': hdfs,

--- a/setup.py
+++ b/setup.py
@@ -522,6 +522,7 @@ devel_hadoop = devel_minreq + hdfs + hive + kerberos + presto + webhdfs
 # Dict of all providers which are part of the Apache Airflow repository together with their requirements
 PROVIDERS_REQUIREMENTS: Dict[str, List[str]] = {
     'amazon': amazon,
+    'apache.beam': google,
     'apache.cassandra': cassandra,
     'apache.druid': druid,
     'apache.hdfs': hdfs,

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -22,6 +22,7 @@ from airflow.providers_manager import ProvidersManager
 
 ALL_PROVIDERS = [
     'apache-airflow-providers-amazon',
+    'apache-airflow-providers-apache-beam',
     'apache-airflow-providers-apache-cassandra',
     'apache-airflow-providers-apache-druid',
     'apache-airflow-providers-apache-hdfs',

--- a/tests/providers/apache/beam/__init__.py
+++ b/tests/providers/apache/beam/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/apache/beam/hooks/__init__.py
+++ b/tests/providers/apache/beam/hooks/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/apache/beam/hooks/test_beam.py
+++ b/tests/providers/apache/beam/hooks/test_beam.py
@@ -1,0 +1,242 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import copy
+import subprocess
+import unittest
+from unittest import mock
+from unittest.mock import MagicMock
+
+from parameterized import parameterized
+
+from airflow.exceptions import AirflowException
+from airflow.providers.apache.beam.hooks.beam import BeamHook, _BeamRunner
+
+PY_FILE = 'apache_beam.examples.wordcount'
+JAR_FILE = 'unitest.jar'
+JOB_CLASS = 'com.example.UnitTest'
+PY_OPTIONS = ['-m']
+TEST_JOB_ID = 'test-job-id'
+
+DEFAULT_RUNNER = "DirectRunner"
+BEAM_STRING = 'airflow.providers.apache.beam.hooks.beam.{}'
+BEAM_VARIABLES_PY = {'output': 'gs://test/output', 'labels': {'foo': 'bar'}}
+BEAM_VARIABLES_JAVA = {
+    'output': 'gs://test/output',
+    'labels': {'foo': 'bar'},
+}
+
+APACHE_BEAM_V_2_14_0_JAVA_SDK_LOG = f""""\
+Dataflow SDK version: 2.14.0
+Jun 15, 2020 2:57:28 PM org.apache.beam.runners.dataflow.DataflowRunner run
+INFO: To access the Dataflow monitoring console, please navigate to https://console.cloud.google.com/dataflow\
+/jobsDetail/locations/europe-west3/jobs/{TEST_JOB_ID}?project=XXX
+Submitted job: {TEST_JOB_ID}
+Jun 15, 2020 2:57:28 PM org.apache.beam.runners.dataflow.DataflowRunner run
+INFO: To cancel the job using the 'gcloud' tool, run:
+> gcloud dataflow jobs --project=XXX cancel --region=europe-west3 {TEST_JOB_ID}
+"""
+
+
+class TestBeamHook(unittest.TestCase):
+    @mock.patch(BEAM_STRING.format('_BeamRunner'))
+    def test_start_python_pipeline(self, mock_runner):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+
+        hook.start_python_pipeline(  # pylint: disable=no-value-for-parameter
+            variables=copy.deepcopy(BEAM_VARIABLES_PY),
+            py_file=PY_FILE,
+            py_options=PY_OPTIONS,
+        )
+
+        expected_cmd = [
+            "python3",
+            '-m',
+            PY_FILE,
+            f'--runner={DEFAULT_RUNNER}',
+            '--output=gs://test/output',
+            '--labels=foo=bar',
+        ]
+        mock_runner.assert_called_once_with(cmd=expected_cmd)
+        wait_for_done.assert_called_once_with()
+
+    @parameterized.expand(
+        [
+            ('default_to_python3', 'python3'),
+            ('major_version_2', 'python2'),
+            ('major_version_3', 'python3'),
+            ('minor_version', 'python3.6'),
+        ]
+    )
+    @mock.patch(BEAM_STRING.format('_BeamRunner'))
+    def test_start_python_pipeline_with_custom_interpreter(self, _, py_interpreter, mock_runner):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+
+        hook.start_python_pipeline(  # pylint: disable=no-value-for-parameter
+            variables=copy.deepcopy(BEAM_VARIABLES_PY),
+            py_file=PY_FILE,
+            py_options=PY_OPTIONS,
+            py_interpreter=py_interpreter,
+        )
+
+        expected_cmd = [
+            py_interpreter,
+            '-m',
+            PY_FILE,
+            f'--runner={DEFAULT_RUNNER}',
+            '--output=gs://test/output',
+            '--labels=foo=bar',
+        ]
+        mock_runner.assert_called_once_with(cmd=expected_cmd)
+        wait_for_done.assert_called_once_with()
+
+    @parameterized.expand(
+        [
+            (['foo-bar'], False),
+            (['foo-bar'], True),
+            ([], True),
+        ]
+    )
+    @mock.patch(BEAM_STRING.format('prepare_virtualenv'))
+    @mock.patch(BEAM_STRING.format('_BeamRunner'))
+    def test_start_python_pipeline_with_non_empty_py_requirements_and_without_system_packages(
+        self, current_py_requirements, current_py_system_site_packages, mock_runner, mock_virtualenv
+    ):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+        mock_virtualenv.return_value = '/dummy_dir/bin/python'
+
+        hook.start_python_pipeline(  # pylint: disable=no-value-for-parameter
+            variables=copy.deepcopy(BEAM_VARIABLES_PY),
+            py_file=PY_FILE,
+            py_options=PY_OPTIONS,
+            py_requirements=current_py_requirements,
+            py_system_site_packages=current_py_system_site_packages,
+        )
+
+        expected_cmd = [
+            '/dummy_dir/bin/python',
+            '-m',
+            PY_FILE,
+            f'--runner={DEFAULT_RUNNER}',
+            '--output=gs://test/output',
+            '--labels=foo=bar',
+        ]
+        mock_runner.assert_called_once_with(cmd=expected_cmd)
+        wait_for_done.assert_called_once_with()
+        mock_virtualenv.assert_called_once_with(
+            venv_directory=mock.ANY,
+            python_bin="python3",
+            system_site_packages=current_py_system_site_packages,
+            requirements=current_py_requirements,
+        )
+
+    @mock.patch(BEAM_STRING.format('_BeamRunner'))
+    def test_start_python_pipeline_with_empty_py_requirements_and_without_system_packages(self, mock_runner):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+
+        with self.assertRaisesRegex(AirflowException, "Invalid method invocation."):
+            hook.start_python_pipeline(  # pylint: disable=no-value-for-parameter
+                variables=copy.deepcopy(BEAM_VARIABLES_PY),
+                py_file=PY_FILE,
+                py_options=PY_OPTIONS,
+                py_requirements=[],
+            )
+
+        mock_runner.assert_not_called()
+        wait_for_done.assert_not_called()
+
+    @mock.patch(BEAM_STRING.format('_BeamRunner'))
+    def test_start_java_pipeline(self, mock_runner):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+
+        hook.start_java_pipeline(  # pylint: disable=no-value-for-parameter
+            jar=JAR_FILE,
+            variables=copy.deepcopy(BEAM_VARIABLES_JAVA),
+        )
+
+        expected_cmd = [
+            'java',
+            '-jar',
+            JAR_FILE,
+            f'--runner={DEFAULT_RUNNER}',
+            '--output=gs://test/output',
+            '--labels={"foo":"bar"}',
+        ]
+        mock_runner.assert_called_once_with(cmd=expected_cmd)
+        wait_for_done.assert_called_once_with()
+
+    @mock.patch(BEAM_STRING.format('_BeamRunner'))
+    def test_start_java_pipeline_with_job_class(self, mock_runner):
+        hook = BeamHook(runner=DEFAULT_RUNNER)
+        wait_for_done = mock_runner.return_value.wait_for_done
+
+        hook.start_java_pipeline(  # pylint: disable=no-value-for-parameter
+            jar=JAR_FILE, variables=copy.deepcopy(BEAM_VARIABLES_JAVA), job_class=JOB_CLASS
+        )
+
+        expected_cmd = [
+            'java',
+            '-cp',
+            JAR_FILE,
+            JOB_CLASS,
+            f'--runner={DEFAULT_RUNNER}',
+            '--output=gs://test/output',
+            '--labels={"foo":"bar"}',
+        ]
+        mock_runner.assert_called_once_with(cmd=expected_cmd)
+        wait_for_done.assert_called_once_with()
+
+
+class TestBeamRunner(unittest.TestCase):
+    @mock.patch('airflow.providers.apache.beam.hooks.beam._BeamRunner.log')
+    @mock.patch('subprocess.Popen')
+    @mock.patch('select.select')
+    def test_beam_wait_for_done_logging(self, mock_select, mock_popen, mock_logging):
+        cmd = ['test', 'cmd']
+        mock_logging.info = MagicMock()
+        mock_logging.warning = MagicMock()
+        mock_proc = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stderr.readlines = MagicMock(return_value=['test\n', 'error\n'])
+        mock_stderr_fd = MagicMock()
+        mock_proc.stderr.fileno = MagicMock(return_value=mock_stderr_fd)
+        mock_proc_poll = MagicMock()
+        mock_select.return_value = [[mock_stderr_fd]]
+
+        def poll_resp_error():
+            mock_proc.return_code = 1
+            return True
+
+        mock_proc_poll.side_effect = [None, poll_resp_error]
+        mock_proc.poll = mock_proc_poll
+        mock_popen.return_value = mock_proc
+        beam = _BeamRunner(cmd)
+        mock_logging.info.assert_called_once_with('Running command: %s', " ".join(cmd))
+        mock_popen.assert_called_once_with(
+            cmd,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            close_fds=True,
+        )
+        self.assertRaises(Exception, beam.wait_for_done)

--- a/tests/providers/apache/beam/operators/__init__.py
+++ b/tests/providers/apache/beam/operators/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -1,0 +1,226 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+from unittest import mock
+
+from airflow.providers.apache.beam.operators.beam import (
+    BeamRunJavaPipelineOperator,
+    BeamRunPythonPipelineOperator,
+)
+from airflow.version import version
+
+TASK_ID = 'test-beam-operator'
+DEFAULT_RUNNER = "DirectRunner"
+JOB_NAME = 'test-dataflow-pipeline-name'
+JOB_ID = 'test-dataflow-pipeline-id'
+JAR_FILE = 'gs://my-bucket/example/test.jar'
+JOB_CLASS = 'com.test.NotMain'
+PY_FILE = 'gs://my-bucket/my-object.py'
+PY_INTERPRETER = 'python3'
+PY_OPTIONS = ['-m']
+DEFAULT_OPTIONS_PYTHON = DEFAULT_OPTIONS_JAVA = {
+    'project': 'test',
+    'stagingLocation': 'gs://test/staging',
+}
+ADDITIONAL_OPTIONS = {'output': 'gs://test/output', 'labels': {'foo': 'bar'}}
+TEST_VERSION = 'v{}'.format(version.replace('.', '-').replace('+', '-'))
+EXPECTED_ADDITIONAL_OPTIONS = {
+    'output': 'gs://test/output',
+    'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
+}
+
+
+class TestBeamRunPythonPipelineOperator(unittest.TestCase):
+    def setUp(self):
+        self.operator = BeamRunPythonPipelineOperator(
+            task_id=TASK_ID,
+            py_file=PY_FILE,
+            py_options=PY_OPTIONS,
+            default_pipeline_options=DEFAULT_OPTIONS_PYTHON,
+            pipeline_options=ADDITIONAL_OPTIONS,
+            job_name=JOB_NAME,
+        )
+
+    def test_init(self):
+        """Test BeamRunPythonPipelineOperator instance is properly initialized."""
+        self.assertEqual(self.operator.task_id, TASK_ID)
+        self.assertEqual(self.operator.py_file, PY_FILE)
+        self.assertEqual(self.operator.runner, DEFAULT_RUNNER)
+        self.assertEqual(self.operator.py_options, PY_OPTIONS)
+        self.assertEqual(self.operator.py_interpreter, PY_INTERPRETER)
+        self.assertEqual(self.operator.default_pipeline_options, DEFAULT_OPTIONS_PYTHON)
+        self.assertEqual(self.operator.pipeline_options, EXPECTED_ADDITIONAL_OPTIONS)
+        self.assertEqual(self.operator.job_name, JOB_NAME)
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_exec_direct_runner(self, gcs_hook, beam_hook_mock):
+        """Test BeamHook is created and the right args are passed to
+        start_python_workflow.
+        """
+        start_python_hook = beam_hook_mock.return_value.start_python_pipeline
+        gcs_provide_file = gcs_hook.return_value.provide_file
+        self.operator.execute(None)
+        beam_hook_mock.assert_called_once_with(runner=DEFAULT_RUNNER)
+        expected_options = {
+            'project': 'test',
+            'staging_location': 'gs://test/staging',
+            'output': 'gs://test/output',
+            'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
+        }
+        gcs_provide_file.assert_called_once_with(object_url=PY_FILE)
+        start_python_hook.assert_called_once_with(
+            variables=expected_options,
+            py_file=mock.ANY,
+            py_options=PY_OPTIONS,
+            py_interpreter=PY_INTERPRETER,
+            py_requirements=None,
+            py_system_site_packages=False,
+        )
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_exec_dataflow_runner(self, gcs_hook, dataflow_mock):
+        """Test DataflowHook is created and the right args are passed to
+        start_python_dataflow.
+        """
+        self.operator.runner = "DataflowRunner"
+        start_python_hook = dataflow_mock.return_value.start_python_dataflow
+        gcs_provide_file = gcs_hook.return_value.provide_file
+        self.operator.execute(None)
+        dataflow_mock.assert_called_once_with(gcp_conn_id=self.operator.gcp_conn_id)
+        expected_options = {
+            'project': 'test',
+            'staging_location': 'gs://test/staging',
+            'output': 'gs://test/output',
+            'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
+        }
+        gcs_provide_file.assert_called_once_with(object_url=PY_FILE)
+        start_python_hook.assert_called_once_with(
+            job_name=JOB_NAME,
+            variables=expected_options,
+            dataflow=mock.ANY,
+            py_options=PY_OPTIONS,
+            py_interpreter=PY_INTERPRETER,
+            py_requirements=None,
+            py_system_site_packages=False,
+            on_new_job_id_callback=mock.ANY,
+            project_id=None,
+        )
+
+    #
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_on_kill_dataflow_runner(self, _, dataflow_mock):
+        self.operator.runner = "DataflowRunner"
+        self.operator.job_id = JOB_ID
+        dataflow_cancel_job = dataflow_mock.return_value.cancel_job
+        self.operator.execute(None)
+        self.operator.on_kill()
+        dataflow_cancel_job.assert_called_once_with(job_id=JOB_ID, project_id=None)
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_on_kill_direct_runner(self, _, dataflow_mock, __):
+        dataflow_cancel_job = dataflow_mock.return_value.cancel_job
+        self.operator.execute(None)
+        self.operator.on_kill()
+        dataflow_cancel_job.assert_not_called()
+
+
+class TestBeamRunJavaPipelineOperator(unittest.TestCase):
+    def setUp(self):
+        self.operator = BeamRunJavaPipelineOperator(
+            task_id=TASK_ID,
+            jar=JAR_FILE,
+            job_name=JOB_NAME,
+            job_class=JOB_CLASS,
+            default_pipeline_options=DEFAULT_OPTIONS_JAVA,
+            pipeline_options=ADDITIONAL_OPTIONS,
+        )
+
+    def test_init(self):
+        """Test BeamRunJavaPipelineOperator instance is properly initialized."""
+        self.assertEqual(self.operator.task_id, TASK_ID)
+        self.assertEqual(self.operator.job_name, JOB_NAME)
+        self.assertEqual(self.operator.runner, DEFAULT_RUNNER)
+        self.assertEqual(self.operator.default_pipeline_options, DEFAULT_OPTIONS_JAVA)
+        self.assertEqual(self.operator.job_class, JOB_CLASS)
+        self.assertEqual(self.operator.jar, JAR_FILE)
+        self.assertEqual(self.operator.pipeline_options, ADDITIONAL_OPTIONS)
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_exec_direct_runner(self, gcs_hook, beam_hook_mock):
+        """Test BeamHook is created and the right args are passed to
+        start_java_workflow.
+        """
+        start_java_hook = beam_hook_mock.return_value.start_java_pipeline
+        gcs_provide_file = gcs_hook.return_value.provide_file
+        self.operator.execute(None)
+        beam_hook_mock.assert_called_once_with(runner=DEFAULT_RUNNER)
+        self.assertTrue(beam_hook_mock.called)
+        gcs_provide_file.assert_called_once_with(object_url=JAR_FILE)
+        start_java_hook.assert_called_once_with(
+            variables={**DEFAULT_OPTIONS_JAVA, **ADDITIONAL_OPTIONS},
+            jar=mock.ANY,
+            job_class=JOB_CLASS,
+        )
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_exec_dataflow_runner(self, gcs_hook, dataflow_mock):
+        """Test DataflowHook is created and the right args are passed to
+        start_java_dataflow.
+        """
+        self.operator.runner = "DataflowRunner"
+        start_java_hook = dataflow_mock.return_value.start_java_dataflow
+        dataflow_mock.return_value.is_job_dataflow_running.return_value = False
+        gcs_provide_file = gcs_hook.return_value.provide_file
+        self.operator.execute(None)
+        self.assertTrue(dataflow_mock.called)
+        gcs_provide_file.assert_called_once_with(object_url=JAR_FILE)
+        start_java_hook.assert_called_once_with(
+            job_name=JOB_NAME,
+            variables={**DEFAULT_OPTIONS_JAVA, **ADDITIONAL_OPTIONS},
+            jar=mock.ANY,
+            job_class=JOB_CLASS,
+            on_new_job_id_callback=mock.ANY,
+            project_id=None,
+        )
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_on_kill_dataflow_runner(self, _, dataflow_mock):
+        self.operator.runner = "DataflowRunner"
+        self.operator.job_id = JOB_ID
+        dataflow_cancel_job = dataflow_mock.return_value.cancel_job
+        dataflow_mock.return_value.is_job_dataflow_running.return_value = False
+        self.operator.execute(None)
+        self.operator.on_kill()
+        dataflow_cancel_job.assert_called_once_with(job_id=JOB_ID, project_id=None)
+
+    @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.DataflowHook')
+    @mock.patch('airflow.providers.apache.beam.operators.beam.GCSHook')
+    def test_on_kill_direct_runner(self, _, dataflow_mock, __):
+        dataflow_cancel_job = dataflow_mock.return_value.cancel_job
+        self.operator.execute(None)
+        self.operator.on_kill()
+        dataflow_cancel_job.assert_not_called()

--- a/tests/providers/apache/beam/operators/test_beam.py
+++ b/tests/providers/apache/beam/operators/test_beam.py
@@ -39,7 +39,7 @@ DEFAULT_OPTIONS_PYTHON = DEFAULT_OPTIONS_JAVA = {
     'stagingLocation': 'gs://test/staging',
 }
 ADDITIONAL_OPTIONS = {'output': 'gs://test/output', 'labels': {'foo': 'bar'}}
-TEST_VERSION = 'v{}'.format(version.replace('.', '-').replace('+', '-'))
+TEST_VERSION = f"v{version.replace('.', '-').replace('+', '-')}"
 EXPECTED_ADDITIONAL_OPTIONS = {
     'output': 'gs://test/output',
     'labels': {'foo': 'bar', 'airflow-version': TEST_VERSION},
@@ -106,7 +106,6 @@ class TestBeamRunPythonPipelineOperator(unittest.TestCase):
         gcs_provide_file = gcs_hook.return_value.provide_file
         self.operator.execute(None)
         job_name = dataflow_hook_mock.build_dataflow_job_name.return_value
-        self.assertEqual(job_name, self.operator._dataflow_job_name)
         dataflow_hook_mock.assert_called_once_with(
             gcp_conn_id=dataflow_config.gcp_conn_id,
             delegate_to=dataflow_config.delegate_to,
@@ -248,6 +247,7 @@ class TestBeamRunJavaPipelineOperator(unittest.TestCase):
             job_name=job_name,
             location='us-central1',
             multiple_jobs=dataflow_config.multiple_jobs,
+            project_id=dataflow_hook_mock.return_value.project_id,
         )
 
     @mock.patch('airflow.providers.apache.beam.operators.beam.BeamHook')

--- a/tests/providers/apache/beam/operators/test_beam_system.py
+++ b/tests/providers/apache/beam/operators/test_beam_system.py
@@ -31,6 +31,9 @@ class BeamExampleDagsSystemTest(SystemTest):
     def test_run_example_dag_beam_python(self):
         self.run_dag('example_beam_native_python', BEAM_DAG_FOLDER)
 
+    def test_run_example_dag_beam_python_dataflow_async(self):
+        self.run_dag('example_beam_native_python_dataflow_async', BEAM_DAG_FOLDER)
+
     def test_run_example_dag_beam_java_direct_runner(self):
         self.run_dag('example_beam_native_java_direct_runner', BEAM_DAG_FOLDER)
 

--- a/tests/providers/apache/beam/operators/test_beam_system.py
+++ b/tests/providers/apache/beam/operators/test_beam_system.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import os
+
+import pytest
+
+from tests.test_utils import AIRFLOW_MAIN_FOLDER
+from tests.test_utils.system_tests_class import SystemTest
+
+BEAM_DAG_FOLDER = os.path.join(AIRFLOW_MAIN_FOLDER, "airflow", "providers", "apache", "beam", "example_dags")
+
+
+@pytest.mark.system("apache.beam")
+class BeamExampleDagsSystemTest(SystemTest):
+    def test_run_example_dag_beam_python(self):
+        self.run_dag('example_beam_native_python', BEAM_DAG_FOLDER)
+
+    def test_run_example_dag_beam_java_direct_runner(self):
+        self.run_dag('example_beam_native_java_direct_runner', BEAM_DAG_FOLDER)
+
+    def test_run_example_dag_beam_java_dataflow_runner(self):
+        self.run_dag('example_beam_native_java_dataflow_runner', BEAM_DAG_FOLDER)
+
+    def test_run_example_dag_beam_java_spark_runner(self):
+        self.run_dag('example_beam_native_java_spark_runner', BEAM_DAG_FOLDER)
+
+    def test_run_example_dag_beam_java_flink_runner(self):
+        self.run_dag('example_beam_native_java_flink_runner', BEAM_DAG_FOLDER)


### PR DESCRIPTION
Simple [Apache Beam](https://github.com/apache/beam) operators to run Python and Java pipelines with DirectRunner (DirectRunner is used by default but other runners are supported as well).

It will allow to test DAGs with pipelines which uses DirectRunner for faster feedback, then using e.g. Dataflow operators.