### PR TITLE
Fix insert_all in bigquery hook 

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -876,11 +876,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         """
         self.log.info('Inserting %s row(s) into table %s:%s.%s', len(rows), project_id, dataset_id, table_id)
 
-        table = self._resolve_table_reference(
-            table_resource={}, project_id=project_id, dataset_id=dataset_id, table_id=table_id
-        )
+        table_ref = TableReference(dataset_ref=DatasetReference(project_id, dataset_id), table_id=table_id)
+        table = self.get_client(project_id=project_id).get_table(table_ref)
         errors = self.get_client().insert_rows(
-            table=Table.from_api_repr(table),
+            table=table,
             rows=rows,
             ignore_unknown_values=ignore_unknown_values,
             skip_invalid_rows=skip_invalid_rows,

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -877,8 +877,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.log.info('Inserting %s row(s) into table %s:%s.%s', len(rows), project_id, dataset_id, table_id)
 
         table_ref = TableReference(dataset_ref=DatasetReference(project_id, dataset_id), table_id=table_id)
-        table = self.get_client(project_id=project_id).get_table(table_ref)
-        errors = self.get_client().insert_rows(
+        bq_client = self.get_client(project_id=project_id)
+        table = bq_client.get_table(table_ref)
+        errors = bq_client.insert_rows(
             table=table,
             rows=rows,
             ignore_unknown_values=ignore_unknown_values,

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -690,7 +690,6 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             skip_invalid_rows=True,
         )
         mock_client.return_value.get_table.assert_called_once_with(TABLE_REFERENCE)
-        mock_client.assert_called_once_with(project_id=PROJECT_ID)
         mock_client.return_value.insert_rows.assert_called_once_with(
             table=mock_client.return_value.get_table.return_value,
             rows=rows,

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -677,9 +677,8 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         ):
             self.hook.run_load("test.test", "test_schema.json", ["test_data.json"], source_format="json")
 
-    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Table")
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.Client")
-    def test_insert_all_succeed(self, mock_client, mock_table):
+    def test_insert_all_succeed(self, mock_client):
         rows = [{"json": {"a_key": "a_value_0"}}]
 
         self.hook.insert_all(
@@ -690,9 +689,10 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
             ignore_unknown_values=True,
             skip_invalid_rows=True,
         )
-        mock_table.from_api_repr.assert_called_once_with({"tableReference": TABLE_REFERENCE_REPR})
+        mock_client.return_value.get_table.assert_called_once_with(TABLE_REFERENCE)
+        mock_client.assert_called_once_with(project_id=PROJECT_ID)
         mock_client.return_value.insert_rows.assert_called_once_with(
-            table=mock_table.from_api_repr.return_value,
+            table=mock_client.return_value.get_table.return_value,
             rows=rows,
             ignore_unknown_values=True,
             skip_invalid_rows=True,


### PR DESCRIPTION
# Problem 

When I am trying to use the method `insert_all` from bigquery hook I got:
 
```
ValueError: Could not determine schema for table 'Table(TableReference(DatasetReference(...))
```

The reason is that we are invoking the client insert_rows with a table and that table does not have schema and the client is expecting a table with schema. 

Client expecting schema in the method insert_rows [here](https://github.com/googleapis/python-bigquery/blob/master/google/cloud/bigquery/client.py#L2929), otherwise it will raise exception

However we are giving a table without schema [code](https://github.com/apache/airflow/blob/master/airflow/providers/google/cloud/hooks/bigquery.py#L879-L883 )

```
        table = self._resolve_table_reference(
            table_resource={}, project_id=project_id, dataset_id=dataset_id, table_id=table_id
        )
```

# Solution proposed: 

1. Get the table in bigquery 

```
table_ref = TableReference(dataset_ref=DatasetReference(project_id, dataset_id), table_id=table_id)
table = self.get_client(project_id=project_id).get_table(table_ref)
```

2. Pass the table in the method insert_rows (client)
```
self.get_client().insert_rows(
            table=table,
            rows=rows,
            ignore_unknown_values=ignore_unknown_values,
            skip_invalid_rows=skip_invalid_rows,
        )
```
        