### PR TITLE
Fixes problems with extras for custom connection types

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -31,7 +31,7 @@ $(document).ready(function () {
     $.each($("[id^='extra__']"), function () {
       $(this).parent().parent().addClass('hide')
     });
-    $.each($("[id^='extra__" + connectionType + "']"), function () {
+    $.each($("[id^='extra__" + connectionType + "__']"), function () {
       $(this).parent().parent().removeClass('hide')
     });
     $("label[orig_text]").each(function () {

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2894,9 +2894,13 @@ class ConnectionModelView(AirflowModelView):
 
     def process_form(self, form, is_created):
         """Process form data."""
-        formdata = form.data
-        if formdata['conn_type'] in ['jdbc', 'google_cloud_platform', 'grpc', 'yandexcloud', 'kubernetes']:
-            extra = {key: formdata[key] for key in self.extra_fields if key in formdata}
+        conn_type = form.data['conn_type']
+        extra = {
+            key: form.data[key]
+            for key in self.extra_fields
+            if key in form.data and key.startswith(f"extra__{conn_type}__")
+        }
+        if extra.keys():
             form.extra.data = json.dumps(extra)
 
     def prefill_form(self, form, pk):


### PR DESCRIPTION
The custom providers with custom connections can define
extra widgets and fields, however there were problems with
those custom fields in Aiflow 2.0.0:

* When connection type was a subset of another connection
  type (for example jdbc and jdbcx) widgets from the
  'subset' connection type appeared also in the 'superset'
  one due to prefix matching in javascript.

* Each connection when saved received 'full set' of extra
  fields from other connection types (with empty values).
  This problem is likely present in Airflow 1.10 but due
  to limited number of connections supported it had no
  real implications besides slightly bigger dictionary
  stored in 'extra' field.

* The extra field values were not saved for custom connections.
  Only the predefined connection types could save extras in
  extras field.

This PR fixes it by:

* adding __ matching for javascript to match only full connection
  types not prefixes
* saving only the fields matching extra__<conn_type> when the
  connection is saved
* removing filtering on 'known' connection types (the above
  filtering on `extra__` results in empty extra for
  connections that do not have any extra field defined.

Fixes #13597

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
