### PR TITLE
Fix health spelled incorrectly

### DIFF
--- a/airflow/api_connexion/schemas/health_schema.py
+++ b/airflow/api_connexion/schemas/health_schema.py
@@ -34,11 +34,11 @@ class SchedulerInfoSchema(BaseInfoSchema):
     latest_scheduler_heartbeat = fields.String(dump_only=True)
 
 
-class HeathInfoSchema(Schema):
+class HealthInfoSchema(Schema):
     """Schema for the Health endpoint"""
 
     metadatabase = fields.Nested(MetaDatabaseInfoSchema)
     scheduler = fields.Nested(SchedulerInfoSchema)
 
 
-health_schema = HeathInfoSchema()
+health_schema = HealthInfoSchema()

--- a/blah.py
+++ b/blah.py
@@ -1,1 +1,0 @@
-dflaksjdflkajsdkfj

--- a/blah.py
+++ b/blah.py
@@ -1,0 +1,1 @@
+dflaksjdflkajsdkfj

--- a/tests/api_connexion/endpoints/test_health_endpoint.py
+++ b/tests/api_connexion/endpoints/test_health_endpoint.py
@@ -45,7 +45,7 @@ class TestHealthTestBase(unittest.TestCase):
             session.query(BaseJob).delete()
 
 
-class TestGetHeath(TestHealthTestBase):
+class TestGetHealth(TestHealthTestBase):
     @provide_session
     def test_healthy_scheduler_status(self, session):
         last_scheduler_heartbeat_for_testing_1 = timezone.utcnow()

--- a/tests/api_connexion/schemas/test_health_schema.py
+++ b/tests/api_connexion/schemas/test_health_schema.py
@@ -19,7 +19,7 @@ import unittest
 from airflow.api_connexion.schemas.health_schema import health_schema
 
 
-class TestHeathSchema(unittest.TestCase):
+class TestHealthSchema(unittest.TestCase):
     def setUp(self):
         self.default_datetime = "2020-06-10T12:02:44+00:00"
 


### PR DESCRIPTION
In the healthcheck endpoint, several occurrences of "health" are spelled as "heath". This corrects the misspelling.