### PR TITLE
Added a FAQ section to the Upgrading to 2 doc

### DIFF
--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -524,6 +524,11 @@ At this point, just follow the standard Airflow version upgrade process:
 * Restart Airflow Scheduler, Webserver, and Workers
 
 
+Frequently Asked Questions on Upgrade
+'''''''''''''''''''''''''''''''''''''
+* Q. Why doesn't the list of connection types show up in the Airflow UI after I upgrade to 2.0?
+  * A. It is because Airflow 2.0 does not ship with the provider packages. The connection type list in the Airflow UI is based on the providers you have installed with Airflow 2.0. Please note that these will only show up once you install the provider and restart Airflow. You can read more about providers at :doc:`apache-airflow-providers:index`.
+
 
 Appendix
 ''''''''


### PR DESCRIPTION
Added a FAQ question to the Upgrading to 2 doc and added an initial question and answer around needing providers to be installed before connection types show up. 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
