### PR TITLE
Fix depcrecated K8S api

### DIFF
--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -176,7 +176,7 @@ class TestSparkKubernetesOperator(unittest.TestCase):
         args = {'owner': 'airflow', 'start_date': timezone.datetime(2020, 2, 1)}
         self.dag = DAG('test_dag_id', default_args=args)
 
-    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
     def test_create_application_from_yaml(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = SparkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_YAML,
@@ -194,7 +194,7 @@ class TestSparkKubernetesOperator(unittest.TestCase):
             version='v1beta2',
         )
 
-    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
     def test_create_application_from_json(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = SparkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,
@@ -212,7 +212,7 @@ class TestSparkKubernetesOperator(unittest.TestCase):
             version='v1beta2',
         )
 
-    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
     def test_namespace_from_operator(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = SparkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,
@@ -231,7 +231,7 @@ class TestSparkKubernetesOperator(unittest.TestCase):
             version='v1beta2',
         )
 
-    @patch('kubernetes.client.apis.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
     def test_namespace_from_connection(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = SparkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,

--- a/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -508,7 +508,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         self.dag = DAG("test_dag_id", default_args=args)
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_COMPLETED_APPLICATION,
     )
     def test_completed_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -524,7 +524,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_FAILED_APPLICATION,
     )
     def test_failed_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -540,7 +540,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_NOT_PROCESSED_APPLICATION,
     )
     def test_not_processed_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -556,7 +556,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_NEW_APPLICATION,
     )
     def test_new_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -572,7 +572,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_RUNNING_APPLICATION,
     )
     def test_running_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -588,7 +588,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_SUBMITTED_APPLICATION,
     )
     def test_submitted_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -604,7 +604,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_PENDING_RERUN_APPLICATION,
     )
     def test_pending_rerun_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -620,7 +620,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_UNKNOWN_APPLICATION,
     )
     def test_unknown_application(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -636,7 +636,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_COMPLETED_APPLICATION,
     )
     def test_namespace_from_sensor(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -658,7 +658,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_COMPLETED_APPLICATION,
     )
     def test_namespace_from_connection(self, mock_get_namespaced_crd, mock_kubernetes_hook):
@@ -679,7 +679,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         )
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_FAILED_APPLICATION,
     )
     @patch("logging.Logger.error")
@@ -701,7 +701,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         error_log_call.assert_called_once_with(TEST_POD_LOG_RESULT)
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_COMPLETED_APPLICATION,
     )
     @patch("logging.Logger.info")
@@ -725,7 +725,7 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         self.assertEqual(log_value, TEST_POD_LOG_RESULT)
 
     @patch(
-        "kubernetes.client.apis.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_COMPLETED_APPLICATION,
     )
     @patch("logging.Logger.warning")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Fix this K8S client deprecation warnings
```
/usr/local/lib/python3.6/site-packages/kubernetes/client/apis/__init__.py:12: DeprecationWarning: The package kubernetes.client.apis is renamed and deprecated, use kubernetes.client.api instead (please note that the trailing s was removed).
      DeprecationWarning
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
