### PR TITLE
Only trigger action 'Label when reviewed' for specific event type

### DIFF
--- a/.github/workflows/label_when_reviewed.yml
+++ b/.github/workflows/label_when_reviewed.yml
@@ -17,7 +17,9 @@
 #
 ---
 name: Label when reviewed
-on: pull_request_review  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  pull_request_review:
+    types: [submitted]
 
 jobs:
 


### PR DESCRIPTION
We notice sometimes the Action job `"Label PRs when reviewed"` is triggered for multiple times, even if there is only one approval https://github.com/apache/airflow/pull/12816#issuecomment-739023107

According to https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_review
there are three types, '_submitted_', '_edited_', and '_dismissed_', for `pull_request_review`.
We should only trigger when the type is '_submitted_'.

I don't think this can fully resolve the issue we found above, but should be done anyway before we make any further refactoring.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
