### PR TITLE
Fix: Use "auto" instead of "scroll" to prevent visible (unused) scrollbars

### DIFF
--- a/airflow/www/static/css/bootstrap-theme.css
+++ b/airflow/www/static/css/bootstrap-theme.css
@@ -783,7 +783,7 @@ pre code {
 }
 .pre-scrollable {
   max-height: 340px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 .container {
   margin-right: auto;
@@ -5133,7 +5133,7 @@ button.close {
   top: -9999px;
   width: 50px;
   height: 50px;
-  overflow: scroll;
+  overflow: auto;
 }
 
 @media (min-width: 768px) {

--- a/airflow/www/static/css/dags.css
+++ b/airflow/www/static/css/dags.css
@@ -30,7 +30,7 @@
 
 .dags-table-body {
   margin: 0 1px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .dags-table-more {

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -437,7 +437,7 @@ label[for="timezone-other"],
 
 /* Override FAB table views where table width extends beyond parent containers */
 .panel-body .panel-group + div {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 .task-instance-modal-column {


### PR DESCRIPTION
Firefox on Linux displays scrollbars even when there isn't overflow occurring to make use of them. Changing `scroll` to `auto` will hide these until they are needed (overflow occurs). This behavior will be consistent with the way most other browsers already treat `scroll` and `auto`. I updated all instances in all CSS files.

CC: @ashb the Firefox on Linux user that brought these to my attention.