### PR TITLE
Removing redundant calls to session.commit()

### DIFF
--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -65,8 +65,6 @@ def create_pool(name, slots, description, session=None):
         pool.slots = slots
         pool.description = description
 
-    session.commit()
-
     return pool
 
 
@@ -84,6 +82,5 @@ def delete_pool(name, session=None):
         raise PoolNotFound("Pool '%s' doesn't exist" % name)
 
     session.delete(pool)
-    session.commit()
 
     return pool

--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -65,6 +65,8 @@ def create_pool(name, slots, description, session=None):
         pool.slots = slots
         pool.description = description
 
+    session.flush()
+
     return pool
 
 
@@ -82,5 +84,6 @@ def delete_pool(name, session=None):
         raise PoolNotFound("Pool '%s' doesn't exist" % name)
 
     session.delete(pool)
+    session.flush()
 
     return pool

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -104,6 +104,7 @@ def patch_connection(connection_id, session, update_mask=None):
     for key in data:
         setattr(connection, key, data[key])
     session.add(connection)
+    session.flush()
     return connection_schema.dump(connection)
 
 
@@ -122,5 +123,6 @@ def post_connection(session):
     if not connection:
         connection = Connection(**data)
         session.add(connection)
+        session.flush()
         return connection_schema.dump(connection)
     raise AlreadyExists(detail="Connection already exist. ID: %s" % conn_id)

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -104,7 +104,6 @@ def patch_connection(connection_id, session, update_mask=None):
     for key in data:
         setattr(connection, key, data[key])
     session.add(connection)
-    session.commit()
     return connection_schema.dump(connection)
 
 
@@ -123,6 +122,5 @@ def post_connection(session):
     if not connection:
         connection = Connection(**data)
         session.add(connection)
-        session.commit()
         return connection_schema.dump(connection)
     raise AlreadyExists(detail="Connection already exist. ID: %s" % conn_id)

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -89,5 +89,4 @@ def patch_dag(session, dag_id, update_mask=None):
         patch_body_[update_mask] = patch_body[update_mask]
         patch_body = patch_body_
     setattr(dag, 'is_paused', patch_body['is_paused'])
-    session.commit()
     return dag_schema.dump(dag)

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -89,4 +89,5 @@ def patch_dag(session, dag_id, update_mask=None):
         patch_body_[update_mask] = patch_body[update_mask]
         patch_body = patch_body_
     setattr(dag, 'is_paused', patch_body['is_paused'])
+    session.flush()
     return dag_schema.dump(dag)

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -228,7 +228,6 @@ def post_dag_run(dag_id, session):
     if not dagrun_instance:
         dag_run = DagRun(dag_id=dag_id, run_type=DagRunType.MANUAL, **post_body)
         session.add(dag_run)
-        session.commit()
         return dagrun_schema.dump(dag_run)
     raise AlreadyExists(
         detail=f"DAGRun with DAG ID: '{dag_id}' and DAGRun ID: '{post_body['run_id']}' already exists"

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -228,6 +228,7 @@ def post_dag_run(dag_id, session):
     if not dagrun_instance:
         dag_run = DagRun(dag_id=dag_id, run_type=DagRunType.MANUAL, **post_body)
         session.add(dag_run)
+        session.flush()
         return dagrun_schema.dump(dag_run)
     raise AlreadyExists(
         detail=f"DAGRun with DAG ID: '{dag_id}' and DAGRun ID: '{post_body['run_id']}' already exists"

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -106,7 +106,6 @@ def patch_pool(pool_name, session, update_mask=None):
 
     for key, value in patch_body.items():
         setattr(pool, key, value)
-    session.commit()
     return pool_schema.dump(pool)
 
 
@@ -127,7 +126,6 @@ def post_pool(session):
     pool = Pool(**post_body)
     try:
         session.add(pool)
-        session.commit()
         return pool_schema.dump(pool)
     except IntegrityError:
         raise AlreadyExists(detail=f"Pool: {post_body['pool']} already exists")

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -106,6 +106,7 @@ def patch_pool(pool_name, session, update_mask=None):
 
     for key, value in patch_body.items():
         setattr(pool, key, value)
+    session.flush()
     return pool_schema.dump(pool)
 
 
@@ -126,6 +127,7 @@ def post_pool(session):
     pool = Pool(**post_body)
     try:
         session.add(pool)
+        session.flush()
         return pool_schema.dump(pool)
     except IntegrityError:
         raise AlreadyExists(detail=f"Pool: {post_body['pool']} already exists")

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -366,7 +366,6 @@ class BackfillJob(BaseJob):
                     ti.set_state(State.SCHEDULED, session=session)
                 if ti.state != State.REMOVED:
                     tasks_to_run[ti.key] = ti
-            session.commit()
         except Exception:
             session.rollback()
             raise
@@ -523,7 +522,6 @@ class BackfillJob(BaseJob):
                         )
                         ti_status.running[key] = ti
                         ti_status.to_run.pop(key)
-                    session.commit()
                     return
 
                 if ti.state == State.UPSTREAM_FAILED:
@@ -897,7 +895,6 @@ class BackfillJob(BaseJob):
         reset_tis = helpers.reduce_in_chunks(query, tis_to_reset, [], self.max_tis_per_query)
 
         task_instance_str = '\n\t'.join([repr(x) for x in reset_tis])
-        session.commit()
 
         self.log.info("Reset the following %s TaskInstances:\n\t%s", len(reset_tis), task_instance_str)
         return len(reset_tis)

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -366,6 +366,7 @@ class BackfillJob(BaseJob):
                     ti.set_state(State.SCHEDULED, session=session)
                 if ti.state != State.REMOVED:
                     tasks_to_run[ti.key] = ti
+            session.flush()
         except Exception:
             session.rollback()
             raise
@@ -522,6 +523,7 @@ class BackfillJob(BaseJob):
                         )
                         ti_status.running[key] = ti
                         ti_status.to_run.pop(key)
+                    session.flush()
                     return
 
                 if ti.state == State.UPSTREAM_FAILED:
@@ -895,6 +897,7 @@ class BackfillJob(BaseJob):
         reset_tis = helpers.reduce_in_chunks(query, tis_to_reset, [], self.max_tis_per_query)
 
         task_instance_str = '\n\t'.join([repr(x) for x in reset_tis])
+        session.flush()
 
         self.log.info("Reset the following %s TaskInstances:\n\t%s", len(reset_tis), task_instance_str)
         return len(reset_tis)

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -147,7 +147,6 @@ class BaseJob(Base, LoggingMixin):
         except Exception as e:  # pylint: disable=broad-except
             self.log.error('on_kill() method failed: %s', str(e))
         session.merge(job)
-        session.commit()
         raise AirflowException("Job shut down externally.")
 
     def on_kill(self):
@@ -246,7 +245,6 @@ class BaseJob(Base, LoggingMixin):
             finally:
                 self.end_date = timezone.utcnow()
                 session.merge(self)
-                session.commit()
 
         Stats.incr(self.__class__.__name__.lower() + '_end', 1, 1)
 

--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -147,6 +147,7 @@ class BaseJob(Base, LoggingMixin):
         except Exception as e:  # pylint: disable=broad-except
             self.log.error('on_kill() method failed: %s', str(e))
         session.merge(job)
+        session.flush()
         raise AirflowException("Job shut down externally.")
 
     def on_kill(self):

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -515,7 +515,6 @@ class DagFileProcessor(LoggingMixin):
                     sla.email_sent = email_sent
                     sla.notification_sent = True
                     session.merge(sla)
-            session.commit()
 
     @staticmethod
     def update_import_errors(session: Session, dagbag: DagBag) -> None:
@@ -567,8 +566,6 @@ class DagFileProcessor(LoggingMixin):
                     request.__class__.__name__,
                     request.full_filepath,
                 )
-
-        session.commit()
 
     @provide_session
     def _execute_dag_callbacks(self, dagbag: DagBag, request: DagCallbackRequest, session: Session):

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -515,6 +515,7 @@ class DagFileProcessor(LoggingMixin):
                     sla.email_sent = email_sent
                     sla.notification_sent = True
                     session.merge(sla)
+            session.flush()
 
     @staticmethod
     def update_import_errors(session: Session, dagbag: DagBag) -> None:
@@ -566,6 +567,8 @@ class DagFileProcessor(LoggingMixin):
                     request.__class__.__name__,
                     request.full_filepath,
                 )
+
+        session.flush()
 
     @provide_session
     def _execute_dag_callbacks(self, dagbag: DagBag, request: DagCallbackRequest, session: Session):

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1034,6 +1034,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         results = qry.all()
         count = len(results)
         clear_task_instances(results, session, dag=self.dag)
+        session.flush()
         return count
 
     @provide_session

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1034,7 +1034,6 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         results = qry.all()
         count = len(results)
         clear_task_instances(results, session, dag=self.dag)
-        session.commit()
         return count
 
     @provide_session


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: https://github.com/apache/airflow/issues/12818

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Re: https://github.com/apache/airflow/issues/12818

Replacing calls to `session.commit()` with `session.flush()` in places using `@provide_session` or `with create_session() as:`. 

In these cases, if the function is called without a session provided, the session will be committed as soon as the function returns. If the function is passed a session from the calling function, then it is up to the calling function to commit the session.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
