### PR TITLE
closes #14045 Fixes missing reference in docs.

### DIFF
--- a/docs/apache-airflow/stable-rest-api-ref.rst
+++ b/docs/apache-airflow/stable-rest-api-ref.rst
@@ -20,4 +20,4 @@ REST API Reference
 ==================
 
 It's a stub file. It will be converted automatically during the build process
-to the valid documentation by the Sphinx plugin. See: /docs/exts/sphinx_redoc.py
+to the valid documentation by the Sphinx plugin. See: /docs/conf.py


### PR DESCRIPTION
closes: #14045

Small changed a reference to a file that did not exist anymore in the docs.
