### PR TITLE
docs: Fix misleading statement on sqlite

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -28,7 +28,7 @@ Choosing database backend
 -------------------------
 
 If you want to take a real test drive of Airflow, you should consider setting up a database backend to **MySQL** and **PostgresSQL**.
-By default, Airflow uses **SQLite**, which is not intended for development purposes only.
+By default, Airflow uses **SQLite**, which is intended for development purposes only.
 
 Airflow supports the following database engine versions, so make sure which version you have. Old versions may not support all SQL statements.
 


### PR DESCRIPTION
The statement 
```
By default, Airflow uses **SQLite**, which is *not* intended for development purposes only.
```
is confusing. If `postgres/mysql` are production worthy db backends, and `sqlite` as default db for `airflow` is for development purposes only, this statement is not correct. If I'm mistaken and `sqlite` is for both `production` and `development` purposes, please ignore this PR
