### PR TITLE
Depreciate private_key_pass extra param and rename to private_key_passphrase

### DIFF
--- a/airflow/providers/sftp/CHANGELOG.rst
+++ b/airflow/providers/sftp/CHANGELOG.rst
@@ -22,6 +22,12 @@ Changelog
 1.1.1
 .....
 
+Features
+~~~~~~~~
+
+* ``SFTPHook private_key_pass extra param is deprecated and renamed to private_key_passphrase, for consistency with
+  arguments' naming in SSHHook``
+
 Bug fixes
 ~~~~~~~~~
 

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -76,12 +76,23 @@ class SFTPHook(SSHHook):
             conn = self.get_connection(self.ssh_conn_id)
             if conn.extra is not None:
                 extra_options = conn.extra_dejson
-                if 'private_key_pass' in extra_options:
-                    self.private_key_pass = extra_options.get('private_key_pass')
 
                 # For backward compatibility
                 # TODO: remove in Airflow 2.1
                 import warnings
+
+                if 'private_key_pass' in extra_options:
+                    warnings.warn(
+                        'Extra option `private_key_pass` is deprecated.'
+                        'Please use `private_key_passphrase` instead.'
+                        '`private_key_passphrase` will precede if both options are specified.'
+                        'The old option `private_key_pass` will be removed in Airflow 2.1',
+                        DeprecationWarning,
+                        stacklevel=2,
+                    )
+                self.private_key_pass = extra_options.get(
+                    'private_key_passphrase', extra_options.get('private_key_pass')
+                )
 
                 if 'ignore_hostkey_verification' in extra_options:
                     warnings.warn(


### PR DESCRIPTION
Some operators perform SFTP operations by the means of `SFTPHook`. `SFTPHook` delegates the actual SFTP connection to
 the `pysftp` module.

When connecting with a private key protected by a passphrase, the `private_key_pass` extra parameter must be
 specified in the connection, and this corresponds to the arguments' naming in `pysftp`.

However, `SFTPHook` inherits from `SSHHook` which already manages a `private_key_passphrase` extra param. But this
 param is unused in favor of the `private_key_pass` param introduced in `SFTPHook`.

For consistency, I propose to drop `private_key_pass` in `SFTPHook` and to reuse `private_key_passphrase` from `SSHHook`.
This way, a single connection can be used for both SSH and SFTP operations.
