### PR TITLE
Refactor `@provide_session` to do less "at runtime"

### DIFF
--- a/airflow/lineage/__init__.py
+++ b/airflow/lineage/__init__.py
@@ -25,7 +25,6 @@ import attr
 import jinja2
 from cattr import structure, unstructure
 
-from airflow.models.base import Operator
 from airflow.utils.module_loading import import_string
 
 ENV = jinja2.Environment()
@@ -120,6 +119,8 @@ def prepare_lineage(func: T) -> T:
     # pylint: disable=protected-access
     @wraps(func)
     def wrapper(self, context, *args, **kwargs):
+        from airflow.models.base import Operator
+
         self.log.debug("Preparing lineage inlets and outlets")
 
         if isinstance(self._inlets, (str, Operator)) or attr.has(self._inlets):

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -61,8 +61,8 @@ class SubDagOperator(BaseSensorOperator):
     ui_color = '#555'
     ui_fgcolor = '#fff'
 
-    @provide_session
     @apply_defaults
+    @provide_session
     def __init__(
         self,
         *,

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -61,8 +61,8 @@ class SubDagOperator(BaseSensorOperator):
     ui_color = '#555'
     ui_fgcolor = '#fff'
 
-    @apply_defaults
     @provide_session
+    @apply_defaults
     def __init__(
         self,
         *,

--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -17,6 +17,7 @@
 
 import contextlib
 from functools import wraps
+from inspect import signature
 from typing import Callable, TypeVar
 
 from airflow import settings
@@ -46,14 +47,12 @@ def provide_session(func: Callable[..., RT]) -> Callable[..., RT]:
     database transaction, you pass it to the function, if not this wrapper
     will create one and close it for you.
     """
-    func_params = func.__code__.co_varnames
-    if "session" in func_params:
-        session_args_idx = func_params.index("session")
-    else:
-        raise ValueError(
-            f"Function {func.__qualname__} has no `session` argument (or it's decorated -- try adjusting the"
-            " order of decorators"
-        )
+    func_params = signature(func).parameters
+    try:
+        # func_params is an ordered dict -- this is the "recommended" way of getting the position
+        session_args_idx = tuple(func_params).index("session")
+    except ValueError:
+        raise ValueError(f"Function {func.__qualname__} has no `session` argument") from None
     # We don't need this anymore -- ensure we don't keep a reference to it by mistake
     del func_params
 

--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -46,20 +46,23 @@ def provide_session(func: Callable[..., RT]) -> Callable[..., RT]:
     database transaction, you pass it to the function, if not this wrapper
     will create one and close it for you.
     """
+    func_params = func.__code__.co_varnames
+    if "session" in func_params:
+        session_args_idx = func_params.index("session")
+    else:
+        raise ValueError(
+            f"Function {func.__qualname__} has no `session` argument (or it's decorated -- try adjusting the"
+            " order of decorators"
+        )
+    # We don't need this anymore -- ensure we don't keep a reference to it by mistake
+    del func_params
 
     @wraps(func)
     def wrapper(*args, **kwargs) -> RT:
-        arg_session = 'session'
-
-        func_params = func.__code__.co_varnames
-        session_in_args = arg_session in func_params and func_params.index(arg_session) < len(args)
-        session_in_kwargs = arg_session in kwargs
-
-        if session_in_kwargs or session_in_args:
+        if "session" in kwargs or session_args_idx < len(args):
             return func(*args, **kwargs)
         else:
             with create_session() as session:
-                kwargs[arg_session] = session
-                return func(*args, **kwargs)
+                return func(*args, session=session, **kwargs)
 
     return wrapper


### PR DESCRIPTION
This reworks the `provide_session` decorator to pre-compute the arg
position etc -- we don't need to do this every time the decorated function
is called.

This may be a slight speed increase, but my primary driver for this
change is to make stepping through the decorator in a debugger easier.

The change to lineage was to resolve an import cycle -- I have **no**
idea why it suddenly started mattering. But it did.

The change to subdag_operator is so that `@provide_session` sees the
real arguments, not the arguments of the `@apply_defaults` decorator.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).