### PR TITLE
Run CI (Build Image and committer PRs) on self-hosted runner

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -61,6 +61,7 @@ jobs:
       sourceEvent: ${{ steps.source-run-info.outputs.sourceEvent }}
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
       buildImages: ${{ steps.build-images.outputs.buildImages }}
+      runsOn: "[self-hosted]"
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -191,7 +192,7 @@ jobs:
       Source Sha: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
       Merge commit Sha: ${{ needs.cancel-workflow-runs.outputs.mergeCommitSha }}
       Target commit Sha: ${{ needs.cancel-workflow-runs.outputs.targetCommitSha }}
-    runs-on: [self-hosted]
+    runs-on: ${{ fromJson(needs.cancel-workflow-runs.outputs.runsOn) }}
     needs: [cancel-workflow-runs]
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -255,7 +256,7 @@ jobs:
   build-ci-images:
     timeout-minutes: 80
     name: "Build CI images ${{matrix.python-version}}"
-    runs-on: [self-hosted]
+    runs-on: ${{ fromJson(needs.cancel-workflow-runs.outputs.runsOn) }}
     needs: [build-info, cancel-workflow-runs]
     strategy:
       matrix:
@@ -354,7 +355,9 @@ jobs:
         if: steps.defaults.outputs.proceed == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: steps.defaults.outputs.proceed == 'true'
+        if: |
+          !contains(needs.build-info.outputs.runsOn, 'self-hosted') &&
+          steps.defaults.outputs.proceed == 'true'
       - name: "Build CI images ${{ matrix.python-version }}:${{ github.event.workflow_run.id }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
         if: steps.defaults.outputs.proceed == 'true'
@@ -380,7 +383,7 @@ jobs:
   build-prod-images:
     timeout-minutes: 80
     name: "Build PROD images ${{matrix.python-version}}"
-    runs-on: [self-hosted]
+    runs-on: ${{ fromJson(needs.cancel-workflow-runs.outputs.runsOn) }}
     needs: [build-info, cancel-workflow-runs, build-ci-images]
     strategy:
       matrix:
@@ -480,7 +483,9 @@ jobs:
         if: steps.defaults.outputs.proceed == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: steps.defaults.outputs.proceed == 'true'
+        if: |
+          !contains(needs.build-info.outputs.runsOn, 'self-hosted') &&
+          steps.defaults.outputs.proceed == 'true'
       - name: "Build CI images ${{ matrix.python-version }}:${{ github.event.workflow_run.id }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
         # Pull images built in the previous step
@@ -511,9 +516,9 @@ jobs:
 
   cancel-on-build-cancel:
     name: "Cancel 'CI Build' jobs on build image cancelling."
-    runs-on: [self-hosted]
+    runs-on: ${{ fromJson(needs.cancel-workflow-runs.outputs.runsOn) }}
     if: cancelled()
-    needs: [build-ci-images, build-prod-images]
+    needs: [cancel-workflow-runs, build-ci-images, build-prod-images]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -531,9 +536,9 @@ jobs:
 
   cancel-on-build-failure:
     name: "Cancel 'CI Build' jobs on build image failing."
-    runs-on: [self-hosted]
+    runs-on: ${{ fromJson(needs.cancel-workflow-runs.outputs.runsOn) }}
     if: failure()
-    needs: [build-ci-images, build-prod-images]
+    needs: [cancel-workflow-runs, build-ci-images, build-prod-images]
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2

--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -48,7 +48,7 @@ jobs:
   cancel-workflow-runs:
     timeout-minutes: 10
     name: "Cancel workflow runs"
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
     outputs:
       sourceHeadRepo: ${{ steps.source-run-info.outputs.sourceHeadRepo }}
       sourceHeadBranch: ${{ steps.source-run-info.outputs.sourceHeadBranch }}
@@ -191,7 +191,7 @@ jobs:
       Source Sha: ${{ needs.cancel-workflow-runs.outputs.sourceHeadSha }}
       Merge commit Sha: ${{ needs.cancel-workflow-runs.outputs.mergeCommitSha }}
       Target commit Sha: ${{ needs.cancel-workflow-runs.outputs.targetCommitSha }}
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
     needs: [cancel-workflow-runs]
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
@@ -255,7 +255,7 @@ jobs:
   build-ci-images:
     timeout-minutes: 80
     name: "Build CI images ${{matrix.python-version}}"
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
     needs: [build-info, cancel-workflow-runs]
     strategy:
       matrix:
@@ -380,7 +380,7 @@ jobs:
   build-prod-images:
     timeout-minutes: 80
     name: "Build PROD images ${{matrix.python-version}}"
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
     needs: [build-info, cancel-workflow-runs, build-ci-images]
     strategy:
       matrix:
@@ -511,7 +511,7 @@ jobs:
 
   cancel-on-build-cancel:
     name: "Cancel 'CI Build' jobs on build image cancelling."
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
     if: cancelled()
     needs: [build-ci-images, build-prod-images]
     steps:
@@ -531,7 +531,7 @@ jobs:
 
   cancel-on-build-failure:
     name: "Cancel 'CI Build' jobs on build image failing."
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted]
     if: failure()
     needs: [build-ci-images, build-prod-images]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,21 @@ jobs:
 
   build-info:
     name: "Build info"
-    runs-on: ubuntu-20.04
+    runs-on: >-
+      ${{ (
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER'
+      ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
+      RUNS_ON: ${{ (
+          github.event_name == 'push' ||
+          github.event_name == 'schedule' ||
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'MEMBER'
+        ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:
       waitForImage: ${{ steps.wait-for-image.outputs.wait-for-image }}
       upgradeToNewerDependencies: ${{ steps.selective-checks.outputs.upgrade-to-newer-dependencies }}
@@ -105,7 +117,12 @@ jobs:
       needs-api-codegen: ${{ steps.selective-checks.outputs.needs-api-codegen }}
       pullRequestNumber: ${{ steps.source-run-info.outputs.pullRequestNumber }}
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
+      runsOn: ${{ steps.set-runs-on.outputs.runsOn }}
     steps:
+      # Avoid having to specify the runs-on logic every time
+      - name: Set runs-on
+        id: set-runs-on
+        run: echo "::set-output name=runsOn::$(jq -n 'env.RUNS_ON')"
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:
@@ -156,7 +173,7 @@ jobs:
 
   test-openapi-client-generation:
     name: "Test OpenAPI client generation"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info]
     if: needs.build-info.outputs.needs-api-codegen == 'true'
     steps:
@@ -171,7 +188,7 @@ jobs:
   ci-images:
     timeout-minutes: 120
     name: "Wait for CI images"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info]
     if: needs.build-info.outputs.image-build == 'true'
     env:
@@ -208,7 +225,7 @@ jobs:
   verify-ci-images:
     timeout-minutes: 20
     name: "Verify CI Image Py${{matrix.python-version}}"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     strategy:
       matrix:
@@ -234,7 +251,7 @@ jobs:
   static-checks:
     timeout-minutes: 30
     name: "Static checks"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     env:
       SKIP: "pylint,identity"
@@ -271,7 +288,7 @@ jobs:
   static-checks-basic-checks-only:
     timeout-minutes: 30
     name: "Static checks: basic checks only"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info]
     env:
       SKIP: "build,mypy,flake8,pylint,bats-in-container-tests,identity"
@@ -310,7 +327,7 @@ jobs:
   static-checks-pylint:
     timeout-minutes: 30
     name: "Pylint"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     if: needs.build-info.outputs.basic-checks-only == 'false'
     env:
@@ -345,7 +362,7 @@ jobs:
   docs:
     timeout-minutes: 45
     name: "Build docs"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     if: needs.build-info.outputs.docs-build == 'true'
     steps:
@@ -383,7 +400,7 @@ jobs:
   prepare-backport-provider-packages:
     timeout-minutes: 30
     name: "Backport packages: ${{ matrix.package-format }}"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     strategy:
       matrix:
@@ -438,7 +455,7 @@ jobs:
   prepare-provider-packages:
     timeout-minutes: 30
     name: "Provider packages ${{ matrix.package-format }}"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     env:
       INSTALL_AIRFLOW_VERSION: "${{ matrix.package-format }}"
@@ -483,7 +500,7 @@ jobs:
   test-provider-packages-released-airflow:
     timeout-minutes: 30
     name: "Test Provider packages with 2.0.0 version ${{ matrix.package-format }}"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     env:
       INSTALL_AIRFLOW_VERSION: "2.0.0"
@@ -519,7 +536,7 @@ jobs:
   tests-helm:
     timeout-minutes: 20
     name: "Python unit tests for helm chart"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     env:
       MOUNT_SELECTED_LOCAL_SOURCES: "true"
@@ -572,7 +589,7 @@ jobs:
     name: >
       Postgres${{matrix.postgres-version}},Py${{matrix.python-version}}:
       ${{needs.build-info.outputs.testTypes}}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     strategy:
       matrix:
@@ -629,7 +646,7 @@ jobs:
     timeout-minutes: 130
     name: >
       MySQL${{matrix.mysql-version}}, Py${{matrix.python-version}}: ${{needs.build-info.outputs.testTypes}}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     strategy:
       matrix:
@@ -685,7 +702,7 @@ jobs:
     timeout-minutes: 130
     name: >
       Sqlite Py${{matrix.python-version}}: ${{needs.build-info.outputs.testTypes}}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     strategy:
       matrix:
@@ -738,7 +755,7 @@ jobs:
   tests-quarantined:
     timeout-minutes: 60
     name: "Quarantined tests"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     continue-on-error: true
     needs: [build-info, ci-images]
     strategy:
@@ -816,9 +833,10 @@ jobs:
   upload-coverage:
     timeout-minutes: 5
     name: "Upload coverage"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     continue-on-error: true
     needs:
+      - build-info
       - tests-kubernetes
       - tests-postgres
       - tests-sqlite
@@ -844,7 +862,7 @@ jobs:
   prod-images:
     timeout-minutes: 120
     name: "Wait for PROD images"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
     env:
       BACKEND: sqlite
@@ -877,7 +895,7 @@ jobs:
   verify-prod-images:
     timeout-minutes: 20
     name: "Verify Prod Image Py${{matrix.python-version}}"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, prod-images]
     strategy:
       matrix:
@@ -902,7 +920,7 @@ jobs:
   tests-kubernetes:
     timeout-minutes: 50
     name: K8s ${{matrix.python-version}} ${{matrix.kubernetes-version}} ${{matrix.kubernetes-mode}}
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, prod-images]
     strategy:
       matrix:
@@ -976,7 +994,7 @@ jobs:
   push-prod-images-to-github-registry:
     timeout-minutes: 10
     name: "Push PROD images as cache to GitHub Registry"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs:
       - build-info
       - static-checks
@@ -1025,7 +1043,7 @@ jobs:
   push-ci-images-to-github-registry:
     timeout-minutes: 10
     name: "Push CI images as cache to GitHub Registry"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs:
       - build-info
       - static-checks
@@ -1067,7 +1085,7 @@ jobs:
   constraints:
     timeout-minutes: 10
     name: "Constraints"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     strategy:
       matrix:
         python-version: ${{ fromJson(needs.build-info.outputs.pythonVersions) }}
@@ -1105,7 +1123,7 @@ jobs:
   constraints-push:
     timeout-minutes: 10
     name: "Constraints push"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs:
       - build-info
       - constraints
@@ -1151,7 +1169,7 @@ jobs:
   tag-repo-nightly:
     timeout-minutes: 10
     name: "Tag repo nightly"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs:
       - docs
       - static-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,7 @@ jobs:
         run: aws s3 sync --delete ./files/documentation s3://apache-airflow-docs
 
   prepare-backport-provider-packages:
-    timeout-minutes: 30
+    timeout-minutes: 40
     name: "Backport packages: ${{ matrix.package-format }}"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
@@ -460,7 +460,7 @@ jobs:
           retention-days: 7
 
   prepare-provider-packages:
-    timeout-minutes: 30
+    timeout-minutes: 40
     name: "Provider packages ${{ matrix.package-format }}"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]
@@ -845,7 +845,7 @@ jobs:
           retention-days: 7
 
   upload-coverage:
-    timeout-minutes: 5
+    timeout-minutes: 15
     name: "Upload coverage"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,9 @@ jobs:
         if: needs.build-info.outputs.waitForImage == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: needs.build-info.outputs.waitForImage == 'true'
+        if: |
+          needs.build-info.outputs.waitForImage == 'true' &&
+          !contains(needs.build-info.outputs.runsOn, 'self-hosted')
       - name: >
           Wait for CI images
           ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
@@ -241,7 +243,9 @@ jobs:
           persist-credentials: false
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: needs.build-info.outputs.waitForImage == 'true'
+        if: |
+          needs.build-info.outputs.waitForImage == 'true' &&
+          !contains(needs.build-info.outputs.runsOn, 'self-hosted')
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Verify CI image Py${{matrix.python-version}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -275,6 +279,7 @@ jobs:
           restore-keys: pre-commit-no-pylint-
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Static checks: except pylint"
@@ -352,6 +357,7 @@ jobs:
           restore-keys: pre-commit-pylint-
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Static checks: pylint"
@@ -427,6 +433,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider documentation"
@@ -479,6 +486,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider documentation"
@@ -524,6 +532,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Prepare provider documentation"
@@ -558,6 +567,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -616,6 +626,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -673,6 +684,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -727,6 +739,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: ${{needs.build-info.outputs.testTypes}}"
@@ -798,6 +811,7 @@ jobs:
           echo "ISSUE_ID=10128" >> $GITHUB_ENV
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Tests: Quarantined"
@@ -882,7 +896,9 @@ jobs:
         if: needs.build-info.outputs.waitForImage == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: needs.build-info.outputs.waitForImage == 'true'
+        if: |
+          needs.build-info.outputs.waitForImage == 'true' &&
+          !contains(needs.build-info.outputs.runsOn, 'self-hosted')
       - name: >
           Wait for PROD images
           ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
@@ -910,7 +926,9 @@ jobs:
           persist-credentials: false
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: needs.build-info.outputs.waitForImage == 'true'
+        if: |
+          needs.build-info.outputs.waitForImage == 'true' &&
+          !contains(needs.build-info.outputs.runsOn, 'self-hosted')
       - name: "Prepare PROD Image"
         run: ./scripts/ci/images/ci_prepare_prod_image_on_ci.sh
       - name: "Verify PROD image Py${{matrix.python-version}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
@@ -1030,6 +1048,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name:
           "Prepare PROD image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -1077,6 +1096,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Push CI image ${{ matrix.python-version }}:${{ env.GITHUB_REGISTRY_PUSH_IMAGE_TAG }}"
@@ -1109,6 +1129,7 @@ jobs:
           python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ github.sha }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
       - name: "Generate constraints"
@@ -1189,6 +1210,7 @@ jobs:
           submodules: recursive
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
+        if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Tag commit"
         run: |
           BRANCH_NAME=$(echo "${{ github.ref }}" | sed 's/refs\/heads\///')

--- a/scripts/ci/libraries/_build_airflow_packages.sh
+++ b/scripts/ci/libraries/_build_airflow_packages.sh
@@ -34,7 +34,7 @@ function build_airflow_packages::build_airflow_packages() {
     fi
 
     # Prepare airflow's wheel
-    python setup.py compile_assets "${packages[@]}"
+    PYTHONUNBUFFERED=1 python setup.py compile_assets "${packages[@]}"
 
     # clean-up
     rm -rf -- *egg-info*

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -718,6 +718,10 @@ function initialization::get_environment_for_builds_on_ci() {
     if [[ ${VERBOSE} == "true" && ${PRINT_INFO_FROM_SCRIPTS} == "true" ]]; then
         initialization::summarize_build_environment
     fi
+
+    if [[ -z "${LIBRARY_PATH:-}" && -n "${LD_LIBRARY_PATH:-}" ]]; then
+      export LIBRARY_PATH="$LD_LIBRARY_PATH"
+    fi
 }
 
 # shellcheck disable=SC2034

--- a/scripts/ci/libraries/_script_init.sh
+++ b/scripts/ci/libraries/_script_init.sh
@@ -52,4 +52,9 @@ start_end::group_start "Make constants read-only"
 initialization::make_constants_read_only
 start_end::group_end
 
+# Work around occasional unexplained failure on CI. Clear file flags on
+# STDOUT (which is connected to a tmp file by Github Runner).
+# The one error I did see: BlockingIOError: [Errno 11] write could not complete without blocking
+[[ "$CI" == "true" ]] && python3 -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
+
 traps::add_trap start_end::script_end EXIT HUP INT TERM


### PR DESCRIPTION
The queue for GitHub actions is starting to get painful.

This PR changes it to run any build of main (push or scheduled), or a PR
from a committer on the self-hosted runner.

However since this setting is configured _in_ the repo, it could be
changed by a PR, so we can't rely on that; we also use a custom build of
the self-hosted runner binary that enforces PRs are from contributors,
otherwise it will fail the build


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).