### PR TITLE
Speed up building provider packages by ~4 times

### DIFF
--- a/scripts/in_container/run_prepare_provider_documentation.sh
+++ b/scripts/in_container/run_prepare_provider_documentation.sh
@@ -35,6 +35,9 @@ function run_prepare_documentation() {
     local skipped_documentation=()
     local error_documentation=()
 
+    # Delete the remote, so that we fetch it and update it once, not once per package we build!
+    git remote rm apache-https-for-providers 2>/dev/null || :
+
     local provider_package
     for provider_package in "${PROVIDER_PACKAGES[@]}"
     do
@@ -43,6 +46,7 @@ function run_prepare_documentation() {
         # There is a separate group created in logs for each provider package
         python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
             --version-suffix "${TARGET_VERSION_SUFFIX}" \
+            --no-git-update \
             "${OPTIONAL_BACKPORT_FLAG[@]}" \
             "${OPTIONAL_RELEASE_VERSION_ARGUMENT[@]}" \
             update-package-documentation \


### PR DESCRIPTION
These changes speeds up the build packages step from about 7mins30 to
2min10 on my laptop, and the generate documentation from 3mins to
1min30. On CI it will be even quicker

The changes are:

- Don't do a git fetch for _every_ provider. Once is enough.
- Don't shell out to black, but use the Python API. (Spawning a python
  process is not free)
- As a tidy up, don't print the info about version suffix once per
  package, just once is enough as it doesn't change from package to
  package

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
