### PR TITLE
Add verbose flag to ./build_docs.py

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -115,19 +115,31 @@ def _get_parser():
         action='store_true',
         help='Builds documentation for official release i.e. all links point to stable version',
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest='verbose',
+        action='store_true',
+        help=(
+            'Increases the verbosity of the script i.e. always displays a full log of '
+            'the build process, not just when it encounters errors'
+        ),
+    )
 
     return parser
 
 
 def build_docs_for_packages(
-    current_packages: List[str], docs_only: bool, spellcheck_only: bool, for_production: bool
+    current_packages: List[str], docs_only: bool, spellcheck_only: bool, for_production: bool, verbose: bool
 ) -> Tuple[Dict[str, List[DocBuildError]], Dict[str, List[SpellingError]]]:
     """Builds documentation for single package and returns errors"""
     all_build_errors: Dict[str, List[DocBuildError]] = defaultdict(list)
     all_spelling_errors: Dict[str, List[SpellingError]] = defaultdict(list)
     for package_no, package_name in enumerate(current_packages, start=1):
         print("#" * 20, f"[{package_no}/{len(current_packages)}] {package_name}", "#" * 20)
-        builder = AirflowDocsBuilder(package_name=package_name, for_production=for_production)
+        builder = AirflowDocsBuilder(
+            package_name=package_name, for_production=for_production, verbose=verbose
+        )
         builder.clean_files()
         if not docs_only:
             with with_group(f"Check spelling: {package_name}"):
@@ -215,6 +227,7 @@ def main():
         docs_only=docs_only,
         spellcheck_only=spellcheck_only,
         for_production=for_production,
+        verbose=args.verbose,
     )
     if package_build_errors:
         all_build_errors.update(package_build_errors)
@@ -237,6 +250,7 @@ def main():
             docs_only=docs_only,
             spellcheck_only=spellcheck_only,
             for_production=for_production,
+            verbose=args.verbose,
         )
         if package_build_errors:
             all_build_errors.update(package_build_errors)


### PR DESCRIPTION
When we are working on documentation for one package, displaying logs immediately allows us to fix bugs faster.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
