### PR TITLE
Adds missing python-ldap dependency to LDAP extra.

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1326,7 +1326,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Production image:
                  async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,
-                 http,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,
+                 http,ldap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,
                  virtualenv
 
   --image-tag TAG
@@ -1914,7 +1914,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Production image:
                  async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,
-                 http,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,
+                 http,ldap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,
                  virtualenv
 
   --image-tag TAG
@@ -2436,7 +2436,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           Production image:
                  async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,
-                 http,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,
+                 http,ldap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,
                  virtualenv
 
   --image-tag TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@
 #                        much smaller.
 #
 ARG AIRFLOW_VERSION="2.0.0.dev0"
-ARG AIRFLOW_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,ldap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
 ARG ADDITIONAL_AIRFLOW_EXTRAS=""
 ARG ADDITIONAL_PYTHON_DEPS=""
 
@@ -91,6 +91,7 @@ ARG DEV_APT_DEPS="\
      ldap-utils \
      libffi-dev \
      libkrb5-dev \
+     libldap2-dev \
      libpq-dev \
      libsasl2-2 \
      libsasl2-dev \
@@ -347,6 +348,7 @@ ARG RUNTIME_APT_DEPS="\
        krb5-user \
        ldap-utils \
        libffi6 \
+       libldap-2.4-2 \
        libsasl2-2 \
        libsasl2-modules \
        libssl1.1 \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -86,6 +86,7 @@ RUN mkdir -pv /usr/share/man/man1 \
            graphviz \
            gosu \
            libffi-dev \
+           libldap2-dev \
            libkrb5-dev \
            libpq-dev \
            libsasl2-2 \

--- a/scripts/ci/images/ci_verify_prod_image.sh
+++ b/scripts/ci/images/ci_verify_prod_image.sh
@@ -160,6 +160,7 @@ function verify_production_image_features() {
     check_feature "Import: elasticsearch" "python -c 'import elasticsearch,es.elastic, elasticsearch_dsl'"
     check_feature "Import: grpc" "python -c 'import grpc, google.auth, google_auth_httplib2'"
     check_feature "Import: hashicorp" "python -c 'import hvac'"
+    check_feature "Import: ldap" "python -c 'import ldap'"
     for google_import in "${GOOGLE_IMPORTS[@]}"
     do
         check_feature "Import google: ${google_import}" "python -c 'import ${google_import}'"

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -176,7 +176,7 @@ function initialization::initialize_base_variables() {
         "ssh"
     )
     export INSTALLED_PROVIDERS
-    export INSTALLED_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,imap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
+    export INSTALLED_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,imap,ldap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
 
     # default version of PIP USED (This has to be < 20.3 until https://github.com/apache/airflow/issues/12838 is solved)
     AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION:="20.2.4"}

--- a/setup.py
+++ b/setup.py
@@ -317,6 +317,7 @@ kubernetes = [
 kylin = ['kylinpy>=2.6']
 ldap = [
     'ldap3>=2.5.1',
+    'python-ldap',
 ]
 mongo = [
     'dnspython>=1.13.0,<2.0.0',


### PR DESCRIPTION
Please check only the last commit as this is based on #13329 

It seems that for quite some time (1.10.4) the "ldap" extra
missed python-ldap dependency.

https://issues.apache.org/jira/browse/AIRFLOW-5261

Also LDAP seems to be popular enough to be added as default
extra in the production image.

Fixes #13306

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
