### PR TITLE
Fix broken MySQL Migration

### DIFF
--- a/airflow/migrations/versions/e959f08ac86c_change_field_in_dagcode_to_mediumtext_.py
+++ b/airflow/migrations/versions/e959f08ac86c_change_field_in_dagcode_to_mediumtext_.py
@@ -36,10 +36,12 @@ depends_on = None
 def upgrade():  # noqa: D103
     conn = op.get_bind()  # pylint: disable=no-member
     if conn.dialect.name == "mysql":
-        op.alter_column(table_name='dag_code', column_name='source_code', type_=mysql.MEDIUMTEXT)
+        op.alter_column(
+            table_name='dag_code', column_name='source_code', type_=mysql.MEDIUMTEXT, nullable=False
+        )
 
 
 def downgrade():  # noqa: D103
     conn = op.get_bind()  # pylint: disable=no-member
     if conn.dialect.name == "mysql":
-        op.alter_column(table_name='dag_code', column_name='source_code', type_=mysql.TEXT)
+        op.alter_column(table_name='dag_code', column_name='source_code', type_=mysql.TEXT, nullable=False)


### PR DESCRIPTION
We added a change https://github.com/apache/airflow/pull/12890 to fix type of `source_code` column
in `dag_code` table. But looks like MySQL does not like if we don't specify nullable field.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
