### PR TITLE
 optional schema configuration of S3ToSnowflakeTransferOperator

### DIFF
--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -93,7 +93,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         if self.columns_array:
             columns = ','.join(self.columns_array)
             copy_query = (
-                f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}"
+                f"COPY INTO {self.schema}.{self.table}({columns}) {base_sql}"
                 if self.schema
                 else f"COPY INTO {self.table} ({columns}) {base_sql}"
             )

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -93,7 +93,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         if self.columns_array:
             columns = ','.join(self.columns_array)
             copy_query = (
-                f"COPY INTO {self.schema}.{self.table}({columns}) {base_sql}"
+                f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}"
                 if self.schema
                 else f"COPY INTO {self.table} ({columns}) {base_sql}"
             )

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -92,12 +92,18 @@ class S3ToSnowflakeOperator(BaseOperator):
 
         if self.columns_array:
             columns = ','.join(self.columns_array)
-            copy_query = f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}" if self.schema \
+            copy_query = (
+                f"COPY INTO {self.schema}.{self.table} ({columns}) {base_sql}"
+                if self.schema
                 else f"COPY INTO {self.table} ({columns}) {base_sql}"
+            )
 
         else:
-            copy_query = f"COPY INTO {self.schema}.{self.table} {base_sql}" if self.schema \
+            copy_query = (
+                f"COPY INTO {self.schema}.{self.table} {base_sql}"
+                if self.schema
                 else f"COPY INTO {self.table} {base_sql}"
+            )
 
         self.log.info('Executing COPY command...')
         snowflake_hook.run(copy_query, self.autocommit)

--- a/tests/providers/snowflake/transfers/test_s3_to_snowflake.py
+++ b/tests/providers/snowflake/transfers/test_s3_to_snowflake.py
@@ -103,7 +103,6 @@ class TestS3ToSnowflakeTransfer(unittest.TestCase):
         assert mock_run.call_count == 1
         assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], copy_query)
 
-
     @mock.patch("airflow.providers.snowflake.hooks.snowflake.SnowflakeHook.run")
     def test_execute_with_no_schema_param(self, mock_run):
         s3_keys = ['1.csv', '2.csv']


### PR DESCRIPTION
Close https://github.com/apache/airflow/issues/12001
schema can now be optionally passed, either via a parameter or via connection metadata.
