### PR TITLE
Fix invalid continue_token for cleanup list pods

### DIFF
--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -90,9 +90,9 @@ def cleanup_pods(args):
     print('Loading Kubernetes configuration')
     kube_client = get_kube_client()
     print(f'Listing pods in namespace {namespace}')
-    continue_token = None
+    list_kwargs = {"namespace": namespace, "limit": 500}
     while True:  # pylint: disable=too-many-nested-blocks
-        pod_list = kube_client.list_namespaced_pod(namespace=namespace, limit=500, _continue=continue_token)
+        pod_list = kube_client.list_namespaced_pod(**list_kwargs)
         for pod in pod_list.items:
             pod_name = pod.metadata.name
             print(f'Inspecting pod {pod_name}')
@@ -118,6 +118,7 @@ def cleanup_pods(args):
         continue_token = pod_list.metadata._continue  # pylint: disable=protected-access
         if not continue_token:
             break
+        list_kwargs["_continue"] = continue_token
 
 
 def _delete_pod(name, namespace):

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -19,7 +19,7 @@ import os
 import tempfile
 import unittest
 from unittest import mock
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import kubernetes
 
@@ -72,12 +72,14 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         pod1.metadata.name = 'dummy'
         pod1.status.phase = 'Running'
         pod1.status.reason = None
-        pods = list_namespaced_pod()
+        pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod1]
+        list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
         delete_pod.assert_not_called()
         load_incluster_config.assert_called_once()
 
@@ -89,12 +91,14 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         pod1.metadata.name = 'dummy'
         pod1.status.phase = 'Succeeded'
         pod1.status.reason = None
-        pods = list_namespaced_pod()
+        pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod1]
+        list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
         delete_pod.assert_called_with('dummy', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -109,12 +113,14 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         pod1.status.phase = 'Failed'
         pod1.status.reason = None
         pod1.spec.restart_policy = 'Always'
-        pods = list_namespaced_pod()
+        pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod1]
+        list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
         delete_pod.assert_not_called()
         load_incluster_config.assert_called_once()
 
@@ -129,12 +135,14 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         pod1.status.phase = 'Failed'
         pod1.status.reason = None
         pod1.spec.restart_policy = 'Never'
-        pods = list_namespaced_pod()
+        pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod1]
+        list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
         delete_pod.assert_called_with('dummy3', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -147,12 +155,14 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         pod1.status.phase = 'Failed'
         pod1.status.reason = 'Evicted'
         pod1.spec.restart_policy = 'Never'
-        pods = list_namespaced_pod()
+        pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod1]
+        list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
         delete_pod.assert_called_with('dummy4', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -165,10 +175,38 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         pod1.metadata.name = 'dummy'
         pod1.status.phase = 'Succeeded'
         pod1.status.reason = None
-        pods = list_namespaced_pod()
+        pods = MagicMock()
         pods.metadata._continue = None
         pods.items = [pod1]
+        list_namespaced_pod.return_value = pods
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        load_incluster_config.assert_called_once()
+
+    @mock.patch('airflow.cli.commands.kubernetes_command._delete_pod')
+    @mock.patch('kubernetes.client.CoreV1Api.list_namespaced_pod')
+    @mock.patch('kubernetes.config.load_incluster_config')
+    def test_list_pod_with_continue_token(self, load_incluster_config, list_namespaced_pod, delete_pod):
+        pod1 = MagicMock()
+        pod1.metadata.name = 'dummy'
+        pod1.status.phase = 'Succeeded'
+        pod1.status.reason = None
+        pods = MagicMock()
+        pods.metadata._continue = 'dummy-token'
+        pods.items = [pod1]
+        next_pods = MagicMock()
+        next_pods.metadata._continue = None
+        next_pods.items = [pod1]
+        list_namespaced_pod.side_effect = [pods, next_pods]
+        kubernetes_command.cleanup_pods(
+            self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
+        )
+        calls = [
+            call.first(namespace='awesome-namespace', limit=500),
+            call.second(namespace='awesome-namespace', limit=500, _continue='dummy-token'),
+        ]
+        list_namespaced_pod.assert_has_calls(calls)
+        delete_pod.assert_called_with('dummy', 'awesome-namespace')
         load_incluster_config.assert_called_once()


### PR DESCRIPTION
```
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"invalid continue token: continue key is not valid: invalid character '\\u0089' after top-level value","reason":"BadRequest","code":400}
```
Fix invalid continue token when cleanup pods. `_continue` is None will raise above error in kubernetes python 11.0 .

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
