### PR TITLE
Add open id dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -122,6 +122,8 @@ install_requires =
     python-dateutil>=2.3, <3
     python-nvd3~=0.15.0
     python-slugify>=3.0.0,<5.0
+    # Required for flask-openID which comes with flask-appbuilder
+    python3-openid~=3.2
     requests>=2.20.0
     rich==9.2.0
     setproctitle>=1.1.8, <2

--- a/setup.cfg
+++ b/setup.cfg
@@ -122,7 +122,10 @@ install_requires =
     python-dateutil>=2.3, <3
     python-nvd3~=0.15.0
     python-slugify>=3.0.0,<5.0
-    # Required for flask-openID which comes with flask-appbuilder
+    # Required for flask-openID which comes with flask-appbuilder in case of poetry installation
+    # earlier versions of the dependency are installed but they do not work for Python 3
+    # (pip installs the right version). 
+    # More info: https://github.com/apache/airflow/issues/13149#issuecomment-748705193
     python3-openid~=3.2
     requests>=2.20.0
     rich==9.2.0


### PR DESCRIPTION
Seems that python3-openid dependency is not properly solved by tools
like poetry (it is properly resolved by pip). The result is
that old version of python3-openid is installed when poetry is
used and errors when initdb is run.

While we do not use poetry as an official installation mechanism
this happens frequently enought and it is easy enough to fix
that we can add this dependency to make it easier for
poetry users.

Related to #13711 #13558 #13149


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
