### PR TITLE
Limit old versions of pinotdb to force update on CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -345,7 +345,9 @@ password = [
     'flask-bcrypt>=0.7.1',
 ]
 pinot = [
-    'pinotdb>=0.1.1,<1.0.0',
+    # pinotdb v0.1.1 may still work with older versions of Apache Pinot, but we've confirmed that it
+    # causes a problem with newer versions.
+    'pinotdb>0.1.2,<1.0.0',
 ]
 plexus = [
     'arrow>=0.16.0',


### PR DESCRIPTION
Apache Pinot has two APIs that are available under different endpoints. Newer versions of pinotdb only support the new API, but older versions support the older APIs. Everything looks great, but older versions of pinotdb do not follow the DBAPI specification exactly, so there is a chance that compatibility issues may arise.  There is a small chance that someone is still using these versions as this version is 3 years old and the newer versions of this library fixed many critical issues.

Additionally, it will force the library to be updated to the newer version, because now the cached version is used.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
