### PR TITLE
Fix the broken template of default_airflow

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -290,14 +290,14 @@ log_format = [%%(asctime)s] {{%%(filename)s:%%(lineno)d}} %%(levelname)s - %%(me
 simple_log_format = %%(asctime)s %%(levelname)s - %%(message)s
 
 # Specify prefix pattern like mentioned below with stream handler TaskHandlerWithCustomFormatter
-# Example: task_log_prefix_template = {{ti.dag_id}}-{{ti.task_id}}-{{execution_date}}-{{try_number}}
+# Example: task_log_prefix_template = {{ ti.dag_id }}-{{ ti.task_id }}-{{ execution_date }}-{{ try_number }}
 task_log_prefix_template =
 
 # Formatting for how airflow generates file names/paths for each task run.
-log_filename_template = {{{{ ti.dag_id }}}}/{{{{ ti.task_id }}}}/{{{{ ts }}}}/{{{{ try_number }}}}.log
+log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ ts }}/{{ try_number }}.log
 
 # Formatting for how airflow generates file names for log
-log_processor_filename_template = {{{{ filename }}}}.log
+log_processor_filename_template = {{ filename }}.log
 
 # full path of dag_processor_manager logfile
 dag_processor_manager_log_location = {AIRFLOW_HOME}/logs/dag_processor_manager/dag_processor_manager.log
@@ -941,7 +941,7 @@ sensitive_variable_fields =
 host =
 
 # Format of the log_id, which is used to query for a given tasks logs
-log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+log_id_template = {{ dag_id }}-{{ task_id }}-{{ execution_date }}-{{ try_number }}
 
 # Used to mark the end of a log stream for a task
 end_of_log_mark = end_of_log


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

I tried to apply "[dockerrize](https://github.com/jwilder/dockerize)" to render the "default_airflow.cfg" template for my Airflow, yet Airflow failed to start with the new config file. 

It spent me quite a while to figure out what had happened. When I double checked the "airflow.cfg" auto-generated by `airflow db init`, I finally realized the reason why it failed was because of those extra brackets for delims in the template. 

So this PR is to fix the issue by removing those  extra brackets in the template.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
