### PR TITLE
Fix QueuedLocalWorker crashing with EOFError

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -173,7 +173,15 @@ class QueuedLocalWorker(LocalWorkerBase):
 
     def do_work(self) -> None:
         while True:
-            key, command = self.task_queue.get()
+            try:
+                key, command = self.task_queue.get()
+            except EOFError:
+                self.log.info(
+                    "Failed to read tasks from the task queue because the other "
+                    "end has closed the connection. Terminating worker %s.",
+                    self.name,
+                )
+                break
             try:
                 if key is None or command is None:
                     # Received poison pill, no more tasks to run


### PR DESCRIPTION
`LocalExecutor` uses a [multiprocessing.Queue](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Queue) to distribute tasks to the instances of `QueuedLocalWorker`. If for some reason LocalExecutor exits (e.g. because it encountered an unhandled exception), then each of the QueuedLocalWorker instances that it manages will also exit with an uncaught `EOFError` while trying to read from the task queue.

Because this causes a traceback to be logged for each of the workers that exits, this obfuscates the root cause of the issue, i.e. that the managing `LocalExecutor` terminated. By catching the `EOFError` in QueuedLocalWorker, logging an error and exiting gracefully we circumvent this problem, providing more clarity to the root cause of the issue to the Airflow administrator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
