### PR TITLE
Change the format for sha512 sum for releases

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -380,7 +380,7 @@ Run this:
 ```shell script
 for i in *.sha512
 do
-    echo "Checking $i"; gpg --print-md SHA512 `basename $i .sha512 ` | diff - $i
+    echo "Checking $i"; shasum -a 512 `basename $i .sha512 ` | diff - $i
 done
 ```
 

--- a/dev/sign.sh
+++ b/dev/sign.sh
@@ -30,5 +30,5 @@ SIGN_WITH="${SIGN_WITH:-apache.org}"
 for name in "${@}"
 do
     gpg --armor --local-user "$SIGN_WITH" --output "${name}.asc" --detach-sig "${name}"
-    gpg --print-md SHA512 "${name}" > "${name}.sha512"
+    shasum -a 512 "${name}" > "${name}.sha512"
 done


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/12832

This format is popular and supported by tools like Ansible.

```
❯ sha512sum ../airflow-dev/1.10.14rc3/apache-airflow-1.10.14rc3-bin.tar.gz
953d3c04ee6fd2fa96e126750e642fc0872add96d180901440a91bd61c494a711b48836c634d93dcb181006935772556d5b4426671bf1a638f0a0698b51b119f  ../airflow-dev/1.10.14rc3/apache-airflow-1.10.14rc3-bin.tar.gz
```

vs

```
❯ gpg --print-md SHA512 ../airflow-dev/1.10.14rc3/apache-airflow-1.10.14rc3-bin.tar.gz
../airflow-dev/1.10.14rc3/apache-airflow-1.10.14rc3-bin.tar.gz:
953D3C04 EE6FD2FA 96E12675 0E642FC0 872ADD96 D1809014 40A91BD6 1C494A71 1B48836C
 634D93DC B1810069 35772556 D5B44266 71BF1A63 8F0A0698 B51B119F
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
