### PR TITLE
Added taskgroup decorator

### DIFF
--- a/airflow/decorators.py
+++ b/airflow/decorators.py
@@ -17,3 +17,4 @@
 
 from airflow.models.dag import dag  # noqa # pylint: disable=unused-import
 from airflow.operators.python import task  # noqa # pylint: disable=unused-import
+from airflow.utils.task_group import taskgroup  # noqa # pylint: disable=unused-import

--- a/airflow/example_dags/example_task_group_decorator.py
+++ b/airflow/example_dags/example_task_group_decorator.py
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Example DAG demonstrating the usage of the @taskgroup decorator."""
+
+from airflow.decorators import task, taskgroup
+from airflow.models.dag import DAG
+from airflow.utils.dates import days_ago
+
+
+# [START task_group_decorator_usage]
+# Creating Tasks
+@task
+def task_start():
+    """Dummy Task which is First Task of Dag """
+    return '[Task_start]'
+
+
+@task
+def task_1(value):
+    """ Dummy Task1"""
+    return f'[ Task1 {value} ]'
+
+
+@task
+def task_2(value):
+    """ Dummy Task2"""
+    return f'[ Task2 {value} ]'
+
+
+@task
+def task_3(value):
+    """ Dummy Task3"""
+    print(f'[ Task3 {value} ]')
+
+
+@task
+def task_end():
+    """ Dummy Task which is Last Task of Dag """
+    print('[ Task_End  ]')
+
+
+# Creating TaskGroups
+@taskgroup
+def section_1(value):
+    """ TaskGroup for grouping related Tasks"""
+    return task_3(task_2(task_1(value)))
+
+
+# Executing Tasks and TaskGroups
+with DAG(dag_id="example_task_group_decorator", start_date=days_ago(2), tags=["example"]) as dag:
+    t1 = task_start()
+
+    s1 = section_1(t1)
+    s1.set_downstream(task_end())
+# [END task_group_decorator_usage]

--- a/airflow/example_dags/example_task_group_decorator.py
+++ b/airflow/example_dags/example_task_group_decorator.py
@@ -23,7 +23,7 @@ from airflow.models.dag import DAG
 from airflow.utils.dates import days_ago
 
 
-# [START task_group_decorator_usage]
+# [START howto_task_group_decorator]
 # Creating Tasks
 @task
 def task_start():
@@ -68,4 +68,4 @@ with DAG(dag_id="example_task_group_decorator", start_date=days_ago(2), tags=["e
 
     s1 = section_1(t1)
     s1.set_downstream(task_end())
-# [END task_group_decorator_usage]
+# [END howto_task_group_decorator]

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -56,7 +56,7 @@ class TaskGroup(TaskMixin):
     :param prefix_group_id: If set to True, child task_id and group_id will be prefixed with
         this TaskGroup's group_id. If set to False, child task_id and group_id are not prefixed.
         Default is True.
-    :type prerfix_group_id: bool
+    :type prefix_group_id: bool
     :param parent_group: The parent TaskGroup of this TaskGroup. parent_group is set to None
         for the root TaskGroup.
     :type parent_group: TaskGroup

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -37,7 +37,7 @@ from typing import (
 
 from airflow.exceptions import AirflowException, DuplicateTaskIdFound
 from airflow.models.taskmixin import TaskMixin
-from airflow.utils.decorators import signature
+from inspect import signature
 
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -113,7 +113,6 @@ class TaskGroup(TaskMixin):
         # Example : task_group ==> task_group__1 -> task_group__2 -> task_group__3
         if group_id in self.used_group_ids:
             base = re.split(r'__\d+$', group_id)[0]
-            print([(i, type(i)) for i in self.used_group_ids])
             suffixes = sorted(
                 [
                     int(re.split(r'^.+__', used_group_id)[1])

--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -1121,24 +1121,12 @@ This animated gif shows the UI interactions. TaskGroups are expanded or collapse
 .. image:: img/task_group.gif
 
 
-TaskGroup can be created using ``@taskgroup decorator``, it takes one mandatory argument ``group_id`` which is same as constructor of TaskGroup class, if not given it copies function name as ``group_id``. It works exactly same as creating TaskGroup using context manager ``with TaskGroup('groupid') as section:``.
+TaskGroup can be created using ``@taskgroup`` decorator, it takes one mandatory argument ``group_id`` which is same as constructor of TaskGroup class, if not given it copies function name as ``group_id``. It works exactly same as creating TaskGroup using context manager ``with TaskGroup('groupid') as section:``.
 
-.. code-block:: python
-
-  @task
-  def task_1(value):
-      return f'[ Task1 {value} ]'
-
-
-  @task
-  def task_2(value):
-      print(f'[ Task2 {value} ]')
-
-
-  @taskgroup
-  def section_1(value):
-      return task_2(task_1(value))
-
+.. exampleinclude:: /../../airflow/example_dags/example_task_group_decorator.py
+    :language: python
+    :start-after: [START howto_task_group_decorator]
+    :end-before: [END howto_task_group_decorator]
 
 
 SLAs

--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -1121,6 +1121,33 @@ This animated gif shows the UI interactions. TaskGroups are expanded or collapse
 .. image:: img/task_group.gif
 
 
+TaskGroup can be created using ``@taskgroup decorator``, it takes one mandatory argument ``group_id`` which is same as constructor of TaskGroup class, if not given it copies function name as ``group_id``. It works exactly same as creating TaskGroup using context manager ``with TaskGroup('groupid') as section:``.
+
+.. code-block:: python
+
+  @task
+  def task_1(value):
+      return f'[ Task1 {value} ]'
+
+
+  @task
+  def task_2(value):
+      print(f'[ Task2 {value} ]')
+
+
+  @taskgroup
+  def section_1(value):
+      return task_2(task_1(value))
+
+
+Here is an example of how to use taskgroup decorator :
+
+.. exampleinclude:: /../airflow/example_dags/example_task_group_decorator.py
+    :language: python
+    :start-after: [START task_group_decorator_usage]
+    :end-before: [END task_group_decorator_usage]
+
+
 SLAs
 ====
 

--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -1140,13 +1140,6 @@ TaskGroup can be created using ``@taskgroup decorator``, it takes one mandatory 
       return task_2(task_1(value))
 
 
-Here is an example of how to use taskgroup decorator :
-
-.. exampleinclude:: /../airflow/example_dags/example_task_group_decorator.py
-    :language: python
-    :start-after: [START task_group_decorator_usage]
-    :end-before: [END task_group_decorator_usage]
-
 
 SLAs
 ====

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1287,6 +1287,7 @@ tagKey
 tagValue
 tao
 taskflow
+taskgroup
 taskinstance
 tblproperties
 tcp

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -20,8 +20,10 @@ import pendulum
 import pytest
 
 from airflow.models import DAG
+from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
-from airflow.utils.task_group import TaskGroup
+from airflow.operators.python import PythonOperator
+from airflow.utils.task_group import TaskGroup, taskgroup
 from airflow.www.views import dag_edges, task_group_to_dict
 
 EXPECTED_JSON = {
@@ -576,3 +578,315 @@ def test_task_without_dag():
     assert op1.dag == op2.dag == op3.dag
     assert dag.task_group.children.keys() == {"op1", "op2", "op3"}
     assert dag.task_group.children.keys() == dag.task_dict.keys()
+
+
+# taskgroup decorator tests
+
+
+def test_build_task_group_deco_context_manager():
+    """
+    Tests Following :
+    1. Nested TaskGroup creation using taskgroup decorator should create same TaskGroup which can be
+    created using TaskGroup context manager.
+    2. TaskGroup consisting Tasks created using task decorator.
+    3. Node Ids of dags created with taskgroup decorator.
+    """
+
+    from airflow.operators.python import task
+
+    # Creating Tasks
+    @task
+    def task_start():
+        """Dummy Task which is First Task of Dag """
+        return '[Task_start]'
+
+    @task
+    def task_end():
+        """Dummy Task which is Last Task of Dag"""
+        print('[ Task_End ]')
+
+    @task
+    def task_1(value):
+        """ Dummy Task1"""
+        return f'[ Task1 {value} ]'
+
+    @task
+    def task_2(value):
+        """ Dummy Task2"""
+        print(f'[ Task2 {value} ]')
+
+    @task
+    def task_3(value):
+        """ Dummy Task3"""
+        return f'[ Task3 {value} ]'
+
+    @task
+    def task_4(value):
+        """ Dummy Task3"""
+        print(f'[ Task4 {value} ]')
+
+    # Creating TaskGroups
+    @taskgroup
+    def section_1(value):
+        """ TaskGroup for grouping related Tasks"""
+
+        @taskgroup()
+        def section_2(value2):
+            """ TaskGroup for grouping related Tasks"""
+            return task_4(task_3(value2))
+
+        op1 = task_2(task_1(value))
+        return section_2(op1)
+
+    execution_date = pendulum.parse("20201109")
+    with DAG(
+        dag_id="example_nested_task_group_decorator", start_date=execution_date, tags=["example"]
+    ) as dag:
+        t_start = task_start()
+        sec_1 = section_1(t_start)
+        sec_1.set_downstream(task_end())
+
+    # Testing TaskGroup created using taskgroup decorator
+    assert set(dag.task_group.children.keys()) == {"task_start", "task_end", "section_1"}
+    assert set(dag.task_group.children['section_1'].children.keys()) == {
+        'section_1.task_1',
+        'section_1.task_2',
+        'section_1.section_2',
+    }
+
+    # Testing TaskGroup consisting Tasks created using task decorator
+    assert dag.task_dict['task_start'].downstream_task_ids == {'section_1.task_1'}
+    assert dag.task_dict['section_1.task_2'].downstream_task_ids == {'section_1.section_2.task_3'}
+    assert dag.task_dict['section_1.section_2.task_4'].downstream_task_ids == {'task_end'}
+
+    # Node IDs test
+    node_ids = {
+        'id': None,
+        'children': [
+            {
+                'id': 'section_1',
+                'children': [
+                    {
+                        'id': 'section_1.section_2',
+                        'children': [
+                            {'id': 'section_1.section_2.task_3'},
+                            {'id': 'section_1.section_2.task_4'},
+                        ],
+                    },
+                    {'id': 'section_1.task_1'},
+                    {'id': 'section_1.task_2'},
+                    {'id': 'section_1.downstream_join_id'},
+                ],
+            },
+            {'id': 'task_end'},
+            {'id': 'task_start'},
+        ],
+    }
+
+    assert extract_node_id(task_group_to_dict(dag.task_group)) == node_ids
+
+
+def test_build_task_group_with_operators():
+    """  Tests DAG with Tasks created with *Operators and TaskGroup created with taskgroup decorator """
+
+    from airflow.operators.python import task
+
+    def task_start():
+        """Dummy Task which is First Task of Dag """
+        return '[Task_start]'
+
+    def task_end():
+        """Dummy Task which is Last Task of Dag"""
+        print('[ Task_End  ]')
+
+    # Creating Tasks
+    @task
+    def task_1(value):
+        """ Dummy Task1"""
+        return f'[ Task1 {value} ]'
+
+    @task
+    def task_2(value):
+        """ Dummy Task2"""
+        return f'[ Task2 {value} ]'
+
+    @task
+    def task_3(value):
+        """ Dummy Task3"""
+        print(f'[ Task3 {value} ]')
+
+    # Creating TaskGroups
+    @taskgroup(group_id='section_1')
+    def section_a(value):
+        """ TaskGroup for grouping related Tasks"""
+        return task_3(task_2(task_1(value)))
+
+    execution_date = pendulum.parse("20201109")
+    with DAG(dag_id="example_task_group_decorator_mix", start_date=execution_date, tags=["example"]) as dag:
+        t_start = PythonOperator(task_id='task_start', python_callable=task_start, dag=dag)
+        sec_1 = section_a(t_start.output)
+        t_end = PythonOperator(task_id='task_end', python_callable=task_end, dag=dag)
+        sec_1.set_downstream(t_end)
+
+    # Testing Tasks ing DAG
+    assert set(dag.task_group.children.keys()) == {'section_1', 'task_start', 'task_end'}
+    assert set(dag.task_group.children['section_1'].children.keys()) == {
+        'section_1.task_2',
+        'section_1.task_3',
+        'section_1.task_1',
+    }
+
+    # Testing Tasks downstream
+    assert dag.task_dict['task_start'].downstream_task_ids == {'section_1.task_1'}
+    assert dag.task_dict['section_1.task_3'].downstream_task_ids == {'task_end'}
+
+
+def test_task_group_context_mix():
+    """ Test cases to check nested TaskGroup context manager with taskgroup decorator"""
+
+    from airflow.operators.python import task
+
+    def task_start():
+        """Dummy Task which is First Task of Dag """
+        return '[Task_start]'
+
+    def task_end():
+        """Dummy Task which is Last Task of Dag"""
+        print('[ Task_End  ]')
+
+    # Creating Tasks
+    @task
+    def task_1(value):
+        """ Dummy Task1"""
+        return f'[ Task1 {value} ]'
+
+    @task
+    def task_2(value):
+        """ Dummy Task2"""
+        return f'[ Task2 {value} ]'
+
+    @task
+    def task_3(value):
+        """ Dummy Task3"""
+        print(f'[ Task3 {value} ]')
+
+    # Creating TaskGroups
+    @taskgroup
+    def section_2(value):
+        """ TaskGroup for grouping related Tasks"""
+        return task_3(task_2(task_1(value)))
+
+    execution_date = pendulum.parse("20201109")
+    with DAG(dag_id="example_task_group_decorator_mix", start_date=execution_date, tags=["example"]) as dag:
+        t_start = PythonOperator(task_id='task_start', python_callable=task_start, dag=dag)
+
+        with TaskGroup("section_1", tooltip="section_1") as section_1:
+            sec_2 = section_2(t_start.output)
+            task_s1 = DummyOperator(task_id="task_1")
+            task_s2 = BashOperator(task_id="task_2", bash_command='echo 1')
+            task_s3 = DummyOperator(task_id="task_3")
+
+            sec_2.set_downstream(task_s1)
+            task_s1 >> [task_s2, task_s3]
+
+        t_end = PythonOperator(task_id='task_end', python_callable=task_end, dag=dag)
+        t_start >> section_1 >> t_end
+
+    node_ids = {
+        'id': None,
+        'children': [
+            {
+                'id': 'section_1',
+                'children': [
+                    {
+                        'id': 'section_1.section_2',
+                        'children': [
+                            {'id': 'section_1.section_2.task_1'},
+                            {'id': 'section_1.section_2.task_2'},
+                            {'id': 'section_1.section_2.task_3'},
+                            {'id': 'section_1.section_2.downstream_join_id'},
+                        ],
+                    },
+                    {'id': 'section_1.task_1'},
+                    {'id': 'section_1.task_2'},
+                    {'id': 'section_1.task_3'},
+                    {'id': 'section_1.upstream_join_id'},
+                    {'id': 'section_1.downstream_join_id'},
+                ],
+            },
+            {'id': 'task_end'},
+            {'id': 'task_start'},
+        ],
+    }
+
+    assert extract_node_id(task_group_to_dict(dag.task_group)) == node_ids
+
+
+def test_duplicate_task_group_id():
+    """ Testing automatic suffix assignment for duplicate group_id"""
+
+    from airflow.operators.python import task
+
+    @task(task_id='start_task')
+    def task_start():
+        """Dummy Task which is First Task of Dag """
+        print('[Task_start]')
+
+    @task(task_id='end_task')
+    def task_end():
+        """Dummy Task which is Last Task of Dag"""
+        print('[Task_End]')
+
+    # Creating Tasks
+    @task(task_id='task')
+    def task_1():
+        """ Dummy Task1"""
+        print('[Task1]')
+
+    @task(task_id='task')
+    def task_2():
+        """ Dummy Task2"""
+        print('[Task2]')
+
+    @task(task_id='task1')
+    def task_3():
+        """ Dummy Task3"""
+        print('[Task3]')
+
+    @taskgroup(group_id='task_group1')
+    def task_group1():
+        task_start()
+        task_1()
+        task_2()
+
+    @taskgroup(group_id='task_group1')
+    def task_group2():
+        task_3()
+
+    @taskgroup(group_id='task_group1')
+    def task_group3():
+        task_end()
+
+    execution_date = pendulum.parse("20201109")
+    with DAG(dag_id="example_duplicate_task_group_id", start_date=execution_date, tags=["example"]) as dag:
+        task_group1()
+        task_group2()
+        task_group3()
+
+    node_ids = {
+        'id': None,
+        'children': [
+            {
+                'id': 'task_group1',
+                'children': [
+                    {'id': 'task_group1.start_task'},
+                    {'id': 'task_group1.task'},
+                    {'id': 'task_group1.task__1'},
+                ],
+            },
+            {'id': 'task_group1__1', 'children': [{'id': 'task_group1__1.task1'}]},
+            {'id': 'task_group1__2', 'children': [{'id': 'task_group1__2.end_task'}]},
+        ],
+    }
+
+    assert extract_node_id(task_group_to_dict(dag.task_group)) == node_ids


### PR DESCRIPTION
Added taskgroup decorator which can be used to create taskgroup from python callable. Inside python callable tasks can be grouped by calling tasks (python callable ) created with task decorator.


- taskgroup decorator takes both optional and keyword argument which are passed to Constructor of TaskGroup class.

- TaskGroup can be created with one of following syntax

``` python
@taskgroup
@taskgroup()
@taskgroup(group_id='group_name')
```

- TaskGroup class  constructor takes one mandatory argument group_id, if not given in decorator it sets group_id to python callable name.

Following is a simple example demonstrating use of taskgroup decorator grouping multiple tasks.

``` python
@task
def task_1(value):
  return f'[ Task1 {value} ]'


@task
def task_2(value):
  print(f'[ Task2 {value} ]')


@taskgroup
def section_1(value):
  return task_2(task_1(value))
```

taskgroup decorator utilizes existing TaskGroup context manager currently used for creating TaskGroup, which means we can create nested taskgroup by created nested callable. Following is an example demonstrating use of nested taskgroup.

``` python
@task
def task_start():
    return '[Task_start]'

@task
def task_end():
    print(f'[ Task_End ]')

@task
def task_1(value):
    return f'[ Task1 {value} ]'

@task
def task_2(value):
    print(f'[ Task2 {value} ]')

@task
def task_3(value):
    return f'[ Task3 {value} ]'

@task
def task_4(value):
    print(f'[ Task4 {value} ]')

@taskgroup
def section_1(value):

    @taskgroup
    def section_2(value2):
        return task_4(task_3(value2))

    op1 = task_2(task_1(value))
    return section_2(op1) 
```

Dedicated test cases for taskgroup decorator is created in file 
/tests/utils/test_task_group_decorator.py


Recent changes 

- Added logic to append suffix to duplicate group_id.

closes: #11870

