### PR TITLE
Fix command to filter package provider when building docs

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1235,7 +1235,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
         is generated ('docs/_build') are also mounted to the container - this way results of
         the documentation build is available in the host.
 
-        The possible extra args are: --docs-only, --spellcheck-only, --package, --help
+        The possible extra args are: --docs-only, --spellcheck-only, --package-filter, --help
 
 
   ####################################################################################################

--- a/breeze
+++ b/breeze
@@ -1605,7 +1605,7 @@ ${CMDNAME} build-docs [-- <EXTRA_ARGS>]
       is generated ('docs/_build') are also mounted to the container - this way results of
       the documentation build is available in the host.
 
-      The possible extra args are: --docs-only, --spellcheck-only, --package, --help
+      The possible extra args are: --docs-only, --spellcheck-only, --package-filter, --help
 "
     readonly DETAILED_USAGE_BUILD_DOCS
     export DETAILED_USAGE_BUILD_IMAGE="

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -571,7 +571,7 @@ Documentation for providers can be found in the ``/docs/apache-airflow`` directo
 
     ```shell script
     cd "${AIRFLOW_REPO_ROOT}"
-    ./breeze build-docs -- --package apache-airflow --for-production
+    ./breeze build-docs -- --package-filter apache-airflow --for-production
     ```
 
 - Now you can preview the documentation.

--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -905,9 +905,9 @@ Documentation for providers can be found in the `/docs/apache-airflow-providers`
     ```shell script
     cd "${AIRFLOW_REPO_ROOT}"
     ./breeze build-docs -- \
-      --package apache-airflow-providers \
-      --package apache-airflow-providers-apache-airflow \
-      --package apache-airflow-providers-telegram \
+      --package-filter apache-airflow-providers \
+      --package-filter apache-airflow-providers-apache-airflow \
+      --package-filter apache-airflow-providers-telegram \
       --for-production
     ```
 
@@ -921,9 +921,9 @@ Documentation for providers can be found in the `/docs/apache-airflow-providers`
 
     ```shell script
     ./docs/publish_docs.py \
-        --package apache-airflow-providers \
-        --package apache-airflow-providers-apache-airflow \
-        --package apache-airflow-providers-telegram \
+        --package-filter apache-airflow-providers \
+        --package-filter apache-airflow-providers-apache-airflow \
+        --package-filter apache-airflow-providers-telegram \
 
     cd "${AIRFLOW_SITE_DIRECTORY}"
     ```


### PR DESCRIPTION
Instead of `--package`, it should be `--package-filter` unless I am missing something

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
