### PR TITLE
more specific error handling in undefined jinja variables rule

### DIFF
--- a/airflow/upgrade/rules/undefined_jinja_varaibles.py
+++ b/airflow/upgrade/rules/undefined_jinja_varaibles.py
@@ -97,19 +97,13 @@ The user should do either of the following to fix this -
             try:
                 renderend_content = task.render_template(content, context)
                 completed_rendering = True
-            except ValueError as value_error:
-                undefined_variable = re.search(r"'(.*)'", str(value_error))[1]
+            except (ValueError, jinja2.UndefinedError) as value_error:
+                undefined_variable = re.search(r"'(.*?)'", str(value_error))[1]
                 message = "Could not find the object '{}'".format(undefined_variable)
                 errors_while_rendering.append(message)
-                if re.match(r"(None|NoneType)$", "None"):
-                    break
                 context[undefined_variable] = dict()
-            except TypeError as type_error:
-                undefined_variable = re.search("'(.*)'", str(type_error))[1]
-                errors_while_rendering.append(str(type_error))
-                if re.match(r"(None|NoneType)$", "None"):
+                if undefined_variable == "None":
                     break
-                context[undefined_variable] = dict()
             except Exception as e:
                 errors_while_rendering.append(str(e))
                 break

--- a/airflow/upgrade/rules/undefined_jinja_varaibles.py
+++ b/airflow/upgrade/rules/undefined_jinja_varaibles.py
@@ -102,7 +102,7 @@ The user should do either of the following to fix this -
                 message = "Could not find the object '{}'".format(undefined_variable)
                 errors_while_rendering.append(message)
                 context[undefined_variable] = dict()
-                if undefined_variable == "None":
+                if re.search(r".*has no attribute.*", str(value_error)):
                     break
             except Exception as e:
                 errors_while_rendering.append(str(e))

--- a/tests/upgrade/rules/test_undefined_jinja_varaibles.py
+++ b/tests/upgrade/rules/test_undefined_jinja_varaibles.py
@@ -133,6 +133,31 @@ class TestUndefinedJinjaVariablesRule(TestCase):
             dag=self.invalid_dag,
         )
 
+        miscellaneous_exception_command = """
+            {% for i in None %}
+            {% endfor %}
+            """
+
+        BashOperator(
+            task_id="miscellaneous_exception",
+            depends_on_past=False,
+            bash_command=miscellaneous_exception_command,
+            dag=self.invalid_dag,
+        )
+
+        missing_attribute_command = """
+            echo "{{ params.undefined_variable.foo }}"
+            """
+
+        BashOperator(
+            task_id="missing_attribute",
+            depends_on_past=False,
+            bash_command=missing_attribute_command,
+            dag=self.invalid_dag,
+        )
+   
+
+
     def setUp(self):
         self.setUpValidDag()
         self.setUpDagToSkip()
@@ -190,9 +215,16 @@ class TestUndefinedJinjaVariablesRule(TestCase):
             "dict object['undefined']  NestedTemplateField=att1 NestedTemplateField=nested1",
             "Possible UndefinedJinjaVariable -> DAG: test-undefined-jinja-variables, "
             "Task: templated_string, Attribute: env, Error: no such element: dict object['element']",
+            "Possible UndefinedJinjaVariable -> DAG: test-undefined-jinja-variables, "
+            "Task: miscellaneous_exception, Attribute: bash_command, "
+            "Error: 'NoneType' object is not iterable", 
+            "Possible UndefinedJinjaVariable -> DAG: test-undefined-jinja-variables, "
+            "Task: missing_attribute, Attribute: bash_command, "
+            "Error: Could not find the object 'dict object'"
         ]
 
         assert len(messages) == len(expected_messages)
         assert [m for m in messages if m in expected_messages], len(messages) == len(
             expected_messages
         )
+


### PR DESCRIPTION
1. Use regex to extract variable name from exception message
2. Specific handling for ValueError and TypeError
3. Defend against endless loop