### PR TITLE
Remove duplicated clean_db function for ImportErrors

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -59,7 +59,7 @@ from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.config import conf_vars, env_vars
 from tests.test_utils.db import (
     clear_db_dags,
-    clear_db_errors,
+    clear_db_import_errors,
     clear_db_jobs,
     clear_db_pools,
     clear_db_runs,
@@ -106,7 +106,7 @@ class TestDagFileProcessor(unittest.TestCase):
         clear_db_pools()
         clear_db_dags()
         clear_db_sla_miss()
-        clear_db_errors()
+        clear_db_import_errors()
         clear_db_jobs()
         clear_db_serialized_dags()
 
@@ -781,7 +781,7 @@ class TestSchedulerJob(unittest.TestCase):
         clear_db_pools()
         clear_db_dags()
         clear_db_sla_miss()
-        clear_db_errors()
+        clear_db_import_errors()
 
         # Speed up some tests by not running the tasks, just look at what we
         # enqueue!
@@ -4001,7 +4001,7 @@ class TestSchedulerJobQueriesCount(unittest.TestCase):
         clear_db_pools()
         clear_db_dags()
         clear_db_sla_miss()
-        clear_db_errors()
+        clear_db_import_errors()
         clear_db_serialized_dags()
         clear_db_dags()
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2027,7 +2027,7 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
         db.clear_db_pools()
         db.clear_db_dags()
         db.clear_db_sla_miss()
-        db.clear_db_errors()
+        db.clear_db_import_errors()
 
     def setUp(self) -> None:
         self._clean()

--- a/tests/test_utils/db.py
+++ b/tests/test_utils/db.py
@@ -60,11 +60,6 @@ def clear_db_sla_miss():
         session.query(SlaMiss).delete()
 
 
-def clear_db_errors():
-    with create_session() as session:
-        session.query(errors.ImportError).delete()
-
-
 def clear_db_pools():
     with create_session() as session:
         session.query(Pool).delete()


### PR DESCRIPTION
There were two functions -- clean_db_errors and clean_db_import_errors
that did the same thing.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).