### PR TITLE
Convert columns in get_pandas_df to lowercase SnowflakeHook

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -79,7 +79,7 @@ class SnowflakeHook(DbApiHook):
             "region": self.region or region,
             "role": self.role or role,
             "authenticator": self.authenticator or authenticator,
-            "session_parameters": self.session_parameters or session_parameters
+            "session_parameters": self.session_parameters or session_parameters,
         }
 
         # If private_key_file is specified in the extra json, load the contents of the file as a private
@@ -151,7 +151,7 @@ class SnowflakeHook(DbApiHook):
         """
         overrides DbApiHook get_pandas_df for allowing df columns to be lowercase
         """
-        df = super(SnowflakeHook, self).get_pandas_df(sql, parameters, **kwargs)
+        df = super().get_pandas_df(sql, parameters, **kwargs)
         if self.lowercase_columns:
             df.columns = df.columns.str.lower()
 


### PR DESCRIPTION
In snowflake, everything is uppercase. In get_pandas_df this could be inconvenient. Sometimes you have to access certain columns, and you don't want to type the name of the columns in uppercase. This is especially inconvenient if you are migrating from Redshift or another DW to Snowflake, because you have to change all your pandas code. 

I aim to solve this with this PR. If you include a boolean in the extra field of your snowflake connection as True, all the columns will get lowercase automatically.

I guess this needs test, but I have no idea how to begin. Could anyone help me, please? Thanks