### PR TITLE
[Backport] Update Mongodb inventory URL to fix docs build (#13939)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -258,7 +258,7 @@ keep_warnings = True
 
 intersphinx_mapping = {
     'boto3': ('https://boto3.amazonaws.com/v1/documentation/api/latest/', None),
-    'mongodb': ('https://api.mongodb.com/python/current/', None),
+    'mongodb': ('https://pymongo.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'python': ('https://docs.python.org/3/', None),
     'requests': ('https://requests.readthedocs.io/en/master/', None),


### PR DESCRIPTION
This PR backports (#13939) to v1-10-stable to fix failing CI

Master is failing on docs build because of the following error:

```
Failed to fetch inventory: https://api.mongodb.com/python/current/objects.inv
```

This is because the URL is changed to https://pymongo.readthedocs.io/en/stable/objects.inv

(cherry picked from commit 7a5aafce08374c75562e3eb728413fefc4ab6e01)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
