### PR TITLE
Limit Azure Batch as it breaks dependencies.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,8 @@ atlas = [
     'atlasclient>=0.1.2',
 ]
 azure = [
-    'azure-batch>=8.0.0',
+    # Limited to <10.0.0 until merging https://github.com/apache/airflow/pull/12188
+    'azure-batch>=8.0.0,<10.0.0',
     'azure-cosmos>=3.0.1,<4',
     'azure-datalake-store>=0.0.45',
     'azure-identity>=1.3.1',


### PR DESCRIPTION
Azure Batch introduces dependencies that break Azure Blob Storage.

Until #12188 is solved at least we need to limit Azure Batch
version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
