### PR TITLE
added missing return parameter in read function of FileTaskHandler

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -207,7 +207,7 @@ class FileTaskHandler(logging.Handler):
             logs = [
                 [('default_host', f'Error fetching the logs. Try number {try_number} is invalid.')],
             ]
-            return logs
+            return logs, [{'end_of_log': True}]
         else:
             try_numbers = [try_number]
 


### PR DESCRIPTION
this issue occurs when invalid try_number value is passed in get logs api
FIXES: #13638