### PR TITLE
Replace deprecated module and operator in example_tasks.py

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_tasks.py
+++ b/airflow/providers/google/cloud/example_dags/example_tasks.py
@@ -29,6 +29,7 @@ from google.cloud.tasks_v2.types import Queue
 from google.protobuf import timestamp_pb2
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.operators.tasks import (
     CloudTasksQueueCreateOperator,
@@ -46,7 +47,6 @@ from airflow.providers.google.cloud.operators.tasks import (
     CloudTasksTasksListOperator,
 )
 from airflow.utils.dates import days_ago
-from airflow.utils.helpers import chain
 
 timestamp = timestamp_pb2.Timestamp()
 timestamp.FromDatetime(datetime.now() + timedelta(hours=12))  # pylint: disable=no-member


### PR DESCRIPTION
- `from airflow.utils.helpers import chain` to `from airflow.models.baseoperator import chain`

This commit also adds Bowler refactor for backport packages

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
