### PR TITLE
Allows for more than one warnign in deprecation message

### DIFF
--- a/tests/core/test_core_to_contrib.py
+++ b/tests/core/test_core_to_contrib.py
@@ -82,8 +82,8 @@ class TestMovingCoreToContrib(TestCase):
                 if isinstance(klass, BaseOperator):
                     # In case of operators we are validating that proper stacklevel
                     # is used (=3 or =4 if @apply_defaults)
-                    assert len(warnings) == 1
-                    assert warnings[0].filename == __file__
+                    assert len(warnings) >= 1
+                    assert any(warning.filename == __file__ for warning in warnings)
                 init_mock.assert_called_once_with()
 
     @parameterized.expand(ALL)


### PR DESCRIPTION
Sometimes in our tests we get more than one deprecation
warnings. It is likely caused by transitive warnings
from importing other external libraries.

In order to get rid of those side effects, we are now
accepting more than one warning and we expect that at least
one of the warnings will come from the file being tested

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
