### PR TITLE
Updates docs to include docker resource requirements for quickstart

### DIFF
--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -25,7 +25,7 @@ Before you begin
 
 Follow these steps to install the necessary tools.
 
-1. Install `Docker Community Edition (CE) <https://docs.docker.com/engine/installation/>`__ on your workstation.
+1. Install `Docker Community Edition (CE) <https://docs.docker.com/engine/installation/>`__ on your workstation. Depending on the OS, you may need to configure your Docker instance to use 4.00 GB of memory for all containers to run properly. Please refer to the Resources section if using `Docker for Windows <https://docs.docker.com/docker-for-windows/#resources>`__ or `Docker for Mac <https://docs.docker.com/docker-for-mac/#resources>`__ for more information.
 2. Install `Docker Compose <https://docs.docker.com/compose/install/>`__ v1.27.0 and newer on your workstation.
 
 Older versions of ``docker-compose`` do not support all features required by ``docker-compose.yaml`` file, so double check that it meets the minimum version requirements.


### PR DESCRIPTION
When following along the quickstart using Docker's default resource allocation values, the webserver continuously crashes and it is not immediately obvious as to why. Since this might be someone's first exposure to running Airflow, letting them know that they should consider upping their resource allocations could save new people a lot of aggravation. It makes sense - we default to using Celery, but Airflow may be inadvertently blamed as the problem.

Stacktrace:

```
airflow-webserver_1  | [2021-02-25 17:21:54,330] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | [2021-02-25 17:21:54,803] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  |   ____________       _____________
airflow-webserver_1  |  ____    |__( )_________  __/__  /________      __
airflow-webserver_1  | ____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
airflow-webserver_1  | ___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
airflow-webserver_1  |  _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
airflow-webserver_1  | [2021-02-25 17:21:54,874] {dagbag.py:448} INFO - Filling up the DagBag from /dev/null
airflow-webserver_1  | [2021-02-25 17:21:56,131] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | [2021-02-25 17:21:56,200] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [20] [INFO] Starting gunicorn 19.10.0
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [20] [INFO] Listening at: http://0.0.0.0:8080 (20)
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [20] [INFO] Using worker: sync
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [31] [INFO] Booting worker with pid: 31
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [32] [INFO] Booting worker with pid: 32
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [32] [INFO] Booting worker with pid: 32
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [33] [INFO] Booting worker with pid: 33
airflow-webserver_1  | [2021-02-25 17:21:59 +0000] [34] [INFO] Booting worker with pid: 34
airflow-webserver_1  | [2021-02-25 17:22:02,860] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | [2021-02-25 17:22:02,860] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | [2021-02-25 17:22:02,860] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | [2021-02-25 17:22:02,860] {providers_manager.py:299} WARNING - Exception when importing 'airflow.providers.microsoft.azure.hooks.wasb.WasbHook' from 'apache-airflow-providers-microsoft-azure' package: No module named 'azure.storage.blob'
airflow-webserver_1  | Running the Gunicorn Server with:
airflow-webserver_1  | Workers: 4 sync
airflow-webserver_1  | Host: 0.0.0.0:8080
airflow-webserver_1  | Timeout: 120
airflow-webserver_1  | Logfiles: - -
airflow-webserver_1  | Access Logformat:
airflow-webserver_1  | =================================================================
airflow-webserver_1  | [2021-02-25 17:22:11,015] {webserver_command.py:255} ERROR - [0 / 0] Some workers seem to have died and gunicorn did not restart them as expected
airflow-oss_airflow-webserver_1 exited with code 137

```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
