### PR TITLE
Check that needed (backport) providers are installed

### DIFF
--- a/airflow/upgrade/rules/import_changes.py
+++ b/airflow/upgrade/rules/import_changes.py
@@ -15,28 +15,31 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import itertools
 from typing import NamedTuple, Optional, List
 
 from cached_property import cached_property
+from packaging.version import Version
 
 from airflow import conf
 from airflow.upgrade.rules.base_rule import BaseRule
 from airflow.upgrade.rules.renamed_classes import ALL
 from airflow.utils.dag_processing import list_py_file_paths
 
+try:
+    from importlib_metadata import PackageNotFoundError, distribution
+except ImportError:
+    from importlib.metadata import PackageNotFoundError, distribution
+
 
 class ImportChange(
     NamedTuple(
         "ImportChange",
-        [("old_path", str), ("new_path", str), ("providers_package", Optional[None])],
+        [("old_path", str), ("new_path", str), ("providers_package", Optional[str])],
     )
 ):
     def info(self, file_path=None):
-        msg = "Using `{}` will be replaced by `{}`".format(self.old_path, self.new_path)
-        if self.providers_package:
-            msg += " and requires `{}` providers package".format(
-                self.providers_package
-            )
+        msg = "Using `{}` should be replaced by `{}`".format(self.old_path, self.new_path)
         if file_path:
             msg += ". Affected file: {}".format(file_path)
         return msg
@@ -50,8 +53,19 @@ class ImportChange(
         return self.new_path.split(".")[-1]
 
     @classmethod
+    def provider_stub_from_module(cls, module):
+        if "providers" not in module:
+            return None
+
+        # [2:] strips off the airflow.providers. part
+        parts = module.split(".")[2:]
+        if parts[0] in ('apache', 'cncf'):
+            return '-'.join(parts[:2])
+        return parts[0]
+
+    @classmethod
     def from_new_old_paths(cls, new_path, old_path):
-        providers_package = new_path.split(".")[2] if "providers" in new_path else None
+        providers_package = cls.provider_stub_from_module(new_path)
         return cls(
             old_path=old_path, new_path=new_path, providers_package=providers_package
         )
@@ -73,17 +87,44 @@ class ImportChangesRule(BaseRule):
     @staticmethod
     def _check_file(file_path):
         problems = []
+        providers = set()
         with open(file_path, "r") as file:
             content = file.read()
             for change in ImportChangesRule.ALL_CHANGES:
                 if change.old_class in content:
                     problems.append(change.info(file_path))
-        return problems
+                    if change.providers_package:
+                        providers.add(change.providers_package)
+        return problems, providers
+
+    @staticmethod
+    def _check_missing_providers(providers):
+
+        current_airflow_version = Version(__import__("airflow").__version__)
+        if current_airflow_version.major >= 2:
+            prefix = "apache-airflow-providers-"
+        else:
+            prefix = "apache-airflow-backport-providers-"
+
+        for provider in providers:
+            dist_name = prefix + provider
+            try:
+                distribution(dist_name)
+            except PackageNotFoundError:
+                yield "Please install `{}`".format(dist_name)
 
     def check(self):
         dag_folder = conf.get("core", "dags_folder")
         files = list_py_file_paths(directory=dag_folder, include_examples=False)
         problems = []
+        providers = set()
+        # Split in to two groups - install backports first, then make changes
         for file in files:
-            problems.extend(self._check_file(file))
-        return problems
+            new_problems, new_providers = self._check_file(file)
+            problems.extend(new_problems)
+            providers |= new_providers
+
+        return itertools.chain(
+            self._check_missing_providers(sorted(providers)),
+            problems,
+        )

--- a/airflow/upgrade/rules/import_changes.py
+++ b/airflow/upgrade/rules/import_changes.py
@@ -59,7 +59,7 @@ class ImportChange(
 
         # [2:] strips off the airflow.providers. part
         parts = module.split(".")[2:]
-        if parts[0] in ('apache', 'cncf'):
+        if parts[0] in ('apache', 'cncf', 'microsoft'):
             return '-'.join(parts[:2])
         return parts[0]
 

--- a/tests/upgrade/rules/test_import_changes.py
+++ b/tests/upgrade/rules/test_import_changes.py
@@ -34,16 +34,14 @@ class TestImportChange:
         )
         assert change.info(
             "file.py"
-        ) == "Using `{}` will be replaced by `{}` and requires `{}` providers package. " \
-             "Affected file: file.py".format(OLD_PATH, NEW_PATH, PROVIDER)
+        ) == "Using `{}` should be replaced by `{}`. Affected file: file.py".format(OLD_PATH, NEW_PATH)
         assert change.old_class == OLD_CLASS
         assert change.new_class == NEW_CLASS
 
     def test_from_new_old_paths(self):
         paths_tuple = (NEW_PATH, OLD_PATH)
         change = ImportChange.from_new_old_paths(*paths_tuple)
-        assert change.info() == "Using `{}` will be replaced by `{}` and requires `{}` " \
-                                "providers package".format(OLD_PATH, NEW_PATH, PROVIDER)
+        assert change.info() == "Using `{}` should be replaced by `{}`".format(OLD_PATH, NEW_PATH)
 
 
 class TestImportChangesRule:
@@ -58,11 +56,12 @@ class TestImportChangesRule:
 
             temp.write("from airflow.contrib import %s" % OLD_CLASS)
             temp.flush()
-            msgs = ImportChangesRule().check()
+            msgs = list(ImportChangesRule().check())
 
-        assert len(msgs) == 1
+        assert len(msgs) == 2
         msg = msgs[0]
+        assert msg == 'Please install `apache-airflow-backport-providers-dummy`'
+        msg = msgs[1]
         assert temp.name in msg
         assert OLD_PATH in msg
         assert OLD_CLASS in msg
-        assert "requires `{}`".format(PROVIDER) in msg


### PR DESCRIPTION
It's all very well telling people they need to use a new name, but if
that results in them getting an ImportError they aren't going to be very
happy.

It is also aware of backport vs not for the brave souls who might
upgrade to 2.0.0 _then_ run this.

Example of rule output:

```
Changes in import paths of hooks, operators, sensors and others
---------------------------------------------------------------
Many hooks, operators and other classes has been renamed and moved. Those changes were part of unifying names and imports paths as described in AIP-21.
The `contrib` folder has been replaced by `providers` directory and packages:
https://github.com/apache/airflow#backport-packages

Problems:

  1.  Please install `apache-airflow-backport-providers-amazon`
  2.  Please install `apache-airflow-backport-providers-apache-cassandra`
  3.  Using `airflow.contrib.operators.emr_add_steps_operator.EmrAddStepsOperator` should be replaced by `airflow.providers.amazon.aws.operators.emr_add_steps.EmrAddStepsOperator`. Affected file: /home/ash/airflow/dags/looper3.py
  4.  Using `airflow.operators.bash_operator.BashOperator` should be replaced by `airflow.operators.bash.BashOperator`. Affected file: /home/ash/airflow/dags/looper3.py
  5.  Using `airflow.operators.python_operator.PythonOperator` should be replaced by `airflow.operators.python.PythonOperator`. Affected file: /home/ash/airflow/dags/looper3.py
  6.  Using `airflow.contrib.hooks.cassandra_hook.CassandraHook` should be replaced by `airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook`. Affected file: /home/ash/airflow/dags/looper3.py
  7.  Using `airflow.operators.python_operator.PythonOperator` should be replaced by `airflow.operators.python.PythonOperator`. Affected file: /home/ash/airflow/dags/scheduler_perf_metrics.py
  8.  Using `airflow.operators.bash_operator.BashOperator` should be replaced by `airflow.operators.bash.BashOperator`. Affected file: /home/ash/airflow/dags/scenario1/case2/scenario1_case2_07.py
  9.  Using `airflow.operators.bash_operator.BashOperator` should be replaced by `airflow.operators.bash.BashOperator`. Affected file: /home/ash/airflow/dags/scenario1/case2/scenario1_case2_10.py
 10.  Using `airflow.operators.bash_operator.BashOperator` should be replaced by `airflow.operators.bash.BashOperator`. Affected file: /home/ash/airflow/dags/scenario1/case2/scenario1_case2_06.py
 11.  Using `airflow.operators.bash_operator.BashOperator` should be replaced by `airflow.operators.bash.BashOperator`. Affected file: /home/ash/airflow/dags/scenario1/case2/scenario1_case2_04.py
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).