### PR TITLE
Use the correct link for Apache Airflow Dockerhub repo

### DIFF
--- a/CI.rst
+++ b/CI.rst
@@ -431,7 +431,7 @@ The following components are part of the CI infrastructure
 * **GitHub Private Image Registry**- image registry used as build cache for CI  jobs.
   It is at https://docker.pkg.github.com/apache/airflow/airflow
 * **DockerHub Public Image Registry** - publicly available image registry at DockerHub.
-  It is at https://hub.docker.com/repository/docker/apache/airflow
+  It is at https://hub.docker.com/r/apache/airflow
 * **DockerHub Build Workers** - virtual machines running build jibs at DockerHub
 * **Official Images** (future) - these are official images that are prominently visible in DockerHub.
   We aim our images to become official images so that you will be able to pull them

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -235,7 +235,7 @@ For example:
   apache/airflow:2.0.0-python3.6                 - production image for 2.0.0 release
   apache/airflow:python3.6-master                - base python image for the master branch
 
-You can see DockerHub images at `<https://hub.docker.com/repository/docker/apache/airflow>`_
+You can see DockerHub images at `<https://hub.docker.com/r/apache/airflow>`_
 
 By default DockerHub registry is used when you push or pull such images.
 However for CI builds we keep the images in GitHub registry as well - this way we can easily push

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ who do not want to build the software themselves.
 Those are - in the order of most common ways people install Airflow:
 
 - [PyPI releases](https://pypi.org/project/apache-airflow/) to install Airflow using standard `pip` tool
-- [Docker Images](https://hub.docker.com/repository/docker/apache/airflow) to install airflow via
+- [Docker Images](https://hub.docker.com/r/apache/airflow) to install airflow via
   `docker` tool, use them in Kubernetes, Helm Charts, `docker-compose`, `docker swarm` etc. You can
   read more about using, customising, and extending the images in the
   [Latest docs](https://airflow.apache.org/docs/apache-airflow/stable/production-deployment.html), and


### PR DESCRIPTION
https://hub.docker.com/repository/docker/apache/airflow requires auth while  https://hub.docker.com/r/apache/airflow does not

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
