### PR TITLE
Installed providers are initialized in subshell

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -149,7 +149,7 @@ function initialization::initialize_base_variables() {
     INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES:="true"}
     export INSTALL_PROVIDERS_FROM_SOURCES
 
-    export INSTALLED_PROVIDERS=(
+    INSTALLED_PROVIDERS+=(
         "amazon"
         "celery"
         "cncf.kubernetes"
@@ -170,10 +170,8 @@ function initialization::initialize_base_variables() {
         "slack"
         "ssh"
     )
-    readonly INSTALLED_PROVIDERS
-
+    export INSTALLED_PROVIDERS
     export INSTALLED_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,imap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
-    readonly INSTALLED_EXTRAS
 
     # default version of PIP USED (This has to be < 20.3 until https://github.com/apache/airflow/issues/12838 is solved)
     PIP_VERSION=${PIP_VERSION:="20.2.4"}
@@ -798,6 +796,17 @@ function initialization::make_constants_read_only() {
     readonly LOCAL_IMAGE_BUILD_CACHE_HASH_FILE
     readonly REMOTE_IMAGE_BUILD_CACHE_HASH_FILE
 
+    readonly INSTALLED_EXTRAS
+    readonly INSTALLED_PROVIDERS
+
+    readonly CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
+    readonly CURRENT_KUBERNETES_VERSIONS
+    readonly CURRENT_KUBERNETES_MODES
+    readonly CURRENT_POSTGRES_VERSIONS
+    readonly CURRENT_MYSQL_VERSIONS
+    readonly CURRENT_KIND_VERSIONS
+    readonly CURRENT_HELM_VERSIONS
+    readonly ALL_PYTHON_MAJOR_MINOR_VERSIONS
 }
 
 # converts parameters to json array


### PR DESCRIPTION
In DockerHub when non-release image was built the initialization
was leaving INSTALLED_PROVIDERS array as empty because the
values were not appended to the existing array but the variable
was re-declared inside the function.

This only happened when initialization was run as a subshell.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
