### PR TITLE
Tutorial docs: fix bash_command example to avoid Jinja template not found

### DIFF
--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -159,7 +159,7 @@ parameters and/or objects to your templates. Please take the time
 to understand how the parameter ``my_param`` makes it through to the template.
 
 Files can also be passed to the ``bash_command`` argument, like
-``bash_command='templated_command.sh'``, where the file location is relative to
+``bash_command='templated_command.sh '``, where the file location is relative to
 the directory containing the pipeline file (``tutorial.py`` in this case). This
 may be desirable for many reasons, like separating your script's logic and
 pipeline code, allowing for proper code highlighting in files composed in


### PR DESCRIPTION
closes: #8999

The tutorial explains how to use Jinja templating with BashOperator.
Executing the command as in the tutorial will raise Jinja template not found error.
The reason for this explained at length in the troubleshooting section of [BashOperator](https://airflow.apache.org/docs/apache-airflow/stable/howto/operator/bash.html#jinja-template-not-found).

I chose not to add explanation why the space is needed because this is a tutorial to templating with Jinja and not to BashOperator. Users who go over it might not use bash again so there is no need to trouble them with why this space is required.