### PR TITLE
Reduce the number of variables in Bash scripts

### DIFF
--- a/breeze
+++ b/breeze
@@ -211,7 +211,7 @@ function breeze::initialize_virtualenv() {
     set -e
     if [[ ${res} != "0" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Initializing local virtualenv only works when you have virtualenv activated  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Initializing local virtualenv only works when you have virtualenv activated  ${COLOR_RESET}"
         echo
         echo "Please enter your local virtualenv before (for example using 'pyenv activate' or 'workon') "
         echo
@@ -1173,7 +1173,7 @@ function breeze::parse_arguments() {
         *)
             breeze::flags
             echo
-            echo  "${COLOR_RED_ERROR} Unknown flag  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: Unknown flag  ${COLOR_RESET}"
             echo
             exit 1
             ;;
@@ -1374,7 +1374,7 @@ function breeze::parse_arguments() {
         *)
             breeze::usage
             echo
-            echo  "${COLOR_RED_ERROR} Unknown command  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: Unknown command  ${COLOR_RESET}"
             echo
             exit 1
             ;;
@@ -2884,7 +2884,7 @@ function breeze::check_and_save_all_params() {
     if [[ ${PYTHON_MAJOR_MINOR_VERSION} == "2.7" || ${PYTHON_MAJOR_MINOR_VERSION} == "3.5" ]]; then
         if [[ ${BRANCH_NAME} == "master" || ${BRANCH_NAME} == "v2-0-test" ]]; then
             echo
-            echo  "${COLOR_RED_ERROR} The ${PYTHON_MAJOR_MINOR_VERSION} can only be used when installing Airflow 1.10.*  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: The ${PYTHON_MAJOR_MINOR_VERSION} can only be used when installing Airflow 1.10.*  ${COLOR_RESET}"
             echo
             echo "You can use it only when you specify 1.10 Airflow via --install-airflow-version"
             echo "or --install-airflow-reference and they point to 1.10 version of Airflow"
@@ -3015,7 +3015,7 @@ function breeze::make_sure_precommit_is_installed() {
         pip_binary=pip
     else
         echo
-        echo  "${COLOR_RED_ERROR} You need to have pip or pip3 in your PATH  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: You need to have pip or pip3 in your PATH  ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -3188,7 +3188,7 @@ function breeze::run_build_command() {
         ;;
     *)
         echo
-        echo  "${COLOR_RED_ERROR} Unknown command to run ${command_to_run}  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Unknown command to run ${command_to_run}  ${COLOR_RESET}"
         echo
         exit 1
         ;;
@@ -3333,7 +3333,7 @@ function breeze::run_breeze_command() {
         ;;
     *)
         echo
-        echo  "${COLOR_RED_ERROR} Unknown command to run ${command_to_run}  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Unknown command to run ${command_to_run}  ${COLOR_RESET}"
         echo
         ;;
     esac

--- a/dev/provider_packages/build_source_package.sh
+++ b/dev/provider_packages/build_source_package.sh
@@ -123,7 +123,7 @@ if (( $# > 0 )); then
         BACKPORTS="true"
     else
         echo
-        echo  "${COLOR_RED_ERROR} You can run the script with '--backports' flag only  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: You can run the script with '--backports' flag only  ${COLOR_RESET}"
         echo
         exit 1
     fi

--- a/scripts/ci/dockerfiles/presto/entrypoint.sh
+++ b/scripts/ci/dockerfiles/presto/entrypoint.sh
@@ -32,14 +32,14 @@ function check_service {
         RES=$?
         set -e
         if [[ ${RES} == 0 ]]; then
-            echo  "${COLOR_GREEN_OK}  ${COLOR_RESET}"
+            echo  "${COLOR_GREEN}OK.  ${COLOR_RESET}"
             break
         else
             echo -n "."
             MAX_CHECK=$((MAX_CHECK-1))
         fi
         if [[ ${MAX_CHECK} == 0 ]]; then
-            echo "${COLOR_RED_ERROR} Maximum number of retries while checking service. Exiting.${COLOR_RESET}"
+            echo "${COLOR_RED}ERROR: Maximum number of retries while checking service. Exiting.${COLOR_RESET}"
             break
         else
             sleep 1

--- a/scripts/ci/images/ci_verify_ci_image.sh
+++ b/scripts/ci/images/ci_verify_ci_image.sh
@@ -24,12 +24,12 @@ function verify_ci_image_dependencies() {
     docker run --rm --entrypoint /bin/bash "${AIRFLOW_CI_IMAGE}" -c 'pip check'
     local res=$?
     if [[ ${res} != "0" ]]; then
-        echo  "${COLOR_RED_ERROR} ^^^ Some dependencies are conflicting. See instructions below on how to deal with it.  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: ^^^ Some dependencies are conflicting. See instructions below on how to deal with it.  ${COLOR_RESET}"
         echo
         build_images::inform_about_pip_check ""
     else
         echo
-        echo  "${COLOR_GREEN_OK} The ${AIRFLOW_PROD_IMAGE} image dependencies are consistent.  ${COLOR_RESET}"
+        echo  "${COLOR_GREEN}OK. The ${AIRFLOW_PROD_IMAGE} image dependencies are consistent.  ${COLOR_RESET}"
         echo
     fi
     set -e

--- a/scripts/ci/images/ci_verify_prod_image.sh
+++ b/scripts/ci/images/ci_verify_prod_image.sh
@@ -72,12 +72,12 @@ function verify_prod_image_has_airflow_and_providers() {
     done
     if [[ ${error} == "true" ]]; then
         echo
-        echo "${COLOR_RED_ERROR} Some expected providers are not installed!${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: Some expected providers are not installed!${COLOR_RESET}"
         echo
         exit 1
     else
         echo
-        echo "${COLOR_GREEN_OK} All expected providers installed!${COLOR_RESET}"
+        echo "${COLOR_GREEN}OK. All expected providers installed!${COLOR_RESET}"
         echo
     fi
     start_end::group_end
@@ -90,13 +90,13 @@ function verify_prod_image_dependencies() {
     run_command_in_image 'pip check'
     local res=$?
     if [[ ${res} != "0" ]]; then
-        echo "${COLOR_RED_ERROR} ^^^ Some dependencies are conflicting. See instructions below on how to deal with it.  ${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: ^^^ Some dependencies are conflicting. See instructions below on how to deal with it.  ${COLOR_RESET}"
         echo
         build_images::inform_about_pip_check "--production "
         exit ${res}
     else
         echo
-        echo "${COLOR_GREEN_OK} The ${AIRFLOW_PROD_IMAGE} image dependencies are consistent.  ${COLOR_RESET}"
+        echo "${COLOR_GREEN}OK. The ${AIRFLOW_PROD_IMAGE} image dependencies are consistent.  ${COLOR_RESET}"
         echo
     fi
     set -e
@@ -180,11 +180,11 @@ function verify_production_image_features() {
 
     if [[ ${FEATURES_OK} == "true" ]]; then
         echo
-        echo "${COLOR_GREEN_OK} The ${AIRFLOW_PROD_IMAGE} features are all OK.  ${COLOR_RESET}"
+        echo "${COLOR_GREEN}OK. The ${AIRFLOW_PROD_IMAGE} features are all OK.  ${COLOR_RESET}"
         echo
     else
         echo
-        echo "${COLOR_RED_ERROR} Some features were not ok!${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: Some features were not ok!${COLOR_RESET}"
         echo
         exit 1
     fi

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -119,7 +119,7 @@ function build_images::forget_last_answer() {
 function build_images::confirm_via_terminal() {
     echo >"${DETECTED_TERMINAL}"
     echo >"${DETECTED_TERMINAL}"
-    echo "${COLOR_YELLOW_WARNING}Make sure that you rebased to latest master before rebuilding!${COLOR_RESET}" >"${DETECTED_TERMINAL}"
+    echo "${COLOR_YELLOW}WARNING:Make sure that you rebased to latest master before rebuilding!${COLOR_RESET}" >"${DETECTED_TERMINAL}"
     echo >"${DETECTED_TERMINAL}"
     # Make sure to use output of tty rather than stdin/stdout when available - this way confirm
     # will works also in case of pre-commits (git does not pass stdin/stdout to pre-commit hooks)
@@ -170,7 +170,7 @@ function build_images::confirm_image_rebuild() {
     elif [[ -t 0 ]]; then
         echo
         echo
-        echo "${COLOR_YELLOW_WARNING}Make sure that you rebased to latest master before rebuilding!${COLOR_RESET}"
+        echo "${COLOR_YELLOW}WARNING:Make sure that you rebased to latest master before rebuilding!${COLOR_RESET}"
         echo
         # Check if this script is run interactively with stdin open and terminal attached
         "${AIRFLOW_SOURCES}/confirm" "${ACTION} image ${THE_IMAGE_TYPE}-python${PYTHON_MAJOR_MINOR_VERSION}"
@@ -200,7 +200,7 @@ function build_images::confirm_image_rebuild() {
         echo 'export FORCE_ANSWER_TO_QUESTIONS="no"' >"${LAST_FORCE_ANSWER_FILE}"
     elif [[ ${RES} == "2" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} The ${THE_IMAGE_TYPE} needs to be rebuilt - it is outdated.   ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: The ${THE_IMAGE_TYPE} needs to be rebuilt - it is outdated.   ${COLOR_RESET}"
         echo """
 
    Make sure you build the images bu running
@@ -590,7 +590,7 @@ function build_images::build_ci_image() {
         )
     else
         echo
-        echo  "${COLOR_RED_ERROR} The ${DOCKER_CACHE} cache is unknown!  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: The ${DOCKER_CACHE} cache is unknown!  ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -763,7 +763,7 @@ function build_images::build_prod_images() {
         )
     else
         echo
-        echo  "${COLOR_RED_ERROR} The ${DOCKER_CACHE} cache is unknown  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: The ${DOCKER_CACHE} cache is unknown  ${COLOR_RESET}"
         echo
         echo
         exit 1
@@ -919,7 +919,7 @@ function build_image::assert_variable() {
     local variable_value=${!variable_name}
     if [[ ${variable_value} != "${expected_value}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR}: Variable ${variable_name}: expected_value: '${expected_value}' but was '${variable_value}'!${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Variable ${variable_name}: expected_value: '${expected_value}' but was '${variable_value}'!${COLOR_RESET}"
         echo
         exit 1
     fi

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -511,20 +511,14 @@ function initialization::initialize_build_image_variables() {
 function initialization::set_output_color_variables() {
     COLOR_BLUE=$'\e[34m'
     COLOR_GREEN=$'\e[32m'
-    COLOR_GREEN_OK=$'\e[32mOK.'
     COLOR_RED=$'\e[31m'
-    COLOR_RED_ERROR=$'\e[31mERROR:'
     COLOR_RESET=$'\e[0m'
     COLOR_YELLOW=$'\e[33m'
-    COLOR_YELLOW_WARNING=$'\e[33mWARNING:'
     export COLOR_BLUE
     export COLOR_GREEN
-    export COLOR_GREEN_OK
     export COLOR_RED
-    export COLOR_RED_ERROR
     export COLOR_RESET
     export COLOR_YELLOW
-    export COLOR_YELLOW_WARNING
 }
 
 # Common environment that is initialized by both Breeze and CI scripts

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -118,7 +118,7 @@ function kind::perform_kind_cluster_operation() {
     set +u
     if [[ -z "${1=}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Operation must be provided as first parameter. One of: ${ALLOWED_KIND_OPERATIONS}  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Operation must be provided as first parameter. One of: ${ALLOWED_KIND_OPERATIONS}  ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -201,7 +201,7 @@ function kind::perform_kind_cluster_operation() {
                 -v "${KUBECONFIG}:/root/.kube/config" quay.io/derailed/k9s
         else
             echo
-            echo  "${COLOR_RED_ERROR} Wrong cluster operation: ${OPERATION}. Should be one of: ${ALLOWED_KIND_OPERATIONS}  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: Wrong cluster operation: ${OPERATION}. Should be one of: ${ALLOWED_KIND_OPERATIONS}  ${COLOR_RESET}"
             echo
             exit 1
         fi
@@ -219,12 +219,12 @@ function kind::perform_kind_cluster_operation() {
             kind::create_cluster
         elif [[ ${OPERATION} == "stop" || ${OPERATION} == "deploy" || ${OPERATION} == "test" || ${OPERATION} == "shell" ]]; then
             echo
-            echo  "${COLOR_RED_ERROR} Cluster ${KIND_CLUSTER_NAME} does not exist. It should exist for ${OPERATION} operation  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: Cluster ${KIND_CLUSTER_NAME} does not exist. It should exist for ${OPERATION} operation  ${COLOR_RESET}"
             echo
             exit 1
         else
             echo
-            echo  "${COLOR_RED_ERROR} Wrong cluster operation: ${OPERATION}. Should be one of ${ALLOWED_KIND_OPERATIONS}  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: Wrong cluster operation: ${OPERATION}. Should be one of ${ALLOWED_KIND_OPERATIONS}  ${COLOR_RESET}"
             echo
             exit 1
         fi
@@ -297,7 +297,7 @@ function kind::wait_for_webserver_healthy() {
         num_tries=$((num_tries + 1))
         if [[ ${num_tries} == "${MAX_NUM_TRIES_FOR_HEALTH_CHECK}" ]]; then
             echo
-            echo  "${COLOR_RED_ERROR} Timeout while waiting for the webserver health check  ${COLOR_RESET}"
+            echo  "${COLOR_RED}ERROR: Timeout while waiting for the webserver health check  ${COLOR_RESET}"
             echo
         fi
     done

--- a/scripts/ci/libraries/_parameters.sh
+++ b/scripts/ci/libraries/_parameters.sh
@@ -41,13 +41,13 @@ function parameters::check_allowed_param() {
     _VALUE=${!_VARIABLE_NAME}
     if [[ ${_ALLOWED_VALUES:=} != *" ${_VALUE} "* ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Allowed ${_VARIABLE_DESCRIPTIVE_NAME}: [${_ALLOWED_VALUES}]. Passed: '${!_VARIABLE_NAME}'  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Allowed ${_VARIABLE_DESCRIPTIVE_NAME}: [${_ALLOWED_VALUES}]. Passed: '${!_VARIABLE_NAME}'  ${COLOR_RESET}"
         echo
         echo "Switch to supported value with ${_FLAG} flag."
         echo
         if [[ -n ${!_VARIABLE_NAME} && -f "${BUILD_CACHE_DIR}/.${_VARIABLE_NAME}" && ${!_VARIABLE_NAME} == $(cat "${BUILD_CACHE_DIR}/.${_VARIABLE_NAME}") ]]; then
             echo
-            echo  "${COLOR_YELLOW_WARNING}: Removing ${BUILD_CACHE_DIR}/.${_VARIABLE_NAME}. Next time you run it, it should be OK.  ${COLOR_RESET}"
+            echo  "${COLOR_YELLOW}WARNING: Removing ${BUILD_CACHE_DIR}/.${_VARIABLE_NAME}. Next time you run it, it should be OK.  ${COLOR_RESET}"
             echo
             echo
             rm -f "${BUILD_CACHE_DIR}/.${_VARIABLE_NAME}"

--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -30,7 +30,7 @@ function push_pull_remove_images::push_image_with_retries() {
         set -e
         if [[ ${res} != "0" ]]; then
             echo
-            echo  "${COLOR_YELLOW_WARNING}: Error ${res} when pushing image on ${try_num} try  ${COLOR_RESET}"
+            echo  "${COLOR_YELLOW}WARNING: Error ${res} when pushing image on ${try_num} try  ${COLOR_RESET}"
             echo
             continue
         else
@@ -38,7 +38,7 @@ function push_pull_remove_images::push_image_with_retries() {
         fi
     done
     echo
-    echo  "${COLOR_RED_ERROR} Error ${res} when pushing image on ${try_num} try. Giving up!  ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Error ${res} when pushing image on ${try_num} try. Giving up!  ${COLOR_RESET}"
     echo
     return 1
 }
@@ -66,7 +66,7 @@ function push_pull_remove_images::pull_image_if_not_present_or_forced() {
         if [[ ${EXIT_VALUE} != "0" && ${FAIL_ON_GITHUB_DOCKER_PULL_ERROR} == "true" ]]; then
             echo
             echo """
-${COLOR_RED_ERROR} Exiting on docker pull error
+${COLOR_RED}ERROR: Exiting on docker pull error
 
 If you have authorisation problems, you might want to run:
 
@@ -283,7 +283,7 @@ function push_pull_remove_images::wait_for_github_registry_image() {
             --connect-timeout 60  --max-time 60 \
             -X GET "${GITHUB_API_CALL}" -u "${GITHUB_USERNAME}:${GITHUB_TOKEN}")
         if [[ ${http_status} == "200" ]]; then
-            echo  "${COLOR_GREEN_OK}  ${COLOR_RESET}"
+            echo  "${COLOR_GREEN}OK.  ${COLOR_RESET}"
             break
         else
             echo "${COLOR_YELLOW}Still waiting - status code ${http_status}!${COLOR_RESET}"

--- a/scripts/ci/libraries/_repeats.sh
+++ b/scripts/ci/libraries/_repeats.sh
@@ -35,12 +35,12 @@ function repeats::run_with_retry() {
             return 0
         fi
         echo
-        echo  "${COLOR_YELLOW_WARNING}: Unsuccessful attempt no. ${n}. Result: ${res}  ${COLOR_RESET}"
+        echo  "${COLOR_YELLOW}WARNING: Unsuccessful attempt no. ${n}. Result: ${res}  ${COLOR_RESET}"
         echo
         echo
     done
     echo
-    echo  "${COLOR_RED_ERROR} Giving up after ${num_repeats} attempts!  ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Giving up after ${num_repeats} attempts!  ${COLOR_RESET}"
     echo
     return ${res}
 }

--- a/scripts/ci/libraries/_sanity_checks.sh
+++ b/scripts/ci/libraries/_sanity_checks.sh
@@ -78,7 +78,7 @@ function sanity_checks::check_if_coreutils_installed() {
         verbosity::print_info
         if [[ $(uname -s) == 'Darwin' ]] ; then
             echo """
-${COLOR_RED_ERROR} You are running ${CMDNAME} in OSX environment and ou need to install gnu commands
+${COLOR_RED}ERROR: You are running ${CMDNAME} in OSX environment and ou need to install gnu commands
 
 Run 'brew install gnu-getopt coreutils'
 
@@ -102,7 +102,7 @@ ${COLOR_RESET}
 """
         else
             echo """
-${COLOR_RED_ERROR} You do not have necessary tools in your path (getopt, stat, md5sum).
+${COLOR_RED}ERROR: You do not have necessary tools in your path (getopt, stat, md5sum).
 Please install latest/GNU version of getopt and coreutils.
 This can usually be done with 'apt install util-linux coreutils'
 ${COLOR_RESET}

--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -97,7 +97,7 @@ function start_end::script_end {
         fi
         start_end::group_end
         echo
-        echo "${COLOR_RED_ERROR} The previous step completed with error. Please take a look at output above ${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: The previous step completed with error. Please take a look at output above ${COLOR_RESET}"
         echo
         if [[ ${CI} == "true" ]]; then
             local container

--- a/scripts/ci/pre_commit/pre_commit_check_pre_commits.sh
+++ b/scripts/ci/pre_commit/pre_commit_check_pre_commits.sh
@@ -40,7 +40,7 @@ do
         error="true"
         echo
         echo """
-${COLOR_RED_ERROR} Pre-commit ${pre_commit} is not described in ${STATIC_CODE_CHECKS_FILE}
+${COLOR_RED}ERROR: Pre-commit ${pre_commit} is not described in ${STATIC_CODE_CHECKS_FILE}
 ERROR: Pre-commit ${pre_commit} is not described in ${STATIC_CODE_CHECKS_FILE}
 
 FIX: Please add ${pre_commit} in the table in the 'Pre-commit hooks' chapter in ${STATIC_CODE_CHECKS_FILE}
@@ -52,7 +52,7 @@ ${COLOR_RESET}
     if [[ ! ${_breeze_allowed_static_checks} == *${pre_commit}* ]]; then
         error="true"
         echo """
-${COLOR_RED_ERROR}: Pre-commit ${pre_commit} is missing in _breeze_allowed_static_checks variable in breeze-complete
+${COLOR_RED}ERROR:: Pre-commit ${pre_commit} is missing in _breeze_allowed_static_checks variable in breeze-complete
 
 FIX: Please add ${pre_commit} in the table in the '_breeze_allowed_static_checks' constant in ${AIRFLOW_SOURCES}/breeze-complete
 ${COLOR_RESET}
@@ -62,11 +62,11 @@ done
 
 if [[ ${error} == "true" ]]; then
     echo
-    echo  "${COLOR_RED_ERROR} Some pre-commits are not synchronized! Please fix the errors above!  ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Some pre-commits are not synchronized! Please fix the errors above!  ${COLOR_RESET}"
     echo
     exit 1
 else
     echo
-    echo "${COLOR_GREEN_OK} All pre-commits are synchronized!  ${COLOR_RESET}"
+    echo "${COLOR_GREEN}OK. All pre-commits are synchronized!  ${COLOR_RESET}"
     echo
 fi

--- a/scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
+++ b/scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
@@ -22,7 +22,7 @@ export MOUNT_LOCAL_SOURCES="false"
 
 if [[ ${PACKAGE_FORMAT} != "wheel" && ${PACKAGE_FORMAT} != "sdist" ]]; then
     echo
-    echo "${COLOR_RED_ERROR} Wrong package format ${PACKAGE_FORMAT}. Should be 'wheel' or 'sdist'${COLOR_RESET}"
+    echo "${COLOR_RED}ERROR: Wrong package format ${PACKAGE_FORMAT}. Should be 'wheel' or 'sdist'${COLOR_RESET}"
     echo
     exit 3
 fi

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -147,7 +147,7 @@ function get_changed_files() {
         -r "${INCOMING_COMMIT_SHA}^" "${INCOMING_COMMIT_SHA}" || true)
     if [[ ${CHANGED_FILES} == "" ]]; then
         echo
-        echo  "${COLOR_YELLOW_WARNING}: Could not find any changed files  ${COLOR_RESET}"
+        echo  "${COLOR_YELLOW}WARNING: Could not find any changed files  ${COLOR_RESET}"
         echo Assuming that we should run all tests in this case
         echo
         set_outputs_run_everything_and_exit

--- a/scripts/ci/static_checks/check_license.sh
+++ b/scripts/ci/static_checks/check_license.sh
@@ -38,7 +38,7 @@ function run_check_license() {
             --exclude-file /opt/airflow/.rat-excludes \
             --d /opt/airflow | tee "${AIRFLOW_SOURCES}/logs/rat-results.txt" ; then
         echo
-        echo  "${COLOR_RED_ERROR} RAT exited abnormally  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: RAT exited abnormally  ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -49,13 +49,13 @@ function run_check_license() {
     set -e
     if test ! -z "${errors}"; then
         echo
-        echo  "${COLOR_RED_ERROR} Could not find Apache license headers in the following files:  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Could not find Apache license headers in the following files:  ${COLOR_RESET}"
         echo
         echo "${errors}"
         exit 1
     else
         echo
-        echo "${COLOR_GREEN_OK} RAT checks passed.  ${COLOR_RESET}"
+        echo "${COLOR_GREEN}OK. RAT checks passed.  ${COLOR_RESET}"
         echo
     fi
 }

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -40,7 +40,7 @@ function assert_in_container() {
     export VERBOSE=${VERBOSE:="false"}
     if [[ ! -f /.dockerenv ]]; then
         echo
-        echo "${COLOR_RED_ERROR} You are not inside the Airflow docker container!  ${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: You are not inside the Airflow docker container!  ${COLOR_RESET}"
         echo
         echo "You should only run this script in the Airflow docker container as it may override your files."
         echo "Learn more about how we develop and test airflow in:"
@@ -404,7 +404,7 @@ function verify_suffix_versions_for_package_preparation() {
 
     if [[ ${VERSION_SUFFIX_FOR_SVN} =~ ^rc ]]; then
         echo """
-${COLOR_YELLOW_WARNING} The version suffix for SVN is used only for file names.
+${COLOR_YELLOW}WARNING: The version suffix for SVN is used only for file names.
          The version inside the packages has no version suffix.
          This way we can just rename files when they graduate to final release.
 ${COLOR_RESET}
@@ -425,7 +425,7 @@ ${COLOR_RESET}
     if [[ ${VERSION_SUFFIX_FOR_PYPI} != '' && ${VERSION_SUFFIX_FOR_SVN} != '' ]]; then
         if [[ ${VERSION_SUFFIX_FOR_PYPI} != "${VERSION_SUFFIX_FOR_SVN}" ]]; then
             echo
-            echo "${COLOR_RED_ERROR} If you specify both PyPI and SVN version suffixes they must match  ${COLOR_RESET}"
+            echo "${COLOR_RED}ERROR: If you specify both PyPI and SVN version suffixes they must match  ${COLOR_RESET}"
             echo
             echo "However they are different: PyPI:'${VERSION_SUFFIX_FOR_PYPI}' vs. SVN:'${VERSION_SUFFIX_FOR_SVN}'"
             echo
@@ -433,7 +433,7 @@ ${COLOR_RESET}
         else
             if [[ ${VERSION_SUFFIX_FOR_PYPI} =~ ^rc ]]; then
                 echo
-                echo "${COLOR_RED_ERROR} If you prepare an RC candidate, you need to specify only PyPI suffix  ${COLOR_RESET}"
+                echo "${COLOR_RED}ERROR: If you prepare an RC candidate, you need to specify only PyPI suffix  ${COLOR_RESET}"
                 echo
                 echo "However you specified both: PyPI'${VERSION_SUFFIX_FOR_PYPI}' and SVN '${VERSION_SUFFIX_FOR_SVN}'"
                 echo
@@ -450,7 +450,7 @@ ${COLOR_RESET}
 
             if [[ ${VERSION_SUFFIX_FOR_PYPI} == '' ]]; then
                 echo
-                echo "${COLOR_RED_ERROR} You should never specify version for PyPI only.  ${COLOR_RESET}"
+                echo "${COLOR_RED}ERROR: You should never specify version for PyPI only.  ${COLOR_RESET}"
                 echo
                 echo "You specified PyPI suffix: '${VERSION_SUFFIX_FOR_PYPI}'"
                 echo
@@ -459,7 +459,7 @@ ${COLOR_RESET}
             TARGET_VERSION_SUFFIX=${VERSION_SUFFIX_FOR_PYPI}${VERSION_SUFFIX_FOR_SVN}
             if [[ ! ${TARGET_VERSION_SUFFIX} =~ rc.* ]]; then
                 echo
-                echo "${COLOR_RED_ERROR} If you prepare an alpha/beta release, you need to specify both PyPI/SVN suffixes and they have to match.  ${COLOR_RESET}"
+                echo "${COLOR_RED}ERROR: If you prepare an alpha/beta release, you need to specify both PyPI/SVN suffixes and they have to match.  ${COLOR_RESET}"
                 echo
                 echo "And they have to match. You specified only one suffix:  ${TARGET_VERSION_SUFFIX}."
                 echo
@@ -515,20 +515,14 @@ EOF
 function in_container_set_colors() {
     COLOR_BLUE=$'\e[34m'
     COLOR_GREEN=$'\e[32m'
-    COLOR_GREEN_OK=$'\e[32mOK.'
     COLOR_RED=$'\e[31m'
-    COLOR_RED_ERROR=$'\e[31mERROR:'
     COLOR_RESET=$'\e[0m'
     COLOR_YELLOW=$'\e[33m'
-    COLOR_YELLOW_WARNING=$'\e[33mWARNING:'
     export COLOR_BLUE
     export COLOR_GREEN
-    export COLOR_GREEN_OK
     export COLOR_RED
-    export COLOR_RED_ERROR
     export COLOR_RESET
     export COLOR_YELLOW
-    export COLOR_YELLOW_WARNING
 }
 
 # Starts group for Github Actions - makes logs much more readable

--- a/scripts/in_container/check_environment.sh
+++ b/scripts/in_container/check_environment.sh
@@ -52,14 +52,14 @@ function check_service {
         RES=$?
         set -e
         if [[ ${RES} == 0 ]]; then
-            echo  "${COLOR_GREEN_OK}  ${COLOR_RESET}"
+            echo  "${COLOR_GREEN}OK.  ${COLOR_RESET}"
             break
         else
             echo -n "."
             MAX_CHECK=$((MAX_CHECK-1))
         fi
         if [[ ${MAX_CHECK} == 0 ]]; then
-            echo "${COLOR_RED_ERROR} Maximum number of retries while checking service. Exiting ${COLOR_RESET}"
+            echo "${COLOR_RED}ERROR: Maximum number of retries while checking service. Exiting ${COLOR_RESET}"
             break
         else
             sleep 1

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -115,7 +115,7 @@ if [[ ${INSTALL_PACKAGES_FROM_DIST=} == "true" ]]; then
     fi
     if [[ ${PACKAGE_FORMAT} == "both" ]]; then
         echo
-        echo "${COLOR_RED_ERROR}You can only specify 'wheel' or 'sdist' as PACKAGE_FORMAT not 'both'${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR:You can only specify 'wheel' or 'sdist' as PACKAGE_FORMAT not 'both'${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -328,7 +328,7 @@ else
         SELECTED_TESTS=("${ALL_TESTS[@]}")
     else
         echo
-        echo  "${COLOR_RED_ERROR} Wrong test type ${TEST_TYPE}  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Wrong test type ${TEST_TYPE}  ${COLOR_RESET}"
         echo
         exit 1
     fi

--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -39,7 +39,7 @@ elif [[ "${RES}" != "0" ]]; then
         EXTRA_ARGS="--mysql-version ${MYSQL_VERSION} "
     fi
     echo """
-${COLOR_RED_ERROR}
+${COLOR_RED}ERROR:
 ***********************************************************************************************
 *
 * ERROR! Some tests failed, unfortunately. Those might be transient errors,

--- a/scripts/in_container/run_cli_tool.sh
+++ b/scripts/in_container/run_cli_tool.sh
@@ -20,25 +20,25 @@ set -euo pipefail
 
 if [ -z "${AIRFLOW_CI_IMAGE=}" ]; then
     echo
-    echo  "${COLOR_RED_ERROR} Missing environment variable AIRFLOW_CI_IMAGE  ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Missing environment variable AIRFLOW_CI_IMAGE  ${COLOR_RESET}"
     echo
     exit 1
 fi
 if [ -z "${HOST_AIRFLOW_SOURCES=}" ]; then
     echo
-    echo  "${COLOR_RED_ERROR} Missing environment variable HOST_AIRFLOW_SOURCES  ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Missing environment variable HOST_AIRFLOW_SOURCES  ${COLOR_RESET}"
     echo
     exit 1
 fi
 if [ -z "${HOST_USER_ID=}" ]; then
     echo
-    echo  "${COLOR_RED_ERROR} Missing environment variable HOST_USER_ID  ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Missing environment variable HOST_USER_ID  ${COLOR_RESET}"
     echo
     exit 1
 fi
 if [ -z "${HOST_GROUP_ID=}" ]; then
     echo
-    echo  "${COLOR_RED_ERROR} Missing environment variable HOST_GROUP_ID   ${COLOR_RESET}"
+    echo  "${COLOR_RED}ERROR: Missing environment variable HOST_GROUP_ID   ${COLOR_RESET}"
     echo
     exit 1
 fi
@@ -131,7 +131,7 @@ case "${TOOL_NAME}" in
         ;;
     * )
         echo
-        echo  "${COLOR_RED_ERROR} Unsupported tool name: ${TOOL_NAME}  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Unsupported tool name: ${TOOL_NAME}  ${COLOR_RESET}"
         echo
         exit 1
         ;;

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -26,7 +26,7 @@ function verify_parameters(){
 
     if [[ ${INSTALL_AIRFLOW_VERSION=""} == "" ]]; then
         echo
-        echo "${COLOR_RED_ERROR} You have to specify airflow version to install.${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: You have to specify airflow version to install.${COLOR_RESET}"
         echo
         echo "It might be version from PyPI, wheel with extras or none to uninstall airflow"
         echo
@@ -37,7 +37,7 @@ function verify_parameters(){
 
     if [[ ${PACKAGE_FORMAT} != "wheel" && ${PACKAGE_FORMAT} != "sdist" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Wrong install type ${PACKAGE_FORMAT}. Should be 'wheel' or 'sdist'  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Wrong install type ${PACKAGE_FORMAT}. Should be 'wheel' or 'sdist'  ${COLOR_RESET}"
         echo
         exit 3
     fi
@@ -89,7 +89,7 @@ function install_provider_packages() {
         install_all_provider_packages_from_sdist
     else
         echo
-        echo "${COLOR_RED_ERROR} Wrong package format ${PACKAGE_FORMAT}. Should be wheel or sdist${COLOR_RESET}"
+        echo "${COLOR_RED}ERROR: Wrong package format ${PACKAGE_FORMAT}. Should be wheel or sdist${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -107,7 +107,7 @@ function discover_all_provider_packages() {
     actual_number_of_providers=$(wc -l <<<"$actual_providers")
     if [[ ${actual_number_of_providers} != "${expected_number_of_providers}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR}Number of providers installed is wrong${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR:Number of providers installed is wrong${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_providers}' and got '${actual_number_of_providers}'"
         echo
         echo "Either increase the number of providers if you added one or diagnose and fix the problem."
@@ -129,7 +129,7 @@ function discover_all_hooks() {
     actual_number_of_hooks=$(airflow providers hooks --output table | grep -c "| apache" | xargs)
     if [[ ${actual_number_of_hooks} != "${expected_number_of_hooks}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Number of hooks registered is wrong  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Number of hooks registered is wrong  ${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_hooks}' and got '${actual_number_of_hooks}'"
         echo
         echo "Either increase the number of hooks if you added one or diagnose and fix the problem."
@@ -148,7 +148,7 @@ function discover_all_extra_links() {
     actual_number_of_extra_links=$(airflow providers links --output table | grep -c ^airflow.providers | xargs)
     if [[ ${actual_number_of_extra_links} != "${expected_number_of_extra_links}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Number of links registered is wrong  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Number of links registered is wrong  ${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_extra_links}' and got '${actual_number_of_extra_links}'"
         echo
         echo "Either increase the number of links if you added one or diagnose and fix the problem."
@@ -168,7 +168,7 @@ function discover_all_connection_form_widgets() {
     actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
     if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Number of connections with widgets registered is wrong  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Number of connections with widgets registered is wrong  ${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_widgets}' and got '${actual_number_of_widgets}'"
         echo
         echo "Increase the number of connections with widgets if you added one or investigate"
@@ -189,7 +189,7 @@ function discover_all_field_behaviours() {
     if [[ ${actual_number_of_connections_with_behaviours} != \
             "${expected_number_of_connections_with_behaviours}" ]]; then
         echo
-        echo  "${COLOR_RED_ERROR} Number of connections with customized behaviours is wrong  ${COLOR_RESET}"
+        echo  "${COLOR_RED}ERROR: Number of connections with customized behaviours is wrong  ${COLOR_RESET}"
         echo "Expected number was '${expected_number_of_connections_with_behaviours}' and got '${actual_number_of_connections_with_behaviours}'"
         echo
         echo "Increase the number of connections if you added one or investigate."


### PR DESCRIPTION
I have the impression that these variables are not needed because they do not make the code less. The number of characters is the same. On the other hand, this is a bit confusing because we have variables that have similar names and the developer has to check which one best fits their case.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
