### PR TITLE
Add regional support to the workflow template methods.

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -23,7 +23,6 @@ import uuid
 import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-from cached_property import cached_property
 from google.api_core.exceptions import ServerError
 from google.api_core.retry import Retry
 from google.cloud.dataproc_v1beta2 import (  # pylint: disable=no-name-in-module
@@ -218,11 +217,14 @@ class DataprocHook(GoogleBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
-    @cached_property
-    def get_template_client(self) -> WorkflowTemplateServiceClient:
+    def get_template_client(self, location: Optional[str] = None) -> WorkflowTemplateServiceClient:
         """Returns WorkflowTemplateServiceClient."""
+        client_options = None
+        if location and location != 'global':
+            client_options = {'api_endpoint': f'{location}-dataproc.googleapis.com:443'}
+
         return WorkflowTemplateServiceClient(
-            credentials=self._get_credentials(), client_info=self.client_info
+            credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
     def get_job_client(self, location: Optional[str] = None) -> JobControllerClient:
@@ -591,7 +593,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_template_client
+        client = self.get_template_client(location)
         parent = client.region_path(project_id, location)
         return client.create_workflow_template(
             parent=parent, template=template, retry=retry, timeout=timeout, metadata=metadata
@@ -641,7 +643,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_template_client
+        client = self.get_template_client(location)
         name = client.workflow_template_path(project_id, location, template_name)
         operation = client.instantiate_workflow_template(
             name=name,
@@ -688,7 +690,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_template_client
+        client = self.get_template_client(location)
         parent = client.region_path(project_id, location)
         operation = client.instantiate_inline_workflow_template(
             parent=parent,

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -71,10 +71,23 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
-    def test_get_template_client(self, mock_client, mock_client_info, mock_get_credentials):
-        _ = self.hook.get_template_client
+    def test_get_template_client_global(self, mock_client, mock_client_info, mock_get_credentials):
+        _ = self.hook.get_template_client()
         mock_client.assert_called_once_with(
-            credentials=mock_get_credentials.return_value, client_info=mock_client_info.return_value
+            credentials=mock_get_credentials.return_value,
+            client_info=mock_client_info.return_value,
+            client_options=None,
+        )
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
+    @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
+    def test_get_template_client_region(self, mock_client, mock_client_info, mock_get_credentials):
+        _ = self.hook.get_template_client(location='region1')
+        mock_client.assert_called_once_with(
+            credentials=mock_get_credentials.return_value,
+            client_info=mock_client_info.return_value,
+            client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
@@ -193,34 +206,36 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
     def test_create_workflow_template(self, mock_client):
         template = {"test": "test"}
-        mock_client.region_path.return_value = PARENT
+        mock_client.return_value.region_path.return_value = PARENT
         self.hook.create_workflow_template(location=GCP_LOCATION, template=template, project_id=GCP_PROJECT)
-        mock_client.region_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION)
-        mock_client.create_workflow_template.assert_called_once_with(
+        mock_client.return_value.region_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION)
+        mock_client.return_value.create_workflow_template.assert_called_once_with(
             parent=PARENT, template=template, retry=None, timeout=None, metadata=None
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
     def test_instantiate_workflow_template(self, mock_client):
         template_name = "template_name"
-        mock_client.workflow_template_path.return_value = NAME
+        mock_client.return_value.workflow_template_path.return_value = NAME
         self.hook.instantiate_workflow_template(
             location=GCP_LOCATION, template_name=template_name, project_id=GCP_PROJECT
         )
-        mock_client.workflow_template_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION, template_name)
-        mock_client.instantiate_workflow_template.assert_called_once_with(
+        mock_client.return_value.workflow_template_path.assert_called_once_with(
+            GCP_PROJECT, GCP_LOCATION, template_name
+        )
+        mock_client.return_value.instantiate_workflow_template.assert_called_once_with(
             name=NAME, version=None, parameters=None, request_id=None, retry=None, timeout=None, metadata=None
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
     def test_instantiate_inline_workflow_template(self, mock_client):
         template = {"test": "test"}
-        mock_client.region_path.return_value = PARENT
+        mock_client.return_value.region_path.return_value = PARENT
         self.hook.instantiate_inline_workflow_template(
             location=GCP_LOCATION, template=template, project_id=GCP_PROJECT
         )
-        mock_client.region_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION)
-        mock_client.instantiate_inline_workflow_template.assert_called_once_with(
+        mock_client.return_value.region_path.assert_called_once_with(GCP_PROJECT, GCP_LOCATION)
+        mock_client.return_value.instantiate_inline_workflow_template.assert_called_once_with(
             parent=PARENT, template=template, request_id=None, retry=None, timeout=None, metadata=None
         )
 


### PR DESCRIPTION
Workflow templates of GCP can be regional or global. In case of
regional the GCP API endpoint rpc url should match to the same
region.

In case of global templates needed to pass 'global' as region.
It is not used for endpoint address but needed to as part of
template path.

ISSUE: #12804

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
