### PR TITLE
Add paused column to `dags list` sub-command

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -280,6 +280,7 @@ def dag_list_dags(args):
             "dag_id": x.dag_id,
             "filepath": x.filepath,
             "owner": x.owner,
+            "paused": x.get_is_paused(),
         },
     )
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -794,7 +794,7 @@ class DAG(LoggingMixin):
         return self.get_concurrency_reached()
 
     @provide_session
-    def get_is_paused(self, session=None):
+    def get_is_paused(self, session=None) -> Optional[None]:
         """Returns a boolean indicating whether this DAG is paused"""
         qry = session.query(DagModel).filter(DagModel.dag_id == self.dag_id)
         return qry.value(DagModel.is_paused)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -345,7 +345,9 @@ class TestCliDags(unittest.TestCase):
             out = temp_stdout.getvalue()
         self.assertIn("owner", out)
         self.assertIn("airflow", out)
+        self.assertIn("paused", out)
         self.assertIn("airflow/example_dags/example_complex.py", out)
+        self.assertIn("False", out)
 
     def test_cli_list_dag_runs(self):
         dag_command.dag_trigger(


### PR DESCRIPTION
Previously is_paused_upon_creation would be None, and we relied on SQLA
to set the default value via a default at the column level (client side,
not server side).

That worked and didn't cause any problems, but would have needed more
logic to get the "correct" value here -- so I moved it to DAG's ctor.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).