### PR TITLE
Fix the AzureContainerInstanceOp _monitor_logging method to sleep properly

### DIFF
--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -297,7 +297,7 @@ class AzureContainerInstancesOperator(BaseOperator):
             except Exception:  # pylint: disable=broad-except
                 self.log.exception("Could not delete container group")
 
-        def _monitor_logging(self, resource_group: str, name: str) -> int:
+    def _monitor_logging(self, resource_group: str, name: str) -> int:
         last_state = None
         last_message_logged = None
         last_line_logged = None

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -341,9 +341,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                         )
 
                 if state == "Terminated":
-                    self.log.error(
-                        "Container exited with detail_status %s", detail_status
-                    )
+                    self.log.error("Container exited with detail_status %s", detail_status)
                     return exit_code
 
                 if state == "Failed":
@@ -353,7 +351,7 @@ class AzureContainerInstancesOperator(BaseOperator):
             except AirflowTaskTimeout:
                 raise
             except CloudError as err:
-                if "ResourceNotFound" in str(err):
+                if 'ResourceNotFound' in str(err):
                     self.log.warning(
                         "ResourceNotFound, container is probably removed "
                         "by another process "
@@ -362,7 +360,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                     return 1
                 else:
                     self.log.exception("Exception while getting container groups")
-            except Exception: # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.log.exception("Exception while getting container groups")
 
             sleep(5)

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -360,7 +360,7 @@ class AzureContainerInstancesOperator(BaseOperator):
             except Exception:  # pylint: disable=broad-except
                 self.log.exception("Exception while getting container groups")
 
-        sleep(1)
+            sleep(1)
 
     def _log_last(self, logs: Optional[list], last_line_logged: Any) -> Optional[Any]:
         if logs:

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -302,6 +302,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         last_message_logged = None
         last_line_logged = None
 
+        # pylint: disable=too-many-nested-blocks
         while True:
             try:
                 cg_state = self._ci_hook.get_state(resource_group, name)
@@ -361,7 +362,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                     return 1
                 else:
                     self.log.exception("Exception while getting container groups")
-            except Exception:
+            except Exception: # pylint: disable=broad-except
                 self.log.exception("Exception while getting container groups")
 
             sleep(5)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When running the AzureContainerInstancesOperator in our production instance we noticed very high CPU usage and lots of issues related to getting the state of the container. This would lead to jobs being spun up and completing but Airflow thinking they failed because it timed out trying to get the logs/exit status. Upon further inspection it looked like it was coming from this function, which we confirmed with the fixes in this PR that we now use in our own environment. CPU Usage has dropped dramatically and we're no longer getting errors around the status of the container.

The main fix is just simply moving the sleep to the correct scope and increasing it slightly, the other "just to be extra safe" fix is to check that the event stream is not None before trying to iterate over it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
