### PR TITLE
Removes files from docker-context-files if not used

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -81,6 +81,16 @@ function build_images::add_build_args_for_remote_install() {
     fi
 }
 
+# Remove files from `docker-context-files` if the directory is not used
+# This causes that Docker cache is consistent across different
+# people who might have some files present in the docker-context files from previous builds
+function build_images::remove-docker-context-files_if_not_used() {
+    if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} != "true" ]]; then
+        find "${AIRFLOW_SOURCES}/docker-context-files" ! -name README.md -type f -print0 | xargs --null rm -f
+    fi
+}
+
+
 # Retrieves version of airflow stored in the production image (used to display the actual
 # Version we use if it was build from PyPI or GitHub
 function build_images::get_airflow_version_from_production_image() {
@@ -732,6 +742,7 @@ Docker building ${AIRFLOW_CI_IMAGE}.
     if [[ -n "${RUNTIME_APT_COMMAND}" ]]; then
         additional_runtime_args+=("--build-arg" "RUNTIME_APT_COMMAND=\"${RUNTIME_APT_COMMAND}\"")
     fi
+    build_images::remove-docker-context-files_if_not_used
     docker build \
         "${EXTRA_DOCKER_CI_BUILD_FLAGS[@]}" \
         --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \
@@ -875,6 +886,7 @@ function build_images::build_prod_images() {
     if [[ -n "${DEV_APT_COMMAND}" ]]; then
         additional_dev_args+=("--build-arg" "DEV_APT_COMMAND=\"${DEV_APT_COMMAND}\"")
     fi
+    build_images::remove-docker-context-files_if_not_used
     docker build \
         "${EXTRA_DOCKER_PROD_BUILD_FLAGS[@]}" \
         --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \


### PR DESCRIPTION
In case docker-context files are not used during build, they
shoudl be cleaned just before the build to make sure that
docker context does not contain extra files here. Otherwise
files left from previous runs might be in the context and cause
cache invalidation if you are building the images locally.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
