### PR TITLE
Fix return type in prev-date context variables

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -122,6 +122,8 @@ This is to align the name with the actual code where the Scheduler launches the 
 `[scheduler] parsing_processes` to Parse DAG files, calculates next DagRun date for each DAG,
 serialize them and store them in the DB.
 
+### Context variables `prev_execution_date_success` and `prev_execution_date_success` are now `pendulum.DateTime`
+
 ## Airflow 2.0.0b1
 
 ### Rename policy to task_policy

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -759,7 +759,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         """
         self.log.debug("previous_execution_date was called")
         prev_ti = self.get_previous_ti(state=state, session=session)
-        return prev_ti and prev_ti.execution_date
+        return prev_ti and pendulum.instance(prev_ti.execution_date)
 
     @provide_session
     def get_previous_start_date(
@@ -773,7 +773,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         """
         self.log.debug("previous_start_date was called")
         prev_ti = self.get_previous_ti(state=state, session=session)
-        return prev_ti and prev_ti.start_date
+        return prev_ti and pendulum.instance(prev_ti.start_date)
 
     @property
     def previous_start_date_success(self) -> Optional[pendulum.DateTime]:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -773,7 +773,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         """
         self.log.debug("previous_start_date was called")
         prev_ti = self.get_previous_ti(state=state, session=session)
-        return prev_ti and pendulum.instance(prev_ti.start_date)
+        return prev_ti and prev_ti.start_date and pendulum.instance(prev_ti.start_date)
 
     @property
     def previous_start_date_success(self) -> Optional[pendulum.DateTime]:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -773,7 +773,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         """
         self.log.debug("previous_start_date was called")
         prev_ti = self.get_previous_ti(state=state, session=session)
-        return prev_ti and prev_ti.start_date and pendulum.instance(prev_ti.start_date)
+        return prev_ti and pendulum.instance(prev_ti.start_date)
 
     @property
     def previous_start_date_success(self) -> Optional[pendulum.DateTime]:

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1077,9 +1077,22 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE},
             schedule_interval=INTERVAL,
         )
+        self.dag.create_dagrun(
+            run_type=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
         self.addCleanup(self.dag.clear)
 
+    def tearDown(self):
+        super().tearDown()
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
     def _run_as_operator(self, fn, python_version=sys.version_info[0], **kwargs):
+
         task = PythonVirtualenvOperator(
             python_callable=fn, python_version=python_version, task_id='task', dag=self.dag, **kwargs
         )


### PR DESCRIPTION
Functions `get_previous_execution_date` and `get_previous_start_date` should return pendulum as promised by type annotations and docs

Addresses question here https://github.com/apache/airflow/discussions/12503