### PR TITLE
Losser restriction for colorlog

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ install_requires =
     # cattrs >= 1.1.0 dropped support for Python 3.6
     cattrs>=1.0, <1.1.0;python_version<="3.6"
     cattrs~=1.1;python_version>"3.6"
-    colorlog==4.0.2
+    colorlog>=4.0.2
     connexion[swagger-ui,flask]>=2.6.0,<3
     croniter>=0.3.17, <0.4
     cryptography>=0.9.3


### PR DESCRIPTION
[colorlog](https://pypi.org/project/colorlog/)  is a bit old and it seems we should test newer versions as well.
Current version:  4.0.2 (2 years ago)  
Current version v1.10: 4.0.2 (2 years ago) 
Latest version: 4.6.2 (a month ago)
A shift between the latest release and the one currently in use.: 1 year, 10 months 

Part of: https://github.com/apache/airflow/issues/12120

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
