### PR TITLE
Replace dictionary creation with dictionary literal

### DIFF
--- a/airflow/utils/log/file_processor_handler.py
+++ b/airflow/utils/log/file_processor_handler.py
@@ -90,8 +90,7 @@ class FileProcessorHandler(logging.Handler):
             filename = os.path.join("native_dags", os.path.relpath(filename, airflow_directory))
         else:
             filename = os.path.relpath(filename, self.dag_dir)
-        ctx = {}
-        ctx['filename'] = filename
+        ctx = {'filename': filename}
 
         if self.filename_jinja_template:
             return self.filename_jinja_template.render(**ctx)


### PR DESCRIPTION
Instead of:

```python
ctx = {}
ctx['filename'] = filename
```

we can use:

```python
ctx = {'filename': filename}
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
