### PR TITLE
Bugfix: Unable to import Airflow plugins on Python 3.8

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -35,9 +35,9 @@ from typing import Any, Dict, List, Type
 from six import with_metaclass
 
 try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
     import importlib_metadata
+except ImportError:
+    import importlib.metadata as importlib_metadata
 
 from airflow import settings
 from airflow.models.baseoperator import BaseOperatorLink
@@ -157,7 +157,7 @@ def load_entrypoint_plugins(entry_points, airflow_plugins):
                 airflow_plugins.append(plugin_obj)
         except Exception as e:  # pylint: disable=broad-except
             log.exception("Failed to import plugin %s", entry_point.name)
-            import_errors[entry_point.module_name] = str(e)
+            import_errors[entry_point.module] = str(e)
     return airflow_plugins
 
 

--- a/setup.py
+++ b/setup.py
@@ -439,7 +439,7 @@ devel = [
     'freezegun',
     'gitpython',
     'idna<2.9',  # Required for moto 1.3.14
-    'importlib-metadata~=2.0; python_version<"3.8"',
+    'importlib-metadata~=2.0; python_version<"3.9"',
     'ipdb',
     'jira',
     'mock;python_version<"3.3"',

--- a/tests/plugins/test_plugins_manager_rbac.py
+++ b/tests/plugins/test_plugins_manager_rbac.py
@@ -87,7 +87,7 @@ class TestPluginsRBAC(object):
         mock_entrypoint = mock.Mock()
         mock_entrypoint.name = 'test-entrypoint'
         mock_entrypoint.group = 'airflow.plugins'
-        mock_entrypoint.module_name = 'test.plugins.test_plugins_manager'
+        mock_entrypoint.module = 'test.plugins.test_plugins_manager'
         mock_entrypoint.load.side_effect = ImportError('my_fake_module not found')
         mock_dist.entry_points = [mock_entrypoint]
 


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/12855

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
