### PR TITLE
Update app.py

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -18,6 +18,7 @@
 #
 from datetime import timedelta
 from typing import Optional
+from hashlib import sha256
 
 from flask import Flask
 from flask_appbuilder import SQLA
@@ -102,7 +103,13 @@ def create_app(config=None, testing=False, app_name="Airflow"):
 
     init_api_experimental_auth(flask_app)
 
-    Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
+    Cache(app=flask_app, config={ 
+        'CACHE_TYPE': 'filesystem',
+        'CACHE_DIR': '/tmp',
+        'CACHE_OPTIONS': {
+            'hash_method': sha256
+        }
+    })
 
     init_flash_views(flask_app)
 


### PR DESCRIPTION
This change is required when airflow is running on openshift platform nodes enabled with system level FIPS. Without this airflow webserver won't start at all. The flask_caching module default hash method is md5 which is not allowed in FIPS mode, however it allows you to override the hash method.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
