### PR TITLE
When "full tests needed" label is present, run all tests

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -455,6 +455,10 @@ function run_all_tests_if_environment_files_changed() {
         echo "Important environment files changed. Running everything"
         set_outputs_run_everything_and_exit
     fi
+    if [[ ${FULL_TESTS_NEEDED_LABEL} == "true" ]]; then
+        echo "Full tests requested by label on PR. Running everything"
+        set_outputs_run_everything_and_exit
+    fi
     start_end::group_end
 }
 


### PR DESCRIPTION
This label can be set manually, and the expectation is that it would run
all tests, but in some cases for PRs that don't touch code, it would
still skip most of the matrix and run minimal static checks only.

This changes the behaviour so that if the label is found it will run all
tests no matter what files have been changed -- making the label name
more true :)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).