### PR TITLE
Remove unused libraries - flask-swagger, funcsigs

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -195,7 +195,7 @@ RUN mkdir -pv ${AIRFLOW_HOME} && \
     mkdir -pv ${AIRFLOW_HOME}/logs
 
 # Increase the value here to force reinstalling Apache Airflow pip dependencies
-ARG PIP_DEPENDENCIES_EPOCH_NUMBER="4"
+ARG PIP_DEPENDENCIES_EPOCH_NUMBER="5"
 ENV PIP_DEPENDENCIES_EPOCH_NUMBER=${PIP_DEPENDENCIES_EPOCH_NUMBER}
 
 # Install BATS and its dependencies for "in container" tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,6 @@ install_requires =
     flask-appbuilder~=3.1.1
     flask-caching>=1.5.0, <2.0.0
     flask-login>=0.3, <0.5
-    flask-swagger==0.2.13
     flask-wtf>=0.14.3, <0.15
     funcsigs>=1.0.0, <2.0.0
     graphviz>=0.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,6 @@ install_requires =
     flask-caching>=1.5.0, <2.0.0
     flask-login>=0.3, <0.5
     flask-wtf>=0.14.3, <0.15
-    funcsigs>=1.0.0, <2.0.0
     graphviz>=0.12
     gunicorn>=19.5.0, <20.0
     importlib_metadata~=1.7;python_version<"3.9" # We could work with 3.1, but argparse needs <2


### PR DESCRIPTION
We use connexion to provider swagger UI.
https://github.com/apache/airflow/blob/ff9fb3614864d0135edc316c1c3df7e1a6a13415/airflow/www/extensions/init_appbuilder_links.py#L27-L30

Part of: https://github.com/apache/airflow/issues/12120
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
