### PR TITLE
Updated taskflow api doc to show dependency with sensor

### DIFF
--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -180,7 +180,7 @@ the parameter value is used.
 Adding dependencies to decorated tasks from regular tasks
 ---------------------------------------------------------
 The above tutorial shows how to create dependencies between python-based tasks. However, it is
-quite possible while writing a DAG to have some pre-existing tasks such as BashOperator or FileSensor
+quite possible while writing a DAG to have some pre-existing tasks such as :class:`~airflow.operators.bash.BashOperator` or :class:`~airflow.sensors.filesystem.FileSensor`
 based tasks which need to be run first before a python-based task is run.
 
 Building this dependency is shown in the code below:

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -177,6 +177,40 @@ is automatically set to true.
 Note, If you manually set the ``multiple_outputs`` parameter the inference is disabled and
 the parameter value is used.
 
+Adding dependencies to decorated tasks from regular tasks
+---------------------------------------------------------
+The above tutorial shows how to create dependencies between python-based tasks. However, it is
+quite possible while writing a DAG to have some pre-existing tasks such as BashOperator or FileSensor
+based tasks which need to be run first before a python-based task is run.
+
+Building this dependency is shown in the code below:
+
+.. code-block:: python
+
+    @task()
+        def extract_from_file():
+        """
+        #### Extract from file task
+        A simple Extract task to get data ready for the rest of the data
+        pipeline, by reading the data from a file into a pandas dataframe
+        """
+        order_data_file = '/tmp/order_data.csv'
+        order_data_df = pd.read_csv(order_data_file)
+
+
+    file_task = FileSensor(task_id='check_file', filepath='/tmp/order_data.csv')
+    order_data = extract_from_file()
+
+    file_task >> order_data
+
+
+In the above code block, a new python-based task is defined as ``extract_from_file`` which
+reads the data from a known file location.
+In the main DAG, a new ``FileSensor`` task is defined to check for this file. Please note
+that this is a Sensor task which waits for the file.
+Finally, a dependency between this Sensor task and the python-based task is specified.
+
+
 What's Next?
 ------------
 


### PR DESCRIPTION
Updated the taskflow api tutorial document to show how to setup a
dependency to a python-based decorated task from a classic
FileSensor task.

This doc addition done in response to question asked in Airflow slack. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
