### PR TITLE
Providers are not installed from PyPI when testing local files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,8 +464,6 @@ jobs:
         run: ./scripts/ci/build_airflow/ci_build_airflow_package.sh
       - name: "Install and test provider packages and airflow via ${{ matrix.package-format }} files"
         run: ./scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
-        env:
-          INSTALL_PROVIDERS_FROM_SOURCES: "false"
       - name: "Upload package artifacts"
         uses: actions/upload-artifact@v2
         if: always()


### PR DESCRIPTION
When testing locally generated providers, we should skip installing
them from PyPI because some providers might be added which are
not yet in PyPI.

There was a mistake in copy&pasted workflow which caused that
the providers have been first installed from PyPI and then
uninstalled, but in case of a new providers added, this
caused a failure as newly added providers failed to install
from PyPI.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
