### PR TITLE
Deprecate email credentials from environment variables.

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1248,6 +1248,12 @@
       type: string
       example: ~
       default: "airflow.utils.email.send_email_smtp"
+    - name: email_conn_id
+      description: Email connection to use
+      version_added: ~
+      type: string
+      example: ~
+      default: "smtp_default"
     - name: default_email_on_retry
       description: |
         Whether email alerts should be sent when a task is retried

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -620,6 +620,9 @@ session_lifetime_minutes = 43200
 # Email backend to use
 email_backend = airflow.utils.email.send_email_smtp
 
+# Email connection to use
+email_conn_id = smtp_default
+
 # Whether email alerts should be sent when a task is retried
 default_email_on_retry = True
 

--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -80,6 +80,7 @@ page_size = 100
 
 [email]
 email_backend = airflow.utils.email.send_email_smtp
+email_conn_id = smtp_default
 
 [smtp]
 smtp_host = localhost

--- a/airflow/operators/email.py
+++ b/airflow/operators/email.py
@@ -63,6 +63,7 @@ class EmailOperator(BaseOperator):
         bcc: Optional[Union[List[str], str]] = None,
         mime_subtype: str = 'mixed',
         mime_charset: str = 'utf-8',
+        conn_id: Optional[str] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -74,6 +75,7 @@ class EmailOperator(BaseOperator):
         self.bcc = bcc
         self.mime_subtype = mime_subtype
         self.mime_charset = mime_charset
+        self.conn_id = conn_id
 
     def execute(self, context):
         send_email(
@@ -85,4 +87,5 @@ class EmailOperator(BaseOperator):
             bcc=self.bcc,
             mime_subtype=self.mime_subtype,
             mime_charset=self.mime_charset,
+            conn_id=self.conn_id,
         )

--- a/tests/providers/sendgrid/utils/test_emailer.py
+++ b/tests/providers/sendgrid/utils/test_emailer.py
@@ -95,7 +95,7 @@ class TestSendEmailSendGrid(unittest.TestCase):
                 bcc=self.bcc,
                 files=[f.name],
             )
-            mock_post.assert_called_once_with(expected_mail_data)
+            mock_post.assert_called_once_with(expected_mail_data, "sendgrid_default")
 
     # Test the right email is constructed.
     @mock.patch.dict('os.environ', SENDGRID_MAIL_FROM='foo@bar.com', SENDGRID_MAIL_SENDER='Foo')
@@ -110,7 +110,7 @@ class TestSendEmailSendGrid(unittest.TestCase):
             personalization_custom_args=self.personalization_custom_args,
             categories=self.categories,
         )
-        mock_post.assert_called_once_with(self.expected_mail_data_extras)
+        mock_post.assert_called_once_with(self.expected_mail_data_extras, "sendgrid_default")
 
     @mock.patch.dict('os.environ', clear=True)
     @mock.patch('airflow.providers.sendgrid.utils.emailer._post_sendgrid_mail')
@@ -124,4 +124,4 @@ class TestSendEmailSendGrid(unittest.TestCase):
             from_email='foo@foo.bar',
             from_name='Foo Bar',
         )
-        mock_post.assert_called_once_with(self.expected_mail_data_sender)
+        mock_post.assert_called_once_with(self.expected_mail_data_sender, "sendgrid_default")


### PR DESCRIPTION
Email backends fetch credentials from environment variables, but other
credentials are typically stored in connections. This patch deprecates
email credentials from environment variables and checks connections
first. We can drop the environment variable fallback in a future
release.

Based on conversation in #13463. I would like to standardize credential handling in email backends, then add an SES backend separately. I'm marking this as a draft for feedback, and I'll write tests once we agree on an approach. cc @mik-laj 