### PR TITLE
Store per-task TIDeps in serialized blob

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -657,19 +657,19 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         else:
             return 'adhoc_' + self.owner
 
-    @property
-    def deps(self) -> Set[BaseTIDep]:
-        """
-        Returns the set of dependencies for the operator. These differ from execution
-        context dependencies in that they are specific to tasks and can be
-        extended/overridden by subclasses.
-        """
-        return {
+    deps: Iterable[BaseTIDep] = frozenset(
+        {
             NotInRetryPeriodDep(),
             PrevDagrunDep(),
             TriggerRuleDep(),
             NotPreviouslySkippedDep(),
         }
+    )
+    """
+    Returns the set of dependencies for the operator. These differ from execution
+    context dependencies in that they are specific to tasks and can be
+    extended/overridden by subclasses.
+    """
 
     def prepare_for_execution(self) -> "BaseOperator":
         """

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -279,7 +279,6 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         """Define mode rescheduled sensors."""
         return self.mode == 'reschedule'
 
-    # pylint: disable=no-member
     @property
     def deps(self):
         """
@@ -287,8 +286,8 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         checks if a sensor task instance can be rescheduled.
         """
         if self.reschedule:
-            return BaseOperator.deps.fget(self) | {ReadyToRescheduleDep()}
-        return BaseOperator.deps.fget(self)
+            return super().deps | {ReadyToRescheduleDep()}
+        return super().deps
 
 
 def poke_mode_only(cls):

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -159,7 +159,13 @@
           "type": "array",
           "items": { "type": "string" }
         },
-        "_is_dummy": { "type": "boolean" }
+        "_is_dummy": { "type": "boolean" },
+        "deps": {
+          "description": "list of dep classes -- if non-standard",
+          "type": "array",
+          "items": { "type": "string" },
+          "uniqueItems": true
+        }
       },
       "additionalProperties": true
     },


### PR DESCRIPTION
Without this change sensors in "reschedule" mode were being instantly
rescheduled because they didn't have the extra dep that
BaseSensorOperator added.

To fix that we need to include deps in the serialization format (but to
save space only when they are not the default list). As of this PR right
now, only built-in deps are allowed -- a custom dep will result in a DAG
parse error.

We can fix that for 2.0.x, as I think it is a _very_ uncommon thing to
do.

Fixes #12783


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).