### PR TITLE
fix #11557: Pass optimisation arguments to celery_command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -513,6 +513,18 @@ ARG_UMASK = Arg(
     help="Set the umask of celery worker in daemon mode",
     default=conf.get('celery', 'worker_umask'),
 )
+ARG_WITHOUT_MINGLE = Arg(
+    ("--without-mingle",),
+    default=False,
+    help="Don’t synchronize with other workers at start-up",
+    action="store_true",
+)
+ARG_WITHOUT_GOSSIP = Arg(
+    ("--without-gossip",),
+    default=False,
+    help="Don’t subscribe to other workers events",
+    action="store_true",
+)
 
 # flower
 ARG_BROKER_API = Arg(("-a", "--broker-api"), help="Broker API")
@@ -1292,6 +1304,8 @@ CELERY_COMMANDS = (
             ARG_LOG_FILE,
             ARG_AUTOSCALE,
             ARG_SKIP_SERVE_LOGS,
+            ARG_WITHOUT_MINGLE,
+            ARG_WITHOUT_GOSSIP,
         ),
     ),
     ActionCommand(

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -139,6 +139,8 @@ def worker(args):
         'hostname': args.celery_hostname,
         'loglevel': conf.get('logging', 'LOGGING_LEVEL'),
         'pidfile': pid_file_path,
+        'without_mingle': args.without_mingle,
+        'without_gossip': args.without_gossip,
     }
 
     if conf.has_option("celery", "pool"):

--- a/tests/cli/commands/test_celery_command.py
+++ b/tests/cli/commands/test_celery_command.py
@@ -172,6 +172,8 @@ class TestWorkerStart(unittest.TestCase):
                 celery_hostname,
                 '--queues',
                 queues,
+                '--without-mingle',
+                '--without-gossip',
             ]
         )
 
@@ -189,4 +191,6 @@ class TestWorkerStart(unittest.TestCase):
             autoscale=autoscale,
             hostname=celery_hostname,
             loglevel=conf.get('logging', 'LOGGING_LEVEL'),
+            without_mingle=True,
+            without_gossip=True,
         )


### PR DESCRIPTION
Arguments: --without_mingle and --without_gossip
closes: #11557
related: #11557

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
