### PR TITLE
Fix returning last log line in docker operator

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -269,7 +269,10 @@ class DockerOperator(BaseOperator):
             # duplicated conditional logic because of expensive operation
             ret = None
             if self.do_xcom_push:
-                ret = self.cli.logs(container=self.container['Id']) if self.xcom_all else line.encode('utf-8')
+                if self.xcom_all:
+                    ret = self.cli.logs(container=self.container['Id'])
+                else:
+                    ret = self.cli.logs(container=self.container['Id'], tail=1).strip()
 
             if self.auto_remove:
                 self.cli.remove_container(self.container['Id'])

--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -219,7 +219,7 @@ class DockerOperator(BaseOperator):
             tls=self.__get_tls_config(),
         )
 
-    def _run_image(self) -> Optional[str]:
+    def _run_image(self) -> Optional[bytes]:
         """Run a Docker container with the provided image"""
         self.log.info('Starting docker container from image %s', self.image)
 
@@ -279,7 +279,7 @@ class DockerOperator(BaseOperator):
 
             return ret
 
-    def execute(self, context) -> Optional[str]:
+    def execute(self, context) -> Optional[bytes]:
         self.cli = self._get_cli()
         if not self.cli:
             raise Exception("The 'cli' should be initialized before!")

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -41,8 +41,8 @@ class TestDockerOperator(unittest.TestCase):
         self.client_mock = mock.Mock(spec=APIClient)
         self.client_mock.create_container.return_value = {'Id': 'some_id'}
         self.client_mock.images.return_value = []
-        self.client_mock.attach.return_value = ['container log']
-        self.client_mock.logs.return_value = ['container log']
+        self.client_mock.attach.return_value = [b'container log']
+        self.client_mock.logs.return_value = b'container log'  # logs(..., stream=False) returns bytes
         self.client_mock.pull.return_value = {"status": "pull log"}
         self.client_mock.wait.return_value = {"StatusCode": 0}
         self.client_mock.create_host_config.return_value = mock.Mock()


### PR DESCRIPTION
Iterable values in `cli.attach(..., stream=True)` are not necessarily single lines. 
Lines can be merged together or split because of buffering.
When this split happens just before the last newline character, the returned value of `execute` is an empty byte string.

Also, fix the return type annotation (the return type is not changed, only the annotation).

I used these files to recreate the issue:

`Dockerfile`
```dockerfile
FROM python:3.8-slim-buster
WORKDIR /code
ADD main.py .
CMD [ "python", "main.py" ]
```

`main.py`
```python
from random import randint

for _ in range(randint(1, 100)):
    print(f"output")

print("last_line")
```

`script.py`
```python
from docker import APIClient


cli = APIClient()


def run_image():
    container = cli.create_container(
        command="python main.py",
        host_config=cli.create_host_config(auto_remove=False),
        image="docker-bug",
        tty=True,
    )

    lines = cli.attach(container=container["Id"], stdout=True, stderr=True, stream=True)

    cli.start(container["Id"])

    line = list(lines)[-1]

    cli.wait(container["Id"])

    print("--- LAST LINES ---")
    print(repr(line))
    print(repr(cli.logs(container=container["Id"], tail=1).strip()))

    cli.remove_container(container["Id"])


if __name__ == "__main__":
    for i in range(1000):
        run_image()
```

When running:
```bash
$ docker build -t docker-bug .
$ python script.py
```

The output will look something like:

```
--- LAST LINES ---
b'output\r\noutput\r\noutput\r\noutput\r\noutput\r\noutput\r\noutput\r\nlast_line\r\n'
b'last_line'
--- LAST LINES ---
b'output\r\noutput\r\noutput\r\noutput\r\noutput\r\noutput\r\noutput\r\noutput\r\noutput\r\nlast_line\r\n'
b'last_line'
--- LAST LINES ---
b'output\r\noutput\r\nlast_line\r\n'
b'last_line'
```
