### PR TITLE
Add BigQueryUpdateTableOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1667,6 +1667,7 @@ class BigQueryUpdateTableOperator(BaseOperator):
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:BigQueryUpdateTableOperator`
+
     :param dataset_id: The id of dataset. Don't need to provide,
         if datasetId in table_reference.
     :param table_id: The id of table. Don't need to provide,

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1658,6 +1658,98 @@ class BigQueryPatchDatasetOperator(BaseOperator):
         )
 
 
+class BigQueryUpdateTableOperator(BaseOperator):
+    """
+    This operator is used to update table for your Project in BigQuery.
+    Use ``fields`` to specify which fields of table to update. If a field
+    is listed in ``fields`` and is ``None`` in table, it will be deleted.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:BigQueryUpdateTableOperator`
+    :param dataset_id: The id of dataset. Don't need to provide,
+        if datasetId in table_reference.
+    :param table_id: The id of table. Don't need to provide,
+        if tableId in table_reference.
+    :type table_id: str
+    :param table_resource: Dataset resource that will be provided with request body.
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource
+    :type table_resource: Dict[str, Any]
+    :param fields: The fields of ``table`` to change, spelled as the Table
+        properties (e.g. "friendly_name").
+    :type fields: List[str]
+    :param project_id: The name of the project where we want to create the table.
+        Don't need to provide, if projectId in table_reference.
+    :type project_id: str
+    :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
+    :type gcp_conn_id: str
+    :param delegate_to: The account to impersonate using domain-wide delegation of authority,
+        if any. For this to work, the service account making the request must have
+        domain-wide delegation enabled.
+    :type delegate_to: str
+    :param impersonation_chain: Optional service account to impersonate using short-term
+        credentials, or chained list of accounts required to get the access_token
+        of the last account in the list, which will be impersonated in the request.
+        If set as a string, the account must grant the originating account
+        the Service Account Token Creator IAM role.
+        If set as a sequence, the identities from the list must grant
+        Service Account Token Creator IAM role to the directly preceding identity, with first
+        account from the list granting this role to the originating account (templated).
+    :type impersonation_chain: Union[str, Sequence[str]]
+
+    :rtype: table
+        https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource
+    """
+
+    template_fields = (
+        'dataset_id',
+        'table_id',
+        'project_id',
+        'impersonation_chain',
+    )
+    template_fields_renderers = {"table_resource": "json"}
+    ui_color = BigQueryUIColors.TABLE.value
+
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        table_resource: Dict[str, Any],
+        fields: Optional[List[str]] = None,
+        dataset_id: Optional[str] = None,
+        table_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        gcp_conn_id: str = 'google_cloud_default',
+        delegate_to: Optional[str] = None,
+        impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        **kwargs,
+    ) -> None:
+        self.dataset_id = dataset_id
+        self.table_id = table_id
+        self.project_id = project_id
+        self.fields = fields
+        self.gcp_conn_id = gcp_conn_id
+        self.table_resource = table_resource
+        self.delegate_to = delegate_to
+        self.impersonation_chain = impersonation_chain
+        super().__init__(**kwargs)
+
+    def execute(self, context):
+        bq_hook = BigQueryHook(
+            gcp_conn_id=self.gcp_conn_id,
+            delegate_to=self.delegate_to,
+            impersonation_chain=self.impersonation_chain,
+        )
+
+        return bq_hook.update_table(
+            table_resource=self.table_resource,
+            fields=self.fields,
+            dataset_id=self.dataset_id,
+            table_id=self.table_id,
+            project_id=self.project_id,
+        )
+
+
 class BigQueryUpdateDatasetOperator(BaseOperator):
     """
     This operator is used to update dataset for your Project in BigQuery.
@@ -1675,7 +1767,7 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
     :type dataset_id: str
     :param dataset_resource: Dataset resource that will be provided with request body.
         https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets#resource
-    :type dataset_resource: dict
+    :type dataset_resource: Dict[str, Any]
     :param fields: The properties of dataset to change (e.g. "friendly_name").
     :type fields: Sequence[str]
     :param project_id: The name of the project where we want to create the dataset.
@@ -1713,7 +1805,7 @@ class BigQueryUpdateDatasetOperator(BaseOperator):
     def __init__(
         self,
         *,
-        dataset_resource: dict,
+        dataset_resource: Dict[str, Any],
         fields: Optional[List[str]] = None,
         dataset_id: Optional[str] = None,
         project_id: Optional[str] = None,

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -82,6 +82,23 @@ To retrieve the list of tables in a given dataset use
     :start-after: [START howto_operator_bigquery_get_dataset_tables]
     :end-before: [END howto_operator_bigquery_get_dataset_tables]
 
+.. _howto/operator:BigQueryUpdateTableOperator:
+
+Update table
+""""""""""""""
+
+To update a table in BigQuery you can use
+:class:`~airflow.providers.google.cloud.operators.bigquery.BigQueryUpdateTableOperator`.
+
+The update method replaces the entire Table resource, whereas the patch
+method only replaces fields that are provided in the submitted Table resource.
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_bigquery_operations.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_update_table]
+    :end-before: [END howto_operator_bigquery_update_table]
+
 .. _howto/operator:BigQueryPatchDatasetOperator:
 
 Patch dataset

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1282,6 +1282,7 @@ syspath
 systemd
 tableauserverclient
 tablefmt
+tableId
 tagKey
 tagValue
 tao

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -45,6 +45,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryIntervalCheckOperator,
     BigQueryPatchDatasetOperator,
     BigQueryUpdateDatasetOperator,
+    BigQueryUpdateTableOperator,
     BigQueryUpsertTableOperator,
     BigQueryValueCheckOperator,
 )
@@ -230,6 +231,27 @@ class TestBigQueryGetDatasetOperator(unittest.TestCase):
         operator.execute(None)
         mock_hook.return_value.get_dataset.assert_called_once_with(
             dataset_id=TEST_DATASET, project_id=TEST_GCP_PROJECT_ID
+        )
+
+
+class TestBigQueryUpdateTableOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.bigquery.BigQueryHook')
+    def test_execute(self, mock_hook):
+        table_resource = {"friendlyName": 'Test TB'}
+        operator = BigQueryUpdateTableOperator(
+            table_resource=table_resource,
+            task_id=TASK_ID,
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE_ID,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+
+        operator.execute(None)
+        mock_hook.return_value.update_table.assert_called_once_with(
+            table_resource=table_resource,
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE_ID,
+            project_id=TEST_GCP_PROJECT_ID,
         )
 
 

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -249,6 +249,7 @@ class TestBigQueryUpdateTableOperator(unittest.TestCase):
         operator.execute(None)
         mock_hook.return_value.update_table.assert_called_once_with(
             table_resource=table_resource,
+            fields=None,
             dataset_id=TEST_DATASET,
             table_id=TEST_TABLE_ID,
             project_id=TEST_GCP_PROJECT_ID,


### PR DESCRIPTION
`BigQueryUpdateDatasetOperator` exists, but `BigQueryUpdateTableOperator` does not exist.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
