### PR TITLE
Fix for empty Graph View when task does not have a DAG during relationship setting

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1206,11 +1206,17 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             )
 
         if dag and not self.has_dag():
+            # If this task does not yet have a dag, add it to the same dag as the other task and
+            # put it in the dag's root TaskGroup.
             self.dag = dag
+            self.dag.task_group.add(self)
 
         for task in task_list:
             if dag and not task.has_dag():
+                # If the other task does not yet have a dag, add it to the same dag as this task and
+                # put it in the dag's root TaskGroup.
                 task.dag = dag
+                task.dag.task_group.add(task)
             if upstream:
                 task.add_only_new(task.get_direct_relative_ids(upstream=False), self.task_id)
                 self.add_only_new(self._upstream_task_ids, task.task_id)

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -559,3 +559,19 @@ def test_duplicate_group_id():
             _ = DummyOperator(task_id="task1")
             with TaskGroup("group1"):
                 _ = DummyOperator(task_id="upstream_join_id")
+
+def test_task_without_dag():
+    """
+    Test that if a task doesn't have a DAG when it's being set as the relative of another task which
+    has a DAG, the task should be added to the root TaskGroup of the other task's DAG.
+    """
+    dag = DAG(dag_id='test_task_without_dag', start_date=pendulum.parse("20200101"))
+    op1 = DummyOperator(task_id='op1', dag=dag)
+    op2 = DummyOperator(task_id='op2')
+    op3 = DummyOperator(task_id="op3")
+    op1 >> op2
+    op3 >> op2
+
+    assert op1.dag == op2.dag == op3.dag
+    assert dag.task_group.children.keys() == {"op1", "op2", "op3"}
+    assert dag.task_group.children.keys() == dag.task_dict.keys()

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -560,6 +560,7 @@ def test_duplicate_group_id():
             with TaskGroup("group1"):
                 _ = DummyOperator(task_id="upstream_join_id")
 
+
 def test_task_without_dag():
     """
     Test that if a task doesn't have a DAG when it's being set as the relative of another task which


### PR DESCRIPTION
Closes #12757 

When a task does not have a dag at the time it's being set as a relative of another task, the Graph View becomes empty.

For example:
```python
from airflow import DAG
from airflow.operators.dummy_operator import DummyOperator
from airflow.utils.dates import days_ago

dag = DAG(dag_id='example_graph_view_issue', start_date=days_ago(2))
op1 = DummyOperator(task_id='op1', dag=dag)
op2 = DummyOperator(task_id='op2')
op1 >> op2
```

Note op2 does not have a dag when `op1 >> op2` is called. It's added to op1's DAG after this line, but not added to any `TaskGroup`. This causes Graph View to break.

This PR fixes the issue by adding `op2` to the root `TaskGroup` if op1's DAG when `op1 >> op2` is called.

