### PR TITLE
Fix login error warning

### DIFF
--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -18,7 +18,7 @@
 from functools import wraps
 from typing import Callable, Optional, Sequence, Tuple, TypeVar, cast
 
-from flask import current_app, redirect, request, url_for
+from flask import current_app, flash, redirect, request, url_for
 
 T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
 
@@ -32,6 +32,9 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
             appbuilder = current_app.appbuilder
             if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
                 return func(*args, **kwargs)
+            else:
+                access_denied = "Access is Denied"
+                flash(access_denied, "danger")
             return redirect(
                 url_for(
                     appbuilder.sm.auth_view.__class__.__name__ + ".login",

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -18,7 +18,7 @@
 from functools import wraps
 from typing import Callable, Optional, Sequence, Tuple, TypeVar, cast
 
-from flask import current_app, flash, redirect, request, url_for
+from flask import current_app, redirect, request, url_for
 
 T = TypeVar("T", bound=Callable)  # pylint: disable=invalid-name
 
@@ -32,9 +32,6 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
             appbuilder = current_app.appbuilder
             if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
                 return func(*args, **kwargs)
-            else:
-                access_denied = "Access is Denied"
-                flash(access_denied, "danger")
             return redirect(
                 url_for(
                     appbuilder.sm.auth_view.__class__.__name__ + ".login",

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -41,10 +41,12 @@
 
   {% if regular_alerts %}
     {% for category, m in regular_alerts %}
-      <div class="alert alert-{{ category if category else 'info' }}">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        {{ m }}
-      </div>
+      {% if not ('login' in request.path and 'access is denied' in m.lower()) %}
+        <div class="alert alert-{{ category if category else 'info' }}">
+          <button type="button" class="close" data-dismiss="alert">&times;</button>
+          {{ m }}
+        </div>
+      {% endif %}
     {% endfor %}
   {% endif %}
 

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -41,7 +41,8 @@
 
   {% if regular_alerts %}
     {% for category, m in regular_alerts %}
-      {% if not ('login' in request.path and 'access is denied' in m.lower()) %}
+      {% if not (request.path == appbuilder.get_url_for_login and 'access is denied' in m.lower()) %}
+      {# Don't show 'Access is Denied' alert if user is logged out and on the login page. #}
         <div class="alert alert-{{ category if category else 'info' }}">
           <button type="button" class="close" data-dismiss="alert">&times;</button>
           {{ m }}

--- a/airflow/www/templates/appbuilder/navbar_menu.html
+++ b/airflow/www/templates/appbuilder/navbar_menu.html
@@ -21,7 +21,10 @@
   <a href="{{item.get_url()}}">{{_(item.label)}}</a>
 {% endmacro %}
 
-<li class="dropdown"><a href="{{ url_for('Airflow.index') }}">DAGs</a></li>
+{% if current_user.is_authenticated %}
+  <li class="dropdown"><a href="{{ url_for('Airflow.index') }}">DAGs</a></li>
+{% endif %}
+
 {% for item1 in menu.get_list() %}
   {% if item1 | is_menu_visible %}
     {% if item1.childs %}


### PR DESCRIPTION
Currently, when a user is logged out, the `DAGs` link shows in the menu and the `Not Logged In` warning shows if the user has been directed to `/login` from any other page.

![image (4)](https://user-images.githubusercontent.com/4926004/101269645-f2196400-3725-11eb-9a43-7aee53cb0af2.png)

This hides the `DAGs` menu item unless the user is logged in, and doesn't show a warning if an unauthenticated user redirects to `/login`.
