### PR TITLE
Optimize wait for prod images to be run after ci images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,7 +834,7 @@ jobs:
     timeout-minutes: 120
     name: "Wait for PROD images"
     runs-on: ubuntu-20.04
-    needs: [build-info]
+    needs: [build-info, ci-images]
     env:
       BACKEND: sqlite
       PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.defaultPythonVersion }}


### PR DESCRIPTION
This change slightly optimizes waiting for prod images. Waiting
for images necessarily takes one slot from jobs queue, even if
those jobs do nothing at all. This is unfortunate, but seems
there is no easy way to do it differently because GitHub
Actions does not support yet cross-workflow dependencies.

This PR optimizes waiting for images in the way that PROD images
and CI images waiting happen sequentially rather than in parallell.

PROD images are, as of #13557 prepared sequentially which
means that there is no point to wait for PROD images in parallel
to CI images.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
