### PR TITLE
Install airflow and providers together from context files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -265,33 +265,24 @@ RUN if [[ ${INSTALL_MYSQL_CLIENT} != "true" ]]; then \
         fi; \
     fi; \
     if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
-        # We want to install apache airflow package with extras - that's why it is a separate step \
-        # But we should still install them with all dependencies \
         reinstalling_apache_airflow_package=$(ls /docker-context-files/apache?airflow?[0-9]*.{whl,tar.gz} 2>/dev/null || true); \
         if [[ "${reinstalling_apache_airflow_package}" != "" ]]; then \
-            if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then \
-                pip install --force-reinstall --upgrade --upgrade-strategy eager \
-                    --user "${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}]"; \
-                pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
-            else \
-                # We want to install apache airflow package with constraints \
-                pip install --force-reinstall --upgrade --upgrade-strategy only-if-needed \
-                    --user "${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}]" --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
-                pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
-            fi; \
-        fi ; \
+            # install airflow with extras \
+            reinstalling_apache_airflow_package="${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}]"; \
+        fi; \
         reinstalling_apache_airflow_providers_packages=$(ls /docker-context-files/apache?airflow?providers*.{whl,tar.gz} 2>/dev/null || true); \
-        # We want to install apache airflow package with extras - that's why it is a separate step \
-        # But we should still install them with all dependencies \
-        if [[ "${reinstalling_apache_airflow_providers_packages}" != "" ]]; then \
+        if [[ ${reinstalling_apache_airflow_package} != "" || \
+              ${reinstalling_apache_airflow_providers_packages} == "" ]]; then \
             if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then \
                 pip install --force-reinstall --upgrade --upgrade-strategy eager \
-                    --user ${reinstalling_apache_airflow_providers_packages}; \
+                    --user ${reinstalling_apache_airflow_package} \
+                           ${reinstalling_apache_airflow_providers_packages}; \
                 pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
             else \
-                # We want to install apache airflow provider packages with constraints \
                 pip install --force-reinstall --upgrade --upgrade-strategy only-if-needed \
-                    --user ${reinstalling_apache_airflow_providers_packages} --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
+                    --user ${reinstalling_apache_airflow_package} \
+                           ${reinstalling_apache_airflow_providers_packages} \
+                    --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
                 pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
             fi; \
         fi ; \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -338,28 +338,23 @@ COPY docker-context-files/ /docker-context-files/
 # hadolint ignore=SC2086, SC2010
 RUN if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
         reinstalling_apache_airflow_package=$(ls /docker-context-files/apache?airflow?[0-9]*.{whl,tar.gz} 2>/dev/null || true); \
-        # We want to install apache airflow package with constraints \
         if [[ "${reinstalling_apache_airflow_package}" != "" ]]; then \
-            if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then \
-                pip install --force-reinstall --upgrade --upgrade-strategy eager \
-                    --user ${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}]; \
-                pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
-            else \
-                pip install --force-reinstall --upgrade --upgrade-strategy only-if-needed \
-                    --user ${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}] --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
-                pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
-            fi; \
-        fi ; \
+            # install airflow with extras \
+            reinstalling_apache_airflow_package="${reinstalling_apache_airflow_package}[${AIRFLOW_EXTRAS}]"; \
+        fi; \
         reinstalling_apache_airflow_providers_packages=$(ls /docker-context-files/apache?airflow?providers*.{whl,tar.gz} 2>/dev/null || true); \
-        # We want to install apache airflow provider packages with constraints \
-        if [[ "${reinstalling_apache_airflow_providers_packages}" != "" ]]; then \
+        if [[ ${reinstalling_apache_airflow_package} != "" || \
+              ${reinstalling_apache_airflow_providers_packages} == "" ]]; then \
             if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then \
                 pip install --force-reinstall --upgrade --upgrade-strategy eager \
-                    --user ${reinstalling_apache_airflow_providers_packages}; \
+                    --user ${reinstalling_apache_airflow_package} \
+                           ${reinstalling_apache_airflow_providers_packages}; \
                 pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
             else \
                 pip install --force-reinstall --upgrade --upgrade-strategy only-if-needed \
-                    --user ${reinstalling_apache_airflow_providers_packages} --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
+                    --user ${reinstalling_apache_airflow_package} \
+                           ${reinstalling_apache_airflow_providers_packages} \
+                    --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}"; \
                 pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"; \
             fi; \
         fi ; \


### PR DESCRIPTION
Airflow and provider packages need to be installed together to
make sure that constrainst are taken into account and that airflow
does not get reinstalled from PyPI when eager upgrade runs.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
