### PR TITLE
Stop creating duplicate Dag File Processors

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -714,7 +714,12 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         self._callback_to_execute[request.full_filepath].append(request)
         # Callback has a higher priority over DAG Run scheduling
         if request.full_filepath in self._file_path_queue:
-            self._file_path_queue.remove(request.full_filepath)
+            # Remove file paths matching request.full_filepath from self._file_path_queue
+            # Since we are already going to use that filepath to run callback,
+            # there is no need to have same file path again in the queue
+            self._file_path_queue = [
+                file_path for file_path in self._file_path_queue if file_path != request.full_filepath
+            ]
         self._file_path_queue.insert(0, request.full_filepath)
 
     def _refresh_dag_dir(self):
@@ -988,6 +993,15 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
         """Start more processors if we have enough slots and files to process"""
         while self._parallelism - len(self._processors) > 0 and self._file_path_queue:
             file_path = self._file_path_queue.pop(0)
+            # Stop creating duplicate processor i.e. processor with the same filepath
+            if file_path in self._processors.keys():
+                # If filepath is no longer in the queue and if callback exists to execute
+                # we add the filepath to the end of queue so it still runs before
+                # new filepaths are added to the queue as we should runs callbacks asap
+                if file_path not in self._file_path_queue and self._callback_to_execute[file_path]:
+                    self._file_path_queue.append(file_path)
+                continue
+
             callback_to_execute_for_file = self._callback_to_execute[file_path]
             processor = self._processor_factory(
                 file_path, callback_to_execute_for_file, self._dag_ids, self._pickle_dags

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -995,11 +995,6 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             file_path = self._file_path_queue.pop(0)
             # Stop creating duplicate processor i.e. processor with the same filepath
             if file_path in self._processors.keys():
-                # If filepath is no longer in the queue and if callback exists to execute
-                # we add the filepath to the end of queue so it still runs before
-                # new filepaths are added to the queue as we should runs callbacks asap
-                if file_path not in self._file_path_queue and self._callback_to_execute[file_path]:
-                    self._file_path_queue.append(file_path)
                 continue
 
             callback_to_execute_for_file = self._callback_to_execute[file_path]


### PR DESCRIPTION
When a dag file is executed via Dag File Processors and multiple callbacks are
created either via zombies or executor events, the dag file is added to
the _file_path_queue and the manager will launch a new process to
process it, which it should not since the dag file is currently under
processing. This will bypass the _parallelism eventually especially when
it takes a long time to process some dag files and since `self._processors`
is just a dict with file path as the key. So multiple processors with the same key
count as one and hence parallelism is bypassed.

This address the same issue as https://github.com/apache/airflow/pull/11875
but instead does not exclude file paths that are recently processed and that
run at the limit (which is only used in tests) when Callbacks are sent by the
Agent. This is by design as the execution of Callbacks is critical. This is done
with a caveat to avoid duplicate processor -- i.e. if a processor exists,
 the file path is removed from the queue. This means that the processor with
the file path to run callback will be still run when the filepath is added again in the 
next loop

Tests are added to check the same.

closes https://github.com/apache/airflow/issues/13047, https://github.com/apache/airflow/pull/11875/

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
