### PR TITLE
ci: Docs should be built when config.yml is changed

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -396,6 +396,7 @@ function check_if_docs_should_be_generated() {
         "^docs"
         "^airflow/.*\.py$"
         "^CHANGELOG\.txt"
+        "^airflow/config_templates/config\.yml"
     )
     show_changed_files
 


### PR DESCRIPTION
The "Build Docs" job was not running when the config.yml file changed, example: https://github.com/apache/airflow/pull/13709

It should run it as Configuration Reference page (https://airflow.apache.org/docs/apache-airflow/2.0.0/configurations-ref.html) is built using that file

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
