### PR TITLE
Show DAG serialization errors in the UI.

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -131,7 +131,7 @@ class SerializedDagNotFound(DagNotFound):
 
 
 class SerializationError(AirflowException):
-    """A problem occurred when trying to serialized a DAG"""
+    """A problem occurred when trying to serialize a DAG"""
 
 
 class TaskNotFound(AirflowNotFoundException):

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -130,6 +130,10 @@ class SerializedDagNotFound(DagNotFound):
     """Raise when DAG is not found in the serialized_dags table in DB"""
 
 
+class SerializationError(AirflowException):
+    """A problem occurred when trying to serialized a DAG"""
+
+
 class TaskNotFound(AirflowNotFoundException):
     """Raise when a Task is not available in the system"""
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -519,7 +519,7 @@ class DagBag(LoggingMixin):
 
         def _serialze_dag_capturing_errors(dag, session):
             """
-            Try to serialized the dag to the DB, but make a note of any errors.
+            Try to serialize the dag to the DB, but make a note of any errors.
 
             We can't place them directly in import_errors, as this may be retried, and work the next time
             """

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -517,6 +517,27 @@ class DagBag(LoggingMixin):
         from airflow.models.dag import DAG
         from airflow.models.serialized_dag import SerializedDagModel
 
+        def _serialze_dag_capturing_errors(dag, session):
+            """
+            Try to serialized the dag to the DB, but make a note of any errors.
+
+            We can't place them directly in import_errors, as this may be retried, and work the next time
+            """
+            if dag.is_subdag:
+                return []
+            try:
+                # We cant use bulk_write_to_db as we want to capture each error individually
+                SerializedDagModel.write_dag(
+                    dag,
+                    min_update_interval=settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL,
+                    session=session,
+                )
+                return []
+            except OperationalError:
+                raise
+            except Exception:  # pylint: disable=broad-except
+                return [(dag.fileloc, traceback.format_exc(limit=-self.dagbag_import_error_traceback_depth))]
+
         # Retry 'DAG.bulk_write_to_db' & 'SerializedDagModel.bulk_sync_to_db' in case
         # of any Operational Errors
         # In case of failures, provide_session handles rollback
@@ -528,6 +549,7 @@ class DagBag(LoggingMixin):
             reraise=True,
         ):
             with attempt:
+                serialize_errors = []
                 self.log.debug(
                     "Running dagbag.sync_to_db with retries. Try %d of %d",
                     attempt.retry_state.attempt_number,
@@ -537,9 +559,12 @@ class DagBag(LoggingMixin):
                 try:
                     DAG.bulk_write_to_db(self.dags.values(), session=session)
 
-                    # Write Serialized DAGs to DB
-                    self.log.debug("Calling the SerializedDagModel.bulk_sync_to_db method")
-                    SerializedDagModel.bulk_sync_to_db(self.dags.values(), session=session)
+                    # Write Serialized DAGs to DB, capturing errors
+                    for dag in self.dags.values():
+                        serialize_errors.extend(_serialze_dag_capturing_errors(dag, session))
                 except OperationalError:
                     session.rollback()
                     raise
+                # Only now we are "complete" do we update import_errors - don't want to record errors from
+                # previous failed attempts
+                self.import_errors.update(dict(serialize_errors))

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -647,12 +647,15 @@ class TestDagBag(unittest.TestCase):
             session.rollback()
 
     @patch("airflow.models.dagbag.DagBag.collect_dags")
-    @patch("airflow.models.serialized_dag.SerializedDagModel.bulk_sync_to_db")
+    @patch("airflow.models.serialized_dag.SerializedDagModel.write_dag")
     @patch("airflow.models.dag.DAG.bulk_write_to_db")
-    def test_sync_to_db_is_retried(self, mock_bulk_write_to_db, mock_sdag_sync_to_db, mock_collect_dags):
+    def test_sync_to_db_is_retried(self, mock_bulk_write_to_db, mock_s10n_write_dag, mock_collect_dags):
         """Test that dagbag.sync_to_db is retried on OperationalError"""
 
         dagbag = DagBag("/dev/null")
+        mock_dag = mock.MagicMock(spec=models.DAG)
+        mock_dag.is_subdag = False
+        dagbag.dags['mock_dag'] = mock_dag
 
         op_error = OperationalError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
 
@@ -674,10 +677,14 @@ class TestDagBag(unittest.TestCase):
         )
         # Assert that rollback is called twice (i.e. whenever OperationalError occurs)
         mock_session.rollback.assert_has_calls([mock.call(), mock.call()])
-        # Check that 'SerializedDagModel.bulk_sync_to_db' is also called
+        # Check that 'SerializedDagModel.write_dag' is also called
         # Only called once since the other two times the 'DAG.bulk_write_to_db' error'd
-        # and the session was roll-backed before even reaching 'SerializedDagModel.bulk_sync_to_db'
-        mock_sdag_sync_to_db.assert_has_calls([mock.call(mock.ANY, session=mock.ANY)])
+        # and the session was roll-backed before even reaching 'SerializedDagModel.write_dag'
+        mock_s10n_write_dag.assert_has_calls(
+            [
+                mock.call(mock_dag, min_update_interval=mock.ANY, session=mock_session),
+            ]
+        )
 
     @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_UPDATE_INTERVAL", 5)
     @patch("airflow.models.dagbag.settings.MIN_SERIALIZED_DAG_FETCH_INTERVAL", 5)


### PR DESCRIPTION
The previous behaviour led to "bad" data being written in the DB -- for
example:

```json
    "dag": {
        "tasks": [
            "serialization_failed"
        ],
```

(`tasks` should be a list of dictionaries. It clearly isn't.)

Instead of doing this we throw an error, that is captured and showing
using the existing import_error mechanism for DAGs. This almost
certainly happens because a user has done "something interesting".

Example of error

![2020-12-06_21-04](https://user-images.githubusercontent.com/34150/101294224-e30de100-380d-11eb-9c6a-b2a412f77b95.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
