### PR TITLE
Production image can be run as root

### DIFF
--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -216,7 +216,8 @@ function verify_image::verify_prod_image_as_root() {
     fi
 
     echo "Checking root container with custom PYTHONPATH"
-    local tmp_dir="$(mktemp -d)"
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
     touch "${tmp_dir}/__init__.py"
     echo 'print("Awesome")' >> "${tmp_dir}/awesome.py"
     output=$(docker run \

--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -197,6 +197,49 @@ function verify_image::verify_production_image_python_modules() {
     start_end::group_end
 }
 
+function verify_image::verify_prod_image_as_root() {
+    start_end::group_start "Checking if the image can be run as root."
+    set +e
+    echo "Checking airflow as root"
+    local output
+    local res
+    output=$(docker run --rm --user 0 "${DOCKER_IMAGE}" "airflow" "info" 2>&1)
+    res=$?
+    if [[ ${res} == "0" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+
+    echo "Checking root container with custom PYTHONPATH"
+    local tmp_dir="$(mktemp -d)"
+    touch "${tmp_dir}/__init__.py"
+    echo 'print("Awesome")' >> "${tmp_dir}/awesome.py"
+    output=$(docker run \
+        --rm \
+        -e "PYTHONPATH=${tmp_dir}" \
+        -v "${tmp_dir}:${tmp_dir}" \
+        --user 0 "${DOCKER_IMAGE}" \
+            "python" "-c" "import awesome" \
+        2>&1)
+    res=$?
+    if [[ ${res} == "0" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+    rm -rf "${tmp_dir}"
+    set -e
+}
+
 function verify_image::display_result {
     if [[ ${IMAGE_VALID} == "true" ]]; then
         echo
@@ -218,6 +261,8 @@ function verify_image::verify_prod_image {
     verify_image::verify_production_image_python_modules
 
     verify_image::verify_prod_image_dependencies
+
+    verify_image::verify_prod_image_as_root
 
     verify_image::display_result
 }

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -183,7 +183,8 @@ function set_pythonpath_for_root_user() {
     # the application is not available. because Python then only load system-wide applications.
     # Now also adds applications installed as local user "airflow".
     if [[ $UID == "0" ]]; then
-        local python_major_minor="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
+        local python_major_minor
+        python_major_minor="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
         export PYTHONPATH="${AIRFLOW_USER_HOME_DIR}/.local/lib/python${python_major_minor}/site-packages:${PYTHONPATH:-}"
         >&2 echo "The container is run as root user. For security, consider using a regular user account."
     fi

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -178,6 +178,17 @@ function create_system_user_if_missing() {
     fi
 }
 
+function set_pythonpath_for_root_user() {
+    # Airflow is installed as a local user application which means that if the container is running as root
+    # the application is not available. because Python then only load system-wide applications.
+    # Now also adds applications installed as local user "airflow".
+    if [[ $UID == "0" ]]; then
+        local python_major_minor="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
+        export PYTHONPATH="${AIRFLOW_USER_HOME_DIR}/.local/lib/python${python_major_minor}/site-packages:${PYTHONPATH:-}"
+        >&2 echo "The container is run as root user. For security, consider using a regular user account."
+    fi
+}
+
 function wait_for_airflow_db() {
     # Verifies connection to the Airflow DB
     if [[ -n "${AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD=}" ]]; then
@@ -226,6 +237,7 @@ CONNECTION_CHECK_SLEEP_TIME=${CONNECTION_CHECK_SLEEP_TIME:=3}
 readonly CONNECTION_CHECK_SLEEP_TIME
 
 create_system_user_if_missing
+set_pythonpath_for_root_user
 wait_for_airflow_db
 
 if [[ -n "${_AIRFLOW_DB_UPGRADE=}" ]] ; then


### PR DESCRIPTION
This is a frequently requested feature, so I would to add it.
See:
https://apache-airflow.slack.com/archives/CQAMHKWSJ/p1613060591038500
Depends on:
https://github.com/apache/airflow/pull/14224
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
