### PR TITLE
Log migrations info in consistent way

### DIFF
--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -23,6 +23,8 @@ Revises: 849da589634d
 Create Date: 2020-10-21 00:18:52.529438
 
 """
+import logging
+
 from airflow.security import permissions
 from airflow.www.app import create_app
 
@@ -307,7 +309,10 @@ def remap_permissions():
 
 def upgrade():
     """Apply Resource based permissions."""
+    log = logging.getLogger()
+    handlers = log.handlers[:]
     remap_permissions()
+    log.handlers = handlers
 
 
 def downgrade():


### PR DESCRIPTION
Resource based permissions migration changes logging handlers
so each next migration is differently formatted when doing
airflow db reset. This commit fixes this behavior.

closes: #13214

Before:
<img width="1359" alt="Screenshot 2021-01-04 at 12 46 05" src="https://user-images.githubusercontent.com/9528307/103532036-d0c5a800-4e8a-11eb-829a-9d0270b96a29.png">


After:
<img width="1359" alt="Screenshot 2021-01-04 at 12 46 49" src="https://user-images.githubusercontent.com/9528307/103532098-eaff8600-4e8a-11eb-9fba-2de69abfc07b.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
