### PR TITLE
Allow Tags on AWS Batch Job Submission

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -106,6 +106,7 @@ class AwsBatchProtocol(Protocol):
         arrayProperties: Dict,
         parameters: Dict,
         containerOverrides: Dict,
+        tags: Dict,
     ) -> Dict:
         """
         Submit a batch job
@@ -127,6 +128,9 @@ class AwsBatchProtocol(Protocol):
 
         :param containerOverrides: the same parameter that boto3 will receive
         :type containerOverrides: Dict
+
+        :param tags: the same parameter that boto3 will receive
+        :type tags: Dict
 
         :return: an API response
         :rtype: Dict

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -80,6 +80,10 @@ class AwsBatchOperator(BaseOperator):
         Override the region_name in connection (if provided)
     :type region_name: str
 
+    :param tags: collection of tags to apply to the AWS Batch job submission
+        if None, no tags are submitted
+    :type tags: dict
+
     .. note::
         Any custom waiters must return a waiter for these calls:
         .. code-block:: python
@@ -113,6 +117,7 @@ class AwsBatchOperator(BaseOperator):
         status_retries: Optional[int] = None,
         aws_conn_id: Optional[str] = None,
         region_name: Optional[str] = None,
+        tags: Optional[dict] = None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
 
@@ -125,6 +130,7 @@ class AwsBatchOperator(BaseOperator):
         self.array_properties = array_properties or {}
         self.parameters = parameters or {}
         self.waiters = waiters
+        self.tags = tags or {}
         self.hook = AwsBatchClientHook(
             max_retries=max_retries,
             status_retries=status_retries,
@@ -166,6 +172,7 @@ class AwsBatchOperator(BaseOperator):
                 arrayProperties=self.array_properties,
                 parameters=self.parameters,
                 containerOverrides=self.overrides,
+                tags=self.tags,
             )
             self.job_id = response["jobId"]
 

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -63,6 +63,7 @@ class TestAwsBatchOperator(unittest.TestCase):
             array_properties=None,
             aws_conn_id='airflow_test',
             region_name="eu-west-1",
+            tags={},
         )
         self.client_mock = self.get_client_type_mock.return_value
         self.assertEqual(self.batch.hook.client, self.client_mock)  # setup client property
@@ -91,6 +92,7 @@ class TestAwsBatchOperator(unittest.TestCase):
         self.assertEqual(self.batch.hook.region_name, "eu-west-1")
         self.assertEqual(self.batch.hook.aws_conn_id, "airflow_test")
         self.assertEqual(self.batch.hook.client, self.client_mock)
+        self.assertEqual(self.batch.tags, {})
 
         self.get_client_type_mock.assert_called_once_with("batch", region_name="eu-west-1")
 


### PR DESCRIPTION
**Pull Request Intention**

When submitting a job to AWS Batch, AWS allows you to provide _tags_ to help track, slice and dice costs in AWS Cost Explorer (or similar finance tools). The [boto3 Batch submit_job API](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch.html#Batch.Client.submit_job) allows tags to be passed but Airflow's AwsBatchOperator currently does not provide an argument for passing tags along to the boto3 API. 

**Disclaimer**

This is my first Airflow pull request and I'm imagining that will show through in some form or another. I was having difficulty getting **breeze** set up locally for confirming that my code change passes all of the quality checks--therefore I am opening the PR hoping that I can use the remote CI system for confirming/iterating on ensuring this change meets the quality standard (seems like a small enough change where my ill-advised iteration cycle may suffice but we shall see 🤞 )

NOTE: There is no open issue for this feature but I am happy to create one for tracking purposes if that is standard practice (please let me know if so)
