### PR TITLE
Add 'airflow variables list' command for 1.10.x transition version

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -394,6 +394,10 @@ def _vars_wrapper(args, get=None, set=None, delete=None, export=None, imp=None):
     variables(args)
 
 
+def variables_list(args):
+    _vars_wrapper(args)
+
+
 def variables_get(args):
     _vars_wrapper(args, get=args.key)
 
@@ -3070,6 +3074,12 @@ POOLS_COMMANDS = (
     ),
 )
 VARIABLES_COMMANDS = (
+    ActionCommand(
+        name='list',
+        help='List variables',
+        func=variables_list,
+        args=(NOT_DEPRECATED,),
+    ),
     ActionCommand(
         name='get',
         help='Get variable',


### PR DESCRIPTION
This PR is supplementing PR https://github.com/apache/airflow/pull/14457, as discussed in https://github.com/apache/airflow/pull/14457#discussion_r582968411

Let me know if I missed anything or there is better way to handle this.

Thanks.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
