### PR TITLE
Changes the type of source_code field in DagCode to MEDIUMTEXT

### DIFF
--- a/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
+++ b/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
@@ -35,7 +35,7 @@ depends_on = None
 
 
 def upgrade():  # noqa: D103
-    conn = op.get_bind()
+    conn = op.get_bind()  # pylint: disable=no-member
     if conn.dialect.name == "mysql":
         op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME(fsp=6))
@@ -80,7 +80,7 @@ def upgrade():  # noqa: D103
 
 
 def downgrade():  # noqa: D103
-    conn = op.get_bind()
+    conn = op.get_bind()  # pylint: disable=no-member
     if conn.dialect.name == "mysql":
         op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME())
         op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME())

--- a/airflow/migrations/versions/e959f08ac86c_change_field_in_dagcode_to_mediumtext_.py
+++ b/airflow/migrations/versions/e959f08ac86c_change_field_in_dagcode_to_mediumtext_.py
@@ -16,19 +16,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Increase text size for MySQL (not relevant for other DBs' text types)
+"""Change field in DagCode to MEDIUMTEXT for MySql
 
-Revision ID: d2ae31099d61
-Revises: 947454bf1dff
-Create Date: 2017-08-18 17:07:16.686130
+Revision ID: e959f08ac86c
+Revises: 64a7d6477aae
+Create Date: 2020-12-07 16:31:43.982353
 
 """
 from alembic import op
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
-revision = 'd2ae31099d61'
-down_revision = '947454bf1dff'
+revision = 'e959f08ac86c'
+down_revision = '64a7d6477aae'
 branch_labels = None
 depends_on = None
 
@@ -36,10 +36,10 @@ depends_on = None
 def upgrade():  # noqa: D103
     conn = op.get_bind()  # pylint: disable=no-member
     if conn.dialect.name == "mysql":
-        op.alter_column(table_name='variable', column_name='val', type_=mysql.MEDIUMTEXT)
+        op.alter_column(table_name='dag_code', column_name='source_code', type_=mysql.MEDIUMTEXT)
 
 
 def downgrade():  # noqa: D103
     conn = op.get_bind()  # pylint: disable=no-member
     if conn.dialect.name == "mysql":
-        op.alter_column(table_name='variable', column_name='val', type_=mysql.TEXT)
+        op.alter_column(table_name='dag_code', column_name='source_code', type_=mysql.TEXT)

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -20,7 +20,7 @@ import struct
 from datetime import datetime
 from typing import Iterable, List, Optional
 
-from sqlalchemy import BigInteger, Column, String, UnicodeText, exists
+from sqlalchemy import BigInteger, Column, String, Text, exists
 
 from airflow.exceptions import AirflowException, DagCodeNotFound
 from airflow.models.base import Base
@@ -50,7 +50,7 @@ class DagCode(Base):
     fileloc = Column(String(2000), nullable=False)
     # The max length of fileloc exceeds the limit of indexing.
     last_updated = Column(UtcDateTime, nullable=False)
-    source_code = Column(UnicodeText, nullable=False)
+    source_code = Column(Text, nullable=False)
 
     def __init__(self, full_filepath: str, source_code: Optional[str] = None):
         self.fileloc = full_filepath


### PR DESCRIPTION
This change increases the maximum amount of code one can store
in dag_code in MySQL. The limit for TEXT is 64KB where for
MEDIUMTEXT is 16MB.

Fixes #12776

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
