### PR TITLE
Allow namespace in KubernetesPodOperator to be templated

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -156,6 +156,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
     """
 
     template_fields: Iterable[str] = (
+        'namespace',
         'image',
         'cmds',
         'arguments',

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -180,7 +180,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
 
     def test_jinja_templated_fields(self):
         task = KubernetesPodOperator(
-            namespace='default',
+            namespace="{{ namespace_jinja }}",
             image="{{ image_jinja }}:16.04",
             cmds=["bash", "-cx"],
             name="test_pod",
@@ -188,8 +188,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
         )
 
         self.assertEqual(task.image, "{{ image_jinja }}:16.04")
-        task.render_template_fields(context={"image_jinja": "ubuntu"})
+        task.render_template_fields(context={"image_jinja": "ubuntu", "namespace_jinja": "ns"})
         self.assertEqual(task.image, "ubuntu:16.04")
+        self.assertEqual(task.namespace, "ns")
 
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")


### PR DESCRIPTION
Add support for dynamic kubernetes namespaces, by allowing the field to be templated.