### PR TITLE
Correct XCOM pickle advisory in UPDATING.md

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -185,7 +185,7 @@ The pickle type for XCom messages has been replaced to JSON by default to preven
 Note that JSON serialization is stricter than pickling, so for example if you want to pass
 raw bytes through XCom you must encode them using an encoding like ``base64``.
 If you understand the risk and still want to use [pickling](https://docs.python.org/3/library/pickle.html),
-set `enable_xcom_pickling = False` in your Airflow config's `core` section.
+set `enable_xcom_pickling = True` in your Airflow config's `core` section.
 
 ### Airflowignore of base path
 


### PR DESCRIPTION
This PR flips the suggested boolean for enabling XCOM pickling to the correct value.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
