### PR TITLE
Fix S3KeysUnchangedSensor so that template_fields will work (#13481)

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3_keys_unchanged.py
+++ b/airflow/providers/amazon/aws/sensors/s3_keys_unchanged.py
@@ -88,7 +88,7 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
 
         super().__init__(**kwargs)
 
-        self.bucket = bucket_name
+        self.bucket_name = bucket_name
         self.prefix = prefix
         if inactivity_period < 0:
             raise ValueError("inactivity_period must be non-negative")
@@ -120,7 +120,7 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
             # and update previous_objects for the next poke.
             self.log.info(
                 "New objects found at %s, resetting last_activity_time.",
-                os.path.join(self.bucket, self.prefix),
+                os.path.join(self.bucket_name, self.prefix),
             )
             self.log.debug("New objects: %s", current_objects - self.previous_objects)
             self.last_activity_time = datetime.now()
@@ -143,7 +143,7 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
 
             raise AirflowException(
                 "Illegal behavior: objects were deleted in %s between pokes."
-                % os.path.join(self.bucket, self.prefix)
+                % os.path.join(self.bucket_name, self.prefix)
             )
 
         if self.last_activity_time:
@@ -154,7 +154,7 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
             self.inactivity_seconds = 0
 
         if self.inactivity_seconds >= self.inactivity_period:
-            path = os.path.join(self.bucket, self.prefix)
+            path = os.path.join(self.bucket_name, self.prefix)
 
             if current_num_objects >= self.min_objects:
                 self.log.info(
@@ -172,4 +172,4 @@ class S3KeysUnchangedSensor(BaseSensorOperator):
         return False
 
     def poke(self, context):
-        return self.is_keys_unchanged(set(self.hook.list_keys(self.bucket, prefix=self.prefix)))
+        return self.is_keys_unchanged(set(self.hook.list_keys(self.bucket_name, prefix=self.prefix)))

--- a/tests/providers/amazon/aws/sensors/test_s3_keys_unchanged.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_keys_unchanged.py
@@ -61,6 +61,18 @@ class TestS3KeysUnchangedSensor(TestCase):
                 dag=self.dag,
             )
 
+    def test_render_template_fields(self):
+        S3KeysUnchangedSensor(
+            task_id='sensor_3',
+            bucket_name='test-bucket',
+            prefix='test-prefix/path',
+            inactivity_period=12,
+            poke_interval=0.1,
+            min_objects=1,
+            allow_delete=True,
+            dag=self.dag,
+        ).render_template_fields({})
+
     @freeze_time(DEFAULT_DATE, auto_tick_seconds=10)
     def test_files_deleted_between_pokes_throw_error(self):
         self.sensor.allow_delete = False


### PR DESCRIPTION
- Add a test for rendering template_fields
- Rename the instance variable 'bucket' to 'bucket_name'

This problem can also be solved by removing `bucket_name` from `template_fields`.
But I thought `bucket_name` should be template_field, so I renamed the instance variable to match existing `template_fields`.