### PR TITLE
Remove azure-storage hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -198,6 +198,11 @@ COPY scripts/docker/install_airflow_from_latest_master.sh /scripts/docker/instal
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
 ENV UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}
 
+# By changing CI build epoch we can force reinstalling Airflow from the current master
+# It can also be overwritten manually by setting the AIRFLOW_BUILD_EPOCH environment variable.
+ARG AIRFLOW_BUILD_EPOCH="1"
+ENV AIRFLOW_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH}
+
 # In case of Production build image segment we want to pre-install master version of airflow
 # dependencies from GitHub so that we do not have to always reinstall it from the scratch.
 # The Airflow (and providers in case INSTALL_PROVIDERS_FROM_SOURCES is "false")

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -243,7 +243,7 @@ ENV AIRFLOW_CONSTRAINTS_LOCATION=${AIRFLOW_CONSTRAINTS_LOCATION}
 
 # By changing the CI build epoch we can force reinstalling Airflow from the current master
 # It can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
-ARG AIRFLOW_CI_BUILD_EPOCH="3"
+ARG AIRFLOW_CI_BUILD_EPOCH="4"
 ENV AIRFLOW_CI_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH}
 
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"

--- a/scripts/docker/install_airflow.sh
+++ b/scripts/docker/install_airflow.sh
@@ -63,9 +63,6 @@ function install_airflow() {
             pip install ${AIRFLOW_INSTALL_EDITABLE_FLAG} \
                 "${AIRFLOW_INSTALLATION_METHOD}[${AIRFLOW_EXTRAS}]${AIRFLOW_INSTALL_VERSION}"
         fi
-        # Work around to install azure-storage-blob
-        pip uninstall azure-storage azure-storage-blob azure-storage-file --yes
-        pip install azure-storage-blob azure-storage-file
         # make sure correct PIP version is used
         pip install ${AIRFLOW_INSTALL_USER_FLAG} --upgrade "pip==${AIRFLOW_PIP_VERSION}"
         pip check || ${CONTINUE_ON_PIP_CHECK_FAILURE}
@@ -82,9 +79,6 @@ function install_airflow() {
         pip install ${AIRFLOW_INSTALL_USER_FLAG} --upgrade --upgrade-strategy only-if-needed \
             ${AIRFLOW_INSTALL_EDITABLE_FLAG} \
             "${AIRFLOW_INSTALLATION_METHOD}[${AIRFLOW_EXTRAS}]${AIRFLOW_INSTALL_VERSION}" \
-        # Work around to install azure-storage-blob
-        pip uninstall azure-storage azure-storage-blob azure-storage-file --yes
-        pip install azure-storage-blob azure-storage-file
         # make sure correct PIP version is used
         pip install ${AIRFLOW_INSTALL_USER_FLAG} --upgrade "pip==${AIRFLOW_PIP_VERSION}"
         pip check || ${CONTINUE_ON_PIP_CHECK_FAILURE}

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -302,19 +302,6 @@ function install_airflow_from_sdist() {
     pip install "${airflow_package}${1}" >"${OUTPUT_PRINTED_ONLY_ON_ERROR}" 2>&1
 }
 
-function reinstall_azure_storage_blob() {
-    group_start "Reinstalls azure-storage-blob (temporary workaround)"
-    # Reinstall azure-storage-blob here until https://github.com/apache/airflow/pull/12188 is solved
-    # Azure-storage-blob need to be reinstalled to overwrite azure-storage-blob installed by old version
-    # of the `azure-storage` library
-    echo
-    echo "Reinstalling azure-storage-blob"
-    echo
-    pip uninstall azure-storage azure-storage-blob azure-storage-file --yes
-    pip install azure-storage-blob azure-storage-file --no-deps --force-reinstall
-    group_end
-}
-
 function install_remaining_dependencies() {
     group_start "Installs all remaining dependencies that are not installed by '${AIRFLOW_EXTRAS}' "
     pip install apache-beam[gcp] >"${OUTPUT_PRINTED_ONLY_ON_ERROR}" 2>&1

--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -18,8 +18,6 @@
 # shellcheck source=scripts/in_container/_in_container_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/_in_container_script_init.sh"
 
-reinstall_azure_storage_blob
-
 echo
 echo "Starting the tests with those pytest arguments:" "${@}"
 echo

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -197,7 +197,6 @@ setup_provider_packages
 verify_parameters
 install_airflow_as_specified
 install_remaining_dependencies
-reinstall_azure_storage_blob
 install_provider_packages
 import_all_provider_classes
 

--- a/scripts/in_container/run_prepare_provider_readme.sh
+++ b/scripts/in_container/run_prepare_provider_readme.sh
@@ -31,7 +31,6 @@ pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}"
 
 # TODO: remove it when devel_all == devel_ci
 install_remaining_dependencies
-reinstall_azure_storage_blob
 
 cd "${AIRFLOW_SOURCES}/provider_packages" || exit 1
 

--- a/setup.py
+++ b/setup.py
@@ -218,6 +218,8 @@ azure = [
     'azure-mgmt-containerinstance>=1.5.0,<2.0',
     'azure-mgmt-datalake-store>=0.5.0',
     'azure-mgmt-resource>=2.2.0',
+    'azure-storage-blob>=12.7.0',
+    'azure-storage-common>=2.1.0',
     'azure-storage-file>=2.1.0',
 ]
 cassandra = [
@@ -420,18 +422,8 @@ slack = [
     'slackclient>=2.0.0,<3.0.0',
 ]
 snowflake = [
-    # The `azure` provider uses legacy `azure-storage` library, where `snowflake` uses the
-    # newer and more stable versions of those libraries. Most of `azure` operators and hooks work
-    # fine together with `snowflake` because the deprecated library does not overlap with the
-    # new libraries except the `blob` classes. So while `azure` works fine for most cases
-    # blob is the only exception
-    # Solution to that is being worked on in https://github.com/apache/airflow/pull/12188
-    # once it is merged, we can move those two back to `azure` extra.
-    'azure-core>=1.10.0',
-    'azure-storage-blob',
-    'azure-storage-common',
-    # Snowflake conector > 2.3.8 is needed because it has vendored urrllib3 and requests libraries which
-    # are monkey-patched. In earlier versions of the library, monkeypatching the libraries by snowflake
+    # Snowflake connector > 2.3.8 is needed because it has vendored urllib3 and requests libraries which
+    # are monkey-patched. In earlier versions of the library, monkey-patching the libraries by snowflake
     # caused other providers to fail (Google, Amazon etc.)
     'snowflake-connector-python>=2.3.8',
     'snowflake-sqlalchemy>=1.1.0',


### PR DESCRIPTION
After #12188 has been merged and constraints regenerated, we can
now remove the hack where we had to reinstall azure-storage to
override overlapping versions of azure-storage libraries.

This paves the way to removing last dependency hacks we have in
Airflow.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
