### PR TITLE
Update stable version for published docs

### DIFF
--- a/docs/exts/docs_build/docs_builder.py
+++ b/docs/exts/docs_build/docs_builder.py
@@ -204,6 +204,9 @@ class AirflowDocsBuilder:
         pretty_target = pretty_format_path(output_dir, AIRFLOW_SITE_DIR)
         print(f"Copy directory: {pretty_source} => {pretty_target}")
         shutil.copytree(self._build_dir, output_dir)
+        if self.is_versioned:
+            with open(os.path.join(output_dir, "..", "stable.txt"), "w") as stable_file:
+                stable_file.write(self._current_version)
         print()
 
 


### PR DESCRIPTION
The stable.txt file is used by [`site.sh`](https://github.com/apache/airflow-site/blob/master/site.sh) and [`dump-docs-packages-metadata.py`](https://github.com/apache/airflow-site/blob/master/dump-docs-packages-metadata.py) to make it possible to select a stable documentation version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
