### PR TITLE
Fix Production Deployment doc

### DIFF
--- a/docs/apache-airflow/production-deployment.rst
+++ b/docs/apache-airflow/production-deployment.rst
@@ -121,7 +121,7 @@ way we do, you might want to know very quickly how you can extend or customize t
 for Apache Airflow. This chapter gives you a short answer to those questions.
 
 The docker image provided (as convenience binary package) in the
-`Apache Airflow DockerHub <https://hub.docker.com/repository/docker/apache/airflow>`_ is a bare image
+`Apache Airflow DockerHub <https://hub.docker.com/r/apache/airflow>`_ is a bare image
 that has not many external dependencies and extras installed. Apache Airflow has many extras
 that can be installed alongside the "core" airflow image and they often require some additional
 dependencies. The Apache Airflow image provided as convenience package is optimized for size, so
@@ -413,9 +413,9 @@ Here is the comparison of the two types of building images.
 +----------------------------------------------------+---------------------+-----------------------+
 
 [1] When you combine customizing and extending the image, you can use external sources
-    in the "extend" part. There are plans to add functionality to add external sources
-    option to image customization. You can also modify Dockerfile manually if you want to
-    use non-default sources for dependencies.
+in the "extend" part. There are plans to add functionality to add external sources
+option to image customization. You can also modify Dockerfile manually if you want to
+use non-default sources for dependencies.
 
 Using the production image
 --------------------------


### PR DESCRIPTION
Extra indentation is causing issues: http://airflow.apache.org/docs/apache-airflow/stable/production-deployment.html#comparing-extending-and-customizing-the-image

**Before**:
![image](https://user-images.githubusercontent.com/8811558/104828303-b6fb6c00-585f-11eb-937a-190cce59b5c1.png)

**Now**:
![image](https://user-images.githubusercontent.com/8811558/104828305-ca0e3c00-585f-11eb-8881-68c447cebd72.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
