### PR TITLE
Add PATH to basic_static_checks.

### DIFF
--- a/scripts/ci/static_checks/run_basic_static_checks.sh
+++ b/scripts/ci/static_checks/run_basic_static_checks.sh
@@ -38,6 +38,8 @@ shift
 python -m pip install --user pre-commit \
     --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"
 
+export PATH=~/.local/bin:${PATH}
+
 if [[ $# == "0" ]]; then
     pre-commit run --all-files --show-diff-on-failure --color always \
         --from-ref "${COMMIT_SHA}^" --to-ref "${COMMIT_SHA}"


### PR DESCRIPTION
The #14332 change introduced --local flag for static checks and
caching of the pre-commit virtualenv but the necessary PATH change
was not added to `basic_static_checks.sh`. This PR fixes it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
