### PR TITLE
Disables self-hosted runs for non-apache-owned repositories

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -48,7 +48,7 @@ jobs:
   cancel-workflow-runs:
     timeout-minutes: 10
     name: "Cancel workflow runs"
-    runs-on: [self-hosted]
+    runs-on: ${{ github.repository == 'apache/airflow' && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:
       sourceHeadRepo: ${{ steps.source-run-info.outputs.sourceHeadRepo }}
       sourceHeadBranch: ${{ steps.source-run-info.outputs.sourceHeadBranch }}
@@ -61,7 +61,7 @@ jobs:
       sourceEvent: ${{ steps.source-run-info.outputs.sourceEvent }}
       cacheDirective: ${{ steps.cache-directive.outputs.docker-cache }}
       buildImages: ${{ steps.build-images.outputs.buildImages }}
-      runsOn: '["self-hosted"]'
+      runsOn: ${{ github.repository == 'apache/airflow' && 'self-hosted' || 'ubuntu-20.04' }}
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,22 @@ jobs:
     name: "Build info"
     runs-on: >-
       ${{ (
-        github.event_name == 'push' ||
-        github.event_name == 'schedule' ||
-        github.event.pull_request.author_association == 'OWNER' ||
-        github.event.pull_request.author_association == 'MEMBER'
-      ) && 'self-hosted' || 'ubuntu-20.04' }}
-    env:
-      GITHUB_CONTEXT: ${{ toJson(github) }}
-      RUNS_ON: ${{ (
+        (
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
           github.event.pull_request.author_association == 'OWNER' ||
           github.event.pull_request.author_association == 'MEMBER'
+        ) && github.repository == 'apache/airflow'
+      ) && 'self-hosted' || 'ubuntu-20.04' }}
+    env:
+      GITHUB_CONTEXT: ${{ toJson(github) }}
+      RUNS_ON: ${{ (
+          (
+            github.event_name == 'push' ||
+            github.event_name == 'schedule' ||
+            github.event.pull_request.author_association == 'OWNER' ||
+            github.event.pull_request.author_association == 'MEMBER'
+          ) && github.repository == 'apache/airflow'
         ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:
       waitForImage: ${{ steps.wait-for-image.outputs.wait-for-image }}


### PR DESCRIPTION
When the user wants to test pull requests or - especilly - master
build in their own fork, they will not likely have self-hosted
runners configured and the builds will fail.

This change uses self-hosted runners only if the build is run in
the context of the `apache/airflow` repository.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
