### PR TITLE
Add pre-commit hook limiting hook name length

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -240,7 +240,8 @@ repos:
         pass_filenames: false
         entry: ./scripts/ci/pre_commit/pre_commit_check_order_setup.py
       - id: setup-extra-packages
-        name: Checks if all the libraries in setup.py are listed in extra-packages-ref.rst file
+        name: Checks setup extra packages
+        description: Checks if all the libraries in setup.py are listed in extra-packages-ref.rst file
         language: python
         files: ^setup.py$|^docs/apache-airflow/extra-packages-ref.rst$
         pass_filenames: false
@@ -327,7 +328,8 @@ repos:
         files: \.py$
       - id: base-operator
         language: pygrep
-        name: Make sure BaseOperator[Link] is imported from airflow.models.baseoperator in core
+        name: Check BaseOperator[Link] core imports
+        description: Make sure BaseOperator[Link] is imported from airflow.models.baseoperator in core
         entry: "from airflow\\.models import.* BaseOperator"
         files: \.py$
         pass_filenames: true
@@ -341,7 +343,8 @@ repos:
           ^dev/provider_packages/.*$
       - id: base-operator
         language: pygrep
-        name: Make sure BaseOperator[Link] is imported from airflow.models outside of core
+        name: Check BaseOperator[Link] other imports
+        description: Make sure BaseOperator[Link] is imported from airflow.models outside of core
         entry: "from airflow\\.models\\.baseoperator import.* BaseOperator"
         pass_filenames: true
         files: >
@@ -353,8 +356,9 @@ repos:
           ^airflow/providers/.*\.py$
       - id: provide-create-sessions
         language: pygrep
-        name: provide_session and create_session imported from airflow.utils.session
-        description: To avoid import cycles.
+        name: Check provide_session and create_session imports
+        description: provide_session and create_session should be imported from airflow.utils.session
+          to avoid import cycles.
         entry: "from airflow\\.utils\\.db import.* (provide_session|create_session)"
         files: \.py$
         pass_filenames: true
@@ -461,8 +465,18 @@ repos:
         language: system
         files: ^.pre-commit-config.yaml$|^STATIC_CODE_CHECKS.rst|^breeze-complete$
         require_serial: true
+      - id: pre-commit-hook-names
+        name: Ensure hook ids are not overly long
+        entry: ./scripts/ci/pre_commit/pre_commit_check_pre_commit_hook_names.py
+        args:
+          - --max-length=70
+        language: python
+        files: ^.pre-commit-config.yaml$
+        additional_dependencies: ['pyyaml']
+        require_serial: true
+        pass_filenames: false
       - id: airflow-providers-available
-        name: Checks for providers being available when declared by extras in setup.py
+        name: Checks providers available when declared by extras in setup.py
         language: python
         entry: ./scripts/ci/pre_commit/pre_commit_check_extras_have_providers.py
         files: "setup.py|^airflow/providers/.*.py"

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2156,11 +2156,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
                  lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
                  no-providers-in-core-examples no-relative-imports pre-commit-descriptions
-                 provide-create-sessions providers-init-file provider-yamls pydevd pydocstyle pylint
-                 pylint-tests python-no-log-warn pyupgrade restrict-start_date rst-backticks
-                 setup-order setup-extra-packages shellcheck sort-in-the-wild stylelint
-                 trailing-whitespace update-breeze-file update-extras update-local-yml-file
-                 update-setup-cfg-file version-sync yamllint
+                 pre-commit-hook-names provide-create-sessions providers-init-file provider-yamls
+                 pydevd pydocstyle pylint pylint-tests python-no-log-warn pyupgrade
+                 restrict-start_date rst-backticks setup-order setup-extra-packages shellcheck
+                 sort-in-the-wild stylelint trailing-whitespace update-breeze-file update-extras
+                 update-local-yml-file update-setup-cfg-file version-sync yamllint
 
         You can pass extra arguments including options to to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -134,6 +134,8 @@ require Breeze Docker images to be installed locally:
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``pre-commit-descriptions``           Check if all pre-commits are described in docs.
 ----------------------------------- ---------------------------------------------------------------- ------------
+``pre-commit-hook-names``             Check that hook names are not overly long.
+----------------------------------- ---------------------------------------------------------------- ------------
 ``provide-create-sessions``           Make sure provide-session and create-session imports are OK.
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``providers-init-file``               Check that provider's __init__.py file is removed

--- a/breeze-complete
+++ b/breeze-complete
@@ -108,6 +108,7 @@ mypy-helm
 no-providers-in-core-examples
 no-relative-imports
 pre-commit-descriptions
+pre-commit-hook-names
 provide-create-sessions
 providers-init-file
 provider-yamls

--- a/scripts/ci/pre_commit/pre_commit_check_pre_commit_hook_names.py
+++ b/scripts/ci/pre_commit/pre_commit_check_pre_commit_hook_names.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Module to check pre-commit hook names for length
+"""
+import argparse
+import sys
+
+import yaml
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--max-length', help="Max length for hook names")
+    args = parser.parse_args()
+    max_length = int(args.max_length) or 70
+
+    retval = 0
+
+    with open('.pre-commit-config.yaml', 'rb') as f:
+        content = yaml.safe_load(f)
+        errors = get_errors(content, max_length)
+    if errors:
+        retval = 1
+        print(f"found pre-commit hook names with length exceeding {max_length} characters")
+        print("move add details in description if necessary")
+    for hook_name in errors:
+        print(f"    * '{hook_name}': length {len(hook_name)}")
+    return retval
+
+
+def get_errors(content, max_length):
+    errors = []
+    for repo in content['repos']:
+        for hook in repo['hooks']:
+            if 'name' not in hook:
+                continue
+            name = hook['name']
+            if len(name) > max_length:
+                errors.append(name)
+    return errors
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
If we constrain hook name length to 70, we keep pre-commit display readable

Beyond this number, you get really ugly output.

If it's desirable to document more details, you can put it in `description`.