### PR TITLE
Set minimum SQLite version supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ running multiple schedulers -- please see the "Scheduler" docs.
 
 **Note:** SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development. Some older versions
-of sqlite might not work well, however anything at or above 3.27.2 should work fine.
+of SQLite might not work well, however anything at or above 3.27.2 should work fine.
 
 ## Support for Python versions
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ Apache Airflow is tested with:
 **Note:** MariaDB and MySQL 5.x are unable to or have limitations with
 running multiple schedulers -- please see the "Scheduler" docs.
 
-**Note:** SQLite is used in Airflow tests. Do not use it in production.
+**Note:** SQLite is used in Airflow tests. Do not use it in production. We recommend
+using the latest stable version of SQLite for local development. Some older versions
+of sqlite might not work well, however anything at or above 3.27.2 should work fine.
 
 ## Support for Python versions
 


### PR DESCRIPTION
Some users reported that some older versions of SQLite do not
work with Airflow 2.0. This happens for example with latest
sqlite available by default on RHEL7 (sqlite version available
in fully updated system there is 7 (!) years old)

Example of such issue: #13397.

Not sure which 'minimum' version is supported but
in the Breeze environment based on debian buster we have
3.27.2 version in fully updated system. This shoudl be our
baseline.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
