### PR TITLE
Disable Pause/Unpause switch if user doesn't have edit access for DAG.

### DIFF
--- a/airflow/www/static/css/switch.css
+++ b/airflow/www/static/css/switch.css
@@ -24,6 +24,10 @@
   font-weight: normal;
 }
 
+.switch-label.disabled {
+  cursor: not-allowed;
+}
+
 .switch-input {
   /* Visually hidden input but still accessible */
   position: absolute;
@@ -49,10 +53,6 @@
   cursor: pointer;
 }
 
-.disabled {
-  cursor: auto;
-}
-
 .switch::before {
   border-radius: 50%;
   width: 1.5rem;
@@ -62,6 +62,11 @@
   transition-timing-function: ease-in-out;
   transition-duration: 0.25s;
   transition-property: transform, background-color;
+}
+
+.switch-input:disabled + .switch {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .switch-input:checked + .switch {

--- a/airflow/www/static/css/switch.css
+++ b/airflow/www/static/css/switch.css
@@ -25,7 +25,7 @@
 }
 
 .switch-input {
-  /* Visusally hidden input but still accessible */
+  /* Visually hidden input but still accessible */
   position: absolute;
   overflow: hidden;
   clip: rect(1px, 1px, 1px, 1px);
@@ -47,6 +47,10 @@
   padding: 2px;
   background-color: #c4c2c1;
   cursor: pointer;
+}
+
+.disabled {
+  cursor: auto;
 }
 
 .switch::before {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -47,19 +47,18 @@
         <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
       {% else %}
         {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
-          <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
-            <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
-                  type="checkbox" {{ "checked" if not dag.is_paused else "" }}>
-            <span class="switch" aria-hidden="true"></span>
-          </label>
+          {% set switch_tooltip = 'Pause/Unpause DAG' %}
+          {% set label_class = 'switch-label' %}
         {% else %}
-          <label class="switch-label js-tooltip disabled" title="DAG is {{ 'Paused' if dag.is_paused else 'Active' }}">
-            <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}"
-                 type="checkbox" {{ "checked" if not dag.is_paused else "" }} disabled>
-            <span class="switch disabled" aria-hidden="true"></span>
-          </label>
+          {% set switch_tooltip = 'DAG is Paused' if dag.is_paused else 'DAG is Active' %}
+          {% set label_class = 'switch-label.disabled' %}
         {% endif %}
-
+        <label class="{{ label_class }} js-tooltip" title="{{ switch_tooltip }}">
+          <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
+                 type="checkbox"{{ " checked" if not dag.is_paused else "" }}
+                 {{ " disabled" if not appbuilder.sm.can_edit_dag(dag.dag_id) else "" }}>
+          <span class="switch" aria-hidden="true"></span>
+        </label>
         <span class="text-muted">DAG:</span> {{ dag.dag_id }}
         <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
       {% endif %}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -40,15 +40,26 @@
       <span class="material-icons" aria-hidden="true">keyboard_arrow_up</span>
       DAG: {{ dag.parent_dag.dag_id }}</a>
   {% endif %}
+
   <div>
     <h3 class="pull-left">
       {% if dag.parent_dag is defined and dag.parent_dag %}
         <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
       {% else %}
-        <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
-          <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }}>
-          <span class="switch" aria-hidden="true"></span>
-        </label>
+        {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
+          <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
+            <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
+                  type="checkbox" {{ "checked" if not dag.is_paused else "" }}>
+            <span class="switch" aria-hidden="true"></span>
+          </label>
+        {% else %}
+          <label class="switch-label js-tooltip disabled" title="DAG is {{ 'Paused' if dag.is_paused else 'Active' }}">
+            <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}"
+                 type="checkbox" {{ "checked" if not dag.is_paused else "" }} disabled>
+            <span class="switch disabled" aria-hidden="true"></span>
+          </label>
+        {% endif %}
+
         <span class="text-muted">DAG:</span> {{ dag.dag_id }}
         <small class="text-muted">{{ dag.description[0:150] + '…' if dag.description and dag.description|length > 150 else dag.description|default('', true) }}</small>
       {% endif %}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -46,17 +46,16 @@
       {% if dag.parent_dag is defined and dag.parent_dag %}
         <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
       {% else %}
+        {% set can_edit = appbuilder.sm.can_edit_dag(dag.dag_id) %}
         {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
           {% set switch_tooltip = 'Pause/Unpause DAG' %}
-          {% set label_class = 'switch-label' %}
         {% else %}
           {% set switch_tooltip = 'DAG is Paused' if dag.is_paused else 'DAG is Active' %}
-          {% set label_class = 'switch-label.disabled' %}
         {% endif %}
-        <label class="{{ label_class }} js-tooltip" title="{{ switch_tooltip }}">
+        <label class="switch-label{{' disabled' if not can_edit else ''  }} js-tooltip" title="{{ switch_tooltip }}">
           <input class="switch-input" id="pause_resume" data-dag-id="{{ dag.dag_id }}"
                  type="checkbox"{{ " checked" if not dag.is_paused else "" }}
-                 {{ " disabled" if not appbuilder.sm.can_edit_dag(dag.dag_id) else "" }}>
+                 {{ " disabled" if not can_edit else "" }}>
           <span class="switch" aria-hidden="true"></span>
         </label>
         <span class="text-muted">DAG:</span> {{ dag.dag_id }}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -103,9 +103,17 @@
               <tr>
                 {# Column 1: Turn dag on/off #}
                 <td style="padding-right:0;">
-                  <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
-                    <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}" type="checkbox" {{ "checked" if not dag.is_paused else "" }}>
-                    <span class="switch" aria-hidden="true"></span>
+                  {% if dag.can_edit %}
+                    <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
+                      <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}"
+                           type="checkbox" {{ "checked" if not dag.is_paused else "" }} >
+                    <span class="switch {{ '' if dag.can_edit else 'disabled' }}" aria-hidden="true"></span>
+                  {% else %}
+                    <label class="switch-label js-tooltip disabled" title="DAG is {{ 'Paused' if dag.is_paused else 'Active' }}">
+                      <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}"
+                           type="checkbox" {{ "checked" if not dag.is_paused else "" }} disabled>
+                    <span class="switch disabled" aria-hidden="true"></span>
+                  {% endif %}
                   </label>
                 </td>
                 {# Column 2: Name #}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -104,16 +104,17 @@
                 {# Column 1: Turn dag on/off #}
                 <td style="padding-right:0;">
                   {% if dag.can_edit %}
-                    <label class="switch-label js-tooltip" title="Pause/Unpause DAG">
-                      <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}"
-                           type="checkbox" {{ "checked" if not dag.is_paused else "" }} >
-                    <span class="switch {{ '' if dag.can_edit else 'disabled' }}" aria-hidden="true"></span>
+                    {% set switch_tooltip = 'Pause/Unpause DAG' %}
+                    {% set label_class = 'switch-label' %}
                   {% else %}
-                    <label class="switch-label js-tooltip disabled" title="DAG is {{ 'Paused' if dag.is_paused else 'Active' }}">
-                      <input class="switch-input" id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}"
-                           type="checkbox" {{ "checked" if not dag.is_paused else "" }} disabled>
-                    <span class="switch disabled" aria-hidden="true"></span>
+                    {% set switch_tooltip = 'DAG is Paused' if dag.is_paused else 'DAG is Active' %}
+                    {% set label_class = 'switch-label.disabled' %}
                   {% endif %}
+                  <label class="{{ label_class }} js-tooltip" title="{{ switch_tooltip }}">
+                    <input class="switch-input"  id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}" type="checkbox"
+                           {{ " checked" if not dag.is_paused else "" }}
+                           {{ " disabled" if not dag.can_edit else "" }}>
+                    <span class="switch" aria-hidden="true"></span>
                   </label>
                 </td>
                 {# Column 2: Name #}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -105,12 +105,10 @@
                 <td style="padding-right:0;">
                   {% if dag.can_edit %}
                     {% set switch_tooltip = 'Pause/Unpause DAG' %}
-                    {% set label_class = 'switch-label' %}
                   {% else %}
                     {% set switch_tooltip = 'DAG is Paused' if dag.is_paused else 'DAG is Active' %}
-                    {% set label_class = 'switch-label.disabled' %}
                   {% endif %}
-                  <label class="{{ label_class }} js-tooltip" title="{{ switch_tooltip }}">
+                  <label class="switch-label{{' disabled' if not dag.can_edit else ''  }} js-tooltip" title="{{ switch_tooltip }}">
                     <input class="switch-input"  id="toggle-{{ dag.dag_id }}" data-dag-id="{{ dag.dag_id }}" type="checkbox"
                            {{ " checked" if not dag.is_paused else "" }}
                            {{ " disabled" if not dag.can_edit else "" }}>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -537,6 +537,16 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
                 .all()
             )
 
+            user_permissions = current_app.appbuilder.sm.get_all_permissions_views()
+            all_dags_editable = (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG) in user_permissions
+
+            for dag in dags:
+                if all_dags_editable:
+                    dag.can_edit = True
+                else:
+                    dag_resource_name = permissions.RESOURCE_DAG_PREFIX + dag.dag_id
+                    dag.can_edit = (permissions.ACTION_CAN_EDIT, dag_resource_name) in user_permissions
+
             dagtags = session.query(DagTag.name).distinct(DagTag.name).all()
             tags = [
                 {"name": name, "selected": bool(arg_tags_filter and name in arg_tags_filter)}


### PR DESCRIPTION
Bug:
Currently, if a user doesn't have edit access for a DAG, the Pause/Unpause switch can still be switched in the UI (not in the backend). This PR disables the switch for DAGs the user doesn't have access to edit. This is on the DAG list page as well as individual detail pages.

Activating/deactivating the switch is handled on a per-DAG basis. To prevent slow load time for users with a large number of DAGs, the "algorithm" used to identify whether a list of DAGs is editable has `Time complexity  = O(#DAGs on page * nLog(n) of the # of individual permissions a user has)`. So the lookup time is dependent on the number of permissions a user has, and is independent of the total number of DAGs.

![image](https://user-images.githubusercontent.com/4926004/101458307-91d41f00-38eb-11eb-8a47-06e219c61db8.png)

![image](https://user-images.githubusercontent.com/4926004/101458551-df508c00-38eb-11eb-964b-d1c348b36754.png)
