### PR TITLE
Fix pod launcher role permissions to list events in chart

### DIFF
--- a/chart/templates/rbac/pod-launcher-role.yaml
+++ b/chart/templates/rbac/pod-launcher-role.yaml
@@ -63,4 +63,11 @@ rules:
     verbs:
       - "create"
       - "get"
+  - apiGroups:
+      - ""
+    resources:
+      - "events"
+    verbs:
+      - "list"
+
 {{- end }}


### PR DESCRIPTION
Hello, here is a small fix on the chart to prevent an airflow exception due to https://github.com/apache/airflow/blob/master/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py#L490.

I think adding a test for this is bit hard, but I am opened to suggestion.

More info:

When using the KubernetesPodOperator with
log_events_on_failure=True, and the pod exits,
the executor needs to access the events in the namespace.

Before this resulted in an exception when using the chart
as this it was not permitted by the pod-launcher role.