### PR TITLE
Use apache.spark provider without kubernetes

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -30,7 +30,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 try:
     from airflow.kubernetes import kube_client
-except ImportError:
+except (ImportError, NameError):
     pass
 
 


### PR DESCRIPTION
Steps to reproduce the problem:
1. `pip install "apache-airflow[apache.spark]"`
2. Run the following:
```
>>> from airflow.providers.apache.spark.hooks.spark_submit import SparkSubmitHook
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/khroliz/.local/share/virtualenvs/airflow_2_0_1_spark-2XiasV-V/lib/python3.8/site-packages/airflow/providers/apache/spark/hooks/spark_submit.py", line 32, in <module>
    from airflow.kubernetes import kube_client
  File "/Users/khroliz/.local/share/virtualenvs/airflow_2_0_1_spark-2XiasV-V/lib/python3.8/site-packages/airflow/kubernetes/kube_client.py", line 101, in <module>
    ) -> client.CoreV1Api:
NameError: name 'client' is not defined
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
