### PR TITLE
Remove TI query that creates deadlock due to max_active_runs when clearing tasks of finished DAGs

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1499,12 +1499,12 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
 
             query = (
                 session.query(
-                    TI.dag_id,
-                    TI.execution_date,
+                    DR.dag_id,
+                    DR.execution_date,
                 )
                 .filter(
-                    TI.dag_id.in_(list({dag_run.dag_id for dag_run in dag_runs})),
-                    TI.state.notin_(list(State.finished) + [State.REMOVED]),
+                    DR.dag_id.in_(list({dag_run.dag_id for dag_run in dag_runs})),
+                    DR.state.in_([State.RUNNING]),
                 )
                 .group_by(TI.dag_id, TI.execution_date)
             )


### PR DESCRIPTION
See https://github.com/apache/airflow/issues/13407

Renamed from "use DR instead of TI to get set of active dag runs by dag - issue #13407" to "Remove TI query that creates deadlock due to max_active_runs when clearing tasks of finished DAGs"