### PR TITLE
Fix documentation error in git_sync_template.yaml

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
@@ -47,7 +47,7 @@ spec:
         - name: GIT_SYNC_MAX_SYNC_FAILURES
           value: "0"
       volumeMounts:
-        - name: dags
+        - name: airflow-dags
           mountPath: /git
   containers:
     - args: []
@@ -82,9 +82,6 @@ spec:
         - mountPath: /opt/airflow/dags
           name: airflow-dags
           readOnly: false
-        - mountPath: /opt/airflow/dags
-          name: airflow-dags
-          readOnly: true
   hostNetwork: false
   restartPolicy: Never
   securityContext:
@@ -97,7 +94,7 @@ spec:
     []
   serviceAccountName: 'RELEASE-NAME-worker-serviceaccount'
   volumes:
-    - name: dags
+    - name: airflow-dags
       emptyDir: {}
     - emptyDir: {}
       name: airflow-logs


### PR DESCRIPTION
When reading the documentation (https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html?highlight=pod_override#pod-template-file) I noticed that there are errors in `volumes` and `volumeMounts` sections.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
