### PR TITLE
Fix case of GitHub

### DIFF
--- a/CI.rst
+++ b/CI.rst
@@ -697,7 +697,7 @@ Publishing documentation
 
 Documentation from the ``master`` branch is automatically published on Amazon S3.
 
-To make this possible, Github Action has secrets set up with credentials
+To make this possible, GitHub Action has secrets set up with credentials
 for an Amazon Web Service account - ``DOCS_AWS_ACCESS_KEY_ID`` and ``DOCS_AWS_SECRET_ACCESS_KEY``.
 
 This account has permission to write/list/put objects to bucket ``apache-airflow-docs``. This bucket has public access configured, which means it is accessible through the website endpoint. For more information, see: `Hosting a static website on Amazon S3

--- a/docs/exts/docs_build/github_action_utils.py
+++ b/docs/exts/docs_build/github_action_utils.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 @contextmanager
 def with_group(title):
     """
-    If used in Github Action, creates an expandable group in the Github Action log.
+    If used in GitHub Action, creates an expandable group in the GitHub Action log.
     Otherwise, dispaly simple text groups.
 
     For more information, see:


### PR DESCRIPTION
Changed `Github` to `GitHub`

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
