### PR TITLE
Fix rebuilding images in breeze

### DIFF
--- a/scripts/docker/install_mysql.sh
+++ b/scripts/docker/install_mysql.sh
@@ -41,6 +41,8 @@ install_mysql_client() {
     local key="A4A9406876FCBD3C456770C88C718D3B5072E1F5"
     readonly key
 
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+
     GNUPGHOME="$(mktemp -d)"
     export GNUPGHOME
     set +e


### PR DESCRIPTION
I had problems rebuilding images.

Downloading yarn key helped.

https://askubuntu.com/questions/1306111/why-yarn-key-update-failes-all-the-time-gpg-error-https-dl-yarnpkg-com-debia
