### PR TITLE
Add GCS timespan transform operator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_gcs_timespan_file_transform.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs_timespan_file_transform.py
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Example Airflow DAG for Google Cloud Storage time-span file transform operator.
+"""
+
+import os
+
+from airflow import models
+from airflow.providers.google.cloud.operators.gcs import GCSTimeSpanFileTransformOperator
+from airflow.utils.dates import days_ago
+from airflow.utils.state import State
+
+SOURCE_BUCKET = os.environ.get("GCP_GCS_BUCKET_1", "test-gcs-example-bucket")
+SOURCE_PREFIX = "gcs_timespan_file_transform_source"
+SOURCE_GCP_CONN_ID = "google_cloud_default"
+DESTINATION_BUCKET = SOURCE_BUCKET
+DESTINATION_PREFIX = "gcs_timespan_file_transform_destination"
+DESTINATION_GCP_CONN_ID = "google_cloud_default"
+
+PATH_TO_TRANSFORM_SCRIPT = os.environ.get(
+    'GCP_GCS_PATH_TO_TRANSFORM_SCRIPT', 'test_gcs_timespan_transform_script.py'
+)
+
+
+with models.DAG(
+    "example_gcs_timespan_file_transform",
+    start_date=days_ago(1),
+    schedule_interval=None,
+    tags=['example'],
+) as dag:
+
+    # [START howto_operator_gcs_timespan_file_transform_operator_Task]
+    gcs_timespan_transform_files_task = GCSTimeSpanFileTransformOperator(
+        task_id="gcs_timespan_transform_files",
+        source_bucket=SOURCE_BUCKET,
+        source_prefix=SOURCE_PREFIX,
+        source_gcp_conn_id=SOURCE_GCP_CONN_ID,
+        destination_bucket=DESTINATION_BUCKET,
+        destination_prefix=DESTINATION_PREFIX,
+        destination_gcp_conn_id=DESTINATION_GCP_CONN_ID,
+        transform_script=["python", PATH_TO_TRANSFORM_SCRIPT],
+    )
+    # [END howto_operator_gcs_timespan_file_transform_operator_Task]
+
+
+if __name__ == '__main__':
+    dag.clear(dag_run_state=State.NONE)
+    dag.run()

--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -35,6 +35,7 @@ from google.cloud import storage
 
 from airflow.exceptions import AirflowException
 from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
+from airflow.utils import timezone
 from airflow.version import version
 
 RT = TypeVar('RT')  # pylint: disable=invalid-name
@@ -481,10 +482,9 @@ class GCSHook(GoogleBaseHook):
         """
         blob_update_time = self.get_blob_update_time(bucket_name, object_name)
         if blob_update_time is not None:
-            import dateutil.tz
 
             if not ts.tzinfo:
-                ts = ts.replace(tzinfo=dateutil.tz.tzutc())
+                ts = ts.replace(tzinfo=timezone.utc)
             self.log.info("Verify object date: %s > %s", blob_update_time, ts)
             if blob_update_time > ts:
                 return True
@@ -508,12 +508,11 @@ class GCSHook(GoogleBaseHook):
         """
         blob_update_time = self.get_blob_update_time(bucket_name, object_name)
         if blob_update_time is not None:
-            import dateutil.tz
 
             if not min_ts.tzinfo:
-                min_ts = min_ts.replace(tzinfo=dateutil.tz.tzutc())
+                min_ts = min_ts.replace(tzinfo=timezone.utc)
             if not max_ts.tzinfo:
-                max_ts = max_ts.replace(tzinfo=dateutil.tz.tzutc())
+                max_ts = max_ts.replace(tzinfo=timezone.utc)
             self.log.info("Verify object date: %s is between %s and %s", blob_update_time, min_ts, max_ts)
             if min_ts <= blob_update_time < max_ts:
                 return True
@@ -533,10 +532,9 @@ class GCSHook(GoogleBaseHook):
         """
         blob_update_time = self.get_blob_update_time(bucket_name, object_name)
         if blob_update_time is not None:
-            import dateutil.tz
 
             if not ts.tzinfo:
-                ts = ts.replace(tzinfo=dateutil.tz.tzutc())
+                ts = ts.replace(tzinfo=timezone.utc)
             self.log.info("Verify object date: %s < %s", blob_update_time, ts)
             if blob_update_time < ts:
                 return True
@@ -557,8 +555,6 @@ class GCSHook(GoogleBaseHook):
         blob_update_time = self.get_blob_update_time(bucket_name, object_name)
         if blob_update_time is not None:
             from datetime import timedelta
-
-            from airflow.utils import timezone
 
             current_time = timezone.utcnow()
             given_time = current_time - timedelta(seconds=seconds)
@@ -686,7 +682,6 @@ class GCSHook(GoogleBaseHook):
 
         ids = []
         page_token = None
-        import dateutil.tz
 
         while True:
             blobs = bucket.list_blobs(
@@ -699,7 +694,7 @@ class GCSHook(GoogleBaseHook):
 
             blob_names = []
             for blob in blobs:
-                if timespan_start <= blob.updated.replace(tzinfo=dateutil.tz.tzutc()) < timespan_end:
+                if timespan_start <= blob.updated.replace(tzinfo=timezone.utc) < timespan_end:
                     blob_names.append(blob.name)
 
             prefixes = blobs.prefixes

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -24,12 +24,12 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Dict, Iterable, List, Optional, Sequence, Union
 
-import dateutil.tz
 from google.api_core.exceptions import Conflict
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.utils import timezone
 from airflow.utils.decorators import apply_defaults
 
 
@@ -780,8 +780,8 @@ class GCSTimeSpanFileTransformOperator(BaseOperator):
             self.log.warning("No following schedule found, setting timespan end to max %s", timespan_end)
             timespan_end = datetime.datetime.max
 
-        timespan_start = timespan_start.replace(tzinfo=dateutil.tz.tzutc())
-        timespan_end = timespan_end.replace(tzinfo=dateutil.tz.tzutc())
+        timespan_start = timespan_start.replace(tzinfo=timezone.utc)
+        timespan_end = timespan_end.replace(tzinfo=timezone.utc)
 
         source_prefix_interp = GCSTimeSpanFileTransformOperator.interpolate_prefix(
             self.source_prefix,

--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -16,12 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains a Google Cloud Storage Bucket operator."""
+import datetime
 import subprocess
 import sys
 import warnings
-from tempfile import NamedTemporaryFile
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Dict, Iterable, List, Optional, Sequence, Union
 
+import dateutil.tz
 from google.api_core.exceptions import Conflict
 
 from airflow.exceptions import AirflowException
@@ -654,6 +657,216 @@ class GCSFileTransformOperator(BaseOperator):
                 object_name=self.destination_object,
                 filename=destination_file.name,
             )
+
+
+class GCSTimeSpanFileTransformOperator(BaseOperator):
+    """
+    Determines a list of objects that were added or modified at a GCS source
+    location during a specific time-span, copies them to a temporary location
+    on the local file system, runs a transform on this file as specified by
+    the transformation script and uploads the output to the destination bucket.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:GCSTimeSpanFileTransformOperator`
+
+    The locations of the source and the destination files in the local
+    filesystem is provided as an first and second arguments to the
+    transformation script. The time-span is passed to the transform script as
+    third and fourth argument as UTC ISO 8601 string.
+
+    The transformation script is expected to read the
+    data from source, transform it and write the output to the local
+    destination file.
+
+    :param source_bucket: The bucket to fetch data from. (templated)
+    :type source_bucket: str
+    :param source_prefix: Prefix string which filters objects whose name begin with
+           this prefix. Can interpolate execution date and time components. (templated)
+    :type source_prefix: str
+    :param source_gcp_conn_id: The connection ID to use connecting to Google Cloud
+           to download files to be processed.
+    :type source_gcp_conn_id: str
+    :param source_impersonation_chain: Optional service account to impersonate using short-term
+        credentials (to download files to be processed), or chained list of accounts required to
+        get the access_token of the last account in the list, which will be impersonated in the
+        request. If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type source_impersonation_chain: Union[str, Sequence[str]]
+
+    :param destination_bucket: The bucket to write data to. (templated)
+    :type destination_bucket: str
+    :param destination_prefix: Prefix string for the upload location.
+        Can interpolate execution date and time components. (templated)
+    :type destination_prefix: str
+    :param destination_gcp_conn_id: The connection ID to use connecting to Google Cloud
+           to upload processed files.
+    :type destination_gcp_conn_id: str
+    :param destination_impersonation_chain: Optional service account to impersonate using short-term
+        credentials (to upload processed files), or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type destination_impersonation_chain: Union[str, Sequence[str]]
+
+    :param transform_script: location of the executable transformation script or list of arguments
+        passed to subprocess ex. `['python', 'script.py', 10]`. (templated)
+    :type transform_script: Union[str, List[str]]
+
+    """
+
+    template_fields = (
+        'source_bucket',
+        'source_prefix',
+        'destination_bucket',
+        'destination_prefix',
+        'transform_script',
+        'source_impersonation_chain',
+        'destination_impersonation_chain',
+    )
+
+    @staticmethod
+    def interpolate_prefix(prefix, dt):
+        """Interpolate prefix with datetime.
+
+        :param prefix: The prefix to interpolate
+        :type prefix: str
+        :param dt: The datetime to interpolate
+        :type dt: datetime
+
+        """
+        return None if prefix is None else dt.strftime(prefix)
+
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        source_bucket: str,
+        source_prefix: str,
+        source_gcp_conn_id: str,
+        destination_bucket: str,
+        destination_prefix: str,
+        destination_gcp_conn_id: str,
+        transform_script: Union[str, List[str]],
+        source_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        destination_impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.source_bucket = source_bucket
+        self.source_prefix = source_prefix
+        self.source_gcp_conn_id = source_gcp_conn_id
+        self.source_impersonation_chain = source_impersonation_chain
+
+        self.destination_bucket = destination_bucket
+        self.destination_prefix = destination_prefix
+        self.destination_gcp_conn_id = destination_gcp_conn_id
+        self.destination_impersonation_chain = destination_impersonation_chain
+
+        self.transform_script = transform_script
+        self.output_encoding = sys.getdefaultencoding()
+
+    def execute(self, context: dict) -> None:
+        # Define intervals and prefixes.
+        timespan_start = context["execution_date"]
+        timespan_end = context["dag"].following_schedule(timespan_start)
+        if timespan_end is None:
+            self.log.warning("No following schedule found, setting timespan end to max %s", timespan_end)
+            timespan_end = datetime.datetime.max
+
+        timespan_start = timespan_start.replace(tzinfo=dateutil.tz.tzutc())
+        timespan_end = timespan_end.replace(tzinfo=dateutil.tz.tzutc())
+
+        source_prefix_interp = GCSTimeSpanFileTransformOperator.interpolate_prefix(
+            self.source_prefix,
+            timespan_start,
+        )
+        destination_prefix_interp = GCSTimeSpanFileTransformOperator.interpolate_prefix(
+            self.destination_prefix,
+            timespan_start,
+        )
+
+        source_hook = GCSHook(
+            gcp_conn_id=self.source_gcp_conn_id,
+            impersonation_chain=self.source_impersonation_chain,
+        )
+        destination_hook = GCSHook(
+            gcp_conn_id=self.destination_gcp_conn_id,
+            impersonation_chain=self.destination_impersonation_chain,
+        )
+
+        # Fetch list of files.
+        blobs_to_transform = source_hook.list_by_timespan(
+            bucket_name=self.source_bucket,
+            prefix=source_prefix_interp,
+            timespan_start=timespan_start,
+            timespan_end=timespan_end,
+        )
+
+        with TemporaryDirectory() as temp_input_dir, TemporaryDirectory() as temp_output_dir:
+            temp_input_dir = Path(temp_input_dir)
+            temp_output_dir = Path(temp_output_dir)
+
+            # TODO: download in parallel.
+            for blob_to_transform in blobs_to_transform:
+                destination_file = temp_input_dir / blob_to_transform
+                destination_file.parent.mkdir(parents=True, exist_ok=True)
+                source_hook.download(
+                    bucket_name=self.source_bucket,
+                    object_name=blob_to_transform,
+                    filename=str(destination_file),
+                )
+
+            self.log.info("Starting the transformation")
+            cmd = [self.transform_script] if isinstance(self.transform_script, str) else self.transform_script
+            cmd += [
+                str(temp_input_dir),
+                str(temp_output_dir),
+                timespan_start.replace(microsecond=0).isoformat(),
+                timespan_end.replace(microsecond=0).isoformat(),
+            ]
+            process = subprocess.Popen(
+                args=cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, close_fds=True
+            )
+            self.log.info("Process output:")
+            if process.stdout:
+                for line in iter(process.stdout.readline, b''):
+                    self.log.info(line.decode(self.output_encoding).rstrip())
+
+            process.wait()
+            if process.returncode:
+                raise AirflowException(f"Transform script failed: {process.returncode}")
+
+            self.log.info("Transformation succeeded. Output temporarily located at %s", temp_output_dir)
+
+            files_uploaded = []
+
+            # TODO: upload in parallel.
+            for upload_file in temp_output_dir.glob("**/*"):
+                if upload_file.is_dir():
+                    continue
+
+                upload_file_name = str(upload_file.relative_to(temp_output_dir))
+
+                if self.destination_prefix is not None:
+                    upload_file_name = f"{destination_prefix_interp}/{upload_file_name}"
+
+                self.log.info("Uploading file %s to %s", upload_file, upload_file_name)
+
+                destination_hook.upload(
+                    bucket_name=self.destination_bucket,
+                    object_name=upload_file_name,
+                    filename=str(upload_file),
+                )
+                files_uploaded.append(str(upload_file_name))
+
+            return files_uploaded
 
 
 class GCSDeleteBucketOperator(BaseOperator):

--- a/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
@@ -50,6 +50,26 @@ to execute a BigQuery load job.
     :start-after: [START howto_operator_gcs_to_bigquery]
     :end-before: [END howto_operator_gcs_to_bigquery]
 
+
+.. _howto/operator:GCSTimeSpanFileTransformOperator:
+
+GCSTimeSpanFileTransformOperator
+--------------------------------
+
+Use the
+:class:`~airflow.providers.google.cloud.operators.gcs.GCSTimeSpanFileTransformOperator`
+to transform files that were modified in a specific time span. The time span is defined
+by the DAG instance logical execution timestamp (``execution_date``, start of time span)
+and the timestamp when the next DAG instance execution is scheduled (end of time span). If a DAG
+does not have a *next* DAG instance scheduled, the time span end infinite, meaning the operator
+processes all files older than ``execution_date``.
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_gcs_timespan_file_transform.py
+    :language: python
+    :start-after: [START howto_operator_gcs_timespan_file_transform_operator_Task]
+    :end-before: [END howto_operator_gcs_timespan_file_transform_operator_Task]
+
+
 .. _howto/operator:GCSBucketCreateAclEntryOperator:
 
 GCSBucketCreateAclEntryOperator

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -741,6 +741,39 @@ class TestGCSHook(unittest.TestCase):
             ]
         )
 
+    @mock.patch(GCS_STRING.format('GCSHook.get_conn'))
+    def test_list_by_timespans(self, mock_service):
+        test_bucket = 'test_bucket'
+
+        # Given
+        blob1 = mock.Mock()
+        blob1.name = "in-interval-1"
+        blob1.updated = datetime(2019, 8, 28, 14, 7, 20, 0, dateutil.tz.tzutc())
+        blob2 = mock.Mock()
+        blob2.name = "in-interval-2"
+        blob2.updated = datetime(2019, 8, 28, 14, 37, 20, 0, dateutil.tz.tzutc())
+        blob3 = mock.Mock()
+        blob3.name = "outside-interval"
+        blob3.updated = datetime(2019, 8, 29, 14, 7, 20, 0, dateutil.tz.tzutc())
+
+        mock_service.return_value.bucket.return_value.list_blobs.return_value.__iter__.return_value = [
+            blob1,
+            blob2,
+            blob3,
+        ]
+        mock_service.return_value.bucket.return_value.list_blobs.return_value.prefixes = None
+        mock_service.return_value.bucket.return_value.list_blobs.return_value.next_page_token = None
+
+        # When
+        response = self.gcs_hook.list_by_timespan(
+            bucket_name=test_bucket,
+            timespan_start=datetime(2019, 8, 28, 14, 0, 0, 0, dateutil.tz.tzutc()),
+            timespan_end=datetime(2019, 8, 28, 15, 0, 0, 0, dateutil.tz.tzutc()),
+        )
+
+        # Then
+        assert len(response) == 2 and all(['in-interval' in b for b in response])
+
 
 class TestGCSHookUpload(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/google/cloud/hooks/test_gcs.py
+++ b/tests/providers/google/cloud/hooks/test_gcs.py
@@ -772,7 +772,7 @@ class TestGCSHook(unittest.TestCase):
         )
 
         # Then
-        assert len(response) == 2 and all(['in-interval' in b for b in response])
+        assert len(response) == 2 and all('in-interval' in b for b in response)
 
 
 class TestGCSHookUpload(unittest.TestCase):

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -315,11 +315,15 @@ class TestGCSTimeSpanFileTransformOperator(unittest.TestCase):
                     bucket_name=source_bucket,
                     object_name=f"{source_prefix}/{file1}",
                     filename=f"{source}/{source_prefix}/{file1}",
+                    chunk_size=None,
+                    num_max_attempts=1,
                 ),
                 mock.call(
                     bucket_name=source_bucket,
                     object_name=f"{source_prefix}/{file2}",
                     filename=f"{source}/{source_prefix}/{file2}",
+                    chunk_size=None,
+                    num_max_attempts=1,
                 ),
             ]
         )
@@ -343,11 +347,15 @@ class TestGCSTimeSpanFileTransformOperator(unittest.TestCase):
                     bucket_name=destination_bucket,
                     filename=f"{destination}/{file1}",
                     object_name=f"{destination_prefix}/{file1}",
+                    chunk_size=None,
+                    num_max_attempts=1,
                 ),
                 mock.call(
                     bucket_name=destination_bucket,
                     filename=f"{destination}/{file2}",
                     object_name=f"{destination_prefix}/{file2}",
+                    chunk_size=None,
+                    num_max_attempts=1,
                 ),
             ]
         )

--- a/tests/providers/google/cloud/operators/test_gcs.py
+++ b/tests/providers/google/cloud/operators/test_gcs.py
@@ -17,6 +17,8 @@
 # under the License.
 
 import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest import mock
 
 from airflow.providers.google.cloud.operators.gcs import (
@@ -28,6 +30,7 @@ from airflow.providers.google.cloud.operators.gcs import (
     GCSListObjectsOperator,
     GCSObjectCreateAclEntryOperator,
     GCSSynchronizeBucketsOperator,
+    GCSTimeSpanFileTransformOperator,
 )
 
 TASK_ID = "test-gcs-operator"
@@ -205,6 +208,148 @@ class TestGCSFileTransformOperator(unittest.TestCase):
             bucket_name=destination_bucket,
             object_name=destination_object,
             filename=destination,
+        )
+
+
+class TestGCSTimeSpanFileTransformOperatorDateInterpolation(unittest.TestCase):
+    def test_execute(self):
+        interp_dt = datetime(2015, 2, 1, 15, 16, 17, 345, tzinfo=timezone.utc)
+
+        assert GCSTimeSpanFileTransformOperator.interpolate_prefix(None, interp_dt) is None
+
+        assert (
+            GCSTimeSpanFileTransformOperator.interpolate_prefix("prefix_without_date", interp_dt)
+            == "prefix_without_date"
+        )
+
+        assert (
+            GCSTimeSpanFileTransformOperator.interpolate_prefix("prefix_with_year_%Y", interp_dt)
+            == "prefix_with_year_2015"
+        )
+
+        assert (
+            GCSTimeSpanFileTransformOperator.interpolate_prefix(
+                "prefix_with_year_month_day/%Y/%m/%d/", interp_dt
+            )
+            == "prefix_with_year_month_day/2015/02/01/"
+        )
+
+        assert (
+            GCSTimeSpanFileTransformOperator.interpolate_prefix(
+                "prefix_with_year_month_day_and_percent_%%/%Y/%m/%d/", interp_dt
+            )
+            == "prefix_with_year_month_day_and_percent_%/2015/02/01/"
+        )
+
+
+class TestGCSTimeSpanFileTransformOperator(unittest.TestCase):
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.TemporaryDirectory")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.subprocess")
+    @mock.patch("airflow.providers.google.cloud.operators.gcs.GCSHook")
+    def test_execute(self, mock_hook, mock_subprocess, mock_tempdir):
+        source_bucket = TEST_BUCKET
+        source_prefix = "source_prefix"
+        source_gcp_conn_id = ""
+
+        destination_bucket = TEST_BUCKET + "_dest"
+        destination_prefix = "destination_prefix"
+        destination_gcp_conn_id = ""
+
+        transform_script = "script.py"
+
+        source = "source"
+        destination = "destination"
+
+        file1 = "file1"
+        file2 = "file2"
+
+        timespan_start = datetime(2015, 2, 1, 15, 16, 17, 345, tzinfo=timezone.utc)
+        timespan_end = timespan_start + timedelta(hours=1)
+        mock_dag = mock.Mock()
+        mock_dag.following_schedule = lambda x: x + timedelta(hours=1)
+        context = dict(
+            execution_date=timespan_start,
+            dag=mock_dag,
+        )
+
+        mock_tempdir.return_value.__enter__.side_effect = [source, destination]
+        mock_hook.return_value.list_by_timespan.return_value = [
+            f"{source_prefix}/{file1}",
+            f"{source_prefix}/{file2}",
+        ]
+
+        mock_subprocess.PIPE = "pipe"
+        mock_subprocess.STDOUT = "stdout"
+        mock_subprocess.Popen.return_value.stdout.readline = lambda: b""
+        mock_subprocess.Popen.return_value.wait.return_value = None
+        mock_subprocess.Popen.return_value.returncode = 0
+
+        op = GCSTimeSpanFileTransformOperator(
+            task_id=TASK_ID,
+            source_bucket=source_bucket,
+            source_prefix=source_prefix,
+            source_gcp_conn_id=source_gcp_conn_id,
+            destination_bucket=destination_bucket,
+            destination_prefix=destination_prefix,
+            destination_gcp_conn_id=destination_gcp_conn_id,
+            transform_script=transform_script,
+        )
+
+        with mock.patch.object(Path, 'glob') as path_glob:
+            path_glob.return_value.__iter__.return_value = [
+                Path(f"{destination}/{file1}"),
+                Path(f"{destination}/{file2}"),
+            ]
+            op.execute(context=context)
+
+        mock_hook.return_value.list_by_timespan.assert_called_once_with(
+            bucket_name=source_bucket,
+            timespan_start=timespan_start,
+            timespan_end=timespan_end,
+            prefix=source_prefix,
+        )
+
+        mock_hook.return_value.download.assert_has_calls(
+            [
+                mock.call(
+                    bucket_name=source_bucket,
+                    object_name=f"{source_prefix}/{file1}",
+                    filename=f"{source}/{source_prefix}/{file1}",
+                ),
+                mock.call(
+                    bucket_name=source_bucket,
+                    object_name=f"{source_prefix}/{file2}",
+                    filename=f"{source}/{source_prefix}/{file2}",
+                ),
+            ]
+        )
+
+        mock_subprocess.Popen.assert_called_once_with(
+            args=[
+                transform_script,
+                source,
+                destination,
+                timespan_start.replace(microsecond=0).isoformat(),
+                timespan_end.replace(microsecond=0).isoformat(),
+            ],
+            stdout="pipe",
+            stderr="stdout",
+            close_fds=True,
+        )
+
+        mock_hook.return_value.upload.assert_has_calls(
+            [
+                mock.call(
+                    bucket_name=destination_bucket,
+                    filename=f"{destination}/{file1}",
+                    object_name=f"{destination_prefix}/{file1}",
+                ),
+                mock.call(
+                    bucket_name=destination_bucket,
+                    filename=f"{destination}/{file2}",
+                    object_name=f"{destination_prefix}/{file2}",
+                ),
+            ]
         )
 
 

--- a/tests/providers/google/cloud/operators/test_gcs_timespan_file_transform_system.py
+++ b/tests/providers/google/cloud/operators/test_gcs_timespan_file_transform_system.py
@@ -1,0 +1,113 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import os
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from airflow.providers.google.cloud.example_dags.example_gcs_timespan_file_transform import (
+    DESTINATION_BUCKET,
+    DESTINATION_PREFIX,
+    PATH_TO_TRANSFORM_SCRIPT,
+    SOURCE_BUCKET,
+    SOURCE_PREFIX,
+)
+from tests.providers.google.cloud.operators.test_gcs_system_helper import GcsSystemTestHelper
+from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY
+from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTest, provide_gcp_context
+
+
+@pytest.mark.credential_file(GCP_GCS_KEY)
+class GoogleCloudStorageExampleDagsTest(GoogleSystemTest):
+    helper = GcsSystemTestHelper()
+    testfile_content = ["This is a test file"]
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def setUp(self):
+        super().setUp()
+
+        # 1. Create a bucket
+        self.execute_cmd(["gsutil", "mb", f"gs://{SOURCE_BUCKET}"])
+
+        # 2. Create a file to be processed and upload to source bucket using with source prefix
+        with NamedTemporaryFile() as source_file:
+            with open(source_file.name, "w+") as file:
+                file.writelines(self.testfile_content)
+            self.helper.execute_cmd(
+                [
+                    "gsutil",
+                    "cp",
+                    source_file.name,
+                    f"gs://{SOURCE_BUCKET}/{SOURCE_PREFIX}/test.txt",
+                ]
+            )
+
+        # 3. Create test.py file that processes the file
+        with open(PATH_TO_TRANSFORM_SCRIPT, "w+") as file:
+            file.write(
+                """import sys
+from pathlib import Path
+source = sys.argv[1]
+destination = sys.argv[2]
+timespan_start = sys.argv[3]
+timespan_end = sys.argv[4]
+
+print(sys.argv)
+print(f'running script, called with source: {source}, destination: {destination}')
+print(f'timespan_start: {timespan_start}, timespan_end: {timespan_end}')
+
+with open(Path(destination) / "output.txt", "w+") as dest:
+    for f in Path(source).glob("**/*"):
+        if f.is_dir():
+            continue
+        with open(f) as src:
+            lines = [line.upper() for line in src.readlines()]
+            print(lines)
+            dest.writelines(lines)
+    """
+            )
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def tearDown(self):
+        # 1. Delete test.py file
+        os.remove(PATH_TO_TRANSFORM_SCRIPT)
+
+        # 2. Delete bucket
+        self.execute_cmd(["gsutil", "rm", "-r", f"gs://{SOURCE_BUCKET}"])
+
+        super().tearDown()
+
+    @provide_gcp_context(GCP_GCS_KEY)
+    def test_run_example_dag(self):
+        # Run DAG
+        self.run_dag('example_gcs_timespan_file_transform', CLOUD_DAG_FOLDER)
+
+        # Download file and verify content.
+        with NamedTemporaryFile() as dest_file:
+
+            self.helper.execute_cmd(
+                [
+                    "gsutil",
+                    "cp",
+                    f"gs://{DESTINATION_BUCKET}/{DESTINATION_PREFIX}/output.txt",
+                    dest_file.name,
+                ]
+            )
+            with open(dest_file.name) as file:
+                dest_file_content = file.readlines()
+            assert dest_file_content == [line.upper() for line in self.testfile_content]


### PR DESCRIPTION
This change adds a new GCS transform operator. It is based on the existing transform operator with the addition that it will transform multiple files that match the prefix and that were updated within a time-span. The time-span is implicitly defined: it is the time between the current execution timestamp of the DAG instance (time-span start) and the next execution timestamp of the DAG (time-span end). 

The use-case is some entity generates files at irregular intervals and an undefined number. The operator will pick up all files that were updated since it executed last. Typically the transform script will iterate over the files, open them, extract some information, collate them into one or more files and upload them to GCS. These result files can then be loaded into BigQuery or processed further or served via a webserver.

Here is an illustration that shows the concept:

![bitmap](https://user-images.githubusercontent.com/192171/107156333-0411c000-697e-11eb-96c4-d19184bc4e15.png)

