### PR TITLE
Fix for Issue #13702 - Google Marketing Platform Display and Video 360 SDF Operators Fail

### DIFF
--- a/airflow/providers/google/marketing_platform/hooks/display_video.py
+++ b/airflow/providers/google/marketing_platform/hooks/display_video.py
@@ -228,7 +228,7 @@ class GoogleDisplayVideo360Hook(GoogleBaseHook):
         result = (
             self.get_conn_to_display_video()  # pylint: disable=no-member
             .sdfdownloadtasks()
-            .operation()
+            .operations()
             .get(name=operation_name)
             .execute(num_retries=self.num_retries)
         )

--- a/tests/providers/google/marketing_platform/hooks/test_display_video.py
+++ b/tests/providers/google/marketing_platform/hooks/test_display_video.py
@@ -314,7 +314,7 @@ class TestGoogleDisplayVideo360Hook(TestCase):
         # fmt: off
         get_conn_to_display_video.return_value. \
             sdfdownloadtasks.return_value. \
-            operation.return_value. \
+            operations.return_value. \
             get.assert_called_once_with(name=operation_name)
         # fmt: on
 
@@ -328,7 +328,7 @@ class TestGoogleDisplayVideo360Hook(TestCase):
         # fmt: off
         get_conn_to_display_video.return_value. \
             sdfdownloadtasks.return_value. \
-            operation.return_value. \
+            operations.return_value. \
             get.assert_called_once()
         # fmt: on
 
@@ -340,7 +340,7 @@ class TestGoogleDisplayVideo360Hook(TestCase):
         operation_name = "operation"
         response = "reposonse"
 
-        get_conn_to_display_video.return_value.sdfdownloadtasks.return_value.operation.return_value.get = (
+        get_conn_to_display_video.return_value.sdfdownloadtasks.return_value.operations.return_value.get = (
             response
         )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #13702 
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixes an issue that prevents the DV360 SDF operators from working. 
The [API spec](https://developers.google.com/display-video/api/reference/rest/v1/sdfdownloadtasks.operations/get) shows "operations" is needed, but code currently uses "operation," causing all calls to fail. 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
@tonycoco