### PR TITLE
Add conditional version retrieval from setup.

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -24,6 +24,13 @@ try:
 except ImportError:
     import importlib_metadata as metadata
 
-version = metadata.version('apache-airflow')
+try:
+    version = metadata.version('apache-airflow')
+except metadata.PackageNotFoundError:
+    import logging
+
+    log = logging.getLogger(__name__)
+    log.warning("Package metadata could not be found. Overriding it with version found in setup.py")
+    from setup import version
 
 del metadata


### PR DESCRIPTION
When airflow is not installed as package (for example for local
development from sources) there is no package metadata.

Many of our unit tests use the version field and they fail if they
are run within virtual environment where airflow is not installed
as package (for example in IntelliJ this is default setting.

This PR adds fall-back to read airflow version from setup in
case it cannot be read from package metadata.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
