### PR TITLE
check failed service before auto_remove it

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -144,12 +144,14 @@ class DockerSwarmOperator(DockerOperator):
                 self.log.info('Service status before exiting: %s', self._service_status())
                 break
 
-        if self.auto_remove:
+        if self.service and self._service_status() == 'failed':
+            if self.auto_remove:
+                self.cli.remove_service(self.service['ID'])
+            raise AirflowException('Service failed: ' + repr(self.service))
+        elif self.auto_remove:
             if not self.service:
                 raise Exception("The 'service' should be initialized before!")
             self.cli.remove_service(self.service['ID'])
-        if self._service_status() == 'failed':
-            raise AirflowException('Service failed: ' + repr(self.service))
 
     def _service_status(self) -> Optional[str]:
         if not self.cli:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Closes issue https://github.com/apache/airflow/issues/13532 for DockerSwarmOperator.

If a DockerSwarmOperator task has auto_remove=True it tries to check a service that is already removed, producing a failed task. Tasks works correctly with auto_remove=False  

This PR fixes the problem by checking if the service status is failed before removing it.