### PR TITLE
Fix caching of python images during builds

### DIFF
--- a/CI.rst
+++ b/CI.rst
@@ -254,7 +254,7 @@ You can use those variables when you try to reproduce the build locally.
 |                                                        Image build variables                                                       |
 +-----------------------------------------+-------------+-------------+------------+-------------------------------------------------+
 | ``UPGRADE_TO_NEWER_DEPENDENCIES``       |    false    |    false    |   false\*  | Determines whether the build should             |
-|                                         |             |             |            | attempt to upgrade all                          |
+|                                         |             |             |            | attempt to upgrade python base image and all    |
 |                                         |             |             |            | PIP dependencies to latest ones matching        |
 |                                         |             |             |            | ``setup.py`` limits. This tries to replicate    |
 |                                         |             |             |            | the situation of "fresh" user who just installs |

--- a/breeze
+++ b/breeze
@@ -3185,11 +3185,19 @@ function breeze::make_sure_precommit_is_installed() {
 #
 #######################################################################################################
 function breeze::remove_images() {
-    set +e
-    docker rmi "${PYTHON_BASE_IMAGE}"  2>/dev/null >/dev/null
-    docker rmi "${AIRFLOW_CI_IMAGE}"   2>/dev/null >/dev/null
-    docker rmi "${AIRFLOW_PROD_IMAGE}" 2>/dev/null >/dev/null
-    set -e
+    # shellcheck disable=SC2086
+    docker rmi --force ${PYTHON_BASE_IMAGE} \
+                       ${GITHUB_REGISTRY_PYTHON_BASE_IMAGE} \
+                       ${AIRFLOW_PYTHON_BASE_IMAGE} \
+                       ${AIRFLOW_CI_IMAGE} \
+                       ${DEFAULT_CI_IMAGE} \
+                       ${AIRFLOW_CI_LOCAL_MANIFEST_IMAGE} \
+                       ${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE} \
+                       ${AIRFLOW_PROD_IMAGE} \
+                       ${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE} \
+                       ${AIRFLOW_PROD_BUILD_IMAGE} \
+                       ${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE} \
+        2>/dev/null >/dev/null && true
     echo
     echo "###################################################################"
     echo "NOTE!! Removed Airflow images for Python version ${PYTHON_MAJOR_MINOR_VERSION}."
@@ -3510,6 +3518,8 @@ function breeze::determine_python_version_to_use_in_breeze() {
 breeze::setup_default_breeze_constants
 
 initialization::initialize_common_environment
+
+initialization::get_environment_for_builds_on_ci
 
 breeze::determine_python_version_to_use_in_breeze
 

--- a/scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_ci_image_on_ci.sh
@@ -41,7 +41,7 @@ function build_ci_image_on_ci() {
         # first we pull base python image. We will need it to re-push it after master build
         # Becoming the new "latest" image for other builds
         build_images::wait_for_image_tag "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}" \
-            "${python_tag_suffix}" "${PYTHON_BASE_IMAGE}"
+            "${python_tag_suffix}" "${AIRFLOW_PYTHON_BASE_IMAGE}"
 
         # And then the base image
         build_images::wait_for_image_tag "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}" \

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -375,7 +375,7 @@ function build_images::get_docker_image_names() {
     # CI image to build
     export AIRFLOW_CI_IMAGE="${DOCKERHUB_USER}/${DOCKERHUB_REPO}:${AIRFLOW_CI_BASE_TAG}"
     # Default CI image
-    export AIRFLOW_CI_PYTHON_IMAGE="${DOCKERHUB_USER}/${DOCKERHUB_REPO}:python${PYTHON_MAJOR_MINOR_VERSION}-${BRANCH_NAME}"
+    export AIRFLOW_PYTHON_BASE_IMAGE="${DOCKERHUB_USER}/${DOCKERHUB_REPO}:python${PYTHON_MAJOR_MINOR_VERSION}-${BRANCH_NAME}"
     # CI image to build
     export AIRFLOW_CI_IMAGE="${DOCKERHUB_USER}/${DOCKERHUB_REPO}:${AIRFLOW_CI_BASE_TAG}"
 
@@ -744,7 +744,7 @@ Docker building ${AIRFLOW_CI_IMAGE}.
     fi
     docker build \
         "${EXTRA_DOCKER_CI_BUILD_FLAGS[@]}" \
-        --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \
+        --build-arg PYTHON_BASE_IMAGE="${AIRFLOW_PYTHON_BASE_IMAGE}" \
         --build-arg PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION}" \
         --build-arg AIRFLOW_VERSION="${AIRFLOW_VERSION}" \
         --build-arg AIRFLOW_BRANCH="${BRANCH_NAME}" \
@@ -897,7 +897,7 @@ function build_images::build_prod_images() {
     fi
     docker build \
         "${EXTRA_DOCKER_PROD_BUILD_FLAGS[@]}" \
-        --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \
+        --build-arg PYTHON_BASE_IMAGE="${AIRFLOW_PYTHON_BASE_IMAGE}" \
         --build-arg PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION}" \
         --build-arg INSTALL_MYSQL_CLIENT="${INSTALL_MYSQL_CLIENT}" \
         --build-arg AIRFLOW_VERSION="${AIRFLOW_VERSION}" \
@@ -934,7 +934,7 @@ function build_images::build_prod_images() {
     fi
     docker build \
         "${EXTRA_DOCKER_PROD_BUILD_FLAGS[@]}" \
-        --build-arg PYTHON_BASE_IMAGE="${PYTHON_BASE_IMAGE}" \
+        --build-arg PYTHON_BASE_IMAGE="${AIRFLOW_PYTHON_BASE_IMAGE}" \
         --build-arg PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION}" \
         --build-arg INSTALL_MYSQL_CLIENT="${INSTALL_MYSQL_CLIENT}" \
         --build-arg ADDITIONAL_AIRFLOW_EXTRAS="${ADDITIONAL_AIRFLOW_EXTRAS}" \
@@ -956,6 +956,8 @@ function build_images::build_prod_images() {
         --build-arg AIRFLOW_EXTRAS="${AIRFLOW_EXTRAS}" \
         --build-arg BUILD_ID="${CI_BUILD_ID}" \
         --build-arg COMMIT_SHA="${COMMIT_SHA}" \
+        --build-arg CONSTRAINTS_GITHUB_REPOSITORY="${CONSTRAINTS_GITHUB_REPOSITORY}" \
+        --build-arg AIRFLOW_CONSTRAINTS="${AIRFLOW_CONSTRAINTS}" \
         --build-arg AIRFLOW_IMAGE_REPOSITORY="https://github.com/${GITHUB_REPOSITORY}" \
         --build-arg AIRFLOW_IMAGE_DATE_CREATED="$(date --rfc-3339=seconds | sed 's/ /T/')" \
         "${additional_dev_args[@]}" \

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -710,14 +710,16 @@ EOF
 # we used in other scripts
 function initialization::get_environment_for_builds_on_ci() {
     if [[ ${CI:=} == "true" ]]; then
+        export GITHUB_REPOSITORY="${GITHUB_REPOSITORY="apache/airflow"}"
         export CI_TARGET_REPO="${GITHUB_REPOSITORY}"
         export CI_TARGET_BRANCH="${GITHUB_BASE_REF:="master"}"
-        export CI_BUILD_ID="${GITHUB_RUN_ID}"
-        export CI_JOB_ID="${GITHUB_JOB}"
-        export CI_EVENT_TYPE="${GITHUB_EVENT_NAME}"
-        export CI_REF="${GITHUB_REF:=}"
+        export CI_BUILD_ID="${GITHUB_RUN_ID="0"}"
+        export CI_JOB_ID="${GITHUB_JOB="0"}"
+        export CI_EVENT_TYPE="${GITHUB_EVENT_NAME="pull_request"}"
+        export CI_REF="${GITHUB_REF:="refs/head/master"}"
     else
         # CI PR settings
+        export GITHUB_REPOSITORY="${GITHUB_REPOSITORY="apache/airflow"}"
         export CI_TARGET_REPO="${CI_TARGET_REPO="apache/airflow"}"
         export CI_TARGET_BRANCH="${DEFAULT_BRANCH="master"}"
         export CI_BUILD_ID="${CI_BUILD_ID="0"}"
@@ -726,12 +728,8 @@ function initialization::get_environment_for_builds_on_ci() {
         export CI_REF="${CI_REF="refs/head/master"}"
     fi
 
-    if [[ ${VERBOSE} == "true" && ${PRINT_INFO_FROM_SCRIPTS} == "true" ]]; then
-        initialization::summarize_build_environment
-    fi
-
     if [[ -z "${LIBRARY_PATH:-}" && -n "${LD_LIBRARY_PATH:-}" ]]; then
-      export LIBRARY_PATH="$LD_LIBRARY_PATH"
+      export LIBRARY_PATH="${LD_LIBRARY_PATH}"
     fi
 }
 
@@ -838,6 +836,7 @@ function initialization::make_constants_read_only() {
 
     readonly PYTHON_BASE_IMAGE_VERSION
     readonly PYTHON_BASE_IMAGE
+    readonly AIRFLOW_PYTHON_BASE_IMAGE
     readonly AIRFLOW_CI_BASE_TAG
     readonly AIRFLOW_CI_IMAGE
     readonly AIRFLOW_CI_IMAGE_DEFAULT

--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -104,37 +104,58 @@ function push_pull_remove_images::pull_image_github_dockerhub() {
     set -e
 }
 
+# Pulls base python image used to build CI and PROD imaages, depending on the parameters used
+# if UPGRADE_TO_NEWER_DEPENDENCIES is set - then it pulls latest python image available first and
+#     adds `org.opencontainers.image.source` label to it, so that it is linked to Airflow repository when
+#     we push it to GHCR registry
+# Otherwise, if we are using any of the registries, it pulls the python base image from those registries.
+#     In case we pull specific build image (via suffix), it will pull the right image using the
+#     specified suffix
+
+function push_pull_remove_images::pull_base_python_image() {
+    echo
+    echo "Force pull base image ${AIRFLOW_PYTHON_BASE_IMAGE}. Upgrade to newer dependencies: ${UPGRADE_TO_NEWER_DEPENDENCIES}"
+    echo
+    if [[ -n ${DETECTED_TERMINAL=} ]]; then
+        echo -n "
+Docker pulling ${AIRFLOW_PYTHON_BASE_IMAGE}. Upgrade to newer dependencies ${UPGRADE_TO_NEWER_DEPENDENCIES}
+" > "${DETECTED_TERMINAL}"
+    fi
+    if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ]]; then
+        # Pull latest PYTHON_BASE_IMAGE, so that it is linked to the current project it is build in.
+        # This is necessary in case we use Google Container registry - we always use the
+        # Airflow version of the python image with the opencontainers label, so that GHCR can link it
+        # to the Apache Airflow repository.
+        docker pull "${PYTHON_BASE_IMAGE}"
+        echo "FROM ${PYTHON_BASE_IMAGE}" | \
+            docker build \
+                --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+                -t "${AIRFLOW_PYTHON_BASE_IMAGE}" -
+    else
+        if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
+            PYTHON_TAG_SUFFIX=""
+            if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} != "latest" ]]; then
+                PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            fi
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PYTHON_BASE_IMAGE}" \
+                "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+        else
+            docker pull "${AIRFLOW_PYTHON_BASE_IMAGE}"
+        fi
+    fi
+}
+
 # Pulls CI image in case caching strategy is "pulled" and the image needs to be pulled
 function push_pull_remove_images::pull_ci_images_if_needed() {
+    local python_image_hash
+    python_image_hash=$(docker images -q "${AIRFLOW_PYTHON_BASE_IMAGE}" 2> /dev/null || true)
+    if [[ -z "${python_image_hash=}" || "${FORCE_PULL_IMAGES}" == "true" ]]; then
+        push_pull_remove_images::pull_base_python_image
+    fi
     if [[ "${DOCKER_CACHE}" == "pulled" ]]; then
-        local python_image_hash
-        python_image_hash=$(docker images -q "${AIRFLOW_CI_PYTHON_IMAGE}" 2> /dev/null || true)
-        if [[ -z "${python_image_hash=}" ]]; then
-            FORCE_PULL_IMAGES="true"
-        fi
-        if [[ "${FORCE_PULL_IMAGES}" == "true" ]]; then
-            echo
-            echo "Force pull base image ${PYTHON_BASE_IMAGE}"
-            echo
-            if [[ -n ${DETECTED_TERMINAL=} ]]; then
-                echo -n "
-Docker pulling ${PYTHON_BASE_IMAGE}.
-" > "${DETECTED_TERMINAL}"
-            fi
-            if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
-                PYTHON_TAG_SUFFIX=""
-                if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} != "latest" ]]; then
-                    PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
-                fi
-                push_pull_remove_images::pull_image_github_dockerhub "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
-            else
-                docker pull "${AIRFLOW_CI_PYTHON_IMAGE}"
-                docker tag "${AIRFLOW_CI_PYTHON_IMAGE}" "${PYTHON_BASE_IMAGE}"
-            fi
-            echo
-        fi
         if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
-            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_CI_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_CI_IMAGE}" \
+                "${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
         else
             push_pull_remove_images::pull_image_if_not_present_or_forced "${AIRFLOW_CI_IMAGE}"
         fi
@@ -144,28 +165,19 @@ Docker pulling ${PYTHON_BASE_IMAGE}.
 
 # Pulls PROD image in case caching strategy is "pulled" and the image needs to be pulled
 function push_pull_remove_images::pull_prod_images_if_needed() {
+    local python_image_hash
+    python_image_hash=$(docker images -q "${AIRFLOW_PYTHON_BASE_IMAGE}" 2> /dev/null || true)
+    if [[ -z "${python_image_hash=}" || "${FORCE_PULL_IMAGES}" == "true" ]]; then
+        push_pull_remove_images::pull_base_python_image
+    fi
     if [[ "${DOCKER_CACHE}" == "pulled" ]]; then
-        if [[ "${FORCE_PULL_IMAGES}" == "true" ]]; then
-            echo
-            echo "Force pull base image ${PYTHON_BASE_IMAGE}"
-            echo
-            if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
-                PYTHON_TAG_SUFFIX=""
-                if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} != "latest" ]]; then
-                    PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
-                fi
-                push_pull_remove_images::pull_image_github_dockerhub "${PYTHON_BASE_IMAGE}" "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
-            else
-                docker pull "${AIRFLOW_CI_PYTHON_IMAGE}"
-                docker tag "${AIRFLOW_CI_PYTHON_IMAGE}" "${PYTHON_BASE_IMAGE}"
-            fi
-            echo
-        fi
         if [[ ${USE_GITHUB_REGISTRY} == "true" ]]; then
             # "Build" segment of production image
-            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_BUILD_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_BUILD_IMAGE}" \
+                "${GITHUB_REGISTRY_AIRFLOW_PROD_BUILD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
             # "Main" segment of production image
-            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_IMAGE}" "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
+            push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_IMAGE}" \
+                "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
         else
             push_pull_remove_images::pull_image_if_not_present_or_forced "${AIRFLOW_PROD_BUILD_IMAGE}"
             push_pull_remove_images::pull_image_if_not_present_or_forced "${AIRFLOW_PROD_IMAGE}"
@@ -175,6 +187,7 @@ function push_pull_remove_images::pull_prod_images_if_needed() {
 
 # Pushes Ci images and the manifest to the registry in DockerHub.
 function push_pull_remove_images::push_ci_images_to_dockerhub() {
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_PYTHON_BASE_IMAGE}"
     push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_IMAGE}"
     docker tag "${AIRFLOW_CI_LOCAL_MANIFEST_IMAGE}" "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
     push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_REMOTE_MANIFEST_IMAGE}"
@@ -182,16 +195,29 @@ function push_pull_remove_images::push_ci_images_to_dockerhub() {
         # Only push default image to DockerHub registry if it is defined
         push_pull_remove_images::push_image_with_retries "${DEFAULT_CI_IMAGE}"
     fi
-    # Also push python image so that we use the same image as the CI image it was built with
-    docker tag "${PYTHON_BASE_IMAGE}" "${AIRFLOW_CI_PYTHON_IMAGE}"
-    push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_PYTHON_IMAGE}"
+}
+
+
+# Push image to GitHub registry with the push tag:
+#     "${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
+#     "latest"           - in case of push builds
+# Push python image to GitHub registry with the push tag:
+#     X.Y-slim-buster-"${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
+#     X.Y-slim-buster                    - in case of push builds
+function push_pull_remove_images::push_python_image_to_github() {
+    PYTHON_TAG_SUFFIX=""
+    if [[ ${GITHUB_REGISTRY_PUSH_IMAGE_TAG} != "latest" ]]; then
+        PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
+    fi
+    docker tag "${AIRFLOW_PYTHON_BASE_IMAGE}" \
+        "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
+    push_pull_remove_images::push_image_with_retries \
+        "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
 }
 
 # Pushes Ci images and their tags to registry in GitHub
 function push_pull_remove_images::push_ci_images_to_github() {
-    # Push image to GitHub registry with the push tag:
-    #     "${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
-    #     "latest"           - in case of push builds
+    push_pull_remove_images::push_python_image_to_github
     AIRFLOW_CI_TAGGED_IMAGE="${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     docker tag "${AIRFLOW_CI_IMAGE}" "${AIRFLOW_CI_TAGGED_IMAGE}"
     push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_TAGGED_IMAGE}"
@@ -201,21 +227,6 @@ function push_pull_remove_images::push_ci_images_to_github() {
         docker tag "${AIRFLOW_CI_IMAGE}" "${AIRFLOW_CI_SHA_IMAGE}"
         push_pull_remove_images::push_image_with_retries "${AIRFLOW_CI_SHA_IMAGE}"
     fi
-    # Push python image to GitHub registry with the push tag:
-    #     X.Y-slim-buster-"${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
-    #     X.Y-slim-buster                    - in case of push builds
-    PYTHON_TAG_SUFFIX=""
-    if [[ ${GITHUB_REGISTRY_PUSH_IMAGE_TAG} != "latest" ]]; then
-        PYTHON_TAG_SUFFIX="-${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
-    fi
-
-    # Label the python image for GCR, so that it is linked to the current project it is build in
-    echo "FROM ${PYTHON_BASE_IMAGE}" | \
-        docker build --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
-            -t "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}" -
-
-    push_pull_remove_images::push_image_with_retries \
-        "${GITHUB_REGISTRY_PYTHON_BASE_IMAGE}${PYTHON_TAG_SUFFIX}"
 }
 
 
@@ -230,6 +241,7 @@ function push_pull_remove_images::push_ci_images() {
 
 # Pushes PROD image to registry in DockerHub
 function push_pull_remove_images::push_prod_images_to_dockerhub () {
+    push_pull_remove_images::push_image_with_retries "${AIRFLOW_PYTHON_BASE_IMAGE}"
     # Prod image
     push_pull_remove_images::push_image_with_retries "${AIRFLOW_PROD_IMAGE}"
     if [[ -n ${DEFAULT_PROD_IMAGE=} ]]; then
@@ -241,11 +253,12 @@ function push_pull_remove_images::push_prod_images_to_dockerhub () {
 }
 
 # Pushes PROD image to and their tags to registry in GitHub
+# Push image to GitHub registry with chosen push tag
+# the PUSH tag might be:
+#     "${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
+#     "latest"           - in case of push builds
 function push_pull_remove_images::push_prod_images_to_github () {
-    # Push image to GitHub registry with chosen push tag
-    # the PUSH tag might be:
-    #     "${GITHUB_RUN_ID}" - in case of pull-request triggered 'workflow_run' builds
-    #     "latest"           - in case of push builds
+    push_pull_remove_images::push_python_image_to_github
     AIRFLOW_PROD_TAGGED_IMAGE="${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"
     docker tag "${AIRFLOW_PROD_IMAGE}" "${AIRFLOW_PROD_TAGGED_IMAGE}"
     push_pull_remove_images::push_image_with_retries "${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PUSH_IMAGE_TAG}"

--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -104,14 +104,14 @@ function push_pull_remove_images::pull_image_github_dockerhub() {
     set -e
 }
 
-# Pulls base python image used to build CI and PROD imaages, depending on the parameters used
-# if UPGRADE_TO_NEWER_DEPENDENCIES is set - then it pulls latest python image available first and
+# Pulls the base Python image. This image is used as base for CI and PROD imaages, depending on the parameters used:
+#
+# * if UPGRADE_TO_NEWER_DEPENDENCIES is noy false, then it pulls the latest Python image available first and
 #     adds `org.opencontainers.image.source` label to it, so that it is linked to Airflow repository when
 #     we push it to GHCR registry
-# Otherwise, if we are using any of the registries, it pulls the python base image from those registries.
-#     In case we pull specific build image (via suffix), it will pull the right image using the
-#     specified suffix
-
+# * If UPGRADE_TO_NEWER_DEPENDENCIES it pulls the Python base image from either GitHub registry or from DockerHub
+#     depending on USE_GITHUB_REGISTRY variable. In case we pull specific build image (via suffix)
+#     it will pull the right image using the specified suffix
 function push_pull_remove_images::pull_base_python_image() {
     echo
     echo "Force pull base image ${AIRFLOW_PYTHON_BASE_IMAGE}. Upgrade to newer dependencies: ${UPGRADE_TO_NEWER_DEPENDENCIES}"

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -44,7 +44,7 @@ fi
 
 function check_upgrade_to_newer_dependencies() {
     # shellcheck disable=SC2153
-    if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" == "true" ||
+    if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ||
             ${EVENT_NAME} == 'push' || ${EVENT_NAME} == "scheduled" ]]; then
         # Trigger upgrading to latest constraints where label is set or when
         # SHA of the merge commit triggers rebuilding layer in the docker image


### PR DESCRIPTION
After GHCR change, github image caching for python images was
broken. GHCR requires each image that we push to it to be
tagged with "org.opencontainers.image.source" label to point
to the right project repository. Otherwise it will not appear
in the repository images and we will not be able to manage
permissions of the image.

So we'v been extending the python base image with appropriate
label, but it was not in all places necessary. As the result.
the builds in CI were usign different images than the cache
image in DockerHub, which in turn caused full image rebuilds
ALWAYS. By implementing this change we make sure tha the the
"airflow-tainted" python images - including the label.

All images (when using breeze) are now built using such
airflow-tainted image which in turn should give5 up to 5-8
minutes saving on building the images job per each job (CI
and production)

The change implements the following behaviours:

1) When image is built on CI or locally without
   UPGRADE_TO_NEWER_DEPENDENCIES flag and without
   FORCE_PULL_IMAGES flag -t the latest image from the
   GitHub Registry or DockerHub registry is used.

2) When both FORCE_PULL_IMAGES and UPGRADE_TO_NEWER_DEPENDENCY
   are set to something different than "false" - the latest Python
   images are used - they are pulled first and tagged appropriately.

This way - always when UPGRADE_TO_NEWER_DEPENDENCIES are set (also
when master pushes are done) - such builds will use latest version
of python base images published on DockerHub.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
