### PR TITLE
Fixing broken documentation links in API exceptions

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -59,7 +59,7 @@ def add_deprecation_headers(response: Response):
     <https://tools.ietf.org/id/draft-dalal-deprecation-header-03.html>`__.
     """
     response.headers['Deprecation'] = 'true'
-    doc_url = get_docs_url("stable-rest-api/migration.html")
+    doc_url = get_docs_url("upgrading-to-2.html#migration-guide-from-experimental-api-to-stable-api-v1")
     deprecation_link = f'<{doc_url}>; rel="deprecation"; type="text/html"'
     if 'link' in response.headers:
         response.headers['Link'] += f', {deprecation_link}'

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -59,7 +59,8 @@ class TestBase(unittest.TestCase):
     def assert_deprecated(self, resp):
         assert 'true' == resp.headers['Deprecation']
         assert re.search(
-            r'\<.+/stable-rest-api/migration.html\>; ' 'rel="deprecation"; type="text/html"',
+            r'\<.+/upgrading-to-2.html#migration-guide-from-experimental-api-to-stable-api-v1\>; '
+            'rel="deprecation"; type="text/html"',
             resp.headers['Link'],
         )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
A user on Slack pointed out that the docs URL returned in a 403 API response was broken. 

According to the user's report, the 403 response looked like this:
```
{
    "detail": null,
    "status": 403,
    "title": "Forbidden",
    "type": "https://airflow.apache.org/docs/2.0.0/stable-rest-api-ref.html#section/Errors/PermissionDenied"
}
```

A quick look into the source and it appears that this reference does in fact point to a nonexistent page. 

Before:
https://airflow.apache.org/docs/2.0.0/stable-rest-api-ref.html#section/Errors/PermissionDenied

After:
https://airflow.apache.org/docs/apache-airflow/2.0.0/stable-rest-api-ref.html#section/Errors/PermissionDenied

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
