### PR TITLE
#9803 fix bug in copy operation without wildcard 

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.py
@@ -95,6 +95,16 @@ with models.DAG(
     )
     # [END howto_operator_gcs_to_gcs_wildcard]
 
+    # [START howto_operator_gcs_to_gcs_without_wildcard]
+    copy_files_without_wildcard = GCSToGCSOperator(
+        task_id="copy_files_without_wildcard",
+        source_bucket=BUCKET_1_SRC,
+        source_object="subdir/",
+        destination_bucket=BUCKET_1_DST,
+        destination_object="backup/",
+    )
+    # [END howto_operator_gcs_to_gcs_without_wildcard]
+
     # [START howto_operator_gcs_to_gcs_delimiter]
     copy_files_with_delimiter = GCSToGCSOperator(
         task_id="copy_files_with_delimiter",

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -280,7 +280,7 @@ class GCSToGCSOperator(BaseOperator):
                 self._copy_source_without_wildcard(hook=hook, prefix=prefix)
 
     def _copy_source_without_wildcard(self, hook, prefix):
-        '''
+        """
         For source_objects with no wildcard, this operator would first list 
         all files in source_objects, using provided delimiter if any. Then copy 
         files from source_objects to destination_object and rename each source
@@ -289,7 +289,7 @@ class GCSToGCSOperator(BaseOperator):
         Example 1:
         The following Operator would copy all the files from ``a/``folder 
         (i.e a/a.csv, a/b.csv, a/c.csv)in ``data`` bucket to the ``b/`` folder in 
-        the ``data_backup`` bucket (b/a.csv, b/b.csv, b/c.csv):
+        the ``data_backup`` bucket (b/a.csv, b/b.csv, b/c.csv) ::
 
             copy_files = GCSToGCSOperator(
                 task_id='copy_files_without_wildcard',
@@ -303,7 +303,7 @@ class GCSToGCSOperator(BaseOperator):
         Example 2:
         The following Operator would copy all avro files from ``a/``folder 
         (i.e a/a.avro, a/b.avro, a/c.avro)in ``data`` bucket to the ``b/`` folder in 
-        the ``data_backup`` bucket (b/a.avro, b/b.avro, b/c.avro):
+        the ``data_backup`` bucket (b/a.avro, b/b.avro, b/c.avro) ::
 
             copy_files = GCSToGCSOperator(
                 task_id='copy_files_without_wildcard',
@@ -314,7 +314,7 @@ class GCSToGCSOperator(BaseOperator):
                 delimiter='.avro',
                 gcp_conn_id=google_cloud_conn_id
             )
-        '''
+        """
         objects = hook.list(self.source_bucket, prefix=prefix, delimiter=self.delimiter)
 
         # If objects is empty and we have prefix, let's check if prefix is a blob

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -281,14 +281,18 @@ class GCSToGCSOperator(BaseOperator):
 
     def _copy_source_without_wildcard(self, hook, prefix):
         """
-        For source_objects with no wildcard, this operator would first list 
-        all files in source_objects, using provided delimiter if any. Then copy 
+
+
+        For source_objects with no wildcard, this operator would first list
+        all files in source_objects, using provided delimiter if any. Then copy
         files from source_objects to destination_object and rename each source
         file.
 
         Example 1:
-        The following Operator would copy all the files from ``a/``folder 
-        (i.e a/a.csv, a/b.csv, a/c.csv)in ``data`` bucket to the ``b/`` folder in 
+
+
+        The following Operator would copy all the files from ``a/``folder
+        (i.e a/a.csv, a/b.csv, a/c.csv)in ``data`` bucket to the ``b/`` folder in
         the ``data_backup`` bucket (b/a.csv, b/b.csv, b/c.csv) ::
 
             copy_files = GCSToGCSOperator(
@@ -301,8 +305,10 @@ class GCSToGCSOperator(BaseOperator):
             )
 
         Example 2:
-        The following Operator would copy all avro files from ``a/``folder 
-        (i.e a/a.avro, a/b.avro, a/c.avro)in ``data`` bucket to the ``b/`` folder in 
+
+
+        The following Operator would copy all avro files from ``a/``folder
+        (i.e a/a.avro, a/b.avro, a/c.avro)in ``data`` bucket to the ``b/`` folder in
         the ``data_backup`` bucket (b/a.avro, b/b.avro, b/c.avro) ::
 
             copy_files = GCSToGCSOperator(

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -293,7 +293,7 @@ class GCSToGCSOperator(BaseOperator):
             if self.destination_object is None:
                 destination_object = source_obj
             else:
-                destination_object = self.destination_object
+                destination_object = source_obj.replace(prefix, self.destination_object, 1)
             self._copy_single_object(
                 hook=hook, source_object=source_obj, destination_object=destination_object
             )

--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -280,6 +280,41 @@ class GCSToGCSOperator(BaseOperator):
                 self._copy_source_without_wildcard(hook=hook, prefix=prefix)
 
     def _copy_source_without_wildcard(self, hook, prefix):
+        '''
+        For source_objects with no wildcard, this operator would first list 
+        all files in source_objects, using provided delimiter if any. Then copy 
+        files from source_objects to destination_object and rename each source
+        file.
+
+        Example 1:
+        The following Operator would copy all the files from ``a/``folder 
+        (i.e a/a.csv, a/b.csv, a/c.csv)in ``data`` bucket to the ``b/`` folder in 
+        the ``data_backup`` bucket (b/a.csv, b/b.csv, b/c.csv):
+
+            copy_files = GCSToGCSOperator(
+                task_id='copy_files_without_wildcard',
+                source_bucket='data',
+                source_objects=['a/'],
+                destination_bucket='data_backup',
+                destination_object='b/',
+                gcp_conn_id=google_cloud_conn_id
+            )
+
+        Example 2:
+        The following Operator would copy all avro files from ``a/``folder 
+        (i.e a/a.avro, a/b.avro, a/c.avro)in ``data`` bucket to the ``b/`` folder in 
+        the ``data_backup`` bucket (b/a.avro, b/b.avro, b/c.avro):
+
+            copy_files = GCSToGCSOperator(
+                task_id='copy_files_without_wildcard',
+                source_bucket='data',
+                source_objects=['a/'],
+                destination_bucket='data_backup',
+                destination_object='b/',
+                delimiter='.avro',
+                gcp_conn_id=google_cloud_conn_id
+            )
+        '''
         objects = hook.list(self.source_bucket, prefix=prefix, delimiter=self.delimiter)
 
         # If objects is empty and we have prefix, let's check if prefix is a blob

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
@@ -121,6 +121,18 @@ folder in ``BUCKET_1_DST``, with file names unchanged.
     :start-after: [START howto_operator_gcs_to_gcs_delimiter]
     :end-before: [END howto_operator_gcs_to_gcs_delimiter]
 
+ For source_objects with no wildcard, all files in source_objects would be listed, using provided delimiter if any. 
+ Then copy files from source_objects to destination_object and rename each source file.
+ 
+ The following example would copy all the files in ``subdir/`` folder (i.e subdir/a.csv, subdir/b.csv, subdir/c.csv) from 
+ the ``BUCKET_1_SRC`` GCS bucket to the ``backup/`` folder in ``BUCKET_1_DST`` bucket. (i.e backup/a.csv, backup/b.csv, backup/c.csv)
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_gcs_to_gcs_without_wildcard]
+    :end-before: [END howto_operator_gcs_to_gcs_without_wildcard]
+
 The delimiter filed may be specified to select any source files starting with ``source_object`` and ending with the
 value supplied to ``delimiter``. This example uses the ``delimiter`` value to implement the same functionality as the
 prior example.

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
@@ -121,11 +121,11 @@ folder in ``BUCKET_1_DST``, with file names unchanged.
     :start-after: [START howto_operator_gcs_to_gcs_delimiter]
     :end-before: [END howto_operator_gcs_to_gcs_delimiter]
 
- For source_objects with no wildcard, all files in source_objects would be listed, using provided delimiter if any. 
- Then copy files from source_objects to destination_object and rename each source file.
- 
- The following example would copy all the files in ``subdir/`` folder (i.e subdir/a.csv, subdir/b.csv, subdir/c.csv) from 
- the ``BUCKET_1_SRC`` GCS bucket to the ``backup/`` folder in ``BUCKET_1_DST`` bucket. (i.e backup/a.csv, backup/b.csv, backup/c.csv)
+For source_objects with no wildcard, all files in source_objects would be listed, using provided delimiter if any. 
+Then copy files from source_objects to destination_object and rename each source file.
+
+The following example would copy all the files in ``subdir/`` folder (i.e subdir/a.csv, subdir/b.csv, subdir/c.csv) from 
+the ``BUCKET_1_SRC`` GCS bucket to the ``backup/`` folder in ``BUCKET_1_DST`` bucket. (i.e backup/a.csv, backup/b.csv, backup/c.csv)
 
 .. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.py
     :language: python

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gcs.rst
@@ -121,10 +121,10 @@ folder in ``BUCKET_1_DST``, with file names unchanged.
     :start-after: [START howto_operator_gcs_to_gcs_delimiter]
     :end-before: [END howto_operator_gcs_to_gcs_delimiter]
 
-For source_objects with no wildcard, all files in source_objects would be listed, using provided delimiter if any. 
+For source_objects with no wildcard, all files in source_objects would be listed, using provided delimiter if any.
 Then copy files from source_objects to destination_object and rename each source file.
 
-The following example would copy all the files in ``subdir/`` folder (i.e subdir/a.csv, subdir/b.csv, subdir/c.csv) from 
+The following example would copy all the files in ``subdir/`` folder (i.e subdir/a.csv, subdir/b.csv, subdir/c.csv) from
 the ``BUCKET_1_SRC`` GCS bucket to the ``backup/`` folder in ``BUCKET_1_DST`` bucket. (i.e backup/a.csv, backup/b.csv, backup/c.csv)
 
 .. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_gcs_to_gcs.py

--- a/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_gcs.py
@@ -492,8 +492,8 @@ class TestGoogleCloudStorageToCloudStorageOperator(unittest.TestCase):
 
         operator.execute(None)
         mock_calls = [
-            mock.call(TEST_BUCKET, 'test_object/file1.txt', DESTINATION_BUCKET, DESTINATION_OBJECT),
-            mock.call(TEST_BUCKET, 'test_object/file2.txt', DESTINATION_BUCKET, DESTINATION_OBJECT),
+            mock.call(TEST_BUCKET, 'test_object/file1.txt', DESTINATION_BUCKET, "test_object/file1.txt"),
+            mock.call(TEST_BUCKET, 'test_object/file2.txt', DESTINATION_BUCKET, "test_object/file2.txt"),
         ]
         mock_hook.return_value.rewrite.assert_has_calls(mock_calls)
 


### PR DESCRIPTION
Hi @potiuk,
This PR fix GCS copy operation without wildcard and rename destination object according to source file name.

related: #9803