### PR TITLE
Fix DAGs mount path in Kubernetes worker pod when gitSync is enabled

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -80,6 +80,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: {{ .Values.uid }}
+    fsGroup: {{ .Values.gid }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   affinity: {{ toYaml .Values.affinity | nindent 4 }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}

--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -61,13 +61,16 @@ spec:
           name: git-sync-ssh-key
           subPath: ssh
 {{- end }}
-{{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
+{{- if .Values.dags.persistence.enabled }}
         - mountPath: {{ include "airflow_dags_mount_path" . }}
           name: dags
           readOnly: true
-{{- if .Values.dags.gitSync.enabled }}
-          subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
+{{- if .Values.dags.gitSync.enabled }}
+        - mountPath: {{ include "airflow_dags" . }}
+          name: dags
+          readOnly: true
+          subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
   hostNetwork: false
   {{- if or .Values.registry.secretName .Values.registry.connection }}


### PR DESCRIPTION
closes: #13680

The path to search for DAGs is incorrect in the new pod when gitSync is enabled. The error it causes currently is mentioned in the issue