### PR TITLE
Set timeout for child processes

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -200,7 +200,7 @@ def _display_dot_via_imgcat(dot: Dot):
             )
         else:
             raise
-    out, err = proc.communicate(data)
+    out, err = proc.communicate(data, timeout=60)
     if out:
         print(out.decode('utf-8'))
     if err:

--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -354,7 +354,7 @@ class ToolsInfo(_BaseInfo):
             proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except OSError:
             return "NOT AVAILABLE"
-        stdoutdata, _ = proc.communicate()
+        stdoutdata, _ = proc.communicate(timeout=15)
         data = [f for f in stdoutdata.split(b"\n") if f]
         if grep:
             data = [line for line in data if grep in line]

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -65,7 +65,11 @@ def expand_env_var(env_var):
 
 
 def run_command(command):
-    """Runs command and returns stdout"""
+    """
+    Runs command and returns stdout.
+
+    Any process that takes longer than 60 seconds is automatically terminated.
+    """
     process = subprocess.Popen(
         shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
     )

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -69,7 +69,9 @@ def run_command(command):
     process = subprocess.Popen(
         shlex.split(command), stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
     )
-    output, stderr = [stream.decode(sys.getdefaultencoding(), 'ignore') for stream in process.communicate()]
+    output, stderr = [
+        stream.decode(sys.getdefaultencoding(), 'ignore') for stream in process.communicate(timeout=60)
+    ]
 
     if process.returncode != 0:
         raise AirflowConfigException(

--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -81,7 +81,7 @@ def renew_from_kt(principal: str, keytab: str, exit_on_fail: bool = True):
         bufsize=-1,
         universal_newlines=True,
     )
-    subp.wait()
+    subp.wait(timeout=60)
     if subp.returncode != 0:
         log.error(
             "Couldn't reinit from keytab! `kinit' exited with %s.\n%s\n%s",
@@ -125,7 +125,7 @@ def perform_krb181_workaround(principal: str):
 
     log.info("Renewing kerberos ticket to work around kerberos 1.8.1: %s", " ".join(cmdv))
 
-    ret = subprocess.call(cmdv, close_fds=True)
+    ret = subprocess.call(cmdv, close_fds=True, timeout=60)
 
     if ret != 0:
         principal = "{}/{}".format(principal or conf.get('kerberos', 'principal'), socket.getfqdn())

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -65,7 +65,7 @@ class BaseTaskRunner(LoggingMixin):
             cfg_path = tmp_configuration_copy(chmod=0o600)
 
             # Give ownership of file to user; only they can read and write
-            subprocess.call(['sudo', 'chown', self.run_as_user, cfg_path], close_fds=True)
+            subprocess.call(['sudo', 'chown', self.run_as_user, cfg_path], close_fds=True, timeout=60)
 
             # propagate PYTHONPATH environment variable
             pythonpath_value = os.environ.get(PYTHONPATH_VAR, '')
@@ -160,6 +160,6 @@ class BaseTaskRunner(LoggingMixin):
         """A callback that should be called when this is done running."""
         if self._cfg_path and os.path.isfile(self._cfg_path):
             if self.run_as_user:
-                subprocess.call(['sudo', 'rm', self._cfg_path], close_fds=True)
+                subprocess.call(['sudo', 'rm', self._cfg_path], close_fds=True, timeout=60)
             else:
                 os.remove(self._cfg_path)

--- a/airflow/utils/process_utils.py
+++ b/airflow/utils/process_utils.py
@@ -69,7 +69,7 @@ def reap_process_group(pgid, logger, sig=signal.SIGTERM, timeout=DEFAULT_TIME_TO
             # use sudo -n(--non-interactive) to kill the process
             if err.errno == errno.EPERM:
                 subprocess.check_call(
-                    ["sudo", "-n", "kill", "-" + str(int(sig))] + [str(p.pid) for p in children]
+                    ["sudo", "-n", "kill", "-" + str(int(sig))] + [str(p.pid) for p in children], timeout=60
                 )
             else:
                 raise

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -78,6 +78,8 @@ the same way the usual config options can. For example:
 
     export AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD=bash_command_to_run
 
+Process cannot execute for more than 60 seconds. Otherwise it will be terminated.
+
 Similarly, ``_secret`` config options can also be set using a corresponding environment variable.
 For example:
 

--- a/tests/core/test_impersonation_tests.py
+++ b/tests/core/test_impersonation_tests.py
@@ -96,7 +96,7 @@ file (always present inside container) and checking for PYTHON_BASE_IMAGE variab
 
 def create_user():
     try:
-        subprocess.check_output(['sudo', 'useradd', '-m', TEST_USER, '-g', str(os.getegid())])
+        subprocess.check_output(['sudo', 'useradd', '-m', TEST_USER, '-g', str(os.getegid())], timeout=60)
     except OSError as e:
         if e.errno == errno.ENOENT:
             raise unittest.SkipTest(
@@ -128,7 +128,7 @@ class TestImpersonation(unittest.TestCase):
         create_user()
 
     def tearDown(self):
-        subprocess.check_output(['sudo', 'userdel', '-r', TEST_USER])
+        subprocess.check_output(['sudo', 'userdel', '-r', TEST_USER], timeout=60)
         revoke_permissions()
 
     def run_backfill(self, dag_id, task_id):
@@ -191,7 +191,7 @@ class TestImpersonationWithCustomPythonPath(unittest.TestCase):
         create_user()
 
     def tearDown(self):
-        subprocess.check_output(['sudo', 'userdel', '-r', TEST_USER])
+        subprocess.check_output(['sudo', 'userdel', '-r', TEST_USER], timeout=60)
         revoke_permissions()
 
     def run_backfill(self, dag_id, task_id):

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes_system.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes_system.py
@@ -47,13 +47,13 @@ SPARK_OPERATOR_MANIFESTS = [
 def kubectl_apply_list(manifests):
     for manifest in manifests:
         command = ['kubectl', 'apply', '-f', manifest]
-        subprocess.run(command, check=True)
+        subprocess.run(command, check=True, timeout=60)
 
 
 def kubectl_delete_list(manifests):
     for manifest in manifests:
         command = ['kubectl', 'delete', '--ignore-not-found', '-f', manifest]
-        subprocess.run(command, check=True)
+        subprocess.run(command, check=True, timeout=60)
 
 
 @pytest.mark.system("cncf.kubernetes")

--- a/tests/providers/google/cloud/secrets/test_secret_manager_system.py
+++ b/tests/providers/google/cloud/secrets/test_secret_manager_system.py
@@ -40,13 +40,13 @@ class CloudSecretManagerBackendVariableSystemTest(GoogleSystemTest):
     def test_should_read_secret_from_variable(self):
         cmd = f'echo -n "TEST_CONTENT" | gcloud beta secrets create \
             {self.secret_name} --data-file=-  --replication-policy=automatic'
-        subprocess.run(["bash", "-c", cmd], check=True)
-        result = subprocess.check_output(['airflow', 'variables', 'get', self.name])
+        subprocess.run(["bash", "-c", cmd], check=True, timeout=60)
+        result = subprocess.check_output(['airflow', 'variables', 'get', self.name], timeout=60)
         self.assertIn("TEST_CONTENT", result.decode())
 
     @provide_gcp_context(GCP_SECRET_MANAGER_KEY, project_id=GoogleSystemTest._project_id())
     def tearDown(self) -> None:
-        subprocess.run(["gcloud", "secrets", "delete", self.secret_name, "--quiet"], check=False)
+        subprocess.run(["gcloud", "secrets", "delete", self.secret_name, "--quiet"], check=False, timeout=60)
 
 
 @pytest.mark.credential_file(GCP_SECRET_MANAGER_KEY)
@@ -61,10 +61,10 @@ class CloudSecretManagerBackendConnectionSystemTest(GoogleSystemTest):
     def test_should_read_secret_from_variable(self):
         cmd = f'echo -n "mysql://user:pass@example.org" | gcloud beta secrets create \
             {self.secret_name} --data-file=- --replication-policy=automatic'
-        subprocess.run(["bash", "-c", cmd], check=True)
-        result = subprocess.check_output(['airflow', 'connections', 'get', self.name])
+        subprocess.run(["bash", "-c", cmd], check=True, timeout=60)
+        result = subprocess.check_output(['airflow', 'connections', 'get', self.name], timeout=60)
         self.assertIn("URI: mysql://user:pass@example.org", result.decode())
 
     @provide_gcp_context(GCP_SECRET_MANAGER_KEY, project_id=GoogleSystemTest._project_id())
     def tearDown(self) -> None:
-        subprocess.run(["gcloud", "secrets", "delete", self.secret_name, "--quiet"], check=False)
+        subprocess.run(["gcloud", "secrets", "delete", self.secret_name, "--quiet"], check=False, timeout=60)

--- a/tests/providers/google/cloud/utils/gcp_authenticator.py
+++ b/tests/providers/google/cloud/utils/gcp_authenticator.py
@@ -205,7 +205,8 @@ class GcpAuthenticator(LoggingCommandExecutor):
         self._validate_key_set()
         if not GcpAuthenticator.original_account:
             GcpAuthenticator.original_account = self.check_output(
-                ['gcloud', 'config', 'get-value', 'account', f'--project={self.project_id}']
+                ['gcloud', 'config', 'get-value', 'account', f'--project={self.project_id}'],
+                timeout=60,
             ).decode('utf-8')
             self.log.info("Storing account: to restore it later %s", GcpAuthenticator.original_account)
 

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -298,7 +298,7 @@ class TestSSHHook(unittest.TestCase):
             response = socket.recv(5)
             self.assertEqual(response, b"hello")
             socket.close()
-            server_handle.communicate()
+            server_handle.communicate(timeout=60)
             self.assertEqual(server_handle.returncode, 0)
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')

--- a/tests/test_utils/logging_command_executor.py
+++ b/tests/test_utils/logging_command_executor.py
@@ -39,7 +39,7 @@ class LoggingCommandExecutor(LoggingMixin):
                 cwd=cwd,
                 env=env,
             )
-            output, err = process.communicate(timeout=60)
+            output, err = process.communicate(timeout=timeout)
             retcode = process.poll()
             self.log.info("Stdout: %s", output)
             self.log.info("Stderr: %s", err)

--- a/tests/test_utils/logging_command_executor.py
+++ b/tests/test_utils/logging_command_executor.py
@@ -24,7 +24,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 
 class LoggingCommandExecutor(LoggingMixin):
-    def execute_cmd(self, cmd, silent=False, cwd=None, env=None):
+    def execute_cmd(self, cmd, silent=False, cwd=None, env=None, timeout=60):
         if silent:
             self.log.info("Executing in silent mode: '%s'", " ".join([shlex.quote(c) for c in cmd]))
             with open(os.devnull, 'w') as dev_null:
@@ -39,7 +39,7 @@ class LoggingCommandExecutor(LoggingMixin):
                 cwd=cwd,
                 env=env,
             )
-            output, err = process.communicate()
+            output, err = process.communicate(timeout=60)
             retcode = process.poll()
             self.log.info("Stdout: %s", output)
             self.log.info("Stderr: %s", err)
@@ -47,10 +47,10 @@ class LoggingCommandExecutor(LoggingMixin):
                 self.log.error("Error when executing %s", " ".join([shlex.quote(c) for c in cmd]))
             return retcode
 
-    def check_output(self, cmd):
+    def check_output(self, cmd, timeout=60):
         self.log.info("Executing for output: '%s'", " ".join([shlex.quote(c) for c in cmd]))
         process = subprocess.Popen(args=cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output, err = process.communicate()
+        output, err = process.communicate(timeout=timeout)
         retcode = process.poll()
         if retcode:
             self.log.error("Error when executing '%s'", " ".join([shlex.quote(c) for c in cmd]))

--- a/tests/utils/test_process_utils.py
+++ b/tests/utils/test_process_utils.py
@@ -122,36 +122,40 @@ def my_sleep_subprocess_with_signals():
 
 class TestKillChildProcessesByPids(unittest.TestCase):
     def test_should_kill_process(self):
-        before_num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        before_num_process = (
+            subprocess.check_output(["ps", "-ax", "-o", "pid="], timeout=60).decode().count("\n")
+        )
 
         process = multiprocessing.Process(target=my_sleep_subprocess, args=())
         process.start()
         sleep(0)
 
-        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="], timeout=60).decode().count("\n")
         self.assertEqual(before_num_process + 1, num_process)
 
         process_utils.kill_child_processes_by_pids([process.pid])
 
-        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="], timeout=60).decode().count("\n")
         self.assertEqual(before_num_process, num_process)
 
     @pytest.mark.quarantined
     def test_should_force_kill_process(self):
-        before_num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        before_num_process = (
+            subprocess.check_output(["ps", "-ax", "-o", "pid="], timeout=60).decode().count("\n")
+        )
 
         process = multiprocessing.Process(target=my_sleep_subprocess_with_signals, args=())
         process.start()
         sleep(0)
 
-        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="], timeout=60).decode().count("\n")
         self.assertEqual(before_num_process + 1, num_process)
 
         with self.assertLogs(process_utils.log) as cm:
             process_utils.kill_child_processes_by_pids([process.pid], timeout=0)
         self.assertTrue(any("Killing child PID" in line for line in cm.output))
 
-        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="]).decode().count("\n")
+        num_process = subprocess.check_output(["ps", "-ax", "-o", "pid="], timeout=60).decode().count("\n")
         self.assertEqual(before_num_process, num_process)
 
 


### PR DESCRIPTION
Any child process can hang. When it is happen,  then very difficult to determine what happened.  Adding a timeout when starting processes will make it easier to diagnose problems, because our application will raise an exception. .
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
