### PR TITLE
upgrade mysql-connector-python to 8.0.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ mssql = [
     'pymssql~=2.1,>=2.1.5',
 ]
 mysql = [
-    'mysql-connector-python>=8.0.11, <=8.0.18',
+    'mysql-connector-python>=8.0.11, <=8.0.22',
     'mysqlclient>=1.3.6,<1.4',
 ]
 odbc = [

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ mssql = [
     'pymssql~=2.1,>=2.1.5',
 ]
 mysql = [
-    'mysql-connector-python>=8.0.11, <=8.0.22',
+    'mysql-connector-python>=8.0.11, <=8.0.21',
     'mysqlclient>=1.3.6,<1.4',
 ]
 odbc = [

--- a/setup.py
+++ b/setup.py
@@ -324,7 +324,7 @@ mssql = [
     'pymssql~=2.1,>=2.1.5',
 ]
 mysql = [
-    'mysql-connector-python>=8.0.11, <=8.0.21',
+    'mysql-connector-python>=8.0.11, <=8.0.22',
     'mysqlclient>=1.3.6,<1.4',
 ]
 odbc = [


### PR DESCRIPTION
https://github.com/apache/airflow/pull/6576 added support for  mysql-connector-python lib but also pinned the version as >=8.0.11, <=8.0.18 

 8.0.18 was the newest version when https://github.com/apache/airflow/pull/6576  was submitted but there are newer versions since.
 
 I didn't set as <8.1.0 because it's better to be more cautious with this lib (I assume this was also the original thought when https://github.com/apache/airflow/pull/6576 was summited)