### PR TITLE
Fix Default Config Jinja Template Error

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -541,14 +541,14 @@
       version_added: ~
       type: string
       example: ~
-      default: "{{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log"
+      default: "{{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log"
     - name: log_processor_filename_template
       description: |
         Formatting for how airflow generates file names for log
       version_added: ~
       type: string
       example: ~
-      default: "{{{{ filename }}}}.log"
+      default: "{{ filename }}.log"
     - name: dag_processor_manager_log_location
       description: |
         full path of dag_processor_manager logfile

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -294,10 +294,10 @@ simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 task_log_prefix_template =
 
 # Formatting for how airflow generates file names/paths for each task run.
-log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
+log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log
 
 # Formatting for how airflow generates file names for log
-log_processor_filename_template = {{{{ filename }}}}.log
+log_processor_filename_template = {{ filename }}.log
 
 # full path of dag_processor_manager logfile
 dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log


### PR DESCRIPTION
The default param for these causes jinja to error due to having too many brackets.

Users who copy the default configuration will get the following error on startup:
```
jinja2.exceptions.TemplateSyntaxError: expected token ':', got '}'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 5, in <module>
    from airflow.__main__ import main
  File "/usr/local/lib/python3.6/site-packages/airflow/__init__.py", line 46, in <module>
    settings.initialize()
  File "/usr/local/lib/python3.6/site-packages/airflow/settings.py", line 432, in initialize
    LOGGING_CLASS_PATH = configure_logging()
  File "/usr/local/lib/python3.6/site-packages/airflow/logging_config.py", line 62, in configure_logging
    raise e
  File "/usr/local/lib/python3.6/site-packages/airflow/logging_config.py", line 57, in configure_logging
    dictConfig(logging_config)
  File "/usr/lib64/python3.6/logging/config.py", line 802, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/lib64/python3.6/logging/config.py", line 573, in configure
    '%r: %s' % (name, e))
ValueError: Unable to configure handler 'processor': expected token ':', got '}'
```