### PR TITLE
Add a new argument for HttpSensor to accept a list of http status code to Continue Poking

### DIFF
--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -30,8 +30,8 @@ class HttpSensor(BaseSensorOperator):
 
     HTTP Error codes other than 404 (like 403) or Connection Refused Error
     would raise an exception and fail the sensor itself directly (no more poking).
-    To avoid fail the task for other codes than 404, the argument `extra_option`
-    can be passed with the value `{'check_response': False}`. It will make the `response_check`
+    To avoid failing the task for other codes than 404, the argument ``extra_option``
+    can be passed with the value ``{'check_response': False}``. It will make the ``response_check``
     be execute for any http status code.
 
     The response check can access the template context to the operator:

--- a/airflow/providers/http/sensors/http.py
+++ b/airflow/providers/http/sensors/http.py
@@ -29,7 +29,10 @@ class HttpSensor(BaseSensorOperator):
     404 Not Found or `response_check` returning False.
 
     HTTP Error codes other than 404 (like 403) or Connection Refused Error
-    would fail the sensor itself directly (no more poking).
+    would raise an exception and fail the sensor itself directly (no more poking).
+    To avoid fail the task for other codes than 404, the argument `extra_option`
+    can be passed with the value `{'check_response': False}`. It will make the `response_check`
+    be execute for any http status code.
 
     The response check can access the template context to the operator:
 


### PR DESCRIPTION
Add a new argument for HttpSensor to accept a list of Error codes to continue poking

closes: #13451
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
