### PR TITLE
Adds predefined providers to install_requires.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,10 @@ setup_requires =
 #####################################################################################################
 install_requires =
     alembic>=1.2, <2.0
+    apache-airflow-providers-ftp
+    apache-airflow-providers-http
+    apache-airflow-providers-imap
+    apache-airflow-providers-sqlite
     argcomplete~=1.10
     attrs>=20.0, <21.0
     cached_property~=1.5

--- a/setup.py
+++ b/setup.py
@@ -881,7 +881,7 @@ class AirflowDistribtuion(Distribution):
     def parse_config_files(self, *args, **kwargs):  # pylint: disable=signature-differs
         """
         Ensure that when we have been asked to install providers from sources
-        that we don't *also* try ot install those providers from PyPI
+        that we don't *also* try to install those providers from PyPI
         """
         super().parse_config_files(*args, **kwargs)
         if os.getenv('INSTALL_PROVIDERS_FROM_SOURCES') == 'true':

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ from os.path import dirname
 from textwrap import wrap
 from typing import Dict, Iterable, List
 
-from setuptools import Command, find_namespace_packages, setup
+from setuptools import Command, Distribution, find_namespace_packages, setup
 
 logger = logging.getLogger(__name__)
 
@@ -874,6 +874,22 @@ EXTRAS_REQUIREMENTS.update(
 )
 
 
+class AirflowDistribtuion(Distribution):
+    """setuptools.Distribution subclass with Airflow specific behaviour"""
+
+    # https://github.com/PyCQA/pylint/issues/3737
+    def parse_config_files(self, *args, **kwargs):  # pylint: disable=signature-differs
+        """
+        Ensure that when we have been asked to install providers from sources
+        that we don't *also* try ot install those providers from PyPI
+        """
+        super().parse_config_files(*args, **kwargs)
+        if os.getenv('INSTALL_PROVIDERS_FROM_SOURCES') == 'true':
+            self.install_requires = [  # pylint: disable=attribute-defined-outside-init
+                req for req in self.install_requires if not req.startswith('apache-airflow-providers-')
+            ]
+
+
 def get_provider_package_from_package_id(package_id: str):
     """
     Builds the name of provider package out of the package id provided/
@@ -901,6 +917,7 @@ def do_setup():
 
     write_version()
     setup(
+        distclass=AirflowDistribtuion,
         # Most values come from setup.cfg -- see
         # https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html
         version=version,


### PR DESCRIPTION
The 4 providers (http, ftp, sqlite, imap) are popular and they do not require any additionl dependencies so we decided to include them by default in Airflow 2.0

@potiuk Please take a look -- this is a simple subclassing of Distribution that means we can keep things in setup.cfg (which I get the impression the pip team want to encourage -- as it is statically parsable.)

Closes #12744 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).