### PR TITLE
add AzureDatalakeStorageDeleteOperator

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+from airflow import models
+from airflow.providers.microsoft.azure.operators.adls_delete import AzureDataLakeStorageDeleteOperator
+from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalToAzureDataLakeStorageOperator
+from airflow.utils.dates import days_ago
+
+LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", 'localfile.txt')
+REMOTE_FILE_PATH = os.environ.get("REMOTE_LOCAL_PATH", 'remote.txt')
+
+
+with models.DAG(
+    "example_adls_delete",
+    start_date=days_ago(1),
+    schedule_interval=None,
+    tags=['example'],
+) as dag:
+
+    upload_file = LocalToAzureDataLakeStorageOperator(
+        task_id='upload_task',
+        local_path=LOCAL_FILE_PATH,
+        remote_path=REMOTE_FILE_PATH,
+    )
+    # [START howto_operator_adls_delete]
+    remove_file = AzureDataLakeStorageDeleteOperator(
+        task_id="delete_task", path=REMOTE_FILE_PATH, recursive=True
+    )
+    # [END howto_operator_adls_delete]
+
+    upload_file >> remove_file

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -194,10 +194,10 @@ class AzureDataLakeHook(BaseHook):
     def remove(self, path: str, recursive: bool = False, ignore_not_found: bool = True) -> None:
         """
         Remove files in Azure Data Lake Storage
+
         :param path: A directory or file to remove in ADLS
         :type path: str
-        :param recursive: Whether to loop into directories
-            in the location and remove the files
+        :param recursive: Whether to loop into directories in the location and remove the files
         :type recursive: bool
         :param ignore_not_found: Whether to raise error if file to delete is not found
         :type ignore_not_found: bool

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -28,6 +28,7 @@ from typing import Optional
 
 from azure.datalake.store import core, lib, multithread
 
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
 
@@ -189,3 +190,22 @@ class AzureDataLakeHook(BaseHook):
             return self.get_conn().glob(path)
         else:
             return self.get_conn().walk(path)
+
+    def remove(self, path: str, recursive: bool = False, ignore_not_found: bool = True) -> None:
+        """
+        Remove files in Azure Data Lake Storage
+        :param path: A directory or file to remove in ADLS
+        :type path: str
+        :param recursive: Whether to loop into directories
+            in the location and remove the files
+        :type recursive: bool
+        :param ignore_not_found: Whether to raise error if file to delete is not found
+        :type ignore_not_found: bool
+        """
+        try:
+            self.get_conn().remove(path=path, recursive=recursive)
+        except FileNotFoundError:
+            if ignore_not_found:
+                self.log.info("File %s not found", path)
+            else:
+                raise AirflowException("File %s not found" % path)

--- a/airflow/providers/microsoft/azure/operators/adls_delete.py
+++ b/airflow/providers/microsoft/azure/operators/adls_delete.py
@@ -24,12 +24,15 @@ from airflow.utils.decorators import apply_defaults
 
 class AzureDataLakeStorageDeleteOperator(BaseOperator):
     """
-    Delete file(s) in the specified path.
+    Delete files in the specified path.
+
+        .. seealso::
+            For more information on how to use this operator, take a look at the guide:
+            :ref:`howto/operator:AzureDataLakeStorageDeleteOperator`
 
     :param path: A directory or file to remove
     :type path: str
-    :param recursive: Whether to loop into directories
-        in the location and remove the files
+    :param recursive: Whether to loop into directories in the location and remove the files
     :type recursive: bool
     :param ignore_not_found: Whether to raise error if file to delete is not found
     :type ignore_not_found: bool

--- a/airflow/providers/microsoft/azure/operators/adls_delete.py
+++ b/airflow/providers/microsoft/azure/operators/adls_delete.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Sequence
+
+from airflow.models import BaseOperator
+from airflow.providers.microsoft.azure.hooks.azure_data_lake import AzureDataLakeHook
+from airflow.utils.decorators import apply_defaults
+
+
+class AzureDataLakeStorageDeleteOperator(BaseOperator):
+    """
+    Delete file(s) in the specified path.
+
+    :param path: A directory or file to remove
+    :type path: str
+    :param recursive: Whether to loop into directories
+        in the location and remove the files
+    :type recursive: bool
+    :param ignore_not_found: Whether to raise error if file to delete is not found
+    :type ignore_not_found: bool
+    """
+
+    template_fields: Sequence[str] = ('path',)
+    ui_color = '#901dd2'
+
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        path: str,
+        recursive: bool = False,
+        ignore_not_found: bool = True,
+        azure_data_lake_conn_id: str = 'azure_data_lake_default',
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.path = path
+        self.recursive = recursive
+        self.ignore_not_found = ignore_not_found
+        self.azure_data_lake_conn_id = azure_data_lake_conn_id
+
+    def execute(self, context: dict) -> Any:
+        hook = AzureDataLakeHook(azure_data_lake_conn_id=self.azure_data_lake_conn_id)
+
+        return hook.remove(path=self.path, recursive=self.recursive, ignore_not_found=self.ignore_not_found)

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -44,6 +44,8 @@ integrations:
     external-doc-url: https://azure.microsoft.com/en-us/services/data-explorer/
     tags: [azure]
   - integration-name: Microsoft Azure Data Lake Storage
+    how-to-guide:
+      - /docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
     external-doc-url: https://azure.microsoft.com/en-us/services/storage/data-lake-storage/
     logo: /integration-logos/azure/Data Lake Storage.svg
     tags: [azure]

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -62,6 +62,7 @@ operators:
   - integration-name: Microsoft Azure Data Lake Storage
     python-modules:
       - airflow.providers.microsoft.azure.operators.adls_list
+      - airflow.providers.microsoft.azure.operators.adls_delete
   - integration-name: Microsoft Azure Data Explorer
     python-modules:
       - airflow.providers.microsoft.azure.operators.adx

--- a/docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
@@ -1,0 +1,55 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Azure DataLake Storage Operators
+=================================
+
+.. contents::
+  :depth: 1
+  :local:
+
+
+Prerequisite Tasks
+^^^^^^^^^^^^^^^^^^
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+.. _howto/operator:AzureDataLakeStorageDeleteOperator:
+
+AzureDataLakeStorageDeleteOperator
+----------------------------------
+Use the
+:class:`~airflow.providers.microsoft.azure.operators.adls_delete.AzureDataLakeStorageDeleteOperator` to remove
+file(s) from Azure DataLake Storage
+
+
+Below is an example of using this operator to delete a file from ADL.
+
+.. exampleinclude:: /../../airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
+    :language: python
+    :dedent: 0
+    :start-after: [START howto_operator_adls_delete]
+    :end-before: [END howto_operator_adls_delete]
+
+
+Reference
+---------
+
+For further information, look at:
+
+* `Azure Data lake Storage Documentation <https://docs.microsoft.com/en-us/azure/data-lake-store/>`__

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_lake.py
@@ -132,3 +132,14 @@ class TestAzureDataLakeHook(unittest.TestCase):
         hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
         hook.list('file_path/some_folder/')
         mock_fs.return_value.walk.assert_called_once_with('file_path/some_folder/')
+
+    @mock.patch(
+        'airflow.providers.microsoft.azure.hooks.azure_data_lake.core.AzureDLFileSystem', autospec=True
+    )
+    @mock.patch('airflow.providers.microsoft.azure.hooks.azure_data_lake.lib', autospec=True)
+    def test_remove(self, mock_lib, mock_fs):
+        from airflow.providers.microsoft.azure.hooks.azure_data_lake import AzureDataLakeHook
+
+        hook = AzureDataLakeHook(azure_data_lake_conn_id='adl_test_key')
+        hook.remove('filepath', True)
+        mock_fs.return_value.remove.assert_called_once_with('filepath', recursive=True)

--- a/tests/providers/microsoft/azure/operators/test_adls_delete.py
+++ b/tests/providers/microsoft/azure/operators/test_adls_delete.py
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest import mock
+
+from airflow.providers.microsoft.azure.operators.adls_delete import AzureDataLakeStorageDeleteOperator
+
+TASK_ID = 'test-adls-list-operator'
+TEST_PATH = 'test'
+
+
+class TestAzureDataLakeStorageDeleteOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.microsoft.azure.operators.adls_delete.AzureDataLakeHook')
+    def test_execute(self, mock_hook):
+
+        operator = AzureDataLakeStorageDeleteOperator(task_id=TASK_ID, path=TEST_PATH)
+
+        operator.execute(None)
+        mock_hook.return_value.remove.assert_called_once_with(
+            path=TEST_PATH, recursive=False, ignore_not_found=True
+        )

--- a/tests/providers/microsoft/azure/operators/test_adls_delete_system.py
+++ b/tests/providers/microsoft/azure/operators/test_adls_delete_system.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+import pytest
+
+from airflow.providers.microsoft.azure.example_dags.example_local_to_adls import LOCAL_FILE_PATH
+from tests.test_utils.azure_system_helpers import (
+    AZURE_DAG_FOLDER,
+    AzureSystemTest,
+    provide_azure_data_lake_default_connection,
+)
+
+CREDENTIALS_DIR = os.environ.get('CREDENTIALS_DIR', '/files/airflow-breeze-config/keys')
+DATA_LAKE_DEFAULT_KEY = 'azure_data_lake.json'
+CREDENTIALS_PATH = os.path.join(CREDENTIALS_DIR, DATA_LAKE_DEFAULT_KEY)
+
+
+@pytest.mark.backend('postgres', 'mysql')
+@pytest.mark.credential_file(DATA_LAKE_DEFAULT_KEY)
+class ADLSDeleteSystem(AzureSystemTest):
+    def setUp(self):
+        super().setUp()
+        with open(LOCAL_FILE_PATH, 'w+') as file:
+            file.writelines(['example test files'])
+
+    def tearDown(self):
+        os.remove(LOCAL_FILE_PATH)
+        super().tearDown()
+
+    @provide_azure_data_lake_default_connection(CREDENTIALS_PATH)
+    def test_run_example_adls_delete(self):
+        self.run_dag('example_adls_delete', AZURE_DAG_FOLDER)


### PR DESCRIPTION
This PR adds AzureDatalakeStorageDeleteOperator with example dags and system test

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
