### PR TITLE
docs: NOTICE: Updated 2016-2019 to 2016-now

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Airflow
-Copyright 2016-now The Apache Software Foundation
+Copyright 2016-2021 The Apache Software Foundation
 
 This product includes software developed at The Apache Software
 Foundation (http://www.apache.org/).

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Airflow
-Copyright 2016-2019 The Apache Software Foundation
+Copyright 2016-now The Apache Software Foundation
 
 This product includes software developed at The Apache Software
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
Should it be 2021? For example last year it was completely missed
