### PR TITLE
Gracefully handle missing start_date and end_date for DagRun

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -611,6 +611,12 @@ class DagRun(Base, LoggingMixin):
     def _emit_duration_stats_for_finished_state(self):
         if self.state == State.RUNNING:
             return
+        if self.start_date is None:
+            self.log.warning('Failed to record duration of %s: start_date is not set.', self)
+            return
+        if self.end_date is None:
+            self.log.warning('Failed to record duration of %s: end_date is not set.', self)
+            return
 
         duration = self.end_date - self.start_date
         if self.state is State.SUCCESS:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3302,7 +3302,7 @@ class DagRunModelView(AirflowModelView):
         'external_trigger',
         'conf',
     ]
-    edit_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'conf']
+    edit_columns = ['state', 'dag_id', 'execution_date', 'start_date', 'end_date', 'run_id', 'conf']
 
     base_order = ('execution_date', 'desc')
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/14384

This PR fixes two issues:
1. A `TypeError` that would be raised from `_emit_duration_stats_for_finished_state()` when the scheduler transitions a `DagRun` from a `running` state into a `success` or `failed` state if the `DagRun` did not have a `start_date` or `end_date` set.
2. An issue with the `DagRunEditForm`, which would clear the `start_date` and `end_date` for a DagRun, if the form was used to transition a `DagRun` from a `failed` state back into a `running` state (or any other state). In the event where the scheduler would determine the `DagRun` should've been in the `failed` or `success` state (e.g. because the task instances weren't cleared), then this would lead to a scheduler crash.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
