### PR TITLE
Increase timeout for checking environment

### DIFF
--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -137,23 +137,23 @@ if [[ -n ${BACKEND=} ]]; then
     check_db_backend 20
     echo "-----------------------------------------------------------------------------------------------"
 fi
-check_integration "Kerberos" "kerberos" "nc -zvv kdc-server-example-com 88" 30
-check_integration "MongoDB" "mongo" "nc -zvv mongo 27017" 20
-check_integration "Redis" "redis" "nc -zvv redis 6379" 20
-check_integration "RabbitMQ" "rabbitmq" "nc -zvv rabbitmq 5672" 20
-check_integration "Cassandra" "cassandra" "nc -zvv cassandra 9042" 20
-check_integration "OpenLDAP" "openldap" "nc -zvv openldap 389" 20
-check_integration "Presto (HTTP)" "presto" "nc -zvv presto 8080" 40
-check_integration "Presto (HTTPS)" "presto" "nc -zvv presto 7778" 40
+check_integration "Kerberos" "kerberos" "nc -zvv kdc-server-example-com 88" 60
+check_integration "MongoDB" "mongo" "nc -zvv mongo 27017" 40
+check_integration "Redis" "redis" "nc -zvv redis 6379" 40
+check_integration "RabbitMQ" "rabbitmq" "nc -zvv rabbitmq 5672" 40
+check_integration "Cassandra" "cassandra" "nc -zvv cassandra 9042" 40
+check_integration "OpenLDAP" "openldap" "nc -zvv openldap 389" 40
+check_integration "Presto (HTTP)" "presto" "nc -zvv presto 8080" 80
+check_integration "Presto (HTTPS)" "presto" "nc -zvv presto 7778" 80
 check_integration "Presto (API)" "presto" \
-    "curl --max-time 1 http://presto:8080/v1/info/ | grep '\"starting\":false'" 20
-check_integration "Pinot (HTTP)" "pinot" "nc -zvv pinot 9000" 40
+    "curl --max-time 1 http://presto:8080/v1/info/ | grep '\"starting\":false'" 40
+check_integration "Pinot (HTTP)" "pinot" "nc -zvv pinot 9000" 80
 CMD="curl --max-time 1 -X GET 'http://pinot:9000/health' -H 'accept: text/plain' | grep OK"
-check_integration "Presto (Controller API)" "pinot" "${CMD}" 20
+check_integration "Presto (Controller API)" "pinot" "${CMD}" 40
 CMD="curl --max-time 1 -X GET 'http://pinot:9000/pinot-controller/admin' -H 'accept: text/plain' | grep GOOD"
-check_integration "Presto (Controller API)" "pinot" "${CMD}" 20
+check_integration "Presto (Controller API)" "pinot" "${CMD}" 40
 CMD="curl --max-time 1 -X GET 'http://pinot:8000/health' -H 'accept: text/plain' | grep OK"
-check_integration "Presto (Broker API)" "pinot" "${CMD}" 20
+check_integration "Presto (Broker API)" "pinot" "${CMD}" 40
 
 echo "-----------------------------------------------------------------------------------------------"
 


### PR DESCRIPTION
Recently, we added Apache Pinot integrations, and now other integrations that launch at the same time don't start quite quickly.
<img width="986" alt="Screenshot 2021-01-01 at 23 12 22" src="https://user-images.githubusercontent.com/12058428/103447078-d5ba0a00-4c86-11eb-880f-854ef008a9ea.png">
<img width="1000" alt="Screenshot 2021-01-01 at 23 09 59" src="https://user-images.githubusercontent.com/12058428/103447060-a0152100-4c86-11eb-9cd3-564e72577ebd.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
