### PR TITLE
Fix typo in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -153,7 +153,7 @@ airflow=
     customized_form_field_behaviours.schema.json
     provider.yaml.schema.json
 
-airflow.api.connextion.openaip=*.yaml
+airflow.api_connexion.openapi=*.yaml
 airflow.serialization=*.json
 
 [options.entry_points]


### PR DESCRIPTION
```
airflow.api.connextion.openaip=*.yaml
```

to

```
airflow.api_connexion.openapi=*.yaml
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
