### PR TITLE
Mark required fields in Forms as required

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -40,7 +40,7 @@ from wtforms.fields import (
     StringField,
     TextAreaField,
 )
-from wtforms.validators import DataRequired, NumberRange, Optional
+from wtforms.validators import InputRequired, NumberRange, Optional
 
 from airflow.configuration import conf
 from airflow.utils import timezone
@@ -134,10 +134,10 @@ class DateTimeWithNumRunsWithDagRunsForm(DateTimeWithNumRunsForm):
 class DagRunForm(DynamicForm):
     """Form for adding DAG Run"""
 
-    dag_id = StringField(lazy_gettext('Dag Id'), validators=[DataRequired()], widget=BS3TextFieldWidget())
+    dag_id = StringField(lazy_gettext('Dag Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
     start_date = DateTimeWithTimezoneField(lazy_gettext('Start Date'), widget=AirflowDateTimePickerWidget())
     end_date = DateTimeWithTimezoneField(lazy_gettext('End Date'), widget=AirflowDateTimePickerWidget())
-    run_id = StringField(lazy_gettext('Run Id'), validators=[DataRequired()], widget=BS3TextFieldWidget())
+    run_id = StringField(lazy_gettext('Run Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
     state = SelectField(
         lazy_gettext('State'),
         choices=(
@@ -146,9 +146,12 @@ class DagRunForm(DynamicForm):
             ('failed', 'failed'),
         ),
         widget=Select2Widget(),
+        validators=[InputRequired()],
     )
     execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'), widget=AirflowDateTimePickerWidget()
+        lazy_gettext('Execution Date'),
+        widget=AirflowDateTimePickerWidget(),
+        validators=[InputRequired()],
     )
     external_trigger = BooleanField(lazy_gettext('External Trigger'))
     conf = TextAreaField(
@@ -166,12 +169,14 @@ class DagRunForm(DynamicForm):
 class DagRunEditForm(DagRunForm):
     """Form for editing DAG Run"""
 
-    dag_id = StringField(lazy_gettext('Dag Id'), validators=[DataRequired()], widget=BS3TextFieldROWidget())
+    dag_id = StringField(lazy_gettext('Dag Id'), validators=[InputRequired()], widget=BS3TextFieldROWidget())
     start_date = DateTimeWithTimezoneField(lazy_gettext('Start Date'), widget=AirflowDateTimePickerROWidget())
     end_date = DateTimeWithTimezoneField(lazy_gettext('End Date'), widget=AirflowDateTimePickerROWidget())
-    run_id = StringField(lazy_gettext('Run Id'), validators=[DataRequired()], widget=BS3TextFieldROWidget())
+    run_id = StringField(lazy_gettext('Run Id'), validators=[InputRequired()], widget=BS3TextFieldROWidget())
     execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'), widget=AirflowDateTimePickerROWidget()
+        lazy_gettext('Execution Date'),
+        widget=AirflowDateTimePickerROWidget(),
+        validators=[InputRequired()],
     )
     conf = TextAreaField(
         lazy_gettext('Conf'), validators=[ValidJson(), Optional()], widget=BS3TextAreaROWidget()
@@ -181,8 +186,10 @@ class DagRunEditForm(DagRunForm):
 class TaskInstanceEditForm(DynamicForm):
     """Form for editing TaskInstance"""
 
-    dag_id = StringField(lazy_gettext('Dag Id'), validators=[DataRequired()], widget=BS3TextFieldROWidget())
-    task_id = StringField(lazy_gettext('Task Id'), validators=[DataRequired()], widget=BS3TextFieldROWidget())
+    dag_id = StringField(lazy_gettext('Dag Id'), validators=[InputRequired()], widget=BS3TextFieldROWidget())
+    task_id = StringField(
+        lazy_gettext('Task Id'), validators=[InputRequired()], widget=BS3TextFieldROWidget()
+    )
     start_date = DateTimeWithTimezoneField(lazy_gettext('Start Date'), widget=AirflowDateTimePickerROWidget())
     end_date = DateTimeWithTimezoneField(lazy_gettext('End Date'), widget=AirflowDateTimePickerROWidget())
     state = SelectField(
@@ -194,9 +201,12 @@ class TaskInstanceEditForm(DynamicForm):
             ('up_for_retry', 'up_for_retry'),
         ),
         widget=Select2Widget(),
+        validators=[InputRequired()],
     )
     execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'), widget=AirflowDateTimePickerROWidget()
+        lazy_gettext('Execution Date'),
+        widget=AirflowDateTimePickerROWidget(),
+        validators=[InputRequired()],
     )
 
 
@@ -262,11 +272,12 @@ _connection_types = [
 class ConnectionForm(DynamicForm):
     """Form for editing and adding Connection"""
 
-    conn_id = StringField(lazy_gettext('Conn Id'), widget=BS3TextFieldWidget())
+    conn_id = StringField(lazy_gettext('Conn Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
     conn_type = SelectField(
         lazy_gettext('Conn Type'),
         choices=sorted(_connection_types, key=itemgetter(1)),  # pylint: disable=protected-access
         widget=Select2Widget(),
+        validators=[InputRequired()],
     )
     description = StringField(lazy_gettext('Description'), widget=BS3TextAreaFieldWidget())
     host = StringField(lazy_gettext('Host'), widget=BS3TextFieldWidget())


### PR DESCRIPTION
We have a number of custom forms that have required fields that weren't
explicitly marked as required.

This allowed you to submit the Connection form (for example) with
nothing as the Conn Id, leading to an empty string being used as the
connection id. This marks that and all the other required fields as
required.

We also replace DataRequired with InputRequired. The previous one is
tested the truthyness of the value, rather than just that a value was
submitted.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).