### PR TITLE
Allow users of the KPO to template environment variables

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -275,7 +275,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
 
     def add_template_fields_to_env_vars(self, env_vars):
         """
-        Adds the field `templated_fields` to V1EnvVar so that Airflow can apply jinja templating
+        Adds the field ``templated_fields`` to ``V1EnvVar`` so that Airflow can apply jinja templating
         to both the name and value of an environment variable.
 
         @param env_vars:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -228,6 +228,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.env_vars = convert_env_vars(env_vars) if env_vars else []
         if pod_runtime_info_envs:
             self.env_vars.extend([convert_pod_runtime_info_env(p) for p in pod_runtime_info_envs])
+        env_vars = self.add_template_fields_to_env_vars(env_vars)
+        self.env_vars = env_vars
         self.env_from = env_from or []
         if configmaps:
             self.env_from.extend([convert_configmap(c) for c in configmaps])
@@ -270,6 +272,22 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.termination_grace_period = termination_grace_period
         self.client: CoreV1Api = None
         self.pod: k8s.V1Pod = None
+
+    def add_template_fields_to_env_vars(self, env_vars):
+        """
+        Adds the field `templated_fields` to V1EnvVar so that Airflow can apply jinja templating
+        to both the name and value of an environment variable.
+
+        Addresses https://github.com/apache/airflow/issues/13348
+        @param env_vars:
+        @return:
+        """
+        env_vars = []
+        for env_var in self.env_vars:
+            if not hasattr(env_var, 'template_fields'):
+                env_var.template_fields = ('value', 'name')
+                env_vars.append(env_var)
+        return env_vars
 
     @staticmethod
     def create_labels_for_pod(context) -> dict:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -278,7 +278,6 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         Adds the field `templated_fields` to V1EnvVar so that Airflow can apply jinja templating
         to both the name and value of an environment variable.
 
-        Addresses https://github.com/apache/airflow/issues/13348
         @param env_vars:
         @return:
         """

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -278,8 +278,8 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         Adds the field ``templated_fields`` to ``V1EnvVar`` so that Airflow can apply jinja templating
         to both the name and value of an environment variable.
 
-        @param env_vars:
-        @return:
+        @param env_vars: a list of k8s.V1EnvVar objects
+        @return: A list of k8s.V1EnvVar objects but with the "template_fields" member populated
         """
         env_vars = []
         for env_var in self.env_vars:

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -72,6 +72,28 @@ class TestKubernetesPodOperator(unittest.TestCase):
             config_file=file_path,
         )
 
+    def test_env_vars(self):
+        # WHEN
+        env_vars = [k8s.V1EnvVar(name="{{ bar }}", value='{{ foo }}')]
+        from tests.models import DEFAULT_DATE
+
+        with DAG("test-dag", start_date=DEFAULT_DATE):
+            k = KubernetesPodOperator(
+                namespace='default',
+                image="ubuntu:16.04",
+                cmds=["bash", "-cx"],
+                arguments=["echo 10"],
+                env_vars=env_vars,
+                labels={"foo": "bar"},
+                name="test",
+                task_id="task",
+                in_cluster=False,
+                do_xcom_push=False,
+            )
+        k.render_template_fields(context={"foo": "footemplated", "bar": "bartemplated"})
+        assert k.env_vars[0].value == "footemplated"
+        assert k.env_vars[0].name == "bartemplated"
+
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
     @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")


### PR DESCRIPTION
Addresses https://github.com/apache/airflow/issues/13348

Adds a "templated_fields" variable to k8s.V1EnvVar so jinja templating
will work when passed by users``

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
