### PR TITLE
Fix environment checking for Pinot

### DIFF
--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -148,15 +148,12 @@ check_integration "Presto (HTTPS)" "presto" "nc -zvv presto 7778" 40
 check_integration "Presto (API)" "presto" \
     "curl --max-time 1 http://presto:8080/v1/info/ | grep '\"starting\":false'" 20
 check_integration "Pinot (HTTP)" "pinot" "nc -zvv pinot 9000" 40
-check_integration "Presto (Controller API)" "pinot" \
-    "curl --max-time 1 -X GET 'http://pinot:9000/health' " \
-    "-H 'accept: text/plain' | grep OK" 20
-check_integration "Presto (Controller API)" "pinot" \
-    "curl --max-time 1 -X GET 'http://pinot:9000/pinot-controller/admin' " \
-    "-H 'accept: text/plain' | grep GOOD" 20
-check_integration "Presto (Broker API)" "pinot" \
-    "curl --max-time 1 -X GET 'http://pinot:8000/health' " \
-    "-H 'accept: text/plain' | grep OK" 20
+CMD="curl --max-time 1 -X GET 'http://pinot:9000/health' -H 'accept: text/plain' | grep OK"
+check_integration "Presto (Controller API)" "pinot" "${CMD}" 20
+CMD="curl --max-time 1 -X GET 'http://pinot:9000/pinot-controller/admin' -H 'accept: text/plain' | grep GOOD"
+check_integration "Presto (Controller API)" "pinot" "${CMD}" 20
+CMD="curl --max-time 1 -X GET 'http://pinot:8000/health' -H 'accept: text/plain' | grep OK"
+check_integration "Presto (Broker API)" "pinot" "${CMD}" 20
 
 echo "-----------------------------------------------------------------------------------------------"
 


### PR DESCRIPTION
In some cases, the validation of the environment may fail and end with the message below. 
```
  /opt/airflow/scripts/in_container/check_environment.sh: line 41: -H 'accept: text/plain' | grep OK: syntax error: invalid arithmetic operator (error token is "'accept: text/plain' | grep OK")
  Presto (Broker API): .-----------------------------------------------------------------------------------------------
```
Unfortunately, Bash is not very obvious when it comes to multi-line text, and there is no type validation, so problems like this can happen.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
