### PR TITLE
Refactor plugins command output using AirflowConsole

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1490,7 +1490,7 @@ airflow_commands: List[CLICommand] = [
         name='plugins',
         help='Dump information about loaded plugins',
         func=lazy_load_command('airflow.cli.commands.plugins_command.dump_plugins'),
-        args=(),
+        args=(ARG_OUTPUT,),
     ),
     GroupCommand(
         name="celery",

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -23,20 +23,6 @@ from airflow.plugins_manager import PluginsDirectorySource
 from airflow.utils.cli import suppress_logs_and_warning
 
 # list to maintain the order of items.
-
-PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP = [
-    "plugins",
-    "import_errors",
-    "macros_modules",
-    "executors_modules",
-    "flask_blueprints",
-    "flask_appbuilder_views",
-    "flask_appbuilder_menu_links",
-    "global_operator_extra_links",
-    "operator_extra_links",
-    "registered_operator_link_classes",
-]
-# list to maintain the order of items.
 PLUGINS_ATTRIBUTES_TO_DUMP = [
     "source",
     "hooks",
@@ -83,7 +69,7 @@ def dump_plugins(args):
 
     # Remove empty info
     if args.output == "table":  # pylint: disable=too-many-nested-blocks
-        for col in list(plugins_info[0].keys()):  # it will exist as there's at least one plugin
+        for col in list(plugins_info[0]):  # it will exist as there's at least one plugin
             if all(not bool(p[col]) for p in plugins_info):
                 for plugin in plugins_info:
                     del plugin[col]

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -15,17 +15,14 @@
 # specific language governing permissions and limitations
 # under the License.
 import inspect
-from typing import Any, List, Optional, Union
-
-from rich.console import Console
+from typing import Any, Dict, List, Union
 
 from airflow import plugins_manager
-from airflow.cli.simple_table import SimpleTable
-from airflow.configuration import conf
+from airflow.cli.simple_table import AirflowConsole
 from airflow.plugins_manager import PluginsDirectorySource
+from airflow.utils.cli import suppress_logs_and_warning
 
 # list to maintain the order of items.
-from airflow.utils.cli import suppress_logs_and_warning
 
 PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP = [
     "plugins",
@@ -41,6 +38,7 @@ PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP = [
 ]
 # list to maintain the order of items.
 PLUGINS_ATTRIBUTES_TO_DUMP = [
+    "source",
     "hooks",
     "executors",
     "macros",
@@ -49,7 +47,6 @@ PLUGINS_ATTRIBUTES_TO_DUMP = [
     "appbuilder_menu_items",
     "global_operator_extra_links",
     "operator_extra_links",
-    "source",
 ]
 
 
@@ -78,33 +75,17 @@ def dump_plugins(args):
         print("No plugins loaded")
         return
 
-    console = Console()
-    console.print("[bold yellow]SUMMARY:[/bold yellow]")
-    console.print(
-        f"[bold green]Plugins directory[/bold green]: {conf.get('core', 'plugins_folder')}\n", highlight=False
-    )
-    console.print(
-        f"[bold green]Loaded plugins[/bold green]: {len(plugins_manager.plugins)}\n", highlight=False
-    )
-
-    for attr_name in PLUGINS_MANAGER_ATTRIBUTES_TO_DUMP:
-        attr_value: Optional[List[Any]] = getattr(plugins_manager, attr_name)
-        if not attr_value:
-            continue
-        table = SimpleTable(title=attr_name.capitalize().replace("_", " "))
-        table.add_column(width=100)
-        for item in attr_value:  # pylint: disable=not-an-iterable
-            table.add_row(
-                f"- {_get_name(item)}",
-            )
-        console.print(table)
-
-    console.print("[bold yellow]DETAILED INFO:[/bold yellow]")
+    plugins_info: List[Dict[str, str]] = []
     for plugin in plugins_manager.plugins:
-        table = SimpleTable(title=plugin.name)
-        for attr_name in PLUGINS_ATTRIBUTES_TO_DUMP:
-            value = getattr(plugin, attr_name)
-            if not value:
-                continue
-            table.add_row(attr_name.capitalize().replace("_", " "), _join_plugins_names(value))
-        console.print(table)
+        info = {"name": plugin.name}
+        info.update({n: getattr(plugin, n) for n in PLUGINS_ATTRIBUTES_TO_DUMP})
+        plugins_info.append(info)
+
+    # Remove empty info
+    if args.output == "table":  # pylint: disable=too-many-nested-blocks
+        for col in list(plugins_info[0].keys()):  # it will exist as there's at least one plugin
+            if all(not bool(p[col]) for p in plugins_info):
+                for plugin in plugins_info:
+                    del plugin[col]
+
+    AirflowConsole().print_as(plugins_info, output=args.output)

--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -69,7 +69,9 @@ def dump_plugins(args):
 
     # Remove empty info
     if args.output == "table":  # pylint: disable=too-many-nested-blocks
-        for col in list(plugins_info[0]):  # it will exist as there's at least one plugin
+        # We can do plugins_info[0] as the element it will exist as there's
+        # at least one plugin at this point
+        for col in list(plugins_info[0]):
             if all(not bool(p[col]) for p in plugins_info):
                 for plugin in plugins_info:
                     del plugin[col]

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import inspect
 import json
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -22,6 +23,8 @@ from rich.box import ASCII_DOUBLE_HEAD
 from rich.console import Console
 from rich.syntax import Syntax
 from rich.table import Table
+
+from airflow.plugins_manager import PluginsDirectorySource
 
 
 class AirflowConsole(Console):
@@ -53,13 +56,18 @@ class AirflowConsole(Console):
             table.add_row(*[str(d) for d in row.values()])
         self.print(table)
 
-    def _normalize_data(self, value: Any, output: str) -> Union[list, str, dict]:
+    # pylint: disable=too-many-return-statements
+    def _normalize_data(self, value: Any, output: str) -> Optional[Union[list, str, dict]]:
         if isinstance(value, (tuple, list)):
             if output == "table":
                 return ",".join(self._normalize_data(x, output) for x in value)
             return [self._normalize_data(x, output) for x in value]
         if isinstance(value, dict) and output != "table":
             return {k: self._normalize_data(v, output) for k, v in value.items()}
+        if isinstance(value, PluginsDirectorySource):
+            return str(value)
+        if inspect.isclass(value):
+            return value.__name__
         if value is None:
             return None
         return str(value)

--- a/airflow/cli/simple_table.py
+++ b/airflow/cli/simple_table.py
@@ -64,9 +64,7 @@ class AirflowConsole(Console):
             return [self._normalize_data(x, output) for x in value]
         if isinstance(value, dict) and output != "table":
             return {k: self._normalize_data(v, output) for k, v in value.items()}
-        if isinstance(value, PluginsDirectorySource):
-            return str(value)
-        if inspect.isclass(value):
+        if inspect.isclass(value) and not isinstance(value, PluginsDirectorySource):
             return value.__name__
         if value is None:
             return None

--- a/tests/cli/commands/test_plugins_command.py
+++ b/tests/cli/commands/test_plugins_command.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import io
+import json
 import unittest
 from contextlib import redirect_stdout
 
@@ -43,17 +44,27 @@ class TestPluginsCommand(unittest.TestCase):
     @mock_plugin_manager(plugins=[])
     def test_should_display_no_plugins(self):
         with redirect_stdout(io.StringIO()) as temp_stdout:
-            plugins_command.dump_plugins(self.parser.parse_args(['plugins']))
+            plugins_command.dump_plugins(self.parser.parse_args(['plugins', '--output=json']))
             stdout = temp_stdout.getvalue()
         self.assertIn('No plugins loaded', stdout)
 
     @mock_plugin_manager(plugins=[TestPlugin])
     def test_should_display_one_plugins(self):
         with redirect_stdout(io.StringIO()) as temp_stdout:
-            plugins_command.dump_plugins(self.parser.parse_args(['plugins']))
+            plugins_command.dump_plugins(self.parser.parse_args(['plugins', '--output=json']))
             stdout = temp_stdout.getvalue()
-        print(stdout)
-        self.assertIn('Plugins directory:', stdout)
-        self.assertIn("Loaded plugins: 1", stdout)
-        self.assertIn('test-plugin-cli', stdout)
-        self.assertIn('PluginHook', stdout)
+        info = json.loads(stdout)
+        assert info == [
+            {
+                'name': TestPlugin.name,
+                'source': None,
+                'hooks': [PluginHook.__name__],
+                'executors': [],
+                'macros': [],
+                'flask_blueprints': [],
+                'appbuilder_views': [],
+                'appbuilder_menu_items': [],
+                'global_operator_extra_links': [],
+                'operator_extra_links': [],
+            }
+        ]


### PR DESCRIPTION
This PR refactors the airflow plugins command to be compatible with
'output' parameter which allows users to get output in form of table,
json or yaml.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
