### PR TITLE
Allow PID file path to be relative when daemonize a process (scheduler, kerberos, etc)

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -227,8 +227,11 @@ def setup_locations(process, pid=None, stdout=None, stderr=None, log=None):
         stdout = os.path.join(settings.AIRFLOW_HOME, f'airflow-{process}.out')
     if not log:
         log = os.path.join(settings.AIRFLOW_HOME, f'airflow-{process}.log')
+
     if not pid:
         pid = os.path.join(settings.AIRFLOW_HOME, f'airflow-{process}.pid')
+    else:
+        pid = os.path.abspath(pid)
 
     return pid, stdout, stderr, log
 

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -131,6 +131,23 @@ class TestCliUtil(unittest.TestCase):
         command = json.loads(command.replace("'", '"'))
         self.assertEqual(command, expected_command)
 
+    def test_setup_locations_relative_pid_path(self):
+        relative_pid_path = "fake.pid"
+        pid_full_path = os.path.join(os.getcwd(), relative_pid_path)
+        pid, _, _, _ = cli.setup_locations(process="fake_process", pid=relative_pid_path)
+        self.assertEqual(pid, pid_full_path)
+
+    def test_setup_locations_absolute_pid_path(self):
+        abs_pid_path = os.path.join(os.getcwd(), "fake.pid")
+        pid, _, _, _ = cli.setup_locations(process="fake_process", pid=abs_pid_path)
+        self.assertEqual(pid, abs_pid_path)
+
+    def test_setup_locations_none_pid_path(self):
+        process_name = "fake_process"
+        default_pid_path = os.path.join(settings.AIRFLOW_HOME, f"airflow-{process_name}.pid")
+        pid, _, _, _ = cli.setup_locations(process=process_name)
+        self.assertEqual(pid, default_pid_path)
+
 
 @contextmanager
 def fail_action_logger_callback():


### PR DESCRIPTION
Closes #13200  (please refer to #13200 for detailed background and discussion.)

Currently, if the PID file path provided is relative, the process silently fails to launch.

This fix ensures the path specified to be a normalized absolutized path eventually (expand with cwd), no matter the given value is relative or absolute.

This PR also tries to increase coverage a little bit.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
