### PR TITLE
Fix permission error on non-POSIX filesystem (#13121)

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -244,6 +244,9 @@ class FileTaskHandler(logging.Handler):
         if not os.path.exists(full_path):
             open(full_path, "a").close()
             # TODO: Investigate using 444 instead of 666.
-            os.chmod(full_path, 0o666)
+            try:
+                os.chmod(full_path, 0o666)
+            except OSError:
+                logging.warning("OSError while change ownership of the log file")
 
         return full_path


### PR DESCRIPTION
* Fix https://github.com/apache/airflow/issues/12669
 - failure to change ownership of log file on azure

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
