### PR TITLE
Fix Google BigQueryHook method get_schema()

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1337,7 +1337,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         table_ref = TableReference(dataset_ref=DatasetReference(project_id, dataset_id), table_id=table_id)
         table = self.get_client(project_id=project_id).get_table(table_ref)
-        return {"fields": [s.to_api_repr for s in table.schema]}
+        return {"fields": [s.to_api_repr() for s in table.schema]}
 
     @GoogleBaseHook.fallback_to_default_project_id
     def poll_job_complete(


### PR DESCRIPTION
# Problem
This line does not return a valid schema:
`return {"fields": [s.to_api_repr for s in table.schema]}`

The reason is that `s.to_api_repr` we forgot to invoke the function using `s.to_api_repr()`

# Solution 
Change from: 
`return {"fields": [s.to_api_repr for s in table.schema]}`
to: 
```
return {"fields": [s.to_api_repr() for s in table.schema]}
```