### PR TITLE
Replace deprecated `abc.abstractproperty` decorator

### DIFF
--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -57,7 +57,8 @@ class LoggingMixin:
 class ExternalLoggingMixin:
     """Define a log handler based on an external service (e.g. ELK, StackDriver)."""
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def log_name(self) -> str:
         """Return log name"""
 


### PR DESCRIPTION
`abc.abstractproperty` is deprecated since Python 3.3. Instead we should use `@property` with `abc.abstractmethod`.

Docs: https://docs.python.org/3.6/library/abc.html#abc.abstractproperty

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
