### PR TITLE
Detect missing links to example DAGs

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -244,10 +244,7 @@ def main():
             all_spelling_errors.update(package_spelling_errors)
 
     if not disable_checks:
-        general_errors = []
-        general_errors.extend(lint_checks.check_guide_links_in_operator_descriptions())
-        general_errors.extend(lint_checks.check_enforce_code_block())
-        general_errors.extend(lint_checks.check_exampleinclude_for_example_dags())
+        general_errors = lint_checks.run_all_check()
         if general_errors:
             all_build_errors[None] = general_errors
 

--- a/docs/exts/docs_build/lint_checks.py
+++ b/docs/exts/docs_build/lint_checks.py
@@ -142,17 +142,39 @@ def check_guide_links_in_operator_descriptions() -> List[DocBuildError]:
 def assert_file_not_contains(file_path: str, pattern: str, message: str) -> Optional[DocBuildError]:
     """
     Asserts that file does not contain the pattern. Return message error if it does.
+
     :param file_path: file
     :param pattern: pattern
     :param message: message to return
     """
+    return _extract_file_content(file_path, message, pattern, False)
+
+
+def assert_file_contains(file_path: str, pattern: str, message: str) -> Optional[DocBuildError]:
+    """
+    Asserts that file does contain the pattern. Return message error if it does not.
+
+    :param file_path: file
+    :param pattern: pattern
+    :param message: message to return
+    """
+    return _extract_file_content(file_path, message, pattern, True)
+
+
+def _extract_file_content(file_path: str, message, pattern: str, expected_contain: bool):
     with open(file_path, "rb", 0) as doc_file:
         pattern_compiled = re.compile(pattern)
-
+        found = False
         for num, line in enumerate(doc_file, 1):
             line_decode = line.decode()
-            if re.search(pattern_compiled, line_decode):
+            result = re.search(pattern_compiled, line_decode)
+            if not expected_contain and result:
                 return DocBuildError(file_path=file_path, line_no=num, message=message)
+            elif expected_contain and result:
+                found = True
+
+        if expected_contain and not found:
+            return DocBuildError(file_path=file_path, line_no=None, message=message)
     return None
 
 
@@ -225,3 +247,44 @@ def check_enforce_code_block() -> List[DocBuildError]:
         if build_error:
             build_errors.append(build_error)
     return build_errors
+
+
+def check_example_dags_in_provider_tocs() -> List[DocBuildError]:
+    """Checks that each documentation for provider packages has a link to sample DAG files in the TOC."""
+    build_errors = []
+
+    for provider in ALL_PROVIDER_YAMLS:
+        example_dags_dirs = list(glob(f"{provider['package-dir']}/**/example_dags", recursive=True))
+        if not example_dags_dirs:
+            continue
+        doc_file_path = f"{DOCS_DIR}/{provider['package-name']}/index.rst"
+
+        if len(example_dags_dirs) == 1:
+            package_rel_path = os.path.relpath(example_dags_dirs[0], start=ROOT_PROJECT_DIR)
+            github_url = f"https://github.com/apache/airflow/tree/master/{package_rel_path}"
+            expected_text = f"Example DAGs <{github_url}>"
+        else:
+            expected_text = "Example DAGs <example-dags>"
+
+        build_error = assert_file_contains(
+            file_path=doc_file_path,
+            pattern=re.escape(expected_text),
+            message=(
+                f"A link to the example DAGs in table of contents is missing. Can you add it?\n\n"
+                f"    {expected_text}"
+            ),
+        )
+        if build_error:
+            build_errors.append(build_error)
+
+    return build_errors
+
+
+def run_all_check() -> List[DocBuildError]:
+    """Run all checks from this module"""
+    general_errors = []
+    general_errors.extend(check_guide_links_in_operator_descriptions())
+    general_errors.extend(check_enforce_code_block())
+    general_errors.extend(check_exampleinclude_for_example_dags())
+    general_errors.extend(check_example_dags_in_provider_tocs())
+    return general_errors

--- a/docs/exts/docs_build/lint_checks.py
+++ b/docs/exts/docs_build/lint_checks.py
@@ -22,6 +22,7 @@ from glob import glob
 from itertools import chain
 from typing import Iterable, List, Optional, Set
 
+from docs.exts.docs_build.docs_builder import ALL_PROVIDER_YAMLS
 from docs.exts.docs_build.errors import DocBuildError  # pylint: disable=no-name-in-module
 
 ROOT_PROJECT_DIR = os.path.abspath(
@@ -250,7 +251,7 @@ def check_enforce_code_block() -> List[DocBuildError]:
 
 
 def check_example_dags_in_provider_tocs() -> List[DocBuildError]:
-    """Checks that each documentation for provider packages has a link to sample DAG files in the TOC."""
+    """Checks that each documentation for provider packages has a link to example DAGs in the TOC."""
     build_errors = []
 
     for provider in ALL_PROVIDER_YAMLS:


### PR DESCRIPTION
To make adding new providers easier, I add one check that forces the example DAGs to be available in the documentation.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
