### PR TITLE
Add upgrade check option to list checks

### DIFF
--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -41,6 +41,15 @@ def check_upgrade(formatter, rules):
     return all_rule_statuses
 
 
+def list_checks():
+    print()
+    print("Upgrade Checks:")
+    for rule in ALL_RULES:
+        rule_name = rule.__class__.__name__
+        print("- {} [{}]".format(rule.title, rule_name))
+    print()
+
+
 def register_arguments(subparser):
     subparser.add_argument(
         "-s", "--save",
@@ -49,17 +58,21 @@ def register_arguments(subparser):
     subparser.add_argument(
         "-i", "--ignore",
         help="Ignore a rule. Can be used multiple times.",
-        action='append',
+        action="append",
     )
     subparser.add_argument(
         "-c", "--config",
         help="Path to upgrade check config yaml file.",
     )
-    subparser.set_defaults(func=run)
+    subparser.add_argument(
+        "-l", "--list",
+        help="List the upgrade checks and their class names",
+        action="store_true",
+    )
 
 
 def run(args):
-    from airflow.upgrade.formatters import (ConsoleFormatter, JSONFormatter)
+    from airflow.upgrade.formatters import ConsoleFormatter, JSONFormatter
     from airflow.upgrade.config import UpgradeConfig
 
     if args.save:
@@ -94,7 +107,10 @@ def __main__():
     parser = argparse.ArgumentParser()
     register_arguments(parser)
     args = parser.parse_args()
-    args.func(args)
+    if args.list:
+        list_checks()
+    else:
+        run(args)
 
 
 if __name__ == "__main__":

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -46,7 +46,7 @@ def list_checks():
     print("Upgrade Checks:")
     for rule in ALL_RULES:
         rule_name = rule.__class__.__name__
-        print("- {} [{}]".format(rule.title, rule_name))
+        print("- {}: {}".format(rule_name, rule.title))
     print()
 
 

--- a/airflow/upgrade/rules/__init__.py
+++ b/airflow/upgrade/rules/__init__.py
@@ -31,4 +31,6 @@ def get_rules():
             bases = [b.__name__ for b in cls.__bases__]
             if cls.__name__ != "BaseRule" and "BaseRule" in bases:
                 rule_classes.append(cls)
-    return rule_classes
+    # Sort rules alphabetically by class name, while maintaining that the airflow version
+    # check should remain first
+    return rule_classes[:1] + sorted(rule_classes[1:], key=lambda r: r.__name__)

--- a/tests/upgrade/rules/test_base_rule.py
+++ b/tests/upgrade/rules/test_base_rule.py
@@ -36,7 +36,6 @@ class TestBaseRule:
 
         # Version check should still be first
         assert rule_classes[0] == VersionCheckRule
-        print(rule_classes)
         # The former rule is defined in a file alphabetically before the latter rule,
         # but it should appear later in the list since the classes are sorted alphabetically
         unique_rule_index = rule_classes.index(UniqueConnIdRule)

--- a/tests/upgrade/rules/test_base_rule.py
+++ b/tests/upgrade/rules/test_base_rule.py
@@ -25,3 +25,20 @@ class TestBaseRule:
         rule_classes = get_rules()
         assert BaseRule not in rule_classes
         assert ConnTypeIsNotNullableRule in rule_classes
+
+    def test_rules_are_ordered(self):
+        rule_classes = get_rules()
+        from airflow.upgrade.rules.aaa_airflow_version_check import VersionCheckRule
+        from airflow.upgrade.rules.conn_id_is_unique import UniqueConnIdRule
+        from airflow.upgrade.rules.no_additional_args_in_operators import (
+            NoAdditionalArgsInOperatorsRule,
+        )
+
+        # Version check should still be first
+        assert rule_classes[0] == VersionCheckRule
+        print(rule_classes)
+        # The former rule is defined in a file alphabetically before the latter rule,
+        # but it should appear later in the list since the classes are sorted alphabetically
+        unique_rule_index = rule_classes.index(UniqueConnIdRule)
+        no_addtl_args_rule_index = rule_classes.index(NoAdditionalArgsInOperatorsRule)
+        assert unique_rule_index > no_addtl_args_rule_index, "Rules are not alphabetical by class name"


### PR DESCRIPTION
Closes #13378

This PR adds a `--list` option to the upgrade check to list both the check title and class name (for use when ignoring certain checks).

Example output:

```
$ airflow upgrade_check --list

Upgrade Checks:
- Check for latest versions of apache-airflow and checker [VersionCheckRule]
- Remove airflow.AirflowMacroPlugin class [AirflowMacroPluginRemovedRule]
- Chain between DAG and operator not allowed. [ChainBetweenDAGAndOperatorNotAllowedRule]
- Connection.conn_id is not unique [UniqueConnIdRule]
- Connection.conn_type is not nullable [ConnTypeIsNotNullableRule]
- Ensure users are not using custom metaclasses in custom operators [BaseOperatorMetaclassRule]
- Hooks that run DB functions must inherit from DBApiHook [DbApiRule]
- Fernet is enabled by default [FernetEnabledRule]
- GCP service account key deprecation [GCPServiceAccountKeyRule]
- Unify hostname_callable option in core section [HostnameCallable]
- Changes in import paths of hooks, operators, sensors and others [ImportChangesRule]
- Legacy UI is deprecated by default [LegacyUIDeprecated]
- Logging configuration has been moved to new section [LoggingConfigurationRule]
- Removal of Mesos Executor [MesosExecutorRemovedRule]
- No additional argument allowed in BaseOperator. [NoAdditionalArgsInOperatorsRule]
- Users must set a kubernetes.pod_template_file value [PodTemplateFileRule]
- SendGrid email uses old airflow.contrib module [SendGridEmailerMovedRule]
- Changes in import path of remote task handlers [TaskHandlersMovedRule]
- Jinja Template Variables cannot be undefined [UndefinedJinjaVariablesRule]
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
