### PR TITLE
Speed up clear_task_instances by doing a single sql delete for TaskReschedule

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -175,7 +175,7 @@ def clear_task_instances(
 
     if tr_filter:
         # Clear all reschedules related to the ti to clear
-        tr_qry = session.query(TR).filter(
+        delete_qry = TR.__table__.delete().where(
             or_(
                 and_(
                     TR.dag_id == dag_id,
@@ -186,7 +186,7 @@ def clear_task_instances(
                 for dag_id, task_id, execution_date, try_number in tr_filter
             )
         )
-        tr_qry.delete()
+        session.execute(delete_qry)
 
     if job_ids:
         from airflow.jobs.base_job import BaseJob

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -173,19 +173,20 @@ def clear_task_instances(
 
         tr_filter.append((ti.dag_id, ti.task_id, ti.execution_date, ti.try_number))
 
-    # Clear all reschedules related to the ti to clear
-    tr_qry = session.query(TR).filter(
-        or_(
-            and_(
-                TR.dag_id == dag_id,
-                TR.task_id == task_id,
-                TR.execution_date == execution_date,
-                TR.try_number == try_number,
+    if tr_filter:
+        # Clear all reschedules related to the ti to clear
+        tr_qry = session.query(TR).filter(
+            or_(
+                and_(
+                    TR.dag_id == dag_id,
+                    TR.task_id == task_id,
+                    TR.execution_date == execution_date,
+                    TR.try_number == try_number,
+                )
+                for dag_id, task_id, execution_date, try_number in tr_filter
             )
-            for dag_id, task_id, execution_date, try_number in tr_filter
         )
-    )
-    tr_qry.delete()
+        tr_qry.delete()
 
     if job_ids:
         from airflow.jobs.base_job import BaseJob

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -149,7 +149,7 @@ def clear_task_instances(
 
     job_ids = []
 
-    tr_filter = []
+    ti_filter = []
     for ti in tis:
         if ti.state == State.RUNNING:
             if ti.job_id:
@@ -171,21 +171,35 @@ def clear_task_instances(
             ti.state = State.NONE
             session.merge(ti)
 
-        tr_filter.append((ti.dag_id, ti.task_id, ti.execution_date, ti.try_number))
+        ti_filter.append(ti)
 
-    if tr_filter:
+    if ti_filter:
         # Clear all reschedules related to the ti to clear
-        delete_qry = TR.__table__.delete().where(
-            or_(
-                and_(
-                    TR.dag_id == dag_id,
-                    TR.task_id == task_id,
-                    TR.execution_date == execution_date,
-                    TR.try_number == try_number,
-                )
-                for dag_id, task_id, execution_date, try_number in tr_filter
+        first_ti = ti_filter[0]
+        if all(ti.dag_id == first_ti.dag_id for ti in ti_filter):
+            # Optimization for the case when all tis are for the samd dag_id.
+            filter_by = and_(
+                TR.dag_id == first_ti.dag_id,
+                or_(
+                    and_(
+                        TR.task_id == ti.task_id,
+                        TR.execution_date == ti.execution_date,
+                        TR.try_number == ti.try_number,
+                    )
+                    for ti in ti_filter
+                ),
             )
-        )
+        else:
+            filter_by = or_(
+                and_(
+                    TR.dag_id == ti.dag_id,
+                    TR.task_id == ti.task_id,
+                    TR.execution_date == ti.execution_date,
+                    TR.try_number == ti.try_number,
+                )
+                for ti in ti_filter
+            )
+        delete_qry = TR.__table__.delete().where(filter_by)
         session.execute(delete_qry)
 
     if job_ids:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -145,10 +145,7 @@ def clear_task_instances(
     :param activate_dag_runs: flag to check for active dag run
     :param dag: DAG object
     """
-    from sqlalchemy import and_, or_
-
     job_ids = []
-
     tr_filter = []
     for ti in tis:
         if ti.state == State.RUNNING:


### PR DESCRIPTION
Clearing large number of tasks takes a long time. Most of the time is spent at this line in `clear_task_instances` (more than 95% time). This slowness sometimes causes the webserver to timeout because the `web_server_worker_timeout` is hit.

```python
        # Clear all reschedules related to the ti to clear
        session.query(TR).filter(
            TR.dag_id == ti.dag_id,
            TR.task_id == ti.task_id,
            TR.execution_date == ti.execution_date,
            TR.try_number == ti.try_number,
        ).delete()
```

This line is very slow because it's deleting `TaskReschedule` rows in a for loop one by one. 

This PR simply changes this code to delete `TaskReschedule` in a single sql query with a bunch of `OR` conditions. It's effectively doing the same, but now it's much faster. Simple profiling shows that it's at least seven times faster when deleting thousands of `TaskReschedule`.