### PR TITLE
BugFix: Dag-level Callback Requests were not run

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -348,6 +348,12 @@ class DAG(LoggingMixin):
         self.partial = False
         self.on_success_callback = on_success_callback
         self.on_failure_callback = on_failure_callback
+
+        # To keep it in parity with Serialized DAGs
+        # and identify if DAG has on_*_callback without actually storing them in Serialized JSON
+        self.has_on_success_callback = self.on_success_callback is not None
+        self.has_on_failure_callback = self.on_failure_callback is not None
+
         self.doc_md = doc_md
 
         self._access_control = DAG._upgrade_outdated_dag_access_control(access_control)
@@ -2028,6 +2034,9 @@ class DAG(LoggingMixin):
                 'on_failure_callback',
                 'template_undefined',
                 'jinja_environment_kwargs',
+                # has_on_*_callback are only stored if the value is True, as the default is False
+                'has_on_success_callback',
+                'has_on_failure_callback',
             }
         return cls.__serialized_fields
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -429,7 +429,7 @@ class DagRun(Base, LoggingMixin):
             self.set_state(State.FAILED)
             if execute_callbacks:
                 dag.handle_callback(self, success=False, reason='task_failure', session=session)
-            elif dag.on_failure_callback:
+            elif dag.has_on_failure_callback:
                 callback = callback_requests.DagCallbackRequest(
                     full_filepath=dag.fileloc,
                     dag_id=self.dag_id,
@@ -444,7 +444,7 @@ class DagRun(Base, LoggingMixin):
             self.set_state(State.SUCCESS)
             if execute_callbacks:
                 dag.handle_callback(self, success=True, reason='success', session=session)
-            elif dag.on_success_callback:
+            elif dag.has_on_success_callback:
                 callback = callback_requests.DagCallbackRequest(
                     full_filepath=dag.fileloc,
                     dag_id=self.dag_id,
@@ -459,7 +459,7 @@ class DagRun(Base, LoggingMixin):
             self.set_state(State.FAILED)
             if execute_callbacks:
                 dag.handle_callback(self, success=False, reason='all_tasks_deadlocked', session=session)
-            elif dag.on_failure_callback:
+            elif dag.has_on_failure_callback:
                 callback = callback_requests.DagCallbackRequest(
                     full_filepath=dag.fileloc,
                     dag_id=self.dag_id,

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -96,6 +96,8 @@
         "_default_view": { "type" : "string"},
         "_access_control": {"$ref": "#/definitions/dict" },
         "is_paused_upon_creation":  { "type": "boolean" },
+        "has_on_success_callback":  { "type": "boolean" },
+        "has_on_failure_callback":  { "type": "boolean" },
         "tags": { "type": "array" },
         "_task_group": {"anyOf": [
           { "type": "null" },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -634,6 +634,12 @@ class SerializedDAG(DAG, BaseSerialization):
 
             serialize_dag["tasks"] = [cls._serialize(task) for _, task in dag.task_dict.items()]
             serialize_dag['_task_group'] = SerializedTaskGroup.serialize_task_group(dag.task_group)
+
+            # has_on_*_callback are only stored if the value is True, as the default is False
+            if dag.has_on_success_callback:
+                serialize_dag['has_on_success_callback'] = True
+            if dag.has_on_failure_callback:
+                serialize_dag['has_on_failure_callback'] = True
             return serialize_dag
         except SerializationError:
             raise
@@ -676,6 +682,12 @@ class SerializedDAG(DAG, BaseSerialization):
             for task in dag.tasks:
                 dag.task_group.add(task)
         # pylint: enable=protected-access
+
+        # Set has_on_*_callbacks to True if they exist in Serialized blob as False is the default
+        if "has_on_success_callback" in encoded_dag:
+            dag.has_on_success_callback = True
+        if "has_on_failure_callback" in encoded_dag:
+            dag.has_on_failure_callback = True
 
         keys_to_set_none = dag.get_serialized_fields() - encoded_dag.keys() - cls._CONSTRUCTOR_PARAMS.keys()
         for k in keys_to_set_none:

--- a/airflow/utils/callback_requests.py
+++ b/airflow/utils/callback_requests.py
@@ -34,7 +34,9 @@ class CallbackRequest:
         self.msg = msg
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        if isinstance(other, CallbackRequest):
+            return self.__dict__ == other.__dict__
+        return False
 
     def __repr__(self):
         return str(self.__dict__)

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -30,6 +30,7 @@ from airflow.models.dagrun import DagRun
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import ShortCircuitOperator
+from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.callback_requests import DagCallbackRequest
@@ -304,6 +305,9 @@ class TestDagRun(unittest.TestCase):
             'test_state_succeeded2': State.SUCCESS,
         }
 
+        # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
+        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
+
         dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
         _, callback = dag_run.update_state()
         self.assertEqual(State.SUCCESS, dag_run.state)
@@ -327,6 +331,9 @@ class TestDagRun(unittest.TestCase):
             'test_state_failed2': State.FAILED,
         }
         dag_task1.set_downstream(dag_task2)
+
+        # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
+        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
         _, callback = dag_run.update_state()
@@ -353,6 +360,9 @@ class TestDagRun(unittest.TestCase):
             'test_state_succeeded1': State.SUCCESS,
             'test_state_succeeded2': State.SUCCESS,
         }
+
+        # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
+        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
 
@@ -387,6 +397,9 @@ class TestDagRun(unittest.TestCase):
             'test_state_succeeded1': State.SUCCESS,
             'test_state_failed2': State.FAILED,
         }
+
+        # Scheduler uses Serialized DAG -- so use that instead of the Actual DAG
+        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
 


### PR DESCRIPTION
In https://github.com/apache/airflow/pull/13163 - I attempted to only run
Callback requests when they are defined on DAG. But I just found out
that while we were storing the task-level callbacks as string in Serialized
JSON, we were not storing DAG level callbacks and hence it default to None
when the Serialized DAG was deserialized which meant that the DAG callbacks
were not run.

This PR fixes it, we don't need to store DAG level callbacks as string, as
we don't display them in the Webserver and the actual contents are not used anywhere
in the Scheduler itself. Scheduler just checks if the callbacks are defined and sends
it to DagFileProcessorProcess to run with the actual DAG file. So instead of storing
the actual callback as string which would have resulted in larger JSON blob, I have
added properties to determine whether a callback is defined or not.

(`dag.has_on_success_callback` and `dag.has_on_failure_callback`)

Note: SLA callbacks don't have issue, as we currently check that SLAs are defined on
any tasks are not, if yes, we send it to DagFileProcessorProcess which then executes
the SLA callback defined on DAG.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
