### PR TITLE
Move snowflake limitations to snowflake

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -41,7 +41,7 @@ ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 
 # By increasing this number we can do force build of all dependencies
-ARG DEPENDENCIES_EPOCH_NUMBER="4"
+ARG DEPENDENCIES_EPOCH_NUMBER="5"
 # Increase the value below to force reinstalling of all dependencies
 ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
 
@@ -193,7 +193,7 @@ RUN mkdir -pv ${AIRFLOW_HOME} && \
     mkdir -pv ${AIRFLOW_HOME}/logs
 
 # Increase the value here to force reinstalling Apache Airflow pip dependencies
-ARG PIP_DEPENDENCIES_EPOCH_NUMBER="4"
+ARG PIP_DEPENDENCIES_EPOCH_NUMBER="5"
 ENV PIP_DEPENDENCIES_EPOCH_NUMBER=${PIP_DEPENDENCIES_EPOCH_NUMBER}
 
 # Install BATS and its dependencies for "in container" tests

--- a/setup.py
+++ b/setup.py
@@ -226,8 +226,7 @@ cloudant = [
 crypto = [
     # Cryptography 3.2 for python 2.7 is broken
     # https://github.com/pyca/cryptography/issues/5359#issuecomment-727622403
-    # Snowflake requires <3.0
-    'cryptography>=0.9.3,<3.0; python_version<"3.0"',
+    'cryptography>=0.9.3,<3.2; python_version<"3.0"',
     'cryptography>=0.9.3;python_version>="3.0"',
 ]
 dask = [
@@ -391,6 +390,9 @@ slack = [
 ]
 snowflake = [
     'boto3<1.11',
+    'cryptography>=0.9.3,<3.0;python_version<"3.0"',  # Snowflake requires <3.0
+    'requests>=2.20.0,<2.23.0;python_version<"3.0"',  # Required to keep snowflake happy
+    'requests>=2.20.0,<2.24.0;python_version>="3.0"',  # Required to keep snowflake happy
     'snowflake-connector-python>=1.5.2',
     'snowflake-sqlalchemy>=1.1.0',
 ]
@@ -605,8 +607,6 @@ INSTALL_REQUIREMENTS = [
     'colorlog==4.0.2',
     'configparser>=3.5.0, <3.6.0',
     'croniter>=0.3.17, <0.4',
-    'cryptography>=0.9.3,<3.0; python_version<"3.0"',  # required by snowflake
-    'cryptography>=0.9.3;python_version>="3.0"',
     'dill>=0.2.2, <0.4',
     'email-validator',
     'enum34~=1.1.6;python_version<"3.4"',
@@ -642,8 +642,7 @@ INSTALL_REQUIREMENTS = [
     'python-dateutil>=2.3, <3',
     'python-nvd3~=0.15.0',
     'python-slugify>=3.0.0,<5.0',
-    'requests>=2.20.0, <2.23.0;python_version<"3.0"',  # Required to keep snowflake happy
-    'requests>=2.20.0, <2.24.0;python_version>="3.0"',  # Required to keep snowflake happy
+    'requests>=2.20.0, <3',
     'setproctitle>=1.1.8, <2',
     'sqlalchemy~=1.3',
     'sqlalchemy_jsonfield==0.8.0;python_version<"3.5"',


### PR DESCRIPTION
This PR follows on #13286 by moving the other package limitations that snowflake brings to the snowflake option.

This limits the impacts that snowflake's peculiarities has on the airflow user base to only those who use snowflake.

I have attempted to revert all of the package limitations to as they were before they went in with #12636
* Cryptography: https://github.com/apache/airflow/commit/7ef3e7a296ead9dd499a6524ecfbfa0d67f9131c
* Requests: https://github.com/apache/airflow/pull/12636/files#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52L122

@potiuk fyi

Note: Bumped the epoch number as specified in the [comment](https://github.com/apache/airflow/blob/v1-10-stable/setup.py#L428)