### PR TITLE
Update Mongodb inventory URL to fix docs build

### DIFF
--- a/docs/exts/docs_build/third_party_inventories.py
+++ b/docs/exts/docs_build/third_party_inventories.py
@@ -20,7 +20,7 @@ THIRD_PARTY_INDEXES = {
     'celery': 'https://docs.celeryproject.org/en/stable',
     'hdfs': 'https://hdfscli.readthedocs.io/en/latest',
     'jinja2': 'https://jinja.palletsprojects.com/en/master',
-    'mongodb': 'https://api.mongodb.com/python/current',
+    'mongodb': 'https://pymongo.readthedocs.io/en/stable/',
     'pandas': 'https://pandas.pydata.org/pandas-docs/stable',
     'python': 'https://docs.python.org/3',
     'requests': 'https://requests.readthedocs.io/en/master',


### PR DESCRIPTION
Master is failing on docs build because of the following [error](https://github.com/apache/airflow/runs/1780469246?check_suite_focus=true#step:4:616):

```
Failed to fetch inventory: https://api.mongodb.com/python/current/objects.inv
```

This is because the URL is changed to https://pymongo.readthedocs.io/en/stable/objects.inv

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
