### PR TITLE
Skip discovering snowflake provider in development mode

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -192,8 +192,16 @@ class ProvidersManager:
         for folder, subdirs, files in os.walk(path, topdown=True):
             for filename in fnmatch.filter(files, "provider.yaml"):
                 package_name = "apache-airflow-providers" + folder[len(root_path) :].replace(os.sep, "-")
-                self._add_provider_info_from_local_source_file(os.path.join(folder, filename), package_name)
-                subdirs[:] = []
+                # We are skipping discovering snowflake because of snowflake monkeypatching problem
+                # This is only for local development - it has no impact for the packaged snowflake provider
+                # That should work on its own
+                # https://github.com/apache/airflow/issues/12881
+                # Once this is back, we can remove this limitation.
+                if package_name != "apache-airflow-providers-snowflake":
+                    self._add_provider_info_from_local_source_file(
+                        os.path.join(folder, filename), package_name
+                    )
+                    subdirs[:] = []
 
     def _add_provider_info_from_local_source_file(self, path, package_name) -> None:
         """

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -74,7 +74,8 @@ ALL_PROVIDERS = [
     'apache-airflow-providers-sftp',
     'apache-airflow-providers-singularity',
     'apache-airflow-providers-slack',
-    'apache-airflow-providers-snowflake',
+    # Uncomment when https://github.com/apache/airflow/issues/12881 is fixed
+    # 'apache-airflow-providers-snowflake',
     'apache-airflow-providers-sqlite',
     'apache-airflow-providers-ssh',
     'apache-airflow-providers-telegram',
@@ -131,7 +132,8 @@ CONNECTIONS_LIST = [
     'samba',
     'segment',
     'sftp',
-    'snowflake',
+    #  Uncomment when https://github.com/apache/airflow/issues/12881 is fixed
+    # 'snowflake',
     'spark',
     'spark_jdbc',
     'spark_sql',


### PR DESCRIPTION
The snowflake provider when imported breaks other providers
Until https://github.com/apache/airflow/issues/12881 is fixed
we should skip discovering snowflake provider in development mode

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
