### PR TITLE
Add CollectionInfo in all Collections that have total_entries

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1419,14 +1419,15 @@ components:
 
     ConnectionCollection:
       type: object
-      description: Connections
-      properties:
-        connections:
-          type: array
-          items:
-            $ref: '#/components/schemas/ConnectionCollectionItem'
-        total_entries:
-          type: integer
+      description: Collection of connections.
+      allOf:
+       - type: object
+         properties:
+           connections:
+            type: array
+            items:
+              $ref: '#/components/schemas/ConnectionCollectionItem'
+       - $ref: '#/components/schemas/CollectionInfo'
 
     Connection:
       description: Full representation of the connection.
@@ -1499,13 +1500,16 @@ components:
           readOnly: true
 
     DAGCollection:
-      description: Collection of DAGs
+      description: Collection of DAGs.
       type: object
-      properties:
-        dags:
-          type: array
-          items:
-            $ref: '#/components/schemas/DAG'
+      allOf:
+        - type: object
+          properties:
+            dags:
+              type: array
+              items:
+                $ref: '#/components/schemas/DAG'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     DAGRun:
       type: object
@@ -1568,12 +1572,15 @@ components:
 
     DAGRunCollection:
       type: object
-      description: Collection of DAG runs
-      properties:
-        dag_runs:
-          type: array
-          items:
-            $ref: '#/components/schemas/DAGRun'
+      description: Collection of DAG runs.
+      allOf:
+        - type: object
+          properties:
+            dag_runs:
+              type: array
+              items:
+                $ref: '#/components/schemas/DAGRun'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     EventLog:
       type: object
@@ -1622,12 +1629,15 @@ components:
 
     EventLogCollection:
       type: object
-      description: Collection of event log
-      properties:
-        event_logs:
-          type: array
-          items:
-            $ref: '#/components/schemas/EventLog'
+      description: Collection of event logs.
+      allOf:
+        - type: object
+          properties:
+            event_logs:
+              type: array
+              items:
+                $ref: '#/components/schemas/EventLog'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     ImportError:
       type: object
@@ -1652,11 +1662,15 @@ components:
 
     ImportErrorCollection:
       type: object
-      properties:
-        import_errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/ImportError'
+      properties: Collection of import errors.
+      allOf:
+        - type: object
+          properties:
+            import_errors:
+              type: array
+              items:
+                $ref: '#/components/schemas/ImportError'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     HealthInfo:
       type: object
@@ -1718,12 +1732,15 @@ components:
 
     PoolCollection:
       type: object
-      description: Collection of pool.
-      properties:
-        pools:
-          type: array
-          items:
-            $ref: '#/components/schemas/Pool'
+      description: Collection of pools.
+      allOf:
+        - type: object
+          properties:
+            pools:
+              type: array
+              items:
+                $ref: '#/components/schemas/Pool'
+        - $ref: '#/components/schemas/CollectionInfo'
 
 
     SLAMiss:
@@ -1806,11 +1823,15 @@ components:
 
     TaskInstanceCollection:
       type: object
-      properties:
-        task_instances:
-          type: array
-          items:
-            $ref: '#/components/schemas/TaskInstance'
+      description: Collection of task instances.
+      allOf:
+        - type: object
+          properties:
+            task_instances:
+              type: array
+              items:
+                $ref: '#/components/schemas/TaskInstance'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     TaskInstanceReference:
       type: object
@@ -1854,12 +1875,15 @@ components:
 
     VariableCollection:
       type: object
-      description: Collection of XCom entries
-      properties:
-        variables:
-          type: array
-          items:
-            $ref: '#/components/schemas/VariableCollectionItem'
+      description: Collection of variables.
+      allOf:
+        - type: object
+          properties:
+            variables:
+              type: array
+              items:
+                $ref: '#/components/schemas/VariableCollectionItem'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     Variable:
       description: Full representation of Variable
@@ -1894,11 +1918,14 @@ components:
     XComCollection:
       type: object
       description: Collection of XCom entries.
-      properties:
-        xcom_entries:
-          type: array
-          items:
-            $ref: '#/components/schemas/XComCollectionItem'
+      allOf:
+        - type: object
+          properties:
+            xcom_entries:
+              type: array
+              items:
+                $ref: '#/components/schemas/XComCollectionItem'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     XCom:
       description: Full representations of XCom entry.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1640,7 +1640,7 @@ components:
 
     ImportErrorCollection:
       type: object
-      properties: Collection of import errors.
+      description: Collection of import errors.
       allOf:
         - type: object
           properties:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1399,13 +1399,13 @@ components:
       type: object
       description: Collection of connections.
       allOf:
-       - type: object
-         properties:
-           connections:
-            type: array
-            items:
-              $ref: '#/components/schemas/ConnectionCollectionItem'
-       - $ref: '#/components/schemas/CollectionInfo'
+        - type: object
+          properties:
+            connections:
+              type: array
+              items:
+                $ref: '#/components/schemas/ConnectionCollectionItem'
+        - $ref: '#/components/schemas/CollectionInfo'
 
     Connection:
       description: Full representation of the connection.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1425,6 +1425,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ConnectionCollectionItem'
+        total_entries:
+          type: integer
 
     Connection:
       description: Full representation of the connection.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -265,9 +265,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ConnectionCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/ConnectionCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -383,9 +381,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DAGCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/DAGCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
 
@@ -535,9 +531,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DAGRunCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/DAGRunCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
 
@@ -591,9 +585,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/DAGRunCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/DAGRunCollection'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -659,9 +651,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/EventLogCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/EventLogCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -705,9 +695,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/ImportErrorCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/ImportErrorCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -751,9 +739,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/PoolCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/PoolCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -888,9 +874,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/TaskInstanceCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/TaskInstanceCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -945,9 +929,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/TaskInstanceCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/TaskInstanceCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -971,9 +953,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/VariableCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/VariableCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
@@ -1100,9 +1080,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
-                  - $ref: '#/components/schemas/XComCollection'
-                  - $ref: '#/components/schemas/CollectionInfo'
+                $ref: '#/components/schemas/XComCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':


### PR DESCRIPTION
Added a missing property in ConnectionCollection to avoid this error when using the generated Python client:
```
ApiAttributeError: ConnectionCollection has no attribute 'total_entries' at ['received_data']['total_entries']
```

See here:
 
https://github.com/apache/airflow/blob/3a046faaeb457572b1484faf158cc96eb81df44a/airflow/api_connexion/schemas/connection_schema.py#L53

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
