### PR TITLE
Fix case of JavaScript

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -103,7 +103,7 @@ class ProvidersManager:
         self._hooks_dict: Dict[str, HookInfo] = {}
         # Keeps methods that should be used to add custom widgets tuple of keyed by name of the extra field
         self._connection_form_widgets: Dict[str, ConnectionFormWidgetInfo] = {}
-        # Customizations for javascript fields are kept here
+        # Customizations for JavaScript fields are kept here
         self._field_behaviours: Dict[str, Dict] = {}
         self._extra_link_class_name_set: Set[str] = set()
         self._provider_schema_validator = _create_provider_schema_validator()

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -862,7 +862,6 @@ iterable
 iteratively
 itertools
 izip
-javascript
 jaydebeapi
 jdbc
 jdk


### PR DESCRIPTION
Changed `javascript` to `JavaScript`

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
