### PR TITLE
Disable row level locking for Mariadb and MySQL <8

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -813,10 +813,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         # as discussed in https://issues.apache.org/jira/browse/AIRFLOW-2516
         if self.using_sqlite or self.using_mysql:
             tis_to_change: List[TI] = with_row_locks(
-                query,
-                of=TI,
-                session=session,
-                **skip_locked(session=session)
+                query, of=TI, session=session, **skip_locked(session=session)
             ).all()
             for ti in tis_to_change:
                 ti.set_state(new_state, session=session)
@@ -1835,10 +1832,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
 
         # Lock these rows, so that another scheduler can't try and adopt these too
         tis_to_reset_or_adopt = with_row_locks(
-            query,
-            of=TI,
-            session=session,
-            **skip_locked(session=session)
+            query, of=TI, session=session, **skip_locked(session=session)
         ).all()
         to_reset = self.executor.try_adopt_task_instances(tis_to_reset_or_adopt)
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -812,7 +812,12 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         # We need to do this for mysql as well because it can cause deadlocks
         # as discussed in https://issues.apache.org/jira/browse/AIRFLOW-2516
         if self.using_sqlite or self.using_mysql:
-            tis_to_change: List[TI] = with_row_locks(query, of=TI, **skip_locked(session=session)).all()
+            tis_to_change: List[TI] = with_row_locks(
+                query,
+                of=TI,
+                session=session,
+                **skip_locked(session=session)
+            ).all()
             for ti in tis_to_change:
                 ti.set_state(new_state, session=session)
                 tis_changed += 1
@@ -922,6 +927,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         task_instances_to_examine: List[TI] = with_row_locks(
             query,
             of=TI,
+            session=session,
             **skip_locked(session=session),
         ).all()
         # TODO[HA]: This was wrong before anyway, as it only looked at a sub-set of dags, not everything.
@@ -1159,7 +1165,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
             for dag_id, task_id, execution_date, try_number in self.executor.queued_tasks.keys()
         ]
         ti_query = session.query(TI).filter(or_(*filter_for_ti_state_change))
-        tis_to_set_to_scheduled: List[TI] = with_row_locks(ti_query).all()
+        tis_to_set_to_scheduled: List[TI] = with_row_locks(ti_query, session=session).all()
         if not tis_to_set_to_scheduled:
             return
 
@@ -1828,7 +1834,12 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         )
 
         # Lock these rows, so that another scheduler can't try and adopt these too
-        tis_to_reset_or_adopt = with_row_locks(query, of=TI, **skip_locked(session=session)).all()
+        tis_to_reset_or_adopt = with_row_locks(
+            query,
+            of=TI,
+            session=session,
+            **skip_locked(session=session)
+        ).all()
         to_reset = self.executor.try_adopt_task_instances(tis_to_reset_or_adopt)
 
         reset_tis_message = []

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1823,7 +1823,7 @@ class DAG(LoggingMixin):
             .options(joinedload(DagModel.tags, innerjoin=False))
             .filter(DagModel.dag_id.in_(dag_ids))
         )
-        orm_dags = with_row_locks(query, of=DagModel).all()
+        orm_dags = with_row_locks(query, of=DagModel, session=session).all()
 
         existing_dag_ids = {orm_dag.dag_id for orm_dag in orm_dags}
         missing_dag_ids = dag_ids.difference(existing_dag_ids)
@@ -2246,7 +2246,7 @@ class DagModel(Base):
             .limit(cls.NUM_DAGS_PER_DAGRUN_QUERY)
         )
 
-        return with_row_locks(query, of=cls, **skip_locked(session=session))
+        return with_row_locks(query, of=cls, session=session, **skip_locked(session=session))
 
     def calculate_dagrun_date_fields(
         self, dag: DAG, most_recent_dag_run: Optional[pendulum.DateTime], active_runs_of_dag: int

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -224,7 +224,12 @@ class DagRun(Base, LoggingMixin):
         if not settings.ALLOW_FUTURE_EXEC_DATES:
             query = query.filter(DagRun.execution_date <= func.now())
 
-        return with_row_locks(query.limit(max_number), of=cls, **skip_locked(session=session))
+        return with_row_locks(
+            query.limit(max_number),
+            of=cls,
+            session=session,
+            **skip_locked(session=session)
+        )
 
     @staticmethod
     @provide_session

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -225,10 +225,7 @@ class DagRun(Base, LoggingMixin):
             query = query.filter(DagRun.execution_date <= func.now())
 
         return with_row_locks(
-            query.limit(max_number),
-            of=cls,
-            session=session,
-            **skip_locked(session=session)
+            query.limit(max_number), of=cls, session=session, **skip_locked(session=session)
         )
 
     @staticmethod

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -102,7 +102,7 @@ class Pool(Base):
         query = session.query(Pool.pool, Pool.slots)
 
         if lock_rows:
-            query = with_row_locks(query, **nowait(session))
+            query = with_row_locks(query, session=session, **nowait(session))
 
         pool_rows: Iterable[Tuple[str, int]] = query.all()
         for (pool_name, total_slots) in pool_rows:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1187,7 +1187,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                     session.query(DagRun).filter_by(
                         dag_id=self.dag_id,
                         execution_date=self.execution_date,
-                    )
+                    ),
+                    session=session
                 ).one()
 
                 # Get a partial dag with just the specific tasks we want to

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1188,7 +1188,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                         dag_id=self.dag_id,
                         execution_date=self.execution_date,
                     ),
-                    session=session
+                    session=session,
                 ).one()
 
                 # Get a partial dag with just the specific tasks we want to

--- a/airflow/utils/sqlalchemy.py
+++ b/airflow/utils/sqlalchemy.py
@@ -188,15 +188,19 @@ def nulls_first(col, session: Session) -> Dict[str, Any]:
 USE_ROW_LEVEL_LOCKING: bool = conf.getboolean('scheduler', 'use_row_level_locking', fallback=True)
 
 
-def with_row_locks(query, **kwargs):
+def with_row_locks(query, session: Session, **kwargs):
     """
     Apply with_for_update to an SQLAlchemy query, if row level locking is in use.
 
     :param query: An SQLAlchemy Query object
+    :param session: ORM Session
     :param kwargs: Extra kwargs to pass to with_for_update (of, nowait, skip_locked, etc)
     :return: updated query
     """
-    if USE_ROW_LEVEL_LOCKING:
+    dialect = session.bind.dialect
+
+    # Don't use row level locks if the MySQL dialect (Mariadb & MySQL < 8) does not support it.
+    if USE_ROW_LEVEL_LOCKING and (dialect.name != "mysql" or dialect.supports_for_update_of):
         return query.with_for_update(**kwargs)
     else:
         return query


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/11899 
closes https://github.com/apache/airflow/issues/13668

This PR disable row-level locking for MySQL variants that do not support skip_locked and no_wait -- **MySQL < 8** and **MariaDB**

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
