### PR TITLE
Bugfix: Sync Access Control defined in DAGs when running sync-perm

### DIFF
--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -30,6 +30,8 @@ def sync_perm(args):
     # Add missing permissions for all the Base Views
     appbuilder.add_permissions(update_perms=True)
     print('Updating permission on all DAG views')
-    dags = DagBag(read_dags_from_db=True).dags.values()
+    dagbag = DagBag(read_dags_from_db=True)
+    dagbag.collect_dags_from_db()
+    dags = dagbag.dags.values()
     for dag in dags:
         appbuilder.sm.sync_perm_for_dag(dag.dag_id, dag.access_control)


### PR DESCRIPTION
fixes https://github.com/apache/airflow/issues/13376

Running `airflow sync-perm` CLI command does not synchronize the permission granted through the DAG via access_control.

This is because of Dag Serialization. When dag serialization is enabled, the dagbag will exhibit a lazy loading behaviour.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
