### PR TITLE
Fix: Add missing space between git version label and value

### DIFF
--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -66,7 +66,7 @@
       <div class="container">
         <div>
           {{ version_label }}: {% if airflow_version %}<a href="https://pypi.python.org/pypi/apache-airflow/{{ airflow_version }}" target="_blank">v{{ airflow_version }}</a>{% else %} N/A{% endif %}
-          {% if git_version %}<br>Git Version:<strong>{{ git_version }}</strong>{% endif %}
+          {% if git_version %}<br>Git Version: <strong>{{ git_version }}</strong>{% endif %}
         </div>
         <div></div>
       </div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3267/106479571-77946880-6478-11eb-8d21-2f0eb6600e2d.png)

After:
![image](https://user-images.githubusercontent.com/3267/106479618-84b15780-6478-11eb-9595-7b91bfc5b75d.png)
