### PR TITLE
Enhancement: Display Task tooltip when a DAG has yet to run (no TI)

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -98,4 +98,17 @@ export default function tiTooltip(ti, { includeTryNumber = false } = {}) {
   return tt;
 }
 
+export function taskNoInstanceTooltip(taskId, task) {
+  let tt = '';
+  if (taskId) {
+    tt += `Task_id: ${escapeHtml(taskId)}<br>`;
+  }
+  if (task.task_type !== undefined) {
+    tt += `Operator: ${escapeHtml(task.task_type)}<br>`;
+  }
+  tt += '<br><em>DAG has yet to run.</em>';
+  return tt;
+}
+
 window.tiTooltip = tiTooltip;
+window.taskNoInstanceTooltip = taskNoInstanceTooltip;

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -562,6 +562,9 @@
             } else if(task_group_tips.has(task_id)) {
               const tt = group_tooltip(task_id, tis)
               taskTip.show(tt, evt.target);
+            } else if (task_id in tasks) {
+              const tt = taskNoInstanceTooltip(task_id, tasks[task_id]);
+              taskTip.show(tt, evt.target)
             }
           };
           elem.onmouseout = taskTip.hide;


### PR DESCRIPTION
This applies to all DAGs that have yet to run, but was especially noticeable on DAGs with Task Groups, as the Task Groups still displayed a tooltip.

| Before | After |
|---|---|
|  ![Screen Recording 2020-12-18 at 04 33 19 PM](https://user-images.githubusercontent.com/3267/102663588-268e1680-414f-11eb-80a8-ab62507cd396.gif) |  ![Screen Recording 2020-12-18 at 04 33 52 PM](https://user-images.githubusercontent.com/3267/102663598-28f07080-414f-11eb-8f24-9d5b8e31f7bd.gif) |

### Example Tooltip:

<img width="282" alt="Image 2020-12-18 at 4 32 23 PM" src="https://user-images.githubusercontent.com/3267/102663747-71a82980-414f-11eb-9fb7-9701edf794eb.png">
