### PR TITLE
[kubernetes_generate_dag_yaml] - Fix dag yaml generate func in version 1.10.14

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1372,10 +1372,11 @@ def kubernetes_generate_dag_yaml(args):
             try_number=ti.try_number,
             date=ti.execution_date,
             command=ti.command_as_list(),
-            kube_executor_config=PodGenerator.from_obj(ti.executor_config),
+            kube_image=kube_config.kube_image,
+            pod_override_object=PodGenerator.from_obj(ti.executor_config),
             worker_uuid="worker-config",
             namespace=kube_config.executor_namespace,
-            worker_config=WorkerConfiguration(kube_config=kube_config).as_pod()
+            base_worker_pod=WorkerConfiguration(kube_config=kube_config).as_pod()
         )
         api_client = ApiClient()
         pod = PodLauncher._mutate_pod_backcompat(pod)


### PR DESCRIPTION
Signed-off-by: Lord-Y <Lord-Y@users.noreply.github.com>

When trying to debug the generated yaml pod to see why I'm not having the right docker image I got this error:

```
airflow kubernetes generate-dag-yaml DAG_NAME 2021-01-19T20:00:00+00:00

[2021-01-21 09:52:56,314] {{__init__.py:50}} INFO - Using executor KubernetesExecutor
[2021-01-21 09:52:56,317] {{dagbag.py:417}} INFO - Filling up the DagBag from /opt/airflow/dags/airflow-dags.git
Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 37, in <module>
    args.func(args)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/utils/cli.py", line 233, in wrapper
    func(args)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/utils/cli.py", line 81, in wrapper
    return f(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/bin/cli.py", line 1367, in kubernetes_generate_dag_yaml
    pod = PodGenerator.construct_pod(
TypeError: construct_pod() got an unexpected keyword argument 'kube_executor_config'
```
After fixing `kube_executor_config`, I got the same error for `worker_config` parameter and also `kube_image` was missing.