### PR TITLE
Created DatabaseVersionCheckRule class

### DIFF
--- a/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
+++ b/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
@@ -21,7 +21,6 @@ from airflow.utils.db import provide_session
 
 
 class DatabaseVersionCheckRule(BaseRule):
-    """DatabaseVersionCheckRule class rule to ease upgrade to Airflow 2.0"""
 
     title = "Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0"
 

--- a/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
+++ b/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
@@ -21,7 +21,7 @@ from airflow.utils.db import provide_session
 
 
 class DatabaseVersionCheckRule(BaseRule):
-    """DatabaseVersionCheckRule class upgrade check rule"""
+    """DatabaseVersionCheckRule class rule to ease upgrade to Airflow 2.0"""
 
     title = "Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0"
 
@@ -42,9 +42,9 @@ SQLite - 3.15+
         if "sqlite" in conn_str:
             result = session.execute('select sqlite_version();').fetchone()[0]
             if int(result.split('.')[0]) < 3:
-                return "SQLite version below 3.15+ not supported. \n" + more_info
+                return "SQLite version below 3.15 not supported. \n" + more_info
             elif int(result.split('.')[0]) == 3 and int(result.split('.')[1]) < 15:
-                return "SQLite version below 3.15+ not supported. \n" + more_info
+                return "SQLite version below 3.15 not supported. \n" + more_info
 
         elif "postgres" in conn_str:
             result = session.execute('SELECT VERSION();').fetchone()[0]

--- a/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
+++ b/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.utils.db import provide_session
+
+
+class DatabaseVersionCheckRule(BaseRule):
+    """DatabaseVersionCheckRule class upgrade check rule"""
+
+    title = "Check versions of PostgreSQL, MySQL, and SQLite to ease upgrade to Airflow 2.0"
+
+    description = """\
+From Airflow 2.0, the following database versions are supported:
+PostgreSQl - 9.6, 10, 11, 12, 13;
+MySQL - 5.7, 8;
+SQLite - 3.15+
+    """
+
+    @provide_session
+    def check(self, session=None):
+
+        more_info = "See link below for more details: https://github.com/apache/airflow#requirements"
+
+        conn_str = conf.get(section="core", key="sql_alchemy_conn")
+
+        if "sqlite" in conn_str:
+            result = session.execute('select sqlite_version();').fetchone()[0]
+            if int(result.split('.')[0]) < 3:
+                return "SQLite version below 3.15+ not supported. \n" + more_info
+            elif int(result.split('.')[0]) == 3 and int(result.split('.')[1]) < 15:
+                return "SQLite version below 3.15+ not supported. \n" + more_info
+
+        elif "postgres" in conn_str:
+            result = session.execute('SELECT VERSION();').fetchone()[0]
+            version = result.split(' ')[1]
+            if int(version.split('.')[0]) < 9:
+                return "PostgreSQL version below 9.6 not supported. \n" + more_info
+            elif int(version.split('.')[0]) == 9 and int(version.split('.')[1]) < 6:
+                return "PostgreSQL version below 9.6 not supported. \n" + more_info
+
+        elif "mysql" in conn_str:
+            result = session.execute('SELECT VERSION();').fetchone()[0]
+            if int(result.split('.')[0]) < 5:
+                return "MySQL version below 5.7 not supported. \n" + more_info
+            elif int(result.split('.')[0]) == 5 and int(result.split('.')[1]) < 7:
+                return "MySQL version below 5.7 not supported. \n" + more_info

--- a/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
+++ b/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
@@ -47,8 +47,7 @@ SQLite - 3.15+
 
         elif "postgres" in conn_str:
             min_req_postgres_version = Version('9.6')
-            query = session.execute('SELECT VERSION();').scalar()
-            installed_postgres_version = Version(query.split(' ')[1])
+            installed_postgres_version = Version(session.execute('SHOW server_version;').scalar())
             if installed_postgres_version < min_req_postgres_version:
                 return "From Airflow 2.0, PostgreSQL version below 9.6 is no longer supported. \n" + more_info
 

--- a/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
+++ b/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
@@ -1,0 +1,115 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.postgres_mysql_sqlite_version_upgrade_check import DatabaseVersionCheckRule
+from tests.compat import patch
+from tests.test_utils.config import conf_vars
+
+SQLITE_CONN = "sqlite:////home/user/airflow.db"
+POSTGRES_CONN = "postgresql+psycopg2://username:password@localhost:5432/airflow"
+MYSQL_CONN = "mysql+mysqldb://username:password@localhost/airflow"
+
+MOCK_MSG = "See link below for more details: https://github.com/apache/airflow#requirements"
+
+
+@patch('airflow.settings.Session')
+class TestDatabaseVersionCheckRule(TestCase):
+
+    @conf_vars({("core", "sql_alchemy_conn"): SQLITE_CONN})
+    def test_valid_sqlite_check(self, MockSession):
+        session = MockSession()
+        session.execute().fetchone.return_value = ('3.34.1',)
+
+        rule = DatabaseVersionCheckRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        msg = rule.check(session=session)
+        assert msg is None
+
+    @conf_vars({("core", "sql_alchemy_conn"): SQLITE_CONN})
+    def test_invalid_sqlite_check(self, MockSession):
+        session = MockSession()
+        session.execute().fetchone.return_value = ('2.25.2',)
+
+        rule = DatabaseVersionCheckRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        expected = "SQLite version below 3.15+ not supported. \n" + MOCK_MSG
+
+        msg = rule.check(session=session)
+        assert msg == expected
+
+    @conf_vars({("core", "sql_alchemy_conn"): POSTGRES_CONN})
+    def test_valid_postgres_check(self, MockSession):
+        session = MockSession()
+        session.execute().fetchone.return_value = ('PostgreSQL 12.3 on x86_64-apple-darwin...',)
+
+        rule = DatabaseVersionCheckRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        msg = rule.check(session=session)
+        assert msg is None
+
+    @conf_vars({("core", "sql_alchemy_conn"): POSTGRES_CONN})
+    def test_invalid_postgres_check(self, MockSession):
+        session = MockSession()
+        session.execute().fetchone.return_value = ('PostgreSQL 9.5 on x86_64-apple-darwin...',)
+
+        rule = DatabaseVersionCheckRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        expected = "PostgreSQL version below 9.6 not supported. \n" + MOCK_MSG
+
+        msg = rule.check(session=session)
+        assert msg == expected
+
+    @conf_vars({("core", "sql_alchemy_conn"): MYSQL_CONN})
+    def test_valid_mysql_check(self, MockSession):
+        session = MockSession()
+        session.execute().fetchone.return_value = ('8.0.23',)
+
+        rule = DatabaseVersionCheckRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        msg = rule.check(session=session)
+        assert msg is None
+
+    @conf_vars({("core", "sql_alchemy_conn"): MYSQL_CONN})
+    def test_invalid_mysql_check(self, MockSession):
+        session = MockSession()
+        session.execute().fetchone.return_value = ('5.6.11',)
+
+        rule = DatabaseVersionCheckRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        expected = "MySQL version below 5.7 not supported. \n" + MOCK_MSG
+
+        msg = rule.check(session=session)
+        assert msg == expected

--- a/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
+++ b/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
@@ -61,7 +61,7 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): POSTGRES_CONN})
     def test_valid_postgres_check(self, MockSession):
         session = MockSession()
-        session.execute().scalar.return_value = 'PostgreSQL 12.3 on x86_64-apple-darwin...'
+        session.execute().scalar.return_value = '12.3'
 
         rule = DatabaseVersionCheckRule()
 
@@ -74,7 +74,7 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): POSTGRES_CONN})
     def test_invalid_postgres_check(self, MockSession):
         session = MockSession()
-        session.execute().scalar.return_value = 'PostgreSQL 9.5 on x86_64-apple-darwin...'
+        session.execute().scalar.return_value = '9.5'
 
         rule = DatabaseVersionCheckRule()
 

--- a/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
+++ b/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
@@ -33,7 +33,7 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): SQLITE_CONN})
     def test_valid_sqlite_check(self, MockSession):
         session = MockSession()
-        session.execute().fetchone.return_value = ('3.34.1',)
+        session.execute().scalar.return_value = '3.34.1'
 
         rule = DatabaseVersionCheckRule()
 
@@ -46,14 +46,14 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): SQLITE_CONN})
     def test_invalid_sqlite_check(self, MockSession):
         session = MockSession()
-        session.execute().fetchone.return_value = ('2.25.2',)
+        session.execute().scalar.return_value = '2.25.2'
 
         rule = DatabaseVersionCheckRule()
 
         assert isinstance(rule.title, str)
         assert isinstance(rule.description, str)
 
-        expected = "SQLite version below 3.15 not supported. \n" + MOCK_MSG
+        expected = "From Airflow 2.0, SQLite version below 3.15 is no longer supported. \n" + MOCK_MSG
 
         msg = rule.check(session=session)
         assert msg == expected
@@ -61,7 +61,7 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): POSTGRES_CONN})
     def test_valid_postgres_check(self, MockSession):
         session = MockSession()
-        session.execute().fetchone.return_value = ('PostgreSQL 12.3 on x86_64-apple-darwin...',)
+        session.execute().scalar.return_value = 'PostgreSQL 12.3 on x86_64-apple-darwin...'
 
         rule = DatabaseVersionCheckRule()
 
@@ -74,14 +74,14 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): POSTGRES_CONN})
     def test_invalid_postgres_check(self, MockSession):
         session = MockSession()
-        session.execute().fetchone.return_value = ('PostgreSQL 9.5 on x86_64-apple-darwin...',)
+        session.execute().scalar.return_value = 'PostgreSQL 9.5 on x86_64-apple-darwin...'
 
         rule = DatabaseVersionCheckRule()
 
         assert isinstance(rule.title, str)
         assert isinstance(rule.description, str)
 
-        expected = "PostgreSQL version below 9.6 not supported. \n" + MOCK_MSG
+        expected = "From Airflow 2.0, PostgreSQL version below 9.6 is no longer supported. \n" + MOCK_MSG
 
         msg = rule.check(session=session)
         assert msg == expected
@@ -89,7 +89,7 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): MYSQL_CONN})
     def test_valid_mysql_check(self, MockSession):
         session = MockSession()
-        session.execute().fetchone.return_value = ('8.0.23',)
+        session.execute().scalar.return_value = '8.0.23'
 
         rule = DatabaseVersionCheckRule()
 
@@ -102,14 +102,14 @@ class TestDatabaseVersionCheckRule(TestCase):
     @conf_vars({("core", "sql_alchemy_conn"): MYSQL_CONN})
     def test_invalid_mysql_check(self, MockSession):
         session = MockSession()
-        session.execute().fetchone.return_value = ('5.6.11',)
+        session.execute().scalar.return_value = '5.6.11'
 
         rule = DatabaseVersionCheckRule()
 
         assert isinstance(rule.title, str)
         assert isinstance(rule.description, str)
 
-        expected = "MySQL version below 5.7 not supported. \n" + MOCK_MSG
+        expected = "From Airflow 2.0, MySQL version below 5.7 is no longer supported. \n" + MOCK_MSG
 
         msg = rule.check(session=session)
         assert msg == expected

--- a/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
+++ b/tests/upgrade/rules/test_postgres_mysql_sqlite_version_upgrade_check.py
@@ -53,7 +53,7 @@ class TestDatabaseVersionCheckRule(TestCase):
         assert isinstance(rule.title, str)
         assert isinstance(rule.description, str)
 
-        expected = "SQLite version below 3.15+ not supported. \n" + MOCK_MSG
+        expected = "SQLite version below 3.15 not supported. \n" + MOCK_MSG
 
         msg = rule.check(session=session)
         assert msg == expected


### PR DESCRIPTION
This upgrade check inspects the version of the supported database
backend (PostgreSQL, MySQL, and SQLite) so as to verify if the version
is supported in Airflow 2.0

This is ease upgrade to Airflow 2.0

closes: #13850 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
