### PR TITLE
Fix error with S3/GCS remote logs not being written

### DIFF
--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -68,6 +68,10 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             with open(self.handler.baseFilename, 'w'):
                 pass
 
+        # Ensure the hook is connected now -- at close time we will have
+        # already disconnected from the DB
+        self.hook
+
     def close(self):
         """Close and upload local log file to remote storage S3."""
         # When application exit, system shuts down all handlers by

--- a/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -109,6 +109,10 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         self.log_relative_path = self._render_filename(ti, ti.try_number)
         self.upload_on_close = not ti.raw
 
+        # Ensure the client is connected now -- at close time we will have
+        # already disconnected from the DB
+        self.client
+
     def close(self):
         """Close and upload local log file to remote storage GCS."""
         # When application exit, system shuts down all handlers by


### PR DESCRIPTION
The problem was we delayed the hook creation until s3_write as called, at which point the ORM has already been disconnected, meaning we can't get credential information.

This ensures that the connection is created and cached in set_context -- called when the logging is being "set up" for a task.

Closes #12969.

@potiuk I haven't (yet) tested this change, but I think it might solve the issue, and thankfully is a change in the provider so doesn't need an apache-airflow 2.0.0rc3. If you are able to test this tonight great, otherwise I will do it first thing tomorrow morning.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).