### PR TITLE
Fix disable login option behavior

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -216,8 +216,8 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         if user is None:
             user = g.user
         if user.is_anonymous:
-            public_role = current_app.appbuilder.config.get('AUTH_ROLE_PUBLIC')
-            return [current_app.appbuilder.security_manager.find_role(public_role)] if public_role else []
+            public_role = current_app.appbuilder.get_app.config["AUTH_ROLE_PUBLIC"]
+            return [current_app.appbuilder.sm.find_role(public_role)] if public_role else []
         return user.roles
 
     def get_all_permissions_views(self):

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -68,6 +68,14 @@ following CLI commands to create an account:
 It is however possible to switch on authentication by either using one of the supplied
 backends or creating your own.
 
+To deactivate the authentication and allow users to be identified as Anonymous, the following entry
+in ``$AIRFLOW_HOME/webserver_config.py`` needs to be set with the desired role that the Anonymous
+user will have by default:
+
+.. code-block:: ini
+
+    AUTH_ROLE_PUBLIC = 'Admin'
+
 Be sure to checkout :doc:`/rest-api-ref` for securing the API.
 
 .. note::

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -179,6 +179,55 @@ class TestSecurity(unittest.TestCase):
         user.roles = roles
         self.assertEqual(self.security_manager.get_user_roles(user), roles)
 
+    def test_get_user_roles_for_anonymous_user(self):
+        viewer_role_perms = {
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_CONFIG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_CODE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_IMPORT_ERROR),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_JOB),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_PLUGIN),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_SLA_MISS),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_BROWSE_MENU),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DOCS_LINK),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DOCS_MENU),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_JOB),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_AUDIT_LOG),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_PLUGIN),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_SLA_MISS),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_THIS_FORM_GET, permissions.RESOURCE_RESET_MY_PASSWORD_VIEW),
+            (permissions.ACTION_CAN_THIS_FORM_POST, permissions.RESOURCE_RESET_MY_PASSWORD_VIEW),
+            (permissions.ACTION_RESETMYPASSWORD, permissions.RESOURCE_USER_DB_MODELVIEW),
+            (permissions.ACTION_CAN_THIS_FORM_GET, permissions.RESOURCE_USERINFO_EDIT_VIEW),
+            (permissions.ACTION_CAN_THIS_FORM_POST, permissions.RESOURCE_USERINFO_EDIT_VIEW),
+            (permissions.ACTION_USERINFOEDIT, permissions.RESOURCE_USER_DB_MODELVIEW),
+            (permissions.ACTION_CAN_USERINFO, permissions.RESOURCE_USER_DB_MODELVIEW),
+            (permissions.ACTION_CAN_USERINFO, permissions.RESOURCE_USER_OID_MODELVIEW),
+            (permissions.ACTION_CAN_USERINFO, permissions.RESOURCE_USER_LDAP_MODELVIEW),
+            (permissions.ACTION_CAN_USERINFO, permissions.RESOURCE_USER_OAUTH_MODELVIEW),
+            (permissions.ACTION_CAN_USERINFO, permissions.RESOURCE_USER_REMOTEUSER_MODELVIEW),
+        }
+        self.app.config['AUTH_ROLE_PUBLIC'] = 'Viewer'
+
+        with self.app.app_context():
+            user = mock.MagicMock()
+            user.is_anonymous = True
+
+            perms_views = set()
+            for role in self.security_manager.get_user_roles(user):
+                perms_views.update(
+                    {(perm_view.permission.name, perm_view.view_menu.name) for perm_view in role.permissions}
+                )
+            self.assertEqual(perms_views, viewer_role_perms)
+
     @mock.patch('airflow.www.security.AirflowSecurityManager.get_user_roles')
     def test_get_all_permissions_views(self, mock_get_user_roles):
         role_name = 'MyRole5'


### PR DESCRIPTION
When set the AUTH_ROLE_PUBLIC entry in the webserver_config.py, the app needs to be able to read the value for this entry and this pull request fix the way to access this entry value
closes: #13142
closes: #8815