### PR TITLE
Use CustomSQLAInterface instead of SQLAInterface

### DIFF
--- a/airflow/upgrade/rules/use_customsqlainterface_class_rule.py
+++ b/airflow/upgrade/rules/use_customsqlainterface_class_rule.py
@@ -19,7 +19,6 @@ from airflow.upgrade.rules.base_rule import BaseRule
 
 
 class UseCustomSQLAInterfaceClassRule(BaseRule):
-
     title = "Use CustomSQLAInterface instead of SQLAInterface for custom data models."
 
     description = """\
@@ -55,12 +54,11 @@ and in 2.0:
                         plugins_with_sqlainterface_data_model_instance.append(view_obj.get("name"))
 
         if plugins_with_sqlainterface_data_model_instance:
-            print(plugins_with_sqlainterface_data_model_instance)
             return (
                 "Deprecation Warning: The following views: {} have "
                 "data models instantiated "
                 "from the SQLAInterface class.\n".format(plugins_with_sqlainterface_data_model_instance) +
-                "Use the CustomSQLAInterface class instead:"
-                "`from airflow.www.utils import CustomSQLAInterface`\n"
-                "`datamodel = CustomSQLAInterface(your_data_model)`"
+                "See: "
+                "https://github.com/apache/airflow/blob/master/"
+                "UPDATING.md#use-customsqlainterface-instead-of-sqlqinterface-for-custom-data-models"
             )

--- a/airflow/upgrade/rules/use_customsqlainterface_class_rule.py
+++ b/airflow/upgrade/rules/use_customsqlainterface_class_rule.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.www_rbac.utils import CustomSQLAInterface
 
 
 class UseCustomSQLAInterfaceClassRule(BaseRule):
@@ -49,9 +50,8 @@ and in 2.0:
 
         if flask_appbuilder_views:
             for view_obj in flask_appbuilder_views:
-                for attr in dir(view_obj.get("view")):
-                    if type(getattr(view_obj.get("view"), attr)).__name__ == 'SQLAInterface':
-                        plugins_with_sqlainterface_data_model_instance.append(view_obj.get("name"))
+                if not isinstance(view_obj.get("view").datamodel, CustomSQLAInterface):
+                    plugins_with_sqlainterface_data_model_instance.append(view_obj.get("name"))
 
         if plugins_with_sqlainterface_data_model_instance:
             return (
@@ -60,5 +60,5 @@ and in 2.0:
                 "from the SQLAInterface class.\n".format(plugins_with_sqlainterface_data_model_instance) +
                 "See: "
                 "https://github.com/apache/airflow/blob/master/"
-                "UPDATING.md#use-customsqlainterface-instead-of-sqlqinterface-for-custom-data-models"
+                "UPDATING.md#use-customsqlainterface-instead-of-sqlainterface-for-custom-data-models"
             )

--- a/airflow/upgrade/rules/use_customsqlainterface_class_rule.py
+++ b/airflow/upgrade/rules/use_customsqlainterface_class_rule.py
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class UseCustomSQLAInterfaceClassRule(BaseRule):
+
+    title = "Use CustomSQLAInterface instead of SQLAInterface for custom data models."
+
+    description = """\
+From Airflow 2.0, if you want to define your own Flask App Builder models you need to
+use CustomSQLAInterface instead of SQLAInterface.
+
+For Non-RBAC replace:
+
+`from flask_appbuilder.models.sqla.interface import SQLAInterface`
+`datamodel = SQLAInterface(your_data_model)`
+
+with RBAC (in 1.10):
+
+`from airflow.www_rbac.utils import CustomSQLAInterface`
+`datamodel = CustomSQLAInterface(your_data_model)`
+
+and in 2.0:
+
+`from airflow.www.utils import CustomSQLAInterface`
+`datamodel = CustomSQLAInterface(your_data_model)`
+                  """
+
+    def check(self):
+
+        from airflow.plugins_manager import flask_appbuilder_views
+
+        plugins_with_sqlainterface_data_model_instance = []
+
+        if flask_appbuilder_views:
+            for view_obj in flask_appbuilder_views:
+                for attr in dir(view_obj.get("view")):
+                    if type(getattr(view_obj.get("view"), attr)).__name__ == 'SQLAInterface':
+                        plugins_with_sqlainterface_data_model_instance.append(view_obj.get("name"))
+
+        if plugins_with_sqlainterface_data_model_instance:
+            print(plugins_with_sqlainterface_data_model_instance)
+            return (
+                "Deprecation Warning: The following views: {} have "
+                "data models instantiated "
+                "from the SQLAInterface class.\n".format(plugins_with_sqlainterface_data_model_instance) +
+                "Use the CustomSQLAInterface class instead:"
+                "`from airflow.www.utils import CustomSQLAInterface`\n"
+                "`datamodel = CustomSQLAInterface(your_data_model)`"
+            )

--- a/tests/upgrade/rules/test_use_customsqlainterface_class_rule.py
+++ b/tests/upgrade/rules/test_use_customsqlainterface_class_rule.py
@@ -67,7 +67,7 @@ class TestUseCustomSQLAInterfaceClassRule(TestCase):
             "data models instantiated from the SQLAInterface class.\n"
             "See: "
             "https://github.com/apache/airflow/blob/master/"
-            "UPDATING.md#use-customsqlainterface-instead-of-sqlqinterface-for-custom-data-models"
+            "UPDATING.md#use-customsqlainterface-instead-of-sqlainterface-for-custom-data-models"
         )
 
         assert msg == rule.check()

--- a/tests/upgrade/rules/test_use_customsqlainterface_class_rule.py
+++ b/tests/upgrade/rules/test_use_customsqlainterface_class_rule.py
@@ -65,9 +65,9 @@ class TestUseCustomSQLAInterfaceClassRule(TestCase):
         msg = (
             "Deprecation Warning: The following views: ['Test View', 'Test View'] have "
             "data models instantiated from the SQLAInterface class.\n"
-            "Use the CustomSQLAInterface class instead:"
-            "`from airflow.www.utils import CustomSQLAInterface`\n"
-            "`datamodel = CustomSQLAInterface(your_data_model)`"
+            "See: "
+            "https://github.com/apache/airflow/blob/master/"
+            "UPDATING.md#use-customsqlainterface-instead-of-sqlqinterface-for-custom-data-models"
         )
 
         assert msg == rule.check()

--- a/tests/upgrade/rules/test_use_customsqlainterface_class_rule.py
+++ b/tests/upgrade/rules/test_use_customsqlainterface_class_rule.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from unittest import TestCase
+
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+
+from airflow.models import User
+from airflow.upgrade.rules.use_customsqlainterface_class_rule import UseCustomSQLAInterfaceClassRule
+from airflow.www_rbac.utils import CustomSQLAInterface
+from tests.compat import patch, MagicMock
+
+mock_appbuilder_sqla_interface = MagicMock(datamodel=SQLAInterface(User))
+
+mock_appbuilder_custom_sqla_interface = MagicMock(datamodel=CustomSQLAInterface(User))
+
+test_plugins_sqla_interface = [{
+    "name": "Test View",
+    "category": "Test Plugin",
+    "endpoint": "plugin",
+    "view": mock_appbuilder_sqla_interface
+}, {
+    "name": "Test View",
+    "category": "Test Plugin",
+    "endpoint": "plugin",
+    "view": mock_appbuilder_sqla_interface
+}]
+
+test_plugins_custom_sqla_interface = [{
+    "name": "Test View",
+    "category": "Test Plugin",
+    "endpoint": "plugin",
+    "view": mock_appbuilder_custom_sqla_interface
+}, {
+    "name": "Test View",
+    "category": "Test Plugin",
+    "endpoint": "plugin",
+    "view": mock_appbuilder_custom_sqla_interface
+}]
+
+
+class TestUseCustomSQLAInterfaceClassRule(TestCase):
+
+    @patch('airflow.plugins_manager.flask_appbuilder_views', test_plugins_sqla_interface)
+    def test_invalid_check(self):
+        rule = UseCustomSQLAInterfaceClassRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        msg = (
+            "Deprecation Warning: The following views: ['Test View', 'Test View'] have "
+            "data models instantiated from the SQLAInterface class.\n"
+            "Use the CustomSQLAInterface class instead:"
+            "`from airflow.www.utils import CustomSQLAInterface`\n"
+            "`datamodel = CustomSQLAInterface(your_data_model)`"
+        )
+
+        assert msg == rule.check()
+
+    @patch('airflow.plugins_manager.flask_appbuilder_views', test_plugins_custom_sqla_interface)
+    def test_valid_check(self):
+        rule = UseCustomSQLAInterfaceClassRule()
+
+        assert isinstance(rule.title, str)
+        assert isinstance(rule.description, str)
+
+        assert rule.check() is None


### PR DESCRIPTION
for custom data models.

From Airflow 2.0, if you want to define your own Flask App Builder
models you need to use CustomSQLAInterface instead of SQLAInterface.

For Non-RBAC replace:

`from flask_appbuilder.models.sqla.interface import SQLAInterface`
`datamodel = SQLAInterface(your_data_model)`

with RBAC (in 1.10):

`from airflow.www_rbac.utils import CustomSQLAInterface`
`datamodel = CustomSQLAInterface(your_data_model)`

and in 2.0:

`from airflow.www.utils import CustomSQLAInterface`
`datamodel = CustomSQLAInterface(your_data_model)`

related: #13226 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
