### PR TITLE
feat: Scheduler now supports k8s liveness probe customization

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -116,8 +116,10 @@ spec:
           # If the scheduler stops heartbeating for 5 minutes (10*30s) kill the
           # scheduler and let Kubernetes restart it
           livenessProbe:
-            failureThreshold: 10
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.scheduler.livenessProbe.initialDelaySeconds | default 15 }}
+            timeoutSeconds: {{ .Values.scheduler.livenessProbe.timeoutSeconds | default 30 }}
+            failureThreshold: {{ .Values.scheduler.livenessProbe.failureThreshold | default 20 }}
+            periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds | default 5 }}
             exec:
               command:
               - python

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -633,6 +633,29 @@
                   "description": "Airflow 2.0 allows users to run multiple schedulers. This feature is only recommended for Mysql 8+ and postgres",
                   "type": "integer"
                 },
+                "livenessProbe": {
+                    "description": "Liveness probe configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "description": "Scheduler Liveness probe initial delay.",
+                            "type": "integer"
+                        },
+                        "timeoutSeconds": {
+                            "description": "Scheduler Liveness probe timeout seconds.",
+                            "type": "integer"
+                        },
+                        "failureThreshold": {
+                            "description": "Scheduler Liveness probe failure threshold.",
+                            "type": "integer"
+                        },
+                        "periodSeconds": {
+                            "description": "Scheduler Liveness probe period seconds.",
+                            "type": "integer"
+                        }
+                    }
+                },
                 "podDisruptionBudget": {
                     "description": "Scheduler pod disruption budget.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -354,6 +354,14 @@ scheduler:
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres
   replicas: 1
+  
+  # Liveness Probe settings
+  livenessProbe:
+    initialDelaySeconds: 15
+    timeoutSeconds: 30
+    failureThreshold: 20
+    periodSeconds: 5
+
   # Scheduler pod disruption budget
   podDisruptionBudget:
     enabled: false


### PR DESCRIPTION
Similarly to the webserver liveness probe, this makes the liveness probe customizable on the scheduler.