### PR TITLE
Customizable javascript configuration in connnection form

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -52,6 +52,12 @@ assists users migrating to a new version.
 
 ## Master
 
+### SparkJDBCHook default connection
+
+For SparkJDBCHook default connection was `spark-default`, and for SparkSubmitHook it was
+`spark_default`. Both hooks now use the `spark_default` which is a common pattern for the connection
+names used across all providers.
+
 ### Changes to output argument in commands
 
 From Airflow 2.0, We are replacing [tabulate](https://pypi.org/project/tabulate/) with [rich](https://github.com/willmcgugan/rich) to render commands output. Due to this change, the `--output` argument
@@ -99,7 +105,6 @@ The `all` extras were reduced to include only user-facing dependencies. This mea
 that this extra does not contain development dependencies. If you were relying on
 `all` extra then you should use now `devel_all` or figure out if you need development
 extras at all.
-
 
 ### `[scheduler] max_threads` config has been renamed to `[scheduler] parsing_processes`
 

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -69,6 +69,11 @@ if not settings.LAZY_LOAD_PLUGINS:
 
     plugins_manager.ensure_plugins_loaded()
 
+if not settings.LAZY_LOAD_PROVIDERS:
+    from airflow import providers_manager
+
+    providers_manager.ProvidersManager().initialize_providers_manager()
+
 
 # This is never executed, but tricks static analyzers (PyDev, PyCharm,
 # pylint, etc.) into knowing the types of these symbols, and what

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1152,12 +1152,6 @@ CONNECTIONS_COMMANDS = (
 )
 PROVIDERS_COMMANDS = (
     ActionCommand(
-        name='hooks',
-        help='List registered provider hooks',
-        func=lazy_load_command('airflow.cli.commands.provider_command.hooks_list'),
-        args=(ARG_OUTPUT,),
-    ),
-    ActionCommand(
         name='list',
         help='List installed providers',
         func=lazy_load_command('airflow.cli.commands.provider_command.providers_list'),
@@ -1179,6 +1173,18 @@ PROVIDERS_COMMANDS = (
         name='widgets',
         help='Get information about registered connection form widgets',
         func=lazy_load_command('airflow.cli.commands.provider_command.connection_form_widget_list'),
+        args=(ARG_OUTPUT,),
+    ),
+    ActionCommand(
+        name='hooks',
+        help='List registered provider hooks',
+        func=lazy_load_command('airflow.cli.commands.provider_command.hooks_list'),
+        args=(ARG_OUTPUT,),
+    ),
+    ActionCommand(
+        name='fields',
+        help='Get information about registered connection types with field customizations',
+        func=lazy_load_command('airflow.cli.commands.provider_command.connection_field_behaviours'),
         args=(ARG_OUTPUT,),
     ),
 )

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1175,6 +1175,12 @@ PROVIDERS_COMMANDS = (
         func=lazy_load_command('airflow.cli.commands.provider_command.extra_links_list'),
         args=(ARG_OUTPUT,),
     ),
+    ActionCommand(
+        name='widgets',
+        help='Get information about registered connection form widgets',
+        func=lazy_load_command('airflow.cli.commands.provider_command.connection_form_widget_list'),
+        args=(ARG_OUTPUT,),
+    ),
 )
 
 USERS_COMMANDS = (

--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -42,13 +42,13 @@ log = logging.getLogger(__name__)
 class Anonymizer(Protocol):
     """Anonymizer protocol."""
 
-    def process_path(self, value):
+    def process_path(self, value) -> str:
         """Remove pii from paths"""
 
-    def process_username(self, value):
+    def process_username(self, value) -> str:
         """Remove pii from username"""
 
-    def process_url(self, value):
+    def process_url(self, value) -> str:
         """Remove pii from URL"""
 
 

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -31,8 +31,8 @@ def provider_get(args):
     """Get a provider info."""
     providers = ProvidersManager().providers
     if args.provider_name in providers:
-        provider_version = providers[args.provider_name][0]
-        provider_info = providers[args.provider_name][1]
+        provider_version = providers[args.provider_name].version
+        provider_info = providers[args.provider_name].provider_info
         if args.full:
             provider_info["description"] = _remove_rst_syntax(provider_info["description"])
             AirflowConsole().print_as(
@@ -50,7 +50,7 @@ def provider_get(args):
 def providers_list(args):
     """Lists all providers at the command line"""
     AirflowConsole().print_as(
-        data=ProvidersManager().providers.values(),
+        data=list(ProvidersManager().providers.values()),
         output=args.output,
         mapper=lambda x: {
             "package_name": x[1]["package-name"],
@@ -64,12 +64,29 @@ def providers_list(args):
 def hooks_list(args):
     """Lists all hooks at the command line"""
     AirflowConsole().print_as(
-        data=ProvidersManager().hooks.items(),
+        data=list(ProvidersManager().hooks.items()),
         output=args.output,
         mapper=lambda x: {
             "connection_type": x[0],
-            "class": x[1][0],
-            "conn_attribute_name": x[1][1],
+            "class": x[1].connection_class,
+            "conn_id_attribute_name": x[1].connection_id_attribute_name,
+            'package_name': x[1].package_name,
+            'hook_name': x[1].hook_name,
+        },
+    )
+
+
+@suppress_logs_and_warning()
+def connection_form_widget_list(args):
+    """Lists all custom connection form fields at the command line"""
+    AirflowConsole().print_as(
+        data=list(ProvidersManager().connection_form_widgets.items()),
+        output=args.output,
+        mapper=lambda x: {
+            "connection_parameter_name": x[0],
+            "class": x[1].connection_class,
+            'package_name': x[1].package_name,
+            'field_type': x[1].field.field_class.__name__,
         },
     )
 

--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -91,6 +91,19 @@ def connection_form_widget_list(args):
     )
 
 
+@suppress_logs_and_warning()
+def connection_field_behaviours(args):
+    """Lists field behaviours"""
+    AirflowConsole().print_as(
+        data=list(ProvidersManager().field_behaviours.keys()),
+        output=args.output,
+        mapper=lambda x: {
+            "field_behaviours": x,
+        },
+    )
+
+
+@suppress_logs_and_warning()
 def extra_links_list(args):
     """Lists all extra links at the command line"""
     AirflowConsole().print_as(

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -394,6 +394,15 @@
       type: boolean
       example: ~
       default: "True"
+    - name: lazy_discover_providers
+      description: |
+        By default Airflow providers are lazily-discovered (discovery and imports happen only when required).
+        Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
+        loaded from module.
+      version_added: 2.0.0
+      type: boolean
+      example: ~
+      default: "True"
     - name: max_db_retries
       description: |
         Number of times the code should be retried in case of DB Operational Errors.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -225,6 +225,11 @@ xcom_backend = airflow.models.xcom.BaseXCom
 # if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
 lazy_load_plugins = True
 
+# By default Airflow providers are lazily-discovered (discovery and imports happen only when required).
+# Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
+# loaded from module.
+lazy_discover_providers = True
+
 # Number of times the code should be retried in case of DB Operational Errors.
 # Not all transactions will be retried as it can cause undesired state.
 # Currently it is only used in ``DagFileProcessor.process_file`` to retry ``dagbag.sync_to_db``.

--- a/airflow/customized_form_fields.schema.json
+++ b/airflow/customized_form_fields.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "hidden_fields": {
+      "description": "List of hidden fields for for the hook.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "relabeling": {
+      "type": "object",
+      "description": "Keeps information about re-labeling of field names.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "placeholders": {
+      "type": "object",
+      "description": "Placeholders that are used to fill the values",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "hidden_fields",
+    "relabeling"
+  ]
+}

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -18,9 +18,12 @@
 """Base class for all hooks"""
 import logging
 import warnings
-from typing import Any, List
+from typing import Any, Dict, List
+
+from wtforms import Field
 
 from airflow.models.connection import Connection
+from airflow.typing_compat import Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 log = logging.getLogger(__name__)
@@ -90,3 +93,78 @@ class BaseHook(LoggingMixin):
     def get_conn(self) -> Any:
         """Returns connection for the hook."""
         raise NotImplementedError()
+
+
+class DiscoverableHook(Protocol):
+    """
+    This protocol Just describes what Hook classes that want to be discovered by ProvidersManager can
+    implement. It is not used by any of the Hooks, but simply methods and class fields described here
+    are implemented by those Hooks.
+
+    The conn_name_attr, default_conn_name, conn_type should be implemented by those
+    Hooks that want to be automatically mapped from the connection_type -> Hook when get_hook method
+    is called with connection_type.
+
+    Additionally hook_name should be set when you want the hook to have a custom name in the UI selection
+    Name. If not specified, conn_name will be used.
+
+    The "get_ui_field_behaviour" and "get_connection_form_widgets" are optional - override them if you want
+    to customize the Connection Form screen. You can add extra widgets to parse your extra fields via the
+    get_connection_form_widgets method as well as hide or relabel the fields or pre-fill
+    them with placeholders via get_ui_field_behaviour method.
+
+    Note that the "get_ui_field_behaviour" and "get_connection_form_widgets" need to be set by each class
+    in the class hierarchy in order to apply widget customizations.
+
+    For example, even if you want to use the fields from your parent class, you must explicitly
+    have a method on *your* class:
+
+    .. code-block:: python
+
+        @classmethod
+        def get_ui_field_behaviour(cls):
+            return super().get_ui_field_behaviour()
+
+    You also need to add the Hook class name to list 'hook_class_names' in provider.yaml in case you
+    build an internal provider or to return it in dictionary returned by provider_info entrypoint in the
+    package you prepare.
+
+    You can see some examples in airflow/providers/jdbc/hooks/jdbc.py.
+
+    """
+
+    conn_name_attr: str
+    default_conn_name: str
+    conn_type: str
+    hook_name: str
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Field]:
+        """
+        Returns dictionary of widgets to be added for the hook to handle extra values.
+
+        If you have class hierarchy, usually the widgets needed by your class are already
+        added by the base class, so there is no need to implement this method. It might
+        actually result in warning in the logs if you try to add widgets that have already
+        been added by the base class.
+
+        """
+        ...
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """
+        Returns dictionary describing customizations to implement in javascript handling the
+        connection form. Should be compliant with airflow/customized_form_fields.schema.json'
+
+
+        If you change conn_type in a derived class, you should also
+        implement this method and return field customizations appropriate to your Hook. This
+        is because the child hook will have usually different conn_type and the customizations
+        are per connection type.
+
+        .. seealso::
+            :class:`~airflow.providers.google.cloud.hooks.compute_ssh.ComputeSSH`
+
+        """
+        ...

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -328,9 +328,14 @@ class AwsBaseHook(BaseHook):
     :type config: Optional[botocore.client.Config]
     """
 
+    conn_name_attr = 'aws_conn_id'
+    default_conn_name = 'aws_default'
+    conn_type = 'aws'
+    hook_name = 'Amazon Web Services'
+
     def __init__(
         self,
-        aws_conn_id: Optional[str] = "aws_default",
+        aws_conn_id: Optional[str] = default_conn_name,
         verify: Union[bool, str, None] = None,
         region_name: Optional[str] = None,
         client_type: Optional[str] = None,

--- a/airflow/providers/amazon/aws/hooks/emr.py
+++ b/airflow/providers/amazon/aws/hooks/emr.py
@@ -33,7 +33,12 @@ class EmrHook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
-    def __init__(self, emr_conn_id: Optional[str] = None, *args, **kwargs) -> None:
+    conn_name_attr = 'emr_conn_id'
+    default_conn_name = 'emr_default'
+    conn_type = 'emr'
+    hook_name = 'Elastic MapReduce'
+
+    def __init__(self, emr_conn_id: Optional[str] = default_conn_name, *args, **kwargs) -> None:
         self.emr_conn_id = emr_conn_id
         kwargs["client_type"] = "emr"
         super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -103,6 +103,9 @@ class S3Hook(AwsBaseHook):
         :class:`~airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook`
     """
 
+    conn_type = 's3'
+    hook_name = 'S3'
+
     def __init__(self, *args, **kwargs) -> None:
         kwargs['client_type'] = 's3'
 

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -322,3 +322,8 @@ transfers:
   - source-integration-name: SSH File Transfer Protocol (SFTP)
     target-integration-name: Amazon Simple Storage Service (S3)
     python-module: airflow.providers.amazon.aws.transfers.sftp_to_s3
+
+hook-class-names:
+  - airflow.providers.amazon.aws.hooks.s3.S3Hook
+  - airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook
+  - airflow.providers.amazon.aws.hooks.emr.EmrHook

--- a/airflow/providers/apache/cassandra/hooks/cassandra.py
+++ b/airflow/providers/apache/cassandra/hooks/cassandra.py
@@ -86,6 +86,7 @@ class CassandraHook(BaseHook, LoggingMixin):
     conn_name_attr = 'cassandra_conn_id'
     default_conn_name = 'cassandra_default'
     conn_type = 'cassandra'
+    hook_name = 'Cassandra'
 
     def __init__(self, cassandra_conn_id: str = default_conn_name):
         super().__init__()

--- a/airflow/providers/apache/hdfs/hooks/hdfs.py
+++ b/airflow/providers/apache/hdfs/hooks/hdfs.py
@@ -46,6 +46,11 @@ class HDFSHook(BaseHook):
     :type autoconfig: bool
     """
 
+    conn_name_attr = 'hdfs_conn_id'
+    default_conn_name = 'hdfs_default'
+    conn_type = 'hdfs'
+    hook_name = 'HDFS'
+
     def __init__(
         self, hdfs_conn_id: str = 'hdfs_default', proxy_user: Optional[str] = None, autoconfig: bool = False
     ):

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -48,3 +48,6 @@ hooks:
   - integration-name: WebHDFS
     python-modules:
       - airflow.providers.apache.hdfs.hooks.webhdfs
+
+hook-class-names:
+  - airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -81,6 +81,7 @@ class HiveCliHook(BaseHook):
     conn_name_attr = 'hive_cli_conn_id'
     default_conn_name = 'hive_cli_default'
     conn_type = 'hive_cli'
+    hook_name = 'Hive Client Wrapper'
 
     def __init__(
         self,
@@ -474,7 +475,12 @@ class HiveMetastoreHook(BaseHook):
     # java short max val
     MAX_PART_COUNT = 32767
 
-    def __init__(self, metastore_conn_id: str = 'metastore_default') -> None:
+    conn_name_attr = 'metastore_conn_id'
+    default_conn_name = 'metastore_default'
+    conn_type = 'hive_metastore'
+    hook_name = 'Hive Metastore Thrift'
+
+    def __init__(self, metastore_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = metastore_conn_id
         self.metastore = self.get_metastore_client()
@@ -814,6 +820,7 @@ class HiveServer2Hook(DbApiHook):
     conn_name_attr = 'hiveserver2_conn_id'
     default_conn_name = 'hiveserver2_default'
     conn_type = 'hiveserver2'
+    hook_name = 'Hive Server 2 Thrift'
     supports_autocommit = False
 
     def get_conn(self, schema: Optional[str] = None) -> Any:

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -70,3 +70,4 @@ transfers:
 hook-class-names:
   - airflow.providers.apache.hive.hooks.hive.HiveCliHook
   - airflow.providers.apache.hive.hooks.hive.HiveServer2Hook
+  - airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook

--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -64,7 +64,12 @@ class LivyHook(HttpHook, LoggingMixin):
 
     _def_headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
 
-    def __init__(self, livy_conn_id: str = 'livy_default') -> None:
+    conn_name_attr = 'livy_conn_id'
+    default_conn_name = 'livy_default'
+    conn_type = 'livy'
+    hook_name = 'Apache Livy'
+
+    def __init__(self, livy_conn_id: str = default_conn_name) -> None:
         super().__init__(http_conn_id=livy_conn_id)
 
     def get_conn(self, headers: Optional[Dict[str, Any]] = None) -> Any:

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -42,3 +42,6 @@ hooks:
   - integration-name: Apache Livy
     python-modules:
       - airflow.providers.apache.livy.hooks.livy
+
+hook-class-names:
+  - airflow.providers.apache.livy.hooks.livy.LivyHook

--- a/airflow/providers/apache/pig/hooks/pig.py
+++ b/airflow/providers/apache/pig/hooks/pig.py
@@ -36,6 +36,7 @@ class PigCliHook(BaseHook):
     conn_name_attr = 'pig_cli_conn_id'
     default_conn_name = 'pig_cli_default'
     conn_type = 'pig_cli'
+    hook_name = 'Pig Client Wrapper'
 
     def __init__(self, pig_cli_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/apache/spark/hooks/spark_jdbc.py
+++ b/airflow/providers/apache/spark/hooks/spark_jdbc.py
@@ -112,11 +112,16 @@ class SparkJDBCHook(SparkSubmitHook):
                                       types.
     """
 
+    conn_name_attr = 'spark_conn_id'
+    default_conn_name = 'spark_default'
+    conn_type = 'spark_jdbc'
+    hook_name = 'Spark JDBC'
+
     # pylint: disable=too-many-arguments,too-many-locals
     def __init__(
         self,
         spark_app_name: str = 'airflow-spark-jdbc',
-        spark_conn_id: str = 'spark-default',
+        spark_conn_id: str = default_conn_name,
         spark_conf: Optional[Dict[str, Any]] = None,
         spark_py_files: Optional[str] = None,
         spark_files: Optional[str] = None,

--- a/airflow/providers/apache/spark/hooks/spark_sql.py
+++ b/airflow/providers/apache/spark/hooks/spark_sql.py
@@ -56,12 +56,17 @@ class SparkSqlHook(BaseHook):
     :type yarn_queue: str
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'spark_sql_default'
+    conn_type = 'spark_sql'
+    hook_name = 'Spark SQL'
+
     # pylint: disable=too-many-arguments
     def __init__(
         self,
         sql: str,
         conf: Optional[str] = None,
-        conn_id: str = 'spark_sql_default',
+        conn_id: str = default_conn_name,
         total_executor_cores: Optional[int] = None,
         executor_cores: Optional[int] = None,
         executor_memory: Optional[str] = None,

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -109,6 +109,14 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     conn_type = 'spark'
     hook_name = 'Spark'
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'login', 'password'],
+            "relabeling": {},
+        }
+
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(
         self,

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -104,6 +104,11 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
     :type spark_binary: str
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'spark_default'
+    conn_type = 'spark'
+    hook_name = 'Spark'
+
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches
     def __init__(
         self,

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -44,3 +44,8 @@ hooks:
       - airflow.providers.apache.spark.hooks.spark_jdbc_script
       - airflow.providers.apache.spark.hooks.spark_sql
       - airflow.providers.apache.spark.hooks.spark_submit
+
+hook-class-names:
+  - airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook
+  - airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook
+  - airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook

--- a/airflow/providers/apache/sqoop/hooks/sqoop.py
+++ b/airflow/providers/apache/sqoop/hooks/sqoop.py
@@ -52,9 +52,14 @@ class SqoopHook(BaseHook):
     :type properties: dict
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'sqoop_default'
+    conn_type = 'sqoop'
+    hook_name = 'Sqoop'
+
     def __init__(
         self,
-        conn_id: str = 'sqoop_default',
+        conn_id: str = default_conn_name,
         verbose: bool = False,
         num_mappers: Optional[int] = None,
         hcatalog_database: Optional[str] = None,

--- a/airflow/providers/apache/sqoop/provider.yaml
+++ b/airflow/providers/apache/sqoop/provider.yaml
@@ -37,3 +37,6 @@ hooks:
   - integration-name: Apache Sqoop
     python-modules:
       - airflow.providers.apache.sqoop.hooks.sqoop
+
+hook-class-names:
+  - airflow.providers.apache.sqoop.hooks.sqoop.SqoopHook

--- a/airflow/providers/cloudant/hooks/cloudant.py
+++ b/airflow/providers/cloudant/hooks/cloudant.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 """Hook for Cloudant"""
+from typing import Dict
+
 from cloudant import cloudant
 
 from airflow.exceptions import AirflowException
@@ -36,6 +38,14 @@ class CloudantHook(BaseHook):
     default_conn_name = 'cloudant_default'
     conn_type = 'cloudant'
     hook_name = 'Cloudant'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['port', 'extra'],
+            "relabeling": {'host': 'Account', 'login': 'Username (or API Key)', 'schema': 'Database'},
+        }
 
     def __init__(self, cloudant_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/cloudant/hooks/cloudant.py
+++ b/airflow/providers/cloudant/hooks/cloudant.py
@@ -35,6 +35,7 @@ class CloudantHook(BaseHook):
     conn_name_attr = 'cloudant_conn_id'
     default_conn_name = 'cloudant_default'
     conn_type = 'cloudant'
+    hook_name = 'Cloudant'
 
     def __init__(self, cloudant_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -15,11 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 import tempfile
-from typing import Any, Generator, Optional, Tuple, Union
+from typing import Any, Dict, Generator, Optional, Tuple, Union
 
 import yaml
 from cached_property import cached_property
+from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+from flask_babel import lazy_gettext
 from kubernetes import client, config, watch
+from wtforms import BooleanField, Field, StringField
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
@@ -57,6 +60,23 @@ class KubernetesHook(BaseHook):
     conn_name_attr = 'kubernetes_conn_id'
     default_conn_name = 'kubernetes_default'
     conn_type = 'kubernetes'
+    hook_name = 'Kubernetes Cluster Connection'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Field]:
+        """Returns connection widgets to add to connection form"""
+        return {
+            "extra__kubernetes__in_cluster": BooleanField(lazy_gettext('In cluster configuration')),
+            "extra__kubernetes__kube_config_path": StringField(
+                lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()
+            ),
+            "extra__kubernetes__kube_config": StringField(
+                lazy_gettext('Kube config (JSON format)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__kubernetes__namespace": StringField(
+                lazy_gettext('Namespace'), widget=BS3TextFieldWidget()
+            ),
+        }
 
     def __init__(
         self, conn_id: str = default_conn_name, client_configuration: Optional[client.Configuration] = None

--- a/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/hooks/kubernetes.py
@@ -78,6 +78,14 @@ class KubernetesHook(BaseHook):
             ),
         }
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
+
     def __init__(
         self, conn_id: str = default_conn_name, client_configuration: Optional[client.Configuration] = None
     ) -> None:

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -103,9 +103,14 @@ class DatabricksHook(BaseHook):  # noqa
     :type retry_delay: float
     """
 
+    conn_name_attr = 'databricks_conn_id'
+    default_conn_name = 'databricks_default'
+    conn_type = 'databricks'
+    hook_name = 'Databricks'
+
     def __init__(
         self,
-        databricks_conn_id: str = 'databricks_default',
+        databricks_conn_id: str = default_conn_name,
         timeout_seconds: int = 180,
         retry_limit: int = 3,
         retry_delay: float = 1.0,

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: Databricks
     python-modules:
       - airflow.providers.databricks.hooks.databricks
+
+hook-class-names:
+  - airflow.providers.databricks.hooks.databricks.DatabricksHook

--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -27,7 +27,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 class DockerHook(BaseHook, LoggingMixin):
     """
-    Interact with a private Docker registry.
+    Interact with a Docker Daemon or Registry.
 
     :param docker_conn_id: ID of the Airflow connection where
         credentials and extra configuration are stored
@@ -37,6 +37,7 @@ class DockerHook(BaseHook, LoggingMixin):
     conn_name_attr = 'docker_conn_id'
     default_conn_name = 'docker_default'
     conn_type = 'docker'
+    hook_name = 'Docker'
 
     def __init__(
         self,
@@ -53,7 +54,7 @@ class DockerHook(BaseHook, LoggingMixin):
 
         conn = self.get_connection(docker_conn_id)
         if not conn.host:
-            raise AirflowException('No Docker registry URL provided')
+            raise AirflowException('No Docker URL provided')
         if not conn.login:
             raise AirflowException('No username provided')
         extra_options = conn.extra_dejson
@@ -76,7 +77,7 @@ class DockerHook(BaseHook, LoggingMixin):
         return client
 
     def __login(self, client) -> int:
-        self.log.debug('Logging into Docker registry')
+        self.log.debug('Logging into Docker')
         try:
             client.login(
                 username=self.__username,
@@ -87,5 +88,5 @@ class DockerHook(BaseHook, LoggingMixin):
             )
             self.log.debug('Login successful')
         except APIError as docker_error:
-            self.log.error('Docker registry login failed: %s', str(docker_error))
-            raise AirflowException(f'Docker registry login failed: {docker_error}')
+            self.log.error('Docker login failed: %s', str(docker_error))
+            raise AirflowException(f'Docker login failed: {docker_error}')

--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional
+from typing import Dict, Optional
 
 from docker import APIClient
 from docker.errors import APIError
@@ -38,6 +38,17 @@ class DockerHook(BaseHook, LoggingMixin):
     default_conn_name = 'docker_default'
     conn_type = 'docker'
     hook_name = 'Docker'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema'],
+            "relabeling": {
+                'host': 'Registry URL',
+                'login': 'Username',
+            },
+        }
 
     def __init__(
         self,

--- a/airflow/providers/elasticsearch/hooks/elasticsearch.py
+++ b/airflow/providers/elasticsearch/hooks/elasticsearch.py
@@ -30,6 +30,7 @@ class ElasticsearchHook(DbApiHook):
     conn_name_attr = 'elasticsearch_conn_id'
     default_conn_name = 'elasticsearch_default'
     conn_type = 'elasticsearch'
+    hook_name = 'Elasticsearch'
 
     def __init__(self, schema: str = "http", connection: Optional[AirflowConnection] = None, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/airflow/providers/exasol/hooks/exasol.py
+++ b/airflow/providers/exasol/hooks/exasol.py
@@ -39,6 +39,7 @@ class ExasolHook(DbApiHook):
     conn_name_attr = 'exasol_conn_id'
     default_conn_name = 'exasol_default'
     conn_type = 'exasol'
+    hook_name = 'Exasol'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/facebook/ads/hooks/ads.py
+++ b/airflow/providers/facebook/ads/hooks/ads.py
@@ -55,9 +55,14 @@ class FacebookAdsReportingHook(BaseHook):
 
     """
 
+    conn_name_attr = 'facebook_conn_id'
+    default_conn_name = 'facebook_default'
+    conn_type = 'facebook_social'
+    hook_name = 'Facebook Ads'
+
     def __init__(
         self,
-        facebook_conn_id: str = "facebook_default",
+        facebook_conn_id: str = default_conn_name,
         api_version: str = "v6.0",
     ) -> None:
         super().__init__()

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -32,3 +32,6 @@ hooks:
   - integration-name: Facebook Ads
     python-modules:
       - airflow.providers.facebook.ads.hooks.ads
+
+hook-class-names:
+  - airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -34,7 +34,12 @@ class FTPHook(BaseHook):
     connection as ``{"passive": "true"}``.
     """
 
-    def __init__(self, ftp_conn_id: str = 'ftp_default') -> None:
+    conn_name_attr = 'ftp_conn_id'
+    default_conn_name = 'ftp_default'
+    conn_type = 'ftp'
+    hook_name = 'FTP'
+
+    def __init__(self, ftp_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.ftp_conn_id = ftp_conn_id
         self.conn: Optional[ftplib.FTP] = None

--- a/airflow/providers/ftp/provider.yaml
+++ b/airflow/providers/ftp/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: File Transfer Protocol (FTP)
     python-modules:
       - airflow.providers.ftp.hooks.ftp
+
+hook-class-names:
+  - airflow.providers.ftp.hooks.ftp.FTPHook

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -70,10 +70,11 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     conn_name_attr = 'gcp_conn_id'
     default_conn_name = 'google_cloud_default'
     conn_type = 'google_cloud_platform'
+    hook_name = 'Google Cloud'
 
     def __init__(
         self,
-        gcp_conn_id: str = 'google_cloud_default',
+        gcp_conn_id: str = default_conn_name,
         delegate_to: Optional[str] = None,
         use_legacy_sql: bool = True,
         location: Optional[str] = None,

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -76,10 +76,15 @@ class CloudSQLHook(GoogleBaseHook):
     keyword arguments rather than positional.
     """
 
+    conn_name_attr = 'gcp_conn_id'
+    default_conn_name = 'google_cloud_default'
+    conn_type = 'gcpcloudsql'
+    hook_name = 'Google Cloud SQL'
+
     def __init__(
         self,
         api_version: str,
-        gcp_conn_id: str = "google_cloud_default",
+        gcp_conn_id: str = default_conn_name,
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
     ) -> None:
@@ -709,10 +714,10 @@ class CloudSQLDatabaseHook(BaseHook):  # noqa
            in the connection URL
     :type default_gcp_project_id: str
     """
-
     conn_name_attr = 'gcp_cloudsql_conn_id'
     default_conn_name = 'google_cloud_sql_default'
-    conn_type = 'gcpcloudsql'
+    conn_type = 'gcpcloudsqldb'
+    hook_name = 'Google Cloud SQL Database Hook'
 
     _conn = None  # type: Optional[Any]
 

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -717,7 +717,7 @@ class CloudSQLDatabaseHook(BaseHook):  # noqa
     conn_name_attr = 'gcp_cloudsql_conn_id'
     default_conn_name = 'google_cloud_sql_default'
     conn_type = 'gcpcloudsqldb'
-    hook_name = 'Google Cloud SQL Database Hook'
+    hook_name = 'Google Cloud SQL Database'
 
     _conn = None  # type: Optional[Any]
 

--- a/airflow/providers/google/cloud/hooks/compute_ssh.py
+++ b/airflow/providers/google/cloud/hooks/compute_ssh.py
@@ -17,7 +17,7 @@
 import shlex
 import time
 from io import StringIO
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import paramiko
 from cached_property import cached_property
@@ -92,6 +92,14 @@ class ComputeEngineSSHHook(SSHHook):
     conn_name_attr = 'gcp_conn_id'
     default_conn_name = 'google_cloud_default'
     conn_type = 'gcpssh'
+    hook_name = 'Google Cloud SSH'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
 
     def __init__(  # pylint: disable=too-many-arguments
         self,

--- a/airflow/providers/google/cloud/hooks/dataprep.py
+++ b/airflow/providers/google/cloud/hooks/dataprep.py
@@ -40,6 +40,7 @@ class GoogleDataprepHook(BaseHook):
     conn_name_attr = 'dataprep_conn_id'
     default_conn_name = 'dataprep_default'
     conn_type = 'dataprep'
+    hook_name = 'Google Dataprep'
 
     def __init__(self, dataprep_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -189,6 +189,14 @@ class GoogleBaseHook(BaseHook):
             ),
         }
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
+
     def __init__(
         self,
         gcp_conn_id: str = 'google_cloud_default',

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -633,9 +633,11 @@ transfers:
 
 hook-class-names:
   - airflow.providers.google.cloud.hooks.dataprep.GoogleDataprepHook
+  - airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLHook
   - airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook
   - airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineSSHHook
   - airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
+  - airflow.providers.google.common.hooks.base_google.GoogleBaseHook
 
 extra-links:
   - airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink

--- a/airflow/providers/grpc/hooks/grpc.py
+++ b/airflow/providers/grpc/hooks/grpc.py
@@ -16,15 +16,18 @@
 # under the License.
 
 """GRPC Hook"""
-from typing import Callable, Generator, List, Optional
+from typing import Callable, Dict, Generator, List, Optional
 
 import grpc
+from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+from flask_babel import lazy_gettext
 from google import auth as google_auth
 from google.auth import jwt as google_auth_jwt
 from google.auth.transport import (
     grpc as google_auth_transport_grpc,
     requests as google_auth_transport_requests,
 )
+from wtforms import Field, StringField
 
 from airflow.exceptions import AirflowConfigException
 from airflow.hooks.base_hook import BaseHook
@@ -50,6 +53,22 @@ class GrpcHook(BaseHook):
     conn_name_attr = 'grpc_conn_id'
     default_conn_name = 'grpc_default'
     conn_type = 'grpc'
+    hook_name = 'GRPC Connection'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Field]:
+        """Returns connection widgets to add to connection form"""
+        return {
+            "extra__grpc__auth_type": StringField(
+                lazy_gettext('Grpc Auth Type'), widget=BS3TextFieldWidget()
+            ),
+            "extra__grpc__credential_pem_file": StringField(
+                lazy_gettext('Credential Keyfile Path'), widget=BS3TextFieldWidget()
+            ),
+            "extra__grpc__scopes": StringField(
+                lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()
+            ),
+        }
 
     def __init__(
         self,

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -110,9 +110,14 @@ class VaultHook(BaseHook):
 
     """
 
+    conn_name_attr = 'vault_conn_id'
+    default_conn_name = 'imap_default'
+    conn_type = 'vault'
+    hook_name = 'Hashicorp Vault'
+
     def __init__(  # pylint: disable=too-many-arguments
         self,
-        vault_conn_id: str,
+        vault_conn_id: str = default_conn_name,
         auth_type: Optional[str] = None,
         auth_mount_point: Optional[str] = None,
         kv_engine_version: Optional[int] = None,

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -32,3 +32,6 @@ hooks:
   - integration-name: Hashicorp Vault
     python-modules:
       - airflow.providers.hashicorp.hooks.vault
+
+hook-class-names:
+  - airflow.providers.hashicorp.hooks.vault.VaultHook

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -39,10 +39,15 @@ class HttpHook(BaseHook):
     :type auth_type: AuthBase of python requests lib
     """
 
+    conn_name_attr = 'http_conn_id'
+    default_conn_name = 'http_default'
+    conn_type = 'http'
+    hook_name = 'HTTP'
+
     def __init__(
         self,
         method: str = 'POST',
-        http_conn_id: str = 'http_default',
+        http_conn_id: str = default_conn_name,
         auth_type: Any = HTTPBasicAuth,
     ) -> None:
         super().__init__()

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -44,3 +44,6 @@ hooks:
   - integration-name: Hypertext Transfer Protocol (HTTP)
     python-modules:
       - airflow.providers.http.hooks.http
+
+hook-class-names:
+  - airflow.providers.http.hooks.http.HttpHook

--- a/airflow/providers/imap/hooks/imap.py
+++ b/airflow/providers/imap/hooks/imap.py
@@ -45,6 +45,7 @@ class ImapHook(BaseHook):
     conn_name_attr = 'imap_conn_id'
     default_conn_name = 'imap_default'
     conn_type = 'imap'
+    hook_name = 'IMAP'
 
     def __init__(self, imap_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -52,6 +52,14 @@ class JdbcHook(DbApiHook):
             ),
         }
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['port', 'schema', 'extra'],
+            "relabeling": {'host': 'Connection URL'},
+        }
+
     def get_conn(self) -> jaydebeapi.Connection:
         conn: Connection = self.get_connection(getattr(self, self.conn_name_attr))
         host: str = conn.host

--- a/airflow/providers/jdbc/hooks/jdbc.py
+++ b/airflow/providers/jdbc/hooks/jdbc.py
@@ -16,9 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Optional
+from typing import Dict, Optional
 
 import jaydebeapi
+from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+from flask_babel import lazy_gettext
+from wtforms import Field, StringField
 
 from airflow.hooks.dbapi_hook import DbApiHook
 from airflow.models.connection import Connection
@@ -36,7 +39,18 @@ class JdbcHook(DbApiHook):
     conn_name_attr = 'jdbc_conn_id'
     default_conn_name = 'jdbc_default'
     conn_type = 'jdbc'
+    hook_name = 'JDBC Connection'
     supports_autocommit = True
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Field]:
+        """Returns connection widgets to add to connection form"""
+        return {
+            "extra__jdbc__drv_path": StringField(lazy_gettext('Driver Path'), widget=BS3TextFieldWidget()),
+            "extra__jdbc__drv_clsname": StringField(
+                lazy_gettext('Driver Class'), widget=BS3TextFieldWidget()
+            ),
+        }
 
     def get_conn(self) -> jaydebeapi.Connection:
         conn: Connection = self.get_connection(getattr(self, self.conn_name_attr))

--- a/airflow/providers/jenkins/hooks/jenkins.py
+++ b/airflow/providers/jenkins/hooks/jenkins.py
@@ -27,7 +27,12 @@ from airflow.hooks.base_hook import BaseHook
 class JenkinsHook(BaseHook):
     """Hook to manage connection to jenkins server"""
 
-    def __init__(self, conn_id: str = 'jenkins_default') -> None:
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'jenkins_default'
+    conn_type = 'jenkins'
+    hook_name = 'Jenkins'
+
+    def __init__(self, conn_id: str = default_conn_name) -> None:
         super().__init__()
         connection = self.get_connection(conn_id)
         self.connection = connection

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -36,3 +36,6 @@ hooks:
   - integration-name: Jenkins
     python-modules:
       - airflow.providers.jenkins.hooks.jenkins
+
+hook-class-names:
+  - airflow.providers.jenkins.hooks.jenkins.JenkinsHook

--- a/airflow/providers/jira/hooks/jira.py
+++ b/airflow/providers/jira/hooks/jira.py
@@ -36,6 +36,7 @@ class JiraHook(BaseHook):
     default_conn_name = 'jira_default'
     conn_type = "jira"
     conn_name_attr = "jira_conn_id"
+    hook_name = "JIRA"
 
     def __init__(self, jira_conn_id: str = default_conn_name, proxies: Optional[Any] = None) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -78,7 +78,12 @@ class AzureDataExplorerHook(BaseHook):
     :type azure_data_explorer_conn_id: str
     """
 
-    def __init__(self, azure_data_explorer_conn_id: str = 'azure_data_explorer_default') -> None:
+    conn_name_attr = 'azure_data_explorer_conn_id'
+    default_conn_name = 'azure_data_explorer_default'
+    conn_type = 'azure_data_explorer'
+    hook_name = 'Azure Data Explorer'
+
+    def __init__(self, azure_data_explorer_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = azure_data_explorer_conn_id
         self.connection = self.get_conn()

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -40,6 +40,7 @@ class AzureBatchHook(BaseHook):
     conn_name_attr = 'azure_batch_conn_id'
     default_conn_name = 'azure_batch_default'
     conn_type = 'azure_batch'
+    hook_name = 'Azure Batch Service'
 
     def __init__(self, azure_batch_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -41,7 +41,12 @@ class AzureContainerInstanceHook(AzureBaseHook):
     :type conn_id: str
     """
 
-    def __init__(self, conn_id: str = 'azure_default') -> None:
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'azure_default'
+    conn_type = 'azure_container_instances'
+    hook_name = 'Azure Container Instance'
+
+    def __init__(self, conn_id: str = default_conn_name) -> None:
         super().__init__(sdk_client=ContainerInstanceManagementClient, conn_id=conn_id)
         self.connection = self.get_conn()
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -48,6 +48,7 @@ class AzureCosmosDBHook(BaseHook):
     conn_name_attr = 'azure_cosmos_conn_id'
     default_conn_name = 'azure_cosmos_default'
     conn_type = 'azure_cosmos'
+    hook_name = 'Azure CosmosDB'
 
     def __init__(self, azure_cosmos_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -46,6 +46,7 @@ class AzureDataLakeHook(BaseHook):
     conn_name_attr = 'azure_data_lake_conn_id'
     default_conn_name = 'azure_data_lake_default'
     conn_type = 'azure_data_lake'
+    hook_name = 'Azure Data Lake'
 
     def __init__(self, azure_data_lake_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -33,6 +33,11 @@ class AzureBaseHook(BaseHook):
     :param conn_id: The azure connection id which refers to the information to connect to the service.
     """
 
+    conn_name_attr = 'conn_id'
+    default_conn_name = 'azure_default'
+    conn_type = 'azure'
+    hook_name = 'Azure'
+
     def __init__(self, sdk_client: Any, conn_id: str = 'azure_default'):
         self.sdk_client = sdk_client
         self.conn_id = conn_id

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -57,6 +57,7 @@ class WasbHook(BaseHook):
     conn_name_attr = 'wasb_conn_id'
     default_conn_name = 'wasb_default'
     conn_type = 'wasb'
+    hook_name = 'Azure Blob Storage'
 
     def __init__(self, wasb_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -126,7 +126,10 @@ transfers:
     python-module: airflow.providers.microsoft.azure.transfers.azure_blob_to_gcs
 
 hook-class-names:
+  - airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook
+  - airflow.providers.microsoft.azure.hooks.adx.AzureDataExplorerHook
   - airflow.providers.microsoft.azure.hooks.azure_batch.AzureBatchHook
   - airflow.providers.microsoft.azure.hooks.azure_cosmos.AzureCosmosDBHook
   - airflow.providers.microsoft.azure.hooks.azure_data_lake.AzureDataLakeHook
+  - airflow.providers.microsoft.azure.hooks.azure_container_instance.AzureContainerInstanceHook
   - airflow.providers.microsoft.azure.hooks.wasb.WasbHook

--- a/airflow/providers/microsoft/mssql/hooks/mssql.py
+++ b/airflow/providers/microsoft/mssql/hooks/mssql.py
@@ -28,6 +28,7 @@ class MsSqlHook(DbApiHook):
     conn_name_attr = 'mssql_conn_id'
     default_conn_name = 'mssql_default'
     conn_type = 'mssql'
+    hook_name = 'Microsoft SQL Server'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/mongo/hooks/mongo.py
+++ b/airflow/providers/mongo/hooks/mongo.py
@@ -43,6 +43,7 @@ class MongoHook(BaseHook):
     conn_name_attr = 'conn_id'
     default_conn_name = 'mongo_default'
     conn_type = 'mongo'
+    hook_name = 'MongoDB'
 
     def __init__(self, conn_id: str = default_conn_name, *args, **kwargs) -> None:
 

--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -42,6 +42,7 @@ class MySqlHook(DbApiHook):
     conn_name_attr = 'mysql_conn_id'
     default_conn_name = 'mysql_default'
     conn_type = 'mysql'
+    hook_name = 'MySQL'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -36,6 +36,7 @@ class OdbcHook(DbApiHook):
     conn_name_attr = 'odbc_conn_id'
     default_conn_name = 'odbc_default'
     conn_type = 'odbc'
+    hook_name = 'ODBC Connection'
     supports_autocommit = True
 
     def __init__(

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -31,6 +31,8 @@ class OracleHook(DbApiHook):
     conn_name_attr = 'oracle_conn_id'
     default_conn_name = 'oracle_default'
     conn_type = 'oracle'
+    hook_name = 'Oracle'
+
     supports_autocommit = False
 
     # pylint: disable=c-extension-no-member

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -58,6 +58,7 @@ class PostgresHook(DbApiHook):
     conn_name_attr = 'postgres_conn_id'
     default_conn_name = 'postgres_default'
     conn_type = 'postgres'
+    hook_name = 'Postgres'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/presto/hooks/presto.py
+++ b/airflow/providers/presto/hooks/presto.py
@@ -56,6 +56,7 @@ class PrestoHook(DbApiHook):
     conn_name_attr = 'presto_conn_id'
     default_conn_name = 'presto_default'
     conn_type = 'presto'
+    hook_name = 'Presto'
 
     def get_conn(self) -> Connection:
         """Returns a connection object"""

--- a/airflow/providers/qubole/hooks/qubole.py
+++ b/airflow/providers/qubole/hooks/qubole.py
@@ -109,9 +109,14 @@ COMMAND_ARGS, HYPHEN_ARGS = build_command_args()
 class QuboleHook(BaseHook):
     """Hook for Qubole communication"""
 
+    conn_name_attr = 'qubole_conn_id'
+    default_conn_name = 'qubole_default'
+    conn_type = 'qubole'
+    hook_name = 'Qubole'
+
     def __init__(self, *args, **kwargs) -> None:  # pylint: disable=unused-argument
         super().__init__()
-        conn = self.get_connection(kwargs['qubole_conn_id'])
+        conn = self.get_connection(kwargs.get('qubole_conn_id') or self.default_conn_name)
         Qubole.configure(api_token=conn.password, api_url=conn.host)
         self.task_id = kwargs['task_id']
         self.dag_id = kwargs['dag'].dag_id

--- a/airflow/providers/qubole/hooks/qubole.py
+++ b/airflow/providers/qubole/hooks/qubole.py
@@ -114,6 +114,18 @@ class QuboleHook(BaseHook):
     conn_type = 'qubole'
     hook_name = 'Qubole'
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['login', 'schema', 'port', 'extra'],
+            "relabeling": {
+                'host': 'API Endpoint',
+                'password': 'Auth Token',
+            },
+            "placeholders": {'host': 'https://<env>.qubole.com/api'},
+        }
+
     def __init__(self, *args, **kwargs) -> None:  # pylint: disable=unused-argument
         super().__init__()
         conn = self.get_connection(kwargs.get('qubole_conn_id') or self.default_conn_name)

--- a/airflow/providers/qubole/provider.yaml
+++ b/airflow/providers/qubole/provider.yaml
@@ -46,5 +46,8 @@ hooks:
       - airflow.providers.qubole.hooks.qubole
       - airflow.providers.qubole.hooks.qubole_check
 
+hook-class-names:
+  - airflow.providers.qubole.hooks.qubole.QuboleHook
+
 extra-links:
   - airflow.providers.qubole.operators.qubole.QDSLink

--- a/airflow/providers/redis/hooks/redis.py
+++ b/airflow/providers/redis/hooks/redis.py
@@ -34,6 +34,7 @@ class RedisHook(BaseHook):
     conn_name_attr = 'redis_conn_id'
     default_conn_name = 'redis_default'
     conn_type = 'redis'
+    hook_name = 'Redis'
 
     def __init__(self, redis_conn_id: str = default_conn_name) -> None:
         """

--- a/airflow/providers/salesforce/hooks/tableau.py
+++ b/airflow/providers/salesforce/hooks/tableau.py
@@ -54,6 +54,7 @@ class TableauHook(BaseHook):
     conn_name_attr = 'tableau_conn_id'
     default_conn_name = 'tableau_default'
     conn_type = 'tableau'
+    hook_name = 'Tableau'
 
     def __init__(self, site_id: Optional[str] = None, tableau_conn_id: str = default_conn_name) -> None:
         super().__init__()

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -26,7 +26,12 @@ from airflow.hooks.base_hook import BaseHook
 class SambaHook(BaseHook):
     """Allows for interaction with an samba server."""
 
-    def __init__(self, samba_conn_id: str) -> None:
+    conn_name_attr = 'samba_conn_id'
+    default_conn_name = 'samba_default'
+    conn_type = 'samba'
+    hook_name = 'Samba'
+
+    def __init__(self, samba_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn = self.get_connection(samba_conn_id)
 

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -33,3 +33,6 @@ hooks:
   - integration-name: Samba
     python-modules:
       - airflow.providers.samba.hooks.samba
+
+hook-class-names:
+  - airflow.providers.samba.hooks.samba.SambaHook

--- a/airflow/providers/segment/hooks/segment.py
+++ b/airflow/providers/segment/hooks/segment.py
@@ -53,6 +53,11 @@ class SegmentHook(BaseHook):
         `{"write_key":"YOUR_SECURITY_TOKEN"}`
     """
 
+    conn_name_attr = 'segment_conn_id'
+    default_conn_name = 'segment_default'
+    conn_type = 'segment'
+    hook_name = 'Segment'
+
     def __init__(
         self, segment_conn_id: str = 'segment_default', segment_debug_mode: bool = False, *args, **kwargs
     ) -> None:

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: Segment
     python-modules:
       - airflow.providers.segment.hooks.segment
+
+hook-class-names:
+  - airflow.providers.segment.hooks.segment.SegmentHook

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -45,6 +45,20 @@ class SFTPHook(SSHHook):
     Errors that may occur throughout but should be handled downstream.
     """
 
+    conn_name_attr = 'ftp_conn_id'
+    default_conn_name = 'sftp_default'
+    conn_type = 'sftp'
+    hook_name = 'SFTP'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        return {
+            "hidden_fields": ['schema'],
+            "relabeling": {
+                'login': 'Username',
+            },
+        }
+
     def __init__(self, ftp_conn_id: str = 'sftp_default', *args, **kwargs) -> None:
         kwargs['ssh_conn_id'] = ftp_conn_id
         super().__init__(*args, **kwargs)

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -43,3 +43,6 @@ hooks:
   - integration-name: SSH File Transfer Protocol (SFTP)
     python-modules:
       - airflow.providers.sftp.hooks.sftp
+
+hook-class-names:
+  - airflow.providers.sftp.hooks.sftp.SFTPHook

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -36,6 +36,7 @@ class SnowflakeHook(DbApiHook):
     conn_name_attr = 'snowflake_conn_id'
     default_conn_name = 'snowflake_default'
     conn_type = 'snowflake'
+    hook_name = 'Snowflake'
     supports_autocommit = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/sqlite/hooks/sqlite.py
+++ b/airflow/providers/sqlite/hooks/sqlite.py
@@ -27,6 +27,7 @@ class SqliteHook(DbApiHook):
     conn_name_attr = 'sqlite_conn_id'
     default_conn_name = 'sqlite_default'
     conn_type = 'sqlite'
+    hook_name = 'Sqlite'
 
     def get_conn(self) -> sqlite3.dbapi2.Connection:
         """Returns a sqlite connection object"""

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -57,9 +57,14 @@ class SSHHook(BaseHook):
     :type keepalive_interval: int
     """
 
+    conn_name_attr = 'ssh_conn_id'
+    default_conn_name = 'ssh_default'
+    conn_type = 'ssh'
+    hook_name = 'SSH'
+
     def __init__(
         self,
-        ssh_conn_id: Optional[str] = None,
+        ssh_conn_id: Optional[str] = "ssh_default",
         remote_host: Optional[str] = None,
         username: Optional[str] = None,
         password: Optional[str] = None,

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -20,7 +20,7 @@ import getpass
 import os
 import warnings
 from io import StringIO
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import paramiko
 from paramiko.config import SSH_PORT
@@ -61,6 +61,16 @@ class SSHHook(BaseHook):
     default_conn_name = 'ssh_default'
     conn_type = 'ssh'
     hook_name = 'SSH'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema'],
+            "relabeling": {
+                'login': 'Username',
+            },
+        }
 
     def __init__(
         self,

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -38,3 +38,6 @@ hooks:
   - integration-name: Secure Shell (SSH)
     python-modules:
       - airflow.providers.ssh.hooks.ssh
+
+hook-class-names:
+  - airflow.providers.ssh.hooks.ssh.SSHHook

--- a/airflow/providers/vertica/hooks/vertica.py
+++ b/airflow/providers/vertica/hooks/vertica.py
@@ -28,6 +28,7 @@ class VerticaHook(DbApiHook):
     conn_name_attr = 'vertica_conn_id'
     default_conn_name = 'vertica_default'
     conn_type = 'vertica'
+    hook_name = 'Vertica'
     supports_autocommit = True
 
     def get_conn(self) -> connect:

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -16,9 +16,13 @@
 # under the License.
 
 import json
+import warnings
 from typing import Any, Dict, Optional, Union
 
 import yandexcloud
+from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
+from flask_babel import lazy_gettext
+from wtforms import Field, PasswordField, StringField
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base_hook import BaseHook
@@ -32,14 +36,65 @@ class YandexCloudBaseHook(BaseHook):
     :type connection_id: str
     """
 
+    conn_name_attr = 'yandex_conn_id'
+    default_conn_name = 'yandexcloud_default'
+    conn_type = 'yandexcloud'
+    hook_name = 'Yandex Cloud'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Field]:
+        """Returns connection widgets to add to connection form"""
+        return {
+            "extra__yandexcloud__service_account_json": PasswordField(
+                lazy_gettext('Service account auth JSON'),
+                widget=BS3PasswordFieldWidget(),
+                description='Service account auth JSON. Looks like '
+                '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
+                'Will be used instead of OAuth token and SA JSON file path field if specified.',
+            ),
+            "extra__yandexcloud__service_account_json_path": StringField(
+                lazy_gettext('Service account auth JSON file path'),
+                widget=BS3TextFieldWidget(),
+                description='Service account auth JSON file path. File content looks like '
+                '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
+                'Will be used instead of OAuth token if specified.',
+            ),
+            "extra__yandexcloud__oauth": PasswordField(
+                lazy_gettext('OAuth Token'),
+                widget=BS3PasswordFieldWidget(),
+                description='User account OAuth token. '
+                'Either this or service account JSON must be specified.',
+            ),
+            "extra__yandexcloud__folder_id": StringField(
+                lazy_gettext('Default folder ID'),
+                widget=BS3TextFieldWidget(),
+                description='Optional. This folder will be used '
+                'to create all new clusters and nodes by default',
+            ),
+            "extra__yandexcloud__public_ssh_key": StringField(
+                lazy_gettext('Public SSH key'),
+                widget=BS3TextFieldWidget(),
+                description='Optional. This key will be placed to all created Compute nodes'
+                'to let you have a root shell there',
+            ),
+        }
+
     def __init__(
         self,
+        # Connection id is deprecated. Use yandex_conn_id instead
         connection_id: Optional[str] = None,
+        yandex_conn_id: Optional[str] = None,
         default_folder_id: Union[dict, bool, None] = None,
         default_public_ssh_key: Optional[str] = None,
     ) -> None:
         super().__init__()
-        self.connection_id = connection_id or 'yandexcloud_default'
+        if connection_id:
+            warnings.warn(
+                "Using `connection_id` is deprecated. Please use `yandex_conn_id` parameter.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self.connection_id = yandex_conn_id or connection_id or self.default_conn_name
         self.connection = self.get_connection(self.connection_id)
         self.extras = self.connection.extra_dejson
         credentials = self._get_credentials()

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -79,6 +79,14 @@ class YandexCloudBaseHook(BaseHook):
             ),
         }
 
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['host', 'schema', 'login', 'password', 'port', 'extra'],
+            "relabeling": {},
+        }
+
     def __init__(
         self,
         # Connection id is deprecated. Use yandex_conn_id instead

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -47,3 +47,6 @@ hooks:
   - integration-name: Yandex.Cloud Dataproc
     python-modules:
       - airflow.providers.yandex.hooks.yandexcloud_dataproc
+
+hook-class-names:
+  - airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -22,19 +22,19 @@ import json
 import logging
 import os
 from collections import OrderedDict
-from typing import Dict, Set, Tuple
+from typing import Any, Dict, NamedTuple, Set
 
 import jsonschema
 import yaml
+from wtforms import Field
 
 from airflow.utils.entry_points import entry_points_with_dist
 
 try:
     import importlib.resources as importlib_resources
 except ImportError:
-    # Try backported to PY<37 `importlib_resources`.
+    # Try back-ported to PY<37 `importlib_resources`.
     import importlib_resources
-
 
 log = logging.getLogger(__name__)
 
@@ -45,6 +45,30 @@ def _create_validator():
     cls = jsonschema.validators.validator_for(schema)
     validator = cls(schema)
     return validator
+
+
+class ProviderInfo(NamedTuple):
+    """Provider information"""
+
+    version: str
+    provider_info: Dict
+
+
+class HookInfo(NamedTuple):
+    """Hook information"""
+
+    connection_class: str
+    connection_id_attribute_name: str
+    package_name: str
+    hook_name: str
+
+
+class ConnectionFormWidgetInfo(NamedTuple):
+    """Connection Form Widget information"""
+
+    connection_class: str
+    package_name: str
+    field: Field
 
 
 class ProvidersManager:
@@ -63,13 +87,25 @@ class ProvidersManager:
         return cls._instance
 
     def __init__(self):
-        # Keeps dict of providers keyed by module name and value is Tuple: version, provider_info
-        self._provider_dict: Dict[str, Tuple[str, Dict]] = {}
-        # Keeps dict of hooks keyed by connection type and value is
-        # Tuple: connection class, connection_id_attribute_name
-        self._hooks_dict: Dict[str, Tuple[str, str]] = {}
+        # Keeps dict of providers keyed by module name
+        self._provider_dict: Dict[str, ProviderInfo] = {}
+        # Keeps dict of hooks keyed by connection type
+        self._hooks_dict: Dict[str, HookInfo] = {}
+        # Keeps methods that should be used to add custom widgets tuple of keyed by name of the extra field
+        self._connection_form_widgets: Dict[str, ConnectionFormWidgetInfo] = {}
         self._extra_link_class_name_set: Set[str] = set()
         self._validator = _create_validator()
+        self._initialized = False
+
+    def initialize_providers_manager(self):
+        """Lazy initialization of provider data."""
+        # We cannot use @cache here because it does not work during pytests, apparently each test
+        # runs it it's own namespace and ProvidersManager is a different object in each namespace
+        # even if it is singleton but @cache on the initialize_providers_manager message still works in the
+        # way that it is called only once for one of the objects (at least this is how it looks like
+        # from running tests)
+        if self._initialized:
+            return
         # Local source folders are loaded first. They should take precedence over the package ones for
         # Development purpose. In production provider.yaml files are not present in the 'airflow" directory
         # So there is no risk we are going to override package provider accidentally. This can only happen
@@ -77,9 +113,11 @@ class ProvidersManager:
         self._discover_all_airflow_builtin_providers_from_local_sources()
         self._discover_all_providers_from_packages()
         self._discover_hooks()
-        self._provider_dict = OrderedDict(sorted(self.providers.items()))
-        self._hooks_dict = OrderedDict(sorted(self.hooks.items()))
+        self._provider_dict = OrderedDict(sorted(self._provider_dict.items()))  # noqa
+        self._hooks_dict = OrderedDict(sorted(self._hooks_dict.items()))  # noqa
+        self._connection_form_widgets = OrderedDict(sorted(self._connection_form_widgets.items()))  # noqa
         self._discover_extra_links()
+        self._initialized = True
 
     def _discover_all_providers_from_packages(self) -> None:
         """
@@ -175,7 +213,15 @@ class ProvidersManager:
                 for hook_class_name in hook_class_names:
                     self._add_hook(hook_class_name, provider_package)
 
-    def _add_hook(self, hook_class_name, provider_package) -> None:
+    @staticmethod
+    def _get_attr(obj: Any, attr_name: str):
+        """Retrieves attributes of an object, or warns if not found"""
+        if not hasattr(obj, attr_name):
+            log.warning("The '%s' is missing %s attribute and cannot be registered", obj, attr_name)
+            return None
+        return getattr(obj, attr_name)
+
+    def _add_hook(self, hook_class_name: str, provider_package: str) -> None:
         """
         Adds hook class name to list of hooks
 
@@ -201,6 +247,12 @@ class ProvidersManager:
         try:
             module, class_name = hook_class_name.rsplit('.', maxsplit=1)
             hook_class = getattr(importlib.import_module(module), class_name)
+            # Do not use attr here. We want to check only direct class fields not those
+            # inherited from parent hook. This way we add form fields only once for the whole
+            # hierarchy and we add it only from the parent hook that provides those!
+            if 'get_connection_form_widgets' in hook_class.__dict__:
+                widgets = hook_class.get_connection_form_widgets()
+                self._add_widgets(provider_package, hook_class, widgets)
         except Exception as e:  # noqa pylint: disable=broad-except
             log.warning(
                 "Exception when importing '%s' from '%s' package: %s",
@@ -209,22 +261,41 @@ class ProvidersManager:
                 e,
             )
             return
-        conn_type = getattr(hook_class, 'conn_type')
-        if not conn_type:
-            log.warning(
-                "The hook_class '%s' is missing connection_type attribute and cannot be registered",
-                hook_class,
-            )
-            return
-        connection_id_attribute_name = getattr(hook_class, 'conn_name_attr')
-        if not connection_id_attribute_name:
-            log.warning(
-                "The hook_class '%s' is missing conn_name_attr attribute and cannot be registered",
-                hook_class,
-            )
+
+        conn_type: str = self._get_attr(hook_class, 'conn_type')
+        connection_id_attribute_name: str = self._get_attr(hook_class, 'conn_name_attr')
+        hook_name: str = self._get_attr(hook_class, 'hook_name')
+
+        if not conn_type or not connection_id_attribute_name or not hook_name:
             return
 
-        self._hooks_dict[conn_type] = (hook_class_name, connection_id_attribute_name)
+        self._hooks_dict[conn_type] = HookInfo(
+            hook_class_name,
+            connection_id_attribute_name,
+            provider_package,
+            hook_name,
+        )
+
+    def _add_widgets(self, package_name: str, hook_class: type, widgets: Dict[str, Field]):
+        for field_name, field in widgets.items():
+            if not field_name.startswith("extra__"):
+                log.warning(
+                    "The field %s from class %s does not start with 'extra__'. Ignoring it.",
+                    field_name,
+                    hook_class.__name__,
+                )
+                continue
+            if field_name in self._connection_form_widgets:
+                log.warning(
+                    "The field %s from class %s has already been added by another provider. Ignoring it.",
+                    field_name,
+                    hook_class.__name__,
+                )
+                # In case of inherited hooks this might be happening several times
+                continue
+            self._connection_form_widgets[field_name] = ConnectionFormWidgetInfo(
+                hook_class.__name__, package_name, field
+            )
 
     def _discover_extra_links(self) -> None:
         """Retrieves all extra links defined in the providers"""
@@ -253,16 +324,25 @@ class ProvidersManager:
         self._extra_link_class_name_set.add(extra_link_class_name)
 
     @property
-    def providers(self):
+    def providers(self) -> Dict[str, ProviderInfo]:
         """Returns information about available providers."""
+        self.initialize_providers_manager()
         return self._provider_dict
 
     @property
-    def hooks(self):
+    def hooks(self) -> Dict[str, HookInfo]:
         """Returns dictionary of connection_type-to-hook mapping"""
+        self.initialize_providers_manager()
         return self._hooks_dict
 
     @property
     def extra_links_class_names(self):
         """Returns set of extra link class names."""
+        self.initialize_providers_manager()
         return sorted(list(self._extra_link_class_name_set))
+
+    @property
+    def connection_form_widgets(self) -> Dict[str, ConnectionFormWidgetInfo]:
+        """Returns widgets for connection forms."""
+        self.initialize_providers_manager()
+        return self._connection_form_widgets

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -494,6 +494,11 @@ USE_JOB_SCHEDULE = conf.getboolean('scheduler', 'use_job_schedule', fallback=Tru
 # if you want to load plugins whenever 'airflow' is invoked via cli or loaded from module.
 LAZY_LOAD_PLUGINS = conf.getboolean('core', 'lazy_load_plugins', fallback=True)
 
+# By default Airflow providers are lazily-discovered (discovery and imports happen only when required).
+# Set it to False, if you want to discover providers whenever 'airflow' is invoked via cli or
+# loaded from module.
+LAZY_LOAD_PROVIDERS = conf.getboolean('core', 'lazy_discover_providers', fallback=True)
+
 # Determines if the executor utilizes Kubernetes
 IS_K8S_OR_K8SCELERY_EXECUTOR = conf.get('core', 'EXECUTOR') in {
     executor_constants.KUBERNETES_EXECUTOR,

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -123,7 +123,6 @@ def create_app(config=None, testing=False, app_name="Airflow"):
         init_jinja_globals(flask_app)
         init_xframe_protection(flask_app)
         init_permanent_session(flask_app)
-
     return flask_app
 
 

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -24,6 +24,7 @@ from flask import Flask, request
 
 from airflow.api_connexion.exceptions import common_error_handler
 from airflow.security import permissions
+from airflow.www.forms import lazy_add_provider_discovered_options_to_connection_form
 
 log = logging.getLogger(__name__)
 
@@ -79,6 +80,7 @@ def init_appbuilder_views(app):
         category=permissions.RESOURCE_ADMIN_MENU,
         category_icon="fa-user",
     )
+    lazy_add_provider_discovered_options_to_connection_form()
     appbuilder.add_view(
         views.ConnectionModelView, permissions.RESOURCE_CONNECTION, category=permissions.RESOURCE_ADMIN_MENU
     )

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -19,6 +19,7 @@
 import json
 from datetime import datetime as dt
 from operator import itemgetter
+from typing import List, Tuple
 
 import pendulum
 from flask_appbuilder.fieldwidgets import (
@@ -34,6 +35,7 @@ from wtforms import widgets
 from wtforms.fields import (
     BooleanField,
     Field,
+    HiddenField,
     IntegerField,
     PasswordField,
     SelectField,
@@ -223,16 +225,15 @@ class ConnectionForm(DynamicForm):
     port = IntegerField(lazy_gettext('Port'), validators=[Optional()], widget=BS3TextFieldWidget())
     extra = TextAreaField(lazy_gettext('Extra'), widget=BS3TextAreaFieldWidget())
 
-    # You should add connection form fields in the hooks via get_connection_form_widgets() method
-    # See for example airflow/providers/jdbc/hooks/jdbc.py
-    # It is esed to customized the form, the forms elements get rendered
-    # and results are stored in the extra field as json. All of these
-    # need to be prefixed with extra__ and then the conn_type ___ as in
-    # extra__{conn_type}__name. You can also hide form elements and rename
-    # others from the connection_form.js file
+    # Used to store a dictionary of field customizations used to dynamically change available
+    # fields in ConnectionForm based on type of connection chosen
+    field_parameters = HiddenField(
+        'field_parameters', default=json.dumps(ProvidersManager().field_behaviours)
+    )
+    # See airflow.hooks.base_hook.DiscoverableProtocol for details on how to customize your Hooks.
 
 
-def _get_connection_types():
+def _get_connection_types() -> List[Tuple[str, str]]:
     """Returns connection types available."""
     _connection_types = [
         ('fs', 'File (path)'),

--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -40,9 +40,10 @@ from wtforms.fields import (
     StringField,
     TextAreaField,
 )
-from wtforms.validators import InputRequired, NumberRange, Optional
+from wtforms.validators import InputRequired, Optional
 
 from airflow.configuration import conf
+from airflow.providers_manager import ProvidersManager
 from airflow.utils import timezone
 from airflow.utils.types import DagRunType
 from airflow.www.validators import ValidJson
@@ -210,75 +211,10 @@ class TaskInstanceEditForm(DynamicForm):
     )
 
 
-_connection_types = [
-    ('docker', 'Docker Registry'),
-    ('elasticsearch', 'Elasticsearch'),
-    ('exasol', 'Exasol'),
-    ('facebook_social', 'Facebook Social'),
-    ('fs', 'File (path)'),
-    ('ftp', 'FTP'),
-    ('google_cloud_platform', 'Google Cloud'),
-    ('hdfs', 'HDFS'),
-    ('http', 'HTTP'),
-    ('pig_cli', 'Pig Client Wrapper'),
-    ('hive_cli', 'Hive Client Wrapper'),
-    ('hive_metastore', 'Hive Metastore Thrift'),
-    ('hiveserver2', 'Hive Server 2 Thrift'),
-    ('jdbc', 'JDBC Connection'),
-    ('odbc', 'ODBC Connection'),
-    ('jenkins', 'Jenkins'),
-    ('mysql', 'MySQL'),
-    ('postgres', 'Postgres'),
-    ('oracle', 'Oracle'),
-    ('vertica', 'Vertica'),
-    ('presto', 'Presto'),
-    ('s3', 'S3'),
-    ('samba', 'Samba'),
-    ('sqlite', 'Sqlite'),
-    ('ssh', 'SSH'),
-    ('cloudant', 'IBM Cloudant'),
-    ('mssql', 'Microsoft SQL Server'),
-    ('mesos_framework-id', 'Mesos Framework ID'),
-    ('jira', 'JIRA'),
-    ('redis', 'Redis'),
-    ('wasb', 'Azure Blob Storage'),
-    ('databricks', 'Databricks'),
-    ('aws', 'Amazon Web Services'),
-    ('emr', 'Elastic MapReduce'),
-    ('snowflake', 'Snowflake'),
-    ('segment', 'Segment'),
-    ('sqoop', 'Sqoop'),
-    ('azure_batch', 'Azure Batch Service'),
-    ('azure_data_lake', 'Azure Data Lake'),
-    ('azure_container_instances', 'Azure Container Instances'),
-    ('azure_cosmos', 'Azure CosmosDB'),
-    ('azure_data_explorer', 'Azure Data Explorer'),
-    ('cassandra', 'Cassandra'),
-    ('qubole', 'Qubole'),
-    ('mongo', 'MongoDB'),
-    ('gcpcloudsql', 'Google Cloud SQL'),
-    ('grpc', 'GRPC Connection'),
-    ('yandexcloud', 'Yandex Cloud'),
-    ('livy', 'Apache Livy'),
-    ('tableau', 'Tableau'),
-    ('kubernetes', 'Kubernetes Cluster Connection'),
-    ('spark', 'Spark'),
-    ('imap', 'IMAP'),
-    ('vault', 'Hashicorp Vault'),
-    ('azure', 'Azure'),
-]
-
-
 class ConnectionForm(DynamicForm):
     """Form for editing and adding Connection"""
 
     conn_id = StringField(lazy_gettext('Conn Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
-    conn_type = SelectField(
-        lazy_gettext('Conn Type'),
-        choices=sorted(_connection_types, key=itemgetter(1)),  # pylint: disable=protected-access
-        widget=Select2Widget(),
-        validators=[InputRequired()],
-    )
     description = StringField(lazy_gettext('Description'), widget=BS3TextAreaFieldWidget())
     host = StringField(lazy_gettext('Host'), widget=BS3TextFieldWidget())
     schema = StringField(lazy_gettext('Schema'), widget=BS3TextFieldWidget())
@@ -287,71 +223,34 @@ class ConnectionForm(DynamicForm):
     port = IntegerField(lazy_gettext('Port'), validators=[Optional()], widget=BS3TextFieldWidget())
     extra = TextAreaField(lazy_gettext('Extra'), widget=BS3TextAreaFieldWidget())
 
-    # Used to customized the form, the forms elements get rendered
+    # You should add connection form fields in the hooks via get_connection_form_widgets() method
+    # See for example airflow/providers/jdbc/hooks/jdbc.py
+    # It is esed to customized the form, the forms elements get rendered
     # and results are stored in the extra field as json. All of these
     # need to be prefixed with extra__ and then the conn_type ___ as in
     # extra__{conn_type}__name. You can also hide form elements and rename
     # others from the connection_form.js file
-    extra__jdbc__drv_path = StringField(lazy_gettext('Driver Path'), widget=BS3TextFieldWidget())
-    extra__jdbc__drv_clsname = StringField(lazy_gettext('Driver Class'), widget=BS3TextFieldWidget())
-    extra__google_cloud_platform__project = StringField(
-        lazy_gettext('Project Id'), widget=BS3TextFieldWidget()
+
+
+def _get_connection_types():
+    """Returns connection types available."""
+    _connection_types = [
+        ('fs', 'File (path)'),
+        ('mesos_framework-id', 'Mesos Framework ID'),
+    ]
+    providers_manager = ProvidersManager()
+    for connection_type, (_, _, _, hook_name) in providers_manager.hooks.items():
+        _connection_types.append((connection_type, hook_name))
+    return _connection_types
+
+
+def lazy_add_provider_discovered_options_to_connection_form():
+    """Adds provider-discovered connection parameters as late as possible"""
+    ConnectionForm.conn_type = SelectField(
+        lazy_gettext('Conn Type'),
+        choices=sorted(_get_connection_types(), key=itemgetter(1)),
+        widget=Select2Widget(),
+        validators=[InputRequired()],
     )
-    extra__google_cloud_platform__key_path = StringField(
-        lazy_gettext('Keyfile Path'), widget=BS3TextFieldWidget()
-    )
-    extra__google_cloud_platform__keyfile_dict = PasswordField(
-        lazy_gettext('Keyfile JSON'), widget=BS3PasswordFieldWidget()
-    )
-    extra__google_cloud_platform__scope = StringField(
-        lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget()
-    )
-    extra__google_cloud_platform__num_retries = IntegerField(
-        lazy_gettext('Number of Retries'),
-        validators=[NumberRange(min=0)],
-        widget=BS3TextFieldWidget(),
-        default=5,
-    )
-    extra__grpc__auth_type = StringField(lazy_gettext('Grpc Auth Type'), widget=BS3TextFieldWidget())
-    extra__grpc__credential_pem_file = StringField(
-        lazy_gettext('Credential Keyfile Path'), widget=BS3TextFieldWidget()
-    )
-    extra__grpc__scopes = StringField(lazy_gettext('Scopes (comma separated)'), widget=BS3TextFieldWidget())
-    extra__yandexcloud__service_account_json = PasswordField(
-        lazy_gettext('Service account auth JSON'),
-        widget=BS3PasswordFieldWidget(),
-        description='Service account auth JSON. Looks like '
-        '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
-        'Will be used instead of OAuth token and SA JSON file path field if specified.',
-    )
-    extra__yandexcloud__service_account_json_path = StringField(
-        lazy_gettext('Service account auth JSON file path'),
-        widget=BS3TextFieldWidget(),
-        description='Service account auth JSON file path. File content looks like '
-        '{"id", "...", "service_account_id": "...", "private_key": "..."}. '
-        'Will be used instead of OAuth token if specified.',
-    )
-    extra__yandexcloud__oauth = PasswordField(
-        lazy_gettext('OAuth Token'),
-        widget=BS3PasswordFieldWidget(),
-        description='User account OAuth token. Either this or service account JSON must be specified.',
-    )
-    extra__yandexcloud__folder_id = StringField(
-        lazy_gettext('Default folder ID'),
-        widget=BS3TextFieldWidget(),
-        description='Optional. This folder will be used to create all new clusters and nodes by default',
-    )
-    extra__yandexcloud__public_ssh_key = StringField(
-        lazy_gettext('Public SSH key'),
-        widget=BS3TextFieldWidget(),
-        description='Optional. This key will be placed to all created Compute nodes'
-        'to let you have a root shell there',
-    )
-    extra__kubernetes__in_cluster = BooleanField(lazy_gettext('In cluster configuration'))
-    extra__kubernetes__kube_config_path = StringField(
-        lazy_gettext('Kube config path'), widget=BS3TextFieldWidget()
-    )
-    extra__kubernetes__kube_config = StringField(
-        lazy_gettext('Kube config (JSON format)'), widget=BS3TextFieldWidget()
-    )
-    extra__kubernetes__namespace = StringField(lazy_gettext('Namespace'), widget=BS3TextFieldWidget())
+    for key, value in ProvidersManager().connection_form_widgets.items():
+        setattr(ConnectionForm, key, value.field)

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -21,59 +21,6 @@
  */
 
 $(document).ready(function () {
-  var config = {
-    jdbc: {
-      hidden_fields: ['port', 'schema', 'extra'],
-      relabeling: {'host': 'Connection URL'},
-    },
-    google_cloud_platform: {
-      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
-      relabeling: {},
-    },
-    cloudant: {
-      hidden_fields: ['port', 'extra'],
-      relabeling: {
-        'host': 'Account',
-        'login': 'Username (or API Key)',
-        'schema': 'Database'
-      }
-    },
-    docker: {
-      hidden_fields: ['port', 'schema'],
-      relabeling: {
-        'host': 'Registry URL',
-        'login': 'Username',
-      },
-    },
-    qubole: {
-      hidden_fields: ['login', 'schema', 'port', 'extra'],
-      relabeling: {
-        'host': 'API Endpoint',
-        'password': 'Auth Token',
-      },
-      placeholders: {
-        'host': 'https://<env>.qubole.com/api'
-      }
-    },
-    kubernetes: {
-      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
-      relabeling: {},
-    },
-    ssh: {
-      hidden_fields: ['schema'],
-      relabeling: {
-        'login': 'Username',
-      }
-    },
-    yandexcloud: {
-      hidden_fields: ['host', 'schema', 'login', 'password', 'port', 'extra'],
-      relabeling: {},
-    },
-    spark: {
-      hidden_fields: ['schema', 'login', 'password'],
-      relabeling: {},
-    },
-  };
 
   function connTypeChange(connectionType) {
     $(".hide").removeClass("hide");
@@ -87,7 +34,7 @@ $(document).ready(function () {
       $(this).text($(this).attr("orig_text"));
     });
     $(".form-control").each(function(){$(this).attr('placeholder', '')});
-
+    let config = JSON.parse($("#field_parameters").val())
     if (config[connectionType] != undefined) {
       $.each(config[connectionType].hidden_fields, function (i, field) {
         $("#" + field).parent().parent().addClass('hide')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -77,6 +77,7 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagcode import DagCode
 from airflow.models.dagrun import DagRun, DagRunType
 from airflow.models.taskinstance import TaskInstance
+from airflow.providers_manager import ProvidersManager
 from airflow.security import permissions
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import RUNNING_DEPS, SCHEDULER_QUEUED_DEPS
@@ -2814,26 +2815,7 @@ class ConnectionModelView(AirflowModelView):
         permissions.ACTION_CAN_ACCESS_MENU,
     ]
 
-    extra_fields = [
-        'extra__jdbc__drv_path',
-        'extra__jdbc__drv_clsname',
-        'extra__google_cloud_platform__project',
-        'extra__google_cloud_platform__key_path',
-        'extra__google_cloud_platform__keyfile_dict',
-        'extra__google_cloud_platform__scope',
-        'extra__google_cloud_platform__num_retries',
-        'extra__grpc__auth_type',
-        'extra__grpc__credential_pem_file',
-        'extra__grpc__scopes',
-        'extra__yandexcloud__service_account_json',
-        'extra__yandexcloud__service_account_json_path',
-        'extra__yandexcloud__oauth',
-        'extra__yandexcloud__public_ssh_key',
-        'extra__yandexcloud__folder_id',
-        'extra__kubernetes__in_cluster',
-        'extra__kubernetes__kube_config',
-        'extra__kubernetes__namespace',
-    ]
+    extra_fields = list(ProvidersManager().connection_form_widgets.keys())
     list_columns = [
         'conn_id',
         'conn_type',
@@ -2854,6 +2836,7 @@ class ConnectionModelView(AirflowModelView):
         'port',
         'extra',
     ] + extra_fields
+
     add_form = edit_form = ConnectionForm
     add_template = 'airflow/conn_create.html'
     edit_template = 'airflow/conn_edit.html'

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -90,7 +90,7 @@ function discover_all_provider_packages() {
     local actual_number_of_providers
     actual_providers=$(airflow providers list --output yaml | grep package_name)
     actual_number_of_providers=$(wc -l <<<"$actual_providers")
-    if [[ "${actual_number_of_providers}" != "${expected_number_of_providers}" ]]; then
+    if [[ ${actual_number_of_providers} != "${expected_number_of_providers}" ]]; then
         echo
         echo  "${COLOR_RED_ERROR}Number of providers installed is wrong${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_providers}' and got '${actual_number_of_providers}'"
@@ -111,9 +111,9 @@ function discover_all_hooks() {
 
     airflow providers hooks
 
-    local expected_number_of_hooks=33
+    local expected_number_of_hooks=58
     local actual_number_of_hooks
-    actual_number_of_hooks=$(airflow providers hooks --output table | grep -c conn_id | xargs)
+    actual_number_of_hooks=$(airflow providers hooks --output table | grep -c "| apache" | xargs)
     if [[ ${actual_number_of_hooks} != "${expected_number_of_hooks}" ]]; then
         echo
         echo  "${COLOR_RED_ERROR} Number of hooks registered is wrong  ${COLOR_RESET}"
@@ -146,9 +146,31 @@ function discover_all_extra_links() {
     fi
 }
 
+function discover_all_connection_form_widgets() {
+    echo
+    echo Listing available widgets via 'airflow providers widgets'
+    echo
+
+    airflow providers widgets
+
+    local expected_number_of_widgets=19
+    local actual_number_of_widgets
+    actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
+    if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
+        echo
+        echo  "${COLOR_RED_ERROR} Number of hooks registered is wrong  ${COLOR_RESET}"
+        echo "Expected number was '${expected_number_of_widgets}' and got '${actual_number_of_widgets}'"
+        echo
+        echo "Either increase the number of hooks if you added one or fix problem with imports if you see one."
+        echo
+        exit 1
+    fi
+}
+
 
 if [[ ${BACKPORT_PACKAGES} != "true" ]]; then
     discover_all_provider_packages
     discover_all_hooks
     discover_all_extra_links
+    discover_all_connection_form_widgets
 fi

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -158,10 +158,33 @@ function discover_all_connection_form_widgets() {
     actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
     if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Number of hooks registered is wrong  ${COLOR_RESET}"
+        echo  "${COLOR_RED_ERROR} Number of connections with widgets registered is wrong  ${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_widgets}' and got '${actual_number_of_widgets}'"
         echo
-        echo "Either increase the number of hooks if you added one or fix problem with imports if you see one."
+        echo "Increase the number of connections with widgets if you added one or investigate"
+        echo
+        exit 1
+    fi
+}
+
+function discover_all_field_behaviours() {
+    echo
+    echo Listing available fields via 'airflow providers fields'
+    echo
+
+    airflow providers fields
+
+    local expected_number_of_connections_with_behaviours=10
+    local actual_number_of_connections_with_behaviours
+    actual_number_of_connections_with_behaviours=$(airflow providers fields --output table | grep -v "===" | \
+        grep -v customized_connections | grep -cv "^ " | xargs)
+    if [[ ${actual_number_of_connections_with_behaviours} != \
+            "${expected_number_of_connections_with_behaviours}" ]]; then
+        echo
+        echo  "${COLOR_RED_ERROR} Number of connections field behaviours is wrong  ${COLOR_RESET}"
+        echo "Expected number was '${expected_number_of_connections_with_behaviours}' and got '${actual_number_of_connections_with_behaviours}'"
+        echo
+        echo "Increase the number of connections if you added one or investigate."
         echo
         exit 1
     fi
@@ -171,6 +194,7 @@ function discover_all_connection_form_widgets() {
 if [[ ${BACKPORT_PACKAGES} != "true" ]]; then
     discover_all_provider_packages
     discover_all_hooks
-    discover_all_extra_links
     discover_all_connection_form_widgets
+    discover_all_field_behaviours
+    discover_all_extra_links
 fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -146,6 +146,9 @@ airflow=
     py.typed
     alembic.ini
     git_version
+    customized_form_fields.schema.json
+    provider.yaml.schema.json
+
 airflow.api.connextion.openaip=*.yaml
 airflow.serialization=*.json
 

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -84,25 +84,39 @@ ALL_PROVIDERS = [
 ]
 
 CONNECTIONS_LIST = [
+    'aws',
+    'azure',
     'azure_batch',
+    'azure_container_instances',
     'azure_cosmos',
+    'azure_data_explorer',
     'azure_data_lake',
     'cassandra',
     'cloudant',
+    'databricks',
     'dataprep',
     'docker',
     'elasticsearch',
+    'emr',
     'exasol',
+    'facebook_social',
+    'ftp',
     'gcpcloudsql',
+    'gcpcloudsqldb',
     'gcpssh',
     'google_cloud_platform',
     'grpc',
+    'hdfs',
     'hive_cli',
+    'hive_metastore',
     'hiveserver2',
+    'http',
     'imap',
     'jdbc',
+    'jenkins',
     'jira',
     'kubernetes',
+    'livy',
     'mongo',
     'mssql',
     'mysql',
@@ -111,12 +125,45 @@ CONNECTIONS_LIST = [
     'pig_cli',
     'postgres',
     'presto',
+    'qubole',
     'redis',
+    's3',
+    'samba',
+    'segment',
     'snowflake',
+    'spark',
+    'spark_jdbc',
+    'spark_sql',
     'sqlite',
+    'sqoop',
+    'ssh',
     'tableau',
+    'vault',
     'vertica',
     'wasb',
+    'yandexcloud',
+]
+
+CONNECTION_FORM_WIDGETS = [
+    'extra__google_cloud_platform__key_path',
+    'extra__google_cloud_platform__keyfile_dict',
+    'extra__google_cloud_platform__num_retries',
+    'extra__google_cloud_platform__project',
+    'extra__google_cloud_platform__scope',
+    'extra__grpc__auth_type',
+    'extra__grpc__credential_pem_file',
+    'extra__grpc__scopes',
+    'extra__jdbc__drv_clsname',
+    'extra__jdbc__drv_path',
+    'extra__kubernetes__in_cluster',
+    'extra__kubernetes__kube_config',
+    'extra__kubernetes__kube_config_path',
+    'extra__kubernetes__namespace',
+    'extra__yandexcloud__folder_id',
+    'extra__yandexcloud__oauth',
+    'extra__yandexcloud__public_ssh_key',
+    'extra__yandexcloud__service_account_json',
+    'extra__yandexcloud__service_account_json_path',
 ]
 
 EXTRA_LINKS = [
@@ -137,7 +184,6 @@ class TestProviderManager(unittest.TestCase):
             version = provider_manager.providers[provider][0]
             self.assertRegex(version, r'[0-9]*\.[0-9]*\.[0-9]*.*')
             self.assertEqual(package_name, provider)
-
         self.assertEqual(ALL_PROVIDERS, provider_list)
 
     def test_hooks(self):
@@ -149,3 +195,8 @@ class TestProviderManager(unittest.TestCase):
         provider_manager = ProvidersManager()
         extra_link_class_names = list(provider_manager.extra_links_class_names)
         self.assertEqual(EXTRA_LINKS, extra_link_class_names)
+
+    def test_connection_form_widgets(self):
+        provider_manager = ProvidersManager()
+        connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
+        self.assertEqual(CONNECTION_FORM_WIDGETS, connections_form_widgets)

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -130,6 +130,7 @@ CONNECTIONS_LIST = [
     's3',
     'samba',
     'segment',
+    'sftp',
     'snowflake',
     'spark',
     'spark_jdbc',
@@ -166,6 +167,20 @@ CONNECTION_FORM_WIDGETS = [
     'extra__yandexcloud__service_account_json_path',
 ]
 
+CUSTOMIZED_CONNECTIONS = [
+    'cloudant',
+    'docker',
+    'gcpssh',
+    'google_cloud_platform',
+    'jdbc',
+    'kubernetes',
+    'qubole',
+    'sftp',
+    'spark',
+    'ssh',
+    'yandexcloud',
+]
+
 EXTRA_LINKS = [
     'airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink',
     'airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink',
@@ -191,12 +206,17 @@ class TestProviderManager(unittest.TestCase):
         connections_list = list(provider_manager.hooks.keys())
         self.assertEqual(CONNECTIONS_LIST, connections_list)
 
-    def test_extra_links(self):
-        provider_manager = ProvidersManager()
-        extra_link_class_names = list(provider_manager.extra_links_class_names)
-        self.assertEqual(EXTRA_LINKS, extra_link_class_names)
-
     def test_connection_form_widgets(self):
         provider_manager = ProvidersManager()
         connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
         self.assertEqual(CONNECTION_FORM_WIDGETS, connections_form_widgets)
+
+    def test_field_customizations(self):
+        provider_manager = ProvidersManager()
+        field_customizations = list(provider_manager.field_behaviours.keys())
+        self.assertEqual(CUSTOMIZED_CONNECTIONS, field_customizations)
+
+    def test_extra_links(self):
+        provider_manager = ProvidersManager()
+        extra_link_class_names = list(provider_manager.extra_links_class_names)
+        self.assertEqual(EXTRA_LINKS, extra_link_class_names)

--- a/tests/providers/presto/hooks/test_presto.py
+++ b/tests/providers/presto/hooks/test_presto.py
@@ -217,6 +217,23 @@ class TestPrestoHookIntegration(unittest.TestCase):
         records = hook.get_records(sql)
         self.assertEqual([['Customer#000000001'], ['Customer#000000002'], ['Customer#000000003']], records)
 
+    @pytest.mark.xfail(
+        condition=True,
+        reason="""
+This test will fail when full suite of tests are run, because of Snowflake monkeypatching urllib3
+library as described in https://github.com/snowflakedb/snowflake-connector-python/issues/324
+the offending code is here:
+https://github.com/snowflakedb/snowflake-connector-python/blob/133d6215f7920d304c5f2d466bae38127c1b836d/src/snowflake/connector/network.py#L89-L92
+
+This test however runs fine when run in total isolation. We could move it to Heisentests, but then we would
+have to enable integrations there and make sure no snowflake gets imported.
+
+In the future Snowflake plans to get rid of the MonkeyPatching.
+
+Issue to keep track of it: https://github.com/apache/airflow/issues/12881
+
+""",
+    )
     @pytest.mark.integration("presto")
     @pytest.mark.integration("kerberos")
     def test_should_record_records_with_kerberos_auth(self):

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -266,6 +266,13 @@ class TestSSHHook(unittest.TestCase):
             (_, stdout, _) = client.exec_command('ls')  # pylint: disable=no-member
             self.assertIsNotNone(stdout.read())
 
+    def test_ssh_connection_no_connection_id(self):
+        hook = SSHHook(remote_host='localhost')
+        with hook.get_conn() as client:
+            # Note - Pylint will fail with no-member here due to https://github.com/PyCQA/pylint/issues/1437
+            (_, stdout, _) = client.exec_command('ls')  # pylint: disable=no-member
+            self.assertIsNotNone(stdout.read())
+
     def test_ssh_connection_old_cm(self):
         with SSHHook(ssh_conn_id='ssh_default') as hook:
             client = hook.get_conn()


### PR DESCRIPTION
Please only look at last commit as it is based on #12837

In the connection form, part of customizations was a
per-provider customized javascript to hide/rename fields.

This PR uses provider discoverability to configure the
fields per-provider. It builds dictionary of connection
field customization parameters and passes it as a hidden
field of FAB form.

Part of #11429


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
