### PR TITLE
Scheduler: Remove TIs from starved pools from the critical path.

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -907,8 +907,6 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         # If _somehow_ the pool is overfull, don't let the limit go negative - it breaks SQL
         pool_slots_free = max(0, sum(pool['open'] for pool in pools.values()))
 
-        starved_pools = [pool_name for pool_name, stats in pools.items() if stats['open'] == 0]
-
         if pool_slots_free == 0:
             self.log.debug("All pools are full!")
             return executable_tis
@@ -925,10 +923,13 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
             .join(TI.dag_model)
             .filter(not_(DM.is_paused))
             .filter(TI.state == State.SCHEDULED)
-            .filter(not_(TI.pool.in_(starved_pools)))
             .options(selectinload('dag_model'))
-            .limit(max_tis)
         )
+        starved_pools = [pool_name for pool_name, stats in pools.items() if stats['open'] <= 0]
+        if starved_pools:
+            query = query.filter(not_(TI.pool.in_(starved_pools)))
+
+        query = query.limit(max_tis)
 
         task_instances_to_examine: List[TI] = with_row_locks(
             query,

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2740,8 +2740,10 @@ class TestSchedulerJob(unittest.TestCase):
 
         # Make sure we get TIs from a non-full pool in the 2nd list
         assert len(task_instances_list2) > 0
-        assert all(task_instance.pool != 'test_scheduler_keeps_scheduling_when_a_pool_is_full_p1'
-                   for task_instance in task_instances_list2)
+        assert all(
+            task_instance.pool != 'test_scheduler_keeps_scheduling_when_a_pool_is_full_p1'
+            for task_instance in task_instances_list2
+        )
 
     def test_scheduler_verify_priority_and_slots(self):
         """

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2670,6 +2670,79 @@ class TestSchedulerJob(unittest.TestCase):
         # As tasks require 2 slots, only 3 can fit into 6 available
         assert len(task_instances_list) == 3
 
+    def test_scheduler_keeps_scheduling_when_a_pool_is_full(self):
+        """
+        Test task instances in a pool that isn't full keep getting scheduled even when a pool is full.
+        """
+        dag_d1 = DAG(dag_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_d1', start_date=DEFAULT_DATE)
+        BashOperator(
+            task_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_t1',
+            dag=dag_d1,
+            owner='airflow',
+            pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p1',
+            bash_command='echo hi',
+        )
+
+        dag_d2 = DAG(dag_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_d2', start_date=DEFAULT_DATE)
+        BashOperator(
+            task_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_t2',
+            dag=dag_d2,
+            owner='airflow',
+            pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p2',
+            bash_command='echo hi',
+        )
+        dagbag = DagBag(
+            dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"),
+            include_examples=False,
+            read_dags_from_db=True,
+        )
+        dagbag.bag_dag(dag=dag_d1, root_dag=dag_d1)
+        dagbag.bag_dag(dag=dag_d2, root_dag=dag_d2)
+        dagbag.sync_to_db()
+
+        session = settings.Session()
+        pool_p1 = Pool(pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p1', slots=1)
+        pool_p2 = Pool(pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p2', slots=10)
+        session.add(pool_p1)
+        session.add(pool_p2)
+        session.commit()
+
+        dag_d1 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_d1))
+
+        scheduler = SchedulerJob(executor=self.null_exec)
+        scheduler.processor_agent = mock.MagicMock()
+
+        # Create 5 dagruns for each DAG.
+        # To increase the chances the TIs from the "full" pool will get retrieved first, we schedule all TIs from the
+        # first dag first.
+        date = DEFAULT_DATE
+        for _ in range(5):
+            dr = dag_d1.create_dagrun(
+                run_type=DagRunType.SCHEDULED,
+                execution_date=date,
+                state=State.RUNNING,
+            )
+            scheduler._schedule_dag_run(dr, {}, session)
+            date = dag_d1.following_schedule(date)
+
+        date = DEFAULT_DATE
+        for _ in range(5):
+            dr = dag_d2.create_dagrun(
+                run_type=DagRunType.SCHEDULED,
+                execution_date=date,
+                state=State.RUNNING,
+            )
+            scheduler._schedule_dag_run(dr, {}, session)
+            date = dag_d2.following_schedule(date)
+
+        task_instances_list1 = scheduler._executable_task_instances_to_queued(max_tis=2, session=session)
+        task_instances_list2 = scheduler._executable_task_instances_to_queued(max_tis=2, session=session)
+
+        # Make sure we get TIs from a non-full pool in the 2nd list
+        assert len(task_instances_list2) > 0
+        assert all(task_instance.pool != 'test_scheduler_keeps_scheduling_when_a_pool_is_full_p1' for task_instance in task_instances_list2)
+
+
     def test_scheduler_verify_priority_and_slots(self):
         """
         Test task instances with higher priority are not queued

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2713,8 +2713,8 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler.processor_agent = mock.MagicMock()
 
         # Create 5 dagruns for each DAG.
-        # To increase the chances the TIs from the "full" pool will get retrieved first, we schedule all TIs from the
-        # first dag first.
+        # To increase the chances the TIs from the "full" pool will get retrieved first, we schedule all
+        # TIs from the first dag first.
         date = DEFAULT_DATE
         for _ in range(5):
             dr = dag_d1.create_dagrun(
@@ -2735,13 +2735,13 @@ class TestSchedulerJob(unittest.TestCase):
             scheduler._schedule_dag_run(dr, {}, session)
             date = dag_d2.following_schedule(date)
 
-        task_instances_list1 = scheduler._executable_task_instances_to_queued(max_tis=2, session=session)
+        scheduler._executable_task_instances_to_queued(max_tis=2, session=session)
         task_instances_list2 = scheduler._executable_task_instances_to_queued(max_tis=2, session=session)
 
         # Make sure we get TIs from a non-full pool in the 2nd list
         assert len(task_instances_list2) > 0
-        assert all(task_instance.pool != 'test_scheduler_keeps_scheduling_when_a_pool_is_full_p1' for task_instance in task_instances_list2)
-
+        assert all(task_instance.pool != 'test_scheduler_keeps_scheduling_when_a_pool_is_full_p1'
+                   for task_instance in task_instances_list2)
 
     def test_scheduler_verify_priority_and_slots(self):
         """

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2670,25 +2670,25 @@ class TestSchedulerJob(unittest.TestCase):
         # As tasks require 2 slots, only 3 can fit into 6 available
         assert len(task_instances_list) == 3
 
-    def test_scheduler_keeps_scheduling_when_a_pool_is_full(self):
+    def test_scheduler_keeps_scheduling_pool_full(self):
         """
         Test task instances in a pool that isn't full keep getting scheduled even when a pool is full.
         """
-        dag_d1 = DAG(dag_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_d1', start_date=DEFAULT_DATE)
+        dag_d1 = DAG(dag_id='test_scheduler_keeps_scheduling_pool_full_d1', start_date=DEFAULT_DATE)
         BashOperator(
-            task_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_t1',
+            task_id='test_scheduler_keeps_scheduling_pool_full_t1',
             dag=dag_d1,
             owner='airflow',
-            pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p1',
+            pool='test_scheduler_keeps_scheduling_pool_full_p1',
             bash_command='echo hi',
         )
 
-        dag_d2 = DAG(dag_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_d2', start_date=DEFAULT_DATE)
+        dag_d2 = DAG(dag_id='test_scheduler_keeps_scheduling_pool_full_d2', start_date=DEFAULT_DATE)
         BashOperator(
-            task_id='test_scheduler_keeps_scheduling_when_a_pool_is_full_t2',
+            task_id='test_scheduler_keeps_scheduling_pool_full_t2',
             dag=dag_d2,
             owner='airflow',
-            pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p2',
+            pool='test_scheduler_keeps_scheduling_pool_full_p2',
             bash_command='echo hi',
         )
         dagbag = DagBag(
@@ -2701,8 +2701,8 @@ class TestSchedulerJob(unittest.TestCase):
         dagbag.sync_to_db()
 
         session = settings.Session()
-        pool_p1 = Pool(pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p1', slots=1)
-        pool_p2 = Pool(pool='test_scheduler_keeps_scheduling_when_a_pool_is_full_p2', slots=10)
+        pool_p1 = Pool(pool='test_scheduler_keeps_scheduling_pool_full_p1', slots=1)
+        pool_p2 = Pool(pool='test_scheduler_keeps_scheduling_pool_full_p2', slots=10)
         session.add(pool_p1)
         session.add(pool_p2)
         session.commit()
@@ -2741,7 +2741,7 @@ class TestSchedulerJob(unittest.TestCase):
         # Make sure we get TIs from a non-full pool in the 2nd list
         assert len(task_instances_list2) > 0
         assert all(
-            task_instance.pool != 'test_scheduler_keeps_scheduling_when_a_pool_is_full_p1'
+            task_instance.pool != 'test_scheduler_keeps_scheduling_pool_full_p1'
             for task_instance in task_instances_list2
         )
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Currently the scheduler can be stuck in a loop if the query tweaked in this PR continually returns a set of task instances that aren't schedule-able because all their respective pools are full. This is even more apparent when your `max_tis` gets low with the various `min`s in the scheduler main loop code path ( either because your overall pool open slots are low, your parallelism is low, or you've set `max_tis_per_query` too low ).

The unit test reproduces the issue ( though I'm still not convinced it's the best way to show it, I've included further down a "setup", I guess this should be thrown into an integration test instead? ):

The test setup idea is to fill the set of schedule-able TIs returned by that query full of TIs that will starve a first pool from open slots, and then add another set of schedule-able TIs that should be easy to schedule and execute because their execution pool is much bigger. Without filtering out TIs from the first pool ( that will be further discarded in that code path ) we end up with a scheduler stuck until the first pool gets through its work, this starves the second pool for no reason other than the scheduler never getting to them:

Using a minimal "real-life" example ( you need to create a `starving_pool` with only a couple of slots, and "limit" your `max_tis` either manually or through `parallelism` ... ), your scheduler will quickly converge to a log similar to this, even though TIs from `starved_dag` could easily be scheduled and executed:
```
[2021-02-26 08:56:43,604] {scheduler_job.py:950} INFO - 2 tasks up for execution:
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:20:00+00:00 [scheduled]>
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:10:00+00:00 [scheduled]>
[2021-02-26 08:56:43,606] {scheduler_job.py:979} INFO - Figuring out tasks to run in Pool(name=starving_pool) with 0 open slots and 2 task instances ready to be queued
[2021-02-26 08:56:43,606] {scheduler_job.py:994} INFO - Not scheduling since there are 0 open slots in pool starving_pool
[2021-02-26 08:56:43,606] {scheduler_job.py:1072} INFO - Setting the following tasks to queued state:

[2021-02-26 08:56:44,757] {scheduler_job.py:950} INFO - 2 tasks up for execution:
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:20:00+00:00 [scheduled]>
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:10:00+00:00 [scheduled]>
[2021-02-26 08:56:44,759] {scheduler_job.py:979} INFO - Figuring out tasks to run in Pool(name=starving_pool) with 0 open slots and 2 task instances ready to be queued
[2021-02-26 08:56:44,759] {scheduler_job.py:994} INFO - Not scheduling since there are 0 open slots in pool starving_pool
[2021-02-26 08:56:44,759] {scheduler_job.py:1072} INFO - Setting the following tasks to queued state:

[2021-02-26 08:56:45,068] {scheduler_job.py:950} INFO - 2 tasks up for execution:
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:20:00+00:00 [scheduled]>
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:10:00+00:00 [scheduled]>
[2021-02-26 08:56:45,070] {scheduler_job.py:979} INFO - Figuring out tasks to run in Pool(name=starving_pool) with 0 open slots and 2 task instances ready to be queued
[2021-02-26 08:56:45,070] {scheduler_job.py:994} INFO - Not scheduling since there are 0 open slots in pool starving_pool
[2021-02-26 08:56:45,070] {scheduler_job.py:1072} INFO - Setting the following tasks to queued state:

[2021-02-26 08:56:45,309] {scheduler_job.py:950} INFO - 2 tasks up for execution:
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:20:00+00:00 [scheduled]>
        <TaskInstance: starving_pool.sleeper 2021-02-26 03:10:00+00:00 [scheduled]>
[2021-02-26 08:56:45,311] {scheduler_job.py:979} INFO - Figuring out tasks to run in Pool(name=starving_pool) with 0 open slots and 2 task instances ready to be queued
[2021-02-26 08:56:45,311] {scheduler_job.py:994} INFO - Not scheduling since there are 0 open slots in pool starving_pool
```

`starved_dag.py`
```
"""DAG starved even though its TIs are executable in a non starved pool ( default pool )"""
from datetime import datetime, timedelta

from airflow.models.dag import DAG
from airflow.operators.bash import BashOperator
from airflow.utils.dates import days_ago

DAG_NAME = 'starved_dag'

default_args = {'owner': 'airflow', 'start_date': days_ago(0), 'dagrun_timeout': timedelta(minutes=6)}
dag = DAG(DAG_NAME, schedule_interval='*/10 * * * *', default_args=default_args)

echoer = BashOperator(
    task_id='echoer',
    bash_command='echo "bonjour"',
    dag=dag,
)

if __name__ == "__main__":
    dag.cli()
```

`starving_pool.py`
```
"""DAG to starve schedulable TIs query"""
from datetime import datetime, timedelta

from airflow.models.dag import DAG
from airflow.operators.bash import BashOperator
from airflow.utils.dates import days_ago

DAG_NAME = 'starving_pool'

default_args = {'owner': 'airflow', 'start_date': days_ago(0), 'dagrun_timeout': timedelta(minutes=6)}
dag = DAG(DAG_NAME, schedule_interval='*/10 * * * *', default_args=default_args)

sleeper = BashOperator(
    task_id='sleeper',
    bash_command='sleep 300',
    dag=dag,
    pool='starving_pool'
)

if __name__ == "__main__":
    dag.cli()
```

We hit this issue in our production stack with real life DAGs. To bypass it, we're currently running with an insanely big unused pool ( `999999` slots :D ), an insanely big `max_tis_per_query`, and an insanely big `parallelism` ( even though we don't have the actual workers behind it ) to make sure that the number of TIs returned by the tweaked query will always be bigger than the maximum number of TIs stuck in starved pools at any point in time.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
