### PR TITLE
GitHub PROD image build is pushed to GitHub Registry.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -929,7 +929,7 @@ jobs:
 
   push-prod-images-to-github-registry:
     timeout-minutes: 10
-    name: "Push PROD images"
+    name: "Push PROD images as cache to GitHub Registry"
     runs-on: ubuntu-20.04
     needs:
       - build-info
@@ -965,14 +965,19 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-      - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
+      - name:
+          "Prepare PROD image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+        env:
+          # Since we are going to push both final image and build image segment, we need to pull the
+          # build image, in case we are pulling from registry rather than building.
+          WAIT_FOR_PROD_BUILD_IMAGE: "true"
       - name: "Push PROD images ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_push_production_images.sh
 
   push-ci-images-to-github-registry:
     timeout-minutes: 10
-    name: "Push CI images"
+    name: "Push CI images as cache to GitHub Registry"
     runs-on: ubuntu-20.04
     needs:
       - build-info

--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -32,12 +32,14 @@ function build_prod_images_on_ci() {
     build_images::prepare_prod_build
 
     if [[ ${USE_GITHUB_REGISTRY} == "true" && ${GITHUB_REGISTRY_WAIT_FOR_IMAGE} == "true" ]]; then
-
-        # Tries to wait for the image indefinitely
-        # skips further image checks - since we already have the target image
-
         build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}" \
             ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_IMAGE}"
+
+        if [[ "${WAIT_FOR_PROD_BUILD_IMAGE=}" == "true" ]]; then
+            # If specified in variable - also waits for the build image
+            build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}" \
+                ":${GITHUB_REGISTRY_PULL_IMAGE_TAG}" "${AIRFLOW_PROD_BUILD_IMAGE}"
+        fi
 
     else
         build_images::build_prod_images_from_locally_built_airflow_packages


### PR DESCRIPTION
One of the earlier changes removed unneccessary pulling of the
'build' segment from GitHub Registry in `ci_wait_for_prod_image.sh'.
It is not needed, because the K8S tests only use the final image
and pulling the build image is not necessary.

This has the undesired effect that 'ci_wait_for_prod_image.sh' was
also used at the step where master image pushes the prod image
to the repository as the 'latest' cache. In this case both - the
'final' prod image and the 'build' segment should be pulled,
because both are needed for PROD image build optimizations.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
