### PR TITLE
[Doc] Replace module path to Class with just Class Name

### DIFF
--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -71,7 +71,7 @@ if started by systemd.
 Out of the box, Airflow uses a sqlite database, which you should outgrow
 fairly quickly since no parallelization is possible using this database
 backend. It works in conjunction with the
-:class:`SequentialExecutor <airflow.executors.sequential_executor.SequentialExecutor>` which will
+:class:`~airflow.executors.sequential_executor.SequentialExecutor` which will
 only run task instances sequentially. While this is very limiting, it allows
 you to get up and running quickly and take a tour of the UI and the
 command line utilities.

--- a/docs/apache-airflow/start.rst
+++ b/docs/apache-airflow/start.rst
@@ -70,7 +70,8 @@ if started by systemd.
 
 Out of the box, Airflow uses a sqlite database, which you should outgrow
 fairly quickly since no parallelization is possible using this database
-backend. It works in conjunction with the :class:`airflow.executors.sequential_executor.SequentialExecutor` which will
+backend. It works in conjunction with the
+:class:`SequentialExecutor <airflow.executors.sequential_executor.SequentialExecutor>` which will
 only run task instances sequentially. While this is very limiting, it allows
 you to get up and running quickly and take a tour of the UI and the
 command line utilities.


### PR DESCRIPTION
Instead of `the airflow.executors.sequential_executor.SequentialExecutor`
just have `SequentialExecutor with the link to the actual class.

**Before**:

![image](https://user-images.githubusercontent.com/8811558/104823484-44c85e80-5842-11eb-9a0a-a57b9d5f03bb.png)


**After**:

![image](https://user-images.githubusercontent.com/8811558/104823495-53af1100-5842-11eb-94df-c762ed98a0f7.png)

http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/start.html

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
