### PR TITLE
Allow list and dict item to be rendered as taget renderer instead of showing as JSON

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -321,6 +321,17 @@ def render(obj, lexer):
     return out
 
 
+def json_render(obj, lexer):
+    """Render a given Python object with json lexer"""
+    out = ""
+    if isinstance(obj, str):
+        out = Markup(pygment_html_render(obj, lexer))
+    elif isinstance(obj, (dict, list)):
+        content = json.dumps(obj, sort_keys=True, indent=4)
+        out = Markup(pygment_html_render(content, lexer))
+    return out
+
+
 def wrapped_markdown(s, css_class=None):
     """Convert a Markdown string to HTML."""
     if s is None:
@@ -343,7 +354,7 @@ def get_attr_renderer():
         'doc_rst': lambda x: render(x, lexers.RstLexer),
         'doc_yaml': lambda x: render(x, lexers.YamlLexer),
         'doc_md': wrapped_markdown,
-        'json': lambda x: render(x, lexers.JsonLexer),
+        'json': lambda x: json_render(x, lexers.JsonLexer),
         'md': wrapped_markdown,
         'py': lambda x: render(get_python_source(x), lexers.PythonLexer),
         'python_callable': lambda x: render(get_python_source(x), lexers.PythonLexer),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -898,8 +898,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             content = getattr(task, template_field)
             renderer = task.template_fields_renderers.get(template_field, template_field)
             if renderer in renderers:
-                if isinstance(content, (dict, list)):
-                    content = json.dumps(content, sort_keys=True, indent=4)
                 html_dict[template_field] = renderers[renderer](content)
             else:
                 html_dict[template_field] = Markup("<pre><code>{}</pre></code>").format(


### PR DESCRIPTION
closes: #13988


In  #11061 i believe  @turbaszek merged code for better rendering dictionary, but code 

https://github.com/apache/airflow/blob/d2efb33239d36e58fb69066fd23779724cb11a90/airflow/www/views.py#L901-L903

also dumps list as json which is passed to render() function as string containing json which is causing this issue.

https://github.com/apache/airflow/blob/d2efb33239d36e58fb69066fd23779724cb11a90/airflow/www/utils.py#L308-L317

If we remove list from  
https://github.com/apache/airflow/blob/d2efb33239d36e58fb69066fd23779724cb11a90/airflow/www/views.py#L901

it will pass list to render function and render each list item as target render.
In this case as SQL

![rendertmp](https://user-images.githubusercontent.com/11897651/106604899-473af000-6586-11eb-9e24-19975d246ebd.png)


