### PR TITLE
Adds information about PIP being the only official install tool

### DIFF
--- a/docs/apache-airflow/installation.rst
+++ b/docs/apache-airflow/installation.rst
@@ -60,6 +60,18 @@ Those "known-to-be-working" constraints are per major/minor python version. You 
 files when installing Airflow from PyPI. Note that you have to specify correct Airflow version
 and python versions in the URL.
 
+The official way of installing Airflow is with the ``pip`` tool.
+There was a recent (November 2020) change in resolver, so currently only 20.2.4 version is officially
+supported, although you might have a success with 20.3.3+ version (to be confirmed if all initial
+issues from ``pip`` 20.3.0 release have been fixed in 20.3.3).
+
+While they are some successes with using other tools like `poetry <https://python-poetry.org/>`_ or
+`pip-tools <https://pypi.org/project/pip-tools/>`_, but they do not share the same workflow as
+``pip``- especially when it comes to constraint vs. requirements management.
+Installing via ``Poetry`` or ``pip-tools`` is not currently supported. If you wish to install airflow
+using those tools you should use the constraint files described below and convert them to appropriate
+format and workflow that your tool requires.
+
   **Prerequisites**
 
   On Debian based Linux OS:


### PR DESCRIPTION
Installation with remote constraint files is supported with PIP
and we are using it in order to maintain constistent set of
requirements, however we keep getting issues from people using
poetry and pip-tools who try to install airflow without following
the official way.

This chapter explains why and sets PIP as the only official
installation tool supported.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
