### PR TITLE
Fix missing region in Glue connector

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -74,7 +74,7 @@ class AwsGlueJobHook(AwsBaseHook):
         self.role_name = iam_role_name
         self.s3_glue_logs = 'logs/glue-logs/'
         kwargs['client_type'] = 'glue'
-        super().__init__(*args, **kwargs)
+        super().__init__(region_name=region_name, *args, **kwargs)
 
     def list_jobs(self) -> List:
         """:return: Lists of Jobs"""


### PR DESCRIPTION
The super class  needs a region in order to create a boto3 session.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
