### PR TITLE
Remove testfixtures module that is only used once

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -505,7 +505,6 @@ devel = [
     'pywinrm',
     'qds-sdk>=1.9.6',
     'requests_mock',
-    'testfixtures',
     'wheel',
     'yamllint',
 ]

--- a/tests/providers/amazon/aws/hooks/test_glacier.py
+++ b/tests/providers/amazon/aws/hooks/test_glacier.py
@@ -19,8 +19,6 @@
 import unittest
 from unittest import mock
 
-from testfixtures import LogCapture
-
 from airflow.providers.amazon.aws.hooks.glacier import GlacierHook
 
 CREDENTIALS = "aws_conn"
@@ -52,26 +50,20 @@ class TestAmazonGlacierHook(unittest.TestCase):
         # given
         job_id = {"jobId": "1234abcd"}
         # when
-        with LogCapture() as log:
+        with self.assertLogs() as log:
             mock_conn.return_value.initiate_job.return_value = job_id
             self.hook.retrieve_inventory(VAULT_NAME)
             # then
-            log.check(
-                (
-                    'airflow.providers.amazon.aws.hooks.glacier.GlacierHook',
-                    'INFO',
-                    f"Retrieving inventory for vault: {VAULT_NAME}",
-                ),
-                (
-                    'airflow.providers.amazon.aws.hooks.glacier.GlacierHook',
-                    'INFO',
-                    f"Initiated inventory-retrieval job for: {VAULT_NAME}",
-                ),
-                (
-                    'airflow.providers.amazon.aws.hooks.glacier.GlacierHook',
-                    'INFO',
-                    f"Retrieval Job ID: {job_id.get('jobId')}",
-                ),
+            self.assertEqual(
+                log.output,
+                [
+                    'INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:'
+                    + f"Retrieving inventory for vault: {VAULT_NAME}",
+                    'INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:'
+                    + f"Initiated inventory-retrieval job for: {VAULT_NAME}",
+                    'INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:'
+                    + f"Retrieval Job ID: {job_id.get('jobId')}",
+                ],
             )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
@@ -86,16 +78,16 @@ class TestAmazonGlacierHook(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
     def test_retrieve_inventory_results_should_log_mgs(self, mock_conn):
         # when
-        with LogCapture() as log:
+        with self.assertLogs() as log:
             mock_conn.return_value.get_job_output.return_value = REQUEST_RESULT
             self.hook.retrieve_inventory_results(VAULT_NAME, JOB_ID)
             # then
-            log.check(
-                (
-                    'airflow.providers.amazon.aws.hooks.glacier.GlacierHook',
-                    'INFO',
-                    f"Retrieving the job results for vault: {VAULT_NAME}...",
-                ),
+            self.assertEqual(
+                log.output,
+                [
+                    'INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:'
+                    + f"Retrieving the job results for vault: {VAULT_NAME}...",
+                ],
             )
 
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
@@ -110,19 +102,16 @@ class TestAmazonGlacierHook(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.glacier.GlacierHook.get_conn")
     def test_describe_job_should_log_mgs(self, mock_conn):
         # when
-        with LogCapture() as log:
+        with self.assertLogs() as log:
             mock_conn.return_value.describe_job.return_value = JOB_STATUS
             self.hook.describe_job(VAULT_NAME, JOB_ID)
             # then
-            log.check(
-                (
-                    'airflow.providers.amazon.aws.hooks.glacier.GlacierHook',
-                    'INFO',
-                    f"Retrieving status for vault: {VAULT_NAME} and job {JOB_ID}",
-                ),
-                (
-                    'airflow.providers.amazon.aws.hooks.glacier.GlacierHook',
-                    'INFO',
-                    f"Job status: {JOB_STATUS.get('Action')}, code status: {JOB_STATUS.get('StatusCode')}",
-                ),
+            self.assertEqual(
+                log.output,
+                [
+                    'INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:'
+                    + f"Retrieving status for vault: {VAULT_NAME} and job {JOB_ID}",
+                    'INFO:airflow.providers.amazon.aws.hooks.glacier.GlacierHook:'
+                    + f"Job status: {JOB_STATUS.get('Action')}, code status: {JOB_STATUS.get('StatusCode')}",
+                ],
             )


### PR DESCRIPTION
This is only used in a single test, everywhere else we use Pytest or unittest's built in feature


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).