### PR TITLE
Add dependency to azure-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -427,6 +427,7 @@ snowflake = [
     # blob is the only exception
     # Solution to that is being worked on in https://github.com/apache/airflow/pull/12188
     # once it is merged, we can move those two back to `azure` extra.
+    'azure-core>=1.10.0',
     'azure-storage-blob',
     'azure-storage-common',
     # Snowflake conector > 2.3.8 is needed because it has vendored urrllib3 and requests libraries which


### PR DESCRIPTION
Snowflake has implicit azure-core>=1.10.0 dependency because it
uses AzureSASCredential via azure storage-blob.

This dependency will be moved to Azure soon when we merge
the #12188 and azure-storage-blob will be added as dependency there

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
