### PR TITLE
added support for device_requests in DockerOperator

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -249,7 +249,7 @@ class DockerOperator(BaseOperator):
                     mem_limit=self.mem_limit,
                     cap_add=self.cap_add,
                     extra_hosts=self.extra_hosts,
-                    device_requests=self.device_requests
+                    device_requests=self.device_requests,
                 ),
                 image=self.image,
                 user=self.user,

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -123,6 +123,9 @@ class DockerOperator(BaseOperator):
     :type tty: bool
     :param cap_add: Include container capabilities
     :type cap_add: list[str]
+    :param device_requests: device requests to docker runtime when creating Docker container.
+        eg. ``[docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])]``
+    :type device_requests: list[any]
     """
 
     template_fields = ('command', 'environment', 'container_name')
@@ -166,6 +169,7 @@ class DockerOperator(BaseOperator):
         tty: bool = False,
         cap_add: Optional[Iterable[str]] = None,
         extra_hosts: Optional[Dict[str, str]] = None,
+        device_requests: Optional[List[any]] = None,
         **kwargs,
     ) -> None:
 
@@ -200,6 +204,8 @@ class DockerOperator(BaseOperator):
         self.tty = tty
         self.cap_add = cap_add
         self.extra_hosts = extra_hosts
+        self.device_requests = device_requests or []
+
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
@@ -243,6 +249,7 @@ class DockerOperator(BaseOperator):
                     mem_limit=self.mem_limit,
                     cap_add=self.cap_add,
                     extra_hosts=self.extra_hosts,
+                    device_requests=self.device_requests
                 ),
                 image=self.image,
                 user=self.user,

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -21,6 +21,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List, Optional, Union
 
 from docker import APIClient, tls
+from docker.types import DeviceRequest
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -169,7 +170,7 @@ class DockerOperator(BaseOperator):
         tty: bool = False,
         cap_add: Optional[Iterable[str]] = None,
         extra_hosts: Optional[Dict[str, str]] = None,
-        device_requests: Optional[List[any]] = None,
+        device_requests: Optional[List[DeviceRequest]] = None,
         **kwargs,
     ) -> None:
 

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -127,6 +127,8 @@ class DockerOperator(BaseOperator):
     :param device_requests: device requests to docker runtime when creating Docker container.
         eg. ``[docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])]``
     :type device_requests: list[any]
+    :param runtime: Runtime to use with this container.
+    :type runtime: str
     """
 
     template_fields = ('command', 'environment', 'container_name')
@@ -171,6 +173,7 @@ class DockerOperator(BaseOperator):
         cap_add: Optional[Iterable[str]] = None,
         extra_hosts: Optional[Dict[str, str]] = None,
         device_requests: Optional[List[DeviceRequest]] = None,
+        runtime: Optional[str] = None,
         **kwargs,
     ) -> None:
 
@@ -206,6 +209,7 @@ class DockerOperator(BaseOperator):
         self.cap_add = cap_add
         self.extra_hosts = extra_hosts
         self.device_requests = device_requests or []
+        self.runtime = runtime
 
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
@@ -251,6 +255,7 @@ class DockerOperator(BaseOperator):
                     cap_add=self.cap_add,
                     extra_hosts=self.extra_hosts,
                     device_requests=self.device_requests,
+                    runtime=self.runtime,
                 ),
                 image=self.image,
                 user=self.user,

--- a/setup.py
+++ b/setup.py
@@ -223,7 +223,7 @@ doc = [
     'sphinxcontrib-spelling==5.2.1',
 ]
 docker = [
-    'docker~=3.0',
+    'docker>=4.3',
 ]
 druid = [
     'pydruid>=0.4.1',


### PR DESCRIPTION
closes: #9492

* this uses the device_requests parameter when creating the docker container to enable container to access host devices
* feature was introduced in docker-py [here](https://github.com/docker/docker-py/pull/2471) and released in [4.3.0](https://docker-py.readthedocs.io/en/stable/change-log.html)
* had to increase the docker-py version to >=4.3, breaking changes mentioned in Changelog of docker-py (above) should have no effect

## intended use
```
    with_gpu = DockerOperator(
        task_id='with_gpu',
        image='nvidia/cuda:11.0-base',
        device_requests=[
            docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])
        ]            
    )
```