### PR TITLE
Warns politely, do not force run a long operation

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -343,7 +343,7 @@ RUN if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} != "true" ]]; then \
 # commands so as otherwise it copies the _contents_ of static/ in to www/
 COPY airflow/www/webpack.config.js ${AIRFLOW_SOURCES}/airflow/www/
 COPY airflow/www/static ${AIRFLOW_SOURCES}/airflow/www/static/
-
+COPY airflow/www/compile_assets.sh ${AIRFLOW_SOURCES}/airflow/www/compile_assets.sh
 # Package JS/css for production
 RUN airflow/www/compile_assets.sh
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -345,7 +345,7 @@ COPY airflow/www/webpack.config.js ${AIRFLOW_SOURCES}/airflow/www/
 COPY airflow/www/static ${AIRFLOW_SOURCES}/airflow/www/static/
 
 # Package JS/css for production
-RUN yarn --cwd airflow/www run prod
+RUN airflow/www/compile_assets.sh
 
 COPY scripts/in_container/entrypoint_ci.sh /entrypoint
 RUN chmod a+x /entrypoint

--- a/airflow/www/ask_for_recompile_assets_if_needed.sh
+++ b/airflow/www/ask_for_recompile_assets_if_needed.sh
@@ -23,14 +23,18 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 MD5SUM_FILE="static/dist/sum.md5"
 readonly MD5SUM_FILE
 
-md5sum=$(find package.json yarn.lock static/css static/js -type f | sort  | xargs md5sum)
+YELLOW='\033[1;33m'
+NO_COLOR='\033[0m'
+
+md5sum=$(find package.json yarn.lock static/css static/js -type f | sort | xargs md5sum)
 old_md5sum=$(cat "${MD5SUM_FILE}" 2>/dev/null || true)
 if [[ ${old_md5sum} != "${md5sum}" ]]; then
     echo
-    echo "The assets need to be recompiled because some of the www source files changed"
-    echo
-    ./compile_assets.sh
-    echo "${md5sum}" > "${MD5SUM_FILE}"
+    echo "${YELLOW}WARNING: It seems that the generated assets files do not match the content of the sources.${NO_COLOR}"
+    echo "To recompile assets, run:"
+    echo ""
+    echo "   ./airflow/www/compile_assets.sh"
+    echo ""
 else
     echo "No need to recompile www assets"
 fi

--- a/airflow/www/compile_assets.sh
+++ b/airflow/www/compile_assets.sh
@@ -20,6 +20,9 @@ set -e
 
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 
+MD5SUM_FILE="static/dist/sum.md5"
+readonly MD5SUM_FILE
+
 # first bump up package.json manually, commit and tag
 if [[ -d ./static/dist ]]; then
   rm -f ./static/dist/*
@@ -27,3 +30,5 @@ fi
 
 yarn install --frozen-lockfile
 yarn run build
+
+find package.json yarn.lock static/css static/js -type f | sort | xargs md5sum > "${MD5SUM_FILE}"

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -75,7 +75,7 @@ if [[ -z ${INSTALL_AIRFLOW_VERSION=} ]]; then
     echo
     echo "Using already installed airflow version"
     echo
-    "${AIRFLOW_SOURCES}/airflow/www/compile_assets_if_needed.sh"
+    "${AIRFLOW_SOURCES}/airflow/www/ask_for_recompile_assets_if_needed.sh"
     # Cleanup the logs, tmp when entering the environment
     sudo rm -rf "${AIRFLOW_SOURCES}"/logs/*
     sudo rm -rf "${AIRFLOW_SOURCES}"/tmp/*

--- a/scripts/in_container/run_tmux.sh
+++ b/scripts/in_container/run_tmux.sh
@@ -51,6 +51,10 @@ if [[ ${START_AIRFLOW:="false"} == "true" ]]; then
     tmux select-pane -t 2
     tmux send-keys 'airflow webserver' C-m
 
+    tmux select-pane -t 0
+    tmux split-window -h
+    tmux send-keys 'cd airflow/www/; yarn dev' C-m
+
     # Attach Session, on the Main window
     tmux select-pane -t 0
     tmux send-keys "./scripts/in_container/run_tmux_welcome.sh" C-m


### PR DESCRIPTION
I personally (as probably most of the developers in this project) do not deal with the development of Javascript code, but `entrypoint_ci.sh` forces us to recompile resources even when we don't need it. This takes a lot of time and is frustrating. This can happen very often as even a small change forces you to recompile assets.  This is especially problematic when working with two branches that have two different versions of JS files. Then, each restart of the environment means that we have to wait until the files are regenerated.

Since most developers don't need to keep these files in good shape, I didn't decide to add an additional question, but did give a warning with yellow text.

Additionally, I fixed one problem. When we run the environment with the use of a pre-baked image, e.g. on CI, or when using the "--github-image-id" option, we do not want to recompile assets. Unfortunately, the finished images did not contain checksums, because `Dockerfile` files run `compile_assets.sh` scripts, which did not generate checksums. I moved the checksum generation to the compile_assets.sh file, so now the pre-baked image will have checksums and won't regenerate assets.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
