### PR TITLE
Fix typo under scheduler performance tips

### DIFF
--- a/docs/apache-airflow/faq.rst
+++ b/docs/apache-airflow/faq.rst
@@ -207,7 +207,7 @@ How to reduce airflow dag scheduling latency in production?
 
 - ``parsing_processes``: Scheduler will spawn multiple threads in parallel to parse dags.
   This is controlled by ``parsing_processes`` with default value of 2.
-  User should increase this value to a larger value (e.g numbers of cpus where scheduler runs + 1) in production.
+  User should increase this value to a larger value (e.g numbers of cpus where scheduler runs - 1) in production.
 - If you're using Airflow 1.10.x, consider moving to Airflow 2, which has reduced dag scheduling latency dramatically,
   and allows for running multiple schedulers.
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
I don't think it makes sense to have `{num_processors}+1` parsing processes, as the processes won't all be able to execute in parallel. 

I believe that this is supposed to say `{num_processors}-1`, which would also agree with [this blog post from Astronomer](https://airflow.apache.org/docs/apache-airflow/stable/faq.html#how-to-reduce-airflow-dag-scheduling-latency-in-production)

Discussed with @mik-laj on slack and they were in agreement. 

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
