### PR TITLE
Utilize util method to yield versioned doc link

### DIFF
--- a/airflow/www/templates/airflow/plugin.html
+++ b/airflow/www/templates/airflow/plugin.html
@@ -27,7 +27,7 @@ under the License.
   <h2>{{ title }}</h2>
   {% if plugins|length == 0 %}
     <p>No plugins loaded. Learn more in the
-      <a href="https://airflow.apache.org/docs/apache-airflow/stable/plugins.html" target="_blank">plugins documentation</a>.
+      <a href="{{ doc_url }}" target="_blank">plugins documentation</a>.
     </p>
   {% endif %}
   {% for plugin in plugins %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -87,6 +87,7 @@ from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import RUNNING_DEPS, SCHEDULER_QUEUED_DEPS
 from airflow.utils import json as utils_json, timezone
 from airflow.utils.dates import infer_time_unit, scale_time_units
+from airflow.utils.docs import get_docs_url
 from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils.log.log_reader import TaskLogReader
 from airflow.utils.session import create_session, provide_session
@@ -2992,10 +2993,12 @@ class PluginView(AirflowBaseView):
             plugins.append(plugin_data)
 
         title = "Airflow Plugins"
+        doc_url = get_docs_url("plugins.html")
         return self.render_template(
             'airflow/plugin.html',
             plugins=plugins,
             title=title,
+            doc_url=doc_url,
         )
 
 


### PR DESCRIPTION
Follow-up to #13599. I wasn't aware of the existence of the `get_docs_url` utility until yesterday—this PR makes use of it so the Doc link is versioned properly.