### PR TITLE
Unable to trigger backfill or manual jobs with Kubernetes executor.

### DIFF
--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -785,6 +785,7 @@ class BackfillJob(BaseJob):
             pickle_id = pickle.id
 
         executor = self.executor
+        executor.job_id = "backfill"
         executor.start()
 
         ti_status.total_runs = len(run_dates)  # total dag runs in backfill

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1361,6 +1361,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             )
             return redirect(origin)
 
+        executor.job_id = "manual"
         executor.start()
         executor.queue_task_instance(
             ti,

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1533,4 +1533,4 @@ class TestBackfillJob(unittest.TestCase):
             run_backwards=True,
         )
         job.run()
-        assert executor.job_id != None
+        assert executor.job_id is not None

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1517,3 +1517,20 @@ class TestBackfillJob(unittest.TestCase):
         job.run()
         dr: DagRun = dag.get_last_dagrun()
         assert dr.creating_job_id == job.id
+
+    def test_backfill_has_job_id(self):
+        """Make sure that backfill jobs are assigned job_ids."""
+        dag = self.dagbag.get_dag("test_start_date_scheduling")
+        dag.clear()
+
+        executor = MockExecutor(parallelism=16)
+
+        job = BackfillJob(
+            executor=executor,
+            dag=dag,
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            run_backwards=True,
+        )
+        job.run()
+        assert executor.job_id != None

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2681,7 +2681,6 @@ class TestRenderedView(TestBase):
 
 
 class TestTriggerDag(TestBase):
-    EXAMPLE_DAG_DEFAULT_DATE = dates.days_ago(2)
 
     def setUp(self):
         super().setUp()
@@ -2826,26 +2825,6 @@ class TestTriggerDag(TestBase):
         resp = self.client.get(url, follow_redirects=True)
         response_data = resp.data.decode()
         assert "Access is Denied" in response_data
-
-    @mock.patch('airflow.executors.executor_loader.ExecutorLoader.get_default_executor')
-    def test_run_executor_has_job_id(self, get_default_executor_function):
-        """Makes sure that dags triggered from the UI are assigned a job_id"""
-        executor = CeleryExecutor()
-        executor.heartbeat = lambda: True
-        get_default_executor_function.return_value = executor
-
-        task_id = 'runme_0'
-
-        form = dict(
-            task_id=task_id,
-            dag_id="example_bash_operator",
-            ignore_all_deps="false",
-            ignore_ti_state="false",
-            execution_date=self.EXAMPLE_DAG_DEFAULT_DATE,
-            origin='/home',
-        )
-        self.client.post('run', data=form, follow_redirects=True)
-        assert executor.job_id is not None
 
 
 class TestExtraLinks(TestBase):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2844,8 +2844,8 @@ class TestTriggerDag(TestBase):
             execution_date=self.EXAMPLE_DAG_DEFAULT_DATE,
             origin='/home',
         )
-        resp = self.client.post('run', data=form, follow_redirects=True)
-        assert executor.job_id != None
+        self.client.post('run', data=form, follow_redirects=True)
+        assert executor.job_id is not None
 
 
 class TestExtraLinks(TestBase):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2681,7 +2681,6 @@ class TestRenderedView(TestBase):
 
 
 class TestTriggerDag(TestBase):
-
     def setUp(self):
         super().setUp()
         models.DagBag().get_dag("example_bash_operator").sync_to_db(session=self.session)

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2681,6 +2681,8 @@ class TestRenderedView(TestBase):
 
 
 class TestTriggerDag(TestBase):
+    EXAMPLE_DAG_DEFAULT_DATE = dates.days_ago(2)
+
     def setUp(self):
         super().setUp()
         models.DagBag().get_dag("example_bash_operator").sync_to_db(session=self.session)
@@ -2825,6 +2827,25 @@ class TestTriggerDag(TestBase):
         response_data = resp.data.decode()
         assert "Access is Denied" in response_data
 
+    @mock.patch('airflow.executors.executor_loader.ExecutorLoader.get_default_executor')
+    def test_run_executor_has_job_id(self, get_default_executor_function):
+        """Makes sure that dags triggered from the UI are assigned a job_id"""
+        executor = CeleryExecutor()
+        executor.heartbeat = lambda: True
+        get_default_executor_function.return_value = executor
+
+        task_id = 'runme_0'
+
+        form = dict(
+            task_id=task_id,
+            dag_id="example_bash_operator",
+            ignore_all_deps="false",
+            ignore_ti_state="false",
+            execution_date=self.EXAMPLE_DAG_DEFAULT_DATE,
+            origin='/home',
+        )
+        resp = self.client.post('run', data=form, follow_redirects=True)
+        assert executor.job_id !=None
 
 class TestExtraLinks(TestBase):
     def setUp(self):

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2847,6 +2847,7 @@ class TestTriggerDag(TestBase):
         resp = self.client.post('run', data=form, follow_redirects=True)
         assert executor.job_id != None
 
+
 class TestExtraLinks(TestBase):
     def setUp(self):
         from tests.test_utils.mock_operators import Dummy2TestOperator, Dummy3TestOperator

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2845,7 +2845,7 @@ class TestTriggerDag(TestBase):
             origin='/home',
         )
         resp = self.client.post('run', data=form, follow_redirects=True)
-        assert executor.job_id !=None
+        assert executor.job_id != None
 
 class TestExtraLinks(TestBase):
     def setUp(self):


### PR DESCRIPTION
related: #13805

This is to address issue #13805 where when using the Kubernetes executor backfill jobs or jobs triggered from the UI will produce this error:

```
[2021-01-27 06:35:50,376] {kubernetes_executor.py:491} INFO - Start Kubernetes executor
Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/__main__.py", line 40, in main
    args.func(args)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/utils/cli.py", line 89, in wrapper
    return f(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/cli/commands/dag_command.py", line 116, in dag_backfill
    run_backwards=args.run_backwards,
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/models/dag.py", line 1701, in run
    job.run()
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/jobs/base_job.py", line 237, in run
    self._execute()
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/utils/session.py", line 65, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/jobs/backfill_job.py", line 788, in _execute
    executor.start()
  File "/home/airflow/.local/lib/python3.7/site-packages/airflow/executors/kubernetes_executor.py", line 493, in start
    raise AirflowException("Could not get scheduler_job_id")
airflow.exceptions.AirflowException: Could not get scheduler_job_id
```

The fix is to simply add a hardcoded executor `job_id` in `airflow/jobs/backfill_job.py` and `airflow/www/views.py`.

The changes still need tests, but I figured that this PR would be a good place to discuss where those tests should live (I'm not familiar with the testing landscape yet).
