### PR TITLE
Retry critical methods in Scheduler loop in case of OperationalError

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -25,8 +25,10 @@ import warnings
 from typing import Optional
 
 import pendulum
+import tenacity
 from sqlalchemy import create_engine, exc
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.orm.session import Session as SASession
 from sqlalchemy.pool import NullPool
@@ -484,8 +486,7 @@ CHECK_SLAS = conf.getboolean('core', 'check_slas', fallback=True)
 # Number of times, the code should be retried in case of DB Operational Errors
 # Retries are done using tenacity. Not all transactions should be retried as it can cause
 # undesired state.
-# Currently used in the following places:
-# `DagFileProcessor.process_file` to retry `dagbag.sync_to_db`
+# Currently used in settings.run_with_db_retries
 MAX_DB_RETRIES = conf.getint('core', 'max_db_retries', fallback=3)
 
 USE_JOB_SCHEDULE = conf.getboolean('scheduler', 'use_job_schedule', fallback=True)
@@ -504,3 +505,18 @@ IS_K8S_OR_K8SCELERY_EXECUTOR = conf.get('core', 'EXECUTOR') in {
     executor_constants.KUBERNETES_EXECUTOR,
     executor_constants.CELERY_KUBERNETES_EXECUTOR,
 }
+
+
+def run_with_db_retries(logger: logging.Logger, **kwargs):
+    """Return Tenacity Retrying object with project specific default"""
+    # Default kwargs
+    retry_kwargs = dict(
+        retry=tenacity.retry_if_exception_type(exception_types=OperationalError),
+        wait=tenacity.wait_random_exponential(multiplier=0.5, max=5),
+        stop=tenacity.stop_after_attempt(MAX_DB_RETRIES),
+        before_sleep=tenacity.before_sleep_log(logger, logging.DEBUG),
+        reraise=True,
+    )
+    retry_kwargs.update(kwargs)
+
+    return tenacity.Retrying(**retry_kwargs)


### PR DESCRIPTION
Review without whitespace changes: https://github.com/apache/airflow/pull/14032/files?diff=split&w=1

In the case of `OperationalError` (caused deadlocks, network blips), the scheduler will now retry those methods 3 times.

closes https://github.com/apache/airflow/issues/11899 
closes https://github.com/apache/airflow/issues/13668


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
