### PR TITLE
Configuration.getsection now copes with sections that only exist in user config

### DIFF
--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -357,6 +357,8 @@ key2 = airflow
         test_config = '''
 [test]
 key1 = hello
+[new_section]
+key = value
 '''
         test_config_default = '''
 [test]
@@ -373,6 +375,16 @@ key3 = value3
         self.assertEqual(
             OrderedDict([('key3', 'value3'), ('testkey', 'testvalue'), ('testpercent', 'with%percent')]),
             test_conf.getsection('testsection'),
+        )
+
+        self.assertEqual(
+            OrderedDict([('key', 'value')]),
+            test_conf.getsection('new_section'),
+        )
+
+        self.assertEqual(
+            None,
+            test_conf.getsection('non_existant_secion'),
         )
 
     def test_get_section_should_respect_cmd_env_variable(self):


### PR DESCRIPTION
If you try to run `airflow config list` with an old config you upgraded
from 1.8, it would fail for any sections that have been removed from the
default cofing -- `ldap` for instance.

This would also be a problem if the user makes a typo in a config
section, or is using the airflow config for storing their own
information.

While I was changing this code, I also removed the use of private
methods/variable access in favour of public API


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).