### PR TITLE
Refactor redundant doc url logic to use utility

### DIFF
--- a/airflow/api_connexion/exceptions.py
+++ b/airflow/api_connexion/exceptions.py
@@ -19,15 +19,9 @@ from typing import Dict, Optional
 import werkzeug
 from connexion import FlaskApi, ProblemException, problem
 
-from airflow import version
+from airflow.utils.docs import get_docs_url
 
-if any(suffix in version.version for suffix in ['dev', 'a', 'b']):
-    doc_link = (
-        "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest"
-        "/stable-rest-api-ref.html"
-    )
-else:
-    doc_link = f'https://airflow.apache.org/docs/{version.version}/stable-rest-api-ref.html'
+doc_link = get_docs_url("stable-rest-api-ref.html")
 
 EXCEPTIONS_LINK_MAP = {
     400: f"{doc_link}#section/Errors/BadRequest",

--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -22,7 +22,7 @@ from airflow import version
 
 def get_docs_url(page: Optional[str] = None) -> str:
     """Prepare link to Airflow documentation."""
-    if "dev" in version.version:
+    if any(suffix in version.version for suffix in ['dev', 'a', 'b']):
         result = (
             "http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/"
         )


### PR DESCRIPTION
The API exceptions had redundant logic to generate versioned documentation URLs instead of using the `get_docs_url` utility method. I also tweaked the condition to also capture `a`/`b` (alpha/beta) suffixes.