### PR TITLE
json-merge-patch becomes optional library and has looser restrictions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -107,7 +107,6 @@ install_requires =
     iso8601>=0.1.12
     itsdangerous>=1.1.0
     jinja2>=2.10.1, <2.12.0
-    json-merge-patch==0.2
     jsonschema~=3.0
     lazy-object-proxy<1.5.0  # Required to keep pip-check happy with astroid
     lockfile>=0.12.2

--- a/setup.py
+++ b/setup.py
@@ -278,6 +278,7 @@ google = [
     'google-cloud-videointelligence>=1.7.0,<2.0.0',
     'google-cloud-vision>=0.35.2,<2.0.0',
     'grpcio-gcp>=0.2.2',
+    'json-merge-patch~=0.2',
     'pandas-gbq',
 ]
 grpc = [


### PR DESCRIPTION
This library is only used by one google operator::
https://github.com/apache/airflow/blob/349b0811c3022605426ba57d30936240a7c2848a/airflow/providers/google/cloud/operators/compute.py#L24
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
