### PR TITLE
Change log level from debug to info when spawning new gunicorn workers

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -260,7 +260,8 @@ class GunicornMonitor(LoggingMixin):
                 new_worker_count = min(
                     self.num_workers_expected - num_workers_running, self.worker_refresh_batch_size
                 )
-                self.log.debug(
+                # log at info since we are trying fix an error logged just above
+                self.log.info(
                     '[%d / %d] Spawning %d workers',
                     num_ready_workers_running,
                     num_workers_running,


### PR DESCRIPTION
Restoring the change to the log level as requested by @kaxil , see here: https://github.com/apache/airflow/pull/13518#discussion_r560544581

The rational for changing the log level to `info` on this specific log while leaving it at `debug` in other places in the same function is that this specific log relates to an action taken specifically to correct an error condition logged prior to it. Other debug logs seem to be related to more routine conditions/actions.