### PR TITLE
Replace deprecated doc links to the correct one

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1479,7 +1479,7 @@ airflow_commands: List[CLICommand] = [
         help='Rotate encrypted connection credentials and variables',
         description=(
             'Rotate all encrypted connection credentials and variables; see '
-            'https://airflow.apache.org/docs/stable/howto/secure-connections.html'
+            'https://airflow.apache.org/docs/apache-airflow/stable/howto/secure-connections.html'
             '#rotating-encryption-keys'
         ),
         args=(),
@@ -1506,7 +1506,7 @@ airflow_commands: List[CLICommand] = [
         help='Celery components',
         description=(
             'Start celery components. Works only when using CeleryExecutor. For more information, see '
-            'https://airflow.apache.org/docs/stable/executor/celery.html'
+            'https://airflow.apache.org/docs/apache-airflow/stable/executor/celery.html'
         ),
         subcommands=CELERY_COMMANDS,
     ),

--- a/airflow/example_dags/tutorial_taskflow_api_etl.py
+++ b/airflow/example_dags/tutorial_taskflow_api_etl.py
@@ -45,7 +45,7 @@ def tutorial_taskflow_api_etl():
     the TaskFlow API using three simple tasks for Extract, Transform, and Load.
     Documentation that goes along with the Airflow TaskFlow API tutorial is
     located
-    [here](https://airflow.apache.org/docs/stable/tutorial_taskflow_api.html)
+    [here](https://airflow.apache.org/docs/apache-airflow/stable/tutorial_taskflow_api.html)
     """
     # [END instantiate_dag]
 

--- a/airflow/providers/dingding/example_dags/example_dingding.py
+++ b/airflow/providers/dingding/example_dags/example_dingding.py
@@ -181,17 +181,17 @@ with DAG(
             "links": [
                 {
                     "title": "Airflow DAG feed card",
-                    "messageURL": "https://airflow.apache.org/docs/stable/ui.html",
+                    "messageURL": "https://airflow.apache.org/docs/apache-airflow/stable/ui.html",
                     "picURL": "https://airflow.apache.org/_images/dags.png",
                 },
                 {
                     "title": "Airflow tree feed card",
-                    "messageURL": "https://airflow.apache.org/docs/stable/ui.html",
+                    "messageURL": "https://airflow.apache.org/docs/apache-airflow/stable/ui.html",
                     "picURL": "https://airflow.apache.org/_images/tree.png",
                 },
                 {
                     "title": "Airflow graph feed card",
-                    "messageURL": "https://airflow.apache.org/docs/stable/ui.html",
+                    "messageURL": "https://airflow.apache.org/docs/apache-airflow/stable/ui.html",
                     "picURL": "https://airflow.apache.org/_images/graph.png",
                 },
             ]

--- a/tests/providers/dingding/hooks/test_dingding.py
+++ b/tests/providers/dingding/hooks/test_dingding.py
@@ -187,17 +187,17 @@ class TestDingdingHook(unittest.TestCase):
             "links": [
                 {
                     "title": "Airflow DAG feed card",
-                    "messageURL": "https://airflow.apache.org/docs/stable/ui.html",
+                    "messageURL": "https://airflow.apache.org/docs/apache-airflow/stable/ui.html",
                     "picURL": "https://airflow.apache.org/_images/dags.png",
                 },
                 {
                     "title": "Airflow tree feed card",
-                    "messageURL": "https://airflow.apache.org/docs/stable/ui.html",
+                    "messageURL": "https://airflow.apache.org/docs/apache-airflow/stable/ui.html",
                     "picURL": "https://airflow.apache.org/_images/tree.png",
                 },
                 {
                     "title": "Airflow graph feed card",
-                    "messageURL": "https://airflow.apache.org/docs/stable/ui.html",
+                    "messageURL": "https://airflow.apache.org/docs/apache-airflow/stable/ui.html",
                     "picURL": "https://airflow.apache.org/_images/graph.png",
                 },
             ]


### PR DESCRIPTION
https://airflow.apache.org/docs/stable/ has been moved to https://airflow.apache.org/docs/apache-airflow/stable/

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
