### PR TITLE
Make sure perms list isn't None before looking within list.

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -362,7 +362,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
     def _has_perm(self, permission_name, view_menu_name):
         """Whether the user has this perm"""
-        if hasattr(self, 'perms'):
+        if hasattr(self, 'perms') and self.perms is not None:
             if (permission_name, view_menu_name) in self.perms:
                 return True
         # rebuild the permissions set


### PR DESCRIPTION
Currently, the `._has_access()` method in `Security.py` checks whether the security manager object has `.perms` property, which is then checked for the presence of a specific permission. This causes an error when the `.perms` property is set to `None`, rather than an iterable.

This fix makes sure that `.perms` isn't `None` before looking inside. Otherwise, the permissions are lookup up and saved to the `.perms` property.