### PR TITLE
Bump openapi-spec-validator to 0.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -110,6 +110,9 @@ install_requires =
     markdown>=2.5.2, <4.0
     markupsafe>=1.1.1, <2.0
     marshmallow-oneofschema>=2.0.1
+    # Dependency of connexion but it does not pin this library
+    # We need >= 0.3 to use https://github.com/p1c2u/openapi-spec-validator/pull/91/files
+    openapi-spec-validator>=0.3.0
     # Numpy stopped releasing 3.6 binaries for 1.20.* series.
     numpy<1.20;python_version<"3.7"
     numpy;python_version>="3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,12 +110,12 @@ install_requires =
     markdown>=2.5.2, <4.0
     markupsafe>=1.1.1, <2.0
     marshmallow-oneofschema>=2.0.1
-    # Dependency of connexion but it does not pin this library
-    # We need >= 0.3 to use https://github.com/p1c2u/openapi-spec-validator/pull/91/files
-    openapi-spec-validator>=0.3.0
     # Numpy stopped releasing 3.6 binaries for 1.20.* series.
     numpy<1.20;python_version<"3.7"
     numpy;python_version>="3.7"
+    # Dependency of connexion but it does not pin this library
+    # We need >= 0.3 to use https://github.com/p1c2u/openapi-spec-validator/pull/91/files
+    openapi-spec-validator>=0.3.0
     # Pandas stopped releasing 3.6 binaries for 1.2.* series.
     pandas>=0.17.1, <1.2;python_version<"3.7"
     pandas>=0.17.1, <2.0;python_version>="3.7"

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -443,15 +443,15 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
     @parameterized.expand(
         [
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_gte=2020-06-18T18:00:00Z",
                 ["TEST_START_EXEC_DAY_18", "TEST_START_EXEC_DAY_19"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte=2020-06-11T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte=2020-06-11T18:00:00Z",
                 ["TEST_START_EXEC_DAY_10", "TEST_START_EXEC_DAY_11"],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte= 2020-06-15T18:00:00+00:00"
+                "api/v1/dags/TEST_DAG_ID/dagRuns?start_date_lte=2020-06-15T18:00:00Z"
                 "&start_date_gte=2020-06-12T18:00:00Z",
                 [
                     "TEST_START_EXEC_DAY_12",
@@ -461,7 +461,7 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
                 ],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_lte=2020-06-13T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_lte=2020-06-13T18:00:00Z",
                 [
                     "TEST_START_EXEC_DAY_10",
                     "TEST_START_EXEC_DAY_11",
@@ -470,7 +470,7 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
                 ],
             ),
             (
-                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-16T18:00:00+00:00",
+                "api/v1/dags/TEST_DAG_ID/dagRuns?execution_date_gte=2020-06-16T18:00:00Z",
                 [
                     "TEST_START_EXEC_DAY_16",
                     "TEST_START_EXEC_DAY_17",
@@ -525,12 +525,12 @@ class TestGetDagRunsEndDateFilters(TestDagRunEndpoint):
         [
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_gte="
-                f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
+                f"{(timezone.utcnow().replace(tzinfo=None) + timedelta(days=1)).isoformat()}",
                 [],
             ),
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_lte="
-                f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
+                f"{(timezone.utcnow().replace(tzinfo=None) + timedelta(days=1)).isoformat()}",
                 ["TEST_DAG_RUN_ID_1"],
             ),
         ]
@@ -666,7 +666,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
             ),
             ({"dag_ids": ["TEST_DAG_ID"], "page_limit": 0}, "0 is less than the minimum of 1 - 'page_limit'"),
             ({"dag_ids": "TEST_DAG_ID"}, "'TEST_DAG_ID' is not of type 'array' - 'dag_ids'"),
-            ({"start_date_gte": "2020-06-12T18"}, "{'start_date_gte': ['Not a valid datetime.']}"),
+            ({"start_date_gte": "2020-06-12T18"}, "'2020-06-12T18' is not a 'date-time' - 'start_date_gte'"),
         ]
     )
     def test_payload_validation(self, payload, error):
@@ -846,24 +846,30 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
 
     @parameterized.expand(
         [
-            ({"execution_date_gte": '2020-11-09T16:25:56.939143'}, 'Naive datetime is disallowed'),
+            (
+                {"execution_date_gte": '2020-11-09T16:25:56.939143'},
+                "'2020-11-09T16:25:56.939143' is not a 'date-time' - 'execution_date_gte'",
+            ),
             (
                 {"start_date_gte": "2020-06-18T16:25:56.939143"},
-                'Naive datetime is disallowed',
+                "'2020-06-18T16:25:56.939143' is not a 'date-time' - 'start_date_gte'",
             ),
             (
                 {"start_date_lte": "2020-06-18T18:00:00.564434"},
-                'Naive datetime is disallowed',
+                "'2020-06-18T18:00:00.564434' is not a 'date-time' - 'start_date_lte'",
             ),
             (
                 {"start_date_lte": "2020-06-15T18:00:00.653434", "start_date_gte": "2020-06-12T18:00.343534"},
-                'Naive datetime is disallowed',
+                "'2020-06-12T18:00.343534' is not a 'date-time' - 'start_date_gte'",
             ),
             (
                 {"execution_date_lte": "2020-06-13T18:00:00.353454"},
-                'Naive datetime is disallowed',
+                "'2020-06-13T18:00:00.353454' is not a 'date-time' - 'execution_date_lte'",
             ),
-            ({"execution_date_gte": "2020-06-16T18:00:00.676443"}, 'Naive datetime is disallowed'),
+            (
+                {"execution_date_gte": "2020-06-16T18:00:00.676443"},
+                "'2020-06-16T18:00:00.676443' is not a 'date-time' - 'execution_date_gte'",
+            ),
         ]
     )
     def test_naive_date_filters_raises_400(self, payload, expected_response):
@@ -932,8 +938,14 @@ class TestPostDagRun(TestDagRunEndpoint):
 
     @parameterized.expand(
         [
-            ({'execution_date': "2020-11-10T08:25:56.939143"}, 'Naive datetime is disallowed'),
-            ({'execution_date': "2020-11-10T08:25:56P"}, "{'execution_date': ['Not a valid datetime.']}"),
+            (
+                {'execution_date': "2020-11-10T08:25:56.939143"},
+                "'2020-11-10T08:25:56.939143' is not a 'date-time' - 'execution_date'",
+            ),
+            (
+                {'execution_date': "2020-11-10T08:25:56P"},
+                "'2020-11-10T08:25:56P' is not a 'date-time' - 'execution_date'",
+            ),
         ]
     )
     def test_should_response_400_for_naive_datetime_and_bad_datetime(self, data, expected):

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -658,12 +658,30 @@ class TestGetTaskInstancesBatch(TestTaskInstanceEndpoint):
 
     @parameterized.expand(
         [
-            ({"end_date_lte": '2020-11-10T12:42:39.442973'}, "Naive datetime is disallowed"),
-            ({"end_date_gte": '2020-11-10T12:42:39.442973'}, "Naive datetime is disallowed"),
-            ({"start_date_lte": '2020-11-10T12:42:39.442973'}, "Naive datetime is disallowed"),
-            ({"start_date_gte": '2020-11-10T12:42:39.442973'}, "Naive datetime is disallowed"),
-            ({"execution_date_gte": '2020-11-10T12:42:39.442973'}, "Naive datetime is disallowed"),
-            ({"execution_date_lte": '2020-11-10T12:42:39.442973'}, "Naive datetime is disallowed"),
+            (
+                {"end_date_lte": '2020-11-10T12:42:39.442973'},
+                "'2020-11-10T12:42:39.442973' is not a 'date-time' - 'end_date_lte'",
+            ),
+            (
+                {"end_date_gte": '2020-11-10T12:42:39.442973'},
+                "'2020-11-10T12:42:39.442973' is not a 'date-time' - 'end_date_gte'",
+            ),
+            (
+                {"start_date_lte": '2020-11-10T12:42:39.442973'},
+                "'2020-11-10T12:42:39.442973' is not a 'date-time' - 'start_date_lte'",
+            ),
+            (
+                {"start_date_gte": '2020-11-10T12:42:39.442973'},
+                "'2020-11-10T12:42:39.442973' is not a 'date-time' - 'start_date_gte'",
+            ),
+            (
+                {"execution_date_gte": '2020-11-10T12:42:39.442973'},
+                "'2020-11-10T12:42:39.442973' is not a 'date-time' - 'execution_date_gte'",
+            ),
+            (
+                {"execution_date_lte": '2020-11-10T12:42:39.442973'},
+                "'2020-11-10T12:42:39.442973' is not a 'date-time' - 'execution_date_lte'",
+            ),
         ]
     )
     @provide_session

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -31,8 +31,8 @@ from tests.test_utils.api_connexion_utils import assert_401, create_user, delete
 from tests.test_utils.db import clear_db_runs, clear_db_sla_miss
 
 DEFAULT_DATETIME_1 = datetime(2020, 1, 1)
-DEFAULT_DATETIME_STR_1 = "2020-01-01T00:00:00+00:00"
-DEFAULT_DATETIME_STR_2 = "2020-01-02T00:00:00+00:00"
+DEFAULT_DATETIME_STR_1 = "2020-01-01T00:00:00Z"
+DEFAULT_DATETIME_STR_2 = "2020-01-02T00:00:00Z"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
A new version of openapi-spec-validator was released  (https://pypi.org/project/openapi-spec-validator/#history) today which broke some tests https://github.com/apache/airflow/runs/1974443463?check_suite_focus=true .

```
root@63779b6c29e8:/opt/airflow# pipdeptree --reverse --packages openapi-spec-validator
openapi-spec-validator==0.2.9
  - connexion==2.7.0 [requires: openapi-spec-validator>=0.2.4]
    - apache-airflow==2.1.0.dev0 [requires: connexion>=2.6.0,<3]
```

Looks like https://github.com/zalando/connexion isn't maintained that much and hence we need to bump this library ourselves and fix tests

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
