### PR TITLE
Fix "airflow db upgrade" to upgrade db as intended

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -3111,7 +3111,7 @@ DB_COMMANDS = (
     ActionCommand(
         name='upgrade',
         help="Upgrade the metadata database to latest version",
-        func=upgrade_check,
+        func=upgradedb,
         args=(NOT_DEPRECATED,),
     ),
     ActionCommand(


### PR DESCRIPTION
This commit points the cli "airflow db upgrade" to the intended target of that command.
