### PR TITLE
BugFix: Set correct Pod State in queue after processing status.

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -205,7 +205,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
             self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
         elif status == 'Succeeded':
             self.log.info('Event: %s Succeeded', pod_id)
-            self.watcher_queue.put((pod_id, namespace, None, annotations, resource_version))
+            self.watcher_queue.put((pod_id, namespace, State.SUCCESS, annotations, resource_version))
         elif status == 'Running':
             self.log.info('Event: %s is Running', pod_id)
         else:


### PR DESCRIPTION
We're facing problems with Pods being endlessly restarted, event after task is successfully completed.
This seems to be result of State being set to `None` instead of `State.SUCCESS`.

This PR fixes state in queue from `None` to `State.SUCCESS` for `Succeeded` events.

