### PR TITLE
Skip SLA check only if SLA is None

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -419,8 +419,11 @@ class DagFileProcessor(LoggingMixin):
         ts = timezone.utcnow()
         for ti in max_tis:
             task = dag.get_task(ti.task_id)
-            if not task.sla:
-                continue
+            if task.sla and not isinstance(task.sla, timedelta):
+                raise TypeError(
+                    f"SLA is expected to be timedelta object, got "
+                    f"{type(task.sla)} in {task.dag_id}:{task.task_id}"
+                )
 
             dttm = dag.following_schedule(ti.execution_date)
             while dttm < timezone.utcnow():

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -419,7 +419,7 @@ class DagFileProcessor(LoggingMixin):
         ts = timezone.utcnow()
         for ti in max_tis:
             task = dag.get_task(ti.task_id)
-            if not isinstance(task.sla, timedelta):
+            if not task.sla:
                 continue
 
             dttm = dag.following_schedule(ti.execution_date)


### PR DESCRIPTION
Users have to provide SLA as timedelta. If not provided it should
be a default None value.

This change will result in run time errors if other type than
timedelta is passed as SLA. With this change spotting #14056
would be easier.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
