### PR TITLE
Fix statsd metrics not sending when using daemon mode

### DIFF
--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -136,6 +136,7 @@ class TestStats(unittest.TestCase):
             ),
         ):
             importlib.reload(airflow.stats)
+            airflow.stats.Stats.incr("dummy_key")
 
     def tearDown(self) -> None:
         # To avoid side-effect


### PR DESCRIPTION

closes: https://github.com/apache/airflow/issues/13741

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
