### PR TITLE
Upgrade to newer dependencies only set when setup changed for PR

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -42,7 +42,7 @@ else
     FULL_TESTS_NEEDED_LABEL="false"
 fi
 
-function check_upgrade_to_newer_dependencies() {
+function check_upgrade_to_newer_dependencies_needed() {
     # shellcheck disable=SC2153
     if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ||
             ${EVENT_NAME} == 'push' || ${EVENT_NAME} == "scheduled" ]]; then
@@ -51,8 +51,6 @@ function check_upgrade_to_newer_dependencies() {
         # Each build that upgrades to latest constraints will get truly latest constraints, not those
         # Cached in the image this way
         upgrade_to_newer_dependencies="${INCOMING_COMMIT_SHA}"
-    else
-        upgrade_to_newer_dependencies="false"
     fi
 }
 
@@ -216,7 +214,7 @@ function set_outputs_run_everything_and_exit() {
     set_basic_checks_only "false"
     set_docs_build "true"
     set_image_build "true"
-    set_upgrade_to_newer_dependencies "${INCOMING_COMMIT_SHA}"
+    set_upgrade_to_newer_dependencies "${upgrade_to_newer_dependencies}"
     exit
 }
 
@@ -607,7 +605,9 @@ function calculate_test_types_to_run() {
     start_end::group_end
 }
 
-start_end::group_start "Check if COMMIT_SHA passed"
+
+
+upgrade_to_newer_dependencies="false"
 
 if (($# < 1)); then
     echo
@@ -623,11 +623,14 @@ if (($# < 1)); then
 else
     INCOMING_COMMIT_SHA="${1}"
     readonly INCOMING_COMMIT_SHA
+    echo
+    echo "Commit SHA passed: ${INCOMING_COMMIT_SHA}!"
+    echo
+    readonly FULL_TESTS_NEEDED_LABEL
 fi
-start_end::group_end
 
-check_upgrade_to_newer_dependencies
-readonly FULL_TESTS_NEEDED_LABEL
+check_upgrade_to_newer_dependencies_needed
+
 output_all_basic_variables
 
 image_build_needed="false"


### PR DESCRIPTION
Upgrade to newer dependencies is only set to something else than
false in two cases now:

* when setup.py or setup.cfg change
* when we are running push build

Previously - mistakenly - it was also set when "full_tests_needed"
label was set on a PR.

This caused for example the #19610 build to fail before
moto was limited to <2 in #14433.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
