### PR TITLE
Remove 'typing' dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -132,7 +132,6 @@ install_requires =
     tenacity~=6.2.0
     termcolor>=1.1.0
     thrift>=0.9.2
-    typing;python_version<"3.6"
     typing-extensions>=3.7.4;python_version<"3.8"
     unicodecsv>=0.14.1
     urllib3<1.26  # Required to keep boto3 happy


### PR DESCRIPTION
We only needed `typing` for Python < 3.6 and Airflow 2.0 and Master are only Py 3.6+

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
