### PR TITLE
Fix Kerberos network creation on older docker-compose

### DIFF
--- a/scripts/ci/docker-compose/integration-kerberos.yml
+++ b/scripts/ci/docker-compose/integration-kerberos.yml
@@ -81,7 +81,6 @@ networks:
   example.com:
     name: example.com
     driver: bridge
-    attachable: true
     ipam:
       config:
         - subnet: 10.5.0.0/16

--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -53,12 +53,6 @@ function run_airflow_testing_in_docker() {
         echo
         echo "Starting try number ${try_num}"
         echo
-        if [[ " ${ENABLED_INTEGRATIONS} " =~ " kerberos " ]]; then
-            echo "Creating Kerberos network"
-            kerberos::create_kerberos_network
-        else
-            echo "Skip creating kerberos network"
-        fi
         docker-compose --log-level INFO \
           -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
           -f "${SCRIPTS_CI_DIR}/docker-compose/backend-${BACKEND}.yml" \
@@ -66,10 +60,6 @@ function run_airflow_testing_in_docker() {
           "${DOCKER_COMPOSE_LOCAL[@]}" \
              run airflow "${@}"
         exit_code=$?
-        if [[ " ${INTEGRATIONS[*]} " =~ " kerberos " ]]; then
-            echo "Delete kerberos network"
-            kerberos::delete_kerberos_network
-        fi
         if [[ ${exit_code} == "254" && ${try_num} != "5" ]]; then
             echo
             echo "Failed try num ${try_num}. Sleeping 5 seconds for retry"


### PR DESCRIPTION
This was failing on self-hosted runners with an error `networks.example.com value Additional properties are not allowed ('attachable' was unexpected)`. A docker-compose upgrade would fix that, but acording to 2.x spec this is not a valid property anyway.

This is a tidy up to #13999 -- we deleted the bash functions but left the usage (but were in a `set +e` block so it wasn't fatal)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).