### PR TITLE
Compile assets automatically when needed at Breeze entry

### DIFF
--- a/airflow/www/compile_assets_if_needed.sh
+++ b/airflow/www/compile_assets_if_needed.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+MD5SUM_FILE="static/dist/sum.md5"
+readonly MD5SUM_FILE
+
+md5sum=$(find package.json yarn.lock static/css static/js -type f | sort  | xargs md5sum)
+old_md5sum=$(cat "${MD5SUM_FILE}" 2>/dev/null || true)
+if [[ ${old_md5sum} != "${md5sum}" ]]; then
+    echo
+    echo "The assets need to be compiled because some of the www source files changed"
+    echo
+    ./compile_assets.sh
+    echo "${md5sum}" > "${MD5SUM_FILE}"
+else
+    echo "No need to compile www assets"
+fi

--- a/airflow/www/compile_assets_if_needed.sh
+++ b/airflow/www/compile_assets_if_needed.sh
@@ -32,5 +32,5 @@ if [[ ${old_md5sum} != "${md5sum}" ]]; then
     ./compile_assets.sh
     echo "${md5sum}" > "${MD5SUM_FILE}"
 else
-    echo "No need to compile www assets"
+    echo "No need to recompile www assets"
 fi

--- a/airflow/www/compile_assets_if_needed.sh
+++ b/airflow/www/compile_assets_if_needed.sh
@@ -27,7 +27,7 @@ md5sum=$(find package.json yarn.lock static/css static/js -type f | sort  | xarg
 old_md5sum=$(cat "${MD5SUM_FILE}" 2>/dev/null || true)
 if [[ ${old_md5sum} != "${md5sum}" ]]; then
     echo
-    echo "The assets need to be compiled because some of the www source files changed"
+    echo "The assets need to be recompiled because some of the www source files changed"
     echo
     ./compile_assets.sh
     echo "${md5sum}" > "${MD5SUM_FILE}"

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -75,26 +75,7 @@ if [[ -z ${INSTALL_AIRFLOW_VERSION=} ]]; then
     echo
     echo "Using already installed airflow version"
     echo
-    if [[ ! -d "${AIRFLOW_SOURCES}/airflow/www/node_modules" ]]; then
-        echo
-        echo "Installing node modules as they are not yet installed (Sources mounted from Host)"
-        echo
-        pushd "${AIRFLOW_SOURCES}/airflow/www/" &>/dev/null || exit 1
-        yarn install --frozen-lockfile
-        echo
-        popd &>/dev/null || exit 1
-    fi
-    if [[ ! -d "${AIRFLOW_SOURCES}/airflow/www/static/dist" ]]; then
-        pushd "${AIRFLOW_SOURCES}/airflow/www/" &>/dev/null || exit 1
-        echo
-        echo "Building production version of JavaScript files (Sources mounted from Host)"
-        echo
-        echo
-        yarn run prod
-        echo
-        echo
-        popd &>/dev/null || exit 1
-    fi
+    "${AIRFLOW_SOURCES}/airflow/www/compile_assets_if_needed.sh"
     # Cleanup the logs, tmp when entering the environment
     sudo rm -rf "${AIRFLOW_SOURCES}"/logs/*
     sudo rm -rf "${AIRFLOW_SOURCES}"/tmp/*


### PR DESCRIPTION
We are storing md5 sum of all relevant files to know when we need
to recompile the assets.

Fixes #12262

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
