### PR TITLE
Configurable API response (CORS) headers

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -162,6 +162,15 @@ info:
     Note that with *Postman*, you can also generate code snippets by selecting a request and clicking on
     the **Code** button.
 
+    ## Enabling CORS
+
+    [Cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+    is a browser security feature that restricts HTTP requests that are
+    initiated from scripts running in the browser.
+
+    For details on enabling/configuring CORS, see
+    [Enabling CORS](https://airflow.apache.org/docs/apache-airflow/stable/security/api.html).
+
     # Authentication
 
     To be able to meet the requirements of many organizations, Airflow supports many authentication methods,

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -759,6 +759,27 @@
       version_added: ~
       example: /files/service-account-json
       default: ""
+    - name: access_control_allow_headers
+      description: |
+        Used in response to a preflight request to indicate which HTTP
+        headers can be used when making the actual request. This header is
+        the server side response to the browser's
+        Access-Control-Request-Headers header.
+      type: string
+      example: ~
+      default: ""
+    - name: access_control_allow_methods
+      description: |
+        Specifies the method or methods allowed when accessing the resource.
+      type: string
+      example: ~
+      default: ""
+    - name: access_control_allow_origin
+      description: |
+        Indicates whether the response can be shared with requesting code from the given origin.
+      type: string
+      example: ~
+      default: ""
 - name: lineage
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -766,18 +766,21 @@
         the server side response to the browser's
         Access-Control-Request-Headers header.
       type: string
+      version_added: ~
       example: ~
       default: ""
     - name: access_control_allow_methods
       description: |
         Specifies the method or methods allowed when accessing the resource.
       type: string
+      version_added: ~
       example: ~
       default: ""
     - name: access_control_allow_origin
       description: |
         Indicates whether the response can be shared with requesting code from the given origin.
       type: string
+      version_added: ~
       example: ~
       default: ""
 - name: lineage

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -408,6 +408,18 @@ google_oauth2_audience =
 # Example: google_key_path = /files/service-account-json
 google_key_path =
 
+# Used in response to a preflight request to indicate which HTTP
+# headers can be used when making the actual request. This header is
+# the server side response to the browser's
+# Access-Control-Request-Headers header.
+access_control_allow_headers =
+
+# Specifies the method or methods allowed when accessing the resource.
+access_control_allow_methods =
+
+# Indicates whether the response can be shared with requesting code from the given origin.
+access_control_allow_origin =
+
 [lineage]
 # what lineage backend to use
 backend =

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -185,7 +185,9 @@ def init_api_connexion(app: Flask) -> None:
     api_bp = connexion_app.add_api(
         specification='v1.yaml', base_path=base_path, validate_responses=True, strict_validation=True
     ).blueprint
-    app.after_request(set_cors_headers_on_response)
+    # Like "api_bp.after_request", but the BP is already registered, so we have
+    # to register it in the app directly.
+    app.after_request_funcs.setdefault(api_bp.name, []).append(set_cors_headers_on_response)
     app.register_error_handler(ProblemException, common_error_handler)
     app.extensions['csrf'].exempt(api_bp)
 

--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -147,6 +147,20 @@ def init_error_handlers(app: Flask):
     app.register_error_handler(404, views.circles)
 
 
+def set_cors_headers_on_response(response):
+    """Add response headers"""
+    allow_headers = conf.get('api', 'access_control_allow_headers')
+    allow_methods = conf.get('api', 'access_control_allow_methods')
+    allow_origin = conf.get('api', 'access_control_allow_origin')
+    if allow_headers is not None:
+        response.headers['Access-Control-Allow-Headers'] = allow_headers
+    if allow_methods is not None:
+        response.headers['Access-Control-Allow-Methods'] = allow_methods
+    if allow_origin is not None:
+        response.headers['Access-Control-Allow-Origin'] = allow_origin
+    return response
+
+
 def init_api_connexion(app: Flask) -> None:
     """Initialize Stable API"""
     base_path = '/api/v1'
@@ -171,6 +185,7 @@ def init_api_connexion(app: Flask) -> None:
     api_bp = connexion_app.add_api(
         specification='v1.yaml', base_path=base_path, validate_responses=True, strict_validation=True
     ).blueprint
+    app.after_request(set_cors_headers_on_response)
     app.register_error_handler(ProblemException, common_error_handler)
     app.extensions['csrf'].exempt(api_bp)
 

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -135,6 +135,26 @@ section of ``airflow.cfg``.
 
 Additional options to your auth backend can be configured in ``airflow.cfg``, as a new option.
 
+Enabling CORS
+---------------
+
+[Cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+is a browser security feature that restricts HTTP requests that are initiated
+from scripts running in the browser.
+
+`Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, and
+`Access-Control-Allow-Origin` headers can be added by setting values for
+``access_control_allow_headers``, ``access_control_allow_methods``, and
+``access_control_allow_origin`` options in the ``[api]`` section of the
+``airflow.cfg`` file.
+
+.. code-block:: ini
+
+    [api]
+    access_control_allow_headers = origin, content-type, accept
+    access_control_allow_methods = POST, GET, OPTIONS, DELETE
+    access_control_allow_origin = https://exampleclientapp.com
+
 Page size limit
 ---------------
 

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -138,12 +138,12 @@ Additional options to your auth backend can be configured in ``airflow.cfg``, as
 Enabling CORS
 ---------------
 
-[Cross-origin resource sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+`Cross-origin resource sharing (CORS) <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_
 is a browser security feature that restricts HTTP requests that are initiated
 from scripts running in the browser.
 
-`Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, and
-`Access-Control-Allow-Origin` headers can be added by setting values for
+``Access-Control-Allow-Headers``, ``Access-Control-Allow-Methods``, and
+``Access-Control-Allow-Origin`` headers can be added by setting values for
 ``access_control_allow_headers``, ``access_control_allow_methods``, and
 ``access_control_allow_origin`` options in the ``[api]`` section of the
 ``airflow.cfg`` file.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1067,6 +1067,7 @@ preemptible
 prefetch
 prefetched
 prefetches
+preflight
 prefork
 preloading
 prepend


### PR DESCRIPTION
Employing the newly improved REST API from an independent web application is currently prohibited by browsers due to the lack of [CORS (Cross-Origin Resource Sharing) headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) in the API response.

This PR adds 3 configuration options to add the following headers:

- `Access-Control-Allow-Headers` via `AIRFLOW__API__ACCESS_CONTROL_ALLOW_HEADERS`
- `Access-Control-Allow-Methods` via `AIRFLOW__API__ACCESS_CONTROL_ALLOW_METHODS`
- `Access-Control-Allow-Origin` via `AIRFLOW__API__ACCESS_CONTROL_ALLOW_ORIGIN`

This only covers a minimum of all potential headers that could be utilized, but the added `set_cors_headers_on_response` function establishes an obvious place for it to be further extended in the future if needed.

We did look into utilizing [Flask-CORS](https://github.com/corydolphin/flask-cors) to add this functionality, but ultimately found it to be overkill given we only want to add this to the API endpoint and not the entire Webserver application.

I've added documentation of this feature to Security/API and also cross-linked to that documentation from within the API documentation as well.