### PR TITLE
Don't allow SlackHook accept *args

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -82,7 +82,7 @@ class SlackHook(BaseHook):  # noqa
 
         raise AirflowException('Cannot get token: No valid Slack token nor slack_conn_id supplied.')
 
-    def call(self, api_method: str, *args, **kwargs) -> None:
+    def call(self, api_method: str, **kwargs) -> None:
         """
         Calls Slack WebClient `WebClient.api_call` with given arguments.
 
@@ -100,4 +100,4 @@ class SlackHook(BaseHook):  # noqa
         :param json: JSON for the body to attach to the request. Optional.
         :type json: dict
         """
-        self.client.api_call(api_method, *args, **kwargs)
+        self.client.api_call(api_method, **kwargs)

--- a/tests/providers/slack/hooks/test_slack.py
+++ b/tests/providers/slack/hooks/test_slack.py
@@ -120,7 +120,7 @@ class TestSlackHook(unittest.TestCase):
         test_api_params = {'key1': 'value1', 'key2': 'value2'}
 
         with pytest.raises(SlackApiError):
-            slack_hook.call(test_method, test_api_params)
+            slack_hook.call(test_method, data=test_api_params)
 
     @mock.patch('airflow.providers.slack.hooks.slack.WebClient.api_call', autospec=True)
     @mock.patch('airflow.providers.slack.hooks.slack.WebClient')


### PR DESCRIPTION
Underlying Slack WebClient doesn't accept *args anymore

<img width="482" alt="Screenshot 2021-02-18 at 09 06 33" src="https://user-images.githubusercontent.com/3982146/108320588-ad04ba00-71cb-11eb-9000-0fd946fd6f57.png">

```
>>> from airflow.providers.slack.hooks.slack import SlackHook
>>> alert = SlackHook('...')
>>> alert.call('chat.postMessage', {'text': 'Igor is testing', 'channel': 'test-channel'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/khroliz/.local/share/virtualenvs/parcel-vGquKnoL/lib/python3.8/site-packages/airflow/providers/slack/hooks/slack.py", line 103, in call
    self.client.api_call(api_method, *args, **kwargs)
TypeError: api_call() takes 2 positional arguments but 3 were given
>>> alert.call('chat.postMessage', data={'text': 'Igor is testing', 'channel': 'test-channel'})
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
