### PR TITLE
Add 'mongo_collection' to template_fields in MongoToS3Operator

### DIFF
--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -38,7 +38,7 @@ class MongoToS3Operator(BaseOperator):
                 to perform transformations unique to those operators needs
     """
 
-    template_fields = ['s3_key', 'mongo_query']
+    template_fields = ['s3_key', 'mongo_query', 'mongo_collection']
     # pylint: disable=too-many-instance-attributes
 
     @apply_defaults

--- a/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
@@ -65,7 +65,7 @@ class TestMongoToS3Operator(unittest.TestCase):
         self.assertEqual(self.mock_operator.s3_key, S3_KEY)
 
     def test_template_field_overrides(self):
-        self.assertEqual(self.mock_operator.template_fields, ['s3_key', 'mongo_query'])
+        self.assertEqual(self.mock_operator.template_fields, ['s3_key', 'mongo_query', 'mongo_collection'])
 
     def test_render_template(self):
         ti = TaskInstance(self.mock_operator, DEFAULT_DATE)


### PR DESCRIPTION
Add `mongo_collection` to template_fields in `MongoToS3Operator` class to allow templating mongo collections.

closes #13360 