### PR TITLE
Docs: Fix heading for Mocking section in best-practices.rst

### DIFF
--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -238,7 +238,7 @@ You can use environment variables to parameterize the DAG.
    )
 
 Mocking variables and connections
-=================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When you write tests for code that uses variables or a connection, you must ensure that they exist when you run the tests. The obvious solution is to save these objects to the database so they can be read while your code is executing. However, reading and writing objects to the database are burdened with additional time overhead. In order to speed up the test execution, it is worth simulating the existence of these objects without saving them to the database. For this, you can create environment variables with mocking :any:`os.environ` using :meth:`unittest.mock.patch.dict`.
 


### PR DESCRIPTION
Currently 'Mocking variables and connections' section is on same level
as Best Practices (`h1` heading):

http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/best-practices.html

Because of which this heading shows in TOC

![image](https://user-images.githubusercontent.com/8811558/104499147-8bb11c80-55d4-11eb-9ae9-d370d2a7b949.png)
![image](https://user-images.githubusercontent.com/8811558/104499155-8f44a380-55d4-11eb-9fc4-a4ab7b2df17c.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
