### PR TITLE
Fix link and section in CONTRIBUTORS_QUICK_START.rst

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -436,12 +436,12 @@ Following are some of important topics of Breeze documentation:
    Breeze environment</a>
 
 
-- |CLIs for cloud providers|
+- |Installing Additional tools to the Docker Image|
 
-.. |CLIs for cloud providers| raw:: html
+.. |Installing Additional tools to the Docker Image| raw:: html
 
-   <a href="https://github.com/apache/airflow/blob/master/BREEZE.rst#clis-for-cloud-providers" target="_blank">CLIs for
-   cloud providers</a>
+   <a href="https://github.com/apache/airflow/blob/master/BREEZE.rst#additional-tools" target="_blank">Installing
+   Additional tools to the Docker Image</a>
 
 
 - |Internal details of Breeze|


### PR DESCRIPTION
https://github.com/apache/airflow/blob/master/BREEZE.rst#clis-for-cloud-providers no longer exists and is replaced by https://github.com/apache/airflow/blob/master/BREEZE.rst#additional-tools

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
