### PR TITLE
Remove unused pre-commit and Fix CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,12 +146,6 @@ repos:
         args:
           - "--maxlevel"
           - "2"
-      - id: doctoc
-        name: Add TOC for upgrade documentation
-        files: ^UPGRADING_TO_2.0.md
-        args:
-          - "--maxlevel"
-          - "3"
   - repo: meta
     hooks:
       - id: check-hooks-apply


### PR DESCRIPTION
Master is failing on Static checks and this check fails because `doctoc` is no longer used as `UPGRADING_TO_2.0.md` file no longer exists:

```
Add TOC for upgrade documentation...................................................(no files to check)Skipped
Check hooks apply to the repository.....................................................................Failed
- hook id: check-hooks-apply
- exit code: 1

doctoc does not apply to this repository
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
