### PR TITLE
Remove inapplicable arg 'output' for CLI pools import/export

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1025,7 +1025,6 @@ POOLS_COMMANDS = (
         func=lazy_load_command('airflow.cli.commands.pool_command.pool_import'),
         args=(
             ARG_POOL_IMPORT,
-            ARG_OUTPUT,
         ),
     ),
     ActionCommand(
@@ -1034,7 +1033,6 @@ POOLS_COMMANDS = (
         func=lazy_load_command('airflow.cli.commands.pool_command.pool_export'),
         args=(
             ARG_POOL_EXPORT,
-            ARG_OUTPUT,
         ),
     ),
 )

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1023,17 +1023,13 @@ POOLS_COMMANDS = (
         name='import',
         help='Import pools',
         func=lazy_load_command('airflow.cli.commands.pool_command.pool_import'),
-        args=(
-            ARG_POOL_IMPORT,
-        ),
+        args=(ARG_POOL_IMPORT,),
     ),
     ActionCommand(
         name='export',
         help='Export all pools',
         func=lazy_load_command('airflow.cli.commands.pool_command.pool_export'),
-        args=(
-            ARG_POOL_EXPORT,
-        ),
+        args=(ARG_POOL_EXPORT,),
     ),
 )
 VARIABLES_COMMANDS = (


### PR DESCRIPTION
`-o`/`--output` is not applicable for CLI `airflow pools export` or `airflow pools import`.
It should be removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
