### PR TITLE
The check for image is now more robust

### DIFF
--- a/scripts/ci/images/ci_wait_for_ci_image.sh
+++ b/scripts/ci/images/ci_wait_for_ci_image.sh
@@ -20,8 +20,6 @@
 
 push_pull_remove_images::check_if_github_registry_wait_for_image_enabled
 
-push_pull_remove_images::check_if_jq_installed
-
 build_image::login_to_github_registry_if_needed
 
 export AIRFLOW_CI_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}-ci"

--- a/scripts/ci/images/ci_wait_for_prod_image.sh
+++ b/scripts/ci/images/ci_wait_for_prod_image.sh
@@ -20,8 +20,6 @@
 
 push_pull_remove_images::check_if_github_registry_wait_for_image_enabled
 
-push_pull_remove_images::check_if_jq_installed
-
 build_image::login_to_github_registry_if_needed
 
 export AIRFLOW_PROD_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}"


### PR DESCRIPTION
The request to get manifest of the image in GitHub Packages
might randomly return either schma 1 response:

{
     "schemaVersion": 1,
     "name": "apache/airflow/master-python3.6-ci",
     "tag": "470317521",
     "architecture": "amd64",
     "fsLayers": [
        {

Or schema 2 response:

{
     "schemaVersion": 2,
     "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
     "config": {
        "mediaType": "application/vnd.docker.container.image.v1+json",
        "size": 56952,
        "digest": "sha256:5c80e2ab289647802affafc5c1efc879fe4f5b559cb7a2a1215868e84b1d6424"
     },


In order to check image more reliably we check the status code
of the curl response instead.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
