### PR TITLE
When CLI changes, we also re-run K8S tests

### DIFF
--- a/PULL_REQUEST_WORKFLOW.rst
+++ b/PULL_REQUEST_WORKFLOW.rst
@@ -154,7 +154,8 @@ The logic implemented for the changes works as follows:
       modifications to any Python code occurs. Example test of this type is verifying proper structure of
       the project including proper naming of all files.
    b) if any of the Airflow API files changed we enable ``API`` test type
-   c) if any of the Airflow CLI files changed we enable ``CLI`` test type
+   c) if any of the Airflow CLI files changed we enable ``CLI`` test type and Kubernetes tests (the
+      K8S tests depend on CLI changes as helm chart uses CLI to run Airflow).
    d) if any of the Provider files changed we enable ``Providers`` test type
    e) if any of the WWW files changed we enable ``WWW`` test type
    f) if any of the Kubernetes files changed we enable ``Kubernetes`` test type

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -536,9 +536,10 @@ function calculate_test_types_to_run() {
         fi
         if [[ ${COUNT_CLI_CHANGED_FILES} != "0" ]]; then
             echo
-            echo "Adding CLI to selected files as ${COUNT_CLI_CHANGED_FILES} CLI files changed"
+            echo "Adding CLI and Kubernetes (they depend on CLI) to selected files as ${COUNT_CLI_CHANGED_FILES} CLI files changed"
             echo
             SELECTED_TESTS="${SELECTED_TESTS} CLI"
+            kubernetes_tests_needed="true"
         fi
         if [[ ${COUNT_PROVIDERS_CHANGED_FILES} != "0" ]]; then
             echo


### PR DESCRIPTION
Since K8S tests use Airflow CLI (via Helm Chart) we should
also run the K8S tests when CLI changes.

Fixes #12780

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
