### PR TITLE
BugFix:  fix the delete_dag function of json_client

### DIFF
--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -59,7 +59,7 @@ class Client(api_client.Client):
         return data['message']
 
     def delete_dag(self, dag_id):
-        endpoint = '/api/experimental/dags/{}/delete_dag'.format(dag_id)
+        endpoint = '/api/experimental/dags/{}'.format(dag_id)
         url = urljoin(self._api_base_url, endpoint)
         data = self._request(url, method='DELETE')
         return data['message']


### PR DESCRIPTION
Correction the variable of endpoint in delete_dag

the related issue is :   #14373

thanks @kaxil  for reminding that experimental API is deprecated in 2.0.0+