### PR TITLE
Streamline & simplify __eq__ methods in models Dag and BaseOperator

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -520,8 +520,10 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             )
 
     def __eq__(self, other):
-        if type(self) is type(other) and self.task_id == other.task_id:
-            return all(self.__dict__.get(c, None) == other.__dict__.get(c, None) for c in self._comps)
+        if type(self) is type(other):
+            # Use getattr() instead of __dict__ as __dict__ doesn't return
+            # correct values for properties.
+            return all(getattr(self, c, None) == getattr(other, c, None) for c in self._comps)
         return False
 
     def __ne__(self, other):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -361,8 +361,7 @@ class DAG(LoggingMixin):
         return f"<DAG: {self.dag_id}>"
 
     def __eq__(self, other):
-        if type(self) == type(other) and self.dag_id == other.dag_id:
-
+        if type(self) == type(other):
             # Use getattr() instead of __dict__ as __dict__ doesn't return
             # correct values for properties.
             return all(getattr(self, c, None) == getattr(other, c, None) for c in self._comps)


### PR DESCRIPTION
- Change-1: Use `getattr()` instead of __dict__ as __dict__ doesn't return correct values for properties (sample code reproducing the issue is given below). This was fixed for `dag` model, but was not fixed for `baseoperator` model.

- Change-2: Avoid unnecessary condition check (the removed condition checks are covered by `_comps`)


#### Sample Code Reproducing Issue in Change-1

```python
class C:

    def __init__(self, elements):
        self._elements = elements

    @property
    def elements(self):
        return self._elements

    def test(self):
        print(self.__dict__.get("elements", None))
        print(getattr(self, "elements", None))

a = C([1,2,3])
a.test()
```
 Output:

```
None
[1, 2, 3]
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
