### PR TITLE
Add possibility to check if upgrade check rule applies

### DIFF
--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -25,10 +25,10 @@ class RuleStatus(NamedTuple(
     'RuleStatus',
     [
         ('rule', BaseRule),
-        ('messages', List[str])
+        ('messages', List[str]),
+        ('skipped', bool)
     ]
 )):
-
     @property
     def is_success(self):
         return len(self.messages) == 0
@@ -36,10 +36,14 @@ class RuleStatus(NamedTuple(
     @classmethod
     def from_rule(cls, rule):
         # type: (BaseRule) -> RuleStatus
+        msg = rule.should_skip()
+        if msg:
+            return cls(rule=rule, messages=[msg], skipped=True)
+
         messages = []  # type: List[str]
         result = rule.check()
         if isinstance(result, str):
             messages = [result]
         elif isinstance(result, Iterable):
             messages = list(result)
-        return cls(rule=rule, messages=messages)
+        return cls(rule=rule, messages=messages, skipped=False)

--- a/airflow/upgrade/rules/base_rule.py
+++ b/airflow/upgrade/rules/base_rule.py
@@ -33,5 +33,12 @@ class BaseRule(object):
         """A long description explaining the problem in detail. This can be an entry from UPDATING.md file."""
         pass
 
+    def should_skip(self):
+        """
+        Executes a pre check of configuration. If returned value is
+        True then the checking the rule is omitted.
+        """
+        pass
+
     def check(self):
         pass

--- a/airflow/upgrade/rules/pod_template_file_rule.py
+++ b/airflow/upgrade/rules/pod_template_file_rule.py
@@ -52,6 +52,11 @@ value for all pods launched by the KubernetesExecutor. Many Kubernetes configs a
 needed once this pod_template_file has been generated.
 """
 
+    def should_skip(self):
+        # Check this rule only if users use KubernetesExecutor
+        if conf.get("core", "executor") != "KubernetesExecutor":
+            return "Skipped because this rule applies only to environment using KubernetesExecutor."
+
     def check(self):
         pod_template_file = conf.get("kubernetes", "pod_template_file", fallback=None)
         if not pod_template_file:

--- a/tests/upgrade/test_formattes.py
+++ b/tests/upgrade/test_formattes.py
@@ -34,8 +34,16 @@ class MockRule(BaseRule):
         return MESSAGES
 
 
+class MockRuleToSkip(BaseRule):
+    title = "title"
+    description = "description"
+
+    def should_skip(self):
+        return "Yes, skipp this rule"
+
+
 class TestJSONFormatter:
-    @mock.patch("airflow.upgrade.checker.ALL_RULES", [MockRule()])
+    @mock.patch("airflow.upgrade.checker.ALL_RULES", [MockRule(), MockRuleToSkip()])
     @mock.patch("airflow.upgrade.checker.logging.disable")  # mock to avoid side effects
     def test_output(self, _):
         expected = [
@@ -43,6 +51,11 @@ class TestJSONFormatter:
                 "rule": MockRule.__name__,
                 "title": MockRule.title,
                 "messages": MESSAGES,
+            },
+            {
+                "rule": MockRuleToSkip.__name__,
+                "title": MockRuleToSkip.title,
+                "messages": ["Yes, skipp this rule"],
             }
         ]
         parser = cli.CLIFactory.get_parser()

--- a/tests/upgrade/test_problem.py
+++ b/tests/upgrade/test_problem.py
@@ -22,14 +22,15 @@ from airflow.upgrade.problem import RuleStatus
 
 class TestRuleStatus:
     def test_is_success(self):
-        assert RuleStatus(rule=mock.MagicMock(), messages=[]).is_success is True
-        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"]).is_success is False
+        assert RuleStatus(rule=mock.MagicMock(), messages=[], skipped=False).is_success is True
+        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"], skipped=False).is_success is False
 
     def test_rule_status_from_rule(self):
         msgs = ["An interesting problem to solve"]
         rule = mock.MagicMock()
         rule.check.return_value = msgs
+        rule.should_skip.return_value = None
 
         result = RuleStatus.from_rule(rule)
         rule.check.assert_called_once_with()
-        assert result == RuleStatus(rule, msgs)
+        assert result == RuleStatus(rule, msgs, skipped=False)


### PR DESCRIPTION
closes: #12897

```
root@36cdf678d49c:/opt/airflow# airflow upgrade_check

================================================ STATUS ================================================

Check for latest versions of apache-airflow and checker.......................................FAIL
Remove airflow.AirflowMacroPlugin class.......................................................SUCCESS
Chain between DAG and operator not allowed....................................................SUCCESS
Connection.conn_id is not unique..............................................................SUCCESS
Connection.conn_type is not nullable..........................................................SUCCESS
Ensure users are not using custom metaclasses in custom operators.............................SUCCESS
Fernet is enabled by default..................................................................SUCCESS
GCP service account key deprecation...........................................................SUCCESS
Unify hostname_callable option in core section................................................FAIL
Changes in import paths of hooks, operators, sensors and others...............................FAIL
Legacy UI is deprecated by default............................................................SUCCESS
Logging configuration has been moved to new section...........................................SUCCESS
Removal of Mesos Executor.....................................................................SUCCESS
Users must set a kubernetes.pod_template_file value...........................................SKIPPED
SendGrid email uses old airflow.contrib module................................................SUCCESS
Changes in import path of remote task handlers................................................SUCCESS
Jinja Template Variables cannot be undefined..................................................SUCCESS
Found 8 problems.

=========================================== RECOMMENDATIONS ============================================

Check for latest versions of apache-airflow and checker
-------------------------------------------------------
Check that the latest version of apache-airflow-upgrade-check is installed, and
that you are on the latest 1.10.x release of apache-airflow.

Problems:

  1.  There is a more recent version of apache-airflow-upgrade-check. Please upgrade to 1.0.0 and re-run this script

Unify hostname_callable option in core section
----------------------------------------------

Problems:

  1.  Error: hostname_callable `socket:getfqdn` contains a colon instead of a dot. please change to `socket.getfqdn`

Changes in import paths of hooks, operators, sensors and others
---------------------------------------------------------------
Many hooks, operators and other classes has been renamed and moved. Those changes were part of unifying names and imports paths as described in AIP-21.
The `contrib` folder has been replaced by `providers` directory and packages:
https://github.com/apache/airflow#backport-packages

Problems:

  1.  Using `airflow.operators.bash_operator.BashOperator` will be replaced by `airflow.operators.bash.BashOperator`. Affected file: /files/dags/blogpost.py
  2.  Using `airflow.operators.python_operator.PythonOperator` will be replaced by `airflow.operators.python.PythonOperator`. Affected file: /files/dags/blogpost.py
  3.  Using `airflow.operators.bash_operator.BashOperator` will be replaced by `airflow.operators.bash.BashOperator`. Affected file: /files/dags/none-from-time-to-time.py
  4.  Using `airflow.operators.bash_operator.BashOperator` will be replaced by `airflow.operators.bash.BashOperator`. Affected file: /files/dags/td_test.py
  5.  Using `airflow.operators.python_operator.PythonOperator` will be replaced by `airflow.operators.python.PythonOperator`. Affected file: /files/dags/td_test.py

Users must set a kubernetes.pod_template_file value
---------------------------------------------------
Skipped because this rule applies only to environment using KubernetesExecutor.
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
