### PR TITLE
Fix pylint issues - broken master

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -137,19 +137,17 @@ def build_docs_for_packages(
     all_spelling_errors: Dict[str, List[SpellingError]] = defaultdict(list)
     for package_no, package_name in enumerate(current_packages, start=1):
         print("#" * 20, f"[{package_no}/{len(current_packages)}] {package_name}", "#" * 20)
-        builder = AirflowDocsBuilder(
-            package_name=package_name, for_production=for_production, verbose=verbose
-        )
+        builder = AirflowDocsBuilder(package_name=package_name, for_production=for_production)
         builder.clean_files()
         if not docs_only:
             with with_group(f"Check spelling: {package_name}"):
-                spelling_errors = builder.check_spelling()
+                spelling_errors = builder.check_spelling(verbose=verbose)
             if spelling_errors:
                 all_spelling_errors[package_name].extend(spelling_errors)
 
         if not spellcheck_only:
             with with_group(f"Building docs: {package_name}"):
-                docs_errors = builder.build_sphinx_docs()
+                docs_errors = builder.build_sphinx_docs(verbose=verbose)
             if docs_errors:
                 all_build_errors[package_name].extend(docs_errors)
 

--- a/docs/exts/docs_build/docs_builder.py
+++ b/docs/exts/docs_build/docs_builder.py
@@ -43,10 +43,9 @@ PROCESS_TIMEOUT = 4 * 60
 class AirflowDocsBuilder:
     """Documentation builder for Airflow."""
 
-    def __init__(self, package_name: str, for_production: bool, verbose: bool):
+    def __init__(self, package_name: str, for_production: bool):
         self.package_name = package_name
         self.for_production = for_production
-        self.verbose = verbose
 
     @property
     def _doctree_dir(self) -> str:
@@ -100,7 +99,7 @@ class AirflowDocsBuilder:
         os.makedirs(api_dir, exist_ok=True)
         os.makedirs(self._build_dir, exist_ok=True)
 
-    def check_spelling(self):
+    def check_spelling(self, verbose):
         """Checks spelling."""
         spelling_errors = []
         with TemporaryDirectory() as tmp_dir, NamedTemporaryFile() as output:
@@ -119,7 +118,7 @@ class AirflowDocsBuilder:
                 tmp_dir,
             ]
             print("Executing cmd: ", " ".join([shlex.quote(c) for c in build_cmd]))
-            if not self.verbose:
+            if not verbose:
                 print("The output is hidden until an error occurs.")
             env = os.environ.copy()
             env['AIRFLOW_PACKAGE_NAME'] = self.package_name
@@ -129,8 +128,8 @@ class AirflowDocsBuilder:
                 build_cmd,
                 cwd=self._src_dir,
                 env=env,
-                stdout=output if not self.verbose else None,
-                stderr=output if not self.verbose else None,
+                stdout=output if not verbose else None,
+                stderr=output if not verbose else None,
                 timeout=PROCESS_TIMEOUT,
             )
             if completed_proc.returncode != 0:
@@ -157,7 +156,7 @@ class AirflowDocsBuilder:
                 spelling_errors.extend(parse_spelling_warnings(warning_text, self._src_dir))
         return spelling_errors
 
-    def build_sphinx_docs(self) -> List[DocBuildError]:
+    def build_sphinx_docs(self, verbose) -> List[DocBuildError]:
         """Build Sphinx documentation"""
         build_errors = []
         with NamedTemporaryFile() as tmp_file, NamedTemporaryFile() as output:
@@ -177,7 +176,7 @@ class AirflowDocsBuilder:
                 self._build_dir,  # path to output directory
             ]
             print("Executing cmd: ", " ".join([shlex.quote(c) for c in build_cmd]))
-            if not self.verbose:
+            if not verbose:
                 print("The output is hidden until an error occurs.")
 
             env = os.environ.copy()
@@ -189,8 +188,8 @@ class AirflowDocsBuilder:
                 build_cmd,
                 cwd=self._src_dir,
                 env=env,
-                stdout=output if not self.verbose else None,
-                stderr=output if not self.verbose else None,
+                stdout=output if not verbose else None,
+                stderr=output if not verbose else None,
                 timeout=PROCESS_TIMEOUT,
             )
             if completed_proc.returncode != 0:


### PR DESCRIPTION
```
************* Module publish_docs
docs/publish_docs.py:92:18: E1120: No value for argument 'verbose' in constructor call (no-value-for-parameter)
```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
