### PR TITLE
Add python-daemon limit for python 3.8+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -119,7 +119,9 @@ install_requires =
     pygments>=2.0.1, <3.0
     # snowflake-connector-python, flask-jwt-extended, msal are not compatible with newest version.
     pyjwt<2
-    python-daemon>=2.1.1
+    # python daemon crashes with 'socket operation on non-socket' for python 3.8+ in version < 2.2.4
+    # https://pagure.io/python-daemon/issue/34
+    python-daemon>=2.2.4
     python-dateutil>=2.3, <3
     python-nvd3~=0.15.0
     python-slugify>=3.0.0,<5.0


### PR DESCRIPTION
Related to #11456. Python daemon crashes with 'socket operation on
non-socket' for versions < 2.2.4.

The issue is https://pagure.io/python-daemon/issue/34

The fix is: https://pagure.io/python-daemon/c/b708912

And it's been released in 2.2.4 version:

https://pagure.io/python-daemon/blob/55ea71020486ea299ecbc03aec8e7f9dca2f5a85/f/ChangeLog

This PR adds limitation for python 3.8 to require
python-daemon at least 2.2.4.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
