### PR TITLE
Move logging properties on values.yaml

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -645,6 +645,9 @@ config:
     dags_folder: '{{ include "airflow_dags" . }}'
     load_examples: 'False'
     executor: '{{ .Values.executor }}'
+    # For Airflow 1.10, backward compatibility
+		colored_console_log: 'False'
+    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
   # Authentication backend used for the experimental API
   api:
     auth_backend: airflow.api.auth.backend.deny_all

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -646,7 +646,7 @@ config:
     load_examples: 'False'
     executor: '{{ .Values.executor }}'
     # For Airflow 1.10, backward compatibility
-		colored_console_log: 'False'
+    colored_console_log: 'False'
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
   # Authentication backend used for the experimental API
   api:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -644,13 +644,13 @@ config:
   core:
     dags_folder: '{{ include "airflow_dags" . }}'
     load_examples: 'False'
-    colored_console_log: 'False'
     executor: '{{ .Values.executor }}'
-    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
   # Authentication backend used for the experimental API
   api:
     auth_backend: airflow.api.auth.backend.deny_all
   logging:
+    remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
+    colored_console_log: 'False'
     logging_level: DEBUG
   metrics:
     statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
@@ -661,10 +661,8 @@ config:
     enable_proxy_fix: 'True'
     expose_config: 'True'
     rbac: 'True'
-
   celery:
-    default_queue: celery
-
+    default_queue: celery   
   scheduler:
     scheduler_heartbeat_sec: 5
     # For Airflow 1.10, backward compatibility
@@ -672,7 +670,6 @@ config:
     statsd_port: 9125
     statsd_prefix: airflow
     statsd_host: '{{ printf "%s-statsd" .Release.Name }}'
-
     # Restart Scheduler every 41460 seconds (11 hours 31 minutes)
     # The odd time is chosen so it is not always restarting on the same "hour" boundary
     run_duration: 41460
@@ -683,13 +680,11 @@ config:
     max_retries: 3
     timeout: 30
     retry_timeout: 'True'
-
   kerberos:
     keytab: '{{ .Values.kerberos.keytabPath }}'
     reinit_frequency: '{{ .Values.kerberos.reinitFrequency }}'
     principal: '{{ .Values.kerberos.principal }}'
     ccache: '{{ .Values.kerberos.ccacheMountPath }}/{{ .Values.kerberos.ccacheFileName }}'
-
   kubernetes:
     namespace: '{{ .Release.Namespace }}'
     airflow_configmap: '{{ include "airflow_config" . }}'

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -662,7 +662,7 @@ config:
     expose_config: 'True'
     rbac: 'True'
   celery:
-    default_queue: celery   
+    default_queue: celery
   scheduler:
     scheduler_heartbeat_sec: 5
     # For Airflow 1.10, backward compatibility


### PR DESCRIPTION
Since `remote_logging` and `logging_level` was under  `core` section on config, it was throwing deprecation messages on the Pods logs. I moved it into the `logging` section

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
