### PR TITLE
Check for minimum version of Sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,14 @@ Apache Airflow is tested with:
 | Python       | 3.6, 3.7, 3.8             | 3.6, 3.7, 3.8            | 2.7, 3.5, 3.6, 3.7, 3.8    |
 | PostgreSQL   | 9.6, 10, 11, 12, 13       | 9.6, 10, 11, 12, 13      | 9.6, 10, 11, 12, 13        |
 | MySQL        | 5.7, 8                    | 5.7, 8                   | 5.6, 5.7                   |
-| SQLite       | latest stable             | latest stable            | latest stable              |
+| SQLite       | 3.15.0+                   | 3.15.0+                  | 3.15.0+                    |
 | Kubernetes   | 1.16.9, 1.17.5, 1.18.6    | 1.16.9, 1.17.5, 1.18.6   | 1.16.9, 1.17.5, 1.18.6     |
 
-**Note:** MariaDB and MySQL 5.x are unable to or have limitations with
-running multiple schedulers -- please see the "Scheduler" docs.
+**Note:** MySQL 5.x versions are unable to or have limitations with
+running multiple schedulers -- please see the "Scheduler" docs. MariaDB is not tested/recommended.
 
 **Note:** SQLite is used in Airflow tests. Do not use it in production. We recommend
-using the latest stable version of SQLite for local development. Some older versions
-of SQLite might not work well, however anything at or above 3.27.2 should work fine.
+using the latest stable version of SQLite for local development.
 
 ## Support for Python versions
 

--- a/docs/apache-airflow/installation.rst
+++ b/docs/apache-airflow/installation.rst
@@ -21,6 +21,28 @@ Installation
 
 .. contents:: :local:
 
+
+Prerequisites
+-------------
+
+Airflow is tested with:
+
+* Python: 3.6, 3.7, 3.8
+
+* Databases:
+
+  * PostgreSQL:  9.6, 10, 11, 12, 13
+  * MySQL: 5.7, 8
+  * SQLite: 3.15.0+
+
+* Kubernetes: 1.16.9, 1.17.5, 1.18.6
+
+**Note:** MySQL 5.x versions are unable to or have limitations with
+running multiple schedulers -- please see the "Scheduler" docs. MariaDB is not tested/recommended.
+
+**Note:** SQLite is used in Airflow tests. Do not use it in production. We recommend
+using the latest stable version of SQLite for local development.
+
 Getting Airflow
 '''''''''''''''
 


### PR DESCRIPTION
Some users testing Airlfow 2.0 with sqlite noticed that for
old versions of sqlite, Airflow does not run tasks and fails with
'sqlite3.OperationalError: near ",": syntax error' when running
tasks. More details about it in #13397.

Bisecting had shown that minimum supported version of sqlite is
3.15.0, therefore this PR adds checking if sqlite version is
higher than that and fails hard if it is not.

Documentation has been updated with minimum requirements, some
inconsisttencies have been removed, also the minimum requirements
for stable 2.0 version were moved to installation.rst because
the requirements were never explicitely stated in the user-facing
documentation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
