### PR TITLE
Fixes execution of get_custom_secrets_backend before it is defined

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -199,7 +199,7 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
 
         self.is_validated = False
 
-    def _validate(self):
+    def validate(self):
 
         self._validate_config_dependencies()
 
@@ -452,11 +452,9 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
 
     def read(self, filenames, encoding=None):
         super().read(filenames=filenames, encoding=encoding)
-        self._validate()
 
     def read_dict(self, dictionary, source='<dict>'):
         super().read_dict(dictionary=dictionary, source=source)
-        self._validate()
 
     def has_option(self, section, option):
         try:
@@ -993,3 +991,5 @@ def initialize_secrets_backends() -> List[BaseSecretsBackend]:
 
 
 secrets_backend_list = initialize_secrets_backends()
+
+conf.validate()

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -513,6 +513,7 @@ AIRFLOW_HOME = /root/airflow
                     },
                 }
             )
+            test_conf.validate()
             return test_conf
 
         with self.assertWarns(FutureWarning):


### PR DESCRIPTION
While reading the configuration, custom secret backends
should be already initialized because the secret backends might
provide some configuration values.

Fixes #13254

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
