### PR TITLE
Allow retrieving Variables, Connections, XCom without breaking HA Locks

### DIFF
--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -29,7 +29,9 @@ def create_session():
     session = settings.Session()
     try:
         yield session
-        session.commit()
+        # Only Commit if a new or a modified object exists in the session
+        if not session._is_clean():  # pylint: disable=protected-access
+            session.commit()
     except Exception:
         session.rollback()
         raise


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/13811

Previously, because we use `create_session` context manager with or
without `@provide_session`: we always used to commit the session if
the session is not explicitly passed to a function example:

```
dag_run = task_instance.get_dagrun()
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/session.py", line 65, in wrapper
    return func(*args, session=session, **kwargs)
  File "/usr/local/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/session.py", line 32, in create_session
    session.commit()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 1042, in commit
    self.transaction.commit()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 504, in commit
    self._prepare_impl()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 472, in _prepare_impl
    self.session.dispatch.before_commit(self.session)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/event/attr.py", line 322, in __call__
    fn(*args, **kw)
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/sqlalchemy.py", line 217, in _validate_commit
    raise RuntimeError("UNEXPECTED COMMIT - THIS WILL BREAK HA LOCKS!")
```

The same happens when using `Variable.get()` because of
https://github.com/apache/airflow/blob/594069ee061e9839b2b12aa43aa3a23e05beed86/airflow/secrets/metastore.py#L55-L70

This commit makes sure that we only commit the session if we add a new object or modify an existing object in the session
by using `session._is_clean`:

https://github.com/sqlalchemy/sqlalchemy/blob/25ee5a05df0daeb7dc7ba432172d6abc76ffab56/lib/sqlalchemy/orm/session.py#L3236-L3241

```python
    def _is_clean(self):
        return (
            not self.identity_map.check_modified()
            and not self._deleted
            and not self._new
        )

```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
