### PR TITLE
Fix S3ToFTPOperator

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -43,14 +43,14 @@ class S3ToFTPOperator(BaseOperator):
     template_fields = ('s3_bucket', 's3_key', 'ftp_path')
 
     def __init__(
-            self,
-            *,
-            s3_bucket,
-            s3_key,
-            ftp_path,
-            aws_conn_id='aws_default',
-            ftp_conn_id='ftp_default',
-            **kwargs,
+        self,
+        *,
+        s3_bucket,
+        s3_key,
+        ftp_path,
+        aws_conn_id='aws_default',
+        ftp_conn_id='ftp_default',
+        **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.s3_bucket = s3_bucket

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -30,7 +30,7 @@ class S3ToFTPOperator(BaseOperator):
         establishing a connection to the FTP server.
     :type ftp_conn_id: str
     :param ftp_path: The ftp remote path in where the file will be stored.
-        The desired filename bust be specified here.
+        The desired filename must be specified here.
     :type ftp_path: str
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
         where the file is downloaded.

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -29,8 +29,7 @@ class S3ToFTPOperator(BaseOperator):
     :param ftp_conn_id: The ftp connection id. The name or identifier for
         establishing a connection to the FTP server.
     :type ftp_conn_id: str
-    :param ftp_path: The ftp remote path in where the file will be stored.
-        The desired file name must be specified here.
+    :param ftp_path: The ftp remote path where the file will be stored, inclusive of filename.
     :type ftp_path: str
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
         where the file is downloaded.

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -69,8 +69,8 @@ class S3ToFTPOperator(BaseOperator):
         s3_obj = s3_hook.get_key(self.s3_key, self.s3_bucket)
 
         with NamedTemporaryFile() as local_tmp_file:
-            self.log.info(f'Downloading file from {self.s3_key}')
+            self.log.info('Downloading file from %s', self.s3_key)
             s3_obj.download_fileobj(local_tmp_file)
             local_tmp_file.seek(0)
             ftp_hook.store_file(self.ftp_path, local_tmp_file.name)
-            self.log.info(f'File stored in {self.ftp_path}')
+            self.log.info('File stored in %s', {self.ftp_path})

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -26,6 +26,7 @@ from airflow.providers.ftp.hooks.ftp import FTPHook
 class S3ToFTPOperator(BaseOperator):
     """
     This operator enables the transferring of files from S3 to a FTP server.
+
     :param ftp_conn_id: The ftp connection id. The name or identifier for
         establishing a connection to the FTP server.
     :type ftp_conn_id: str

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -30,7 +30,7 @@ class S3ToFTPOperator(BaseOperator):
         establishing a connection to the FTP server.
     :type ftp_conn_id: str
     :param ftp_path: The ftp remote path in where the file will be stored.
-        The desired filename must be specified here.
+        The desired file name must be specified here.
     :type ftp_path: str
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
         where the file is downloaded.

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -27,17 +27,20 @@ class S3ToFTPOperator(BaseOperator):
     """
     This operator enables the transferring of files from S3 to a FTP server.
 
+    :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
+    where the file is downloaded.
+    :type s3_bucket: str
+    :param s3_key: The targeted s3 key. This is the specified file path for
+    downloading the file from S3.
+    :type s3_key: str
+    :param ftp_path: The ftp remote path. This is the specified file path for
+    uploading file to the FTP server.
+    :type ftp_path: str
+    :param aws_conn_id: reference to a specific AWS connection
+    :type aws_conn_id: str
     :param ftp_conn_id: The ftp connection id. The name or identifier for
         establishing a connection to the FTP server.
     :type ftp_conn_id: str
-    :param ftp_path: The ftp remote path where the file will be stored, inclusive of filename.
-    :type ftp_path: str
-    :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
-        where the file is downloaded.
-    :type s3_bucket: str
-    :param s3_key: The targeted s3 key. This is the specified file path for
-        downloading the file from S3.
-    :type s3_key: str
     """
 
     template_fields = ('s3_bucket', 's3_key', 'ftp_path')
@@ -63,8 +66,11 @@ class S3ToFTPOperator(BaseOperator):
         s3_hook = S3Hook(self.aws_conn_id)
         ftp_hook = FTPHook(ftp_conn_id=self.ftp_conn_id)
 
-        s3_client = s3_hook.get_conn()
+        s3_obj = s3_hook.get_key(self.s3_key, self.s3_bucket)
 
         with NamedTemporaryFile() as local_tmp_file:
-            s3_client.download_file(self.s3_bucket, self.s3_key, local_tmp_file.name)
+            self.log.info(f'Downloading file from {self.s3_key}')
+            s3_obj.download_fileobj(local_tmp_file)
+            local_tmp_file.seek(0)
             ftp_hook.store_file(self.ftp_path, local_tmp_file.name)
+            self.log.info(f'File stored in {self.ftp_path}')

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -28,13 +28,13 @@ class S3ToFTPOperator(BaseOperator):
     This operator enables the transferring of files from S3 to a FTP server.
 
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
-    where the file is downloaded.
+        where the file is downloaded.
     :type s3_bucket: str
     :param s3_key: The targeted s3 key. This is the specified file path for
-    downloading the file from S3.
+        downloading the file from S3.
     :type s3_key: str
     :param ftp_path: The ftp remote path. This is the specified file path for
-    uploading file to the FTP server.
+        uploading file to the FTP server.
     :type ftp_path: str
     :param aws_conn_id: reference to a specific AWS connection
     :type aws_conn_id: str

--- a/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_ftp.py
@@ -26,12 +26,11 @@ from airflow.providers.ftp.hooks.ftp import FTPHook
 class S3ToFTPOperator(BaseOperator):
     """
     This operator enables the transferring of files from S3 to a FTP server.
-
     :param ftp_conn_id: The ftp connection id. The name or identifier for
         establishing a connection to the FTP server.
     :type ftp_conn_id: str
-    :param ftp_path: The ftp remote path. This is the specified file path for
-        uploading file to the FTP server.
+    :param ftp_path: The ftp remote path in where the file will be stored.
+        The desired filename bust be specified here.
     :type ftp_path: str
     :param s3_bucket: The targeted s3 bucket. This is the S3 bucket from
         where the file is downloaded.
@@ -41,17 +40,17 @@ class S3ToFTPOperator(BaseOperator):
     :type s3_key: str
     """
 
-    template_fields = ('s3_bucket', 's3_key')
+    template_fields = ('s3_bucket', 's3_key', 'ftp_path')
 
     def __init__(
-        self,
-        *,
-        s3_bucket,
-        s3_key,
-        ftp_path,
-        aws_conn_id='aws_default',
-        ftp_conn_id='ftp_default',
-        **kwargs,
+            self,
+            *,
+            s3_bucket,
+            s3_key,
+            ftp_path,
+            aws_conn_id='aws_default',
+            ftp_conn_id='ftp_default',
+            **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.s3_bucket = s3_bucket
@@ -64,8 +63,8 @@ class S3ToFTPOperator(BaseOperator):
         s3_hook = S3Hook(self.aws_conn_id)
         ftp_hook = FTPHook(ftp_conn_id=self.ftp_conn_id)
 
-        s3_obj = s3_hook.get_key(self.s3_key, self.s3_bucket)
+        s3_client = s3_hook.get_conn()
 
         with NamedTemporaryFile() as local_tmp_file:
-            s3_obj.download_fileobj(local_tmp_file)
+            s3_client.download_file(self.s3_bucket, self.s3_key, local_tmp_file.name)
             ftp_hook.store_file(self.ftp_path, local_tmp_file.name)

--- a/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
@@ -30,7 +30,7 @@ FTP_CONN_ID = 'ftp_default'
 
 class TestS3ToFTPOperator(unittest.TestCase):
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.store_file")
-    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_conn().download_file")
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_conn.download_file")
     @mock.patch("airflow.providers.amazon.aws.transfers.s3_to_ftp.NamedTemporaryFile")
     def test_execute(self, mock_local_tmp_file, mock_s3_hook_download_file, mock_ftp_hook_store_file):
         operator = S3ToFTPOperator(task_id=TASK_ID, s3_bucket=BUCKET, s3_key=S3_KEY, ftp_path=FTP_PATH)

--- a/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
@@ -16,8 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
-from unittest import mock
+from unittest import mock, Mock
 
+from airflow.provider.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.transfers.s3_to_ftp import S3ToFTPOperator
 
 TASK_ID = 'test_s3_to_ftp'

--- a/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
@@ -30,7 +30,7 @@ FTP_CONN_ID = 'ftp_default'
 
 class TestS3ToFTPOperator(unittest.TestCase):
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.store_file")
-    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_conn.download_file")
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_conn().download_file")
     @mock.patch("airflow.providers.amazon.aws.transfers.s3_to_ftp.NamedTemporaryFile")
     def test_execute(self, mock_local_tmp_file, mock_s3_hook_download_file, mock_ftp_hook_store_file):
         operator = S3ToFTPOperator(task_id=TASK_ID, s3_bucket=BUCKET, s3_key=S3_KEY, ftp_path=FTP_PATH)

--- a/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
@@ -16,9 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
-from unittest import mock, Mock
+from unittest import mock
 
-from airflow.provider.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.transfers.s3_to_ftp import S3ToFTPOperator
 
 TASK_ID = 'test_s3_to_ftp'
@@ -31,19 +30,14 @@ FTP_CONN_ID = 'ftp_default'
 
 class TestS3ToFTPOperator(unittest.TestCase):
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.store_file")
+    @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_key")
     @mock.patch("airflow.providers.amazon.aws.transfers.s3_to_ftp.NamedTemporaryFile")
-    @mock.patch('airflow.providers.amazon.aws.transfers.s3_to_ftp.S3Hook')
-    def test_execute(self, mock_s3_hook, mock_local_tmp_file, mock_ftp_hook_store_file):
+    def test_execute(self, mock_local_tmp_file, mock_s3_hook_get_key, mock_ftp_hook_store_file):
         operator = S3ToFTPOperator(task_id=TASK_ID, s3_bucket=BUCKET, s3_key=S3_KEY, ftp_path=FTP_PATH)
         operator.execute(None)
 
+        mock_s3_hook_get_key.assert_called_once_with(operator.s3_key, operator.s3_bucket)
+
         mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value
-        key = operator.s3_key
-        bucket = operator.s3_bucket
-
-        s3_client = mock_s3_hook.get_conn()
-
-        s3_client.download_file(bucket, key, mock_local_tmp_file.name)
-        s3_client.download_file.assert_called_once_with(bucket, key, mock_local_tmp_file.name)
-
+        mock_s3_hook_get_key.return_value.download_fileobj.assert_called_once_with(mock_local_tmp_file_value)
         mock_ftp_hook_store_file.assert_called_once_with(operator.ftp_path, mock_local_tmp_file_value.name)

--- a/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_ftp.py
@@ -32,22 +32,18 @@ FTP_CONN_ID = 'ftp_default'
 class TestS3ToFTPOperator(unittest.TestCase):
     @mock.patch("airflow.providers.ftp.hooks.ftp.FTPHook.store_file")
     @mock.patch("airflow.providers.amazon.aws.transfers.s3_to_ftp.NamedTemporaryFile")
-    def test_execute(self, mock_local_tmp_file, mock_ftp_hook_store_file):
+    @mock.patch('airflow.providers.amazon.aws.transfers.s3_to_ftp.S3Hook')
+    def test_execute(self, mock_s3_hook, mock_local_tmp_file, mock_ftp_hook_store_file):
         operator = S3ToFTPOperator(task_id=TASK_ID, s3_bucket=BUCKET, s3_key=S3_KEY, ftp_path=FTP_PATH)
         operator.execute(None)
 
         mock_local_tmp_file_value = mock_local_tmp_file.return_value.__enter__.return_value
-
-        s3_hook = S3Hook(aws_conn_id=AWS_CONN_ID)
-        s3_hook.check_for_key = Mock(return_value=True)
-        s3_obj = Mock()
-        s3_obj.download_fileobj = Mock(return_value=None)
-        s3_hook.get_key = Mock(return_value=s3_obj)
         key = operator.s3_key
         bucket = operator.s3_bucket
-        s3_hook.download_file(key=key, bucket_name=bucket)
-        s3_hook.check_for_key.assert_called_once_with(key, bucket)
-        s3_hook.get_key.assert_called_once_with(key, bucket)
-        s3_obj.download_fileobj.assert_called_once_with(mock_local_tmp_file_value.name)
+
+        s3_client = mock_s3_hook.get_conn()
+
+        s3_client.download_file(bucket, key, mock_local_tmp_file.name)
+        s3_client.download_file.assert_called_once_with(bucket, key, mock_local_tmp_file.name)
 
         mock_ftp_hook_store_file.assert_called_once_with(operator.ftp_path, mock_local_tmp_file_value.name)


### PR DESCRIPTION
Recently this operator was merged, and even though the tests was passed, the file that the operator creates in the FTP server is empty. This solves the problem.

