### PR TITLE
Updates example/docs related to overriding the pod_template_file to m…

### DIFF
--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -110,7 +110,7 @@ try:
             task_id="task_with_template",
             python_callable=print_stuff,
             executor_config={
-                "pod_template_file": "/usr/local/airflow/pod_templates/basic_template.yaml",
+                "pod_template_override": "/usr/local/airflow/pod_templates/basic_template.yaml",
                 "pod_override": k8s.V1Pod(metadata=k8s.V1ObjectMeta(labels={"release": "stable"})),
             },
         )

--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -124,8 +124,9 @@ name ``base`` and a second container containing your desired sidecar.
     :start-after: [START task_with_sidecar]
     :end-before: [END task_with_sidecar]
 
-You can also create custom ``pod_template_file`` on a per-task basis so that you can recycle the same base values between multiple tasks.
-This will replace the default ``pod_template_file`` named in the airflow.cfg and then override that template using the ``pod_override_spec``.
+You can also create custom ``pod_template_file`` on a per-task basis so that you can recycle the same base values between multiple tasks by
+setting the ``pod_template_override`` option. This will replace the default ``pod_template_file`` named in the airflow.cfg and then override
+that template using the ``pod_override_spec``.
 
 Here is an example of a task with both features:
 


### PR DESCRIPTION
When the option was originally [added](https://github.com/apache/airflow/pull/11784) to allow for users to override the `pod_template_file` on a per-task basis via the `executor_config`, there were never docs added that mentioned the [proper](https://github.com/astronomer/airflow/blob/master/airflow/executors/kubernetes_executor.py#L495) way to override the `pod_template_file`. This PR updates the example to now include a note to use `pod_template_override` as mentions the need for setting it in the documentation. 