### PR TITLE
critical class definition issue

### DIFF
--- a/airflow/providers/telegram/operators/telegram.py
+++ b/airflow/providers/telegram/operators/telegram.py
@@ -61,6 +61,7 @@ class TelegramOperator(BaseOperator):
         **kwargs,
     ):
         self.chat_id = chat_id
+        self.text = text or None
         self.token = token
         self.telegram_kwargs = telegram_kwargs or {}
 

--- a/airflow/providers/telegram/operators/telegram.py
+++ b/airflow/providers/telegram/operators/telegram.py
@@ -61,7 +61,7 @@ class TelegramOperator(BaseOperator):
         **kwargs,
     ):
         self.chat_id = chat_id
-        self.text = text or None
+        self.text = text
         self.token = token
         self.telegram_kwargs = telegram_kwargs or {}
 


### PR DESCRIPTION
`getattr(parent, 'text')` at https://github.com/apache/airflow/blob/master/airflow/models/baseoperator.py#L870

will always raise `AttributeError: 'TelegramOperator' object has no attribute 'text'`

**TelegramOperator** actually does not have such an attribute(`self.text`)

issue occured while these valid arguments were passed to the operator: _token_, _chat_id_, _text_

the same argument set worked as intended right after that fix
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
