### PR TITLE
docs: TESTING.rst: fix not loading image

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -746,7 +746,7 @@ b) Choose pytest as test runner:
 
 c) Run/Debug tests using standard "Run/Debug" feature of IntelliJ
 
-.. image:: images/testing/run-tests.png
+.. image:: images/testing/run-test.png
     :align: center
     :alt: Run/Debug tests
 


### PR DESCRIPTION
[This image loads](https://github.com/apache/airflow/blob/master/images/testing/run-test.png) but [this](https://github.com/apache/airflow/blob/master/images/testing/run-tests.png) as referred to in the docs, not.
