### PR TITLE
Add return to execute method

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -490,7 +490,7 @@ class PythonVirtualenvOperator(PythonOperator):
 
     def execute(self, context: Dict):
         serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
-        super().execute(context=serializable_context)
+        return super().execute(context=serializable_context)
 
     def execute_callable(self):
         with TemporaryDirectory(prefix='venv') as tmp_dir:


### PR DESCRIPTION
Missing return statement in PythonVirtualenvOperator's execute method. Discovered when upgrading some of our custom operators from 1.10.14 to 2.0.0

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
