### PR TITLE
Install providers from sources is disabled for prod image build

### DIFF
--- a/scripts/ci/images/ci_build_dockerhub.sh
+++ b/scripts/ci/images/ci_build_dockerhub.sh
@@ -85,6 +85,7 @@ if [[ ! "${DOCKER_TAG}" =~ ^[0-9].* ]]; then
     )
     (
         export INSTALL_FROM_PYPI="false"
+        export INSTALL_PROVIDERS_FROM_SOURCES="false"
         export INSTALL_FROM_DOCKER_CONTEXT_FILES="true"
         export AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
         export DOCKER_CACHE="pulled"

--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -17,6 +17,7 @@
 # under the License.
 
 export INSTALL_FROM_PYPI="false"
+export INSTALL_PROVIDERS_FROM_SOURCES="false"
 export INSTALL_FROM_DOCKER_CONTEXT_FILES="true"
 export AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
 export DOCKER_CACHE="pulled"


### PR DESCRIPTION
One of the earlier changes caused production image to also install
providers from sources. This is now disabled.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
