### PR TITLE
Docs: Fix FAQ on scheduler latency

### DIFF
--- a/docs/apache-airflow/faq.rst
+++ b/docs/apache-airflow/faq.rst
@@ -205,7 +205,7 @@ This means ``explicit_defaults_for_timestamp`` is disabled in your mysql server 
 How to reduce airflow dag scheduling latency in production?
 -----------------------------------------------------------
 
-Airflow 2 has low DAG scheduling latency out of the box (particularly when compare with Airflow 1.10.x),
+Airflow 2 has low DAG scheduling latency out of the box (particularly when compared with Airflow 1.10.x),
 however if you need more throughput you can :ref:`start multiple schedulers<scheduler:ha>`.
 
 Why next_ds or prev_ds might not contain expected values?

--- a/docs/apache-airflow/faq.rst
+++ b/docs/apache-airflow/faq.rst
@@ -205,11 +205,8 @@ This means ``explicit_defaults_for_timestamp`` is disabled in your mysql server 
 How to reduce airflow dag scheduling latency in production?
 -----------------------------------------------------------
 
-- ``parsing_processes``: Scheduler will spawn multiple threads in parallel to parse dags.
-  This is controlled by ``parsing_processes`` with default value of 2.
-  User should increase this value to a larger value (e.g numbers of cpus where scheduler runs + 1) in production.
-- If you're using Airflow 1.10.x, consider moving to Airflow 2, which has reduced dag scheduling latency dramatically,
-  and allows for running multiple schedulers.
+Airflow 2 has low DAG scheduling latency out of the box (particularly when compare with Airflow 1.10.x),
+however if you need more throughput you can :ref:`start multiple schedulers<scheduler:ha>`.
 
 Why next_ds or prev_ds might not contain expected values?
 ---------------------------------------------------------

--- a/docs/apache-airflow/scheduler.rst
+++ b/docs/apache-airflow/scheduler.rst
@@ -66,10 +66,10 @@ This only has effect if your DAG has no ``schedule_interval``.
 If you keep default ``allow_trigger_in_future = False`` and try 'external trigger' to run future-dated execution dates,
 the scheduler won't execute it now but the scheduler will execute it in the future once the current date rolls over to the execution date.
 
+.. _scheduler:ha:
+
 Running More Than One Scheduler
 -------------------------------
-
-.. _scheduler:ha:
 
 .. versionadded: 2.0.0
 

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -75,7 +75,7 @@ def _promote_new_flags():
         print("Still too slow?")
         print()
     print("You can only build one documentation package:")
-    print("    ./breeze build-docs --package-filter <PACKAGE-NAME>")
+    print("    ./breeze build-docs -- --package-filter <PACKAGE-NAME>")
     print()
     print("This usually takes from 20 seconds to 2 minutes.")
     print()


### PR DESCRIPTION
`parsing_processes` no longer has an impact on scheduler latency, so reword this section and point folks to running more than 1 scheduler.

Also, fix typo in the "promote new flags" output.


