### PR TITLE
Fixed up entrypoint regex

### DIFF
--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -52,9 +52,12 @@ function verify_db_connection {
 
     if [[ ${DB_URL} != sqlite* ]]; then
         # Auto-detect DB parameters
-        [[ ${DB_URL} =~ ([^:]*)://([^@/]*)@?([^/:]*):?([0-9]*)/([^\?]*)\??(.*) ]] && \
+        [[ ${DB_URL} =~ ([^:]*)://([^:]*[@.*]?):([^@]*)@?([^/:]*):?([0-9]*)/([^\?]*)\??(.*) ]] && \
             DETECTED_DB_BACKEND=${BASH_REMATCH[1]} &&
             # Not used USER match
+            # Not used PASSWORD match
+            DETECTED_DB_HOST=${BASH_REMATCH[4]} &&
+            DETECTED_DB_PORT=${BASH_REMATCH[5]} &&
             DETECTED_DB_HOST=${BASH_REMATCH[3]} &&
             DETECTED_DB_PORT=${BASH_REMATCH[4]} &&
             # Not used SCHEMA match

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -58,8 +58,6 @@ function verify_db_connection {
             # Not used PASSWORD match
             DETECTED_DB_HOST=${BASH_REMATCH[4]} &&
             DETECTED_DB_PORT=${BASH_REMATCH[5]} &&
-            DETECTED_DB_HOST=${BASH_REMATCH[3]} &&
-            DETECTED_DB_PORT=${BASH_REMATCH[4]} &&
             # Not used SCHEMA match
             # Not used PARAMS match
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
I noticed this regex wouldn't work for me, because my postgres instance requires the username to be \<username\>@\<dbname\>, so I added the option to have the @\<dbname\> included in there. It now works either way. 

See here for reasoning: https://apache-airflow.slack.com/archives/CCZRF2U5A/p1610541602113400
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
