### PR TITLE
Sync DB Migrations in Master with 2.0.1

### DIFF
--- a/airflow/migrations/versions/449b4072c2da_increase_size_of_connection_extra_field_.py
+++ b/airflow/migrations/versions/449b4072c2da_increase_size_of_connection_extra_field_.py
@@ -19,7 +19,7 @@
 """Increase size of connection.extra field to handle multiple RSA keys
 
 Revision ID: 449b4072c2da
-Revises: e959f08ac86c
+Revises: 82b7c48c147f
 Create Date: 2020-03-16 19:02:55.337710
 
 """
@@ -29,7 +29,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '449b4072c2da'
-down_revision = 'e959f08ac86c'
+down_revision = '82b7c48c147f'
 branch_labels = None
 depends_on = None
 

--- a/airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py
+++ b/airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py
@@ -19,7 +19,7 @@
 """Remove can_read permission on config resource for User and Viewer role
 
 Revision ID: 82b7c48c147f
-Revises: 449b4072c2da
+Revises: e959f08ac86c
 Create Date: 2021-02-04 12:45:58.138224
 
 """
@@ -29,7 +29,7 @@ from airflow.www.app import create_app
 
 # revision identifiers, used by Alembic.
 revision = '82b7c48c147f'
-down_revision = '449b4072c2da'
+down_revision = 'e959f08ac86c'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
`449b4072c2da_increase_size_of_connection_extra_field_.py` does not exist in 2.0.1

so we need to update `down_revision`

```
INFO  [alembic.runtime.migration] Running upgrade 2c6edca13270 -> 61ec73d9401f, Add description field to connection
INFO  [alembic.runtime.migration] Running upgrade 61ec73d9401f -> 64a7d6477aae, fix description field in connection to be text
INFO  [alembic.runtime.migration] Running upgrade 64a7d6477aae -> e959f08ac86c, Change field in DagCode to MEDIUMTEXT for MySql
INFO  [alembic.runtime.migration] Running upgrade e959f08ac86c -> 82b7c48c147f, Remove can_read permission on config resource for User and Viewer role
[2021-02-09 19:17:31,307] {migration.py:555} INFO - Running upgrade 82b7c48c147f -> 449b4072c2da, Increase size of connection.extra field to handle multiple RSA keys
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
