### PR TITLE
Fix ./breeze exec command error: /bin/bash: -c: option requires an argument

### DIFF
--- a/scripts/in_container/entrypoint_exec.sh
+++ b/scripts/in_container/entrypoint_exec.sh
@@ -24,4 +24,4 @@
 # shellcheck source=scripts/in_container/run_init_script.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/run_init_script.sh"
 
-exec /bin/bash -c "${@}"
+exec /bin/bash "${@}"


### PR DESCRIPTION
Currently, running `./breeze exec` throws an error that `/bin/bash: -c: option requires an argument`. This PR fixes it by removing `-c` since argument is not needed when you don't want to use tmux.  `./breeze exec run_tmux` still works fine

CC: @mik-laj 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
