### PR TITLE
Add S3KeySizeSensor

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -173,7 +173,7 @@ class S3KeySizeSensor(S3KeySensor):
         if self.wildcard_match:
             prefix = re.split(r'[*]', self.bucket_key, 1)[0]
 
-        paginator = self.get_conn().get_paginator('list_objects_v2')
+        paginator = s3_hook.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(
             Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter,
             PaginationConfig=config

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -15,9 +15,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional, Union, List, Callable
-from urllib.parse import urlparse
 import re
+from typing import Callable, List, Optional, Union
+from urllib.parse import urlparse
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -175,8 +175,7 @@ class S3KeySizeSensor(S3KeySensor):
 
         paginator = s3_hook.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(
-            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter,
-            PaginationConfig=config
+            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter, PaginationConfig=config
         )
         keys = []
         for page in response:

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -188,5 +188,5 @@ class S3KeySizeSensor(S3KeySensor):
         return keys
 
     def summarizer_fn(self, data: List) -> bool:
-        """"Default function for checking that S3 Objects have size more than 0"""
+        """Default function for checking that S3 Objects have size more than 0"""
         return sum([f.get('Size', 0) for f in data if isinstance(f, dict)]) > 0

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -182,7 +182,7 @@ class S3KeySizeSensor(S3KeySensor):
 
         paginator = s3_hook.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(
-            Bucket=self.bucket_name, Prefix=prefix, Delimiter='/', PaginationConfig=config
+            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter, PaginationConfig=config
         )
         keys = []
         for page in response:

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -165,9 +165,9 @@ class S3KeySizeSensor(S3KeySensor):
             return False
 
         s3_objects = self.get_files(s3_hook=self.get_hook())
-        check_fn = self.check_fn_user
-        if check_fn is None:
-            check_fn = self.check_fn
+        check_fn = self.check_fn if self.check_fn_user is None else self.check_fn_user
+        if not s3_objects:
+            return False
         return check_fn(s3_objects)
 
     def get_files(self, s3_hook: S3Hook) -> List:

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -152,18 +152,20 @@ class S3KeySizeSensor(S3KeySensor):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        if summarizer_fn:
-            self.summarizer_fn = summarizer_fn
+        self.summarizer_fn_user = summarizer_fn
 
     def poke(self, context):
         if super().poke(context=context) is False:
             return False
 
         s3_objects = self.get_files(s3_hook=self.get_hook())
-
-        return self.summarizer_fn(s3_objects)
+        summarizer_fn = self.summarizer_fn_user
+        if summarizer_fn is None:
+            summarizer_fn = self.summarizer_fn
+        return summarizer_fn(s3_objects)
 
     def get_files(self, s3_hook: S3Hook) -> List:
+        """Gets a list of files in the bucket"""
         prefix = self.bucket_key
         delimiter = '/'
         config = {

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -191,7 +191,7 @@ class S3KeySizeSensor(S3KeySensor):
                 keys = keys + _temp
         return keys
 
-    def check_fn(self, data: List, object_min_size: Optional[Union[int,float]] = 0) -> bool:
+    def check_fn(self, data: List, object_min_size: Optional[Union[int, float]] = 0) -> bool:
         """Default function for checking that S3 Objects have size more than 0
 
         :param data: List of the objects in S3 bucket.

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -165,9 +165,9 @@ class S3KeySizeSensor(S3KeySensor):
             return False
 
         s3_objects = self.get_files(s3_hook=self.get_hook())
-        check_fn = self.check_fn if self.check_fn_user is None else self.check_fn_user
         if not s3_objects:
             return False
+        check_fn = self.check_fn if self.check_fn_user is None else self.check_fn_user
         return check_fn(s3_objects)
 
     def get_files(self, s3_hook: S3Hook) -> List:

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -179,8 +179,6 @@ class S3KeySizeSensor(S3KeySensor):
                 for k in page['Contents']:
                     if isinstance(k.get('Size', None), (int, float):
                         keys.append(k)
-
-
         return keys
 
     def summarizer_fn(self, data: List) -> bool:

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -183,10 +183,10 @@ class S3KeySizeSensor(S3KeySensor):
         keys = []
         for page in response:
             if 'Contents' in page:
-                for k in page['Contents']:
-                    if isinstance(k.get('Size', None), (int, float)):
-                        keys.append(k)
+                _temp = [k for k in page['Contents'] if isinstance(k.get('Size', None), (int, float))]
+                keys = keys + _temp
         return keys
 
     def summarizer_fn(self, data: List) -> bool:
+        """"Default function for checking that S3 Objects have size more than 0"""
         return sum([f.get('Size', 0) for f in data if isinstance(f, dict)]) > 0

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -144,6 +144,7 @@ class S3KeySizeSensor(S3KeySensor):
     :type summarizer_fn: Optional[Callable[..., bool]]
 
     """
+
     @apply_defaults
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -139,15 +139,15 @@ class S3KeySizeSensor(S3KeySensor):
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type verify: bool or str
-    :param check_fn: function that receives the list of the S3 objects,
-        and returns the boolean.
     :type check_fn: Optional[Callable[..., bool]]
-        Function that receives list of the S3 objects and return bool, where:
-            `True` - a certain criteria is met
-            `False` - the criteria isn't met
-        **Example**: Wait for any S3 object size more than 1 mebibyte
-        def check_fn(self, data: List) -> bool:
-            return any(f.get('Size', 0) > 1048576 for f in data if isinstance(f, dict))
+    :param check_fn: Function that receives the list of the S3 objects,
+        and returns the boolean:
+        - ``True``: a certain criteria is met
+        - ``False``: the criteria isn't met
+        **Example**: Wait for any S3 object size more than 1 megabyte  ::
+
+            def check_fn(self, data: List) -> bool:
+                return any(f.get('Size', 0) > 1048576 for f in data if isinstance(f, dict))
     """
 
     @apply_defaults

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -166,18 +166,23 @@ class S3KeySizeSensor(S3KeySensor):
     def get_files(self, s3_hook: S3Hook) -> List:
         prefix = self.bucket_key
         delimiter = '/'
+        config = {
+            'PageSize': None,
+            'MaxItems': None,
+        }
         if self.wildcard_match:
-            prefix = re.split(r'[*]', wildcard_key, 1)[0]
+            prefix = re.split(r'[*]', self.bucket_key, 1)[0]
 
         paginator = self.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(
-            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter, PaginationConfig=config
+            Bucket=self.bucket_name, Prefix=prefix, Delimiter=delimiter,
+            PaginationConfig=config
         )
         keys = []
         for page in response:
             if 'Contents' in page:
                 for k in page['Contents']:
-                    if isinstance(k.get('Size', None), (int, float):
+                    if isinstance(k.get('Size', None), (int, float)):
                         keys.append(k)
         return keys
 

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -144,12 +144,12 @@ class TestS3KeySizeSensor(unittest.TestCase):
             [{"Contents": [{"Size": 0}]}, False],
             [{"Contents": []}, False],
             [{"Contents": [{"Size": 10}]}, True],
-            [{"Contents": [{"Size": 10}, {"Size": 0}]}, True],
+            [{"Contents": [{"Size": 10}, {"Size": 0}]}, False],
             [{"Contents": [{"Size": 10}, {"Size": 10}]}, True],
         ]
     )
     @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
-    def test_poke(self, mock_hook, paginate_return_value, poke_return_value):
+    def test_poke(self, paginate_return_value, poke_return_value, mock_hook):
         op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file')
 
         mock_check_for_key = mock_hook.return_value.check_for_key
@@ -159,6 +159,6 @@ class TestS3KeySizeSensor(unittest.TestCase):
         mock_conn = mock.Mock()
         mock_conn.return_value.get_paginator.return_value = mock_paginator
         mock_hook.return_value.get_conn = mock_conn
-        mock_paginator.paginate.return_value = paginate_return_value
+        mock_paginator.paginate.return_value = [paginate_return_value]
         self.assertIs(op.poke(None), poke_return_value)
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -141,10 +141,10 @@ class TestS3KeySizeSensor(unittest.TestCase):
         mock_conn = mock.Mock()
         mock_conn.return_value.get_paginator.return_value = mock_paginator
         mock_hook.return_value.get_conn = mock_conn
-        mock_paginator.paginate.return_value = [{"Contents":[{"Size":0}]}]
+        mock_paginator.paginate.return_value = [{"Contents": [{"Size": 0}]}]
         self.assertFalse(op.poke(None))
 
-        mock_paginator.paginate.return_value = [{"Contents":[{"Size":10}]}]
+        mock_paginator.paginate.return_value = [{"Contents": [{"Size": 10}]}]
         self.assertTrue(op.poke(None))
         mock_check_for_key.return_value = False
         self.assertFalse(op.poke(None))

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -26,8 +26,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import TaskInstance
 from airflow.models.dag import DAG
 from airflow.models.variable import Variable
-from airflow.providers.amazon.aws.sensors.s3_key import S3KeySensor
-from airflow.providers.amazon.aws.sensors.s3_key import S3KeySizeSensor
+from airflow.providers.amazon.aws.sensors.s3_key import S3KeySensor, S3KeySizeSensor
 
 
 class TestS3KeySensor(unittest.TestCase):
@@ -142,18 +141,10 @@ class TestS3KeySizeSensor(unittest.TestCase):
         mock_conn = mock.Mock()
         mock_conn.return_value.get_paginator.return_value = mock_paginator
         mock_hook.return_value.get_conn = mock_conn
-        mock_paginator.paginate.return_value = [{'Contents': [
-            {
-                'Size': 0
-            }
-        ]}]
+        mock_paginator.paginate.return_value = [{"Contents":[{"Size":0}]}]
         self.assertFalse(op.poke(None))
 
-        mock_paginator.paginate.return_value = [{'Contents': [
-            {
-                'Size': 10
-            }
-        ]}]
+        mock_paginator.paginate.return_value = [{"Contents":[{"Size":10}]}]
         self.assertTrue(op.poke(None))
         mock_check_for_key.return_value = False
         self.assertFalse(op.poke(None))

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -127,7 +127,6 @@ class TestS3KeySizeSensor(unittest.TestCase):
     @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook.check_for_key', return_value=False)
     def test_poke_check_for_key_false(self, mock_check_for_key):
         op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file')
-
         self.assertFalse(op.poke(None))
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)
 

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -130,13 +130,13 @@ class TestS3KeySizeSensor(unittest.TestCase):
         self.assertFalse(op.poke(None))
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)
 
-    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook.get_files', return_value=True)
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3KeySizeSensor.get_files', return_value=[])
     @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook.check_for_key', return_value=True)
     def test_poke_get_files_false(self, mock_check_for_key, mock_get_files):
         op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file')
         self.assertFalse(op.poke(None))
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)
-        mock_get_files.assert_called_once_with(op.get_hook())
+        mock_get_files.assert_called_once_with(s3_hook=op.get_hook())
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Adding S3KeySizeSensor that allows checking the S3 object sizes or perform any other actions needed by users.

**Motivation:**

Since Dec 1, 2020 [Amazon S3 delivers strong read-after-write consistency automatically for all applications](https://aws.amazon.com/about-aws/whats-new/2020/12/amazon-s3-now-delivers-strong-read-after-write-consistency-automatically-for-all-applications/). It's mean that we need rely not only on the fact that S3 object exists but also on its size.

**Why not change `S3KeySensor`?**
I believe that it's an independent use-case. When we have a custom function that decides if the list of S3 objects is satisfying some criteria (by default size > 0)


**Example of usage:**

```python
def check_zip_only_fn(data: List) -> bool:
        return sum([
            f.get('Size', 0) for f in data
            if isinstance(f, dict)
            and str(f.get('Key')).endswith('zip')
            ]) > 100000

s3 = S3KeySizeSensor(
        task_id='s3',
        mode='reschedule',
        bucket_name='some-s3-bucket',
        summarizer_fn=check_zip_only_fn,
        bucket_key='some/path'
)
```