### PR TITLE
fix k8s scheduler liveness probe for multi scheduler setup

### DIFF
--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -117,7 +117,7 @@ class BaseJob(Base, LoggingMixin):
         :param session: Database session
         :rtype: BaseJob or None
         """
-        return session.query(cls).order_by(cls.latest_heartbeat.desc()).limit(1).first()
+        return session.query(cls).filter(cls.hostname == self.hostname).order_by(cls.latest_heartbeat.desc()).limit(1).first()
 
     def is_alive(self, grace_multiplier=2.1):
         """

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -136,7 +136,7 @@ spec:
                 import sys
 
                 job = SchedulerJob.most_recent_job()
-                sys.exit(0 if job.is_alive() and job.hostname == get_hostname() else 1)
+                sys.exit(0 if job and job.is_alive() else 1)
           resources:
 {{ toYaml .Values.scheduler.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
Hej together, this should fix the liveness probe for a multi scheduler k8s setup. Currently the liveness probe fails due to `BaseJob::most_recent_job` reporting a random scheduler from the running schedulers which causes `job.hostname == get_hostname()` to fail in the liveness probe. 

Close:  #13677  #12098