### PR TITLE
Fix pylint pre-commit checks when only todo files are changed

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -585,7 +585,7 @@ repos:
       - id: pylint
         name: Run pylint for main code
         language: system
-        entry: "./scripts/ci/pre_commit/pre_commit_pylint.sh --rcfile pylintrc"
+        entry: "./scripts/ci/pre_commit/pre_commit_pylint.sh"
         files: \.py$
         exclude: ^scripts/.*\.py$|^dev|^provider_packages|^chart|^tests|^kubernetes_tests
         pass_filenames: true
@@ -593,14 +593,14 @@ repos:
       - id: pylint
         name: Run pylint for tests
         language: system
-        entry: "./scripts/ci/pre_commit/pre_commit_pylint.sh --rcfile pylintrc-tests"
+        entry: "env PYLINTRC=pylintrc-tests ./scripts/ci/pre_commit/pre_commit_pylint.sh"
         files: ^tests/.*\.py$
         pass_filenames: true
         require_serial: true
       - id: pylint
         name: Run pylint for helm chart tests
         language: system
-        entry: "./scripts/ci/pre_commit/pre_commit_pylint.sh --rcfile pylintrc-tests"
+        entry: "env PYLINTRC=pylintrc-tests ./scripts/ci/pre_commit/pre_commit_pylint.sh"
         files: ^chart/.*\.py$
         pass_filenames: true
         require_serial: true

--- a/scripts/ci/static_checks/pylint.sh
+++ b/scripts/ci/static_checks/pylint.sh
@@ -36,14 +36,21 @@ build_images::prepare_ci_build
 
 build_images::rebuild_ci_image_if_needed
 
+# Bug: Pylint only looks at PYLINTRC if it can't find a file in the _default_
+# locations, meaning we can't use this env var to over-ride it
+args=()
+
+if [[ -n "${PYLINTRC:-}" ]]; then
+  args=(--rcfile "${PYLINTRC}")
+fi
+
 if [[ "${#@}" != "0" ]]; then
     pylint::filter_out_files_from_pylint_todo_list "$@"
 
     if [[ "${#FILTERED_FILES[@]}" == "0" ]]; then
         echo "Filtered out all files. Skipping pylint."
-    else
-        run_pylint "${FILTERED_FILES[@]}"
+        exit 0
     fi
-else
-    run_pylint
+    args+=("${FILTERED_FILES[@]}")
 fi
+run_pylint "${args[@]}"


### PR DESCRIPTION
Because we specified `--rcfile` as an argument to the script, the check
for "no files" was failing and pylint was being run with no files,
resulting in an error.

This bug was introduced in #14332

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
