### PR TITLE
Adding support to use Glue Connections for Job  correct subnet selection

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -43,8 +43,10 @@ class AwsGlueJobHook(AwsBaseHook):
     :type num_of_dpus: int
     :param region_name: aws region name (example: us-east-1)
     :type region_name: Optional[str]
-    :param iam_role_name: AWS IAM Role for Glue Job
+    :param iam_role_name: AWS IAM Role for Glue Job Execution
     :type iam_role_name: Optional[str]
+    :param create_job_kwargs: Extra arguments for Glue Job Creation
+    :type create_job_kwargs: Optional[dict]
     """
 
     JOB_POLL_INTERVAL = 6  # polls job status after every JOB_POLL_INTERVAL seconds
@@ -60,9 +62,10 @@ class AwsGlueJobHook(AwsBaseHook):
         num_of_dpus: int = 10,
         region_name: Optional[str] = None,
         iam_role_name: Optional[str] = None,
+        create_job_kwargs: Optional[dict] = None,
         *args,
         **kwargs,
-    ):
+    ):  # pylint: disable=too-many-arguments
         self.job_name = job_name
         self.desc = desc
         self.concurrent_run_limit = concurrent_run_limit
@@ -73,6 +76,7 @@ class AwsGlueJobHook(AwsBaseHook):
         self.s3_bucket = s3_bucket
         self.role_name = iam_role_name
         self.s3_glue_logs = 'logs/glue-logs/'
+        self.create_job_kwargs = create_job_kwargs or {}
         kwargs['client_type'] = 'glue'
         super().__init__(*args, **kwargs)
 
@@ -181,6 +185,7 @@ class AwsGlueJobHook(AwsBaseHook):
                     Command={"Name": "glueetl", "ScriptLocation": self.script_location},
                     MaxRetries=self.retry_limit,
                     AllocatedCapacity=self.num_of_dpus,
+                    **self.create_job_kwargs,
                 )
                 return create_job_response['Name']
             except Exception as general_error:

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -51,6 +51,8 @@ class AwsGlueJobOperator(BaseOperator):
     :type s3_bucket: Optional[str]
     :param iam_role_name: AWS IAM Role for Glue Job Execution
     :type iam_role_name: Optional[str]
+    :param create_job_kwargs: Extra arguments for Glue Job Creation
+    :type create_job_kwargs: Optional[dict]
     """
 
     template_fields = ()
@@ -72,6 +74,7 @@ class AwsGlueJobOperator(BaseOperator):
         region_name: Optional[str] = None,
         s3_bucket: Optional[str] = None,
         iam_role_name: Optional[str] = None,
+        create_job_kwargs: Optional[dict] = None,
         **kwargs,
     ):  # pylint: disable=too-many-arguments
         super().__init__(**kwargs)
@@ -88,6 +91,7 @@ class AwsGlueJobOperator(BaseOperator):
         self.iam_role_name = iam_role_name
         self.s3_protocol = "s3://"
         self.s3_artifacts_prefix = 'artifacts/glue-scripts/'
+        self.create_job_kwargs = create_job_kwargs
 
     def execute(self, context):
         """
@@ -110,6 +114,7 @@ class AwsGlueJobOperator(BaseOperator):
             region_name=self.region_name,
             s3_bucket=self.s3_bucket,
             iam_role_name=self.iam_role_name,
+            create_job_kwargs=self.create_job_kwargs,
         )
         self.log.info("Initializing AWS Glue Job: %s", self.job_name)
         glue_job_run = glue_job.initialize_job(self.script_args)


### PR DESCRIPTION
Adding Connections parameter to AwsGlueJobHook in order to previse which subnet must be used for Job deployment.

If we have a Connection only accessible from an specific subnet (not the default one) and we do not pass this parameter, Job will be deployed to default subnet, so will not have access to DDBB, resulting in a Timeout error.

This small patch fix this issue based on [Glue Client documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/glue.html#Glue.Client.create_job).
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
