### PR TITLE
Fix: Linux/Chrome window bouncing

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -21,6 +21,7 @@ body {
   position: relative;
   padding: 70px 0 100px;
   min-height: 100vh;
+  overflow-y: scroll;
   background-color: #fff;
 }
 


### PR DESCRIPTION
Closes #13713

The `min-height: 100vh;` was causing Linux/Chromium browsers to continually trigger the vertical scrollbar in and out of the window yielding a bouncing effect.

I'm confirmed this fix in a local VM running Chromium. @mattwelke or @INGCRENGIFO since you identified this behavior, maybe you could also confirm this fix works (by simply modifying in DevTools)?

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
