### PR TITLE
Fix Apache Airflow icon link in Helm Chart

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -21,6 +21,6 @@ apiVersion: v1
 name: airflow
 version: 1.0.0
 description: Helm chart to deploy Apache Airflow
-icon: https://www.astronomer.io/static/airflowNewA.png
+icon: https://airflow.apache.org/docs/apache-airflow/stable/_images/pin_large.png
 keywords:
   - airflow


### PR DESCRIPTION
Previous link (https://www.astronomer.io/static/airflowNewA.png) is broken.

This commit uses link from official docs too instead of Astronomer.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
