### PR TITLE
Bugfix: Manual DagRun trigger should not skip scheduled runs

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1846,7 +1846,6 @@ class DAG(LoggingMixin):
                 or_(
                     DagRun.run_type == DagRunType.BACKFILL_JOB,
                     DagRun.run_type == DagRunType.SCHEDULED,
-                    DagRun.external_trigger.is_(True),
                 ),
             )
             .group_by(DagRun.dag_id)


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/13434

Currently, manual dag runs are causing catchups to fail and also skip the next dag run because `dag_model.next_dagrun` was set incorrectly

![image](https://user-images.githubusercontent.com/8811558/106216366-ddf45f00-61ca-11eb-8af6-fe2a30122a4a.png)

**After fixing**:

![image](https://user-images.githubusercontent.com/8811558/106216595-65da6900-61cb-11eb-832e-1c1ef7f68582.png)
![image](https://user-images.githubusercontent.com/8811558/106216611-6d017700-61cb-11eb-9592-762d38ca6df0.png)




<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
