### PR TITLE
BaseBranchOperator will push to xcom by default.

### DIFF
--- a/airflow/operators/branch.py
+++ b/airflow/operators/branch.py
@@ -49,4 +49,6 @@ class BaseBranchOperator(BaseOperator, SkipMixin):
         raise NotImplementedError
 
     def execute(self, context: Dict):
-        self.skip_all_except(context['ti'], self.choose_branch(context))
+        branches_to_execute = self.choose_branch(context)
+        self.skip_all_except(context['ti'], branches_to_execute)
+        return branches_to_execute


### PR DESCRIPTION
This change will allow BaseBranchOperator to xcom push the branch it chose to follow.
It will also add support to use the `do_xcom_push` parameter.

The change includes the returning the result of `choose_branch()` whenever `execute()` is called.

Currently the BaseBranchOperator neither pushes the chosen branch to xcom nor support's the `do_xcom_push` parameter.

Closes: #13704