### PR TITLE
Add extras when installing prod image from packages

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -337,26 +337,39 @@ COPY docker-context-files/ /docker-context-files/
 
 # hadolint ignore=SC2086, SC2010
 RUN if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
-        reinstalling_apache_airflow_packages=$(ls /docker-context-files/apache?airflow*.{whl,tar.gz} 2>/dev/null || true); \
-        # We want to install apache airflow packages with constraints \
-        if [[ "${reinstalling_apache_airflow_packages}" != "" ]]; then \
+        reinstalling_apache_airflow_package=$(ls /docker-context-files/apache?airflow?[0-9]*.{whl,tar.gz} 2>/dev/null || true); \
+        # We want to install apache airflow package with constraints \
+        if [[ "${reinstalling_apache_airflow_package}" != "" ]]; then \
             if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then \
                 pip install --force-reinstall --upgrade --upgrade-strategy eager \
-                    --user ${reinstalling_apache_airflow_packages}; \
+                    --user ${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}]; \
                 pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
             else \
                 pip install --force-reinstall --upgrade --upgrade-strategy only-if-needed \
-                    --user ${reinstalling_apache_airflow_packages} --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
+                    --user ${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}] --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
                 pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
             fi; \
         fi ; \
-        # All the others we want to reinstall as-is, without dependencies \
+        reinstalling_apache_airflow_providers_packages=$(ls /docker-context-files/apache?airflow?providers*.{whl,tar.gz} 2>/dev/null || true); \
+        # We want to install apache airflow provider packages with constraints \
+        if [[ "${reinstalling_apache_airflow_providers_packages}" != "" ]]; then \
+            if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then \
+                pip install --force-reinstall --upgrade --upgrade-strategy eager \
+                    --user ${reinstalling_apache_airflow_providers_packages}; \
+                pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
+            else \
+                pip install --force-reinstall --upgrade --upgrade-strategy only-if-needed \
+                    --user ${reinstalling_apache_airflow_providers_packages} --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
+                pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
+            fi; \
+        fi ; \
+        # All the other packages we want to reinstall as-is, without dependencies \
         reinstalling_other_packages=$(ls /docker-context-files/*.{whl,tar.gz} 2>/dev/null | \
             grep -v apache_airflow | grep -v apache-airflow || true); \
         if [[ "${reinstalling_other_packages}" != "" ]]; then \
             pip install --force-reinstall --user --no-deps ${reinstalling_other_packages}; \
         fi; \
-    fi;
+    fi
 
 # Copy all the www/ files we need to compile assets. Done as two separate COPY
 # commands so as otherwise it copies the _contents_ of static/ in to www/


### PR DESCRIPTION
In the latest change #13422 change in the way product images are
prepared removed extras from installed airflow - thus caused
failing production image verification check.

This change restores extras when airflow is installed from packages

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
