### PR TITLE
Allow ./run_tmux.sh script to run standalone

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -338,8 +338,12 @@ start integrations (separate Docker images) if specified as extra ``--integratio
 chose which backend database should be used with ``--backend`` flag and python version with ``--python`` flag.
 
 You can also have breeze launch Airflow automatically ``breeze start-airflow``, this will drop you in a
-tmux session with three panes (one to monitor the scheduler, one for the webserver and one with a shell
-for additional commands.
+tmux session with four panes:
+
+   - one to monitor the scheduler
+   - one for the webserver,
+   - one monitors and compiles Javascript files
+   - one with a shell for additional commands.
 
 Managing Prod environment (with ``--production-image`` flag):
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -340,9 +340,9 @@ chose which backend database should be used with ``--backend`` flag and python v
 You can also have breeze launch Airflow automatically ``breeze start-airflow``, this will drop you in a
 tmux session with four panes:
 
-   - one to monitor the scheduler
+   - one to monitor the scheduler,
    - one for the webserver,
-   - one monitors and compiles Javascript files
+   - one monitors and compiles Javascript files,
    - one with a shell for additional commands.
 
 Managing Prod environment (with ``--production-image`` flag):

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -62,6 +62,7 @@ if [[ ${GITHUB_ACTIONS:="false"} == "false" ]]; then
     # Create links for useful CLI tools
     # shellcheck source=scripts/in_container/run_cli_tool.sh
     source <(bash scripts/in_container/run_cli_tool.sh)
+    ln -s '/opt/airflow/scripts/in_container/run_tmux.sh' /usr/bin/run_tmux
 fi
 
 if [[ ${AIRFLOW_VERSION} == *1.10* || ${INSTALL_AIRFLOW_VERSION} == *1.10* ]]; then
@@ -195,10 +196,14 @@ ssh-keyscan -H localhost >> ~/.ssh/known_hosts 2>/dev/null
 # shellcheck source=scripts/in_container/run_init_script.sh
 . "${IN_CONTAINER_DIR}/run_init_script.sh"
 
-# shellcheck source=scripts/in_container/run_tmux.sh
-. "${IN_CONTAINER_DIR}/run_tmux.sh"
-
 cd "${AIRFLOW_SOURCES}"
+
+if [[ ${START_AIRFLOW:="false"} == "true" ]]; then
+    export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
+    export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
+    # shellcheck source=scripts/in_container/run_tmux.sh
+    exec /bin/bash "${IN_CONTAINER_DIR}/run_tmux.sh"
+fi
 
 set +u
 # If we do not want to run tests, we simply drop into bash

--- a/scripts/in_container/run_tmux.sh
+++ b/scripts/in_container/run_tmux.sh
@@ -25,7 +25,7 @@ if [[ ${BACKEND} != "sqlite"  ]]; then
     export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
 fi
 
-#this is because I run docker in WSL - Hi Bill!
+#this is because I run docker in WSL - Hi Nadella!
 export TMUX_TMPDIR=~/.tmux/tmp
 if [ -e ~/.tmux/tmp ]; then
     rm -rf ~/.tmux/tmp
@@ -53,11 +53,11 @@ tmux send-keys 'airflow webserver' C-m
 
 tmux select-pane -t 0
 tmux split-window -h
-tmux send-keys 'cd airflow/www/; yarn dev' C-m
+tmux send-keys 'cd /opt/airflow/airflow/www/; yarn dev' C-m
 
 # Attach Session, on the Main window
 tmux select-pane -t 0
-tmux send-keys "./scripts/in_container/run_tmux_welcome.sh" C-m
+tmux send-keys "/opt/airflow/scripts/in_container/run_tmux_welcome.sh" C-m
 
 tmux attach-session -t "${TMUX_SESSION}":0
 rm /usr/local/bin/stop_airflow

--- a/scripts/in_container/run_tmux.sh
+++ b/scripts/in_container/run_tmux.sh
@@ -15,49 +15,49 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-if [[ ${START_AIRFLOW:="false"} == "true" ]]; then
 
-    ln -s "${IN_CONTAINER_DIR}/stop_tmux_airflow.sh" stop_airflow.sh
-
-    export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=${LOAD_DEFAULT_CONNECTIONS}
-    export AIRFLOW__CORE__LOAD_EXAMPLES=${LOAD_EXAMPLES}
-
-    # Use LocalExecutor if not set and if backend is not sqlite as it gives
-    # better performance
-    if [[ ${BACKEND} != "sqlite"  ]]; then
-        export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
-    fi
-
-    #this is because I run docker in WSL - Hi Bill!
-    export TMUX_TMPDIR=~/.tmux/tmp
-    mkdir -p ~/.tmux/tmp
-    chmod 777 -R ~/.tmux/tmp
-
-    # Set Session Name
-    export TMUX_SESSION="Airflow"
-
-    # Start New Session with our name
-    tmux new-session -d -s "${TMUX_SESSION}"
-
-    # Name first Pane and start bash
-    tmux rename-window -t 0 'Main'
-    tmux send-keys -t 'Main' 'bash' C-m 'clear' C-m
-
-    tmux split-window -v
-    tmux select-pane -t 1
-    tmux send-keys 'airflow scheduler' C-m
-
-    tmux split-window -h
-    tmux select-pane -t 2
-    tmux send-keys 'airflow webserver' C-m
-
-    tmux select-pane -t 0
-    tmux split-window -h
-    tmux send-keys 'cd airflow/www/; yarn dev' C-m
-
-    # Attach Session, on the Main window
-    tmux select-pane -t 0
-    tmux send-keys "./scripts/in_container/run_tmux_welcome.sh" C-m
-
-    tmux attach-session -t "${TMUX_SESSION}":0
+if [ ! -e /usr/local/bin/stop_airflow ]; then
+    ln -s "/opt/airflow/scripts/in_container/stop_tmux_airflow.sh" /usr/local/bin/stop_airflow || true
 fi
+# Use LocalExecutor if not set and if backend is not sqlite as it gives
+# better performance
+if [[ ${BACKEND} != "sqlite"  ]]; then
+    export AIRFLOW__CORE__EXECUTOR=${AIRFLOW__CORE__EXECUTOR:-LocalExecutor}
+fi
+
+#this is because I run docker in WSL - Hi Bill!
+export TMUX_TMPDIR=~/.tmux/tmp
+if [ -e ~/.tmux/tmp ]; then
+    rm -rf ~/.tmux/tmp
+fi
+mkdir -p ~/.tmux/tmp
+chmod 777 -R ~/.tmux/tmp
+
+# Set Session Name
+export TMUX_SESSION="Airflow"
+
+# Start New Session with our name
+tmux new-session -d -s "${TMUX_SESSION}"
+
+# Name first Pane and start bash
+tmux rename-window -t 0 'Main'
+tmux send-keys -t 'Main' 'bash' C-m 'clear' C-m
+
+tmux split-window -v
+tmux select-pane -t 1
+tmux send-keys 'airflow scheduler' C-m
+
+tmux split-window -h
+tmux select-pane -t 2
+tmux send-keys 'airflow webserver' C-m
+
+tmux select-pane -t 0
+tmux split-window -h
+tmux send-keys 'cd airflow/www/; yarn dev' C-m
+
+# Attach Session, on the Main window
+tmux select-pane -t 0
+tmux send-keys "./scripts/in_container/run_tmux_welcome.sh" C-m
+
+tmux attach-session -t "${TMUX_SESSION}":0
+rm /usr/local/bin/stop_airflow

--- a/scripts/in_container/run_tmux_welcome.sh
+++ b/scripts/in_container/run_tmux_welcome.sh
@@ -19,5 +19,5 @@ cd /opt/airflow/ || exit
 clear
 echo "Welcome to your tmux based running Airflow environment (courtesy of Breeze)."
 echo
-echo "     To stop Airflow and exit tmux just './stop_airflow.sh'."
+echo "     To stop Airflow and exit tmux just 'stop_airflow'."
 echo


### PR DESCRIPTION
I use breez like a virtual machine i.e. i run the terminal and then work in it all the time Unfortunately, the useful run_tmux script was only available when it was run in a new Breez session. I improved it a bit so that it can also be used inside an existing console..
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
