### PR TITLE
Fix crash when user clicks on  "Task Instance Details" caused by start_date being None

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -823,7 +823,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         """
         self.log.debug("previous_start_date was called")
         prev_ti = self.get_previous_ti(state=state, session=session)
-        return prev_ti and pendulum.instance(prev_ti.start_date)
+        # prev_ti may not exist and prev_ti.start_date may be None.
+        return prev_ti and prev_ti.start_date and pendulum.instance(prev_ti.start_date)
 
     @property
     def previous_start_date_success(self) -> Optional[pendulum.DateTime]:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1490,7 +1490,7 @@ class TestTaskInstance(unittest.TestCase):
 
     def test_get_previous_start_date_none(self):
         """
-        Test that get_previous_start_date() can handle TaskInstance no start_date.
+        Test that get_previous_start_date() can handle TaskInstance with no start_date.
         """
         with DAG("test_get_previous_start_date_none", start_date=DEFAULT_DATE, schedule_interval=None) as dag:
             task = DummyOperator(task_id="op")

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1488,6 +1488,30 @@ class TestTaskInstance(unittest.TestCase):
         assert ti_list[3].get_previous_start_date(state=State.SUCCESS) == ti_list[1].start_date
         assert ti_list[3].get_previous_start_date(state=State.SUCCESS) != ti_list[2].start_date
 
+    def test_get_previous_start_date_none(self):
+        """
+        Test that get_previous_start_date() can handle TaskInstance no start_date.
+        """
+        with DAG("test_get_previous_start_date_none", start_date=DEFAULT_DATE, schedule_interval=None) as dag:
+            task = DummyOperator(task_id="op")
+
+        dag.create_dagrun(
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+            run_type=DagRunType.MANUAL,
+        )
+
+        next_day = DEFAULT_DATE + datetime.timedelta(days=1)
+
+        dag.create_dagrun(
+            execution_date=next_day,
+            state=State.RUNNING,
+            run_type=DagRunType.MANUAL,
+        )
+
+        ti = TI(task=task, execution_date=next_day)
+        assert ti.get_previous_start_date() is None
+
     def test_pendulum_template_dates(self):
         dag = models.DAG(
             dag_id='test_pendulum_template_dates',

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1495,22 +1495,31 @@ class TestTaskInstance(unittest.TestCase):
         with DAG("test_get_previous_start_date_none", start_date=DEFAULT_DATE, schedule_interval=None) as dag:
             task = DummyOperator(task_id="op")
 
-        dag.create_dagrun(
-            execution_date=DEFAULT_DATE,
+        day_1 = DEFAULT_DATE
+        day_2 = DEFAULT_DATE + datetime.timedelta(days=1)
+
+        # Create a DagRun for day_1 and day_2. Calling ti_2.get_previous_start_date()
+        # should return the start_date of ti_1 (which is None because ti_1 was not run).
+        # It should not raise an error.
+        dagrun_1 = dag.create_dagrun(
+            execution_date=day_1,
             state=State.RUNNING,
             run_type=DagRunType.MANUAL,
         )
 
-        next_day = DEFAULT_DATE + datetime.timedelta(days=1)
-
-        dag.create_dagrun(
-            execution_date=next_day,
+        dagrun_2 = dag.create_dagrun(
+            execution_date=day_2,
             state=State.RUNNING,
             run_type=DagRunType.MANUAL,
         )
 
-        ti = TI(task=task, execution_date=next_day)
-        assert ti.get_previous_start_date() is None
+        ti_1 = dagrun_1.get_task_instance(task.task_id)
+        ti_2 = dagrun_2.get_task_instance(task.task_id)
+        ti_1.task = task
+        ti_2.task = task
+
+        assert ti_2.get_previous_start_date() == ti_1.start_date
+        assert ti_1.start_date is None
 
     def test_pendulum_template_dates(self):
         dag = models.DAG(


### PR DESCRIPTION
This is to fix the following error that happens when a user clicks on 'Task Instance Details' for a TaskInstance that has previous TaskInstance not yet run. E.g.
 - The previous TaskInstance has not yet run because its dependencies are not yet met
 - The previous TaskInstance has not yet run because scheduler is busy, 
 - the previous TaskInstance was marked success without running.

This bug was caused by #12910. It affects Airflow 2.0.0 and 2.0.1.

```python
...
  File "/opt/airflow/airflow/utils/session.py", line 65, in wrapper
    return func(*args, session=session, **kwargs)
  File "/opt/airflow/airflow/models/taskinstance.py", line 826, in get_previous_start_date
    return prev_ti and pendulum.instance(prev_ti.start_date)
  File "/usr/local/lib/python3.6/site-packages/pendulum/__init__.py", line 174, in instance
    raise ValueError("instance() only accepts datetime objects.")
ValueError: instance() only accepts datetime objects.
```