### PR TITLE
Add submodules in added workflow job

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -205,6 +205,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+          submodules: recursive
       - name: >
           Event: ${{ needs.cancel-workflow-runs.outputs.sourceEvent }}
           Repo: ${{ needs.cancel-workflow-runs.outputs.sourceHeadRepo }}
@@ -223,12 +224,14 @@ jobs:
           ref: ${{ needs.cancel-workflow-runs.outputs.targetCommitSha }}
           fetch-depth: 2
           persist-credentials: false
+          submodules: recursive
         if: needs.cancel-workflow-runs.outputs.sourceEvent  == 'pull_request'
       # checkout the master version again, to use the right script in master workflow
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+          submodules: recursive
       - name: Selective checks
         id: selective-checks
         env:
@@ -281,6 +284,7 @@ jobs:
         with:
           ref: ${{ needs.cancel-workflow-runs.outputs.targetCommitSha }}
           persist-credentials: false
+          submodules: recursive
       - name: "Retrieve DEFAULTS from the _initialization.sh"
         # We cannot "source" the script here because that would be a security problem (we cannot run
         # any code that comes from the sources coming from the PR. Therefore we extract the
@@ -353,7 +357,7 @@ jobs:
         run: ./scripts/ci/images/ci_push_ci_images.sh
         if: steps.defaults.outputs.proceed == 'true'
       - name: Update GitHub Checks for Building image with status
-        uses: apache/airflow-checks-action@9f02872da71b6f558c6a6f190f925dde5e4d8798  # v1.1.0
+        uses: ./main-airflow/.github/actions/checks-action
         if: always() && steps.defaults.outputs.proceed == 'true'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -405,6 +409,7 @@ jobs:
         with:
           ref: ${{ needs.cancel-workflow-runs.outputs.targetCommitSha }}
           persist-credentials: false
+          submodules: recursive
       - name: "Retrieve DEFAULTS from the _initialization.sh"
         # We cannot "source" the script here because that would be a security problem (we cannot run
         # any code that comes from the sources coming from the PR. Therefore we extract the
@@ -426,8 +431,8 @@ jobs:
           else
               echo "::set-output name=proceed::true"
           fi
-      - name: Initiate GitHub Checks for Building image
-        uses: apache/airflow-checks-action@9f02872da71b6f558c6a6f190f925dde5e4d8798  # v1.1.0
+      - name: Initiate GitHub Checks for Building image with status
+        uses: ./main-airflow/.github/actions/checks-action
         id: build-image-check
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -449,6 +454,7 @@ jobs:
           path: "main-airflow"
           ref: "${{ needs.cancel-workflow-runs.outputs.targetBranch }}"
           persist-credentials: false
+          submodules: recursive
         if: steps.defaults.outputs.proceed == 'true'
       - name: "Setup python"
         uses: actions/setup-python@v2


### PR DESCRIPTION
The most recent submodule change for actions #13514 was done in
parallel to Optimising worklfows in #13562 and the job added in
the #13562 still uses non-submodule version of check action.

This PR fixes that and all 3rd-party actions now are used
from submodule.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
