### PR TITLE
Fix webserver exiting when gunicorn master crashes. Closes #13469

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1090,13 +1090,13 @@ class GunicornMonitor(LoggingMixin):
             num_workers_running = self._get_num_workers_running()
             if num_workers_running < self.num_workers_expected:
                 new_worker_count = min(
-                    num_workers_running - self.worker_refresh_batch_size, self.worker_refresh_batch_size
+                    self.num_workers_expected - num_workers_running, self.worker_refresh_batch_size
                 )
-                self.log.debug(
+                self.log.info(
                     '[%d / %d] Spawning %d workers',
                     num_ready_workers_running, num_workers_running, new_worker_count
                 )
-                self._spawn_new_workers(num_workers_running)
+                self._spawn_new_workers(new_worker_count)
             return
 
         # Now the number of running and expected worker should be equal


### PR DESCRIPTION
As described in #13469, when gunicorn master processes exits, the webserver process continues to run indefinitely, periodically logging an error message.

The method `_spawn_new_workers()` attempts to spawn new workers, and if that fails the webserver is meant to exit. However, this does not currently work due to a logical mistake when computing number of workers to spawn, and a typo (passing current number of workers instead of the count of workers to spawn).

Btw, I believe the same issue is present in the 2.0 branch.