### PR TITLE
Add Cross reference for Accessing Task Context in TaskFlow API

### DIFF
--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -198,6 +198,9 @@ Example DAG built with the TaskFlow API
         html_content=email_info['body']
     )
 
+To retrieve current Task execution context dictionary and use it in the function check:
+:ref:`Accessing context <concepts:accessing_context>`.
+
 DAG decorator
 -------------
 
@@ -356,6 +359,8 @@ someone inserts a new task before ``task__2``. The ``task_id`` after that will a
 This is going to produce ``task__1``, ``task__2``, ``task__3``, ``task__4``. But at this point the ``task__3`` is
 no longer the same ``task__3`` as before. This may create confusion when analyzing history logs / DagRuns of a DAG
 that changed over time.
+
+.. _concepts:accessing_context:
 
 Accessing current context
 -------------------------


### PR DESCRIPTION
Lot of users have been asking this on Slack, SO etc on how to do
that. While we have it in our doc, it isn't cross-referenced in
TaskFlow API which causes that feature to be hidden.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
