### PR TITLE
Update chart readme to remove astronomer references

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -286,18 +286,12 @@ Confirm it's up:
 kubectl cluster-info --context kind-kind
 ```
 
-**Add Astronomer's Helm repo:**
-
-```
-helm repo add astronomer https://helm.astronomer.io
-helm repo update
-```
 
 **Create namespace + install the chart:**
 
 ```
 kubectl create namespace airflow
-helm install airflow --n airflow astronomer/airflow
+helm install airflow --n airflow .
 ```
 
 It may take a few minutes. Confirm the pods are up:
@@ -312,11 +306,15 @@ to port-forward the Airflow UI to http://localhost:8080/ to confirm Airflow is w
 
 **Build a Docker image from your DAGs:**
 
-1. Start a project using [astro-cli](https://github.com/astronomer/astro-cli), which will generate a Dockerfile, and load your DAGs in. You can test locally before pushing to kind with `astro airflow start`.
+1. Create a project
 
     ```shell script
     mkdir my-airflow-project && cd my-airflow-project
-    astro dev init
+    mkdir dags  # put dags here
+    cat <<EOM > Dockerfile
+    FROM apache/airflow
+    COPY . .
+    EOM
     ```
 
 2. Then build the image:
@@ -334,10 +332,11 @@ to port-forward the Airflow UI to http://localhost:8080/ to confirm Airflow is w
 4. Upgrade Helm deployment:
 
     ```shell script
+    # from airflow chart directory
     helm upgrade airflow -n airflow \
         --set images.airflow.repository=my-dags \
         --set images.airflow.tag=0.0.1 \
-        astronomer/airflow
+        .
     ```
 
 ## Contributing


### PR DESCRIPTION
There were some references to astronomer in the chart readme (from when it was donated) that are obsolete.

Mainly three things.

1. astronomer helm repo is not necessary for this chart.
2. the install example comands assume you are installing from `astronomer/airflow` but this is actually a different chart.   This chart at this time must be installed from source.
3. update the `kind` demo example to obviate need for astro cli (probably should be provider-neutral with this type of thing)