### PR TITLE
Fix GoogleDisplayVideo360CreateSDFDownloadTaskOperator does not push necessary xcom

### DIFF
--- a/airflow/providers/google/marketing_platform/hooks/display_video.py
+++ b/airflow/providers/google/marketing_platform/hooks/display_video.py
@@ -228,7 +228,7 @@ class GoogleDisplayVideo360Hook(GoogleBaseHook):
         result = (
             self.get_conn_to_display_video()  # pylint: disable=no-member
             .sdfdownloadtasks()
-            .operation()
+            .operations()
             .get(name=operation_name)
             .execute(num_retries=self.num_retries)
         )

--- a/airflow/providers/google/marketing_platform/operators/display_video.py
+++ b/airflow/providers/google/marketing_platform/operators/display_video.py
@@ -635,6 +635,10 @@ class GoogleDisplayVideo360CreateSDFDownloadTaskOperator(BaseOperator):
         self.log.info("Creating operation for SDF download task...")
         operation = hook.create_sdf_download_operation(body_request=self.body_request)
 
+        name = operation["name"]
+        self.xcom_push(context, key="name", value=name)
+        self.log.info("Created SDF operation with name: %s", name)
+
         return operation
 
 

--- a/tests/providers/google/marketing_platform/hooks/test_display_video.py
+++ b/tests/providers/google/marketing_platform/hooks/test_display_video.py
@@ -314,7 +314,7 @@ class TestGoogleDisplayVideo360Hook(TestCase):
         # fmt: off
         get_conn_to_display_video.return_value. \
             sdfdownloadtasks.return_value. \
-            operation.return_value. \
+            operations.return_value. \
             get.assert_called_once_with(name=operation_name)
         # fmt: on
 
@@ -328,7 +328,7 @@ class TestGoogleDisplayVideo360Hook(TestCase):
         # fmt: off
         get_conn_to_display_video.return_value. \
             sdfdownloadtasks.return_value. \
-            operation.return_value. \
+            operations.return_value. \
             get.assert_called_once()
         # fmt: on
 
@@ -340,7 +340,7 @@ class TestGoogleDisplayVideo360Hook(TestCase):
         operation_name = "operation"
         response = "reposonse"
 
-        get_conn_to_display_video.return_value.sdfdownloadtasks.return_value.operation.return_value.get = (
+        get_conn_to_display_video.return_value.sdfdownloadtasks.return_value.operations.return_value.get = (
             response
         )
 


### PR DESCRIPTION
The GoogleDisplayVideo360CreateSDFDownloadTaskOperator does not create an xcom that is necessary in the SDF workflow. The "name" xcom is needed for the next step in the process, GoogleDisplayVideo360SDFtoGCSOperator, to work correctly. This patch adds that xcom so it is available to the next step in the workflow.

Fixes: https://github.com/apache/airflow/issues/14073