### PR TITLE
fix running local task with --pickle

### DIFF
--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -34,7 +34,6 @@ class StandardTaskRunner(BaseTaskRunner):
     def __init__(self, local_task_job):
         super().__init__(local_task_job)
         self._rc = None
-        self.dag = local_task_job.task_instance.task.dag
 
     def start(self):
         if CAN_FORK and not self.run_as_user:
@@ -82,9 +81,10 @@ class StandardTaskRunner(BaseTaskRunner):
             setproctitle(proc_title.format(args))
 
             try:
-                args.func(args, dag=self.dag)
+                args.func(args)
                 return_code = 0
-            except Exception:  # pylint: disable=broad-except
+            except Exception as err:  # pylint: disable=broad-except
+                self.log.exception("Error while running task: %s", err)
                 return_code = 1
             finally:
                 # Explicitly flush any pending exception to Sentry if enabled


### PR DESCRIPTION
Running tasks with command `airflow tasks run <dag_id> <task_id> <start_date> --local --pickle <pickle_id>`
fails because in `airflow/airflow/cli/commands/task_command.py::task_run` method the `dag` is not `None` so error is thrown.