### PR TITLE
Make `airflow --help` run five times quicker

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -31,16 +31,18 @@ import traceback
 import warnings
 from argparse import Namespace
 from datetime import datetime
-from typing import Callable, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, Optional, TypeVar, cast
 
 from airflow import settings
 from airflow.exceptions import AirflowException
-from airflow.models import DAG, DagBag, DagModel, DagPickle, Log
 from airflow.utils import cli_action_loggers
 from airflow.utils.platform import is_terminal_support_colors
 from airflow.utils.session import provide_session
 
 T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
+
+if TYPE_CHECKING:
+    from airflow.models import DAG
 
 
 def action_logging(f: T) -> T:
@@ -106,6 +108,8 @@ def _build_metrics(func_name, namespace):
     :param namespace: Namespace instance from argparse
     :return: dict with metrics
     """
+    from airflow.models import Log
+
     sensitive_fields = {'-p', '--password', '--conn-password'}
     full_command = list(sys.argv)
     for idx, command in enumerate(full_command):  # pylint: disable=too-many-nested-blocks
@@ -161,6 +165,8 @@ def process_subdir(subdir: Optional[str]):
 
 def get_dag_by_file_location(dag_id: str):
     """Returns DAG of a given dag_id by looking up file location"""
+    from airflow.models import DagBag, DagModel
+
     # Benefit is that logging from other dags in dagbag will not appear
     dag_model = DagModel.get_current(dag_id)
     if dag_model is None:
@@ -172,8 +178,10 @@ def get_dag_by_file_location(dag_id: str):
     return dagbag.dags[dag_id]
 
 
-def get_dag(subdir: Optional[str], dag_id: str) -> DAG:
+def get_dag(subdir: Optional[str], dag_id: str) -> "DAG":
     """Returns DAG of a given dag_id"""
+    from airflow.models import DagBag
+
     dagbag = DagBag(process_subdir(subdir))
     if dag_id not in dagbag.dags:
         raise AirflowException(
@@ -185,6 +193,8 @@ def get_dag(subdir: Optional[str], dag_id: str) -> DAG:
 
 def get_dags(subdir: Optional[str], dag_id: str, use_regex: bool = False):
     """Returns DAG(s) matching a given regex or dag_id"""
+    from airflow.models import DagBag
+
     if not use_regex:
         return [get_dag(subdir, dag_id)]
     dagbag = DagBag(process_subdir(subdir))
@@ -200,6 +210,8 @@ def get_dags(subdir: Optional[str], dag_id: str, use_regex: bool = False):
 @provide_session
 def get_dag_by_pickle(pickle_id, session=None):
     """Fetch DAG from the database using pickling"""
+    from airflow.models import DagPickle
+
     dag_pickle = session.query(DagPickle).filter(DagPickle.id == pickle_id).first()
     if not dag_pickle:
         raise AirflowException("Who hid the pickle!? [missing pickle]")

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -19,13 +19,15 @@
 import logging
 import os
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import requests
 
 from airflow.configuration import AirflowConfigException, conf
-from airflow.models import TaskInstance
 from airflow.utils.helpers import parse_template_string
+
+if TYPE_CHECKING:
+    from airflow.models import TaskInstance
 
 
 class FileTaskHandler(logging.Handler):
@@ -45,7 +47,7 @@ class FileTaskHandler(logging.Handler):
         self.local_base = base_log_folder
         self.filename_template, self.filename_jinja_template = parse_template_string(filename_template)
 
-    def set_context(self, ti: TaskInstance):
+    def set_context(self, ti: "TaskInstance"):
         """
         Provide task_instance context to airflow task handler.
 


### PR DESCRIPTION
Importing anything from airflow.models pulls in _a lot_ of airflow, so
delay imports until the functions are called, or make use of the
`TYPE_CHECKING` to not actually import at runtime.

**Before**: mean 2.58s (with a lot of variance)
```
airflow ❯ for i in 1 2 3; do time airflow --help >/dev/null; done
airflow --help > /dev/null  2.00s user 1.39s system 176% cpu 1.928 total
airflow --help > /dev/null  2.84s user 1.43s system 151% cpu 2.817 total
airflow --help > /dev/null  3.00s user 1.37s system 145% cpu 3.009 total

```

**After**: 0.526s

```
airflow --help > /dev/null  0.39s user 0.04s system 99% cpu 0.435 total
airflow --help > /dev/null  0.40s user 0.05s system 99% cpu 0.446 total
airflow --help > /dev/null  0.64s user 0.05s system 99% cpu 0.698 total
```

This also has an advantage in development where a syntax error doesn't
fail with a slightly confusing error message about "unable to configure
logger 'task'".


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).