### PR TITLE
Prevent mixed case env vars from crashing processes like worker

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -636,6 +636,9 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
                 opt = self._get_env_var_option(section, key)
             except ValueError:
                 continue
+            if opt is None:
+                log.warning("Ignoring unknown env var '%s'", env_var)
+                continue
             if not display_sensitive and env_var != self._env_var_name('core', 'unit_test_mode'):
                 opt = '< hidden >'
             elif raw:

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -116,7 +116,7 @@ def _execute_in_fork(command_to_exec: CommandType) -> None:
         args.func(args)
         ret = 0
     except Exception as e:  # pylint: disable=broad-except
-        log.error("Failed to execute task %s.", str(e))
+        log.exception("Failed to execute task %s.", str(e))
         ret = 1
     finally:
         Sentry.flush()

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -80,6 +80,15 @@ class TestConf(unittest.TestCase):
         assert conf.get("core", "PERCENT") == "with%inside"
         assert conf.get("CORE", "PERCENT") == "with%inside"
 
+    def test_config_as_dict(self):
+        """Test that getting config as dict works even if
+        environment has non-legal env vars"""
+        with unittest.mock.patch.dict('os.environ'):
+            os.environ['AIRFLOW__VAR__broken'] = "not_ok"
+            asdict = conf.as_dict(raw=True, display_sensitive=True)
+        assert asdict.get('VAR') is None
+        assert asdict['testsection']['testkey'] == 'testvalue'
+
     def test_env_var_config(self):
         opt = conf.get('testsection', 'testkey')
         assert opt == 'testvalue'


### PR DESCRIPTION
An environment variable that almost looks like an Airflow var but is not (e.g `AIRFLOW__SOME__brokenthing`) leads to a NPE in `airflow/configuration.py`. In addition, when using the Celery Executor and triggering this exception, the context is silenced in the log message (using `.error` instead of `.exception`) which makes troubleshooting needlessly hard.

This patch ignores but logs env vars that have trailing lowercase part, and uses `log.exception` when running a Celery task fails.
