### PR TITLE
Add Clarification to pod_template_file examples

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
+# This file is used for documentation purposes. Example can be found at docs/executor/kubernetes.rst
+#
 # [START template_with_dags_in_image]
 ---
 apiVersion: v1

--- a/airflow/kubernetes/pod_template_file_examples/dags_in_volume_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/dags_in_volume_template.yaml
@@ -14,6 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
+# This file is used for documentation purposes. Example can be found at docs/executor/kubernetes.rst
+#
 # [START template_with_dags_in_volume]
 ---
 apiVersion: v1

--- a/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
@@ -14,8 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
----
+#
+# This file is used for documentation purposes. Example can be found at docs/executor/kubernetes.rst
+#
 # [START git_sync_template]
+---
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
Addresses https://github.com/apache/airflow/issues/11686

Clarifies why we have three files of pod_template_file examples

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
