### PR TITLE
Add log message when moving objects out of gcs

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_gcs.py
@@ -386,4 +386,5 @@ class GCSToGCSOperator(BaseOperator):
         hook.rewrite(self.source_bucket, source_object, self.destination_bucket, destination_object)
 
         if self.move_object:
+            self.log.info("Executing delete of gs://%s/%s", self.source_bucket, source_object)
             hook.delete(self.source_bucket, source_object)

--- a/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
+++ b/airflow/providers/google/suite/transfers/gcs_to_gdrive.py
@@ -168,4 +168,5 @@ class GCSToGoogleDriveOperator(BaseOperator):
             self.gdrive_hook.upload_file(local_location=filename, remote_location=destination_object)
 
         if self.move_object:
+            self.log.info("Executing delete of gs://%s/%s", self.source_bucket, source_object)
             self.gcs_hook.delete(self.source_bucket, source_object)


### PR DESCRIPTION
Add a log messages when moving an object out of gcs (deleting it after copying it) just like it's done here: https://github.com/apache/airflow/blob/8c5594b02ffbfc631ebc2366dbde6d8c4e56d550/airflow/providers/google/cloud/transfers/gcs_to_sftp.py#L209