### PR TITLE
Fix webserver exiting when gunicorn master crashes

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -260,7 +260,7 @@ class GunicornMonitor(LoggingMixin):
                 new_worker_count = min(
                     self.num_workers_expected - num_workers_running, self.worker_refresh_batch_size
                 )
-                self.log.info(
+                self.log.debug(
                     '[%d / %d] Spawning %d workers',
                     num_ready_workers_running,
                     num_workers_running,

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -258,15 +258,15 @@ class GunicornMonitor(LoggingMixin):
             num_workers_running = self._get_num_workers_running()
             if num_workers_running < self.num_workers_expected:
                 new_worker_count = min(
-                    num_workers_running - self.worker_refresh_batch_size, self.worker_refresh_batch_size
+                    self.num_workers_expected - num_workers_running, self.worker_refresh_batch_size
                 )
-                self.log.debug(
+                self.log.info(
                     '[%d / %d] Spawning %d workers',
                     num_ready_workers_running,
                     num_workers_running,
                     new_worker_count,
                 )
-                self._spawn_new_workers(num_workers_running)
+                self._spawn_new_workers(new_worker_count)
             return
 
         # Now the number of running and expected worker should be equal


### PR DESCRIPTION
…#13469)

A key consequence of this fix is that webserver will properly
exit when gunicorn master dies and stops responding to signals.


