### PR TITLE
Add verify_ssl config for kubernetes

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2069,6 +2069,13 @@
       type: integer
       example: ~
       default: "6"
+    - name: verify_ssl
+      description: |
+        Set this to false to skip verifying SSL certificate of Kubernetes python client.
+      version_added: ~
+      type: boolean
+      example: ~
+      default: "True"
 - name: smart_sensor
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1015,6 +1015,9 @@ tcp_keep_intvl = 30
 # a connection is considered to be broken.
 tcp_keep_cnt = 6
 
+# Set this to false to skip verifying SSL certificate of Kubernetes python client.
+verify_ssl = True
+
 [smart_sensor]
 # When `use_smart_sensor` is True, Airflow redirects multiple qualified sensor tasks to
 # smart sensor task.

--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -58,6 +58,11 @@ try:
         else:
             return client.CoreV1Api()
 
+    def _disable_verify_ssl() -> None:
+        configuration = Configuration()
+        configuration.verify_ssl = False
+        Configuration.set_default(configuration)
+
 
 except ImportError as e:
     # We need an exception class to be able to use it in ``except`` elsewhere
@@ -122,6 +127,9 @@ def get_kube_client(
 
     if conf.getboolean('kubernetes', 'enable_tcp_keepalive', fallback=False):
         _enable_tcp_keepalive()
+
+    if not conf.getboolean('kubernetes', 'verify_ssl', fallback=True):
+        _disable_verify_ssl()
 
     client_conf = _get_kube_config(in_cluster, cluster_context, config_file)
     return _get_client_with_patched_configuration(client_conf)

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -19,9 +19,15 @@ import socket
 import unittest
 from unittest import mock
 
+from kubernetes.client import Configuration
 from urllib3.connection import HTTPConnection, HTTPSConnection
 
-from airflow.kubernetes.kube_client import RefreshConfiguration, _enable_tcp_keepalive, get_kube_client
+from airflow.kubernetes.kube_client import (
+    RefreshConfiguration,
+    _disable_verify_ssl,
+    _enable_tcp_keepalive,
+    get_kube_client,
+)
 
 
 class TestClient(unittest.TestCase):
@@ -50,3 +56,12 @@ class TestClient(unittest.TestCase):
 
         self.assertEqual(HTTPConnection.default_socket_options, expected_http_connection_options)
         self.assertEqual(HTTPSConnection.default_socket_options, expected_https_connection_options)
+
+    def test_disable_verify_ssl(self):
+        configuration = Configuration()
+        self.assertTrue(configuration.verify_ssl)
+
+        _disable_verify_ssl()
+
+        configuration = Configuration()
+        self.assertFalse(configuration.verify_ssl)


### PR DESCRIPTION
`certificate verify failed` is a common issue for k8s python client without ssl_cert, I have the some problem with deploy airflow in k8s on alicloud.
- use `cleanup_pods` to clean up k8s pod raise this error
- use `KubernetesPodOperator` also raised

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
