### PR TITLE
fix serialize_dag schema migration data column type

### DIFF
--- a/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
+++ b/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
@@ -45,7 +45,7 @@ def upgrade():
         try:
             conn.execute("SELECT JSON_VALID(1)").fetchone()
         except (sa.exc.OperationalError, sa.exc.ProgrammingError):
-            json_type = sa.Text
+            json_type = sa.LargeBinary
 
     op.create_table(
         'serialized_dag',  # pylint: disable=no-member


### PR DESCRIPTION
text column in mysql is too small for large DAGs, resulting in invalid json blob being stored.