### PR TITLE
Pre-commit cache is tied to a specific python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,18 +293,25 @@ jobs:
         if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+      - name: "Get Python version"
+        run: "echo \"::set-output name=host-python-version::$(python -c
+ 'import platform; print(platform.python_version())')\""
+        id: host-python-version
       - name: "Cache pre-commit local-installation"
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: pre-commit-local-installation-${{ hashFiles('setup.py', 'setup.cfg') }}
-          restore-keys: pre-commit-local-installation-
+          key: "pre-commit-local-installation-${{steps.host-python-version.outputs.host-python-version}}-\
+${{ hashFiles('setup.py', 'setup.cfg') }}"
+          restore-keys: "\
+pre-commit-local-installation-${{steps.host-python-version.outputs.host-python-version}}-"
       - name: "Cache pre-commit envs: no-pylint"
         uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-no-pylint-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: pre-commit-no-pylint-
+          key: "pre-commit-no-pylint-${{steps.host-python-version.outputs.host-python-version}}-\
+${{ hashFiles('.pre-commit-config.yaml') }}"
+          restore-keys: pre-commit-no-pylint-${{steps.host-python-version.outputs.host-python-version}}
       - name: "Static checks: except pylint"
         run: ./scripts/ci/static_checks/run_static_checks.sh
         env:
@@ -339,18 +346,25 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 2
           persist-credentials: false
-      - name: "Cache pre-commit local installation"
+      - name: "Get Python version"
+        run: "echo \"::set-output name=host-python-version::$(python -c
+ 'import platform; print(platform.python_version())')\""
+        id: host-python-version
+      - name: "Cache pre-commit local-installation"
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: pre-commit-local-installation-${{ hashFiles('setup.py', 'setup.cfg') }}
-          restore-keys: pre-commit-local-installation-
-      - name: "Cache pre-commit envs - basic"
+          key: "pre-commit-local-installation-${{steps.host-python-version.outputs.host-python-version}}-\
+${{ hashFiles('setup.py', 'setup.cfg') }}"
+          restore-keys: "\
+pre-commit-local-installation-${{steps.host-python-version.outputs.host-python-version}}-"
+      - name: "Cache pre-commit envs: no-pylint"
         uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-basic-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: pre-commit-basic-
+          key: "pre-commit-no-pylint-${{steps.host-python-version.outputs.host-python-version}}-\
+${{ hashFiles('.pre-commit-config.yaml') }}"
+          restore-keys: pre-commit-no-pylint-${{steps.host-python-version.outputs.host-python-version}}
       - name: "Static checks: basic checks only"
         run: ./scripts/ci/static_checks/run_basic_static_checks.sh "${{ github.sha }}"
         env:
@@ -383,18 +397,25 @@ jobs:
         if: "!contains(needs.build-info.outputs.runsOn, 'self-hosted')"
       - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+      - name: "Get Python version"
+        run: "echo \"::set-output name=host-python-version::$(python -c
+ 'import platform; print(platform.python_version())')\""
+        id: host-python-version
       - name: "Cache pre-commit local-installation"
         uses: actions/cache@v2
         with:
           path: ~/.local
-          key: pre-commit-local-installation-${{ hashFiles('setup.py', 'setup.cfg') }}
-          restore-keys: pre-commit-local-installation-
+          key: "pre-commit-local-installation-${{steps.host-python-version.outputs.host-python-version}}-\
+${{ hashFiles('setup.py', 'setup.cfg') }}"
+          restore-keys: "\
+pre-commit-local-installation-${{steps.host-python-version.outputs.host-python-version}}-"
       - name: "Cache pre-commit envs - pylint"
         uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit-pylint-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: pre-commit-pylint-
+          key: "pre-commit-pylint-${{steps.host-python-version.outputs.host-python-version}}-\
+${{ hashFiles('.pre-commit-config.yaml') }}"
+          restore-keys: pre-commit-pylint-${{steps.host-python-version.outputs.host-python-version}}
       - name: "Static checks: pylint"
         run: ./scripts/ci/static_checks/run_static_checks.sh pylint
         env:


### PR DESCRIPTION
The Pre-commit cache did not work when there is a change in
version of host python version used. When python version changed
from 3.6.12 to 3.6.13, the cache rendered useless.

This change adds python versio to the cache key specification,
including fallback value also including the python version, so
that even after changing pre-commit, the cache can be rebuilt
from the last-good cache but for the same python version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
