### PR TITLE
PythonOperator decorator @python_task

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -128,6 +128,37 @@ class PythonOperator(BaseOperator):
         return self.python_callable(*self.op_args, **self.op_kwargs)
 
 
+def python_task(**kwargs):
+    """
+     Decorator for PythonOperator
+
+     If task_id is not given as argument, it takes function name as task_id.
+
+     Defining :
+
+     @python_task(task_id='task1')
+     def some_py_task():
+        do_some_work()
+
+    usage:
+
+    with DAG(dag_name, default_args=default_args) as dag:
+        t1 = some_py_task()
+
+    """
+
+    def wrapper(func):
+        def wrapped(*op_args, **op_kwargs):
+            task_id = kwargs.pop('task_id', None) or func.__name__
+            return PythonOperator(
+                python_callable=func, task_id=task_id, op_args=op_args, op_kwargs=op_kwargs, **kwargs
+            )
+
+        return wrapped
+
+    return wrapper
+
+
 class _PythonDecoratedOperator(BaseOperator):
     """
     Wraps a Python callable and captures args/kwargs when called for execution.

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -151,14 +151,9 @@ def python_task(func):
 
     """
 
-    def wrapper(task_id):
+    def wrapper(*args, **kwargs):
         def wrapped(*op_args, **op_kwargs):
-            return PythonOperator(
-                python_callable=func,
-                task_id=task_id,
-                op_args=op_args,
-                op_kwargs=op_kwargs,
-            )
+            return PythonOperator(*args, python_callable=func, op_args=op_args, op_kwargs=op_kwargs, **kwargs)
 
         return wrapped
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -128,7 +128,7 @@ class PythonOperator(BaseOperator):
         return self.python_callable(*self.op_args, **self.op_kwargs)
 
 
-def python_task(**kwargs):
+def python_task(func):
     """
      Decorator for PythonOperator
 
@@ -136,22 +136,28 @@ def python_task(**kwargs):
 
      Defining :
 
-     @python_task(task_id='task1')
-     def some_py_task():
+     @python_task
+     def some_py_task(name):
         do_some_work()
 
     usage:
 
     with DAG(dag_name, default_args=default_args) as dag:
-        t1 = some_py_task()
+
+        t1 = some_py_task(task_id='task1')('Python Task 1')
+        t2 = some_py_task(task_id='task2')('Python Task 2')
+
+        t1 >> t2
 
     """
 
-    def wrapper(func):
+    def wrapper(task_id):
         def wrapped(*op_args, **op_kwargs):
-            task_id = kwargs.pop('task_id', None) or func.__name__
             return PythonOperator(
-                python_callable=func, task_id=task_id, op_args=op_args, op_kwargs=op_kwargs, **kwargs
+                python_callable=func,
+                task_id=task_id,
+                op_args=op_args,
+                op_kwargs=op_kwargs,
             )
 
         return wrapped


### PR DESCRIPTION
Added @python_task decorator for PythonOperator which can be used as shown in following example 

```  python
from airflow.models import DAG
import os

from airflow.operators.python import python_task, PythonOperator
from airflow.utils.dates import days_ago

default_args = {'start_date': days_ago(1)}
dag_name = os.path.splitext(os.path.basename(__file__))[0]


@python_task
def some_py_task(name):
    """ some py task """
    print(f'Inside Python Task name: {name}')


def some_other_task(name):
    """ some other task"""
    print(f'Inside {name} Task')


with DAG(dag_name, default_args=default_args) as dag:

    t1 = some_py_task(task_id='task1')('Python Task 1')
    t2 = some_py_task(task_id='task2')('Python Task 2')

    t3 = PythonOperator(python_callable=some_other_task, task_id='task3', op_args=['task3'])

    t1 >> t2 >> t3

```

![Screenshot from 2021-01-26 14-54-47](https://user-images.githubusercontent.com/11897651/105826324-a200a480-5fe6-11eb-92cc-d7337fe367ad.png)