### PR TITLE
added parameters to template_fields to support upstream task ordering by xcom 

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -41,7 +41,7 @@ class PostgresOperator(BaseOperator):
     :type database: str
     """
 
-    template_fields = ('sql',)
+    template_fields = ('sql', 'op_args', 'op_kwargs')
     template_fields_renderers = {'sql': 'sql'}
     template_ext = ('.sql',)
     ui_color = '#ededed'

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -39,6 +39,13 @@ class PostgresOperator(BaseOperator):
     :type parameters: dict or iterable
     :param database: name of database which overwrite defined one in connection
     :type database: str
+    :param op_args: a list of positional arguments that will get unpacked when
+        calling your callable (templated)
+    :type op_args: list
+    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
+        in your function (templated)
+    :type op_kwargs: dict
+
     """
 
     template_fields = ('sql', 'op_args', 'op_kwargs')

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterable, Mapping, Optional, Union
+from typing import Dict, Iterable, List, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
@@ -55,6 +55,8 @@ class PostgresOperator(BaseOperator):
         autocommit: bool = False,
         parameters: Optional[Union[Mapping, Iterable]] = None,
         database: Optional[str] = None,
+        op_args: Optional[List] = None,
+        op_kwargs: Optional[Dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -64,6 +66,8 @@ class PostgresOperator(BaseOperator):
         self.parameters = parameters
         self.database = database
         self.hook = None
+        self.op_args = op_args or []
+        self.op_kwargs = op_kwargs or {}
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Dict, Iterable, List, Mapping, Optional, Union
+from typing import Iterable, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
@@ -39,16 +39,9 @@ class PostgresOperator(BaseOperator):
     :type parameters: dict or iterable
     :param database: name of database which overwrite defined one in connection
     :type database: str
-    :param op_args: a list of positional arguments that will get unpacked when
-        calling your callable (templated)
-    :type op_args: list
-    :param op_kwargs: a dictionary of keyword arguments that will get unpacked
-        in your function (templated)
-    :type op_kwargs: dict
-
     """
 
-    template_fields = ('sql', 'op_args', 'op_kwargs')
+    template_fields = ('sql', 'parameters')
     template_fields_renderers = {'sql': 'sql'}
     template_ext = ('.sql',)
     ui_color = '#ededed'
@@ -62,8 +55,6 @@ class PostgresOperator(BaseOperator):
         autocommit: bool = False,
         parameters: Optional[Union[Mapping, Iterable]] = None,
         database: Optional[str] = None,
-        op_args: Optional[List] = None,
-        op_kwargs: Optional[Dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -73,8 +64,6 @@ class PostgresOperator(BaseOperator):
         self.parameters = parameters
         self.database = database
         self.hook = None
-        self.op_args = op_args or []
-        self.op_kwargs = op_kwargs or {}
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)


### PR DESCRIPTION
added template_fields to support upstream task ordering by xcom .

``` python
from airflow.models import DAG
from airflow.providers.postgres.operators.postgres import PostgresOperator
import os

from airflow.utils.dates import days_ago

default_args = {'start_date': days_ago(1)}

dag_name = os.path.splitext(os.path.basename(__file__))[0]

with DAG(dag_name, default_args=default_args) as dag:

    @dag.task
    def some_py_task() -> str:
        return some_str

    some_str = some_py_task()

    some_pg_task = PostgresOperator(task_id='some_pg_task', 
                     sql='select * from %s',
                     parameters=[some_str],
                     postgres_conn_id='postgres_bob')
```

![pgtask](https://user-images.githubusercontent.com/11897651/105701011-afa72300-5f2f-11eb-9ce6-5b7a1f62ba26.png)


closes : #13823
