### PR TITLE
Remove left-over fields from required in provider_info schema.

### DIFF
--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -187,7 +187,7 @@
     },
     "extra-links": {
       "type": "array",
-      "description": "Class name that provide extra link functionality",
+      "description": "Operator class names that provide extra link functionality",
       "items": {
         "type": "string"
       }

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -23,7 +23,7 @@
     },
     "extra-links": {
       "type": "array",
-      "description": "Class name that provide extra link functionality",
+      "description": "Operator class names that provide extra link functionality",
       "items": {
         "type": "string"
       }
@@ -31,8 +31,6 @@
   },
   "required": [
     "name",
-    "package-name",
-    "description",
-    "versions"
+    "description"
   ]
 }

--- a/docs/apache-airflow-providers/index.rst
+++ b/docs/apache-airflow-providers/index.rst
@@ -124,7 +124,8 @@ Displaying package information in CLI/API:
 * ``description`` - Additional description of the provider.
 
 * ``version`` - List of versions of the package (in reverse-chronological order). The first version in the
-  list is the current package version.
+  list is the current package version. It is taken from the version of package installed, not from the
+  provider_info information.
 
 Exposing customized functionality to the Airflow's core:
 
@@ -217,9 +218,12 @@ You need to do the following to turn an existing Python package into a provider 
 * Create the function that you refer to in the first step as part of your package: this functions returns a
   dictionary that contains all meta-data about your provider package
 * note that the dictionary should be compliant with ``airflow/provider_info.schema.json`` JSON-schema
-  specification and the community-managed providers have more fields there that are used to build
-  documentation, but the requirement for runtime information only contains several fields from the
-  runtime schema. See below for examples.
+  specification. The community-managed providers have more fields there that are used to build
+  documentation, but the requirement for runtime information only contains several fields which are defined
+  in the schema:
+
+.. exampleinclude:: /../../airflow/provider_info.schema.json
+    :language: json
 
 Example ``setup.cfg``:
 
@@ -242,7 +246,6 @@ Example ``myproviderpackage/somemodule.py``:
           "hook-class-names": [
               "myproviderpackage.hooks.source.SourceHook",
           ],
-          'versions': ["1.0.0"],
       }
 
 **How do provider packages work under the hood?**


### PR DESCRIPTION
Those fields were left-over from the full provider.yaml schema.

Apparently they caused no problems but they should be removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
