### PR TITLE
#13081 add note block to 2.x migration docs

### DIFF
--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -359,7 +359,7 @@ respect to the Kubernetes Executor. This is called out below for users of the Ku
 
 **Upgrade KubernetesExecutor settings**
 
-*The KubernetesExecutor Will t` Longer Read from the airflow.cfg for Base Pod Configurations.*
+*The KubernetesExecutor Will No Longer Read from the airflow.cfg for Base Pod Configurations.*
 
 In Airflow 2.0, the KubernetesExecutor will require a base pod template written in yaml. This file can exist
 anywhere on the host machine and will be linked using the ``pod_template_file`` configuration in the ``airflow.cfg`` file.

--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -325,6 +325,13 @@ the only supported UI.
 
 **Breaking Change in OAuth**
 
+.. note::
+
+    When multiple replicas of the airflow-web pods are running in Kubernetes they
+    need to share the same *secret_key* to access the same user session accross pods. Inject
+    this via the environmnet and rotate it regularly like the fernet_key to ensure security.
+    The 1.10.14 bridge-release has this feature.
+
 The ``flask-ouathlib`` has been replaced with ``authlib`` because ``flask-outhlib`` has
 been deprecated in favor of ``authlib``.
 The Old and New provider configuration keys that have changed are as follows
@@ -352,7 +359,7 @@ respect to the Kubernetes Executor. This is called out below for users of the Ku
 
 **Upgrade KubernetesExecutor settings**
 
-*The KubernetesExecutor Will No Longer Read from the airflow.cfg for Base Pod Configurations.*
+*The KubernetesExecutor Will t` Longer Read from the airflow.cfg for Base Pod Configurations.*
 
 In Airflow 2.0, the KubernetesExecutor will require a base pod template written in yaml. This file can exist
 anywhere on the host machine and will be linked using the ``pod_template_file`` configuration in the ``airflow.cfg`` file.

--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -328,8 +328,8 @@ the only supported UI.
 .. note::
 
     When multiple replicas of the airflow-web pods are running in Kubernetes they
-    need to share the same *secret_key* to access the same user session accross pods. Inject
-    this via the environmnet and rotate it regularly like the fernet_key to ensure security.
+    need to share the same *secret_key* to access the same user session across pods. Inject
+    this via the environment and rotate it regularly like the fernet_key to ensure security.
     The 1.10.14 bridge-release has this feature.
 
 The ``flask-ouathlib`` has been replaced with ``authlib`` because ``flask-outhlib`` has

--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -327,7 +327,7 @@ the only supported UI.
 
 .. note::
 
-    When multiple replicas of the airflow-web are running they
+    When multiple replicas of the airflow webserver are running they
     need to share the same *secret_key* to access the same user session. Inject
     this via any configuration mechanism. The 1.10.14 bridge-release modifies this feature
     to use randomly generated secret keys instead of an insecure default and may break existing

--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -327,10 +327,11 @@ the only supported UI.
 
 .. note::
 
-    When multiple replicas of the airflow-web pods are running in Kubernetes they
-    need to share the same *secret_key* to access the same user session across pods. Inject
-    this via the environment and rotate it regularly like the fernet_key to ensure security.
-    The 1.10.14 bridge-release has this feature.
+    When multiple replicas of the airflow-web are running they
+    need to share the same *secret_key* to access the same user session. Inject
+    this via any configuration mechanism. The 1.10.14 bridge-release modifies this feature
+    to use randomly generated secret keys instead of an insecure default and may break existing
+    deployments that rely on the default.
 
 The ``flask-ouathlib`` has been replaced with ``authlib`` because ``flask-outhlib`` has
 been deprecated in favor of ``authlib``.


### PR DESCRIPTION
closes: #13081

Added 2.x upgrading note in the OAuth section. Affects 1.10.14 bridge release as well. Auto-upgrade in our environment to 1.10.14 caused a minor OAuth2 login downtime. We will create a note in the official helm-chart repo as well for the *secret_key* to be highlighted similar to the *fernet_key*.
