### PR TITLE
Avoid confusion in doc for CeleryKubernetesExecutor

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1328,7 +1328,8 @@
     - name: kubernetes_queue
       description: |
         Define when to send a task to ``KubernetesExecutor`` when using ``CeleryKubernetesExecutor``.
-        When the queue of a task is ``kubernetes_queue``, the task is executed via ``KubernetesExecutor``,
+        When the queue of a task is the value of ``kubernetes_queue`` (default ``kubernetes``),
+        the task is executed via ``KubernetesExecutor``,
         otherwise via ``CeleryExecutor``
       version_added: ~
       type: string

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -647,7 +647,8 @@ sentry_dsn =
 # This section only applies if you are using the ``CeleryKubernetesExecutor`` in
 # ``[core]`` section above
 # Define when to send a task to ``KubernetesExecutor`` when using ``CeleryKubernetesExecutor``.
-# When the queue of a task is ``kubernetes_queue``, the task is executed via ``KubernetesExecutor``,
+# When the queue of a task is the value of ``kubernetes_queue`` (default ``kubernetes``),
+# the task is executed via ``KubernetesExecutor``,
 # otherwise via ``CeleryExecutor``
 kubernetes_queue = kubernetes
 

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -29,7 +29,8 @@ class CeleryKubernetesExecutor(LoggingMixin):
     """
     CeleryKubernetesExecutor consists of CeleryExecutor and KubernetesExecutor.
     It chooses an executor to use based on the queue defined on the task.
-    When the queue is `kubernetes`, KubernetesExecutor is selected to run the task,
+    When the queue is the value of ``kubernetes_queue`` in section ``[celery_kubernetes_executor]``
+    of the configuration (default value: `kubernetes`), KubernetesExecutor is selected to run the task,
     otherwise, CeleryExecutor is used.
     """
 


### PR DESCRIPTION
The current docstring around CeleryKubernetesExecutor is not clear enough.

- Docstring `When the queue is 'kubernetes', KubernetesExecutor is selected to run the task` is incorrect. The value is configurable, and "kubernetes" is only the default value.
- In the configuration doc, `When the queue of a task is 'kubernetes_queue', ...` is inaccurate. Instead, it should be something like `When the queue of a task is the value of 'kubernetes_queue', ...`.

This PR makes minor changes in the docs to avoid such potential confusions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
