### PR TITLE
UI: Add queued_by_job_id & external_executor_id Columns to TI View

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3525,10 +3525,14 @@ class TaskInstanceModelView(AirflowModelView):
         'queued_dttm',
         'try_number',
         'pool',
+        'queued_by_job_id',
+        'external_executor_id',
         'log_url',
     ]
 
-    order_columns = [item for item in list_columns if item not in ['try_number', 'log_url']]
+    order_columns = [
+        item for item in list_columns if item not in ['try_number', 'log_url', 'external_executor_id']
+    ]
 
     search_columns = [
         'state',


### PR DESCRIPTION
While debugging one of issues with Celery, it would have helped if `queued_by_job_id` & `external_executor_id` were available to see in Webserver under Browse TaskInstances instead of running psql.

![image](https://user-images.githubusercontent.com/8811558/102943187-41de8600-44af-11eb-9c43-6d93b56aa32d.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
