### PR TITLE
Google Dataflow Flex Operator to handle no Job Type

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -377,32 +377,29 @@ class _DataflowJobsController(LoggingMixin):
         :rtype: bool
         :raise: Exception
         """
-        if 'type' in job:
-            if self._wait_until_finished is None:
-                wait_for_running = job['type'] == DataflowJobType.JOB_TYPE_STREAMING
-            else:
-                wait_for_running = not self._wait_until_finished
-
-            if job['currentState'] == DataflowJobStatus.JOB_STATE_DONE:
-                return True
-            elif job['currentState'] == DataflowJobStatus.JOB_STATE_FAILED:
-                raise Exception("Google Cloud Dataflow job {} has failed.".format(job['name']))
-            elif job['currentState'] == DataflowJobStatus.JOB_STATE_CANCELLED:
-                raise Exception("Google Cloud Dataflow job {} was cancelled.".format(job['name']))
-            elif job['currentState'] == DataflowJobStatus.JOB_STATE_DRAINED:
-                raise Exception("Google Cloud Dataflow job {} was drained.".format(job['name']))
-            elif job['currentState'] == DataflowJobStatus.JOB_STATE_UPDATED:
-                raise Exception("Google Cloud Dataflow job {} was updated.".format(job['name']))
-            elif job['currentState'] == DataflowJobStatus.JOB_STATE_RUNNING and wait_for_running:
-                return True
-            elif job['currentState'] in DataflowJobStatus.AWAITING_STATES:
-                return self._wait_until_finished is False
-            self.log.debug("Current job: %s", str(job))
-            raise Exception(
-                "Google Cloud Dataflow job {} was unknown state: {}".format(job["name"], job["currentState"])
-            )
+        if self._wait_until_finished is None:
+            wait_for_running = job.get('type', '') == DataflowJobType.JOB_TYPE_STREAMING
         else:
-            return False
+            wait_for_running = not self._wait_until_finished
+
+        if job['currentState'] == DataflowJobStatus.JOB_STATE_DONE:
+            return True
+        elif job['currentState'] == DataflowJobStatus.JOB_STATE_FAILED:
+            raise Exception("Google Cloud Dataflow job {} has failed.".format(job['name']))
+        elif job['currentState'] == DataflowJobStatus.JOB_STATE_CANCELLED:
+            raise Exception("Google Cloud Dataflow job {} was cancelled.".format(job['name']))
+        elif job['currentState'] == DataflowJobStatus.JOB_STATE_DRAINED:
+            raise Exception("Google Cloud Dataflow job {} was drained.".format(job['name']))
+        elif job['currentState'] == DataflowJobStatus.JOB_STATE_UPDATED:
+            raise Exception("Google Cloud Dataflow job {} was updated.".format(job['name']))
+        elif job['currentState'] == DataflowJobStatus.JOB_STATE_RUNNING and wait_for_running:
+            return True
+        elif job['currentState'] in DataflowJobStatus.AWAITING_STATES:
+            return self._wait_until_finished is False
+        self.log.debug("Current job: %s", str(job))
+        raise Exception(
+            "Google Cloud Dataflow job {} was unknown state: {}".format(job["name"], job["currentState"])
+        )
 
     def wait_for_done(self) -> None:
         """Helper method to wait for result of submitted job."""

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -377,29 +377,32 @@ class _DataflowJobsController(LoggingMixin):
         :rtype: bool
         :raise: Exception
         """
-        if self._wait_until_finished is None:
-            wait_for_running = job['type'] == DataflowJobType.JOB_TYPE_STREAMING
-        else:
-            wait_for_running = not self._wait_until_finished
+        if 'type' in job:
+            if self._wait_until_finished is None:
+                wait_for_running = job['type'] == DataflowJobType.JOB_TYPE_STREAMING
+            else:
+                wait_for_running = not self._wait_until_finished
 
-        if job['currentState'] == DataflowJobStatus.JOB_STATE_DONE:
-            return True
-        elif job['currentState'] == DataflowJobStatus.JOB_STATE_FAILED:
-            raise Exception("Google Cloud Dataflow job {} has failed.".format(job['name']))
-        elif job['currentState'] == DataflowJobStatus.JOB_STATE_CANCELLED:
-            raise Exception("Google Cloud Dataflow job {} was cancelled.".format(job['name']))
-        elif job['currentState'] == DataflowJobStatus.JOB_STATE_DRAINED:
-            raise Exception("Google Cloud Dataflow job {} was drained.".format(job['name']))
-        elif job['currentState'] == DataflowJobStatus.JOB_STATE_UPDATED:
-            raise Exception("Google Cloud Dataflow job {} was updated.".format(job['name']))
-        elif job['currentState'] == DataflowJobStatus.JOB_STATE_RUNNING and wait_for_running:
-            return True
-        elif job['currentState'] in DataflowJobStatus.AWAITING_STATES:
-            return self._wait_until_finished is False
-        self.log.debug("Current job: %s", str(job))
-        raise Exception(
-            "Google Cloud Dataflow job {} was unknown state: {}".format(job["name"], job["currentState"])
-        )
+            if job['currentState'] == DataflowJobStatus.JOB_STATE_DONE:
+                return True
+            elif job['currentState'] == DataflowJobStatus.JOB_STATE_FAILED:
+                raise Exception("Google Cloud Dataflow job {} has failed.".format(job['name']))
+            elif job['currentState'] == DataflowJobStatus.JOB_STATE_CANCELLED:
+                raise Exception("Google Cloud Dataflow job {} was cancelled.".format(job['name']))
+            elif job['currentState'] == DataflowJobStatus.JOB_STATE_DRAINED:
+                raise Exception("Google Cloud Dataflow job {} was drained.".format(job['name']))
+            elif job['currentState'] == DataflowJobStatus.JOB_STATE_UPDATED:
+                raise Exception("Google Cloud Dataflow job {} was updated.".format(job['name']))
+            elif job['currentState'] == DataflowJobStatus.JOB_STATE_RUNNING and wait_for_running:
+                return True
+            elif job['currentState'] in DataflowJobStatus.AWAITING_STATES:
+                return self._wait_until_finished is False
+            self.log.debug("Current job: %s", str(job))
+            raise Exception(
+                "Google Cloud Dataflow job {} was unknown state: {}".format(job["name"], job["currentState"])
+            )
+        else:
+            return False
 
     def wait_for_done(self) -> None:
         """Helper method to wait for result of submitted job."""


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #13262
related: N/A

-->
Google Dataflow Flex Operator to handle no Job Type

Dataflow job initially started has no Job Type details returnable to the  _check_dataflow_job_state. The code change handles this condition until the job type can be determined.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
