### PR TITLE
Fix race condition when using Dynamic DAGs

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -557,11 +557,11 @@ class DagBag(LoggingMixin):
                 )
                 self.log.debug("Calling the DAG.bulk_sync_to_db method")
                 try:
-                    DAG.bulk_write_to_db(self.dags.values(), session=session)
-
                     # Write Serialized DAGs to DB, capturing errors
                     for dag in self.dags.values():
                         serialize_errors.extend(_serialze_dag_capturing_errors(dag, session))
+
+                    DAG.bulk_write_to_db(self.dags.values(), session=session)
                 except OperationalError:
                     session.rollback()
                     raise


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/13504

Currently the DagFileProcessor parses the DAG files, writes it to the
`dag` table and then writes DAGs to `serialized_dag` table.

At the same time, the scheduler loop is constantly looking for the next
DAGs to process based on ``next_dagrun_create_after`` column of the DAG
table.

It might happen that as soon as the DagFileProcessor writes DAG to `dag`
table, the scheduling loop in the Scheduler picks up the DAG for preocessing.
However, as the DagFileProcessor has not written to serialized DAG table yet
the scheduler will error with "Serialized Dag not Found" error.

This would mainly happen when the DAGs are dynamic where the result of one DAG,
creates multiple DAGs.

This commit changes the order of writing DAG and Serialized DAG and hence
before a DAG is written to `dag` table it will be written to `serialized_dag` table.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
