### PR TITLE
Prefer newer CLI syntax over legacy in helm chart

### DIFF
--- a/chart/templates/create-user-job.yaml
+++ b/chart/templates/create-user-job.yaml
@@ -65,7 +65,7 @@ spec:
             - "bash"
             - "-c"
             # Support running against 1.10.x and 2.0.0dev/master
-            - 'airflow create_user "$@" || airflow users create "$@"'
+            - 'airflow users create "$@" || airflow create_user "$@"'
             - --
             - "-r"
             - {{ .Values.webserver.defaultUser.role }}

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         - name: flower
           image: {{ template "flower_image" . }}
           imagePullPolicy: {{ .Values.images.flower.pullPolicy }}
-          args: ["bash", "-c", "airflow flower || airflow celery flower"]
+          args: ["bash", "-c", "airflow celery flower || airflow flower"]
           resources:
 {{ toYaml .Values.flower.resources | indent 12 }}
           volumeMounts:

--- a/chart/templates/migrate-database-job.yaml
+++ b/chart/templates/migrate-database-job.yaml
@@ -61,7 +61,7 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           # Support running against 1.10.x and 2.0.0dev/master
-          args: ["bash", "-c", "airflow upgradedb || airflow db upgrade"]
+          args: ["bash", "-c", "airflow db upgrade || airflow upgradedb"]
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -115,7 +115,7 @@ spec:
         - name: worker
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          args: ["bash", "-c", "airflow worker || airflow celery worker"]
+          args: ["bash", "-c", "airflow celery worker || airflow worker"]
           resources:
 {{ toYaml .Values.workers.resources | indent 12 }}
           ports:


### PR DESCRIPTION
Helm chart currently tries legacy commands first e.g. `airflow upgradedb || airflow db upgrade`.

At this point we should try newer syntax first since it is supported by 1.10.14 and 2.0.0.

It will save a little time in pod start and clean up logs.
