### PR TITLE
Don't add User role perms to custom roles.

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -528,7 +528,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
                 .all()
             )
 
-            user_permissions = current_app.appbuilder.sm.get_all_permissions_views()
+            user_permissions = current_app.appbuilder.sm.get_current_user_permissions()
             all_dags_editable = (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG) in user_permissions
 
             for dag in dags:

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -226,11 +226,11 @@ class TestSecurity(unittest.TestCase):
             assert perms_views == viewer_role_perms
 
     @mock.patch('airflow.www.security.AirflowSecurityManager.get_user_roles')
-    def test_get_all_permissions_views(self, mock_get_user_roles):
+    def test_get_current_user_permissions(self, mock_get_user_roles):
         role_name = 'MyRole5'
         role_perm = 'can_some_action'
         role_vm = 'SomeBaseView'
-        username = 'get_all_permissions_views'
+        username = 'get_current_user_permissions'
 
         with self.app.app_context():
             user = fab_utils.create_user(
@@ -244,10 +244,10 @@ class TestSecurity(unittest.TestCase):
             role = user.roles[0]
             mock_get_user_roles.return_value = [role]
 
-            assert self.security_manager.get_all_permissions_views() == {(role_perm, role_vm)}
+            assert self.security_manager.get_current_user_permissions() == {(role_perm, role_vm)}
 
             mock_get_user_roles.return_value = []
-            assert len(self.security_manager.get_all_permissions_views()) == 0
+            assert len(self.security_manager.get_current_user_permissions()) == 0
 
     def test_get_accessible_dag_ids(self):
         role_name = 'MyRole1'

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1824,6 +1824,10 @@ class TestDagACLView(TestBase):
             permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG
         )
         self.appbuilder.sm.add_permission_role(all_dag_role, read_perm_on_all_dag)
+        read_perm_on_task_instance = self.appbuilder.sm.find_permission_view_menu(
+            permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE
+        )
+        self.appbuilder.sm.add_permission_role(all_dag_role, read_perm_on_task_instance)
         self.appbuilder.sm.add_permission_role(all_dag_role, website_permission)
 
         role_user = self.appbuilder.sm.find_role('User')


### PR DESCRIPTION
Solves the problem of roles getting incorrectly populated with all permissions of the User class. Now they are auto-populated with Website.can_read and nothing else.

## Expected Behavior
When a custom role is created, the role should not include any extra permissions beyond what the user added.

## Actual Behavior
All permissions for the default User role are copied into each custom rule.

## Update Behavior
Rather than adding all permissions from the User role, the only permission added now is `Website.can_read`. This is required to allow access to the homepage.

closes: #9245
related: #9245

