### PR TITLE
Added reference to the 2.0 CLI commands in 1.10.14

### DIFF
--- a/UPGRADING_TO_2.0.md
+++ b/UPGRADING_TO_2.0.md
@@ -95,6 +95,20 @@ based on your `airflow.cfg` settings. To generate this file simply run the follo
 
     Once you have performed this step, simply write out the file path to this file in the `pod_template_file` section of the `kubernetes`
 section of your `airflow.cfg`
+3. The new CLI commands with the updated command syntax have also been backported to Airflow 1.10.14. This gives users the time to modify their scripts which invoke these commands to be compatible with Airflow 2.0, so that the upgrade to 2.0 does not have disruption with invoking services.
+For example, in Airflow 1.10.x, the CLI command syntax for listing DAGs has been the following command:
+
+```shell script
+    airflow list_dags
+```
+
+However, in Airflow 2.0, the CLI command is now:
+
+```shell script
+    airflow dags list
+```
+
+Both forms of the CLI command are available in 1.10.14 to assist in the changes to scripts which invoke Airflow CLI commands.
 
 ## Step 3: Install and run the Upgrade check scripts
 


### PR DESCRIPTION
Updated to include reference to the 2.0 CLI commands backported to 
Airflow 1.10.14 to make it easier to migrate without disruption. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
