### PR TITLE
airflow should use same JSONEncoder as flask

### DIFF
--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -16,10 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 from datetime import date, datetime
 
 import numpy as np
+from flask.json import JSONEncoder
 
 try:
     from kubernetes.client import models as k8s
@@ -29,7 +29,7 @@ except ImportError:
 # Dates and JSON encoding/decoding
 
 
-class AirflowJsonEncoder(json.JSONEncoder):
+class AirflowJsonEncoder(JSONEncoder):
     """Custom Airflow json encoder implementation."""
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/13046

When library `simplejson` is used, flask uses it.  But our AirflowJSONEncoder class _always_ subclasses `json.JSONEncoder`.  

Because of the incompatibility between the two, when simplejson is installed, the airflow webserver is inaccessible.

We can resolve this by using whatever encoder class flask is using.
