### PR TITLE
Bugfix: Allow getting details of a DAG with null start_date(REST API)

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1937,6 +1937,7 @@ components:
               type: string
               format: 'date-time'
               readOnly: true
+              nullable: true
             dag_run_timeout:
               nullable: true
               $ref: '#/components/schemas/TimeDelta'


### PR DESCRIPTION
Currently, when you request for dag details of a DAG with no start_date, it throughs an error:
```
{
    "detail": "None is not of type 'string'\n\nFailed validating 'type' in schema['allOf'][1]['properties']['start_date']:\n    {'format': 'date-time', 'readOnly': True, 'type': 'string'}\n\nOn instance['start_date']:\n    None",
    "status": 500,
    "title": "Response body does not conform to specification",
    "type": "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/stable-rest-api-ref.html#section/Errors/Unknown"
}
```
This PR resolves this by nullifying the start_date of DAG detail schema in openapi 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
