### PR TITLE
Fix the docs for Transfer Operators

### DIFF
--- a/docs/exts/operators_and_hooks_ref-transfers.rst.jinja2
+++ b/docs/exts/operators_and_hooks_ref-transfers.rst.jinja2
@@ -17,7 +17,7 @@
  under the License.
 #}
 {%- for item in items %}
-{% set title = item['source-integration-name'] + " to " + item['source-integration-name'] %}
+{% set title = item['source-integration-name'] + " to " + item['target-integration-name'] %}
 {{ title }}
 {{ header_separator * (title|length) }}
 {# Force new line #}


### PR DESCRIPTION
Currently instead of "S3 to GCS" it says "S3 to S3"

**Before:**

![image](https://user-images.githubusercontent.com/8811558/104360318-c6e61980-5508-11eb-9c91-a1d303355c43.png)

**After**:
![image](https://user-images.githubusercontent.com/8811558/104360382-debd9d80-5508-11eb-8cd6-76e7e7c6be1d.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
