### PR TITLE
Builds prod images on DockerHub from packages

### DIFF
--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -23,23 +23,6 @@ export AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
 export DOCKER_CACHE="local"
 export VERBOSE="true"
 
-export INSTALLED_PROVIDERS=(
-    "amazon"
-    "microsoft.azure"
-    "celery"
-    "elasticsearch"
-    "google"
-    "cncf.kubernetes"
-    "mysql"
-    "postgres"
-    "redis"
-    "slack"
-    "ssh"
-)
-readonly INSTALLED_PROVIDERS
-
-export INSTALLED_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
-readonly INSTALLED_EXTRAS
 
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
@@ -57,43 +40,8 @@ function build_prod_images_on_ci() {
         build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" \
             ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_IMAGE}"
 
-        build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" \
-            ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_BUILD_IMAGE}"
     else
-        # Cleanup dist and docker-context-files folders
-        mkdir -pv "${AIRFLOW_SOURCES}/dist"
-        mkdir -pv "${AIRFLOW_SOURCES}/docker-context-files"
-        rm -f "${AIRFLOW_SOURCES}/dist/"*.{whl,tar.gz}
-        rm -f "${AIRFLOW_SOURCES}/docker-context-files/"*.{whl,tar.gz}
-
-        pip_download_command="pip download -d /dist '.[${INSTALLED_EXTRAS}]' --constraint 'https://raw.githubusercontent.com/apache/airflow/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt'"
-
-        docker run --rm --entrypoint /bin/bash \
-            "${EXTRA_DOCKER_FLAGS[@]}" \
-            "${AIRFLOW_CI_IMAGE}" -c "${pip_download_command}"
-
-        # Remove all downloaded apache airflow packages
-        rm -f "${AIRFLOW_SOURCES}/dist/"apache_airflow*.whl
-        rm -f "${AIRFLOW_SOURCES}/dist/"apache-airflow*.tar.gz
-
-        # Remove all downloaded apache airflow packages
-        mv -f "${AIRFLOW_SOURCES}/dist/"* "${AIRFLOW_SOURCES}/docker-context-files/"
-
-        # Build necessary provider packages
-        runs::run_prepare_provider_packages "${INSTALLED_PROVIDERS[@]}"
-
-        mv "${AIRFLOW_SOURCES}/dist/"*.whl "${AIRFLOW_SOURCES}/docker-context-files/"
-
-        # Build apache airflow packages
-        build_airflow_packages::build_airflow_packages
-
-        # Remove generated tar.gz packages
-        rm -f "${AIRFLOW_SOURCES}/dist/"apache-airflow*.tar.gz
-
-        # move the packages to docker-context-files folder
-        mkdir -pv "${AIRFLOW_SOURCES}/docker-context-files"
-        mv "${AIRFLOW_SOURCES}/dist/"* "${AIRFLOW_SOURCES}/docker-context-files/"
-        build_images::build_prod_images
+        build_images::build_prod_images_from_packages
     fi
 
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -148,6 +148,32 @@ function initialization::initialize_base_variables() {
     INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES:="true"}
     export INSTALL_PROVIDERS_FROM_SOURCES
 
+    export INSTALLED_PROVIDERS=(
+        "amazon"
+        "celery"
+        "cncf.kubernetes"
+        "docker"
+        "elasticsearch"
+        "ftp"
+        "grpc"
+        "hashicorp"
+        "http"
+        "imap"
+        "google"
+        "microsoft.azure"
+        "mysql"
+        "postgres"
+        "redis"
+        "sendgrid"
+        "sftp"
+        "slack"
+        "ssh"
+    )
+    readonly INSTALLED_PROVIDERS
+
+    export INSTALLED_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,imap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
+    readonly INSTALLED_EXTRAS
+
     PIP_VERSION="20.2.4"
     export PIP_VERSION
 


### PR DESCRIPTION
This build combines building both CI and PROD image in one
script execution on DockerHub per python version.

First the CI image is build and secondly, the image is used
to build all the packages from sources and then those
packages are used to build the PROD image.

Resulting image will be package image built from latest sources.

Closes: #12261

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
