### PR TITLE
Scheduler should acknowledge active runs properly (in 1.10.x)

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -792,6 +792,7 @@ class SchedulerJob(BaseJob):
             run.verify_integrity(session=session)
             ready_tis = run.update_state(session=session)
             if run.state == State.RUNNING:
+                active_dag_runs.append(run)
                 self.log.debug("Examining active DAG run: %s", run)
                 for ti in ready_tis:
                     self.log.debug('Queuing task: %s', ti)


### PR DESCRIPTION
This commit fixes the scheduler to acknowledge active runs properly
when comparing against max_active_runs for unscheduled DAG runs.

closes: #13802