### PR TITLE
Move tests for airflow.utils.dates out of tests/core/

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -23,9 +23,6 @@ import unittest
 from datetime import timedelta
 from time import sleep
 
-from dateutil.relativedelta import relativedelta
-from numpy.testing import assert_array_almost_equal
-
 from airflow import settings
 from airflow.exceptions import AirflowException, AirflowTaskTimeout
 from airflow.hooks.base import BaseHook
@@ -38,7 +35,6 @@ from airflow.operators.check_operator import CheckOperator, ValueCheckOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
 from airflow.settings import Session
-from airflow.utils.dates import infer_time_unit, round_time, scale_time_units
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
@@ -321,52 +317,6 @@ class TestCore(unittest.TestCase):
             run_type=DagRunType.MANUAL, state=State.RUNNING, execution_date=DEFAULT_DATE
         )
         ti.run(ignore_ti_state=True)
-
-    def test_round_time(self):
-
-        rt1 = round_time(datetime(2015, 1, 1, 6), timedelta(days=1))
-        self.assertEqual(datetime(2015, 1, 1, 0, 0), rt1)
-
-        rt2 = round_time(datetime(2015, 1, 2), relativedelta(months=1))
-        self.assertEqual(datetime(2015, 1, 1, 0, 0), rt2)
-
-        rt3 = round_time(datetime(2015, 9, 16, 0, 0), timedelta(1), datetime(2015, 9, 14, 0, 0))
-        self.assertEqual(datetime(2015, 9, 16, 0, 0), rt3)
-
-        rt4 = round_time(datetime(2015, 9, 15, 0, 0), timedelta(1), datetime(2015, 9, 14, 0, 0))
-        self.assertEqual(datetime(2015, 9, 15, 0, 0), rt4)
-
-        rt5 = round_time(datetime(2015, 9, 14, 0, 0), timedelta(1), datetime(2015, 9, 14, 0, 0))
-        self.assertEqual(datetime(2015, 9, 14, 0, 0), rt5)
-
-        rt6 = round_time(datetime(2015, 9, 13, 0, 0), timedelta(1), datetime(2015, 9, 14, 0, 0))
-        self.assertEqual(datetime(2015, 9, 14, 0, 0), rt6)
-
-    def test_infer_time_unit(self):
-
-        self.assertEqual('minutes', infer_time_unit([130, 5400, 10]))
-
-        self.assertEqual('seconds', infer_time_unit([110, 50, 10, 100]))
-
-        self.assertEqual('hours', infer_time_unit([100000, 50000, 10000, 20000]))
-
-        self.assertEqual('days', infer_time_unit([200000, 100000]))
-
-    def test_scale_time_units(self):
-
-        # use assert_almost_equal from numpy.testing since we are comparing
-        # floating point arrays
-        arr1 = scale_time_units([130, 5400, 10], 'minutes')
-        assert_array_almost_equal(arr1, [2.167, 90.0, 0.167], decimal=3)
-
-        arr2 = scale_time_units([110, 50, 10, 100], 'seconds')
-        assert_array_almost_equal(arr2, [110.0, 50.0, 10.0, 100.0], decimal=3)
-
-        arr3 = scale_time_units([100000, 50000, 10000, 20000], 'hours')
-        assert_array_almost_equal(arr3, [27.778, 13.889, 2.778, 5.556], decimal=3)
-
-        arr4 = scale_time_units([200000, 100000], 'days')
-        assert_array_almost_equal(arr4, [2.315, 1.157], decimal=3)
 
     def test_bad_trigger_rule(self):
         with self.assertRaises(AirflowException):

--- a/tests/utils/test_dates.py
+++ b/tests/utils/test_dates.py
@@ -20,6 +20,8 @@ import unittest
 from datetime import datetime, timedelta
 
 import pendulum
+from dateutil.relativedelta import relativedelta
+from pytest import approx
 
 from airflow.utils import dates, timezone
 
@@ -50,6 +52,57 @@ class TestDates(unittest.TestCase):
             dates.parse_execution_date(execution_date_str_w_ms),
         )
         self.assertRaises(ValueError, dates.parse_execution_date, bad_execution_date_str)
+
+    def test_round_time(self):
+
+        rt1 = dates.round_time(timezone.datetime(2015, 1, 1, 6), timedelta(days=1))
+        assert timezone.datetime(2015, 1, 1, 0, 0) == rt1
+
+        rt2 = dates.round_time(timezone.datetime(2015, 1, 2), relativedelta(months=1))
+        assert timezone.datetime(2015, 1, 1, 0, 0) == rt2
+
+        rt3 = dates.round_time(
+            timezone.datetime(2015, 9, 16, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
+        )
+        assert timezone.datetime(2015, 9, 16, 0, 0) == rt3
+
+        rt4 = dates.round_time(
+            timezone.datetime(2015, 9, 15, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
+        )
+        assert timezone.datetime(2015, 9, 15, 0, 0) == rt4
+
+        rt5 = dates.round_time(
+            timezone.datetime(2015, 9, 14, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
+        )
+        assert timezone.datetime(2015, 9, 14, 0, 0) == rt5
+
+        rt6 = dates.round_time(
+            timezone.datetime(2015, 9, 13, 0, 0), timedelta(1), timezone.datetime(2015, 9, 14, 0, 0)
+        )
+        assert timezone.datetime(2015, 9, 14, 0, 0) == rt6
+
+    def test_infer_time_unit(self):
+        assert dates.infer_time_unit([130, 5400, 10]) == 'minutes'
+
+        assert dates.infer_time_unit([110, 50, 10, 100]) == 'seconds'
+
+        assert dates.infer_time_unit([100000, 50000, 10000, 20000]) == 'hours'
+
+        assert dates.infer_time_unit([200000, 100000]) == 'days'
+
+    def test_scale_time_units(self):
+        # floating point arrays
+        arr1 = dates.scale_time_units([130, 5400, 10], 'minutes')
+        assert arr1 == approx([2.1667, 90.0, 0.1667], rel=1e-3)
+
+        arr2 = dates.scale_time_units([110, 50, 10, 100], 'seconds')
+        assert arr2 == approx([110.0, 50.0, 10.0, 100.0])
+
+        arr3 = dates.scale_time_units([100000, 50000, 10000, 20000], 'hours')
+        assert arr3 == approx([27.7778, 13.8889, 2.7778, 5.5556], rel=1e-3)
+
+        arr4 = dates.scale_time_units([200000, 100000], 'days')
+        assert arr4 == approx([2.3147, 1.1574], rel=1e-3)
 
 
 class TestUtilsDatesDateRange(unittest.TestCase):


### PR DESCRIPTION
These three functions were in test_core, but the separate test_dates
file is better suited.

In addition I have removed the use of `assert_array_almost_equal` from
numpy as pytest providers it's own version

A (tiny) part of https://github.com/apache/airflow/issues/12500
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).