### PR TITLE
Support Brotli compression for web views

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -30,6 +30,7 @@ from airflow.logging_config import configure_logging
 from airflow.utils.json import AirflowJsonEncoder
 from airflow.www.extensions.init_appbuilder import init_appbuilder
 from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
+from airflow.www.extensions.init_compressor import init_compress
 from airflow.www.extensions.init_dagbag import init_dagbag
 from airflow.www.extensions.init_jinja_globals import init_jinja_globals
 from airflow.www.extensions.init_manifest_files import configure_manifest_files
@@ -104,6 +105,7 @@ def create_app(config=None, testing=False, app_name="Airflow"):
 
     Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
 
+    init_compress(flask_app)
     init_flash_views(flask_app)
 
     configure_logging()

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -17,12 +17,11 @@
 # under the License.
 
 import functools
-import gzip
-from io import BytesIO as IO
+import warnings
 from typing import Callable, TypeVar, cast
 
 import pendulum
-from flask import after_this_request, g, request
+from flask import after_this_request, current_app, g, request
 
 from airflow.models import Log
 from airflow.utils.session import create_session
@@ -62,38 +61,28 @@ def action_logging(f: T) -> T:
     return cast(T, wrapper)
 
 
-def gzipped(f: T) -> T:
+def compressed(f: T) -> T:
     """Decorator to make a view compressed"""
 
     @functools.wraps(f)
     def view_func(*args, **kwargs):
-        @after_this_request
-        def zipper(response):  # pylint: disable=unused-variable
-            accept_encoding = request.headers.get('Accept-Encoding', '')
+        def compressor(response):
+            compress = current_app.extensions['compress']
+            return compress.after_request(response)
 
-            if 'gzip' not in accept_encoding.lower():
-                return response
-
-            response.direct_passthrough = False
-
-            if (
-                response.status_code < 200
-                or response.status_code >= 300
-                or 'Content-Encoding' in response.headers
-            ):
-                return response
-            gzip_buffer = IO()
-            gzip_file = gzip.GzipFile(mode='wb', fileobj=gzip_buffer)
-            gzip_file.write(response.data)
-            gzip_file.close()
-
-            response.data = gzip_buffer.getvalue()
-            response.headers['Content-Encoding'] = 'gzip'
-            response.headers['Vary'] = 'Accept-Encoding'
-            response.headers['Content-Length'] = len(response.data)
-
-            return response
+        after_this_request(compressor)
 
         return f(*args, **kwargs)
 
-    return cast(T, view_func)
+    return view_func
+
+
+def gzipped(*args, **kwargs) -> T:
+    """This function is deprecated. Please use `airflow.www.decorators.compressed`."""
+    warnings.warn(
+        "This function is deprecated. Please use `airflow.www.decorators.compressed`.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    return compressed(*args, **kwargs)

--- a/airflow/www/extensions/init_compressor.py
+++ b/airflow/www/extensions/init_compressor.py
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from flask_compress import Compress
+
+
+def init_compress(flask_app):
+    """Initialize flask_compress extension"""
+    flask_app.config["COMPRESS_REGISTER"] = False  # disable default compression of all eligible requests
+
+    compress = Compress(app=flask_app)
+    flask_app.extensions['compress'] = compress

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -93,7 +93,7 @@ from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
-from airflow.www.decorators import action_logging, gzipped
+from airflow.www.decorators import action_logging, compressed
 from airflow.www.forms import (
     ConnectionForm,
     DagRunEditForm,
@@ -1840,7 +1840,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
         ]
     )
-    @gzipped  # pylint: disable=too-many-locals
+    @compressed  # pylint: disable=too-many-locals
     @action_logging  # pylint: disable=too-many-locals
     def tree(self):
         """Get Dag as tree."""
@@ -2004,7 +2004,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
         ]
     )
-    @gzipped
+    @compressed
     @action_logging
     @provide_session
     def graph(self, session=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -94,6 +94,7 @@ install_requires =
     flask>=1.1.0, <2.0
     flask-appbuilder~=3.1.1
     flask-caching>=1.5.0, <2.0.0
+    flask-compress>=1.8.0, <2.0.0
     flask-login>=0.3, <0.5
     flask-wtf>=0.14.3, <0.15
     graphviz>=0.12

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -819,6 +819,11 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('section-1-task-1', resp)
 
+    def test_tree_compression(self):
+        url = 'tree?dag_id=example_bash_operator'
+        resp = self.client.get(url, headers=[('Accept-Encoding', 'br')])
+        self.assertEqual(resp.headers['Content-Encoding'], 'br')
+
     def test_duration(self):
         url = 'duration?days=30&dag_id=example_bash_operator'
         resp = self.client.get(url, follow_redirects=True)


### PR DESCRIPTION
Brotli is a more modern compression algorithm that provides better compression ratios than gzip and is widely supported by browsers. If the browser does not support Brotli, another supported algorithm will be used - gzip, deflate.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
