### PR TITLE
Update pod-template-file.kubernetes-helm-yaml - only include subPath for dags mount if gitSync is enabled

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -65,7 +65,7 @@ spec:
         - mountPath: {{ include "airflow_dags_mount_path" . }}
           name: dags
           readOnly: true
-{{- if .Values.dags.persistence.enabled }}
+{{- if .Values.dags.gitSync.enabled }}
           subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
closes: #10793
related: #11751

The details is in the issue.
There is already a related PR, but it has been inactive for a few months
