### PR TITLE
Add support for capacityProviderStrategy option in ECSOperator.

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -124,6 +124,10 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
     :param reattach: If set to True, will check if a task from the same family is already running.
         If so, the operator will attach to it instead of starting a new task.
     :type reattach: bool
+    :param capacity_provider_strategy: The capacity provider strategy to use for the task.
+        When starting a new task if capacity_provider_strategy is specified,
+        then the launch_type parameter must be omitted.
+    :type capacity_provider_strategy: list
     """
 
     ui_color = '#f0ede4'
@@ -150,6 +154,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
         awslogs_stream_prefix: Optional[str] = None,
         propagate_tags: Optional[str] = None,
         reattach: bool = False,
+        capacity_provider_strategy: Optional[list] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -172,6 +177,7 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
         self.awslogs_region = awslogs_region
         self.propagate_tags = propagate_tags
         self.reattach = reattach
+        self.capacity_provider_strategy = capacity_provider_strategy
 
         if self.awslogs_region is None:
             self.awslogs_region = region_name
@@ -207,7 +213,9 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
             'startedBy': self.owner,
         }
 
-        if self.launch_type:
+        if self.capacity_provider_strategy is not None:
+            run_opts['capacityProviderStrategy'] = self.capacity_provider_strategy
+        elif self.launch_type:
             run_opts['launchType'] = self.launch_type
             if self.launch_type == 'FARGATE':
                 run_opts['platformVersion'] = self.platform_version


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
This PR adds support for `capacityProviderStrategy `option in ECSOperator. AWS docs for starting a new ECS task via the `RunTask` API mention that If a `capacityProviderStrategy` is specified, the `launchType` parameter must be omitted. If no `capacityProviderStrategy` or` launchType` is specified, the `defaultCapacityProviderStrategy` for the cluster is used. More details [here](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#API_RunTask_RequestSyntax). So, logic takes care of this by omitting/ignoring the `launchType` if `capacityProviderStrategy` is specified.

closes: #8381 


Also, I'd like to know if manual testing by creating an ECS task on AWS cloud is required for this feqture?


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
