### PR TITLE
Restructure COMMITTERS.rst

### DIFF
--- a/COMMITTERS.rst
+++ b/COMMITTERS.rst
@@ -24,21 +24,81 @@ This document assumes that you know how Airflow's community work, but you would 
 
 Before reading this document, you should be familiar with `Contributor's guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__.
 
-Becoming a Committer
---------------------
+Guidelines to become an Airflow Committer
+------------------------------------------
 
-There is no strict protocol for becoming a committer.
-Candidates for new committers are typically people that are active contributors and community members.
+Committers are community members who have write access to the project’s
+repositories, i.e., they can modify the code, documentation, and website by themselves and also
+accept other contributions. There is no strict protocol for becoming a committer. Candidates for new
+committers are typically people that are active contributors and community members.
 
-The key aspects of a committer are:
+Some people might be active in several of those areas and while they might have not enough 'achievements' in any
+single one of those, their combined contributions in several areas all count.
 
-* Consistent contributions over the past 6 months
-* Understanding of Airflow Core or has displayed a holistic understanding of a particular part and made
-  contributions towards a more strategic goal
-* Understanding of contributor/committer guidelines: `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
-* Quality of the commits
-* Visibility in community discussions (dev mailing list, Slack and GitHub)
-* Testing Release Candidates
+As a community, we appreciate contributions to the Airflow codebase, but we also place equal value
+on those who help Airflow by improving the community in some way. It is entirely possible to become
+a committer (and eventually a PMC member) without ever having to change a single line of code.
+
+
+Prerequisites
+^^^^^^^^^^^^^^
+
+General prerequisites that we look for in all candidates:
+
+1.  Consistent contribution over last few months
+2.  Visibility on discussions on the dev mailing list, Slack channels or Github issues/discussions
+3.  Contributions to community health and project's sustainability for the long-term
+4.  Understands contributor/committer guidelines:
+    `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
+
+
+Code contribution
+^^^^^^^^^^^^^^^^^^
+
+1.  Makes high-quality commits (especially commit messages), and assess the impact of the changes, including
+    upgrade paths or deprecation policies
+2.  Testing Release Candidates to help the release cycle
+3.  Proposed and led to completion Airflow Improvement Proposal(s)
+4.  Demonstrates an understanding of one of the following areas or has displayed a holistic understanding
+    of a particular part and made contributions towards a more strategic goal
+
+    - Airflow Core
+    - API
+    - Docker Image
+    - Helm Chart
+    - Dev Tools (Breeze / CI)
+    - Certain Providers
+
+5.  Has made a significant improvement or added an integration with services/technologies important to the Airflow
+    Ecosystem
+
+Community contributions
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+1.  Was instrumental in triaging issues
+2.  Improved documentation of Airflow in significant way
+3.  Lead change and improvements introduction in the “community” processes and tools
+4.  Actively spreads the word about Airflow, for example organising Airflow summit, workshops for
+    community members, giving and recording talks, writing blogs
+5.  Reporting bugs with detailed reproduction steps
+
+
+Committer Responsibilities
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Committers are more than contributors. While it's important for committers to maintain standing by
+committing code, their key role is to build and foster a healthy and active community.
+This means that committers should:
+
+* Review PRs in a timely and reliable fashion
+* They should also help to actively whittle down the PR backlog
+* Answer questions (i.e. on the dev list, in PRs, in GitHub Issues, slack, etc...)
+* Take on core changes/bugs/feature requests
+* Some changes are important enough that a committer needs to ensure it gets done. This is especially
+  the case if no one from the community is taking it on.
+* Improve processes and tooling
+* Refactoring code
+
 
 Guidelines for promoting Committers to Airflow PMC
 ---------------------------------------------------
@@ -115,79 +175,3 @@ become active again you can simply email the PMC and ask to be reinstated.
 
 The PMC also can mark committers as inactive after they have not been involved in the community for
 more than 12 months.
-
-
-Guidelines to become an Airflow Committer
-------------------------------------------
-
-Committers are community members who have write access to the project’s
-repositories, i.e., they can modify the code, documentation, and website by themselves and also
-accept other contributions. There is no strict protocol for becoming a committer. Candidates for new
-committers are typically people that are active contributors and community members.
-
-Some people might be active in several of those areas and while they might have not enough 'achievements' in any
-single one of those, their combined contributions in several areas all count.
-
-As a community, we appreciate contributions to the Airflow codebase, but we also place equal value
-on those who help Airflow by improving the community in some way. It is entirely possible to become
-a committer (and eventually a PMC member) without ever having to change a single line of code.
-
-
-Prerequisites
-^^^^^^^^^^^^^^
-
-General prerequisites that we look for in all candidates:
-
-1.  Consistent contribution over last few months
-2.  Visibility on discussions on the dev mailing list, Slack channels or Github issues/discussions
-3.  Contributions to community health and project's sustainability for the long-term
-4.  Understands contributor/committer guidelines:
-    `Contributors' Guide <https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst>`__
-
-
-Code contribution
-^^^^^^^^^^^^^^^^^^
-
-1.  Makes high-quality commits (especially commit messages), and assess the impact of the changes, including
-    upgrade paths or deprecation policies
-2.  Testing Release Candidates to help the release cycle
-3.  Proposed and led to completion Airflow Improvement Proposal(s)
-4.  Demonstrates an understanding of one of the following areas or has displayed a holistic understanding
-    of a particular part and made contributions towards a more strategic goal
-
-    - Airflow Core
-    - API
-    - Docker Image
-    - Helm Chart
-    - Dev Tools (Breeze / CI)
-    - Certain Providers
-
-5.  Has made a significant improvement or added an integration with services/technologies important to the Airflow
-    Ecosystem
-
-Community contributions
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-1.  Was instrumental in triaging issues
-2.  Improved documentation of Airflow in significant way
-3.  Lead change and improvements introduction in the “community” processes and tools
-4.  Actively spreads the word about Airflow, for example organising Airflow summit, workshops for
-    community members, giving and recording talks, writing blogs
-5.  Reporting bugs with detailed reproduction steps
-
-
-Committer Responsibilities
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Committers are more than contributors. While it's important for committers to maintain standing by
-committing code, their key role is to build and foster a healthy and active community.
-This means that committers should:
-
-* Review PRs in a timely and reliable fashion
-* They should also help to actively whittle down the PR backlog
-* Answer questions (i.e. on the dev list, in PRs, in GitHub Issues, slack, etc...)
-* Take on core changes/bugs/feature requests
-* Some changes are important enough that a committer needs to ensure it gets done. This is especially
-  the case if no one from the community is taking it on.
-* Improve processes and tooling
-* Refactoring code


### PR DESCRIPTION
- Move "Guidelines to become an Airflow Committer" before "Guidelines for promoting Committers to Airflow PMC"
- Remove "Becoming a Committer" section which is same as "Guidelines to become an Airflow Committer"

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
