### PR TITLE
Update docker-compose.yaml default AIRFLOW_IMAGE_NAME

### DIFF
--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -39,7 +39,7 @@
 version: '3'
 x-airflow-common:
   &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.0.1}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:master-python3.8}
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor


### PR DESCRIPTION
Updates default docker image name used in the docker compose file for v2-0-stable to run Airflow in the Running Airflow in Docker documentation. This change is consistent with current master branch. 

closes: #14379
