### PR TITLE
Make docs clear that Auth can't be disabled for Stable API

### DIFF
--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -59,7 +59,7 @@ If you wish to have the experimental API work, and aware of the risks of enablin
 
 .. note::
 
-    You can only disable authentication for experimental API not the sable rest API.
+    You can only disable authentication for experimental API not the stable rest API.
 
 See :doc:`../modules_management` for details on how Python and Airflow manage modules.
 

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -59,7 +59,7 @@ If you wish to have the experimental API work, and aware of the risks of enablin
 
 .. note::
 
-    You can only disable authentication for experimental API not the stable rest API.
+    You can only disable authentication for experimental API, not the stable REST API.
 
 See :doc:`../modules_management` for details on how Python and Airflow manage modules.
 

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -57,6 +57,10 @@ If you wish to have the experimental API work, and aware of the risks of enablin
     [api]
     auth_backend = airflow.api.auth.backend.default
 
+.. note::
+
+    You can only disable authentication for experimental API not the sable rest API.
+
 See :doc:`../modules_management` for details on how Python and Airflow manage modules.
 
 Kerberos authentication


### PR DESCRIPTION
There were many users asking this question on Slack (recent one: https://apache-airflow.slack.com/archives/CCQ7EGB1P/p1609834765189300) that disabling auth is not working with new API.

This PR makes it clear

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
