### PR TITLE
Fix string encoding in DockerOperator when using xcom / json in xcom.py

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -232,6 +232,8 @@ class BaseXCom(Base, LoggingMixin):
         if conf.getboolean('core', 'enable_xcom_pickling'):
             return pickle.dumps(value)
         try:
+            if hasattr(value, 'decode'):
+                value = value.decode('utf-8')
             return json.dumps(value).encode('UTF-8')
         except (ValueError, TypeError):
             log.error(


### PR DESCRIPTION
closes: #13535

fixes the xcom issue by decoding the byte array of the log file before submitting it to xcom

replaces pull request #13536