### PR TITLE
shorten pre-commit hook name re imports of provide_session etc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -358,8 +358,8 @@ repos:
           ^airflow/providers/.*\.py$
       - id: provide-create-sessions
         language: pygrep
-        name: To avoid import cycles make sure provide_session and create_session are imported from
-              airflow.utils.session
+        name: provide_session and create_session imported from airflow.utils.session
+        description: To avoid import cycles.
         entry: "from airflow\\.utils\\.db import.* (provide_session|create_session)"
         files: \.py$
         pass_filenames: true


### PR DESCRIPTION
I noticed that the hook name was very long.  107 characters actually.  

```To avoid import cycles make sure provide_session and create_session are imported from airflow.utils.session```

Unless your terminal is very wide, this makes it very ugly and hard to read.

E.g. here is my terminal with width 125:

![image](https://user-images.githubusercontent.com/15932138/101587550-4c6e2b00-3999-11eb-815e-ac4eb9e1ad7b.png)

Here I make the name shorter and to the point.  And I move the comments on motivation -- previously part of hook name -- to the description.

After change, much better:
![image](https://user-images.githubusercontent.com/15932138/101587674-8808f500-3999-11eb-931f-0ef70ad8abee.png)
