### PR TITLE
fix parenthesis preventing keda ScaledObject creation

### DIFF
--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Worker KEDA Scaler
 #################################
-{{- if (and .Values.workers.keda.enabled ( or (eq .Values.executor "CeleryExecutor"))  (eq .Values.executor "CeleryKubernetesExecutor")) }}
+{{- if (and .Values.workers.keda.enabled ( or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor"))) }}
 apiVersion: keda.k8s.io/v1alpha1
 kind: ScaledObject
 metadata:

--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -61,7 +61,7 @@ def validate_k8s_object(instance):
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None):
+def render_chart(name="RELEASE-NAME", values=None, show_only=None, validate_schema=True):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
@@ -77,8 +77,9 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None):
         templates = subprocess.check_output(command)
         k8s_objects = yaml.load_all(templates)
         k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore
-        for k8s_object in k8s_objects:
-            validate_k8s_object(k8s_object)
+        if validate_schema:
+            for k8s_object in k8s_objects:
+                validate_k8s_object(k8s_object)
         return k8s_objects
 
 

--- a/chart/tests/test_keda.py
+++ b/chart/tests/test_keda.py
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+
+import jmespath
+from parameterized import parameterized
+
+from tests.helm_template_generator import render_chart
+
+
+class KedaTest(unittest.TestCase):
+    def test_keda_disabled_by_default(self):
+        """disabled by default"""
+        docs = render_chart(
+            values={},
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+            validate_schema=False,
+        )
+        self.assertListEqual(docs, [])
+
+    @parameterized.expand(
+        [
+            ('SequentialExecutor', False),
+            ('CeleryExecutor', True),
+            ('CeleryKubernetesExecutor', True),
+        ]
+    )
+    def test_keda_enabled(self, executor, is_created):
+        """
+        ScaledObject should only be created when set to enabled and executor is Celery or CeleryKubernetes
+        """
+        docs = render_chart(
+            values={
+                "workers": {"keda": {"enabled": True}, "persistence": {"enabled": False}},
+                'executor': executor,
+            },
+            show_only=["templates/workers/worker-kedaautoscaler.yaml"],
+            validate_schema=False,
+        )
+        if is_created:
+            self.assertEqual("RELEASE-NAME-worker", jmespath.search("metadata.name", docs[0]))
+        else:
+            self.assertListEqual(docs, [])


### PR DESCRIPTION
fix placement of parentheses in keda autoscaler template so that keda scaledobject is created when enabled

adds simple test to verify that keda object is created under right circumstances (though not all permutations covered)

to do so, had to make schema validation optional cus the existing validator could not find schema.  maybe this is cus it's a custom resource def?  @dimberman maybe you know?

closes: https://github.com/apache/airflow/issues/13181