### PR TITLE
Don't reference sphinx airflow theme via `@` URL in requirements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,10 +153,13 @@ def write_version(filename: str = os.path.join(*[my_dir, "airflow", "git_version
         file.write(text)
 
 
-_SPHINX_AIRFLOW_THEME_URL = (
-    "https://github.com/apache/airflow-site/releases/download/v0.0.2/"
-    "sphinx_airflow_theme-0.0.2-py3-none-any.whl"
-)
+if os.environ.get('USE_THEME_FROM_GIT'):
+    _SPHINX_AIRFLOW_THEME_URL = (
+        "@ https://github.com/apache/airflow-site/releases/download/v0.0.2/"
+        "sphinx_airflow_theme-0.0.2-py3-none-any.whl"
+    )
+else:
+    _SPHINX_AIRFLOW_THEME_URL = ''
 
 # 'Start dependencies group' and 'Start dependencies group' are mark for ./scripts/ci/check_order_setup.py
 # If you change this mark you should also change ./scripts/ci/check_order_setup.py
@@ -220,7 +223,7 @@ doc = [
     'sphinxcontrib-httpdomain>=1.7.0',
     "sphinxcontrib-redoc>=1.6.0",
     "sphinxcontrib-spelling==5.2.1",
-    f"sphinx-airflow-theme @ {_SPHINX_AIRFLOW_THEME_URL}",
+    f"sphinx-airflow-theme{_SPHINX_AIRFLOW_THEME_URL}",
 ]
 docker = [
     'docker~=3.0',


### PR DESCRIPTION
PyPI rejects uploading a dist with an `@` in the requirements.

I have taken the 2.0 and uploaded it to PyPi https://pypi.org/project/sphinx-airflow-theme/

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
