### PR TITLE
Deprecate `tableau` extra

### DIFF
--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -203,8 +203,6 @@ can be reported by some tools (even if it is harmless).
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+-----------+
 | statsd              | ``pip install 'apache-airflow[statsd]'``            | Needed by StatsD metrics                                                           |           |
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+-----------+
-| tableau             | ``pip install 'apache-airflow[tableau]'``           | Tableau visualization integration                                                  |           |
-+---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+-----------+
 | virtualenv          | ``pip install 'apache-airflow[virtualenv]'``        | Running python tasks in local virtualenv                                           |           |
 +---------------------+-----------------------------------------------------+------------------------------------------------------------------------------------+-----------+
 
@@ -250,6 +248,8 @@ all replaced by new extras, which have naming consistent with the names of provi
 The ``crypto`` extra is not needed any more, because all crypto dependencies are part of airflow package,
 so there is no replacement for ``crypto`` extra.
 
+The ``tableau`` extra dependencies have been included in the ``salesforce`` extra.
+
 +---------------------+-----------------------------+
 | Deprecated extra    | Extra to be used instead    |
 +=====================+=============================+
@@ -284,6 +284,8 @@ so there is no replacement for ``crypto`` extra.
 | s3                  | amazon                      |
 +---------------------+-----------------------------+
 | spark               | apache.spark                |
++---------------------+-----------------------------+
+| tableau             | salesforce                  |
 +---------------------+-----------------------------+
 | webhdfs             | apache.webhdfs              |
 +---------------------+-----------------------------+

--- a/setup.py
+++ b/setup.py
@@ -449,9 +449,6 @@ ssh = [
 statsd = [
     'statsd>=3.3.0, <4.0',
 ]
-tableau = [
-    'tableauserverclient~=0.12',
-]
 telegram = [
     'python-telegram-bot==13.0',
 ]
@@ -626,7 +623,6 @@ EXTRAS_REQUIREMENTS: Dict[str, List[str]] = {
     'rabbitmq': rabbitmq,
     'sentry': sentry,
     'statsd': statsd,
-    'tableau': tableau,
     'virtualenv': virtualenv,
 }
 
@@ -666,6 +662,7 @@ EXTRAS_DEPRECATED_ALIASES: Dict[str, str] = {
     'qds': 'qubole',
     's3': 'amazon',
     'spark': 'apache.spark',
+    'tableau': 'salesforce',
     'webhdfs': 'apache.webhdfs',
     'winrm': 'microsoft.winrm',
 }


### PR DESCRIPTION
There was no separate provider for `tableau` and it's dependencies
have been already incorporated in ``salesforce`` one therefore
this change deprecates it in favour of ``salesforce``.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
