### PR TITLE
Do not allow yanked version of Airflow in upgrade-check tool

### DIFF
--- a/airflow/upgrade/setup.cfg
+++ b/airflow/upgrade/setup.cfg
@@ -46,7 +46,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    apache-airflow>=1.10.13,<3
+    apache-airflow>=1.10.14,<3
     importlib-metadata~=2.0; python_version<"3.8"
     packaging
 python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*


### PR DESCRIPTION
Airflow 1.10.13 has been marked `yanked` after this change, and this requirement was missed to be bumped to 1.10.14 in airflow-upgrade-check 1.1.0.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
