### PR TITLE
Option "privileged" in DockerOperator

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -121,6 +121,8 @@ class DockerOperator(BaseOperator):
     :param tty: Allocate pseudo-TTY to the container
         This needs to be set see logs of the Docker container.
     :type tty: bool
+    :param privileged: Give extended privileges to this container.
+    :type privileged: bool
     :param cap_add: Include container capabilities
     :type cap_add: list[str]
     """
@@ -164,6 +166,7 @@ class DockerOperator(BaseOperator):
         auto_remove: bool = False,
         shm_size: Optional[int] = None,
         tty: bool = False,
+        privileged: bool = False,
         cap_add: Optional[Iterable[str]] = None,
         extra_hosts: Optional[Dict[str, str]] = None,
         **kwargs,
@@ -198,6 +201,7 @@ class DockerOperator(BaseOperator):
         self.docker_conn_id = docker_conn_id
         self.shm_size = shm_size
         self.tty = tty
+        self.privileged = privileged
         self.cap_add = cap_add
         self.extra_hosts = extra_hosts
         if kwargs.get('xcom_push') is not None:
@@ -243,6 +247,7 @@ class DockerOperator(BaseOperator):
                     mem_limit=self.mem_limit,
                     cap_add=self.cap_add,
                     extra_hosts=self.extra_hosts,
+                    privileged=self.privileged,
                 ),
                 image=self.image,
                 user=self.user,

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -260,3 +260,27 @@ class TestDockerOperator(unittest.TestCase):
         assert 'host_config' in self.client_mock.create_container.call_args[1]
         assert 'extra_hosts' in self.client_mock.create_host_config.call_args[1]
         assert hosts_obj is self.client_mock.create_host_config.call_args[1]['extra_hosts']
+
+    def test_privileged_true(self):
+        operator = DockerOperator(task_id='test', image='test', privileged=True)
+        operator.execute(None)
+        self.client_mock.create_container.assert_called_once()
+        assert 'host_config' in self.client_mock.create_container.call_args[1]
+        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
+        assert True is self.client_mock.create_host_config.call_args[1]['privileged']
+
+    def test_privileged_false(self):
+        operator = DockerOperator(task_id='test', image='test', privileged=False)
+        operator.execute(None)
+        self.client_mock.create_container.assert_called_once()
+        assert 'host_config' in self.client_mock.create_container.call_args[1]
+        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
+        assert False is self.client_mock.create_host_config.call_args[1]['privileged']
+
+    def test_privileged_missing(self):
+        operator = DockerOperator(task_id='test', image='test')
+        operator.execute(None)
+        self.client_mock.create_container.assert_called_once()
+        assert 'host_config' in self.client_mock.create_container.call_args[1]
+        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
+        assert False is self.client_mock.create_host_config.call_args[1]['privileged']

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -100,6 +100,7 @@ class TestDockerOperator(unittest.TestCase):
             dns_search=None,
             cap_add=None,
             extra_hosts=None,
+            privileged=False,
         )
         self.tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
         self.client_mock.images.assert_called_once_with(name='ubuntu:latest')

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -262,26 +262,11 @@ class TestDockerOperator(unittest.TestCase):
         assert 'extra_hosts' in self.client_mock.create_host_config.call_args[1]
         assert hosts_obj is self.client_mock.create_host_config.call_args[1]['extra_hosts']
 
-    def test_privileged_true(self):
-        operator = DockerOperator(task_id='test', image='test', privileged=True)
+    def test_privileged(self):
+        privileged = mock.Mock()
+        operator = DockerOperator(task_id='test', image='test', privileged=privileged)
         operator.execute(None)
         self.client_mock.create_container.assert_called_once()
         assert 'host_config' in self.client_mock.create_container.call_args[1]
         assert 'privileged' in self.client_mock.create_host_config.call_args[1]
-        assert True is self.client_mock.create_host_config.call_args[1]['privileged']
-
-    def test_privileged_false(self):
-        operator = DockerOperator(task_id='test', image='test', privileged=False)
-        operator.execute(None)
-        self.client_mock.create_container.assert_called_once()
-        assert 'host_config' in self.client_mock.create_container.call_args[1]
-        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
-        assert False is self.client_mock.create_host_config.call_args[1]['privileged']
-
-    def test_privileged_missing(self):
-        operator = DockerOperator(task_id='test', image='test')
-        operator.execute(None)
-        self.client_mock.create_container.assert_called_once()
-        assert 'host_config' in self.client_mock.create_container.call_args[1]
-        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
-        assert False is self.client_mock.create_host_config.call_args[1]['privileged']
+        assert privileged is self.client_mock.create_host_config.call_args[1]['privileged']


### PR DESCRIPTION
Support for param "privileged" in DockerOperator. This option is useful when you need to give extended privileges to a container. It's already implemented in docker client method create_host_config() and we only need to offer the option in DockerOperator constructor and pass it to docker client. By default should be False.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
