### PR TITLE
Update external docs URL for Segment

### DIFF
--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -26,7 +26,7 @@ versions:
 
 integrations:
   - integration-name: Segment
-    external-doc-url: https://oapi.dingtalk.com
+    external-doc-url: https://segment.com/docs/
     tags: [service]
 
 operators:


### PR DESCRIPTION
closes: #13634. Replaces the incorrect `external-doc-url:` value that was a URL to the dingtalk API with the correct URL to the Segment docs. One line change for docs.