### PR TITLE
Remove failed DockerOperator tasks with auto_remove=True (#13532)

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -264,6 +264,8 @@ class DockerOperator(BaseOperator):
 
             result = self.cli.wait(self.container['Id'])
             if result['StatusCode'] != 0:
+                if self.auto_remove:
+                    self.cli.remove_container(self.container['Id'])
                 raise AirflowException('docker container failed: ' + repr(result))
 
             # duplicated conditional logic because of expensive operation

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -167,6 +167,15 @@ class TestDockerOperator(unittest.TestCase):
         with pytest.raises(AirflowException):
             operator.execute(None)
 
+    def test_auto_remove_container_fails(self):
+        self.client_mock.wait.return_value = {"StatusCode": 1}
+        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest', auto_remove=True)
+        operator.container = {'Id': 'some_id'}
+        with pytest.raises(AirflowException):
+            operator.execute(None)
+
+        self.client_mock.remove_container.assert_called_once_with('some_id')
+
     @staticmethod
     def test_on_kill():
         client_mock = mock.Mock(spec=APIClient)


### PR DESCRIPTION
* Remove failed DockerOperator tasks with auto_remove=True

Removes exited containers if a task based on DockerOperator fails
with StatusCode!=0 and auto_remove=True

Closes https://github.com/apache/airflow/issues/13532 for DockerOperator

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
