### PR TITLE
Kuba openfaas sync call

### DIFF
--- a/airflow/providers/openfaas/hooks/openfaas.py
+++ b/airflow/providers/openfaas/hooks/openfaas.py
@@ -80,9 +80,7 @@ class OpenFaasHook(BaseHook):
             raise AirflowException('failed to invoke function')
 
     def invoke_function(self, body: Dict[str, Any]) -> None:
-        """
-        Invoking function synchronously, will block until function completes and returns
-        """
+        """Invoking function synchronously, will block until function completes and returns"""
         url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
         self.log.info("Invoking function synchronously %s", url)
         response = requests.post(url, body)

--- a/airflow/providers/openfaas/hooks/openfaas.py
+++ b/airflow/providers/openfaas/hooks/openfaas.py
@@ -39,6 +39,7 @@ class OpenFaasHook(BaseHook):
 
     GET_FUNCTION = "/system/function/"
     INVOKE_ASYNC_FUNCTION = "/async-function/"
+    INVOKE_FUNCTION = "/function/"
     DEPLOY_FUNCTION = "/system/functions"
     UPDATE_FUNCTION = "/system/functions"
 
@@ -68,9 +69,9 @@ class OpenFaasHook(BaseHook):
                 self.log.info("Function deployed %s", self.function_name)
 
     def invoke_async_function(self, body: Dict[str, Any]) -> None:
-        """Invoking function"""
+        """Invoking function asynchronously"""
         url = self.get_conn().host + self.INVOKE_ASYNC_FUNCTION + self.function_name
-        self.log.info("Invoking function %s", url)
+        self.log.info("Invoking function asynchronously %s", url)
         response = requests.post(url, body)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
@@ -78,6 +79,22 @@ class OpenFaasHook(BaseHook):
             self.log.error("Response status %d", response.status_code)
             raise AirflowException('failed to invoke function')
 
+    def invoke_function(self, body):
+        """
+        Invoking function synchronously, will block until function completes and returns
+        """
+        url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
+        self.log.info("Invoking function synchronously %s", url)
+        response = requests.post(url, json=body)
+        if response.ok:
+            self.log.info("Invoked %s", self.function_name)
+            self.log.info("Response code %s", response.status_code)
+            self.log.info("Response %s", response.text)
+            return (response.status_code,response.text)
+        else:
+            self.log.error("Response status %d", response.status_code)
+            raise AirflowException('failed to invoke function')
+        
     def update_function(self, body: Dict[str, Any]) -> None:
         """Update OpenFaaS function"""
         url = self.get_conn().host + self.UPDATE_FUNCTION

--- a/airflow/providers/openfaas/hooks/openfaas.py
+++ b/airflow/providers/openfaas/hooks/openfaas.py
@@ -85,7 +85,7 @@ class OpenFaasHook(BaseHook):
         """
         url = self.get_conn().host + self.INVOKE_FUNCTION + self.function_name
         self.log.info("Invoking function synchronously %s", url)
-        response = requests.post(url, json=body)
+        response = requests.post(url, body)
         if response.ok:
             self.log.info("Invoked %s", self.function_name)
             self.log.info("Response code %s", response.status_code)

--- a/airflow/providers/openfaas/hooks/openfaas.py
+++ b/airflow/providers/openfaas/hooks/openfaas.py
@@ -79,7 +79,7 @@ class OpenFaasHook(BaseHook):
             self.log.error("Response status %d", response.status_code)
             raise AirflowException('failed to invoke function')
 
-    def invoke_function(self, body):
+    def invoke_function(self, body: Dict[str, Any]) -> None:
         """
         Invoking function synchronously, will block until function completes and returns
         """

--- a/airflow/providers/openfaas/hooks/openfaas.py
+++ b/airflow/providers/openfaas/hooks/openfaas.py
@@ -91,7 +91,7 @@ class OpenFaasHook(BaseHook):
         else:
             self.log.error("Response status %d", response.status_code)
             raise AirflowException('failed to invoke function')
-        
+
     def update_function(self, body: Dict[str, Any]) -> None:
         """Update OpenFaaS function"""
         url = self.get_conn().host + self.UPDATE_FUNCTION

--- a/airflow/providers/openfaas/hooks/openfaas.py
+++ b/airflow/providers/openfaas/hooks/openfaas.py
@@ -90,7 +90,6 @@ class OpenFaasHook(BaseHook):
             self.log.info("Invoked %s", self.function_name)
             self.log.info("Response code %s", response.status_code)
             self.log.info("Response %s", response.text)
-            return (response.status_code,response.text)
         else:
             self.log.error("Response status %d", response.status_code)
             raise AirflowException('failed to invoke function')

--- a/tests/providers/openfaas/hooks/test_openfaas.py
+++ b/tests/providers/openfaas/hooks/test_openfaas.py
@@ -33,6 +33,7 @@ FUNCTION_NAME = "function_name"
 class TestOpenFaasHook(unittest.TestCase):
     GET_FUNCTION = "/system/function/"
     INVOKE_ASYNC_FUNCTION = "/async-function/"
+    INVOKE_FUNCTION = "/function/"
     DEPLOY_FUNCTION = "/system/functions"
     UPDATE_FUNCTION = "/system/functions"
 

--- a/tests/providers/openfaas/hooks/test_openfaas.py
+++ b/tests/providers/openfaas/hooks/test_openfaas.py
@@ -101,7 +101,7 @@ class TestOpenFaasHook(unittest.TestCase):
         mock_get_connection.return_value = mock_connection
 
         with self.assertRaises(AirflowException) as context:
-            self.hook.invoke_async_function({})
+            self.hook.invoke_function({})
         self.assertIn('failed to invoke function', str(context.exception))
 
     @mock.patch.object(BaseHook, 'get_connection')
@@ -110,11 +110,11 @@ class TestOpenFaasHook(unittest.TestCase):
         m.post(
             "http://open-faas.io" + self.INVOKE_FUNCTION + FUNCTION_NAME,
             json=self.mock_response,
-            status_code=202,
+            status_code=200,
         )
         mock_connection = Connection(host="http://open-faas.io")
         mock_get_connection.return_value = mock_connection
-        self.assertEqual(self.hook.invoke_async_function({}), None)
+        self.assertEqual(self.hook.invoke_function({}), None)
 
     @mock.patch.object(BaseHook, 'get_connection')
     @requests_mock.mock()

--- a/tests/providers/openfaas/hooks/test_openfaas.py
+++ b/tests/providers/openfaas/hooks/test_openfaas.py
@@ -115,7 +115,6 @@ class TestOpenFaasHook(unittest.TestCase):
         mock_get_connection.return_value = mock_connection
         self.assertEqual(self.hook.invoke_async_function({}), None)
 
-        
     @mock.patch.object(BaseHook, 'get_connection')
     @requests_mock.mock()
     def test_invoke_async_function_false(self, mock_get_connection, m):

--- a/tests/providers/openfaas/hooks/test_openfaas.py
+++ b/tests/providers/openfaas/hooks/test_openfaas.py
@@ -90,6 +90,34 @@ class TestOpenFaasHook(unittest.TestCase):
 
     @mock.patch.object(BaseHook, 'get_connection')
     @requests_mock.mock()
+    def test_invoke_function_false(self, mock_get_connection, m):
+        m.post(
+            "http://open-faas.io" + self.INVOKE_FUNCTION + FUNCTION_NAME,
+            json=self.mock_response,
+            status_code=400,
+        )
+        mock_connection = Connection(host="http://open-faas.io")
+        mock_get_connection.return_value = mock_connection
+
+        with self.assertRaises(AirflowException) as context:
+            self.hook.invoke_async_function({})
+        self.assertIn('failed to invoke function', str(context.exception))
+
+    @mock.patch.object(BaseHook, 'get_connection')
+    @requests_mock.mock()
+    def test_invoke_function_true(self, mock_get_connection, m):
+        m.post(
+            "http://open-faas.io" + self.INVOKE_FUNCTION + FUNCTION_NAME,
+            json=self.mock_response,
+            status_code=202,
+        )
+        mock_connection = Connection(host="http://open-faas.io")
+        mock_get_connection.return_value = mock_connection
+        self.assertEqual(self.hook.invoke_async_function({}), None)
+
+        
+    @mock.patch.object(BaseHook, 'get_connection')
+    @requests_mock.mock()
     def test_invoke_async_function_false(self, mock_get_connection, m):
         m.post(
             "http://open-faas.io" + self.INVOKE_ASYNC_FUNCTION + FUNCTION_NAME,


### PR DESCRIPTION
Adding a way to invoke openfaas functions synchronously, waiting for the invocation to complete.

---


Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
