### PR TITLE
Print better error message when tests fail

### DIFF
--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -89,11 +89,16 @@ function start_end::script_end {
     #shellcheck disable=2181
     local exit_code=$?
     if [[ ${exit_code} != 0 ]]; then
+        # Finish previous group so that output can be written
         # Cat output log in case we exit with error but only if we do not PRINT_INFO_FROM_SCRIPTS
         # Because it will be printed immediately by "tee"
         if [[ -f "${OUTPUT_LOG}" && ${PRINT_INFO_FROM_SCRIPTS} == "false" ]]; then
             cat "${OUTPUT_LOG}"
         fi
+        start_end::group_end
+        echo
+        echo "${COLOR_RED_ERROR} The previous step completed with error. Please take a look at output above ${COLOR_RESET}"
+        echo
         if [[ ${CI} == "true" ]]; then
             local container
             for container in $(docker ps --format '{{.Names}}')


### PR DESCRIPTION
The recently added log groupping hides error messages in case
there is an error in tests. You need to manually unfold last test
step which is somewhate hidden - it is followed by several
'dump-container' logs.

This change adds clear error message showing the exact log
group that you need to unfold in case you want to look for
a problem.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
