### PR TITLE
Upgrade tool: skip bad file test for Python 2.7

### DIFF
--- a/tests/upgrade/rules/test_airflow_macro_plugin_removed.py
+++ b/tests/upgrade/rules/test_airflow_macro_plugin_removed.py
@@ -14,11 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
 from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from tempfile import NamedTemporaryFile
 from tests.compat import mock
+
+import pytest
 
 from airflow.upgrade.rules.airflow_macro_plugin_removed import (
     AirflowMacroPluginRemovedRule,
@@ -80,6 +83,10 @@ class TestAirflowMacroPluginRemovedRule(TestCase):
             msgs = rule.check()
             assert 0 == len(msgs)
 
+    @pytest.mark.skipif(
+        sys.version_info.major == 2,
+        reason="Test is irrelevant in Python 2.7 because of unicode differences"
+    )
     def test_bad_file_failure(self, mock_list_files):
         # Write a binary file
         with NamedTemporaryFile("wb+", suffix=".py") as temp_file:


### PR DESCRIPTION
This PR addresses a test failure that was introduced in #13371 and identified by Kaxil/Jarek when syncing the `v1-10-x` branches.

I was able to reproduce the issue locally and found that Python 2.7 is able to read the file with bad bytes just fine without throwing a `UnicodeDecodeError`. Since this allows the rest of the rule to behave normally (i.e. the file is checked for the Airflow macro plugin contents), it won't raise any problems. I could set up this test to behave differently for 2.7 and 3.x respectively, but the easiest thing seemed to just skip this test on python 2.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
