### PR TITLE
Fix decode error for ssh log

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -138,11 +138,11 @@ class SSHOperator(BaseOperator):
                         if recv.recv_ready():
                             line = stdout.channel.recv(len(recv.in_buffer))
                             agg_stdout += line
-                            self.log.info(line.decode('utf-8').strip('\n'))
+                            self.log.info(line.decode('utf-8', 'replace').strip('\n'))
                         if recv.recv_stderr_ready():
                             line = stderr.channel.recv_stderr(len(recv.in_stderr_buffer))
                             agg_stderr += line
-                            self.log.warning(line.decode('utf-8').strip('\n'))
+                            self.log.warning(line.decode('utf-8', 'replace').strip('\n'))
                     if (
                         stdout.channel.exit_status_ready()
                         and not stderr.channel.recv_stderr_ready()


### PR DESCRIPTION

closes: https://github.com/apache/airflow/issues/10149

decode truncated content will raise UnicodeDecodeError

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
