### PR TITLE
Dagrun object doesn't exist in the TriggerDagRunOperator

### DIFF
--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -145,7 +145,7 @@ class TriggerDagRunOperator(BaseOperator):
 
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
 
-                dag_run = dag.get_last_dagrun(include_externally_triggered=True)
+                dag_run = DagRun.find(dag_id=dag.dag_id, run_id=run_id)[0]
             else:
                 raise e
 

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -145,8 +145,7 @@ class TriggerDagRunOperator(BaseOperator):
 
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
 
-                dag_run = DagRun.find(dag_id=dag.dag_id, run_id=run_id)[0]
-
+                dag_run = dag.get_last_dagrun(include_externally_triggered=True)
             else:
                 raise e
 

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -144,6 +144,9 @@ class TriggerDagRunOperator(BaseOperator):
                 dag = dag_bag.get_dag(self.trigger_dag_id)
 
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
+
+                dag_run = DagRun.find(dag_id=dag.dag_id, run_id=run_id)[0]
+
             else:
                 raise e
 


### PR DESCRIPTION
fixes  https://github.com/apache/airflow/issues/12587

Fixes issue where dag_run object is not populated if the dag_run already
exists and is reset

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
