### PR TITLE
Fix behavior to allow anonymous user be able to view and edit dags

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -47,7 +47,7 @@
         <span class="text-muted">SUBDAG:</span> {{ dag.dag_id }}
       {% else %}
         {% set can_edit = appbuilder.sm.can_edit_dag(dag.dag_id) %}
-        {% if appbuilder.sm.can_edit_dag(dag.dag_id) %}
+        {% if can_edit %}
           {% set switch_tooltip = 'Pause/Unpause DAG' %}
         {% else %}
           {% set switch_tooltip = 'DAG is Paused' if dag.is_paused else 'DAG is Active' %}


### PR DESCRIPTION
If the `AUTH_ROLE_PUBLIC` entry in the `webser_config.py` it's uncommented, no authentication is needed and all user will be identified as anonymous and assume the role specified in the `AUTH_ROLE_PUBLIC` entry.

closes: #13340

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
