### PR TITLE
Run openapi-generator as "current" user, not root.

### DIFF
--- a/clients/gen/common.sh
+++ b/clients/gen/common.sh
@@ -27,6 +27,7 @@ function gen_client {
     lang=$1
     shift
     docker run --rm \
+        -u "$(id -u):$(id -g)" \
         -v "${SPEC_PATH}:/spec" \
         -v "${OUTPUT_DIR}:/output" \
         openapitools/openapi-generator-cli:v${OPENAPI_GENERATOR_CLI_VER} \

--- a/scripts/ci/openapi/client_codegen_diff.sh
+++ b/scripts/ci/openapi/client_codegen_diff.sh
@@ -50,7 +50,7 @@ mkdir -p "${GO_CLIENT_PATH}"
 # generate client for target patch
 mkdir -p "${GO_TARGET_CLIENT_PATH}"
 
-git reset --hard "${previous_mainline_commit}"
+git checkout "${previous_mainline_commit}" -- "$SPEC_FILE"
 ./clients/gen/go.sh "${SPEC_FILE}" "${GO_TARGET_CLIENT_PATH}"
 
 diff -u "${GO_TARGET_CLIENT_PATH}" "${GO_CLIENT_PATH}" || true


### PR DESCRIPTION
This tool will happily run without the user existing in the passwd
files, and by running as this user we don't have a lot of files owned by
root left hanging around.

Additionally, only reset the _spec_ file, not the entire repo


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).