### PR TITLE
Only allow passing JSON Serializable conf to TriggerDagRunOperator

### DIFF
--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import datetime
+import json
 import time
 from typing import Dict, List, Optional, Union
 
@@ -107,6 +108,11 @@ class TriggerDagRunOperator(BaseOperator):
             )
 
         self.execution_date: Optional[datetime.datetime] = execution_date  # type: ignore
+
+        try:
+            json.dumps(self.conf)
+        except TypeError:
+            raise AirflowException("conf parameter should be JSON Serializable")
 
     def execute(self, context: Dict):
         if isinstance(self.execution_date, datetime.datetime):

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -164,6 +164,17 @@ class TestDagRunOperator(TestCase):
             assert len(dagruns) == 1
             assert dagruns[0].conf, {"foo": "bar"}
 
+    def test_trigger_dagrun_operator_templated_invalid_conf(self):
+        """Test passing a conf that is not JSON Serializable raise error."""
+
+        with pytest.raises(AirflowException, match="^conf parameter should be JSON Serializable$"):
+            TriggerDagRunOperator(
+                task_id="test_trigger_dagrun_with_invalid_conf",
+                trigger_dag_id=TRIGGERED_DAG_ID,
+                conf={"foo": "{{ dag.dag_id }}", "datetime": timezone.utcnow()},
+                dag=self.dag,
+            )
+
     def test_trigger_dagrun_operator_templated_conf(self):
         """Test passing a templated conf to the triggered DagRun."""
         task = TriggerDagRunOperator(


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/13414

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
