### PR TITLE
Avoid using threads in S3 remote logging by introducing transfer_config_args in S3Hook

### DIFF
--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -46,7 +46,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         try:
             from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
-            return S3Hook(remote_conn_id)
+            return S3Hook(remote_conn_id, transfer_config_args={"use_threads": False})
         except Exception as e:  # pylint: disable=broad-except
             self.log.exception(
                 'Could not create an S3Hook with connection id "%s". '

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -43,6 +43,16 @@ class TestAwsS3Hook:
         hook = S3Hook()
         assert hook.get_conn() is not None
 
+    @mock_s3
+    def test_use_threads_default_value(self):
+        hook = S3Hook()
+        assert hook.transfer_config.use_threads is True
+
+    @mock_s3
+    def test_use_threads_set_value(self):
+        hook = S3Hook(transfer_config_args={"use_threads": False})
+        assert hook.transfer_config.use_threads is False
+
     def test_parse_s3_url(self):
         parsed = S3Hook.parse_s3_url("s3://test/this/is/not/a-real-key.txt")
         assert parsed == ("test", "this/is/not/a-real-key.txt"), "Incorrect parsing of the s3 url"

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -80,6 +80,7 @@ class TestS3TaskHandler(unittest.TestCase):
 
     def test_hook(self):
         assert isinstance(self.s3_task_handler.hook, S3Hook)
+        assert self.s3_task_handler.hook.transfer_config.use_threads is False
 
     @conf_vars({('logging', 'remote_log_conn_id'): 'aws_default'})
     def test_hook_raises(self):


### PR DESCRIPTION
This prevents `RuntimeError: cannot schedule new futures after
interpreter shutdown` as described in #14089

This PR is an alternative implementation to #14399

closes: #14089