### PR TITLE
Have proper default for webserver.expose_config in Helm Chart

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -34,7 +34,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Configuring Airflow
 
-All Airflow configuration parameters (equivalent of `airflow.cfg`) are stored in [values.yaml](https://github.com/apache/airflow/blob/master/chart/values.yaml) under the `config` key . The following code demonstrates how one would deny webserver users from viewing the config from within the webserver application. See the bottom line of the example:
+All Airflow configuration parameters (equivalent of `airflow.cfg`) are stored in [values.yaml](https://github.com/apache/airflow/blob/master/chart/values.yaml) under the `config` key . The following code demonstrates how one would allow webserver users to view the config from within the webserver application. See the bottom line of the example:
 
 ```yaml
 # Config settings to go into the mounted airflow.cfg
@@ -68,7 +68,7 @@ config:
     statsd_host: '{{ printf "%s-statsd" .Release.Name }}'
   webserver:
     enable_proxy_fix: 'True'
-    expose_config: 'False'   # <<<<<<<<<< BY DEFAULT THIS IS 'True' BUT WE CHANGE IT TO 'False' PRIOR TO INSTALLING THE CHART
+    expose_config: 'True'   # <<<<<<<<<< BY DEFAULT THIS IS 'False' BUT WE CHANGE IT TO 'True' PRIOR TO INSTALLING THE CHART
 ```
 
 Generally speaking, it is useful to familiarize oneself with the Airflow configuration prior to installing and deploying the service.
@@ -134,7 +134,7 @@ helm upgrade airflow . \
 
 ## Mounting DAGS using Git-Sync side car without Persistence
 
-This option will use an always running Git-Sync side car on every scheduler,webserver and worker pods. The Git-Sync side car containers will sync DAGs from a git repository every configured number of seconds. If you are using the KubernetesExecutor, Git-sync will run as an initContainer on your worker pods.
+This option will use an always running Git-Sync side car on every scheduler, webserver and worker pods. The Git-Sync side car containers will sync DAGs from a git repository every configured number of seconds. If you are using the KubernetesExecutor, Git-sync will run as an initContainer on your worker pods.
 
 ```bash
 helm upgrade airflow . \

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -705,7 +705,6 @@ config:
     statsd_host: '{{ printf "%s-statsd" .Release.Name }}'
   webserver:
     enable_proxy_fix: 'True'
-    expose_config: 'True'
     rbac: 'True'
   celery:
     default_queue: celery


### PR DESCRIPTION
Configuration `webserver.expose_config` should have consistent default value with the normal Airflow default settings (False). So we can simply remove it in `values.yaml`, so default value in `default_airflow.cfg` is respected.

This helps encourage safer setting up in Helm context, also avoid accidental exposure of config (if users don't carefully check the config before install the chart).

Ref: Slack discussion https://apache-airflow.slack.com/archives/CCPRP7943/p1610213808438200

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
