### PR TITLE
Fix remote log in azure storage blob displays in one line

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -244,7 +244,7 @@ class WasbHook(BaseHook):
         :param kwargs: Optional keyword arguments that `BlobClient.download_blob` takes.
         :type kwargs: object
         """
-        return self.download(container_name, blob_name, **kwargs).readall()
+        return self.download(container_name, blob_name, **kwargs).content_as_text()
 
     def upload(
         self,

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -124,9 +124,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             # local machine even if there are errors reading remote logs, as
             # returned remote_log will contain error messages.
             remote_log = self.wasb_read(remote_loc, return_error=True)
-            log = '*** Reading remote log from {remote_loc}.\n{remote_log}\n'.format(
-                remote_loc=remote_loc, remote_log=remote_log.decode('utf-8')
-            )
+            log = f'*** Reading remote log from {remote_loc}.\n{remote_log}\n'
             return log, {'end_of_log': True}
         else:
             return super()._read(ti, try_number)

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -124,8 +124,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             # local machine even if there are errors reading remote logs, as
             # returned remote_log will contain error messages.
             remote_log = self.wasb_read(remote_loc, return_error=True)
-            log = '*** Reading remote log from {remote_loc}.\n{remote_log}\n'.format(remote_loc=remote_loc, remote_log=remote_log.decod
-e('utf-8'))
+            log = '*** Reading remote log from {remote_loc}.\n{remote_log}\n'.format(remote_loc=remote_loc, remote_log=remote_log.decode('utf-8'))
             return log, {'end_of_log': True}
         else:
             return super()._read(ti, try_number)

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -124,7 +124,9 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             # local machine even if there are errors reading remote logs, as
             # returned remote_log will contain error messages.
             remote_log = self.wasb_read(remote_loc, return_error=True)
-            log = '*** Reading remote log from {remote_loc}.\n{remote_log}\n'.format(remote_loc=remote_loc, remote_log=remote_log.decode('utf-8'))
+            log = '*** Reading remote log from {remote_loc}.\n{remote_log}\n'.format(
+                remote_loc=remote_loc, remote_log=remote_log.decode('utf-8')
+            )
             return log, {'end_of_log': True}
         else:
             return super()._read(ti, try_number)

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -124,7 +124,8 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             # local machine even if there are errors reading remote logs, as
             # returned remote_log will contain error messages.
             remote_log = self.wasb_read(remote_loc, return_error=True)
-            log = f'*** Reading remote log from {remote_loc}.\n{remote_log}\n'
+            log = '*** Reading remote log from {remote_loc}.\n{remote_log}\n'.format(remote_loc=remote_loc, remote_log=remote_log.decod
+e('utf-8'))
             return log, {'end_of_log': True}
         else:
             return super()._read(ti, try_number)


### PR DESCRIPTION
related: https://github.com/apache/airflow/issues/14312

To solve the display issue on UI when using wasb_task_handler.py to store remote log on Azure blob storage

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
