### PR TITLE
[AIRFLOW-3723] Add Gzip capability to mongo_to_S3 operator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -515,6 +515,7 @@ class S3Hook(AwsBaseHook):
         encrypt: bool = False,
         encoding: Optional[str] = None,
         acl_policy: Optional[str] = None,
+        compression: Optional[str] = None,
     ) -> None:
         """
         Loads a string to S3
@@ -539,11 +540,26 @@ class S3Hook(AwsBaseHook):
         :param acl_policy: The string to specify the canned ACL policy for the
             object to be uploaded
         :type acl_policy: str
+        :param compression: Type of compression to use, currently only gzip is supported.
+        :type compression: str
         """
         encoding = encoding or 'utf-8'
 
         bytes_data = string_data.encode(encoding)
+
+        # Compress string
+        available_compressions = ['gzip']
+        if compression is not None and compression not in available_compressions:
+            raise NotImplementedError(
+                "Received {} compression type. String "
+                "can currently be compressed in {} "
+                "only.".format(compression, available_compressions)
+            )
+        if compression == 'gzip':
+            bytes_data = gz.compress(bytes_data)
+
         file_obj = io.BytesIO(bytes_data)
+
         self._upload_file_obj(file_obj, key, bucket_name, replace, encrypt, acl_policy)
         file_obj.close()
 

--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -53,6 +53,7 @@ class MongoToS3Operator(BaseOperator):
         s3_key: str,
         mongo_db: Optional[str] = None,
         replace: bool = False,
+        compression: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -70,6 +71,7 @@ class MongoToS3Operator(BaseOperator):
         self.s3_bucket = s3_bucket
         self.s3_key = s3_key
         self.replace = replace
+        self.compression = compression
 
     def execute(self, context) -> bool:
         """Executed by task_instance at runtime"""
@@ -95,7 +97,11 @@ class MongoToS3Operator(BaseOperator):
 
         # Load Into S3
         s3_conn.load_string(
-            string_data=docs_str, key=self.s3_key, bucket_name=self.s3_bucket, replace=self.replace
+            string_data=docs_str,
+            key=self.s3_key,
+            bucket_name=self.s3_bucket,
+            replace=self.replace,
+            compression=self.compression,
         )
 
         return True

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -231,6 +231,18 @@ class TestAwsS3Hook:
         resource = boto3.resource('s3').Object(s3_bucket, 'my_key')  # pylint: disable=no-member
         assert resource.get()['Body'].read() == b'Cont\xC3\xA9nt'
 
+    def test_load_string_compress(self, s3_bucket):
+        hook = S3Hook()
+        hook.load_string("Contént", "my_key", s3_bucket, compression='gzip')
+        resource = boto3.resource('s3').Object(s3_bucket, 'my_key')  # pylint: disable=no-member
+        data = gz.decompress(resource.get()['Body'].read())
+        assert data == b'Cont\xC3\xA9nt'
+
+    def test_load_string_compress_exception(self, s3_bucket):
+        hook = S3Hook()
+        with pytest.raises(NotImplementedError):
+            hook.load_string("Contént", "my_key", s3_bucket, compression='bad-compression')
+
     def test_load_string_acl(self, s3_bucket):
         hook = S3Hook()
         hook.load_string("Contént", "my_key", s3_bucket, acl_policy='public-read')


### PR DESCRIPTION
Adding the gzip ability to the hook and then the mongo_to_S3 using it
from the hook.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
