### PR TITLE
Fix logging error with task error when JSON logging is enabled

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1476,7 +1476,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             test_mode = self.test_mode
 
         if error:
-            self.log.exception(error)
+            if isinstance(error, Exception):
+                self.log.exception("Task failed with exception")
+            else:
+                self.log.error("%s", error)
             # external monitoring process provides pickle file so _run_raw_task
             # can send its runtime errors for access by failure callback
             if error_file:


### PR DESCRIPTION
If the JSON logging mode for Elasticsearch logs is enabled, the
handle_failure function would fail, as it tried to treat the exception
object as the message and try to JSON serialize it (it expected a
string) -- which fails with:

```
TypeError: Object of type type is not JSON serializable
...
  File "/usr/local/lib/python3.7/site-packages/airflow/models/taskinstance.py", line 1150, in handle_failure
    self.log.exception(error)
...
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/log/file_task_handler.py", line 63, in emit
    self.handler.emit(record)
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).