### PR TITLE
Add Version command for Upgrade Check

### DIFF
--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -69,12 +69,22 @@ def register_arguments(subparser):
         help="List the upgrade checks and their class names",
         action="store_true",
     )
+    subparser.add_argument(
+        "-V", "--version",
+        help="Show the version of upgrade_check",
+        action="store_true",
+    )
     subparser.set_defaults(func=run)
 
 
 def run(args):
     from airflow.upgrade.formatters import ConsoleFormatter, JSONFormatter
     from airflow.upgrade.config import UpgradeConfig
+
+    if args.version:
+        from airflow.upgrade.version import version
+        print(version)
+        return
 
     if args.list:
         list_checks()

--- a/airflow/upgrade/setup.cfg
+++ b/airflow/upgrade/setup.cfg
@@ -16,7 +16,7 @@
 # under the License.
 
 [metadata]
-version=1.1.0
+version=attr: airflow.upgrade.version.version
 name = apache-airflow-upgrade-check
 description = Check for compatibility between Airflow versions
 long_description = file: airflow/upgrade/README.md

--- a/airflow/upgrade/version.py
+++ b/airflow/upgrade/version.py
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version = "1.1.0"


### PR DESCRIPTION
```
❯ airflow upgrade_check --version
1.1.0
```

Help command:

```
❯ airflow upgrade_check --help 
usage: airflow upgrade_check [-h] [-s SAVE] [-i IGNORE] [-c CONFIG] [-l] [-V]

optional arguments:
  -h, --help            show this help message and exit
  -s SAVE, --save SAVE  Saves the result to the indicated file. The file
                        format is determined by the file extension.
  -i IGNORE, --ignore IGNORE
                        Ignore a rule. Can be used multiple times.
  -c CONFIG, --config CONFIG
                        Path to upgrade check config yaml file.
  -l, --list            List the upgrade checks and their class names
  -V, --version         Show the version of upgrade_check
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
