### PR TITLE
#9803 fix bug in copy operation without wildcard 

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -293,7 +293,8 @@ class GCSToGCSOperator(BaseOperator):
             if self.destination_object is None:
                 destination_object = source_obj
             else:
-                destination_object = self.destination_object
+                destination_object = source_obj.replace(prefix,
+                                                           self.destination_object, 1)
             self._copy_single_object(
                 hook=hook, source_object=source_obj, destination_object=destination_object
             )

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -293,8 +293,7 @@ class GCSToGCSOperator(BaseOperator):
             if self.destination_object is None:
                 destination_object = source_obj
             else:
-                destination_object = source_obj.replace(prefix,
-                                                           self.destination_object, 1)
+                destination_object = source_obj.replace(prefix, self.destination_object, 1)
             self._copy_single_object(
                 hook=hook, source_object=source_obj, destination_object=destination_object
             )


### PR DESCRIPTION
Hi @potiuk, 
This PR fix GCS copy operation without wildcard and rename destination object according to source file name. 

related: #9803
