### PR TITLE
Warn about precedence of env var when getting variables

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -17,6 +17,8 @@
 # under the License.
 
 import json
+import logging
+import os
 from typing import Any, Optional
 
 from cryptography.fernet import InvalidToken as InvalidFernetToken
@@ -29,6 +31,8 @@ from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
+
+log = logging.getLogger()
 
 
 class Variable(Base, LoggingMixin):
@@ -143,6 +147,14 @@ class Variable(Base, LoggingMixin):
         :param serialize_json: Serialize the value to a JSON string
         :param session: SQL Alchemy Sessions
         """
+        env_var_name = "AIRFLOW_VAR_" + key.upper()
+        if env_var_name in os.environ:
+            log.warning(
+                "You have the environment variable %s defined, which takes precedence over reading "
+                "from the database. The value will be saved, but to read it you have to delete "
+                "the environment variable.",
+                env_var_name,
+            )
         if serialize_json:
             stored_value = json.dumps(value, indent=2)
         else:


### PR DESCRIPTION
This behavior may not be obvious to everyone, so I display a message when this happens. Hope this will improve DX a little.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
