### PR TITLE
Enable pylint rule to check for missing commas

### DIFF
--- a/airflow/api_connexion/exceptions.py
+++ b/airflow/api_connexion/exceptions.py
@@ -24,7 +24,7 @@ from airflow import version
 if any(suffix in version.version for suffix in ['dev', 'a', 'b']):
     doc_link = (
         "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest"
-        "/stable-rest-api-ref.html"
+        + "/stable-rest-api-ref.html"
     )
 else:
     doc_link = f'https://airflow.apache.org/docs/{version.version}/stable-rest-api-ref.html'

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -67,7 +67,7 @@ class DefaultHelpParser(argparse.ArgumentParser):
             except ImportError:
                 message = (
                     'The kubernetes subcommand requires that you pip install the kubernetes python client.'
-                    "To do it, run: pip install 'apache-airflow[cncf.kubernetes]'"
+                    + "To do it, run: pip install 'apache-airflow[cncf.kubernetes]'"
                 )
                 raise ArgumentError(action, message)
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1224,7 +1224,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                 Stats.incr('scheduler.tasks.killed_externally')
                 msg = (
                     "Executor reports task instance %s finished (%s) although the "
-                    "task says its %s. (Info: %s) Was the task killed externally?"
+                    + "task says its %s. (Info: %s) Was the task killed externally?"
                 )
                 self.log.error(msg, ti, state, ti.state, info)
                 request = TaskCallbackRequest(

--- a/airflow/providers/docker/example_dags/example_docker_copy_data.py
+++ b/airflow/providers/docker/example_dags/example_docker_copy_data.py
@@ -88,8 +88,8 @@ t_move = DockerOperator(
         "/bin/bash",
         "-c",
         "/bin/sleep 30; "
-        "/bin/mv {{params.source_location}}/{{ ti.xcom_pull('view_file') }} {{params.target_location}};"
-        "/bin/echo '{{params.target_location}}/{{ ti.xcom_pull('view_file') }}';",
+        + "/bin/mv {{params.source_location}}/{{ ti.xcom_pull('view_file') }} {{params.target_location}};"
+        + "/bin/echo '{{params.target_location}}/{{ ti.xcom_pull('view_file') }}';",
     ],
     task_id="move_data",
     do_xcom_push=True,

--- a/airflow/providers/google/cloud/example_dags/example_datacatalog.py
+++ b/airflow/providers/google/cloud/example_dags/example_datacatalog.py
@@ -292,7 +292,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_lookup_entry_linked_resource]
     current_entry_template = (
         "//datacatalog.googleapis.com/projects/{project_id}/locations/{location}/"
-        "entryGroups/{entry_group}/entries/{entry}"
+        + "entryGroups/{entry_group}/entries/{entry}"
     )
     lookup_entry_linked_resource = CloudDataCatalogLookupEntryOperator(
         task_id="lookup_entry",

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -111,7 +111,7 @@ class SnowflakeHook(DbApiHook):
         conn_config = self._get_conn_params()
         uri = (
             'snowflake://{user}:{password}@{account}/{database}/{schema}'
-            '?warehouse={warehouse}&role={role}&authenticator={authenticator}'
+            + '?warehouse={warehouse}&role={role}&authenticator={authenticator}'
         )
         return uri.format(**conn_config)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2645,7 +2645,7 @@ class ConfigurationView(AirflowBaseView):
         else:
             config = (
                 "# Your Airflow administrator chose not to expose the "
-                "configuration, most likely for security reasons."
+                + "configuration, most likely for security reasons."
             )
             table = None
 

--- a/airflow/www/widgets.py
+++ b/airflow/www/widgets.py
@@ -32,10 +32,10 @@ class AirflowDateTimePickerWidget:
 
     data_template = (
         '<div class="input-group datetime datetimepicker">'
-        '<span class="input-group-addon"><span class="material-icons cursor-hand">calendar_today</span>'
-        "</span>"
-        '<input class="form-control" %(text)s />'
-        "</div>"
+        + '<span class="input-group-addon"><span class="material-icons cursor-hand">calendar_today</span>'
+        + "</span>"
+        + '<input class="form-control" %(text)s />'
+        + "</div>"
     )
 
     def __call__(self, field, **kwargs):

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -374,7 +374,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
             args = [
                 "echo \"retrieved from mount\" > /tmp/test_volume/test.txt "
-                "&& cat /tmp/test_volume/test.txt"
+                + "&& cat /tmp/test_volume/test.txt"
             ]
             k = KubernetesPodOperator(
                 namespace='default',

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -308,7 +308,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             volume = Volume(name='test-volume', configs=volume_config)
             args = [
                 "echo \"retrieved from mount\" > /tmp/test_volume/test.txt "
-                "&& cat /tmp/test_volume/test.txt"
+                + "&& cat /tmp/test_volume/test.txt"
             ]
             k = KubernetesPodOperator(
                 namespace='default',

--- a/pylintrc
+++ b/pylintrc
@@ -592,3 +592,6 @@ min-public-methods=0
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception".
 overgeneral-exceptions=Exception
+
+[STRING_CONSTANT]
+check-str-concat-over-line-jumps=yes

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ def write_version(filename: str = os.path.join(*[my_dir, "airflow", "git_version
 
 _SPHINX_AIRFLOW_THEME_URL = (
     "https://github.com/apache/airflow-site/releases/download/v0.0.1/"
-    "sphinx_airflow_theme-0.0.1-py3-none-any.whl"
+    + "sphinx_airflow_theme-0.0.1-py3-none-any.whl"
 )
 
 # 'Start dependencies group' and 'Start dependencies group' are mark for ./scripts/ci/check_order_setup.py

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -174,10 +174,10 @@ class TestGoogleProviderProjectStructure(unittest.TestCase):
         'airflow.providers.google.cloud.operators.tasks.CloudTasksQueuesListOperator',
         # Deprecated operator. Ignore it.
         'airflow.providers.google.cloud.operators.cloud_storage_transfer_service'
-        '.CloudDataTransferServiceS3ToGCSOperator',
+        + '.CloudDataTransferServiceS3ToGCSOperator',
         # Deprecated operator. Ignore it.
         'airflow.providers.google.cloud.operators.cloud_storage_transfer_service'
-        '.CloudDataTransferServiceGCSToGCSOperator',
+        + '.CloudDataTransferServiceGCSToGCSOperator',
         # Base operator. Ignore it.
         'airflow.providers.google.cloud.operators.cloud_sql.CloudSQLBaseOperator',
         # Deprecated operator. Ignore it

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -394,7 +394,7 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
             ),
             (
                 "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte= 2020-06-15T18:00:00+00:00"
-                "&start_date_gte=2020-06-12T18:00:00Z",
+                + "&start_date_gte=2020-06-12T18:00:00Z",
                 [
                     "TEST_START_EXEC_DAY_12",
                     "TEST_START_EXEC_DAY_13",

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -318,7 +318,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID/"
-                    "taskInstances?duration_gte=100&duration_lte=200"
+                    + "taskInstances?duration_gte=100&duration_lte=200"
                 ),
                 3,
             ),
@@ -343,7 +343,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 False,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/"
-                    "TEST_DAG_RUN_ID/taskInstances?state=running,queued"
+                    + "TEST_DAG_RUN_ID/taskInstances?state=running,queued"
                 ),
                 2,
             ),
@@ -357,7 +357,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/"
-                    "TEST_DAG_RUN_ID/taskInstances?pool=test_pool_1,test_pool_2"
+                    + "TEST_DAG_RUN_ID/taskInstances?pool=test_pool_1,test_pool_2"
                 ),
                 2,
             ),
@@ -382,7 +382,7 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
                 True,
                 (
                     "/api/v1/dags/example_python_operator/dagRuns/TEST_DAG_RUN_ID"
-                    "/taskInstances?queue=test_queue_1,test_queue_2"
+                    + "/taskInstances?queue=test_queue_1,test_queue_2"
                 ),
                 2,
             ),

--- a/tests/cli/commands/test_connection_command.py
+++ b/tests/cli/commands/test_connection_command.py
@@ -349,23 +349,23 @@ class TestCliExportConnections(unittest.TestCase):
 
         expected_connections = (
             "airflow_db:\n"
-            "  conn_type: mysql\n"
-            "  description: mysql conn description\n"
-            "  extra: null\n"
-            "  host: mysql\n"
-            "  login: root\n"
-            "  password: plainpassword\n"
-            "  port: null\n"
-            "  schema: airflow\n"
-            "druid_broker_default:\n"
-            "  conn_type: druid\n"
-            "  description: druid-broker conn description\n"
-            "  extra: \'{\"endpoint\": \"druid/v2/sql\"}\'\n"
-            "  host: druid-broker\n"
-            "  login: null\n"
-            "  password: null\n"
-            "  port: 8082\n"
-            "  schema: null\n"
+            + "  conn_type: mysql\n"
+            + "  description: mysql conn description\n"
+            + "  extra: null\n"
+            + "  host: mysql\n"
+            + "  login: root\n"
+            + "  password: plainpassword\n"
+            + "  port: null\n"
+            + "  schema: airflow\n"
+            + "druid_broker_default:\n"
+            + "  conn_type: druid\n"
+            + "  description: druid-broker conn description\n"
+            + "  extra: \'{\"endpoint\": \"druid/v2/sql\"}\'\n"
+            + "  host: druid-broker\n"
+            + "  login: null\n"
+            + "  password: null\n"
+            + "  port: 8082\n"
+            + "  schema: null\n"
         )
         mock_splittext.assert_called_once()
         mock_file_open.assert_called_once_with(output_filepath, 'w', -1, 'UTF-8', None)
@@ -388,9 +388,9 @@ class TestCliExportConnections(unittest.TestCase):
 
         expected_connections = [
             "airflow_db=mysql://root:plainpassword@mysql/airflow\n"
-            "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql\n",
+            + "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql\n",
             "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql\n"
-            "airflow_db=mysql://root:plainpassword@mysql/airflow\n",
+            + "airflow_db=mysql://root:plainpassword@mysql/airflow\n",
         ]
 
         mock_splittext.assert_called_once()
@@ -417,9 +417,9 @@ class TestCliExportConnections(unittest.TestCase):
 
         expected_connections = [
             "airflow_db=mysql://root:plainpassword@mysql/airflow\n"
-            "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql\n",
+            + "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql\n",
             "druid_broker_default=druid://druid-broker:8082?endpoint=druid%2Fv2%2Fsql\n"
-            "airflow_db=mysql://root:plainpassword@mysql/airflow\n",
+            + "airflow_db=mysql://root:plainpassword@mysql/airflow\n",
         ]
 
         mock_splittext.assert_called_once()

--- a/tests/cli/commands/test_webserver_command.py
+++ b/tests/cli/commands/test_webserver_command.py
@@ -387,9 +387,9 @@ class TestCliWebServer(unittest.TestCase):
         # json access log format
         access_logformat = (
             "{\"ts\":\"%(t)s\",\"remote_ip\":\"%(h)s\",\"request_id\":\"%({"
-            "X-Request-Id}i)s\",\"code\":\"%(s)s\",\"request_method\":\"%(m)s\","
-            "\"request_path\":\"%(U)s\",\"agent\":\"%(a)s\",\"response_time\":\"%(D)s\","
-            "\"response_length\":\"%(B)s\"} "
+            + "X-Request-Id}i)s\",\"code\":\"%(s)s\",\"request_method\":\"%(m)s\","
+            + "\"request_path\":\"%(U)s\",\"agent\":\"%(a)s\",\"response_time\":\"%(D)s\","
+            + "\"response_length\":\"%(B)s\"} "
         )
         with tempfile.TemporaryDirectory() as tmpdir, mock.patch.dict(
             "os.environ",

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -464,7 +464,7 @@ OPERATORS = [
     ),
     (
         "airflow.providers.google.cloud.operators.compute"
-        ".ComputeEngineInstanceGroupUpdateManagerTemplateOperator",
+        + ".ComputeEngineInstanceGroupUpdateManagerTemplateOperator",
         "airflow.contrib.operators.gcp_compute_operator.GceInstanceGroupManagerUpdateTemplateOperator",
     ),
     (
@@ -625,23 +625,23 @@ OPERATORS = [
     ),
     (
         "airflow.providers.google.cloud.operators.natural_language."
-        "CloudNaturalLanguageAnalyzeEntitiesOperator",
+        + "CloudNaturalLanguageAnalyzeEntitiesOperator",
         "airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeEntitiesOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.natural_language."
-        "CloudNaturalLanguageAnalyzeEntitySentimentOperator",
+        + "CloudNaturalLanguageAnalyzeEntitySentimentOperator",
         "airflow.contrib.operators.gcp_natural_language_operator."
-        "CloudLanguageAnalyzeEntitySentimentOperator",
+        + "CloudLanguageAnalyzeEntitySentimentOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.natural_language."
-        "CloudNaturalLanguageAnalyzeSentimentOperator",
+        + "CloudNaturalLanguageAnalyzeSentimentOperator",
         "airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageAnalyzeSentimentOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.natural_language."
-        "CloudNaturalLanguageClassifyTextOperator",
+        + "CloudNaturalLanguageClassifyTextOperator",
         "airflow.contrib.operators.gcp_natural_language_operator.CloudLanguageClassifyTextOperator",
     ),
     (
@@ -670,42 +670,42 @@ OPERATORS = [
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service"
-        ".CloudDataTransferServiceCreateJobOperator",
+        + ".CloudDataTransferServiceCreateJobOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobCreateOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service"
-        ".CloudDataTransferServiceDeleteJobOperator",
+        + ".CloudDataTransferServiceDeleteJobOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobDeleteOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service"
-        ".CloudDataTransferServiceUpdateJobOperator",
+        + ".CloudDataTransferServiceUpdateJobOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceJobUpdateOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service."
-        "CloudDataTransferServiceCancelOperationOperator",
+        + "CloudDataTransferServiceCancelOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationCancelOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service."
-        "CloudDataTransferServiceGetOperationOperator",
+        + "CloudDataTransferServiceGetOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationGetOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service."
-        "CloudDataTransferServicePauseOperationOperator",
+        + "CloudDataTransferServicePauseOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationPauseOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service."
-        "CloudDataTransferServiceResumeOperationOperator",
+        + "CloudDataTransferServiceResumeOperationOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationResumeOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service."
-        "CloudDataTransferServiceListOperationsOperator",
+        + "CloudDataTransferServiceListOperationsOperator",
         "airflow.contrib.operators.gcp_transfer_operator.GcpTransferServiceOperationsListOperator",
     ),
     (
@@ -718,21 +718,21 @@ OPERATORS = [
     ),
     (
         "airflow.providers.google.cloud.operators.video_intelligence."
-        "CloudVideoIntelligenceDetectVideoExplicitContentOperator",
+        + "CloudVideoIntelligenceDetectVideoExplicitContentOperator",
         "airflow.contrib.operators.gcp_video_intelligence_operator."
-        "CloudVideoIntelligenceDetectVideoExplicitContentOperator",
+        + "CloudVideoIntelligenceDetectVideoExplicitContentOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.video_intelligence."
-        "CloudVideoIntelligenceDetectVideoLabelsOperator",
+        + "CloudVideoIntelligenceDetectVideoLabelsOperator",
         "airflow.contrib.operators.gcp_video_intelligence_operator."
-        "CloudVideoIntelligenceDetectVideoLabelsOperator",
+        + "CloudVideoIntelligenceDetectVideoLabelsOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.video_intelligence."
-        "CloudVideoIntelligenceDetectVideoShotsOperator",
+        + "CloudVideoIntelligenceDetectVideoShotsOperator",
         "airflow.contrib.operators.gcp_video_intelligence_operator."
-        "CloudVideoIntelligenceDetectVideoShotsOperator",
+        + "CloudVideoIntelligenceDetectVideoShotsOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.vision.CloudVisionImageAnnotateOperator",
@@ -872,7 +872,7 @@ OPERATORS = [
     ),
     (
         "airflow.providers.google.cloud."
-        "operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator",
+        + "operators.dataproc.DataprocInstantiateInlineWorkflowTemplateOperator",
         "airflow.contrib.operators.dataproc_operator.DataprocWorkflowTemplateInstantiateInlineOperator",
     ),
     (
@@ -1021,7 +1021,7 @@ OPERATORS = [
     ),
     (
         'airflow.providers.microsoft.azure.operators'
-        '.azure_container_instances.AzureContainerInstancesOperator',
+        + '.azure_container_instances.AzureContainerInstancesOperator',
         'airflow.contrib.operators.azure_container_instances_operator.AzureContainerInstancesOperator',
     ),
     (
@@ -1360,7 +1360,7 @@ SENSORS = [
     ),
     (
         "airflow.providers.google.cloud.sensors.cloud_storage_transfer_service."
-        "CloudDataTransferServiceJobStatusSensor",
+        + "CloudDataTransferServiceJobStatusSensor",
         "airflow.contrib.sensors.gcp_transfer_sensor.GCPTransferServiceWaitForJobStatusSensor",
     ),
     (
@@ -1564,9 +1564,9 @@ TRANSFERS = [
     ),
     (
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service."
-        "CloudDataTransferServiceGCSToGCSOperator",
+        + "CloudDataTransferServiceGCSToGCSOperator",
         "airflow.contrib.operators.gcp_transfer_operator."
-        "GoogleCloudStorageToGoogleCloudStorageTransferOperator",
+        + "GoogleCloudStorageToGoogleCloudStorageTransferOperator",
     ),
     (
         "airflow.providers.google.cloud.operators.vision.CloudVisionAddProductToProductSetOperator",
@@ -1690,7 +1690,7 @@ TRANSFERS = [
     ),
     (
         'airflow.providers.microsoft.azure.transfers.oracle_to_azure_data_lake'
-        '.OracleToAzureDataLakeOperator',
+        + '.OracleToAzureDataLakeOperator',
         'airflow.contrib.operators.oracle_to_azure_data_lake_transfer.OracleToAzureDataLakeOperator',
     ),
     (
@@ -1711,7 +1711,7 @@ TRANSFERS = [
     ),
     (
         'airflow.providers.google.cloud.operators.cloud_storage_transfer_service'
-        '.CloudDataTransferServiceS3ToGCSOperator',
+        + '.CloudDataTransferServiceS3ToGCSOperator',
         'airflow.contrib.operators.s3_to_gcs_transfer_operator.CloudDataTransferServiceS3ToGCSOperator',
     ),
     (

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3077,11 +3077,11 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(import_error.filename, unparseable_filename)
         expected_stacktrace = (
             "Traceback (most recent call last):\n"
-            '  File "{}", line 3, in <module>\n'
-            "    something()\n"
-            '  File "{}", line 2, in something\n'
-            "    return airflow_DAG\n"
-            "NameError: name 'airflow_DAG' is not defined\n"
+            + '  File "{}", line 3, in <module>\n'
+            + "    something()\n"
+            + '  File "{}", line 2, in something\n'
+            + "    return airflow_DAG\n"
+            + "NameError: name 'airflow_DAG' is not defined\n"
         )
         self.assertEqual(
             import_error.stacktrace, expected_stacktrace.format(unparseable_filename, unparseable_filename)
@@ -3106,9 +3106,9 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(import_error.filename, unparseable_filename)
         expected_stacktrace = (
             "Traceback (most recent call last):\n"
-            '  File "{}", line 2, in something\n'
-            "    return airflow_DAG\n"
-            "NameError: name 'airflow_DAG' is not defined\n"
+            + '  File "{}", line 2, in something\n'
+            + "    return airflow_DAG\n"
+            + "NameError: name 'airflow_DAG' is not defined\n"
         )
         self.assertEqual(import_error.stacktrace, expected_stacktrace.format(unparseable_filename))
 
@@ -3131,11 +3131,11 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(import_error.filename, invalid_zip_filename)
         expected_stacktrace = (
             "Traceback (most recent call last):\n"
-            '  File "{}", line 3, in <module>\n'
-            "    something()\n"
-            '  File "{}", line 2, in something\n'
-            "    return airflow_DAG\n"
-            "NameError: name 'airflow_DAG' is not defined\n"
+            + '  File "{}", line 3, in <module>\n'
+            + "    something()\n"
+            + '  File "{}", line 2, in something\n'
+            + "    return airflow_DAG\n"
+            + "NameError: name 'airflow_DAG' is not defined\n"
         )
         self.assertEqual(
             import_error.stacktrace, expected_stacktrace.format(invalid_dag_filename, invalid_dag_filename)
@@ -3161,9 +3161,9 @@ class TestSchedulerJob(unittest.TestCase):
         self.assertEqual(import_error.filename, invalid_zip_filename)
         expected_stacktrace = (
             "Traceback (most recent call last):\n"
-            '  File "{}", line 2, in something\n'
-            "    return airflow_DAG\n"
-            "NameError: name 'airflow_DAG' is not defined\n"
+            + '  File "{}", line 2, in something\n'
+            + "    return airflow_DAG\n"
+            + "NameError: name 'airflow_DAG' is not defined\n"
         )
         self.assertEqual(import_error.stacktrace, expected_stacktrace.format(invalid_dag_filename))
 

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -86,7 +86,7 @@ class TestRenderedTaskInstanceFields(unittest.TestCase):
                     att1="{{ task.task_id }}", att2="{{ task.task_id }}", template_fields=["att1"]
                 ),
                 "ClassWithCustomAttributes({'att1': 'test', 'att2': '{{ task.task_id }}', "
-                "'template_fields': ['att1']})",
+                + "'template_fields': ['att1']})",
             ),
             (
                 ClassWithCustomAttributes(
@@ -99,10 +99,11 @@ class TestRenderedTaskInstanceFields(unittest.TestCase):
                     template_fields=["nested1"],
                 ),
                 "ClassWithCustomAttributes({'nested1': ClassWithCustomAttributes("
-                "{'att1': 'test', 'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
-                "'nested2': ClassWithCustomAttributes("
-                "{'att3': '{{ task.task_id }}', 'att4': '{{ task.task_id }}', 'template_fields': ['att3']}), "
-                "'template_fields': ['nested1']})",
+                + "{'att1': 'test', 'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
+                + "'nested2': ClassWithCustomAttributes("
+                + "{'att3': '{{ task.task_id }}', 'att4': "
+                + "'{{ task.task_id }}', 'template_fields': ['att3']}),"
+                + " 'template_fields': ['nested1']})",
             ),
         ]
     )

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1240,9 +1240,9 @@ class TestTaskInstance(unittest.TestCase):
 
         expected_url = (
             'http://localhost:8080/log?'
-            'execution_date=2018-01-01T00%3A00%3A00%2B00%3A00'
-            '&task_id=op'
-            '&dag_id=dag'
+            + 'execution_date=2018-01-01T00%3A00%3A00%2B00%3A00'
+            + '&task_id=op'
+            + '&dag_id=dag'
         )
         self.assertEqual(ti.log_url, expected_url)
 

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -64,12 +64,13 @@ class TestXComArgBuild:
         assert actual == XComArg(python_op, "test_key")
         expected_str = (
             "{{ task_instance.xcom_pull(task_ids='test_xcom_op', "
-            "dag_id='test_xcom_dag', key='test_key') }}"
+            + "dag_id='test_xcom_dag', key='test_key') }}"
         )
         assert str(actual) == expected_str
         assert (
-            f"echo {actual}" == "echo {{ task_instance.xcom_pull(task_ids='test_xcom_op', "
-            "dag_id='test_xcom_dag', key='test_key') }}"
+            f"echo {actual}"
+            == "echo {{ task_instance.xcom_pull(task_ids='test_xcom_op', "
+            + "dag_id='test_xcom_dag', key='test_key') }}"
         )
 
     def test_xcom_key_is_empty_str(self):
@@ -77,8 +78,8 @@ class TestXComArgBuild:
         actual = XComArg(python_op, key="")
         assert actual.key == ""
         assert (
-            str(actual) == "{{ task_instance.xcom_pull(task_ids='test_xcom_op', "
-            "dag_id='test_xcom_dag', key='') }}"
+            str(actual)
+            == "{{ task_instance.xcom_pull(task_ids='test_xcom_op', " + "dag_id='test_xcom_dag', key='') }}"
         )
 
     def test_set_downstream(self):

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -134,13 +134,13 @@ class TestPluginsManager:
                 "airflow.plugins_manager",
                 logging.WARNING,
                 "Plugin 'test_admin_views_plugin' may not be compatible with the current Airflow version. "
-                "Please contact the author of the plugin.",
+                + "Please contact the author of the plugin.",
             ),
             (
                 "airflow.plugins_manager",
                 logging.WARNING,
                 "Plugin 'test_menu_links_plugin' may not be compatible with the current Airflow version. "
-                "Please contact the author of the plugin.",
+                + "Please contact the author of the plugin.",
             ),
         ]
 

--- a/tests/providers/amazon/aws/operators/test_step_function_get_execution_output.py
+++ b/tests/providers/amazon/aws/operators/test_step_function_get_execution_output.py
@@ -28,7 +28,7 @@ from airflow.providers.amazon.aws.operators.step_function_get_execution_output i
 TASK_ID = 'step_function_get_execution_output'
 EXECUTION_ARN = (
     'arn:aws:states:us-east-1:123456789012:execution:'
-    'pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934'
+    + 'pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934'
 )
 AWS_CONN_ID = 'aws_non_default'
 REGION_NAME = 'us-west-2'

--- a/tests/providers/amazon/aws/operators/test_step_function_start_execution.py
+++ b/tests/providers/amazon/aws/operators/test_step_function_start_execution.py
@@ -61,7 +61,7 @@ class TestStepFunctionStartExecutionOperator(unittest.TestCase):
         # Given
         hook_response = (
             'arn:aws:states:us-east-1:123456789012:execution:'
-            'pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934'
+            + 'pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934'
         )
 
         hook_instance = mock_hook.return_value

--- a/tests/providers/amazon/aws/sensors/test_step_function_execution.py
+++ b/tests/providers/amazon/aws/sensors/test_step_function_execution.py
@@ -28,7 +28,7 @@ from airflow.providers.amazon.aws.sensors.step_function_execution import StepFun
 TASK_ID = 'step_function_execution_sensor'
 EXECUTION_ARN = (
     'arn:aws:states:us-east-1:123456789012:execution:'
-    'pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934'
+    + 'pseudo-state-machine:020f5b16-b1a1-4149-946f-92dd32d97934'
 )
 AWS_CONN_ID = 'aws_non_default'
 REGION_NAME = 'us-west-2'

--- a/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_sftp.py
@@ -75,7 +75,7 @@ class TestS3ToSFTPOperator(unittest.TestCase):
         # Setting
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "
-            "another line here \n this is last line. EOF"
+            + "another line here \n this is last line. EOF"
         )
 
         # Test for creation of s3 bucket

--- a/tests/providers/amazon/aws/transfers/test_sftp_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_sftp_to_s3.py
@@ -74,7 +74,7 @@ class TestSFTPToS3Operator(unittest.TestCase):
         # Setting
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "
-            "another line here \n this is last line. EOF"
+            + "another line here \n this is last line. EOF"
         )
 
         # create a test file remotely

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -119,8 +119,8 @@ class TestHiveCliHook(unittest.TestCase):
     def test_run_cli_with_hive_conf(self, mock_popen):
         hql = (
             "set key;\n"
-            "set airflow.ctx.dag_id;\nset airflow.ctx.dag_run_id;\n"
-            "set airflow.ctx.task_id;\nset airflow.ctx.execution_date;\n"
+            + "set airflow.ctx.dag_id;\nset airflow.ctx.dag_run_id;\n"
+            + "set airflow.ctx.task_id;\nset airflow.ctx.execution_date;\n"
         )
 
         dag_id_ctx_var_name = AIRFLOW_VAR_NAME_FORMAT_MAPPING['AIRFLOW_CONTEXT_DAG_ID']['env_var_format']

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -631,9 +631,9 @@ class TestSparkSubmitHook(unittest.TestCase):
             'WARN NativeCodeLoader: Unable to load native-hadoop library for your '
             + 'platform... using builtin-java classes where applicable',
             'WARN DomainSocketFactory: The short-circuit local reads feature cannot '
-            'be used because libhadoop cannot be loaded.',
+            + 'be used because libhadoop cannot be loaded.',
             'INFO Client: Requesting a new application from cluster with 10 NodeManagers',
-            'INFO Client: Submitting application application_1486558679801_1820 ' + 'to ResourceManager',
+            'INFO Client: Submitting application application_1486558679801_1820 to ResourceManager',
         ]
         # When
         hook._process_spark_submit_log(log_lines)
@@ -692,7 +692,7 @@ class TestSparkSubmitHook(unittest.TestCase):
         log_lines = [
             'Running Spark using the REST application submission protocol.',
             '17/11/28 11:14:15 INFO RestSubmissionClient: Submitting a request '
-            'to launch an application in spark://spark-standalone-master:6066',
+            + 'to launch an application in spark://spark-standalone-master:6066',
             '17/11/28 11:14:15 INFO RestSubmissionClient: Submission successfully '
             + 'created as driver-20171128111415-0001. Polling submission state...',
         ]

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -318,7 +318,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
     def test_render_log_id(self):
         expected_log_id = (
             'dag_for_testing_file_task_handler-'
-            'task_for_testing_file_log_handler-2016-01-01T00:00:00+00:00-1'
+            + 'task_for_testing_file_log_handler-2016-01-01T00:00:00+00:00-1'
         )
         log_id = self.es_task_handler._render_log_id(self.ti, 1)
         self.assertEqual(expected_log_id, log_id)

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -87,7 +87,7 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         bigquery_conn_id = "bigquery conn id"
         warning_message = (
             "The bigquery_conn_id parameter has been deprecated. "
-            "You should pass the gcp_conn_id parameter."
+            + "You should pass the gcp_conn_id parameter."
         )
         with self.assertWarns(DeprecationWarning) as warn:
             BigQueryHook(bigquery_conn_id=bigquery_conn_id)
@@ -296,21 +296,21 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
                 ['INCORRECT_OPTION'],
                 None,
                 r"\['INCORRECT_OPTION'\] contains invalid schema update options\. "
-                r"Please only use one or more of the following options: "
-                r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]",
+                + r"Please only use one or more of the following options: "
+                + r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]",
             ),
             (
                 ['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION', 'INCORRECT_OPTION'],
                 None,
-                r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION', 'INCORRECT_OPTION'\] contains invalid "
-                r"schema update options\. Please only use one or more of the following options: "
-                r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]",
+                r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION', 'INCORRECT_OPTION'\] contains invalid"
+                + r" schema update options\. Please only use one or more of the following options: "
+                + r"\['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION'\]",
             ),
             (
                 ['ALLOW_FIELD_ADDITION'],
                 None,
                 r"schema_update_options is only allowed if write_disposition is "
-                r"'WRITE_APPEND' or 'WRITE_TRUNCATE'",
+                + r"'WRITE_APPEND' or 'WRITE_TRUNCATE'",
             ),
         ]
     )
@@ -795,7 +795,7 @@ class TestBigQueryTableSplitter(unittest.TestCase):
                 "alt1.alt.dataset.table",
                 "var_x",
                 r"Format exception for var_x: Expect format of "
-                r"\(<project\.\|<project:\)<dataset>.<table>, got {}",
+                + r"\(<project\.\|<project:\)<dataset>.<table>, got {}",
             ),
         ]
     )

--- a/tests/providers/google/cloud/hooks/test_cloud_sql.py
+++ b/tests/providers/google/cloud/hooks/test_cloud_sql.py
@@ -1069,10 +1069,10 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_not_too_long_unix_socket_path(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&"
-            "project_id=example-project&location=europe-west1&"
-            "instance="
-            "test_db_with_longname_but_with_limit_of_UNIX_socket&"
-            "use_proxy=True&sql_proxy_use_tcp=False"
+            + "project_id=example-project&location=europe-west1&"
+            + "instance="
+            + "test_db_with_longname_but_with_limit_of_UNIX_socket&"
+            + "use_proxy=True&sql_proxy_use_tcp=False"
         )
         get_connection.side_effect = [Connection(uri=uri)]
         hook = CloudSQLDatabaseHook()
@@ -1094,8 +1094,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_postgres(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=False&use_ssl=False"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=False&use_ssl=False"
         )
         self._verify_postgres_connection(get_connection, uri)
 
@@ -1103,9 +1103,9 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_postgres_ssl(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=False&use_ssl=True&sslcert=/bin/bash&"
-            "sslkey=/bin/bash&sslrootcert=/bin/bash"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=False&use_ssl=True&sslcert=/bin/bash&"
+            + "sslkey=/bin/bash&sslrootcert=/bin/bash"
         )
         connection = self._verify_postgres_connection(get_connection, uri)
         self.assertEqual('/bin/bash', connection.extra_dejson['sslkey'])
@@ -1116,8 +1116,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_postgres_proxy_socket(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=True&sql_proxy_use_tcp=False"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=True&sql_proxy_use_tcp=False"
         )
         get_connection.side_effect = [Connection(uri=uri)]
         hook = CloudSQLDatabaseHook()
@@ -1132,8 +1132,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_project_id_missing(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&"
-            "location=europe-west1&instance=testdb&"
-            "use_proxy=False&use_ssl=False"
+            + "location=europe-west1&instance=testdb&"
+            + "use_proxy=False&use_ssl=False"
         )
         self.verify_mysql_connection(get_connection, uri)
 
@@ -1151,8 +1151,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_postgres_proxy_tcp(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=True&sql_proxy_use_tcp=True"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=True&sql_proxy_use_tcp=True"
         )
         get_connection.side_effect = [Connection(uri=uri)]
         hook = CloudSQLDatabaseHook()
@@ -1166,8 +1166,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_mysql(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=False&use_ssl=False"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=False&use_ssl=False"
         )
         self.verify_mysql_connection(get_connection, uri)
 
@@ -1175,9 +1175,9 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_mysql_ssl(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=False&use_ssl=True&sslcert=/bin/bash&"
-            "sslkey=/bin/bash&sslrootcert=/bin/bash"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=False&use_ssl=True&sslcert=/bin/bash&"
+            + "sslkey=/bin/bash&sslrootcert=/bin/bash"
         )
         connection = self.verify_mysql_connection(get_connection, uri)
         self.assertEqual('/bin/bash', json.loads(connection.extra_dejson['ssl'])['cert'])
@@ -1188,8 +1188,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_mysql_proxy_socket(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=True&sql_proxy_use_tcp=False"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=True&sql_proxy_use_tcp=False"
         )
         get_connection.side_effect = [Connection(uri=uri)]
         hook = CloudSQLDatabaseHook()
@@ -1205,8 +1205,8 @@ class TestCloudSqlDatabaseQueryHook(unittest.TestCase):
     def test_hook_with_correct_parameters_mysql_tcp(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=mysql&"
-            "project_id=example-project&location=europe-west1&instance=testdb&"
-            "use_proxy=True&sql_proxy_use_tcp=True"
+            + "project_id=example-project&location=europe-west1&instance=testdb&"
+            + "use_proxy=True&sql_proxy_use_tcp=True"
         )
         get_connection.side_effect = [Connection(uri=uri)]
         hook = CloudSQLDatabaseHook()

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -837,8 +837,8 @@ class TestGCSHookUpload(unittest.TestCase):
         test_object = 'test_object'
         both_params_excep = (
             "'filename' and 'data' parameter provided. Please "
-            "specify a single parameter, either 'filename' for "
-            "local file uploads or 'data' for file content uploads."
+            + "specify a single parameter, either 'filename' for "
+            + "local file uploads or 'data' for file content uploads."
         )
         no_params_excep = "'filename' and 'data' parameter missing. One is required to upload to gcs."
 

--- a/tests/providers/google/cloud/log/test_gcs_task_handler.py
+++ b/tests/providers/google/cloud/log/test_gcs_task_handler.py
@@ -162,9 +162,9 @@ class TestGCSTaskHandler(unittest.TestCase):
             cm.output,
             [
                 'INFO:airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler:Previous '
-                'log discarded: sequence item 0: expected str instance, bytes found',
+                + 'log discarded: sequence item 0: expected str instance, bytes found',
                 'ERROR:airflow.providers.google.cloud.log.gcs_task_handler.GCSTaskHandler:Could '
-                'not write logs to gs://bucket/remote/log/location/1.log: Failed to connect',
+                + 'not write logs to gs://bucket/remote/log/location/1.log: Failed to connect',
             ],
         )
         mock_blob.assert_has_calls(

--- a/tests/providers/google/cloud/operators/test_cloud_sql.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql.py
@@ -721,7 +721,7 @@ class TestCloudSqlQueryValidation(unittest.TestCase):
                 True,
                 'SELECT * FROM TEST',
                 "Cloud SQL Proxy does not support SSL connections. SSL is not needed as"
-                " Cloud SQL Proxy provides encryption on its own",
+                + " Cloud SQL Proxy provides encryption on its own",
             ),
             (
                 'project_id',
@@ -748,18 +748,19 @@ class TestCloudSqlQueryValidation(unittest.TestCase):
         message,
         get_connection,
     ):
-        uri = (
+        uri_format_string = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?"
-            "database_type={database_type}&"
-            "project_id={project_id}&location={location}&instance={instance_name}&"
-            "use_proxy={use_proxy}&use_ssl={use_ssl}".format(
-                database_type=database_type,
-                project_id=project_id,
-                location=location,
-                instance_name=instance_name,
-                use_proxy=use_proxy,
-                use_ssl=use_ssl,
-            )
+            + "database_type={database_type}&"
+            + "project_id={project_id}&location={location}&instance={instance_name}&"
+            + "use_proxy={use_proxy}&use_ssl={use_ssl}"
+        )
+        uri = uri_format_string.format(  # noqa
+            database_type=database_type,
+            project_id=project_id,
+            location=location,
+            instance_name=instance_name,
+            use_proxy=use_proxy,
+            use_ssl=use_ssl,
         )
         self._setup_connections(get_connection, uri)
         with self.assertRaises(AirflowException) as cm:
@@ -772,11 +773,11 @@ class TestCloudSqlQueryValidation(unittest.TestCase):
     def test_create_operator_with_too_long_unix_socket_path(self, get_connection):
         uri = (
             "gcpcloudsql://user:password@127.0.0.1:3200/testdb?database_type=postgres&"
-            "project_id=example-project&location=europe-west1&"
-            "instance="
-            "test_db_with_long_name_a_bit_above"
-            "_the_limit_of_UNIX_socket_asdadadasadasd&"
-            "use_proxy=True&sql_proxy_use_tcp=False"
+            + "project_id=example-project&location=europe-west1&"
+            + "instance="
+            + "test_db_with_long_name_a_bit_above"
+            + "_the_limit_of_UNIX_socket_asdadadasadasd&"
+            + "use_proxy=True&sql_proxy_use_tcp=False"
         )
         self._setup_connections(get_connection, uri)
         operator = CloudSQLExecuteQueryOperator(sql=['SELECT * FROM TABLE'], task_id='task_id')

--- a/tests/providers/google/cloud/operators/test_compute.py
+++ b/tests/providers/google/cloud/operators/test_compute.py
@@ -339,25 +339,25 @@ class TestGceInstanceSetMachineType(unittest.TestCase):
 
     MOCK_OP_RESPONSE = (
         "{'kind': 'compute#operation', 'id': '8529919847974922736', "
-        "'name': "
-        "'operation-1538578207537-577542784f769-7999ab71-94f9ec1d', "
-        "'zone': 'https://www.googleapis.com/compute/v1/projects/example"
-        "-project/zones/europe-west3-b', 'operationType': "
-        "'setMachineType', 'targetLink': "
-        "'https://www.googleapis.com/compute/v1/projects/example-project"
-        "/zones/europe-west3-b/instances/pa-1', 'targetId': "
-        "'2480086944131075860', 'status': 'DONE', 'user': "
-        "'service-account@example-project.iam.gserviceaccount.com', "
-        "'progress': 100, 'insertTime': '2018-10-03T07:50:07.951-07:00', "
-        "'startTime': '2018-10-03T07:50:08.324-07:00', 'endTime': "
-        "'2018-10-03T07:50:08.484-07:00', 'error': {'errors': [{'code': "
-        "'UNSUPPORTED_OPERATION', 'message': \"Machine type with name "
-        "'machine-type-1' does not exist in zone 'europe-west3-b'.\"}]}, "
-        "'httpErrorStatusCode': 400, 'httpErrorMessage': 'BAD REQUEST', "
-        "'selfLink': "
-        "'https://www.googleapis.com/compute/v1/projects/example-project"
-        "/zones/europe-west3-b/operations/operation-1538578207537"
-        "-577542784f769-7999ab71-94f9ec1d'} "
+        + "'name': "
+        + "'operation-1538578207537-577542784f769-7999ab71-94f9ec1d', "
+        + "'zone': 'https://www.googleapis.com/compute/v1/projects/example"
+        + "-project/zones/europe-west3-b', 'operationType': "
+        + "'setMachineType', 'targetLink': "
+        + "'https://www.googleapis.com/compute/v1/projects/example-project"
+        + "/zones/europe-west3-b/instances/pa-1', 'targetId': "
+        + "'2480086944131075860', 'status': 'DONE', 'user': "
+        + "'service-account@example-project.iam.gserviceaccount.com', "
+        + "'progress': 100, 'insertTime': '2018-10-03T07:50:07.951-07:00', "
+        + "'startTime': '2018-10-03T07:50:08.324-07:00', 'endTime': "
+        + "'2018-10-03T07:50:08.484-07:00', 'error': {'errors': [{'code': "
+        + "'UNSUPPORTED_OPERATION', 'message': \"Machine type with name "
+        + "'machine-type-1' does not exist in zone 'europe-west3-b'.\"}]}, "
+        + "'httpErrorStatusCode': 400, 'httpErrorMessage': 'BAD REQUEST', "
+        + "'selfLink': "
+        + "'https://www.googleapis.com/compute/v1/projects/example-project"
+        + "/zones/europe-west3-b/operations/operation-1538578207537"
+        + "-577542784f769-7999ab71-94f9ec1d'} "
     )
 
     @mock.patch(
@@ -793,22 +793,22 @@ class TestGceInstanceTemplateCopy(unittest.TestCase):
 GCE_INSTANCE_GROUP_MANAGER_NAME = "instance-group-test"
 GCE_INSTANCE_TEMPLATE_SOURCE_URL = (
     "https://www.googleapis.com/compute/beta/projects/project"
-    "/global/instanceTemplates/instance-template-test"
+    + "/global/instanceTemplates/instance-template-test"
 )
 
 GCE_INSTANCE_TEMPLATE_OTHER_URL = (
     "https://www.googleapis.com/compute/beta/projects/project"
-    "/global/instanceTemplates/instance-template-other"
+    + "/global/instanceTemplates/instance-template-other"
 )
 
 GCE_INSTANCE_TEMPLATE_NON_EXISTING_URL = (
     "https://www.googleapis.com/compute/beta/projects/project"
-    "/global/instanceTemplates/instance-template-non-existing"
+    + "/global/instanceTemplates/instance-template-non-existing"
 )
 
 GCE_INSTANCE_TEMPLATE_DESTINATION_URL = (
     "https://www.googleapis.com/compute/beta/projects/project"
-    "/global/instanceTemplates/instance-template-new"
+    + "/global/instanceTemplates/instance-template-new"
 )
 
 GCE_INSTANCE_GROUP_MANAGER_GET = {

--- a/tests/providers/google/cloud/operators/test_functions.py
+++ b/tests/providers/google/cloud/operators/test_functions.py
@@ -319,7 +319,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
             (
                 {'sourceArchiveUrl': '', 'sourceUploadUrl': ''},
                 "Parameter 'sourceUploadUrl' is empty in the body and argument "
-                "'zip_path' is missing or empty.",
+                + "'zip_path' is missing or empty.",
             ),
             (
                 {'sourceArchiveUrl': 'gs://adasda', 'sourceRepository': ''},
@@ -328,17 +328,17 @@ class TestGcfFunctionDeploy(unittest.TestCase):
             (
                 {'sourceUploadUrl': '', 'sourceRepository': ''},
                 "Parameter 'sourceUploadUrl' is empty in the body and argument 'zip_path' "
-                "is missing or empty.",
+                + "is missing or empty.",
             ),
             (
                 {'sourceArchiveUrl': '', 'sourceUploadUrl': '', 'sourceRepository': ''},
                 "Parameter 'sourceUploadUrl' is empty in the body and argument 'zip_path' "
-                "is missing or empty.",
+                + "is missing or empty.",
             ),
             (
                 {'sourceArchiveUrl': 'gs://url', 'sourceUploadUrl': 'https://url'},
                 "The mutually exclusive fields 'sourceUploadUrl' and 'sourceArchiveUrl' "
-                "belonging to the union 'source_code' are both present. Please remove one",
+                + "belonging to the union 'source_code' are both present. Please remove one",
             ),
             (
                 {'sourceUploadUrl': 'https://url', 'zip_path': '/path/to/file'},
@@ -347,7 +347,7 @@ class TestGcfFunctionDeploy(unittest.TestCase):
             (
                 {'sourceUploadUrl': ''},
                 "Parameter 'sourceUploadUrl' is empty in the body "
-                "and argument 'zip_path' is missing or empty.",
+                + "and argument 'zip_path' is missing or empty.",
             ),
             (
                 {'sourceRepository': ''},

--- a/tests/providers/google/cloud/utils/test_credentials_provider.py
+++ b/tests/providers/google/cloud/utils/test_credentials_provider.py
@@ -143,9 +143,9 @@ class TestGetGcpCredentialsAndProjectId(unittest.TestCase):
         self.assertEqual(("CREDENTIALS", "PROJECT_ID"), result)
         self.assertEqual(
             [
-                'INFO:airflow.providers.google.cloud.utils.credentials_provider._CredentialProvider:Getting '
-                'connection using `google.auth.default()` since no key file is defined for '
-                'hook.'
+                'INFO:airflow.providers.google.cloud.utils.credentials_provider._CredentialProvider:Getting'
+                + ' connection using `google.auth.default()` since no key file is defined for '
+                + 'hook.'
             ],
             cm.output,
         )
@@ -249,8 +249,9 @@ class TestGetGcpCredentialsAndProjectId(unittest.TestCase):
         self.assertEqual((mock_from_service_account_file.return_value, self.test_project_id), result)
         self.assertEqual(
             [
-                'DEBUG:airflow.providers.google.cloud.utils.credentials_provider._CredentialProvider:Getting '
-                'connection using JSON key file KEY_PATH.json'
+                'DEBUG:airflow.providers.google.cloud.utils.'
+                + 'credentials_provider._CredentialProvider:Getting '
+                + 'connection using JSON key file KEY_PATH.json'
             ],
             cm.output,
         )
@@ -272,8 +273,9 @@ class TestGetGcpCredentialsAndProjectId(unittest.TestCase):
         self.assertEqual((mock_from_service_account_info.return_value, self.test_project_id), result)
         self.assertEqual(
             [
-                'DEBUG:airflow.providers.google.cloud.utils.credentials_provider._CredentialProvider:Getting '
-                'connection using JSON Dict'
+                'DEBUG:airflow.providers.google.cloud.utils.'
+                + 'credentials_provider._CredentialProvider:Getting '
+                + 'connection using JSON Dict'
             ],
             cm.output,
         )

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -123,7 +123,7 @@ class TestWasbTaskHandler(unittest.TestCase):
                         (
                             '',
                             '*** Reading remote log from wasb://container/remote/log/location/1.log.\n'
-                            'Log line\n',
+                            + 'Log line\n',
                         )
                     ]
                 ],

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -48,11 +48,11 @@ class TestOdbcHook:
         hook = self.get_hook(conn_params=conn_params)
         expected = (
             'DRIVER={Fake Driver};'
-            'SERVER=host;'
-            'DATABASE=schema;'
-            'UID=login;'
-            'PWD=password;'
-            'Fake_Param=Fake Param;'
+            + 'SERVER=host;'
+            + 'DATABASE=schema;'
+            + 'UID=login;'
+            + 'PWD=password;'
+            + 'Fake_Param=Fake Param;'
         )
         assert hook.odbc_connection_string == expected
 
@@ -62,11 +62,11 @@ class TestOdbcHook:
         hook = self.get_hook(hook_params=hook_params, conn_params=conn_params)
         expected = (
             'DRIVER={ParamDriver};'
-            'SERVER=host;'
-            'DATABASE=schema;'
-            'UID=login;'
-            'PWD=password;'
-            'Fake_Param=Fake Param;'
+            + 'SERVER=host;'
+            + 'DATABASE=schema;'
+            + 'UID=login;'
+            + 'PWD=password;'
+            + 'Fake_Param=Fake Param;'
         )
         assert hook.odbc_connection_string == expected
 
@@ -82,12 +82,12 @@ class TestOdbcHook:
         hook = self.get_hook(hook_params=hook_params, conn_params=conn_params)
         expected = (
             'DRIVER={ParamDriver};'
-            'DSN=ParamDSN;'
-            'SERVER=host;'
-            'DATABASE=schema;'
-            'UID=login;'
-            'PWD=password;'
-            'Fake_Param=Fake Param;'
+            + 'DSN=ParamDSN;'
+            + 'SERVER=host;'
+            + 'DATABASE=schema;'
+            + 'UID=login;'
+            + 'PWD=password;'
+            + 'Fake_Param=Fake Param;'
         )
         assert hook.odbc_connection_string == expected
 

--- a/tests/providers/presto/hooks/test_presto.py
+++ b/tests/providers/presto/hooks/test_presto.py
@@ -222,9 +222,9 @@ class TestPrestoHookIntegration(unittest.TestCase):
     def test_should_record_records_with_kerberos_auth(self):
         conn_url = (
             'presto://airflow@presto:7778/?'
-            'auth=kerberos&kerberos__service_name=HTTP&'
-            'verify=False&'
-            'protocol=https'
+            + 'auth=kerberos&kerberos__service_name=HTTP&'
+            + 'verify=False&'
+            + 'protocol=https'
         )
         with mock.patch.dict('os.environ', AIRFLOW_CONN_PRESTO_DEFAULT=conn_url):
             hook = PrestoHook()

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -210,7 +210,7 @@ class TestSFTPOperator(unittest.TestCase):
     def test_pickle_file_transfer_get(self):
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "
-            "another line here \n this is last line. EOF"
+            + "another line here \n this is last line. EOF"
         )
 
         # create a test file remotely
@@ -248,7 +248,7 @@ class TestSFTPOperator(unittest.TestCase):
     def test_json_file_transfer_get(self):
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "
-            "another line here \n this is last line. EOF"
+            + "another line here \n this is last line. EOF"
         )
 
         # create a test file remotely
@@ -286,7 +286,7 @@ class TestSFTPOperator(unittest.TestCase):
     def test_file_transfer_no_intermediate_dir_error_get(self):
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "
-            "another line here \n this is last line. EOF"
+            + "another line here \n this is last line. EOF"
         )
 
         # create a test file remotely
@@ -322,7 +322,7 @@ class TestSFTPOperator(unittest.TestCase):
     def test_file_transfer_with_intermediate_dir_error_get(self):
         test_remote_file_content = (
             "This is remote file content \n which is also multiline "
-            "another line here \n this is last line. EOF"
+            + "another line here \n this is last line. EOF"
         )
 
         # create a test file remotely

--- a/tests/providers/yandex/hooks/test_yandexcloud_dataproc.py
+++ b/tests/providers/yandex/hooks/test_yandexcloud_dataproc.py
@@ -55,7 +55,7 @@ OAUTH_TOKEN = 'my_oauth_token'
 # Ssh public keys will be placed to Dataproc cluster nodes, allowing to get a root shell at the nodes
 SSH_PUBLIC_KEYS = [
     'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCxO38tKAJXIs9ivPxt7AYdfybgtAR1ow3Qkb9GPQ6wkFHQq'
-    'cFDe6faKCxH6iDRteo4D8L8BxwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrhH1pON6P0='
+    + 'cFDe6faKCxH6iDRteo4D8L8BxwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrhH1pON6P0='
 ]
 
 # If Yandex.Cloud credentials are set than full test will be run. Otherwise only mocked tests.

--- a/tests/providers/yandex/operators/test_yandexcloud_dataproc.py
+++ b/tests/providers/yandex/operators/test_yandexcloud_dataproc.py
@@ -57,7 +57,7 @@ OAUTH_TOKEN = 'my_oauth_token'
 # Ssh public keys will be placed to Dataproc cluster nodes, allowing to get a root shell at the nodes
 SSH_PUBLIC_KEYS = [
     'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCxO38tKAJXIs9ivPxt7AYdfybgtAR1ow3Qkb9GPQ6wkFHQq'
-    'cFDe6faKCxH6iDRteo4D8L8BxwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrhH1pON6P0='
+    + 'cFDe6faKCxH6iDRteo4D8L8BxwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrhH1pON6P0='
 ]
 
 
@@ -111,7 +111,7 @@ class DataprocClusterCreateOperatorTest(TestCase):
             services=('HDFS', 'YARN', 'MAPREDUCE', 'HIVE', 'SPARK'),
             ssh_public_keys=[
                 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCxO38tKAJXIs9ivPxt7AYdfybgtAR1ow3Qkb9GPQ6wkFHQqcFD'
-                'e6faKCxH6iDRteo4D8L8BxwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrhH1pON6P0='
+                + 'e6faKCxH6iDRteo4D8L8BxwzN42uZSB0nfmjkIxFTcEU3mFSXEbWByg78aoddMrAAjatyrhH1pON6P0='
             ],
             subnet_id='my_subnet_id',
             zone='ru-central1-c',

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -658,7 +658,7 @@ class TestStringifiedDAGs(unittest.TestCase):
             received_logs = log_output.output[0]
             expected_err_msg = (
                 "Operator Link class 'tests.serialization.test_dag_serialization.TaskStateLink' "
-                "not registered"
+                + "not registered"
             )
             assert expected_err_msg in received_logs
 
@@ -761,7 +761,8 @@ class TestStringifiedDAGs(unittest.TestCase):
                     att1="{{ task.task_id }}", att2="{{ task.task_id }}", template_fields=["att1"]
                 ),
                 "ClassWithCustomAttributes("
-                "{'att1': '{{ task.task_id }}', 'att2': '{{ task.task_id }}', 'template_fields': ['att1']})",
+                + "{'att1': '{{ task.task_id }}', 'att2': "
+                + "'{{ task.task_id }}', 'template_fields': ['att1']})",
             ),
             (
                 ClassWithCustomAttributes(
@@ -774,10 +775,10 @@ class TestStringifiedDAGs(unittest.TestCase):
                     template_fields=["nested1"],
                 ),
                 "ClassWithCustomAttributes("
-                "{'nested1': ClassWithCustomAttributes({'att1': '{{ task.task_id }}', "
-                "'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
-                "'nested2': ClassWithCustomAttributes({'att3': '{{ task.task_id }}', 'att4': "
-                "'{{ task.task_id }}', 'template_fields': ['att3']}), 'template_fields': ['nested1']})",
+                + "{'nested1': ClassWithCustomAttributes({'att1': '{{ task.task_id }}', "
+                + "'att2': '{{ task.task_id }}', 'template_fields': ['att1']}), "
+                + "'nested2': ClassWithCustomAttributes({'att3': '{{ task.task_id }}', 'att4': "
+                + "'{{ task.task_id }}', 'template_fields': ['att3']}), 'template_fields': ['nested1']})",
             ),
         ]
     )

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -30,13 +30,13 @@ class TestGetDocsUrl(unittest.TestCase):
                 '2.0.0.dev0',
                 None,
                 'http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/'
-                'apache-airflow/latest/',
+                + 'apache-airflow/latest/',
             ),
             (
                 '2.0.0.dev0',
                 'migration.html',
                 'http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/'
-                'apache-airflow/latest/migration.html',
+                + 'apache-airflow/latest/migration.html',
             ),
             ('1.10.0', None, 'https://airflow.apache.org/docs/1.10.0/'),
             ('1.10.0', 'migration.html', 'https://airflow.apache.org/docs/1.10.0/migration.html'),

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -583,12 +583,12 @@ class TestAirflowBaseViews(TestBase):
             self.check_content_in_response('DAGs', resp)
             val_state_color_mapping = (
                 'const STATE_COLOR = {"failed": "red", '
-                '"null": "lightblue", "queued": "gray", '
-                '"removed": "lightgrey", "running": "lime", '
-                '"scheduled": "tan", "sensing": "lightseagreen", '
-                '"shutdown": "blue", "skipped": "pink", '
-                '"success": "green", "up_for_reschedule": "turquoise", '
-                '"up_for_retry": "gold", "upstream_failed": "orange"};'
+                + '"null": "lightblue", "queued": "gray", '
+                + '"removed": "lightgrey", "running": "lime", '
+                + '"scheduled": "tan", "sensing": "lightseagreen", '
+                + '"shutdown": "blue", "skipped": "pink", '
+                + '"success": "green", "up_for_reschedule": "turquoise", '
+                + '"up_for_retry": "gold", "upstream_failed": "orange"};'
             )
             self.check_content_in_response(val_state_color_mapping, resp)
 
@@ -1148,7 +1148,7 @@ class TestConfigurationView(TestBase):
             [
                 'Airflow Configuration',
                 '# Your Airflow administrator chose not to expose the configuration, '
-                'most likely for security reasons.',
+                + 'most likely for security reasons.',
             ],
             resp,
         )
@@ -1285,8 +1285,8 @@ class TestLogView(TestBase):
     def test_get_logs_with_metadata_as_download_file(self):
         url_template = (
             "get_logs_with_metadata?dag_id={}&"
-            "task_id={}&execution_date={}&"
-            "try_number={}&metadata={}&format=file"
+            + "task_id={}&execution_date={}&"
+            + "try_number={}&metadata={}&format=file"
         )
         try_number = 1
         url = url_template.format(
@@ -1312,8 +1312,8 @@ class TestLogView(TestBase):
             read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
             url_template = (
                 "get_logs_with_metadata?dag_id={}&"
-                "task_id={}&execution_date={}&"
-                "try_number={}&metadata={}&format=file"
+                + "task_id={}&execution_date={}&"
+                + "try_number={}&metadata={}&format=file"
             )
             try_number = 1
             url = url_template.format(
@@ -1381,8 +1381,8 @@ class TestLogView(TestBase):
     def test_get_logs_response_with_ti_equal_to_none(self):
         url_template = (
             "get_logs_with_metadata?dag_id={}&"
-            "task_id={}&execution_date={}&"
-            "try_number={}&metadata={}&format=file"
+            + "task_id={}&execution_date={}&"
+            + "try_number={}&metadata={}&format=file"
         )
         try_number = 1
         url = url_template.format(
@@ -1400,8 +1400,8 @@ class TestLogView(TestBase):
     def test_get_logs_with_json_response_format(self):
         url_template = (
             "get_logs_with_metadata?dag_id={}&"
-            "task_id={}&execution_date={}&"
-            "try_number={}&metadata={}&format=json"
+            + "task_id={}&execution_date={}&"
+            + "try_number={}&metadata={}&format=json"
         )
         try_number = 1
         url = url_template.format(
@@ -1419,8 +1419,8 @@ class TestLogView(TestBase):
 
         url_template = (
             "get_logs_with_metadata?dag_id={}&"
-            "task_id={}&execution_date={}&"
-            "try_number={}&metadata={}&format=json"
+            + "task_id={}&execution_date={}&"
+            + "try_number={}&metadata={}&format=json"
         )
         try_number = 1
         url = url_template.format(
@@ -3283,7 +3283,7 @@ class TestHelperFunctions(TestBase):
             (
                 "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%test_dag';alert(33)//",
                 "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3F"
-                "dag_id%25test_dag%27&alert%2833%29%2F%2F=",
+                + "dag_id%25test_dag%27&alert%2833%29%2F%2F=",
             ),
             (
                 "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%test_dag",


### PR DESCRIPTION
Using implicit string concatenation in lists, even across multiple lines is almost always a sign of a bug, and Pylint has a check for this we can enable.

This should hopefully catch a few cases like #12880 from happening again.

There may be a few places in the code that his now starts warning about that we will have to fix as a result

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).