### PR TITLE
fix comparing airflow version to work with older versions of packaging library

### DIFF
--- a/airflow/upgrade/rules/import_changes.py
+++ b/airflow/upgrade/rules/import_changes.py
@@ -127,7 +127,7 @@ class ImportChangesRule(BaseRule):
     def _check_missing_providers(providers):
 
         current_airflow_version = Version(__import__("airflow").__version__)
-        if current_airflow_version.major >= 2:
+        if current_airflow_version >= Version("2.0.0"):
             prefix = "apache-airflow-providers-"
         else:
             prefix = "apache-airflow-backport-providers-"


### PR DESCRIPTION

closes: #14359

`current_airflow_version.major` is supported only for `packaging>=20.0`
https://github.com/pypa/packaging/blob/main/CHANGELOG.rst#200---2020-01-06
We don't have minimum requirement for packaging 

This fix makes the code compatible also with `packaging<20.0`
