### PR TITLE
Use consistent style for detecting current DB type in migrations

### DIFF
--- a/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
+++ b/airflow/migrations/versions/4addfa1236f1_add_fractional_seconds_to_mysql_tables.py
@@ -24,7 +24,7 @@ Create Date: 2016-09-11 13:39:18.592072
 
 """
 
-from alembic import context, op
+from alembic import op
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
@@ -35,7 +35,8 @@ depends_on = None
 
 
 def upgrade():  # noqa: D103
-    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+    conn = op.get_bind()
+    if conn.dialect.name == "mysql":
         op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME(fsp=6))
         op.alter_column(table_name='dag', column_name='last_expired', type_=mysql.DATETIME(fsp=6))
@@ -79,7 +80,8 @@ def upgrade():  # noqa: D103
 
 
 def downgrade():  # noqa: D103
-    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+    conn = op.get_bind()
+    if conn.dialect.name == "mysql":
         op.alter_column(table_name='dag', column_name='last_scheduler_run', type_=mysql.DATETIME())
         op.alter_column(table_name='dag', column_name='last_pickled', type_=mysql.DATETIME())
         op.alter_column(table_name='dag', column_name='last_expired', type_=mysql.DATETIME())

--- a/airflow/migrations/versions/d2ae31099d61_increase_text_size_for_mysql.py
+++ b/airflow/migrations/versions/d2ae31099d61_increase_text_size_for_mysql.py
@@ -23,7 +23,7 @@ Revises: 947454bf1dff
 Create Date: 2017-08-18 17:07:16.686130
 
 """
-from alembic import context, op
+from alembic import op
 from sqlalchemy.dialects import mysql
 
 # revision identifiers, used by Alembic.
@@ -34,10 +34,12 @@ depends_on = None
 
 
 def upgrade():  # noqa: D103
-    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+    conn = op.get_bind()
+    if conn.dialect.name == "mysql":
         op.alter_column(table_name='variable', column_name='val', type_=mysql.MEDIUMTEXT)
 
 
 def downgrade():  # noqa: D103
-    if context.config.get_main_option('sqlalchemy.url').startswith('mysql'):
+    conn = op.get_bind()
+    if conn.dialect.name == "mysql":
         op.alter_column(table_name='variable', column_name='val', type_=mysql.TEXT)


### PR DESCRIPTION
Ever other case uses this current style, so let's be consistent about it


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).