### PR TITLE
Fix Jinja undefined upgrade check for non-templated objects

### DIFF
--- a/airflow/upgrade/rules/undefined_jinja_varaibles.py
+++ b/airflow/upgrade/rules/undefined_jinja_varaibles.py
@@ -48,9 +48,6 @@ The user should do either of the following to fix this -
         if isinstance(rendered_content, six.string_types):
             return set(re.findall(r"{{(.*?)}}", rendered_content))
 
-        elif isinstance(rendered_content, (int, float, bool)):
-            return set()
-
         elif isinstance(rendered_content, (tuple, list, set)):
             debug_error_messages = set()
             for element in rendered_content:
@@ -63,10 +60,14 @@ The user should do either of the following to fix this -
                 debug_error_messages.update(self._check_rendered_content(value))
             return debug_error_messages
 
-        else:
+        elif hasattr(rendered_content, "template_fields"):
             if seen_oids is None:
                 seen_oids = set()
             return self._nested_check_rendered(rendered_content, seen_oids)
+
+        else:
+            # Rendered content is not actually rendered
+            return set()
 
     def _nested_check_rendered(self, rendered_content, seen_oids):
         debug_error_messages = set()

--- a/tests/upgrade/rules/test_undefined_jinja_varaibles.py
+++ b/tests/upgrade/rules/test_undefined_jinja_varaibles.py
@@ -19,7 +19,6 @@ from tempfile import mkdtemp
 from unittest import TestCase
 
 import jinja2
-import pytest
 
 from airflow import DAG
 from airflow.models import DagBag
@@ -156,7 +155,6 @@ class TestUndefinedJinjaVariablesRule(TestCase):
 
         assert len(messages) == 0
 
-    @pytest.mark.quarantined
     def test_invalid_check(self):
         dagbag = DagBag(dag_folder=self.empty_dir, include_examples=False)
         dagbag.dags[self.invalid_dag.dag_id] = self.invalid_dag

--- a/tests/upgrade/rules/test_undefined_jinja_varaibles.py
+++ b/tests/upgrade/rules/test_undefined_jinja_varaibles.py
@@ -66,6 +66,12 @@ class TestUndefinedJinjaVariablesRule(TestCase):
                 "float": "{{ params.float }}",
                 "string": "{{ params.string }}",
                 "boolean": "{{ params.boolean }}",
+                "integer_direct": 1,
+                "float_direct": 1.0,
+                "string_direct": "test_string",
+                "boolean_direct": True,
+                "none_direct": None,
+                "object_direct": object(),
             },
             params={
                 "integer": 1,


### PR DESCRIPTION
Resolves #13350

This PR fixes an issue with the `UndefinedJinjaVariablesRule` upgrade check wherein non-templated objects passed into tasks under fields that would be templated would break the upgrade check. The altered logic now correctly handles cases where regular objects are passed in directly without affecting the current tested behavior.

Also, the `test_invalid_check` test was quarantined in #12657 - I've removed the quarantine here in hopes that it might be less flaky.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
