### PR TITLE
Ensure executors end method is called

### DIFF
--- a/airflow/executors/local_executor.py
+++ b/airflow/executors/local_executor.py
@@ -383,6 +383,10 @@ class LocalExecutor(BaseExecutor):
             raise AirflowException(NOT_STARTED_MESSAGE)
         if not self.manager:
             raise AirflowException(NOT_STARTED_MESSAGE)
+        self.log.info(
+            "Shutting down LocalExecutor"
+            "; waiting for running tasks to finish.  Signal again if you don't want to wait."
+        )
         self.impl.end()
         self.manager.shutdown()
 


### PR DESCRIPTION
closes: #11982 

SchedulerJob doesn't actually call the executors `end` method when the scheduler receives SIGINT/SIGTERM or when there is an exception (e.g. database connectivity issues).

If you are using KuberenetesExecutor, this results in the scheduler not actually exiting.

In contrast, if you are using LocalExecutor, this results in the scheduler not dealing with the tasks it is currently running. By ensuring the executors `end` method is called, LocalExecutor will now wait around until the tasks complete or a second SIGINT/SIGTERM/exception. I believe we need to document that behavior change somewhere, I just haven't looked where yet.