### PR TITLE
Sort integrations.json by lowercase integration name

### DIFF
--- a/scripts/tools/generate-integrations-json.py
+++ b/scripts/tools/generate-integrations-json.py
@@ -68,7 +68,7 @@ for provider_info in ALL_PROVIDER_YAMLS:
             result['logo'] = logo
         result_integrations.append(result)
 
-result_integrations = sorted(result_integrations, key=lambda x: x['name'])
+result_integrations = sorted(result_integrations, key=lambda x: x['name'].lower())
 with open(os.path.join(AIRFLOW_SITE_DIR, 'landing-pages/site/static/integrations.json'), 'w') as f:
     f.write(
         json.dumps(


### PR DESCRIPTION
This ensures that Apache comes before AWS and so on. Otherwise uppercase W comes before lowercase p.

@mik-laj 
