### PR TITLE
Change the default celery worker_concurrency to 16

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -27,7 +27,6 @@ assists users migrating to a new version.
 **Table of contents**
 
 - [Master](#master)
-- [Default `[celery] worker_concurrency` is changed to `16`](#default-celery-worker_concurrency-is-changed-to-16)
 - [Airflow 2.0.0](#airflow-200)
 - [Airflow 1.10.14](#airflow-11014)
 - [Airflow 1.10.13](#airflow-11013)
@@ -53,7 +52,7 @@ assists users migrating to a new version.
 
 ## Master
 
-## Default `[celery] worker_concurrency` is changed to `16`
+### Default `[celery] worker_concurrency` is changed to `16`
 
 The default value for `[celery] worker_concurrency` was `16` for Airflow <2.0.0.
 However, it was unintentionally changed to `8` in 2.0.0.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -27,6 +27,7 @@ assists users migrating to a new version.
 **Table of contents**
 
 - [Master](#master)
+- [Default `[celery] worker_concurrency` is changed to `16`](#default-celery-worker_concurrency-is-changed-to-16)
 - [Airflow 2.0.0](#airflow-200)
 - [Airflow 1.10.14](#airflow-11014)
 - [Airflow 1.10.13](#airflow-11013)
@@ -51,6 +52,13 @@ assists users migrating to a new version.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Master
+
+## Default `[celery] worker_concurrency` is changed to `16`
+
+The default value for `[celery] worker_concurrency` was `16` for Airflow <2.0.0.
+However, it was unintentionally changed to `8` in 2.0.0.
+
+From Airflow 2.0.1, we revert to the old default of `16`.
 
 ## Airflow 2.0.0
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1356,7 +1356,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "8"
+      default: "16"
     - name: worker_autoscale
       description: |
         The maximum and minimum concurrency that will be used when starting workers with the

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -663,7 +663,7 @@ celery_app_name = airflow.executors.celery_executor
 # ``airflow celery worker`` command. This defines the number of task instances that
 # a worker will take, so size up your workers based on the resources on
 # your worker box and the nature of your tasks
-worker_concurrency = 8
+worker_concurrency = 16
 
 # The maximum and minimum concurrency that will be used when starting workers with the
 # ``airflow celery worker`` command (always keep minimum processes, but grow

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -152,6 +152,9 @@ unset AIRFLOW__CORE__UNIT_TEST_MODE
 mkdir -pv "${AIRFLOW_HOME}/logs/"
 cp -f "${IN_CONTAINER_DIR}/airflow_ci.cfg" "${AIRFLOW_HOME}/unittests.cfg"
 
+# Change the default worker_concurrency for tests
+export AIRFLOW__CELERY__WORKER_CONCURRENCY=8
+
 disable_rbac_if_requested
 
 set +e


### PR DESCRIPTION
I think this change was unintentional -- https://github.com/apache/airflow/pull/7205

That PR just changed it to work with breeze. Since we had `16` as default in 1.10.x
and to get better performance and keep in line with `dag_concurrency` and
`max_active_runs_per_dag` -- I think `16` makes more sense.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
