### PR TITLE
Fix link to Apache Airflow docs in webserver

### DIFF
--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -27,7 +27,7 @@ def get_docs_url(page: Optional[str] = None) -> str:
             "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/"
         )
     else:
-        result = f'https://airflow.apache.org/docs/{version.version}/'
+        result = f'https://airflow.apache.org/docs/apache-airflow/{version.version}/'
     if page:
         result = result + page
     return result

--- a/tests/utils/test_docs.py
+++ b/tests/utils/test_docs.py
@@ -38,10 +38,14 @@ class TestGetDocsUrl(unittest.TestCase):
                 'http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/'
                 'apache-airflow/latest/migration.html',
             ),
-            ('1.10.0', None, 'https://airflow.apache.org/docs/1.10.0/'),
-            ('1.10.0', 'migration.html', 'https://airflow.apache.org/docs/1.10.0/migration.html'),
+            ('1.10.10', None, 'https://airflow.apache.org/docs/apache-airflow/1.10.10/'),
+            (
+                '1.10.10',
+                'project.html',
+                'https://airflow.apache.org/docs/apache-airflow/1.10.10/project.html',
+            ),
         ]
     )
-    def test_should_return_link(self, version, page, expected_urk):
+    def test_should_return_link(self, version, page, expected_url):
         with mock.patch('airflow.version.version', version):
-            assert expected_urk == get_docs_url(page)
+            assert expected_url == get_docs_url(page)


### PR DESCRIPTION
Current link returns 404
https://airflow.apache.org/docs/2.0.0


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
