### PR TITLE
UX Enhancement: Empty State of Plugins View

### DIFF
--- a/airflow/www/templates/airflow/plugin.html
+++ b/airflow/www/templates/airflow/plugin.html
@@ -19,38 +19,30 @@ under the License.
 
 {% extends base_template %}
 
-
 {% block title %}
-
   {{ title }}
-
 {% endblock %}
 
-
 {% block content %}
-
-  <div>
-
-    <h2>{{ title }}</h2>
-
-    {% for plugin in plugins %}
-      <h4>{{ plugin["plugin_no"] }}. {{ plugin["plugin_name"] }}</h4>
-
-      <table class="table table-striped table-bordered">
+  <h2>{{ title }}</h2>
+  {% if plugins|length == 0 %}
+    <p>No plugins loaded. Learn more in the
+      <a href="https://airflow.apache.org/docs/apache-airflow/stable/plugins.html" target="_blank">plugins documentation</a>.
+    </p>
+  {% endif %}
+  {% for plugin in plugins %}
+    <h4>{{ plugin["plugin_no"] }}. {{ plugin["plugin_name"] }}</h4>
+    <table class="table table-striped table-bordered">
+      <tr>
+        <th>Attribute</th>
+        <th>Value</th>
+      </tr>
+      {% for attr, value in plugin["attrs"].items() %}
         <tr>
-          <th>Attribute</th>
-          <th>Value</th>
+          <td>{{ attr }}</td>
+          <td class='code'>{{ value }}</td>
         </tr>
-        {% for attr, value in plugin["attrs"].items() %}
-          <tr>
-            <td>{{ attr }}</td>
-            <td class='code'>{{ value }}</td>
-          </tr>
-        {% endfor %}
-      </table>
-
-    {% endfor %}
-
-  </div>
-
+      {% endfor %}
+    </table>
+  {% endfor %}
 {% endblock %}


### PR DESCRIPTION
A slight improvement to the Plugins view when no plugins are loaded (similar message as CLI).

![image](https://user-images.githubusercontent.com/3267/104130107-edeff000-533c-11eb-8861-bb375b317241.png)

### Before:
![image](https://user-images.githubusercontent.com/3267/104130014-85087800-533c-11eb-8e42-b46fb648b9c6.png)

### After:
![image](https://user-images.githubusercontent.com/3267/104130191-6c4c9200-533d-11eb-8f0c-15e42ac4560f.png)
