### PR TITLE
Fix wrong parameter for drawDagStatsForDag() in dags.html

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -390,7 +390,7 @@
       $('.js-loading-last-run').remove();
     }
 
-    function drawDagStatsForDag(dag_id, stats) {
+    function drawDagStatsForDag(dag_id, states) {
       g = d3.select('svg#dag-run-' + dag_id.replace(/\./g, '__dot__'))
         .attr('height', diameter + (stroke_width_hover * 2))
         .attr('width', '110px')


### PR DESCRIPTION
I believe this is a typo. It should be `states` rather than `stats`.

Please refer to
https://github.com/apache/airflow/blob/326c74e60871736f43c303068b0aaa5927c50de0/airflow/www/templates/airflow/dags.html#L398

and the signature of similar function `drawTaskStatsForDag()`

https://github.com/apache/airflow/blob/326c74e60871736f43c303068b0aaa5927c50de0/airflow/www/templates/airflow/dags.html#L467


_**So far this is not causing any visible error/issue because of how scoping works in JavaScript.**_

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
