### PR TITLE
Replace deprecated postgresql chart location with bitnami/postgresql

### DIFF
--- a/chart/requirements.lock
+++ b/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 10.2.5
-digest: sha256:60c6a236b441ca86e9f6d096a7c39620c7c0c15d02d05f958c94b5534e245c02
-generated: "2021-01-27T08:28:34.239986385-06:00"
+  version: 6.3.12
+digest: sha256:9c524b20b23abd5ec3a6e264dbf2bd2e2d50fb5a553d7c1d79f88efa0dc69cb9
+generated: "2021-03-02T18:40:05.677618583-05:00"

--- a/chart/requirements.lock
+++ b/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.helm.sh/stable/
-  version: 6.3.12
-digest: sha256:1748aa702050d4e72ffba1b18960f49bfe5368757cf976116afeffbdedda1c98
-generated: "2020-11-07T17:40:45.418723358+01:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.2.5
+digest: sha256:60c6a236b441ca86e9f6d096a7c39620c7c0c15d02d05f958c94b5534e245c02
+generated: "2021-01-27T08:28:34.239986385-06:00"

--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -17,6 +17,6 @@
 ---
 dependencies:
   - name: postgresql
-    version: 6.3.12
-    repository: "@stable"
+    version: 10.2.5
+    repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled

--- a/chart/requirements.yaml
+++ b/chart/requirements.yaml
@@ -17,6 +17,6 @@
 ---
 dependencies:
   - name: postgresql
-    version: 10.2.5
+    version: 6.3.12
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled


### PR DESCRIPTION
- Replace [deprecated PostgreSQL helm chart location](https://github.com/helm/charts/tree/master/stable/postgresql) with [new location](https://github.com/bitnami/charts/tree/master/bitnami/postgresql)
  - [Deprecation information](https://github.com/helm/charts/blob/master/README.md)
- Chart version `10.2.5`, which uses PostgreSQL version `11.10.0`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
