### PR TITLE
Cleans all DBs on ./breeze stop

### DIFF
--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -40,5 +40,3 @@ services:
       - "${MYSQL_HOST_PORT}:3306"
     command: ['mysqld', '--character-set-server=utf8mb4',
               '--collation-server=utf8mb4_unicode_ci']
-volumes:
-  mysql-db-volume:

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -36,5 +36,3 @@ services:
       - postgres-db-volume:/var/lib/postgresql/data
     ports:
       - "${POSTGRES_HOST_PORT}:5432"
-volumes:
-  postgres-db-volume:

--- a/scripts/ci/docker-compose/backend-sqlite.yml
+++ b/scripts/ci/docker-compose/backend-sqlite.yml
@@ -25,5 +25,3 @@ services:
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - sqlite-db-volume:/root/airflow
-volumes:
-  sqlite-db-volume:

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -35,3 +35,7 @@ services:
     ports:
       - "${WEBSERVER_HOST_PORT}:8080"
       - "${FLOWER_HOST_PORT}:5555"
+volumes:
+  sqlite-db-volume:
+  postgres-db-volume:
+  mysql-db-volume:


### PR DESCRIPTION
When ./breeze stop is run, we run docker-compose down under the
hood - by default with --volumes flag which also removes the
volumes. But the volumes were only defined when you
selected the database.

We want to clean up all the volumes on breeze stop
in order to avoid surprizes when you switch the DB and find
the DB is there.

Otherwise when you switch databases while they are running
stop will delete volumes for only the most recently used
database.

The fix makes sure that all the db
volumes are defined always so they are always all deleted on stop

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
