### PR TITLE
KubernetesExecutor should accept images from executor_config

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -535,9 +535,15 @@ class PodGenerator(object):
             - executor_config
             - dynamic arguments
         """
+        try:
+            image = pod_override_object.spec.containers[0].image  # type: ignore
+            if not image:
+                image = kube_image
+        except Exception:  # pylint: disable=W0703
+            image = kube_image
         dynamic_pod = PodGenerator(
             namespace=namespace,
-            image=kube_image,
+            image=image,
             labels={
                 'airflow-worker': worker_uuid,
                 'dag_id': make_safe_label_value(dag_id),


### PR DESCRIPTION
Addresses:
https://github.com/apache/airflow/issues/13003#issuecomment-743733799a

Users should be able to specify custom images in the executor_config. Not being
able to is a regression.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
