### PR TITLE
Fixed reading from zip package to default to text.

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import io
 import logging
 import os
 import re
@@ -84,7 +85,7 @@ def open_maybe_zipped(fileloc, mode='r'):
     """
     _, archive, filename = ZIP_REGEX.search(fileloc).groups()
     if archive and zipfile.is_zipfile(archive):
-        return zipfile.ZipFile(archive, mode=mode).open(filename)
+        return io.TextIOWrapper(zipfile.ZipFile(archive, mode=mode).open(filename))
     else:
         return open(fileloc, mode=mode)
 


### PR DESCRIPTION
The `open_maybe_zipped` function returns different file-like objects depending on whether it's called for a plain file or for a file in a zip archive. The problem is that by default `io.open` (used for plain files) returns file in text mode and subsequent `read` on it returns strings. `ZipFile` on the other hand by default returns a binary file and subsequent `read` on it returns bytes.
The returned value for `open_maybe_zipped` should be the same regardless whether it's a zip or a plain file--it should be in text mode. Returning binaries for zip packages causes problems. For example, when saving DAG code is turned on, the `DagCode` model tries to save DAG source code in the metadata database. SQLAlchemy throws an error for DAGs that come from a zip package, because tries to save binary value in a string column.
This PR fixes the problem.