### PR TITLE
Only show User's local timezone if it's not UTC

### DIFF
--- a/airflow/www/static/js/task-instances.js
+++ b/airflow/www/static/js/task-instances.js
@@ -44,11 +44,13 @@ function generateTooltipDateTimes(startDate, endDate, dagTZ) {
   let tooltipHTML = '<br><strong>UTC:</strong><br>';
   tooltipHTML += makeDateTimeHTML(startDate, endDate);
 
-  // Generate User's Local Start and End Date
-  startDate.tz(localTZ);
-  tooltipHTML += `<br><strong>Local: ${startDate.format(tzFormat)}</strong><br>`;
-  const localEndDate = endDate && endDate instanceof moment ? endDate.tz(localTZ) : endDate;
-  tooltipHTML += makeDateTimeHTML(startDate, localEndDate);
+  // Generate User's Local Start and End Date, unless it's UTC
+  if (localTZ !== 'UTC') {
+    startDate.tz(localTZ);
+    tooltipHTML += `<br><strong>Local: ${startDate.format(tzFormat)}</strong><br>`;
+    const localEndDate = endDate && endDate instanceof moment ? endDate.tz(localTZ) : endDate;
+    tooltipHTML += makeDateTimeHTML(startDate, localEndDate);
+  }
 
   // Generate DAG's Start and End Date
   if (dagTZ !== 'UTC' && dagTZ !== localTZ) {


### PR DESCRIPTION
Instead of duplicating the same UTC start/end dates in the Task Instance tooltip, only show the users local formatted start/end dates if it's not UTC.

Before:
![UTC is duplicated](https://user-images.githubusercontent.com/66968678/105805494-55be5180-5f5f-11eb-9f57-84f00a688409.png)

After:
![without UTC](https://user-images.githubusercontent.com/66968678/105804755-d2e8c700-5f5d-11eb-9ea0-5f991b7bdb1e.png)

With a non-UTC user timezone:
![non-UTC user timezone](https://user-images.githubusercontent.com/66968678/105804775-dda35c00-5f5d-11eb-94b5-d72a0a9641af.png)