### PR TITLE
Rename second pylint pre-commit hook to distinguish it from first

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -571,7 +571,7 @@ repos:
         pass_filenames: true
         require_serial: true
       - id: pylint
-        name: Run pylint
+        name: Run pylint for helm chart tests
         language: system
         entry: "./scripts/ci/pre_commit/pre_commit_pylint.sh"
         files: ^chart/.*\.py$


### PR DESCRIPTION
We have two pylint pre-commit hooks;  i make clear one is for helm chart tests.