### PR TITLE
Update kubernetes.rst

### DIFF
--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -164,7 +164,7 @@ Additionally, the Kubernetes Executor enables specification of additional featur
 .. @startuml
 .. Airflow_Scheduler -> Kubernetes: Request a new pod with command "airflow run..."
 .. Kubernetes -> Airflow_Worker: Create Airflow worker with command "airflow run..."
-.. Airflow_Worker -> Airflow_DB: Report task passing or failure to DB
+.. Airflow_Worker -> Airflow_DB: Report task passing to DB
 .. Airflow_Worker -> Kubernetes: Pod completes with state "Succeeded" and k8s records in ETCD
 .. Kubernetes -> Airflow_Scheduler: Airflow scheduler reads "Succeeded" from k8s watcher thread
 .. @enduml


### PR DESCRIPTION
Diagram for success case in "KubernetesExecutor Architecture" is inconsistent with diagram for "Handling Worker Pod Crashes"
Either success case shouldn't specify that error reporting should be done to db from the pod only in some specific case, or removed (as I've done in this PR)