### PR TITLE
Add bucket_name to template fields in S3 operators

### DIFF
--- a/airflow/providers/amazon/aws/operators/s3_bucket.py
+++ b/airflow/providers/amazon/aws/operators/s3_bucket.py
@@ -39,6 +39,8 @@ class S3CreateBucketOperator(BaseOperator):
     :type region_name: Optional[str]
     """
 
+    template_fields = ("bucket_name",)
+
     @apply_defaults
     def __init__(
         self,
@@ -78,6 +80,8 @@ class S3DeleteBucketOperator(BaseOperator):
         maintained on each worker node).
     :type aws_conn_id: Optional[str]
     """
+
+    template_fields = ("bucket_name",)
 
     def __init__(
         self,


### PR DESCRIPTION
Without that it's impossible to create buckets using for example
execution date. And that is quite common case.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
