### PR TITLE
Fix: Adjust inner/nested radius to remove unwanted visual gap

### DIFF
--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -4670,8 +4670,8 @@ a.list-group-item-danger.active:focus {
 .panel-heading {
   padding: 10px 15px;
   border-bottom: 1px solid transparent;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-top-right-radius: 2px;
+  border-top-left-radius: 2px;
 }
 .panel-heading > .dropdown .dropdown-toggle {
   color: inherit;


### PR DESCRIPTION
This occurs in the FAB views and other places where Bootstrap's "accordion" panels are employed.
| Before | After |
|---|---|
|  ![Image 2020-12-07 at 10 05 16 AM](https://user-images.githubusercontent.com/3267/101368139-cbb60e80-3874-11eb-88e6-b5f623a97464.jpg) | ![Image 2020-12-07 at 10 11 09 AM](https://user-images.githubusercontent.com/3267/101368133-c9ec4b00-3874-11eb-9993-8dbcd9059ed6.jpg)  |

The border width was increased for 2.0, so the inner radius needs to be decreased.

![image](https://user-images.githubusercontent.com/3267/101369720-a1655080-3876-11eb-957c-3093e65ed41f.png)
