### PR TITLE
Fixed reading from zip package to default to text.

### DIFF
--- a/airflow/utils/file.py
+++ b/airflow/utils/file.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import io
 import logging
 import os
 import re
@@ -84,7 +85,7 @@ def open_maybe_zipped(fileloc, mode='r'):
     """
     _, archive, filename = ZIP_REGEX.search(fileloc).groups()
     if archive and zipfile.is_zipfile(archive):
-        return zipfile.ZipFile(archive, mode=mode).open(filename)
+        return io.TextIOWrapper(zipfile.ZipFile(archive, mode=mode).open(filename))
     else:
         return open(fileloc, mode=mode)
 

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -586,13 +586,16 @@ class TestOpenMaybeZipped(unittest.TestCase):
 
     @mock.patch("zipfile.is_zipfile")
     @mock.patch("zipfile.ZipFile")
-    def test_open_maybe_zipped_archive(self, mocked_zip_file, mocked_is_zipfile):
+    @mock.patch("io.TextIOWrapper")
+    def test_open_maybe_zipped_archive(self, mocked_text_io_wrapper, mocked_zip_file, mocked_is_zipfile):
         mocked_is_zipfile.return_value = True
+        open_return_value = mock.mock_open(read_data="data")
         instance = mocked_zip_file.return_value
-        instance.open.return_value = mock.mock_open(read_data="data")
+        instance.open.return_value = open_return_value
 
         open_maybe_zipped('/path/to/archive.zip/deep/path/to/file.txt')
 
+        mocked_text_io_wrapper.assert_called_once_with(open_return_value)
         mocked_is_zipfile.assert_called_once_with('/path/to/archive.zip')
         mocked_zip_file.assert_called_once_with('/path/to/archive.zip', mode='r')
         instance.open.assert_called_once_with('deep/path/to/file.txt')


### PR DESCRIPTION
This is a resubmission of PR #13962. The original PR did not include corresponding unit test adjustments and therefore broke the build. This PR fixes the problem.

Original PR #13962 description for reference:

The `open_maybe_zipped` function returns different file-like objects depending on whether it's called for a plain file or for a file in a zip archive. The problem is that by default `io.open` (used for plain files) returns file in text mode and subsequent `read` on it returns strings. `ZipFile` on the other hand by default returns a binary file and subsequent `read` on it returns bytes.
The returned value for `open_maybe_zipped` should be the same regardless whether it's a zip or a plain file--it should be in text mode. Returning binaries for zip packages causes problems. For example, when saving DAG code is turned on, the `DagCode` model tries to save DAG source code in the metadata database. SQLAlchemy throws an error for DAGs that come from a zip package, because tries to save binary value in a string column.