### PR TITLE
Stop Log Spamming when `[core] lazy_load_plugins` is False

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -283,7 +283,7 @@ def ensure_plugins_loaded():
 
     num_loaded = len(plugins)
     if num_loaded > 0:
-        log.info("Loading %d plugin(s) took %.2f seconds", num_loaded, timer.duration)
+        log.debug("Loading %d plugin(s) took %.2f seconds", num_loaded, timer.duration)
 
 
 def initialize_web_ui_plugins():

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -125,13 +125,14 @@ class TestPluginsManager:
         with mock_plugin_manager(plugins=[AirflowTestPropertyPlugin()]):
             from airflow import plugins_manager
 
+            caplog.set_level(logging.DEBUG)
             plugins_manager.ensure_plugins_loaded()
 
             assert 'AirflowTestPropertyPlugin' in str(plugins_manager.plugins)
             assert 'TestPropertyHook' in str(plugins_manager.registered_hooks)
 
-        assert caplog.records[0].levelname == 'INFO'
-        assert caplog.records[0].msg == 'Loading %d plugin(s) took %.2f seconds'
+        assert caplog.records[-1].levelname == 'DEBUG'
+        assert caplog.records[-1].msg == 'Loading %d plugin(s) took %.2f seconds'
 
     def test_should_warning_about_incompatible_plugins(self, caplog):
         class AirflowAdminViewsPlugin(AirflowPlugin):


### PR DESCRIPTION
Currently when `[core] lazy_load_plugins` is False, it spams logs with the following line:

```
Loading 1 plugin(s) took 0.79 seconds
```

Example

```python
root@a20fe6919413:/usr/local/airflow# python
Python 3.7.9 (default, Dec 11 2020, 14:53:17)

>>> from airflow import version
[2021-01-08 20:20:51,730] {plugins_manager.py:286} INFO - Loading 1 plugin(s) took 0.79 seconds
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
