### PR TITLE
Update Tree View date ticks

### DIFF
--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -146,7 +146,7 @@
     // JSON.parse is faster for large payloads than an object literal (because the JSON grammar is simpler!)
     var data = JSON.parse({{ data|tojson }});
     var barHeight = 20;
-    var axisHeight = 40;
+    var axisHeight = 50;
     var square_x = parseInt(500 * devicePixelRatio);
     var square_size = 10;
     var square_spacing = 2;
@@ -230,7 +230,7 @@
             return '';
           }
           var tickIndex = d === 1 ? num_square - 1 : Math.round(d * num_square);
-          return moment(base_node.instances[tickIndex].execution_date).format('MMM DD');
+          return moment(base_node.instances[tickIndex].execution_date).format('MMM DD, HH:mm');
         })
       )
       .selectAll("text")

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -225,7 +225,7 @@
         // show a tick every 5 instances
         .ticks(Math.floor(num_square / 5) || 1)
         .tickFormat((d, i) => {
-          if (!num_square || (d !== 1 && num_square < 3)) {
+          if (!num_square || (d > 0 && num_square < 3)) {
             // don't render ticks when there are no instances or when the ticks would overlap
             return '';
           }

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -207,11 +207,8 @@
         var base_node = nodes[1];
 
       var num_square = base_node.instances.length;
-      var extent = d3.extent(base_node.instances, function(d) {
-        return new Date(d.execution_date);
-      });
-      var xScale = d3.time.scale()
-      .domain(extent)
+
+      var xScale = d3.scale.linear()
       .range([
         square_size/2,
         (num_square * square_size) + ((num_square-1) * square_spacing) - (square_size/2)
@@ -225,7 +222,16 @@
         d3.svg.axis()
         .scale(xScale)
         .orient("top")
-        .ticks(2)
+        // show a tick every 5 instances
+        .ticks(Math.floor(num_square / 5) || 1)
+        .tickFormat((d, i) => {
+          if (!num_square || (d !== 1 && num_square < 3)) {
+            // don't render ticks when there are no instances or when the ticks would overlap
+            return '';
+          }
+          var tickIndex = d === 1 ? num_square - 1 : Math.round(d * num_square);
+          return moment(base_node.instances[tickIndex].execution_date).format('MMM DD');
+        })
       )
       .selectAll("text")
       .attr("transform", "rotate(-30)")


### PR DESCRIPTION
Updated the x-axis a DAG's `Tree View`. Switched from  x3's date to linear scale to add extra logic for adding/formatting ticks.

- Dates on the axis will better line up with the dates shown in each box's tooltip
- Prevent tick text overlapping
- Properly format all tick dates to prevent millisecond count showing up sometimes

Do let me know if the date should be formatted differently. Right now its formatted in the local timezone as opposed to UTC.

closes: #14046

------------------ BEFORE ------------------

<img width="649" alt="Screen Shot 2021-02-08 at 4 17 09 PM" src="https://user-images.githubusercontent.com/4600967/107289017-03366800-6a2a-11eb-9502-dc79795b46e7.png">

<img width="378" alt="Screen Shot 2021-02-08 at 4 17 13 PM" src="https://user-images.githubusercontent.com/4600967/107289006-fd408700-6a29-11eb-8fd6-040dbc6dda59.png">

------------------ AFTER ------------------

<img width="154" alt="Screen Shot 2021-02-08 at 4 19 55 PM" src="https://user-images.githubusercontent.com/4600967/107289032-09c4df80-6a2a-11eb-9c58-f70b606db8b3.png">

<img width="111" alt="Screen Shot 2021-02-08 at 4 20 04 PM" src="https://user-images.githubusercontent.com/4600967/107289062-15180b00-6a2a-11eb-9452-20deb1208eb8.png">

<img width="335" alt="Screen Shot 2021-02-08 at 4 17 42 PM" src="https://user-images.githubusercontent.com/4600967/107289070-18ab9200-6a2a-11eb-944c-06dbe6e0c817.png">

<img width="116" alt="Screen Shot 2021-02-08 at 4 18 23 PM" src="https://user-images.githubusercontent.com/4600967/107289095-2234fa00-6a2a-11eb-820a-e8d14ba3fea0.png">



