### PR TITLE
Rework client-side script for connection form.

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -121,7 +121,7 @@ $(document).ready(function () {
 
       if (config[connType].relabeling) {
         Object.keys(config[connType].relabeling).forEach(field => {
-          const label = document.querySelector("label[for='" + field + "']");
+          const label = document.querySelector(`label[for='${field}']`);
           label.dataset.origText = label.innerText;
           label.innerText = config[connType].relabeling[field];
         });

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -24,40 +24,124 @@ function decode(str) {
   return new DOMParser().parseFromString(str, "text/html").documentElement.textContent
 }
 
-$(document).ready(function () {
+/**
+ * Returns a map of connection type to its controls.
+ */
+function getConnTypesToControlsMap() {
+  const connTypesToControlsMap = new Map();
 
-  function connTypeChange(connectionType) {
-    $(".hide").removeClass("hide");
-    $.each($("[id^='extra__']"), function () {
-      $(this).parent().parent().addClass('hide')
+  const extraFormControls = Array.from(document.querySelectorAll("[id^='extra__'"));
+  extraFormControls.forEach(control => {
+    const connTypeEnd = control.id.indexOf('__', 'extra__'.length);
+    const connType = control.id.substring('extra__'.length, connTypeEnd);
+
+    const controls = connTypesToControlsMap.has(connType)
+      ? connTypesToControlsMap.get(connType)
+      : [];
+
+    controls.push(control.parentElement.parentElement);
+    connTypesToControlsMap.set(connType, controls);
+  });
+
+  return connTypesToControlsMap;
+}
+
+/**
+ * Returns the DOM element that contains the different controls.
+ */
+function getControlsContainer() {
+  return document.getElementById('conn_id')
+    .parentElement
+    .parentElement
+    .parentElement;
+}
+
+$(document).ready(function () {
+  const fieldBehavioursElem = document.getElementById('field_behaviours');
+  const config = JSON.parse(decode(fieldBehavioursElem.textContent));
+
+  // Save all DOM elements into a map on load.
+  const controlsContainer = getControlsContainer();
+  const connTypesToControlsMap = getConnTypesToControlsMap();
+
+  /**
+   * Changes the connection type.
+   * @param {string} connType The connection type to change to.
+   */
+  function changeConnType(connType) {
+    Array.from(connTypesToControlsMap.values()).forEach(controls => {
+      controls
+        .filter(control => control.parentElement === controlsContainer)
+        .forEach(control => controlsContainer.removeChild(control));
     });
-    $.each($("[id^='extra__" + connectionType + "__']"), function () {
-      $(this).parent().parent().removeClass('hide')
+
+    const controls = connTypesToControlsMap.get(connType) || [];
+    controls.forEach(control => controlsContainer.appendChild(control));
+
+    // Restore field behaviours.
+    restoreFieldBehaviours();
+
+    // Apply behaviours to fields.
+    applyFieldBehaviours(connType);
+  }
+
+  /**
+   * Restores the behaviour for all fields. Used to restore fields to a
+   * well-known state during the change of connection types.
+   */
+  function restoreFieldBehaviours() {
+    Array.from(document.querySelectorAll('label[data-origText]')).forEach(elem => {
+      elem.innerText = elem.dataset.origText;
+      delete elem.dataset.origText;
     });
-    $("label[orig_text]").each(function () {
-      $(this).text($(this).attr("orig_text"));
+
+    Array.from(document.querySelectorAll('.form-control')).forEach(elem => {
+      elem.placeholder = '';
+      elem.parentElement.parentElement.classList.remove('hide');
     });
-    $(".form-control").each(function(){$(this).attr('placeholder', '')});
-    let config = JSON.parse(decode($("#field_behaviours").text()))
-    if (config[connectionType] != undefined) {
-      $.each(config[connectionType].hidden_fields, function (i, field) {
-        $("#" + field).parent().parent().addClass('hide')
-      });
-      $.each(config[connectionType].relabeling, function (k, v) {
-        lbl = $("label[for='" + k + "']");
-        lbl.attr("orig_text", lbl.text());
-        $("label[for='" + k + "']").text(v);
-      });
-      $.each(config[connectionType].placeholders, function(k, v){
-        $("#" + k).attr('placeholder', v);
-      });
+  }
+
+  /**
+   * Applies special behaviour for fields. The behaviour is defined through
+   * config, passed by the server.
+   *
+   * @param {string} connType The connection type to apply.
+   */
+  function applyFieldBehaviours(connType) {
+    if (config[connType]) {
+      if (Array.isArray(config[connType].hidden_fields)) {
+        config[connType].hidden_fields.forEach(field => {
+          document.getElementById(field)
+            .parentElement
+            .parentElement
+            .classList
+            .add('hide');
+        });
+      }
+
+      if (config[connType].relabeling) {
+        Object.keys(config[connType].relabeling).forEach(field => {
+          const label = document.querySelector("label[for='" + field + "']");
+          label.dataset.origText = label.innerText;
+          label.innerText = config[connType].relabeling[field];
+        });
+      }
+
+      if (config[connType].placeholders) {
+        Object.keys(config[connType].placeholders).forEach(field => {
+          const placeholder = config[connType].placeholders[field];
+          document.getElementById(field).placeholder = placeholder;
+        });
+      }
     }
   }
 
-  var connectionType = $("#conn_type").val();
-  $("#conn_type").on('change', function (e) {
-    connectionType = $("#conn_type").val();
-    connTypeChange(connectionType);
+  const connTypeElem = document.getElementById('conn_type');
+  $(connTypeElem).on('change', (e) => {
+    connType = e.target.value;
+    changeConnType(connType);
   });
-  connTypeChange(connectionType);
+
+  // Initialize the form by setting a connection type.
+  changeConnType(connTypeElem.value);
 });


### PR DESCRIPTION
Before this, fields on the connection form were dynamically changed by adding and removing the "hide" CSS class. If a provider were to add a field that requires validation (e.g. InputRequired), or if a different field type was used (e.g. NumberField), the entire form would be unsaveable, even if the currently selected connection type had nothing to do with that provider.

This change takes a different approach; upon loading, the DOM elements for all extra fields are saved into a Map, then removed from the DOM tree. When another connection type is selected, these elements are restored into the DOM.

With this change, we still can't use `wtforms.validators.InputRequired` because of server-side validation, however, a provider can subclass `InputRequired` and conditionally validate based on connection type. Here's an example:

```python
class InputRequired(wtforms.validators.InputRequired):
    field_flags = ('required', )

    def __call__(self, form, field):
        conn_type = form.conn_type.data
        if conn_type == MyHook.conn_type:
            super().__call__(form, field)
```

closes: #13985 

Note: I wasn't sure about the conventions for JavaScript files here; some lines had semicolons, some didn't. In my change, I just made sure that every line ended with a semicolon, but I didn't want to change the other lines to avoid creating too much noise.

Another thing I'm unsure about is Airflow's browser support policy. This change does away with a lot of jQuery use, instead opting for standard DOM APIs. In particular, `Array.from` is used, which means that this won't be supported by any version of Internet Explorer. Microsoft themselves are EOLing IE by 17th August 2021 for their own products, so not sure how much of an issue this is.