### PR TITLE
Add identity pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,6 +148,7 @@ repos:
           - "2"
   - repo: meta
     hooks:
+      - id: identity
       - id: check-hooks-apply
   - repo: https://github.com/psf/black
     rev: 20.8b1

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -751,6 +751,14 @@ The above will run mypy check for all files.
       </a>
     </div>
 
+If you want ever need to get a list of the files that will be checked (for troubleshooting when playing with the
+``--from-ref`` and ``--to-ref``
+
+.. code-block:: bash
+
+     breeze static-check identity --verbose # currently staged files
+     breeze static-check identity --verbose -- --from-ref $(git merge-base master HEAD) --to-ref HEAD #  branch updates
+
 Building the Documentation
 --------------------------
 
@@ -2144,15 +2152,15 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  check-executables-have-shebangs check-hooks-apply check-integrations
                  check-merge-conflict check-xml consistent-pylint daysago-import-check
                  debug-statements detect-private-key doctoc dont-use-safe-filter end-of-file-fixer
-                 fix-encoding-pragma flake8 forbid-tabs helm-lint incorrect-use-of-LoggingMixin
-                 insert-license isort json-schema language-matters lint-dockerfile lint-openapi
-                 markdownlint mermaid mixed-line-ending mypy mypy-helm no-providers-in-core-examples
-                 no-relative-imports pre-commit-descriptions provide-create-sessions
-                 providers-init-file provider-yamls pydevd pydocstyle pylint pylint-tests
-                 python-no-log-warn pyupgrade restrict-start_date rst-backticks setup-order
-                 setup-extra-packages shellcheck sort-in-the-wild stylelint trailing-whitespace
-                 update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
-                 version-sync yamllint
+                 fix-encoding-pragma flake8 forbid-tabs helm-lint identity
+                 incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
+                 lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
+                 no-providers-in-core-examples no-relative-imports pre-commit-descriptions
+                 provide-create-sessions providers-init-file provider-yamls pydevd pydocstyle pylint
+                 pylint-tests python-no-log-warn pyupgrade restrict-start_date rst-backticks
+                 setup-order setup-extra-packages shellcheck sort-in-the-wild stylelint
+                 trailing-whitespace update-breeze-file update-extras update-local-yml-file
+                 update-setup-cfg-file version-sync yamllint
 
         You can pass extra arguments including options to to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -106,6 +106,8 @@ require Breeze Docker images to be installed locally:
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``helm-lint``                         Verifies if helm lint passes for the chart
 ----------------------------------- ---------------------------------------------------------------- ------------
+``identity``                          Prints inputs to the static check hooks for troubleshooting
+----------------------------------- ---------------------------------------------------------------- ------------
 ``incorrect-use-of-LoggingMixin``     Checks if LoggingMixin is properly imported.
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``insert-license``                    Adds licenses for most file types.

--- a/breeze-complete
+++ b/breeze-complete
@@ -92,6 +92,7 @@ fix-encoding-pragma
 flake8
 forbid-tabs
 helm-lint
+identity
 incorrect-use-of-LoggingMixin
 insert-license
 isort


### PR DESCRIPTION
This adds the "standard" `identity` hook to `.pre-commit-config.yaml`. 

The hook is described at [pre-commit cli docs](https://pre-commit.com/#meta-identity)
and just prints all the arguments passed to it (like filenames), so it's useful to show 
what files are "selected" by `pre-commit` when trying out different `--from-ref`, `--to-ref`
combinations.

@potiuk 