### PR TITLE
Add airflow __main__

### DIFF
--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# PYTHON_ARGCOMPLETE_OK
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# THIS FILE IS A REPLICATION OF ./airflow/bin/airflow
+import os
+
+import argcomplete
+
+from airflow.configuration import conf
+from airflow.bin.cli import CLIFactory
+
+if __name__ == '__main__':
+
+    if conf.get("core", "security") == 'kerberos':
+        os.environ['KRB5CCNAME'] = conf.get('kerberos', 'ccache')
+        os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
+
+    parser = CLIFactory.get_parser()
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args()
+    args.func(args)

--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -18,22 +18,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from airflow.bin.cli import cli_main
 
-# THIS FILE IS A REPLICATION OF ./airflow/bin/airflow
-import os
-
-import argcomplete
-
-from airflow.configuration import conf
-from airflow.bin.cli import CLIFactory
-
-if __name__ == '__main__':
-
-    if conf.get("core", "security") == 'kerberos':
-        os.environ['KRB5CCNAME'] = conf.get('kerberos', 'ccache')
-        os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
-
-    parser = CLIFactory.get_parser()
-    argcomplete.autocomplete(parser)
-    args = parser.parse_args()
-    args.func(args)
+if __name__ == "__main__":
+    cli_main()

--- a/airflow/bin/airflow
+++ b/airflow/bin/airflow
@@ -20,18 +20,7 @@
 # under the License.
 import os
 
-import argcomplete
+from airflow.bin.cli import cli_main
 
-from airflow.configuration import conf
-from airflow.bin.cli import CLIFactory
-
-if __name__ == '__main__':
-
-    if conf.get("core", "security") == 'kerberos':
-        os.environ['KRB5CCNAME'] = conf.get('kerberos', 'ccache')
-        os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
-
-    parser = CLIFactory.get_parser()
-    argcomplete.autocomplete(parser)
-    args = parser.parse_args()
-    args.func(args)
+if __name__ == "__main__":
+    cli_main()

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -26,6 +26,7 @@ import itertools
 import locale
 import logging
 
+import argcomplete
 import os
 import platform
 import subprocess
@@ -4307,3 +4308,13 @@ def py2_deprecation_waring():
         msg = "".join([colorama.Fore.YELLOW, msg, colorama.Style.RESET_ALL])
     stream.write(msg)
     stream.flush()
+
+def cli_main():
+    if conf.get("core", "security") == 'kerberos':
+        os.environ['KRB5CCNAME'] = conf.get('kerberos', 'ccache')
+        os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
+
+    parser = CLIFactory.get_parser()
+    argcomplete.autocomplete(parser)
+    args = parser.parse_args()
+    args.func(args)


### PR DESCRIPTION
closes: #12888

This PR proposes to simply add a `__main__.py` file to airflow which is an exact copy of airflow/bin/airflow.

There is probably a better way to do it (see https://github.com/apache/airflow/pull/7808 for versions 2.*+)
