### PR TITLE
Add extra field to get_connnection REST endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -25,7 +25,6 @@ from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.connection_schema import (
     ConnectionCollection,
-    connection_collection_item_schema,
     connection_collection_schema,
     connection_schema,
 )
@@ -58,7 +57,7 @@ def get_connection(connection_id, session):
             "Connection not found",
             detail=f"The Connection with connection_id: `{connection_id}` was not found",
         )
-    return connection_collection_item_schema.dump(connection)
+    return connection_schema.dump(connection)
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_CONNECTION)])

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -116,6 +116,7 @@ class TestGetConnection(TestConnectionEndpoint):
             login='login',
             schema='testschema',
             port=80,
+            extra="{'param': 'value'}",
         )
         session.add(connection_model)
         session.commit()
@@ -132,6 +133,7 @@ class TestGetConnection(TestConnectionEndpoint):
             "login": 'login',
             'schema': 'testschema',
             'port': 80,
+            'extra': "{'param': 'value'}",
         }
 
     def test_should_respond_404(self):


### PR DESCRIPTION
Added missing extra field in REST API Connection Endpoint as solution suggested by @mik-laj  in 
#13744 (comment)
#13684 (comment)

![image](https://user-images.githubusercontent.com/11897651/105660091-42c06880-5ef0-11eb-8999-bdedf0682cbb.png)


closes : #13744