### PR TITLE
Enable to expand the key file path in ssh hooks

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -205,7 +205,7 @@ class SSHHook(BaseHook):
             connect_kwargs.update(pkey=self.pkey)
 
         if self.key_file:
-            connect_kwargs.update(key_filename=self.key_file)
+            connect_kwargs.update(key_filename=os.path.expandvars(self.key_file))
 
         client.connect(**connect_kwargs)
 


### PR DESCRIPTION
Sometimes, the key_file path users defined in the ssh connection is not a absolute path but a path combined with shell variable  e.g. `${AIRFLOW_HOME}/**/**.rsa` or `${SECRET_FOLDER}/**/**.rsa.` 
These variables maybe change in the future and it's better not to do hard code in the connection.
So I think it should be useful to support  expanding the key file path in ssh hook.