### PR TITLE
Don't add Website.can_read access to default roles.

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -441,14 +441,15 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
 
     def add_homepage_access_to_custom_roles(self):
         """
-        Add Website.can_read access to all roles.
+        Add Website.can_read access to all custom roles.
 
         :return: None.
         """
         website_permission = self.add_permission_view_menu(
             permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE
         )
-        for role in self.get_all_roles():
+        custom_roles = [role for role in self.get_all_roles() if role.name not in EXISTING_ROLES]
+        for role in custom_roles:
             self.add_permission_role(role, website_permission)
 
         self.get_session.commit()


### PR DESCRIPTION
While fixing #13856, I made the mistake of adding Website.can_read to all roles, including default roles. This gives public, and thus anonymous, users access to the homepage, which shows an empty list of DAGs.

This fixes that bug by only adding Website.can_read to custom roles.

related: #13856