### PR TITLE
Switching to standard --tag-build flag in setuptools in providers

### DIFF
--- a/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -28,14 +28,13 @@
 
 import logging
 import os
-import sys
 
 from os.path import dirname
 from setuptools import find_namespace_packages, setup
 
 logger = logging.getLogger(__name__)
 
-version = '{{ RELEASE_NO_LEADING_ZEROS }}{{VERSION_SUFFIX }}'
+version = '{{ RELEASE_NO_LEADING_ZEROS }}{{ VERSION_SUFFIX }}'
 
 my_dir = dirname(__file__)
 
@@ -46,7 +45,7 @@ except FileNotFoundError:
     long_description = ''
 
 
-def do_setup(version_suffix_for_pypi=''):
+def do_setup():
     """Perform the package {{ PACKAGE_PIP_NAME }} setup."""
     setup(
         name='{{ PACKAGE_PIP_NAME }}',
@@ -55,7 +54,7 @@ def do_setup(version_suffix_for_pypi=''):
         long_description=long_description,
         long_description_content_type='text/markdown',
         license='Apache License 2.0',
-        version=version + version_suffix_for_pypi,
+        version=version,
         packages=find_namespace_packages(
             include=['airflow.providers.{{ PROVIDER_PACKAGE_ID }}',
                      'airflow.providers.{{ PROVIDER_PACKAGE_ID }}.*']),
@@ -89,17 +88,5 @@ def do_setup(version_suffix_for_pypi=''):
         },
     )
 
-#
-# Note that --version-suffix-for-pypi should only be used in case we generate RC packages for PyPI
-# Those packages should have actual RC version in order to be published even if source version
-# should be the final one.
-#
 if __name__ == "__main__":
-    suffix=''
-    if len(sys.argv) > 1 and sys.argv[1] == "--version-suffix-for-pypi":
-        if len(sys.argv) < 3:
-            print("ERROR! --version-suffix-for-pypi needs parameter!", file=sys.stderr)
-            sys.exit(1)
-        suffix = sys.argv[2]
-        sys.argv = [sys.argv[0]] + sys.argv[3:]
-    do_setup(version_suffix_for_pypi=suffix)
+    do_setup()

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -1598,7 +1598,9 @@ ERROR! Wrong first param: {sys.argv[1]}
     package_format = os.environ.get("PACKAGE_FORMAT", "wheel")
     print(f"Building backport package: {_provider_package} in format ${package_format}")
     copy_readme_and_changelog(_provider_package, BACKPORT_PACKAGES)
-    command = ["python3", "setup.py", "--version-suffix-for-pypi", suffix]
+    command = ["python3", "setup.py"]
+    if suffix != "":
+        command.extend(['egg_info', '--tag-build', suffix])
     if package_format in ['sdist', 'both']:
         command.append("sdist")
     if package_format in ['wheel', 'both']:

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -393,10 +393,14 @@ function verify_suffix_versions_for_package_preparation() {
     fi
 
     if [[ ${VERSION_SUFFIX_FOR_SVN} =~ ^rc ]]; then
+        echo """
+${COLOR_YELLOW_WARNING} The version suffix for SVN is used only for file names.
+         The version inside the packages has no version suffix.
+         This way we can just rename files when they graduate to final release.
+${COLOR_RESET}
+"""
         echo
-        echo "${COLOR_RED_ERROR} The version suffix for SVN is used only for file names in RC version  ${COLOR_RESET}"
-        echo
-        echo "This suffix is only added to the files '${VERSION_SUFFIX_FOR_SVN}' "
+        echo "This suffix is added '${VERSION_SUFFIX_FOR_SVN}' "
         echo
         FILE_VERSION_SUFFIX=${VERSION_SUFFIX_FOR_SVN}
         VERSION_SUFFIX_FOR_SVN=""

--- a/scripts/in_container/run_prepare_provider_packages.sh
+++ b/scripts/in_container/run_prepare_provider_packages.sh
@@ -119,7 +119,8 @@ for PROVIDER_PACKAGE in "${PROVIDER_PACKAGES[@]}"
 do
     rm -rf -- *.egg-info build/
     LOG_FILE=$(mktemp)
-    python3 "${PREPARE_PROVIDER_PACKAGES_PY}" generate-setup-files "${PROVIDER_PACKAGE}"
+    python3 "${PREPARE_PROVIDER_PACKAGES_PY}" --version-suffix "${VERSION_SUFFIX_FOR_PYPI}" \
+        generate-setup-files "${PROVIDER_PACKAGE}"
     echo "==================================================================================="
     echo " Preparing ${PACKAGE_TYPE} package ${PROVIDER_PACKAGE} format: ${PACKAGE_FORMAT}"
     if [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' && "${VERSION_SUFFIX_FOR_SVN}" == ''
@@ -170,14 +171,18 @@ pushd dist
 
 if [[ ${FILE_VERSION_SUFFIX} != "" ]]; then
     # In case we have FILE_VERSION_SUFFIX we rename prepared files
-    for FILE in *.tar.gz
-    do
-        mv "${FILE}" "${FILE//\.tar\.gz/${FILE_VERSION_SUFFIX}-bin.tar.gz}"
-    done
-    for FILE in *.whl
-    do
-        mv "${FILE}" "${FILE//\-py3/${FILE_VERSION_SUFFIX}-py3}"
-    done
+    if [[ "${PACKAGE_FORMAT}" == "sdist" || "${PACKAGE_FORMAT}" == "both" ]]; then
+        for FILE in *.tar.gz
+        do
+            mv "${FILE}" "${FILE//\.tar\.gz/${FILE_VERSION_SUFFIX}-bin.tar.gz}"
+        done
+    fi
+    if [[ "${PACKAGE_FORMAT}" == "wheel" || "${PACKAGE_FORMAT}" == "both" ]]; then
+        for FILE in *.whl
+        do
+            mv "${FILE}" "${FILE//\-py3/${FILE_VERSION_SUFFIX}-py3}"
+        done
+    fi
 fi
 
 popd


### PR DESCRIPTION
Following #13020 provider packages are also switching to
--tag-build flag.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
