### PR TITLE
Add more environment variables to configuration reference

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -67,6 +67,7 @@
         their website
       version_added: ~
       type: string
+      sensitive: true
       example: ~
       default: "sqlite:///{AIRFLOW_HOME}/airflow.db"
     - name: sql_engine_encoding
@@ -225,6 +226,7 @@
         Secret key to save connection passwords in the db
       version_added: ~
       type: string
+      sensitive: true
       example: ~
       default: "{FERNET_KEY}"
     - name: donot_pickle
@@ -770,6 +772,7 @@
       description: ~
       version_added: ~
       type: string
+      sensitive: true
       example: ~
       default: ""
 - name: operators
@@ -929,6 +932,7 @@
         It should be as random as possible
       version_added: ~
       type: string
+      sensitive: true
       example: ~
       default: "{SECRET_KEY}"
     - name: workers
@@ -1241,6 +1245,7 @@
       description: ~
       version_added: ~
       type: string
+      sensitive: true
       example: "airflow"
       default: ~
     - name: smtp_port
@@ -1374,6 +1379,7 @@
         a sqlalchemy database. Refer to the Celery documentation for more information.
       version_added: ~
       type: string
+      sensitive: true
       example: ~
       default: "redis://redis:6379/0"
     - name: result_backend
@@ -1386,6 +1392,7 @@
         http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-result-backend-settings
       version_added: ~
       type: string
+      sensitive: true
       example: ~
       default: "db+postgresql://postgres:airflow@postgres/airflow"
     - name: flower_host
@@ -1416,6 +1423,7 @@
         Accepts user:password pairs separated by a comma
       version_added: 1.10.2
       type: string
+      sensitive: true
       example: "user1:password1,user2:password2"
       default: ""
     - name: default_queue

--- a/docs/apache-airflow/configurations-ref.rst
+++ b/docs/apache-airflow/configurations-ref.rst
@@ -63,7 +63,16 @@ can set in ``airflow.cfg`` file or using environment variables.
 
     :Type: {{ option["type"] }}
     :Default: ``{{ "''" if option["default"] == "" else option["default"] }}``
+    {% if option.get("sensitive") %}
+    :Environment Variables:
+        ``AIRFLOW__{{ section["name"] | upper }}__{{ option["name"] | upper }}``
+
+        ``AIRFLOW__{{ section["name"] | upper }}__{{ option["name"] | upper }}_CMD``
+
+        ``AIRFLOW__{{ section["name"] | upper }}__{{ option["name"] | upper }}_SECRET``
+    {% else %}
     :Environment Variable: ``AIRFLOW__{{ section["name"] | upper }}__{{ option["name"] | upper }}``
+    {% endif %}
     {% if option["example"] %}
     :Example:
         ``{{ option["example"] }}``


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #12773 
related: #12773

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adding a `sensitive` field to config.yml, based on this section of `configuration.py`:

https://github.com/apache/airflow/blob/8f48f12128e0d985c6de2603902524859fecbca8/airflow/configuration.py#L124-L134

Then updating the configuration reference to display the three possible environment variables to set this config. 

Example:
![image](https://user-images.githubusercontent.com/16950874/101208593-6548aa80-3640-11eb-9ae1-bf1de3b5f411.png)


---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
