### PR TITLE
Add clearer exception for read failures in macro plugin upgrade check

### DIFF
--- a/airflow/upgrade/rules/airflow_macro_plugin_removed.py
+++ b/airflow/upgrade/rules/airflow_macro_plugin_removed.py
@@ -39,9 +39,16 @@ class AirflowMacroPluginRemovedRule(BaseRule):
         problems = []
         class_name_to_check = self.MACRO_PLUGIN_CLASS.split(".")[-1]
         with open(file_path, "r") as file_pointer:
-            for line_number, line in enumerate(file_pointer, 1):
-                if class_name_to_check in line:
-                    problems.append(self._change_info(file_path, line_number))
+            try:
+                for line_number, line in enumerate(file_pointer, 1):
+                    if class_name_to_check in line:
+                        problems.append(self._change_info(file_path, line_number))
+            except UnicodeDecodeError:
+                raise Exception(
+                    "Unable to read file {}, it may need to be added to the .airflowignore".format(
+                        file_path
+                    )
+                )
         return problems
 
     def check(self):

--- a/airflow/upgrade/rules/airflow_macro_plugin_removed.py
+++ b/airflow/upgrade/rules/airflow_macro_plugin_removed.py
@@ -44,11 +44,7 @@ class AirflowMacroPluginRemovedRule(BaseRule):
                     if class_name_to_check in line:
                         problems.append(self._change_info(file_path, line_number))
             except UnicodeDecodeError:
-                raise Exception(
-                    "Unable to read file {}, it may need to be added to the .airflowignore".format(
-                        file_path
-                    )
-                )
+                problems.append("Unable to read python file {}".format(file_path))
         return problems
 
     def check(self):
@@ -56,5 +52,7 @@ class AirflowMacroPluginRemovedRule(BaseRule):
         file_paths = list_py_file_paths(directory=dag_folder, include_examples=False)
         problems = []
         for file_path in file_paths:
+            if not file_path.endswith(".py"):
+                continue
             problems.extend(self._check_file(file_path))
         return problems


### PR DESCRIPTION
Resolves #13349

This PR adds a more useful error message when processing files using the `AirflowMacroPluginRemovedRule` upgrade check. It also prompts users to add said files to the `.airflowignore` file (which resolved the issue in our case).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
