### PR TITLE
Revert "Fix error with quick-failing tasks in KubernetesPodOperator (…

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -343,7 +343,6 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
                 raise AirflowException(f'Pod {self.pod.metadata.name} returned a failure: {status}')
             return result
         except AirflowException as ex:
-            self.patch_already_checked(self.pod)
             raise AirflowException(f'Pod Launching failed: {ex}')
 
     def handle_pod_overlap(

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -1000,30 +1000,5 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             k.execute(context)
             create_mock.assert_called_once()
 
-    def test_reatttach_quick_failure(self):
-        client = kube_client.get_kube_client(in_cluster=False)
-        namespace = "default"
-
-        name = "test"
-        k = KubernetesPodOperator(
-            namespace='default',
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["exit 1"],
-            labels={"foo": "bar"},
-            name="test",
-            task_id=name,
-            in_cluster=False,
-            do_xcom_push=False,
-            is_delete_operator_pod=False,
-            termination_grace_period=0,
-        )
-
-        context = create_context(k)
-        with self.assertRaises(AirflowException):
-            k.execute(context)
-        pod = client.read_namespaced_pod(name=k.pod.metadata.name, namespace=namespace)
-        self.assertEqual(pod.metadata.labels["already_checked"], "True")
-
 
 # pylint: enable=unused-argument


### PR DESCRIPTION
…#13621)"

The change #13621 had a failing test case. Stack trace added. In order to stop tests from failing, I temporary revert it.

This reverts commit 94d3ed61d60b134d649a4e9785b2d9c2a88cff05.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
