### PR TITLE
Fix flower ingress annotations in chart

### DIFF
--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -29,9 +29,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-  {{- with .Values.ingress.flower.annotations }}
-  annotations:
-  {{ toYaml . | indent 4 }}
+  {{- if .Values.ingress.flower.annotations }}
+  annotations: {{ toYaml .Values.ingress.flower.annotations | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.ingress.flower.tls.enabled }}
@@ -43,9 +42,13 @@ spec:
   rules:
     - http:
         paths:
-          - path: {{ .Values.ingress.flower.path }}
-            backend:
+          - backend:
               serviceName: {{ .Release.Name }}-flower
               servicePort: flower-ui
+            {{- if .Values.ingress.flower.path }}
+            path: {{ .Values.ingress.flower.path }}
+            {{- end }}
+      {{- if .Values.ingress.flower.host }}
       host: {{ .Values.ingress.flower.host }}
+      {{- end }}
 {{- end }}

--- a/chart/tests/test_ingress_flower.py
+++ b/chart/tests/test_ingress_flower.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import jmespath
+
+from tests.helm_template_generator import render_chart
+
+
+class IngressFlowerTest(unittest.TestCase):
+    def test_should_pass_validation_with_just_ingress_enabled(self):
+        render_chart(
+            values={"ingress": {"enabled": True}, "executor": "CeleryExecutor"},
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )  # checks that no validation exception is raised
+
+    def test_should_allow_more_than_one_annotation(self):
+        docs = render_chart(
+            values={
+                "ingress": {"enabled": True, "flower": {"annotations": {"aa": "bb", "cc": "dd"}}},
+                "executor": "CeleryExecutor",
+            },
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )
+        assert jmespath.search("metadata.annotations", docs[0]) == {"aa": "bb", "cc": "dd"}


### PR DESCRIPTION
Hello,
A small follow up to https://github.com/apache/airflow/pull/12010.

https://github.com/apache/airflow/pull/12010 introduced
a small bug in the way annotations are handled for the
flower ingress.

A test have been added to prevent this from occuring againg.

Also more conditionals have been added to the
flower-ingress.yaml file to make it compatible with schema
validation.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
