### PR TITLE
Remove old option - git_password from sensitive_config_values

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -129,7 +129,6 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
         ('celery', 'result_backend'),
         ('atlas', 'password'),
         ('smtp', 'smtp_password'),
-        ('kubernetes', 'git_password'),
         ('webserver', 'secret_key'),
     }
 

--- a/docs/apache-airflow/cli-and-env-variables-ref.rst
+++ b/docs/apache-airflow/cli-and-env-variables-ref.rst
@@ -68,7 +68,6 @@ Environment Variables
 * ``result_backend`` in ``[celery]`` section
 * ``password`` in ``[atlas]`` section
 * ``smtp_password`` in ``[smtp]`` section
-* ``git_password`` in ``[kubernetes]`` section
 * ``secret_key`` in ``[webserver]`` section
 
 .. envvar:: AIRFLOW__{SECTION}__{KEY}_SECRET

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -69,7 +69,6 @@ The following config options support this ``_cmd`` and ``_secret`` version:
 * ``result_backend`` in ``[celery]`` section
 * ``password`` in ``[atlas]`` section
 * ``smtp_password`` in ``[smtp]`` section
-* ``git_password`` in ``[kubernetes]`` section
 * ``secret_key`` in ``[webserver]`` section
 
 The ``_cmd`` config options can also be set using a corresponding environment variable

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -383,9 +383,7 @@ key3 = value3
             os.chmod(cmd_file.name, 0o0555)
             cmd_file.close()
 
-            with mock.patch.dict(
-                "os.environ", {"AIRFLOW__WEBSERVER__SECRET_KEY_CMD": cmd_file.name}
-            ):
+            with mock.patch.dict("os.environ", {"AIRFLOW__WEBSERVER__SECRET_KEY_CMD": cmd_file.name}):
                 content = conf.getsection("webserver")
             os.unlink(cmd_file.name)
         self.assertEqual(content["secret_key"], "difficult_unpredictable_cat_password")

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -385,9 +385,6 @@ key3 = value3
 
             with mock.patch.dict(
                 "os.environ", {"AIRFLOW__WEBSERVER__SECRET_KEY_CMD": cmd_file.name}
-            ), mock.patch(
-                'airflow.configuration.AirflowConfigParser.sensitive_config_values',
-                {('webserver', 'secret_key')},
             ):
                 content = conf.getsection("webserver")
             os.unlink(cmd_file.name)

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -383,10 +383,15 @@ key3 = value3
             os.chmod(cmd_file.name, 0o0555)
             cmd_file.close()
 
-            with mock.patch.dict("os.environ", {"AIRFLOW__KUBERNETES__GIT_PASSWORD_CMD": cmd_file.name}):
-                content = conf.getsection("kubernetes")
+            with mock.patch.dict(
+                "os.environ", {"AIRFLOW__WEBSERVER__SECRET_KEY_CMD": cmd_file.name}
+            ), mock.patch(
+                'airflow.configuration.AirflowConfigParser.sensitive_config_values',
+                {('webserver', 'secret_key')},
+            ):
+                content = conf.getsection("webserver")
             os.unlink(cmd_file.name)
-        self.assertEqual(content["git_password"], "difficult_unpredictable_cat_password")
+        self.assertEqual(content["secret_key"], "difficult_unpredictable_cat_password")
 
     def test_kubernetes_environment_variables_section(self):
         test_config = '''


### PR DESCRIPTION
This option has been removed 
https://github.com/apache/airflow/pull/10393/files
CC: @SamWheating 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
