### PR TITLE
fix example dag import operator from core to mysql provider

### DIFF
--- a/airflow/providers/mysql/example_dags/example_mysql.py
+++ b/airflow/providers/mysql/example_dags/example_mysql.py
@@ -20,7 +20,7 @@ Example use of MySql related operators.
 """
 
 from airflow import DAG
-from airflow.operators.mysql_operator import MySqlOperator
+from airflow.providers.mysql.operators.mysql import MySqlOperator
 from airflow.utils.dates import days_ago
 
 default_args = {


### PR DESCRIPTION
fixing example dag in mysql provider to import the operator from the provider path rather than from core.
