### PR TITLE
Minor style fix in docs/extra-packages-ref

### DIFF
--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -234,7 +234,7 @@ Here's the list of the :ref:`subpackages <installation:extra_packages>` and what
 +---------------------+-----------------------------------------------------+----------------------------------------------------------------------+
 
 
-** Deprecated 1.10 Extras **
+**Deprecated 1.10 Extras**
 
 Those are the extras that have been deprecated in 2.0 and will be removed
 (current plan is to remove them in 2.1):
@@ -251,7 +251,7 @@ Those are the extras that have been deprecated in 2.0 and will be removed
 +---------------------+-----------------------------+
 | cassandra           | apache.cassandra            |
 +---------------------+-----------------------------+
-| crypto              | - *                         |
+| crypto              | \- \*                       |
 +---------------------+-----------------------------+
 | druid               | apache.druid                |
 +---------------------+-----------------------------+
@@ -279,4 +279,4 @@ Those are the extras that have been deprecated in 2.0 and will be removed
 +---------------------+-----------------------------+
 
 
-* crypto extra is not needed as cryptography is installed by default in Airflow 2.0
+\* crypto extra is not needed as cryptography is installed by default in Airflow 2.0


### PR DESCRIPTION
There are some minor style issues in docs `Extra Packages Reference` (http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/extra-packages-ref.html)

- Header (bold) style is wrong
- Some symbols are not escaped

![Extra_Packages_Reference_—_Airflow_Documentation](https://user-images.githubusercontent.com/11539188/102655600-dde85480-4172-11eb-9c39-af0dd0d17ecc.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
