### PR TITLE
Upgrade check for use of CustomSQLAInterface

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -19,8 +19,7 @@
 
 # Updating Airflow
 
-This file documents any backwards-incompatible changes in Airflow and
-assists users migrating to a new version.
+This file documents any backwards-incompatible changes in Airflow and assists users migrating to a new version.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -69,42 +68,39 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
-
 ## Airflow 2.0.1
 
 ### Permission to view Airflow Configurations has been removed from `User` and `Viewer` role
 
-Previously, Users with `User` or `Viewer` role were able to get/view configurations using
-the REST API or in the Webserver. From Airflow 2.0.1, only users with `Admin` or `Op` role would be able
-to get/view Configurations.
+Previously, Users with `User` or `Viewer` role were able to get/view configurations using the REST API or in the
+Webserver. From Airflow 2.0.1, only users with `Admin` or `Op` role would be able to get/view Configurations.
 
 To allow users with other roles to view configuration, add `can read on Configurations` permissions to that role.
 
-Note that if `[webserver] expose_config` is set to `False`, the API will throw a `403` response even if
-the user has role with `can read on Configurations` permission.
+Note that if `[webserver] expose_config` is set to `False`, the API will throw a `403` response even if the user has
+role with `can read on Configurations` permission.
 
 ### Default `[celery] worker_concurrency` is changed to `16`
 
-The default value for `[celery] worker_concurrency` was `16` for Airflow <2.0.0.
-However, it was unintentionally changed to `8` in 2.0.0.
+The default value for `[celery] worker_concurrency` was `16` for Airflow <2.0.0. However, it was unintentionally changed
+to `8` in 2.0.0.
 
 From Airflow 2.0.1, we revert to the old default of `16`.
 
 ### Default `[scheduler] min_file_process_interval` is changed to `30`
 
-The default value for `[scheduler] min_file_process_interval` was `0`,
-due to which the CPU Usage mostly stayed around 100% as the DAG files are parsed
-constantly.
+The default value for `[scheduler] min_file_process_interval` was `0`, due to which the CPU Usage mostly stayed around
+100% as the DAG files are parsed constantly.
 
-From Airflow 2.0.0, the scheduling decisions have been moved from
-DagFileProcessor to Scheduler, so we can keep the default a bit higher: `30`.
+From Airflow 2.0.0, the scheduling decisions have been moved from DagFileProcessor to Scheduler, so we can keep the
+default a bit higher: `30`.
 
 ## Airflow 2.0.0
 
-The 2.0 release of the Airflow is a significant upgrade, and includes substantial major changes,
-and some of them may be breaking. Existing code written for earlier versions of this project will may require updates
-to use this version. Sometimes necessary configuration changes are also required.
-This document describes the changes that have been made, and what you need to do to update your usage.
+The 2.0 release of the Airflow is a significant upgrade, and includes substantial major changes, and some of them may be
+breaking. Existing code written for earlier versions of this project will may require updates to use this version.
+Sometimes necessary configuration changes are also required. This document describes the changes that have been made,
+and what you need to do to update your usage.
 
 If you experience issues or have questions, please file [an issue](https://github.com/apache/airflow/issues/new/choose).
 
@@ -114,29 +110,29 @@ This section describes the major changes that have been made in this release.
 
 ### The experimental REST API is disabled by default
 
-The experimental REST API is disabled by default. To restore these APIs while migrating to
-the stable REST API, set `enable_experimental_api` option in `[api]` section to `True`.
+The experimental REST API is disabled by default. To restore these APIs while migrating to the stable REST API,
+set `enable_experimental_api` option in `[api]` section to `True`.
 
-Please note that the experimental REST API do not have access control.
-The authenticated user has full access.
+Please note that the experimental REST API do not have access control. The authenticated user has full access.
 
 ### SparkJDBCHook default connection
 
 For SparkJDBCHook default connection was `spark-default`, and for SparkSubmitHook it was
-`spark_default`. Both hooks now use the `spark_default` which is a common pattern for the connection
-names used across all providers.
+`spark_default`. Both hooks now use the `spark_default` which is a common pattern for the connection names used across
+all providers.
 
 ### Changes to output argument in commands
 
-From Airflow 2.0, We are replacing [tabulate](https://pypi.org/project/tabulate/) with [rich](https://github.com/willmcgugan/rich) to render commands output. Due to this change, the `--output` argument
+From Airflow 2.0, We are replacing [tabulate](https://pypi.org/project/tabulate/)
+with [rich](https://github.com/willmcgugan/rich) to render commands output. Due to this change, the `--output` argument
 will no longer accept formats of tabulate tables. Instead, it now accepts:
 
 - `table` - will render the output in predefined table
 - `json` - will render the output as a json
 - `yaml` - will render the output as yaml
 
-By doing this we increased consistency and gave users possibility to manipulate the
-output programmatically (when using json or yaml).
+By doing this we increased consistency and gave users possibility to manipulate the output programmatically (when using
+json or yaml).
 
 Affected commands:
 
@@ -162,17 +158,15 @@ Affected commands:
 
 ### Azure Wasb Hook does not work together with Snowflake hook
 
-The WasbHook in Apache Airflow use a legacy version of Azure library. While the conflict is not
-significant for most of the Azure hooks, it is a problem for Wasb Hook because the `blob` folders
-for both libraries overlap. Installing both Snowflake and Azure extra will result in non-importable
-WasbHook.
+The WasbHook in Apache Airflow use a legacy version of Azure library. While the conflict is not significant for most of
+the Azure hooks, it is a problem for Wasb Hook because the `blob` folders for both libraries overlap. Installing both
+Snowflake and Azure extra will result in non-importable WasbHook.
 
 ### Rename `all` to `devel_all` extra
 
-The `all` extras were reduced to include only user-facing dependencies. This means
-that this extra does not contain development dependencies. If you were relying on
-`all` extra then you should use now `devel_all` or figure out if you need development
-extras at all.
+The `all` extras were reduced to include only user-facing dependencies. This means that this extra does not contain
+development dependencies. If you were relying on
+`all` extra then you should use now `devel_all` or figure out if you need development extras at all.
 
 ### Context variables `prev_execution_date_success` and `prev_execution_date_success` are now `pendulum.DateTime`
 
@@ -192,7 +186,8 @@ From Airflow 2, by default Airflow will retry 3 times to publish task to Celery 
 
 ### Adding Operators and Sensors via plugins is no longer supported
 
-Operators and Sensors should no longer be registered or imported via Airflow's plugin mechanism -- these types of classes are just treated as plain python classes by Airflow, so there is no need to register them with Airflow.
+Operators and Sensors should no longer be registered or imported via Airflow's plugin mechanism -- these types of
+classes are just treated as plain python classes by Airflow, so there is no need to register them with Airflow.
 
 If you previously had a `plugins/my_plugin.py` and you used it like this in a DAG:
 
@@ -206,13 +201,15 @@ You should instead import it as:
 from my_plugin import MyOperator
 ```
 
-The name under `airflow.operators.` was the plugin name, where as in the second example it is the python module name where the operator is defined.
+The name under `airflow.operators.` was the plugin name, where as in the second example it is the python module name
+where the operator is defined.
 
 See https://airflow.apache.org/docs/stable/howto/custom-operator.html for more info.
 
 ### Importing Hooks via plugins is no longer supported
 
-Importing hooks added in plugins via `airflow.hooks.<plugin_name>` is no longer supported, and hooks should just be imported as regular python modules.
+Importing hooks added in plugins via `airflow.hooks.<plugin_name>` is no longer supported, and hooks should just be
+imported as regular python modules.
 
 ```
 from airflow.hooks.my_plugin import MyHook
@@ -224,7 +221,8 @@ You should instead import it as:
 from my_plugin import MyHook
 ```
 
-It is still possible (but not required) to "register" hooks in plugins. This is to allow future support for dynamically populating the Connections form in the UI.
+It is still possible (but not required) to "register" hooks in plugins. This is to allow future support for dynamically
+populating the Connections form in the UI.
 
 See https://airflow.apache.org/docs/stable/howto/custom-operator.html for more info.
 
@@ -232,39 +230,43 @@ See https://airflow.apache.org/docs/stable/howto/custom-operator.html for more i
 
 ### The default value for `[core] enable_xcom_pickling` has been changed to `False`
 
-The pickle type for XCom messages has been replaced to JSON by default to prevent RCE attacks.
-Note that JSON serialization is stricter than pickling, so for example if you want to pass
-raw bytes through XCom you must encode them using an encoding like ``base64``.
-If you understand the risk and still want to use [pickling](https://docs.python.org/3/library/pickle.html),
-set `enable_xcom_pickling = True` in your Airflow config's `core` section.
+The pickle type for XCom messages has been replaced to JSON by default to prevent RCE attacks. Note that JSON
+serialization is stricter than pickling, so for example if you want to pass raw bytes through XCom you must encode them
+using an encoding like ``base64``. If you understand the risk and still want to
+use [pickling](https://docs.python.org/3/library/pickle.html), set `enable_xcom_pickling = True` in your Airflow
+config's `core` section.
 
 ### Airflowignore of base path
 
-There was a bug fixed in https://github.com/apache/airflow/pull/11993 that the "airflowignore" checked
-the base path of the dag folder for forbidden dags, not only the relative part. This had the effect
-that if the base path contained the excluded word the whole dag folder could have been excluded. For
-example if the airflowignore file contained x, and the dags folder was '/var/x/dags', then all dags in
-the folder would be excluded. The fix only matches the relative path only now which means that if you
-previously used full path as ignored, you should change it to relative one. For example if your dag
-folder was '/var/dags/' and your airflowignore contained '/var/dag/excluded/', you should change it
-to 'excluded/'.
+There was a bug fixed in https://github.com/apache/airflow/pull/11993 that the "airflowignore" checked the base path of
+the dag folder for forbidden dags, not only the relative part. This had the effect that if the base path contained the
+excluded word the whole dag folder could have been excluded. For example if the airflowignore file contained x, and the
+dags folder was '/var/x/dags', then all dags in the folder would be excluded. The fix only matches the relative path
+only now which means that if you previously used full path as ignored, you should change it to relative one. For example
+if your dag folder was '/var/dags/' and your airflowignore contained '/var/dag/excluded/', you should change it to '
+excluded/'.
 
 ### `ExternalTaskSensor` provides all task context variables to `execution_date_fn` as keyword arguments
 
-The old syntax of passing `context` as a dictionary will continue to work with the caveat that the argument must be named `context`. The following will break. To fix it, change `ctx` to `context`.
+The old syntax of passing `context` as a dictionary will continue to work with the caveat that the argument must be
+named `context`. The following will break. To fix it, change `ctx` to `context`.
 
 ```python
 def execution_date_fn(execution_date, ctx):
 ```
 
-`execution_date_fn` can take in any number of keyword arguments available in the task context dictionary. The following forms of `execution_date_fn` are all supported:
+`execution_date_fn` can take in any number of keyword arguments available in the task context dictionary. The following
+forms of `execution_date_fn` are all supported:
 
 ```python
 def execution_date_fn(dt):
 
+
 def execution_date_fn(execution_date):
 
+
 def execution_date_fn(execution_date, ds_nodash):
+
 
 def execution_date_fn(execution_date, ds_nodash, dag):
 ```
@@ -276,22 +278,19 @@ As [recommended](https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOK
 
 #### Changes to import paths
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
-package was supported by the community. The project was passed to the Apache community and currently the
-entire code is maintained by the community, so now the division has no justification, and it is only due
-to historical reasons. In Airflow 2.0, we want to organize packages and move integrations
-with third party services to the ``airflow.providers`` package.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
+supported by the community. The project was passed to the Apache community and currently the entire code is maintained
+by the community, so now the division has no justification, and it is only due to historical reasons. In Airflow 2.0, we
+want to organize packages and move integrations with third party services to the ``airflow.providers`` package.
 
-All changes made are backward compatible, but if you use the old import paths you will
-see a deprecation warning. The old import paths can be abandoned in the future.
+All changes made are backward compatible, but if you use the old import paths you will see a deprecation warning. The
+old import paths can be abandoned in the future.
 
 According to [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths)
-`_operator` suffix has been removed from operators. A deprecation warning has also been raised for paths
-importing with the suffix.
-
+`_operator` suffix has been removed from operators. A deprecation warning has also been raised for paths importing with
+the suffix.
 
 The following table shows changes in import paths.
-
 
 | Old path                            | New path                   |
 |-------------------------------------|----------------------------|
@@ -309,47 +308,45 @@ The following table shows changes in import paths.
 | airflow.sensors.time_delta_sensor.TimeDeltaSensor | airflow.sensors.time_delta.TimeDeltaSensor |
 | airflow.contrib.sensors.weekday_sensor.DayOfWeekSensor | airflow.sensors.weekday.DayOfWeekSensor |
 
-
 ### Database schema changes
 
-In order to migrate the database, you should use the command `airflow db upgrade`, but in
-some cases manual steps are required.
+In order to migrate the database, you should use the command `airflow db upgrade`, but in some cases manual steps are
+required.
 
 #### Unique conn_id in connection table
 
-Previously, Airflow allowed users to add more than one connection with the same `conn_id` and on access it would choose one connection randomly. This acted as a basic load balancing and fault tolerance technique, when used in conjunction with retries.
+Previously, Airflow allowed users to add more than one connection with the same `conn_id` and on access it would choose
+one connection randomly. This acted as a basic load balancing and fault tolerance technique, when used in conjunction
+with retries.
 
 This behavior caused some confusion for users, and there was no clear evidence if it actually worked well or not.
 
-Now the `conn_id` will be unique. If you already have duplicates in your metadata database, you will have to manage those duplicate connections before upgrading the database.
+Now the `conn_id` will be unique. If you already have duplicates in your metadata database, you will have to manage
+those duplicate connections before upgrading the database.
 
 #### Not-nullable conn_type column in connection table
 
-The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
-by application logic, but was not enforced by the database schema.
+The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced by application
+logic, but was not enforced by the database schema.
 
-If you made any modifications to the table directly, make sure you don't have
-null in the conn_type column.
+If you made any modifications to the table directly, make sure you don't have null in the conn_type column.
 
 ### Configuration changes
 
-This release contains many changes that require a change in the configuration of this application or
-other application that integrate with it.
+This release contains many changes that require a change in the configuration of this application or other application
+that integrate with it.
 
 This section describes the changes that have been made, and what you need to do to.
 
 #### airflow.contrib.utils.log has been moved
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
-package was supported by the community. The project was passed to the Apache community and currently the
-entire code is maintained by the community, so now the division has no justification, and it is only due
-to historical reasons. In Airflow 2.0, we want to organize packages and move integrations
-with third party services to the ``airflow.providers`` package.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
+supported by the community. The project was passed to the Apache community and currently the entire code is maintained
+by the community, so now the division has no justification, and it is only due to historical reasons. In Airflow 2.0, we
+want to organize packages and move integrations with third party services to the ``airflow.providers`` package.
 
 To clean up, the following packages were moved:
-| Old package | New package |
-|-|-|
-| ``airflow.contrib.utils.log`` | ``airflow.utils.log`` |
+| Old package | New package | |-|-| | ``airflow.contrib.utils.log`` | ``airflow.utils.log`` |
 | ``airflow.utils.log.gcs_task_handler`` | ``airflow.providers.google.cloud.log.gcs_task_handler`` |
 | ``airflow.utils.log.wasb_task_handler`` | ``airflow.providers.microsoft.azure.log.wasb_task_handler`` |
 | ``airflow.utils.log.stackdriver_task_handler`` | ``airflow.providers.google.cloud.log.stackdriver_task_handler`` |
@@ -357,15 +354,14 @@ To clean up, the following packages were moved:
 | ``airflow.utils.log.es_task_handler`` | ``airflow.providers.elasticsearch.log.es_task_handler`` |
 | ``airflow.utils.log.cloudwatch_task_handler`` | ``airflow.providers.amazon.aws.log.cloudwatch_task_handler`` |
 
-You should update the import paths if you are setting log configurations with the ``logging_config_class`` option.
-The old import paths still works but can be abandoned.
+You should update the import paths if you are setting log configurations with the ``logging_config_class`` option. The
+old import paths still works but can be abandoned.
 
 #### SendGrid emailer has been moved
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
-package was supported by the community. The project was passed to the Apache community and currently the
-entire code is maintained by the community, so now the division has no justification, and it is only due
-to historical reasons.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
+supported by the community. The project was passed to the Apache community and currently the entire code is maintained
+by the community, so now the division has no justification, and it is only due to historical reasons.
 
 To clean up, the `send_mail` function from the `airflow.contrib.utils.sendgrid` module has been moved.
 
@@ -391,17 +387,15 @@ The previous option used a colon(`:`) to split the module from function. Now the
 
 The change aims to unify the format of all options that refer to objects in the `airflow.cfg` file.
 
-
 #### Custom executors is loaded using full import path
 
-In previous versions of Airflow it was possible to use plugins to load custom executors. It is still
-possible, but the configuration has changed. Now you don't have to create a plugin to configure a
-custom executor, but you need to provide the full path to the module in the `executor` option
-in the `core` section. The purpose of this change is to simplify the plugin mechanism and make
-it easier to configure executor.
+In previous versions of Airflow it was possible to use plugins to load custom executors. It is still possible, but the
+configuration has changed. Now you don't have to create a plugin to configure a custom executor, but you need to provide
+the full path to the module in the `executor` option in the `core` section. The purpose of this change is to simplify
+the plugin mechanism and make it easier to configure executor.
 
-If your module was in the path `my_acme_company.executors.MyCustomExecutor`  and the plugin was
-called `my_plugin` then your configuration looks like this
+If your module was in the path `my_acme_company.executors.MyCustomExecutor`  and the plugin was called `my_plugin` then
+your configuration looks like this
 
 ```ini
 [core]
@@ -417,27 +411,58 @@ executor = my_acme_company.executors.MyCustomExecutor
 
 The old configuration is still works but can be abandoned at any time.
 
+#### Use `CustomSQLAInterface` instead of `SQLAInterface` for custom data models.
+
+From Airflow 2.0, if you want to define your own Flask App Builder data models you need to use CustomSQLAInterface
+instead of SQLAInterface.
+
+For Non-RBAC replace:
+
+```python
+from flask_appbuilder.models.sqla.interface import SQLAInterface
+
+datamodel = SQLAInterface(your_data_model)
+```
+
+with RBAC (in 1.10):
+
+```python
+from airflow.www_rbac.utils import CustomSQLAInterface
+
+datamodel = CustomSQLAInterface(your_data_model)
+```
+
+and in 2.0:
+
+```python
+from airflow.www.utils import CustomSQLAInterface
+
+datamodel = CustomSQLAInterface(your_data_model)
+```
+
 #### Drop plugin support for stat_name_handler
 
-In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
+In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use
+the `stat_name_handler`
 option in `[scheduler]` section to achieve the same effect.
 
 If your plugin looked like this and was available through the `test_plugin` path:
 
 ```python
 def my_stat_name_handler(stat):
-    return stat
+  return stat
+
 
 class AirflowTestPlugin(AirflowPlugin):
-    name = "test_plugin"
-    stat_name_handler = my_stat_name_handler
+  name = "test_plugin"
+  stat_name_handler = my_stat_name_handler
 ```
 
 then your `airflow.cfg` file should look like this:
 
 ```ini
 [scheduler]
-stat_name_handler=test_plugin.my_stat_name_handler
+stat_name_handler = test_plugin.my_stat_name_handler
 ```
 
 This change is intended to simplify the statsd configuration.
@@ -481,7 +506,8 @@ The following configurations have been moved from `[scheduler]` to the new `[met
 
 #### Changes to Elasticsearch logging provider
 
-When JSON output to stdout is enabled, log lines will now contain the `log_id` & `offset` fields, this should make reading task logs from elasticsearch on the webserver work out of the box. Example configuration:
+When JSON output to stdout is enabled, log lines will now contain the `log_id` & `offset` fields, this should make
+reading task logs from elasticsearch on the webserver work out of the box. Example configuration:
 
 ```ini
 [logging]
@@ -496,25 +522,24 @@ Note that the webserver expects the log line data itself to be present in the `m
 
 #### Remove gcp_service_account_keys option in airflow.cfg file
 
-This option has been removed because it is no longer supported by the Google Kubernetes Engine. The new
-recommended service account keys for the Google Cloud management method is
+This option has been removed because it is no longer supported by the Google Kubernetes Engine. The new recommended
+service account keys for the Google Cloud management method is
 [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
 
 #### Fernet is enabled by default
 
-The fernet mechanism is enabled by default to increase the security of the default installation.  In order to
-restore the previous behavior, the user must consciously set an empty key in the ``fernet_key`` option of
-section ``[core]`` in the ``airflow.cfg`` file.
+The fernet mechanism is enabled by default to increase the security of the default installation. In order to restore the
+previous behavior, the user must consciously set an empty key in the ``fernet_key`` option of section ``[core]`` in
+the ``airflow.cfg`` file.
 
-At the same time, this means that the `apache-airflow[crypto]` extra-packages are always installed.
-However, this requires that your operating system has ``libffi-dev`` installed.
+At the same time, this means that the `apache-airflow[crypto]` extra-packages are always installed. However, this
+requires that your operating system has ``libffi-dev`` installed.
 
 #### Changes to propagating Kubernetes worker annotations
 
-`kubernetes_annotations` configuration section has been removed.
-A new key `worker_annotations` has been added to existing `kubernetes` section instead.
-That is to remove restriction on the character set for k8s annotation keys.
-All key/value pairs from `kubernetes_annotations` should now go to `worker_annotations` as a json. I.e. instead of e.g.
+`kubernetes_annotations` configuration section has been removed. A new key `worker_annotations` has been added to
+existing `kubernetes` section instead. That is to remove restriction on the character set for k8s annotation keys. All
+key/value pairs from `kubernetes_annotations` should now go to `worker_annotations` as a json. I.e. instead of e.g.
 
 ```
 [kubernetes_annotations]
@@ -531,62 +556,61 @@ worker_annotations = { "annotation_key" : "annotation_value", "annotation_key2" 
 
 #### Remove run_duration
 
-We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an inconsistent state.
+We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but
+right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an
+inconsistent state.
 
 #### Rename pool statsd metrics
 
-Used slot has been renamed to running slot to make the name self-explanatory
-and the code more maintainable.
+Used slot has been renamed to running slot to make the name self-explanatory and the code more maintainable.
 
 This means `pool.used_slots.<pool_name>` metric has been renamed to
-`pool.running_slots.<pool_name>`. The `Used Slots` column in Pools Web UI view
-has also been changed to `Running Slots`.
+`pool.running_slots.<pool_name>`. The `Used Slots` column in Pools Web UI view has also been changed to `Running Slots`.
 
 #### Removal of Mesos Executor
 
-The Mesos Executor is removed from the code base as it was not widely used and not maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/thread.html/daa9500026b820c6aaadeffd66166eae558282778091ebbc68819fb7@%3Cdev.airflow.apache.org%3E).
+The Mesos Executor is removed from the code base as it was not widely used and not
+maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/thread.html/daa9500026b820c6aaadeffd66166eae558282778091ebbc68819fb7@%3Cdev.airflow.apache.org%3E)
+.
 
 #### Change dag loading duration metric name
 
 Change DAG file loading duration metric from
-`dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to
-better handle the case when a DAG file has multiple DAGs.
+`dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to better handle the case when a DAG file
+has multiple DAGs.
 
 #### Sentry is disabled by default
 
-Sentry is disabled by default. To enable these integrations, you need set ``sentry_on`` option
-in ``[sentry]`` section to ``"True"``.
+Sentry is disabled by default. To enable these integrations, you need set ``sentry_on`` option in ``[sentry]`` section
+to ``"True"``.
 
 #### Simplified GCSTaskHandler configuration
 
-In previous versions, in order to configure the service account key file, you had to create a connection entry.
-In the current version, you can configure ``google_key_path`` option in ``[logging]`` section to set
-the key file path.
+In previous versions, in order to configure the service account key file, you had to create a connection entry. In the
+current version, you can configure ``google_key_path`` option in ``[logging]`` section to set the key file path.
 
 Users using Application Default Credentials (ADC) need not take any action.
 
-The change aims to simplify the configuration of logging, to prevent corruption of
-the instance configuration by changing the value controlled by the user - connection entry. If you
-configure a backend secret, it also means the webserver doesn't need to connect to it. This
-simplifies setups with multiple GCP projects, because only one project will require the Secret Manager API
-to be enabled.
+The change aims to simplify the configuration of logging, to prevent corruption of the instance configuration by
+changing the value controlled by the user - connection entry. If you configure a backend secret, it also means the
+webserver doesn't need to connect to it. This simplifies setups with multiple GCP projects, because only one project
+will require the Secret Manager API to be enabled.
 
 ### Changes to the core operators/hooks
 
-We strive to ensure that there are no changes that may affect the end user and your files, but this
-release may contain changes that will require changes to your DAG files.
+We strive to ensure that there are no changes that may affect the end user and your files, but this release may contain
+changes that will require changes to your DAG files.
 
-This section describes the changes that have been made, and what you need to do to update your DAG File,
-if you use core operators or any other.
+This section describes the changes that have been made, and what you need to do to update your DAG File, if you use core
+operators or any other.
 
 #### BaseSensorOperator now respects the trigger_rule of downstream tasks
 
-Previously, BaseSensorOperator with setting `soft_fail=True` skips itself
-and skips all its downstream tasks unconditionally, when it fails i.e the trigger_rule of downstream tasks is not
-respected.
+Previously, BaseSensorOperator with setting `soft_fail=True` skips itself and skips all its downstream tasks
+unconditionally, when it fails i.e the trigger_rule of downstream tasks is not respected.
 
-In the new behavior, the trigger_rule of downstream tasks is respected.
-User can preserve/achieve the original behaviour by setting the trigger_rule of each downstream task to `all_success`.
+In the new behavior, the trigger_rule of downstream tasks is respected. User can preserve/achieve the original behaviour
+by setting the trigger_rule of each downstream task to `all_success`.
 
 #### BaseOperator uses metaclass
 
@@ -595,8 +619,8 @@ User can preserve/achieve the original behaviour by setting the trigger_rule of 
 
 #### Remove SQL support in BaseHook
 
-Remove ``get_records`` and ``get_pandas_df`` and ``run`` from BaseHook, which only apply for sql like hook,
-If want to use them, or your custom hook inherit them, please use ``airflow.hooks.dbapi.DbApiHook``
+Remove ``get_records`` and ``get_pandas_df`` and ``run`` from BaseHook, which only apply for sql like hook, If want to
+use them, or your custom hook inherit them, please use ``airflow.hooks.dbapi.DbApiHook``
 
 #### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
 
@@ -613,7 +637,7 @@ This is no longer supported. Instead, we recommend using the DAG as context mana
 
 ```python
 with DAG('my_dag') as dag:
-    dummy = DummyOperator(task_id='dummy')
+  dummy = DummyOperator(task_id='dummy')
 ```
 
 #### Removed deprecated import mechanism
@@ -632,11 +656,11 @@ becomes `from airflow.sensors.base import BaseSensorOperator`
 
 #### Skipped tasks can satisfy wait_for_downstream
 
-Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of
-the previous task instance is successful. Meanwhile, a task instance with `depends_on_past=True`
-will run if the previous task instance is either successful or skipped. These two flags are close siblings
-yet they have different behavior. This inconsistency in behavior made the API less intuitive to users.
-To maintain consistent behavior, both successful or skipped downstream task can now satisfy the
+Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of the previous task
+instance is successful. Meanwhile, a task instance with `depends_on_past=True`
+will run if the previous task instance is either successful or skipped. These two flags are close siblings yet they have
+different behavior. This inconsistency in behavior made the API less intuitive to users. To maintain consistent
+behavior, both successful or skipped downstream task can now satisfy the
 `wait_for_downstream=True` flag.
 
 #### `airflow.utils.helpers.cross_downstream`
@@ -646,13 +670,12 @@ To maintain consistent behavior, both successful or skipped downstream task can 
 The `chain` and `cross_downstream` methods are now moved to airflow.models.baseoperator module from
 `airflow.utils.helpers` module.
 
-The baseoperator module seems to be a better choice to keep
-closely coupled methods together. Helpers module is supposed to contain standalone helper methods
-that can be imported by all classes.
+The baseoperator module seems to be a better choice to keep closely coupled methods together. Helpers module is supposed
+to contain standalone helper methods that can be imported by all classes.
 
-The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports
-any classes or functions from helpers module, then it automatically has an
-implicit dependency to BaseOperator. That can often lead to cyclic dependencies.
+The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports any classes or
+functions from helpers module, then it automatically has an implicit dependency to BaseOperator. That can often lead to
+cyclic dependencies.
 
 More information in [AIRFLOW-6392](https://issues.apache.org/jira/browse/AIRFLOW-6392)
 
@@ -672,74 +695,82 @@ from airflow.models.baseoperator import cross_downstream
 
 #### `airflow.operators.python.BranchPythonOperator`
 
-`BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch,
-where previously it returned None. Since it inherits from BaseOperator it will do an
+`BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch, where previously it returned
+None. Since it inherits from BaseOperator it will do an
 `xcom_push` of this value if `do_xcom_push=True`. This is useful for downstream decision-making.
 
 #### `airflow.sensors.sql_sensor.SqlSensor`
 
 SQLSensor now consistent with python `bool()` function and the `allow_null` parameter has been removed.
 
-It will resolve after receiving any value  that is casted to `True` with python `bool(value)`. That
-changes the previous response receiving `NULL` or `'0'`. Earlier `'0'` has been treated as success
-criteria. `NULL` has been treated depending on value of `allow_null`parameter.  But all the previous
-behaviour is still achievable setting param `success` to `lambda x: x is None or str(x) not in ('0', '')`.
+It will resolve after receiving any value that is casted to `True` with python `bool(value)`. That changes the previous
+response receiving `NULL` or `'0'`. Earlier `'0'` has been treated as success criteria. `NULL` has been treated
+depending on value of `allow_null`parameter. But all the previous behaviour is still achievable setting param `success`
+to `lambda x: x is None or str(x) not in ('0', '')`.
 
 #### `airflow.operators.trigger_dagrun.TriggerDagRunOperator`
 
-The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun.
-As a result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
+The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun. As a
+result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
 
 #### `airflow.operators.python.PythonOperator`
 
-`provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not provide the context anymore. For example:
+`provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator
+is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not
+provide the context anymore. For example:
 
 ```python
 def myfunc(execution_date):
-    print(execution_date)
+  print(execution_date)
+
 
 python_operator = PythonOperator(task_id='mytask', python_callable=myfunc, dag=dag)
 ```
 
-Notice you don't have to set provide_context=True, variables from the task context are now automatically detected and provided.
+Notice you don't have to set provide_context=True, variables from the task context are now automatically detected and
+provided.
 
 All context variables can still be provided with a double-asterisk argument:
 
 ```python
 def myfunc(**context):
-    print(context)  # all variables will be provided to context
+  print(context)  # all variables will be provided to context
+
 
 python_operator = PythonOperator(task_id='mytask', python_callable=myfunc)
 ```
 
-The task context variable names are reserved names in the callable function, hence a clash with `op_args` and `op_kwargs` results in an exception:
+The task context variable names are reserved names in the callable function, hence a clash with `op_args`
+and `op_kwargs` results in an exception:
 
 ```python
 def myfunc(dag):
-    # raises a ValueError because "dag" is a reserved name
-    # valid signature example: myfunc(mydag)
+
+
+# raises a ValueError because "dag" is a reserved name
+# valid signature example: myfunc(mydag)
 
 python_operator = PythonOperator(
-    task_id='mytask',
-    op_args=[1],
-    python_callable=myfunc,
+  task_id='mytask',
+  op_args=[1],
+  python_callable=myfunc,
 )
 ```
 
-The change is backwards compatible, setting `provide_context` will add the `provide_context` variable to the `kwargs` (but won't do anything).
+The change is backwards compatible, setting `provide_context` will add the `provide_context` variable to the `kwargs` (
+but won't do anything).
 
 PR: [#5990](https://github.com/apache/airflow/pull/5990)
 
 #### `airflow.sensors.filesystem.FileSensor`
 
-FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in it then you should replace these with `[*]`, `[?]`, and `[[]`.
+FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in
+it then you should replace these with `[*]`, `[?]`, and `[[]`.
 
 #### `airflow.operators.subdag_operator.SubDagOperator`
 
-`SubDagOperator` is changed to use Airflow scheduler instead of backfill
-to schedule tasks in the subdag. User no longer need to specify the executor
-in `SubDagOperator`.
-
+`SubDagOperator` is changed to use Airflow scheduler instead of backfill to schedule tasks in the subdag. User no longer
+need to specify the executor in `SubDagOperator`.
 
 #### `airflow.providers.google.cloud.operators.datastore.CloudDatastoreExportEntitiesOperator`
 
@@ -759,7 +790,9 @@ in `SubDagOperator`.
 
 #### `airflow.providers.http.operators.http.SimpleHttpOperator`
 
-The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`) on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
+The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different
+incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`)
+on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
 
 The following operators were affected:
 
@@ -776,30 +809,35 @@ See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) for details
 
 #### `airflow.operators.latest_only_operator.LatestOnlyOperator`
 
-In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own. From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any further downstream dependencies.
+In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own.
+From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any
+further downstream dependencies.
 
 No change is needed if only the default trigger rule `all_success` is being used.
 
-If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skipped by the `LatestOnlyOperator`, adjustments to the DAG need to be made to commodate the change in behaviour, i.e. with additional edges from the `LatestOnlyOperator`.
+If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skipped by the `LatestOnlyOperator`,
+adjustments to the DAG need to be made to commodate the change in behaviour, i.e. with additional edges from
+the `LatestOnlyOperator`.
 
-The goal of this change is to achieve a more consistent and configurale cascading behaviour based on the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923) and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
+The goal of this change is to achieve a more consistent and configurale cascading behaviour based on
+the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923)
+and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
 
 ### Changes to the core Python API
 
-We strive to ensure that there are no changes that may affect the end user, and your Python files, but this
-release may contain changes that will require changes to your plugins, DAG File or other integration.
+We strive to ensure that there are no changes that may affect the end user, and your Python files, but this release may
+contain changes that will require changes to your plugins, DAG File or other integration.
 
-Only changes unique to this provider are described here. You should still pay attention to the changes that
-have been made to the core (including core operators) as they can affect the integration behavior
-of this provider.
+Only changes unique to this provider are described here. You should still pay attention to the changes that have been
+made to the core (including core operators) as they can affect the integration behavior of this provider.
 
 This section describes the changes that have been made, and what you need to do to update your Python files.
 
 #### Removed sub-package imports from `airflow/__init__.py`
 
-The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`.
-All implicit references of these objects will no longer be valid. To migrate, all usages of each old path must be
-replaced with its corresponding new path.
+The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`. All implicit
+references of these objects will no longer be valid. To migrate, all usages of each old path must be replaced with its
+corresponding new path.
 
 | Old Path (Implicit Import)   | New Path (Explicit Import)                       |
 |------------------------------|--------------------------------------------------|
@@ -815,13 +853,11 @@ The following variables were removed from the task instance context:
 - latest_date
 - tables
 
-
 #### `airflow.contrib.utils.Weekday`
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
-package was supported by the community. The project was passed to the Apache community and currently the
-entire code is maintained by the community, so now the division has no justification, and it is only due
-to historical reasons.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
+supported by the community. The project was passed to the Apache community and currently the entire code is maintained
+by the community, so now the division has no justification, and it is only due to historical reasons.
 
 To clean up, `Weekday` enum has been moved from `airflow.contrib.utils` into `airflow.utils` module.
 
@@ -848,16 +884,16 @@ conn_2.parse_uri(uri="mysql://AAA/")
 
 Now the second way is not supported.
 
-`Connection.log_info` and `Connection.debug_info` method have been deprecated. Read each Connection field individually or use the
-default representation (`__repr__`).
+`Connection.log_info` and `Connection.debug_info` method have been deprecated. Read each Connection field individually
+or use the default representation (`__repr__`).
 
-The old method is still works but can be abandoned at any time. The changes are intended to delete method
-that are rarely used.
+The old method is still works but can be abandoned at any time. The changes are intended to delete method that are
+rarely used.
 
 #### `airflow.models.dag.DAG.create_dagrun`
 
-DAG.create_dagrun accepts run_type and does not require run_id
-This change is caused by adding `run_type` column to `DagRun`.
+DAG.create_dagrun accepts run_type and does not require run_id This change is caused by adding `run_type` column
+to `DagRun`.
 
 Previous signature:
 
@@ -895,13 +931,12 @@ If user provides `run_type` and `execution_date` then `run_id` is constructed as
 Airflow should construct dagruns using `run_type` and `execution_date`, creation using
 `run_id` is preserved for user actions.
 
-
 #### `airflow.models.dagrun.DagRun`
 
 Use DagRunType.SCHEDULED.value instead of DagRun.ID_PREFIX
 
-All the run_id prefixes for different kind of DagRuns have been grouped into a single
-enum in `airflow.utils.types.DagRunType`.
+All the run_id prefixes for different kind of DagRuns have been grouped into a single enum
+in `airflow.utils.types.DagRunType`.
 
 Previously, there were defined in various places, example as `ID_PREFIX` class variables for
 `DagRun`, `BackfillJob` and in `_trigger_dag` function.
@@ -922,38 +957,35 @@ Replaced by:
 scheduled
 ```
 
-
 #### `airflow.utils.file.TemporaryDirectory`
 
-We remove airflow.utils.file.TemporaryDirectory
-Since Airflow dropped support for Python < 3.5 there's no need to have this custom
-implementation of `TemporaryDirectory` because the same functionality is provided by
+We remove airflow.utils.file.TemporaryDirectory Since Airflow dropped support for Python < 3.5 there's no need to have
+this custom implementation of `TemporaryDirectory` because the same functionality is provided by
 `tempfile.TemporaryDirectory`.
 
 Now users instead of `import from airflow.utils.files import TemporaryDirectory` should
-do `from tempfile import TemporaryDirectory`. Both context managers provide the same
-interface, thus no additional changes should be required.
+do `from tempfile import TemporaryDirectory`. Both context managers provide the same interface, thus no additional
+changes should be required.
 
 #### `airflow.AirflowMacroPlugin`
 
-We removed `airflow.AirflowMacroPlugin` class. The class was there in airflow package but it has not been used (apparently since 2015).
-It has been removed.
+We removed `airflow.AirflowMacroPlugin` class. The class was there in airflow package but it has not been used (
+apparently since 2015). It has been removed.
 
 #### `airflow.settings.CONTEXT_MANAGER_DAG`
 
 CONTEXT_MANAGER_DAG was removed from settings. It's role has been taken by `DagContext` in
-'airflow.models.dag'. One of the reasons was that settings should be rather static than store
-dynamic context from the DAG, but the main one is that moving the context out of settings allowed to
-untangle cyclic imports between DAG, BaseOperator, SerializedDAG, SerializedBaseOperator which was
-part of AIRFLOW-6010.
+'airflow.models.dag'. One of the reasons was that settings should be rather static than store dynamic context from the
+DAG, but the main one is that moving the context out of settings allowed to untangle cyclic imports between DAG,
+BaseOperator, SerializedDAG, SerializedBaseOperator which was part of AIRFLOW-6010.
 
 #### `airflow.utils.log.logging_mixin.redirect_stderr`
 
 #### `airflow.utils.log.logging_mixin.redirect_stdout`
 
-Function `redirect_stderr` and `redirect_stdout` from `airflow.utils.log.logging_mixin` module has
-been deleted because it can be easily replaced by the standard library.
-The functions of the standard library are more flexible and can be used in larger cases.
+Function `redirect_stderr` and `redirect_stdout` from `airflow.utils.log.logging_mixin` module has been deleted because
+it can be easily replaced by the standard library. The functions of the standard library are more flexible and can be
+used in larger cases.
 
 The code below
 
@@ -964,7 +996,7 @@ from airflow.utils.log.logging_mixin import redirect_stderr, redirect_stdout
 
 logger = logging.getLogger("custom-logger")
 with redirect_stdout(logger, logging.INFO), redirect_stderr(logger, logging.WARN):
-    print("I love Airflow")
+  print("I love Airflow")
 ```
 
 can be replaced by the following code:
@@ -977,34 +1009,34 @@ from airflow.utils.log.logging_mixin import StreamLogWriter
 
 logger = logging.getLogger("custom-logger")
 
-with redirect_stdout(StreamLogWriter(logger, logging.INFO)), \
-        redirect_stderr(StreamLogWriter(logger, logging.WARN)):
-    print("I Love Airflow")
+with redirect_stdout(StreamLogWriter(logger, logging.INFO)),
+  redirect_stderr(StreamLogWriter(logger, logging.WARN)):
+  print("I Love Airflow")
 ```
 
 #### `airflow.models.baseoperator.BaseOperator`
 
-Now, additional arguments passed to BaseOperator cause an exception. Previous versions of Airflow took additional arguments and displayed a message on the console. When the
-message was not noticed by users, it caused very difficult to detect errors.
+Now, additional arguments passed to BaseOperator cause an exception. Previous versions of Airflow took additional
+arguments and displayed a message on the console. When the message was not noticed by users, it caused very difficult to
+detect errors.
 
-In order to restore the previous behavior, you must set an ``True`` in  the ``allow_illegal_arguments``
-option of section ``[operators]`` in the ``airflow.cfg`` file. In the future it is possible to completely
-delete this option.
+In order to restore the previous behavior, you must set an ``True`` in the ``allow_illegal_arguments``
+option of section ``[operators]`` in the ``airflow.cfg`` file. In the future it is possible to completely delete this
+option.
 
 #### `airflow.models.dagbag.DagBag`
 
-Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property
-are deprecated and will be removed in future versions.
-
+Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property are
+deprecated and will be removed in future versions.
 
 **Previous signature**:
 
 ```python
 DagBag(
-    dag_folder=None,
-    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
-    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
-    store_serialized_dags=False
+  dag_folder=None,
+  include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
+  safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+  store_serialized_dags=False
 ):
 ```
 
@@ -1012,79 +1044,78 @@ DagBag(
 
 ```python
 DagBag(
-    dag_folder=None,
-    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
-    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
-    read_dags_from_db=False
+  dag_folder=None,
+  include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
+  safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+  read_dags_from_db=False
 ):
 ```
 
-If you were using positional arguments, it requires no change but if you were using keyword
-arguments, please change `store_serialized_dags` to `read_dags_from_db`.
+If you were using positional arguments, it requires no change but if you were using keyword arguments, please
+change `store_serialized_dags` to `read_dags_from_db`.
 
 Similarly, if you were using `DagBag().store_serialized_dags` property, change it to
 `DagBag().read_dags_from_db`.
 
 ### Changes in `google` provider package
 
-We strive to ensure that there are no changes that may affect the end user and your Python files, but this
-release may contain changes that will require changes to your configuration, DAG Files or other integration
-e.g. custom operators.
+We strive to ensure that there are no changes that may affect the end user and your Python files, but this release may
+contain changes that will require changes to your configuration, DAG Files or other integration e.g. custom operators.
 
-Only changes unique to this provider are described here. You should still pay attention to the changes that
-have been made to the core (including core operators) as they can affect the integration behavior
-of this provider.
+Only changes unique to this provider are described here. You should still pay attention to the changes that have been
+made to the core (including core operators) as they can affect the integration behavior of this provider.
 
-This section describes the changes that have been made, and what you need to do to update your if
-you use operators or hooks which integrate with Google services (including Google Cloud - GCP).
+This section describes the changes that have been made, and what you need to do to update your if you use operators or
+hooks which integrate with Google services (including Google Cloud - GCP).
 
 #### Direct impersonation added to operators communicating with Google services
 
 [Directly impersonating a service account](https://cloud.google.com/iam/docs/understanding-service-accounts#directly_impersonating_a_service_account)
 has been made possible for operators communicating with Google services via new argument called `impersonation_chain`
-(`google_impersonation_chain` in case of operators that also communicate with services of other cloud providers).
-As a result, GCSToS3Operator no longer derivatives from GCSListObjectsOperator.
+(`google_impersonation_chain` in case of operators that also communicate with services of other cloud providers). As a
+result, GCSToS3Operator no longer derivatives from GCSListObjectsOperator.
 
 #### Normalize gcp_conn_id for Google Cloud
 
 Previously not all hooks and operators related to Google Cloud use
-`gcp_conn_id` as parameter for GCP connection. There is currently one parameter
-which apply to most services. Parameters like ``datastore_conn_id``, ``bigquery_conn_id``,
-``google_cloud_storage_conn_id`` and similar have been deprecated. Operators that require two connections are not changed.
+`gcp_conn_id` as parameter for GCP connection. There is currently one parameter which apply to most services. Parameters
+like ``datastore_conn_id``, ``bigquery_conn_id``,
+``google_cloud_storage_conn_id`` and similar have been deprecated. Operators that require two connections are not
+changed.
 
 Following components were affected by normalization:
 
-  * airflow.providers.google.cloud.hooks.datastore.DatastoreHook
-  * airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
-  * airflow.providers.google.cloud.hooks.gcs.GoogleCloudStorageHook
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryValueCheckOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryIntervalCheckOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryGetDataOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryDeleteDatasetOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyDatasetOperator
-  * airflow.providers.google.cloud.operators.bigquery.BigQueryTableDeleteOperator
-  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageCreateBucketOperator
-  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageListOperator
-  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDownloadOperator
-  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDeleteOperator
-  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageBucketCreateAclEntryOperator
-  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageObjectCreateAclEntryOperator
-  * airflow.operators.sql_to_gcs.BaseSQLToGoogleCloudStorageOperator
-  * airflow.operators.adls_to_gcs.AdlsToGoogleCloudStorageOperator
-  * airflow.operators.gcs_to_s3.GoogleCloudStorageToS3Operator
-  * airflow.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator
-  * airflow.operators.bigquery_to_gcs.BigQueryToCloudStorageOperator
-  * airflow.operators.local_to_gcs.FileToGoogleCloudStorageOperator
-  * airflow.operators.cassandra_to_gcs.CassandraToGoogleCloudStorageOperator
-  * airflow.operators.bigquery_to_bigquery.BigQueryToBigQueryOperator
+* airflow.providers.google.cloud.hooks.datastore.DatastoreHook
+* airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
+* airflow.providers.google.cloud.hooks.gcs.GoogleCloudStorageHook
+* airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryValueCheckOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryIntervalCheckOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryGetDataOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryDeleteDatasetOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyDatasetOperator
+* airflow.providers.google.cloud.operators.bigquery.BigQueryTableDeleteOperator
+* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageCreateBucketOperator
+* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageListOperator
+* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDownloadOperator
+* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDeleteOperator
+* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageBucketCreateAclEntryOperator
+* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageObjectCreateAclEntryOperator
+* airflow.operators.sql_to_gcs.BaseSQLToGoogleCloudStorageOperator
+* airflow.operators.adls_to_gcs.AdlsToGoogleCloudStorageOperator
+* airflow.operators.gcs_to_s3.GoogleCloudStorageToS3Operator
+* airflow.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator
+* airflow.operators.bigquery_to_gcs.BigQueryToCloudStorageOperator
+* airflow.operators.local_to_gcs.FileToGoogleCloudStorageOperator
+* airflow.operators.cassandra_to_gcs.CassandraToGoogleCloudStorageOperator
+* airflow.operators.bigquery_to_bigquery.BigQueryToBigQueryOperator
 
 #### Changes to import paths and names of GCP operators and hooks
 
 According to [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths)
-operators related to Google Cloud has been moved from contrib to core.
-The following table shows changes in import paths.
+operators related to Google Cloud has been moved from contrib to core. The following table shows changes in import
+paths.
 
 |                                                     Old path                                                     |                                                 New path                                                                     |
 |------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
@@ -1269,13 +1300,11 @@ The following table shows changes in import paths.
 #### Unify default conn_id for Google Cloud
 
 Previously not all hooks and operators related to Google Cloud use
-``google_cloud_default`` as a default conn_id. There is currently one default
-variant. Values like ``google_cloud_storage_default``, ``bigquery_default``,
-``google_cloud_datastore_default`` have been deprecated. The configuration of
-existing relevant connections in the database have been preserved. To use those
-deprecated GCP conn_id, you need to explicitly pass their conn_id into
-operators/hooks. Otherwise, ``google_cloud_default`` will be used as GCP's conn_id
-by default.
+``google_cloud_default`` as a default conn_id. There is currently one default variant. Values
+like ``google_cloud_storage_default``, ``bigquery_default``,
+``google_cloud_datastore_default`` have been deprecated. The configuration of existing relevant connections in the
+database have been preserved. To use those deprecated GCP conn_id, you need to explicitly pass their conn_id into
+operators/hooks. Otherwise, ``google_cloud_default`` will be used as GCP's conn_id by default.
 
 #### `airflow.providers.google.cloud.hooks.dataflow.DataflowHook`
 
@@ -1287,29 +1316,22 @@ by default.
 
 To use project_id argument consistently across GCP hooks and operators, we did the following changes:
 
-- Changed order of arguments in DataflowHook.start_python_dataflow. Uses
-    with positional arguments may break.
-- Changed order of arguments in DataflowHook.is_job_dataflow_running. Uses
-    with positional arguments may break.
-- Changed order of arguments in DataflowHook.cancel_job. Uses
-    with positional arguments may break.
-- Added optional project_id argument to DataflowCreateJavaJobOperator
-    constructor.
-- Added optional project_id argument to DataflowTemplatedJobStartOperator
-    constructor.
-- Added optional project_id argument to DataflowCreatePythonJobOperator
-    constructor.
+- Changed order of arguments in DataflowHook.start_python_dataflow. Uses with positional arguments may break.
+- Changed order of arguments in DataflowHook.is_job_dataflow_running. Uses with positional arguments may break.
+- Changed order of arguments in DataflowHook.cancel_job. Uses with positional arguments may break.
+- Added optional project_id argument to DataflowCreateJavaJobOperator constructor.
+- Added optional project_id argument to DataflowTemplatedJobStartOperator constructor.
+- Added optional project_id argument to DataflowCreatePythonJobOperator constructor.
 
 #### `airflow.providers.google.cloud.sensors.gcs.GCSUploadSessionCompleteSensor`
 
-To provide more precise control in handling of changes to objects in
-underlying GCS Bucket the constructor of this sensor now has changed.
+To provide more precise control in handling of changes to objects in underlying GCS Bucket the constructor of this
+sensor now has changed.
 
 - Old Behavior: This constructor used to optionally take ``previous_num_objects: int``.
 - New replacement constructor kwarg: ``previous_objects: Optional[Set[str]]``.
 
-Most users would not specify this argument because the bucket begins empty
-and the user wants to treat any files as new.
+Most users would not specify this argument because the bucket begins empty and the user wants to treat any files as new.
 
 Example of Updating usage of this sensor:
 Users who used to call:
@@ -1326,9 +1348,10 @@ Where '.keep' is a single file at your prefix that the sensor should not conside
 
 #### `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook`
 
-To simplify BigQuery operators (no need of `Cursor`) and standardize usage of hooks within all GCP integration methods from `BiqQueryBaseCursor`
-were moved to `BigQueryHook`. Using them by from `Cursor` object is still possible due to preserved backward compatibility but they will raise `DeprecationWarning`.
-The following methods were moved:
+To simplify BigQuery operators (no need of `Cursor`) and standardize usage of hooks within all GCP integration methods
+from `BiqQueryBaseCursor`
+were moved to `BigQueryHook`. Using them by from `Cursor` object is still possible due to preserved backward
+compatibility but they will raise `DeprecationWarning`. The following methods were moved:
 
 | Old path                                                                                       | New path                                                                                 |
 |------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
@@ -1359,20 +1382,23 @@ The following methods were moved:
 
 #### `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor`
 
-Since BigQuery is the part of the GCP it was possible to simplify the code by handling the exceptions
-by usage of the `airflow.providers.google.common.hooks.base.GoogleBaseHook.catch_http_exception` decorator however it changes
+Since BigQuery is the part of the GCP it was possible to simplify the code by handling the exceptions by usage of
+the `airflow.providers.google.common.hooks.base.GoogleBaseHook.catch_http_exception` decorator however it changes
 exceptions raised by the following methods:
 
-* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.run_table_delete` raises `AirflowException` instead of `Exception`.
-* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.create_empty_dataset` raises `AirflowException` instead of `ValueError`.
-* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.get_dataset` raises `AirflowException` instead of `ValueError`.
+* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.run_table_delete` raises `AirflowException` instead
+  of `Exception`.
+* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.create_empty_dataset` raises `AirflowException`
+  instead of `ValueError`.
+* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.get_dataset` raises `AirflowException` instead
+  of `ValueError`.
 
 #### `airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyTableOperator`
 
 #### `airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyDatasetOperator`
 
-Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`.
-But to achieve that try / except clause was removed from `create_empty_dataset` and `create_empty_table`
+Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`. But to achieve
+that try / except clause was removed from `create_empty_dataset` and `create_empty_table`
 methods of `BigQueryHook`.
 
 #### `airflow.providers.google.cloud.hooks.dataflow.DataflowHook`
@@ -1381,9 +1407,9 @@ methods of `BigQueryHook`.
 
 #### `airflow.providers.google.cloud.hooks.pubsub.PubSubHook`
 
-The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather
-than positional ones in all methods where `project_id` is used. The methods throw an explanatory exception
-in case they are called using positional parameters.
+The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather than
+positional ones in all methods where `project_id` is used. The methods throw an explanatory exception in case they are
+called using positional parameters.
 
 Other GCP hooks are unaffected.
 
@@ -1401,12 +1427,13 @@ Other GCP hooks are unaffected.
 
 #### `airflow.providers.google.cloud.sensors.pubsub.PubSubPullSensor`
 
-In the `PubSubPublishOperator` and `PubSubHook.publsh` method the data field in a message should be bytestring (utf-8 encoded) rather than base64 encoded string.
+In the `PubSubPublishOperator` and `PubSubHook.publsh` method the data field in a message should be bytestring (utf-8
+encoded) rather than base64 encoded string.
 
 Due to the normalization of the parameters within GCP operators and hooks a parameters like `project` or `topic_project`
-are deprecated and will be substituted by parameter `project_id`.
-In `PubSubHook.create_subscription` hook method in the parameter `subscription_project` is replaced by `subscription_project_id`.
-Template fields are updated accordingly and old ones may not work.
+are deprecated and will be substituted by parameter `project_id`. In `PubSubHook.create_subscription` hook method in the
+parameter `subscription_project` is replaced by `subscription_project_id`. Template fields are updated accordingly and
+old ones may not work.
 
 It is required now to pass key-word only arguments to `PubSub` hook.
 
@@ -1414,17 +1441,16 @@ These changes are not backward compatible.
 
 #### `airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator`
 
-The gcp_conn_id parameter in GKEPodOperator is required. In previous versions, it was possible to pass
-the `None` value to the `gcp_conn_id` in the GKEStartPodOperator
-operator, which resulted in credentials being determined according to the
+The gcp_conn_id parameter in GKEPodOperator is required. In previous versions, it was possible to pass the `None` value
+to the `gcp_conn_id` in the GKEStartPodOperator operator, which resulted in credentials being determined according to
+the
 [Application Default Credentials](https://cloud.google.com/docs/authentication/production) strategy.
 
-Now this parameter requires a value. To restore the previous behavior, configure the connection without
-specifying the service account.
+Now this parameter requires a value. To restore the previous behavior, configure the connection without specifying the
+service account.
 
 Detailed information about connection management is available:
 [Google Cloud Connection](https://airflow.apache.org/howto/connection/gcp.html).
-
 
 #### `airflow.providers.google.cloud.hooks.gcs.GCSHook`
 
@@ -1448,8 +1474,7 @@ Detailed information about connection management is available:
 
 The 'properties' and 'jars' properties for the Dataproc related operators (`DataprocXXXOperator`) have been renamed from
 `dataproc_xxxx_properties` and `dataproc_xxx_jars`  to `dataproc_properties`
-and `dataproc_jars`respectively.
-Arguments for dataproc_properties dataproc_jars
+and `dataproc_jars`respectively. Arguments for dataproc_properties dataproc_jars
 
 #### `airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator`
 
@@ -1458,25 +1483,23 @@ has been renamed to `request_filter`.
 
 #### `airflow.providers.google.cloud.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook`
 
- To obtain pylint compatibility the `filter` argument in `CloudDataTransferServiceHook.list_transfer_job` and
- `CloudDataTransferServiceHook.list_transfer_operations` has been renamed to `request_filter`.
+To obtain pylint compatibility the `filter` argument in `CloudDataTransferServiceHook.list_transfer_job` and
+`CloudDataTransferServiceHook.list_transfer_operations` has been renamed to `request_filter`.
 
 #### `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook`
 
-In general all hook methods are decorated with `@GoogleBaseHook.fallback_to_default_project_id` thus
-parameters to hook can only be passed via keyword arguments.
+In general all hook methods are decorated with `@GoogleBaseHook.fallback_to_default_project_id` thus parameters to hook
+can only be passed via keyword arguments.
 
-- `create_empty_table` method accepts now `table_resource` parameter. If provided all
-other parameters are ignored.
-- `create_empty_dataset` will now use values from `dataset_reference` instead of raising error
-if parameters were passed in `dataset_reference` and as arguments to method. Additionally validation
-of `dataset_reference` is done using `Dataset.from_api_repr`. Exception and log messages has been
-changed.
+- `create_empty_table` method accepts now `table_resource` parameter. If provided all other parameters are ignored.
+- `create_empty_dataset` will now use values from `dataset_reference` instead of raising error if parameters were passed
+  in `dataset_reference` and as arguments to method. Additionally validation of `dataset_reference` is done
+  using `Dataset.from_api_repr`. Exception and log messages has been changed.
 - `update_dataset` requires now new `fields` argument (breaking change)
 - `delete_dataset` has new signature (dataset_id, project_id, ...)
-previous one was (project_id, dataset_id, ...) (breaking change)
-- `get_tabledata` returns list of rows instead of API response in dict format. This method is deprecated in
- favor of `list_rows`. (breaking change)
+  previous one was (project_id, dataset_id, ...) (breaking change)
+- `get_tabledata` returns list of rows instead of API response in dict format. This method is deprecated in favor
+  of `list_rows`. (breaking change)
 
 #### `airflow.providers.google.cloud.hooks.dataflow.DataflowHook.start_python_dataflow`
 
@@ -1492,8 +1515,8 @@ Now the `py_interpreter` argument for DataFlow Hooks/Operators has been changed 
 
 To simplify the code, the decorator provide_gcp_credential_file has been moved from the inner-class.
 
-Instead of `@GoogleBaseHook._Decorators.provide_gcp_credential_file`,
-you should write `@GoogleBaseHook.provide_gcp_credential_file`
+Instead of `@GoogleBaseHook._Decorators.provide_gcp_credential_file`, you should
+write `@GoogleBaseHook.provide_gcp_credential_file`
 
 #### `airflow.providers.google.cloud.operators.dataproc.DataprocCreateClusterOperator`
 
@@ -1520,23 +1543,20 @@ BigQueryGetDatasetTablesOperator(dataset_resource: dict, dataset_id: Optional[st
 
 ### Changes in `amazon` provider package
 
-We strive to ensure that there are no changes that may affect the end user, and your Python files, but this
-release may contain changes that will require changes to your configuration, DAG Files or other integration
-e.g. custom operators.
+We strive to ensure that there are no changes that may affect the end user, and your Python files, but this release may
+contain changes that will require changes to your configuration, DAG Files or other integration e.g. custom operators.
 
-Only changes unique to this provider are described here. You should still pay attention to the changes that
-have been made to the core (including core operators) as they can affect the integration behavior
-of this provider.
+Only changes unique to this provider are described here. You should still pay attention to the changes that have been
+made to the core (including core operators) as they can affect the integration behavior of this provider.
 
-This section describes the changes that have been made, and what you need to do to update your if
-you use operators or hooks which integrate with Amazon services (including Amazon Web Service - AWS).
+This section describes the changes that have been made, and what you need to do to update your if you use operators or
+hooks which integrate with Amazon services (including Amazon Web Service - AWS).
 
 #### Migration of AWS components
 
 All AWS components (hooks, operators, sensors, example DAGs) will be grouped together as decided in
-[AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths). Migrated
-components remain backwards compatible but raise a `DeprecationWarning` when imported from the old module.
-Migrated are:
+[AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths). Migrated components
+remain backwards compatible but raise a `DeprecationWarning` when imported from the old module. Migrated are:
 
 | Old path                                                     | New path                                                 |
 | ------------------------------------------------------------ | -------------------------------------------------------- |
@@ -1563,28 +1583,26 @@ Migrated are:
 
 #### `airflow.providers.amazon.aws.operators.emr_terminate_job_flow.EmrTerminateJobFlowOperator`
 
-The default value for the [aws_conn_id](https://airflow.apache.org/howto/manage-connections.html#amazon-web-services) was accidentally set to 's3_default' instead of 'aws_default' in some of the emr operators in previous
-versions. This was leading to EmrStepSensor not being able to find their corresponding emr cluster. With the new
-changes in the EmrAddStepsOperator, EmrTerminateJobFlowOperator and EmrCreateJobFlowOperator this issue is
-solved.
+The default value for the [aws_conn_id](https://airflow.apache.org/howto/manage-connections.html#amazon-web-services)
+was accidentally set to 's3_default' instead of 'aws_default' in some of the emr operators in previous versions. This
+was leading to EmrStepSensor not being able to find their corresponding emr cluster. With the new changes in the
+EmrAddStepsOperator, EmrTerminateJobFlowOperator and EmrCreateJobFlowOperator this issue is solved.
 
 #### `airflow.providers.amazon.aws.operators.batch.AwsBatchOperator`
 
-The `AwsBatchOperator` was refactored to extract an `AwsBatchClient` (and inherit from it).  The
-changes are mostly backwards compatible and clarify the public API for these classes; some
-private methods on `AwsBatchOperator` for polling a job status were relocated and renamed
-to surface new public methods on `AwsBatchClient` (and via inheritance on `AwsBatchOperator`).  A
-couple of job attributes are renamed on an instance of `AwsBatchOperator`; these were mostly
-used like private attributes but they were surfaced in the public API, so any use of them needs
-to be updated as follows:
+The `AwsBatchOperator` was refactored to extract an `AwsBatchClient` (and inherit from it). The changes are mostly
+backwards compatible and clarify the public API for these classes; some private methods on `AwsBatchOperator` for
+polling a job status were relocated and renamed to surface new public methods on `AwsBatchClient` (and via inheritance
+on `AwsBatchOperator`). A couple of job attributes are renamed on an instance of `AwsBatchOperator`; these were mostly
+used like private attributes but they were surfaced in the public API, so any use of them needs to be updated as
+follows:
 
 - `AwsBatchOperator().jobId` -> `AwsBatchOperator().job_id`
 - `AwsBatchOperator().jobName` -> `AwsBatchOperator().job_name`
 
 The `AwsBatchOperator` gets a new option to define a custom model for waiting on job status changes.
-The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBatchWaiters`, to
-specify that custom job waiters will be used to monitor a batch job.  See the latest API
-documentation for details.
+The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBatchWaiters`, to specify that custom job
+waiters will be used to monitor a batch job. See the latest API documentation for details.
 
 #### `airflow.providers.amazon.aws.sensors.athena.AthenaSensor`
 
@@ -1592,28 +1610,25 @@ Replace parameter `max_retires` with `max_retries` to fix typo.
 
 #### `airflow.providers.amazon.aws.hooks.s3.S3Hook`
 
-Note: The order of arguments has changed for `check_for_prefix`.
-The `bucket_name` is now optional. It falls back to the `connection schema` attribute.
-The `delete_objects` now returns `None` instead of a response, since the method now makes multiple api requests when the keys list length is > 1000.
+Note: The order of arguments has changed for `check_for_prefix`. The `bucket_name` is now optional. It falls back to
+the `connection schema` attribute. The `delete_objects` now returns `None` instead of a response, since the method now
+makes multiple api requests when the keys list length is > 1000.
 
 ### Changes in other provider packages
 
-We strive to ensure that there are no changes that may affect the end user and your Python files, but this
-release may contain changes that will require changes to your configuration, DAG Files or other integration
-e.g. custom operators.
+We strive to ensure that there are no changes that may affect the end user and your Python files, but this release may
+contain changes that will require changes to your configuration, DAG Files or other integration e.g. custom operators.
 
-Only changes unique to providers are described here. You should still pay attention to the changes that
-have been made to the core (including core operators) as they can affect the integration behavior
-of this provider.
+Only changes unique to providers are described here. You should still pay attention to the changes that have been made
+to the core (including core operators) as they can affect the integration behavior of this provider.
 
-This section describes the changes that have been made, and what you need to do to update your if
-you use any code located in `airflow.providers` package.
+This section describes the changes that have been made, and what you need to do to update your if you use any code
+located in `airflow.providers` package.
 
 #### Changed return type of `list_prefixes` and `list_keys` methods in `S3Hook`
 
-Previously, the `list_prefixes` and `list_keys` methods returned `None` when there were no
-results. The behavior has been changed to return an empty list instead of `None` in this
-case.
+Previously, the `list_prefixes` and `list_keys` methods returned `None` when there were no results. The behavior has
+been changed to return an empty list instead of `None` in this case.
 
 #### Removed Hipchat integration
 
@@ -1630,11 +1645,13 @@ Rename `sign_in` function to `get_conn`.
 
 #### `airflow.providers.apache.pinot.hooks.pinot.PinotAdminHook.create_segment`
 
-Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint compatible
+Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint
+compatible
 
 #### `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_partitions`
 
-Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint compatible
+Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint
+compatible
 
 #### `airflow.providers.ftp.hooks.ftp.FTPHook.list_directory`
 
@@ -1655,9 +1672,8 @@ Change parameter name from ``visibleTo`` to ``visible_to`` in OpsgenieAlertOpera
 ImapHook:
 
 * The order of arguments has changed for `has_mail_attachment`,
-`retrieve_mail_attachments` and `download_mail_attachments`.
+  `retrieve_mail_attachments` and `download_mail_attachments`.
 * A new `mail_filter` argument has been added to each of those.
-
 
 #### `airflow.providers.http.hooks.http.HttpHook`
 
@@ -1676,14 +1692,17 @@ For example:
 from airflow.providers.cloudant.hooks.cloudant import CloudantHook
 
 with CloudantHook().get_conn() as cloudant_session:
-    database = cloudant_session['database_name']
+  database = cloudant_session['database_name']
 ```
 
-See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant version.
+See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant
+version.
 
 #### `airflow.providers.snowflake`
 
-When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`, regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched to `snowflake_default` for consistency and will be properly overridden when specified.
+When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`,
+regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched
+to `snowflake_default` for consistency and will be properly overridden when specified.
 
 ### Other changes
 
@@ -1721,15 +1740,13 @@ For example:
 If you want to install integration for Microsoft Azure, then instead of `pip install apache-airflow[atlas]`
 you should use `pip install apache-airflow[apache.atlas]`.
 
-
 NOTE!
 
-On November 2020, new version of PIP (20.3) has been released with a new, 2020 resolver. This resolver
-does not yet work with Apache Airflow and might lead to errors in installation - depends on your choice
-of extras. In order to install Airflow you need to either downgrade pip to version 20.2.4
+On November 2020, new version of PIP (20.3) has been released with a new, 2020 resolver. This resolver does not yet work
+with Apache Airflow and might lead to errors in installation - depends on your choice of extras. In order to install
+Airflow you need to either downgrade pip to version 20.2.4
 `pip install --upgrade pip==20.2.4` or, in case you use Pip 20.3, you need to add option
 `--use-deprecated legacy-resolver` to your pip install command.
-
 
 If you want to install integration for Microsoft Azure, then instead of
 
@@ -1746,26 +1763,27 @@ The deprecated extras will be removed in 3.0.
 
 #### Simplify the response payload of endpoints /dag_stats and /task_stats
 
-The response of endpoints `/dag_stats` and `/task_stats` help UI fetch brief statistics about DAGs and Tasks. The format was like
+The response of endpoints `/dag_stats` and `/task_stats` help UI fetch brief statistics about DAGs and Tasks. The format
+was like
 
 ```json
 {
-    "example_http_operator": [
-        {
-            "state": "success",
-            "count": 0,
-            "dag_id": "example_http_operator",
-            "color": "green"
-        },
-        {
-            "state": "running",
-            "count": 0,
-            "dag_id": "example_http_operator",
-            "color": "lime"
-        },
-        ...
-],
-...
+  "example_http_operator": [
+    {
+      "state": "success",
+      "count": 0,
+      "dag_id": "example_http_operator",
+      "color": "green"
+    },
+    {
+      "state": "running",
+      "count": 0,
+      "dag_id": "example_http_operator",
+      "color": "lime"
+    },
+    ...
+  ],
+  ...
 }
 ```
 
@@ -1775,20 +1793,20 @@ Now the `dag_id` will not appear repeated in the payload, and the response forma
 
 ```json
 {
-    "example_http_operator": [
-        {
-            "state": "success",
-            "count": 0,
-            "color": "green"
-        },
-        {
-            "state": "running",
-            "count": 0,
-            "color": "lime"
-        },
-        ...
-],
-...
+  "example_http_operator": [
+    {
+      "state": "success",
+      "count": 0,
+      "color": "green"
+    },
+    {
+      "state": "running",
+      "count": 0,
+      "color": "lime"
+    },
+    ...
+  ],
+  ...
 }
 ```
 
@@ -1803,25 +1821,27 @@ This is to align the name with the actual code where the Scheduler launches the 
 
 ### Airflow CLI changes in line with 2.0
 
-The Airflow CLI has been organized so that related commands are grouped together as subcommands,
-which means that if you use these commands in your scripts, they will now raise a DeprecationWarning and
-you have to make changes to them before you upgrade to Airflow 2.0.
+The Airflow CLI has been organized so that related commands are grouped together as subcommands, which means that if you
+use these commands in your scripts, they will now raise a DeprecationWarning and you have to make changes to them before
+you upgrade to Airflow 2.0.
 
 This section describes the changes that have been made, and what you need to do to update your script.
 
-The ability to manipulate users from the command line has been changed. ``airflow create_user``,  ``airflow delete_user``
- and ``airflow list_users`` has been grouped to a single command `airflow users` with optional flags `create`, `list` and `delete`.
+The ability to manipulate users from the command line has been changed. ``airflow create_user``
+,  ``airflow delete_user``
+and ``airflow list_users`` has been grouped to a single command `airflow users` with optional flags `create`, `list`
+and `delete`.
 
 The `airflow list_dags` command is now `airflow dags list`, `airflow pause` is `airflow dags pause`, etc.
 
-In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a difference in behavior. In Airflow 1.10,
-it prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`.
-You can check other options by running the command `airflow config --help`
+In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a difference in behavior. In Airflow 1.10, it
+prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`. You
+can check other options by running the command `airflow config --help`
 
 Compatibility with the old CLI has been maintained, but they will no longer appear in the help
 
-You can learn about the commands by running ``airflow --help``. For example to get help about the ``celery`` group command,
-you have to run the help command: ``airflow celery --help``.
+You can learn about the commands by running ``airflow --help``. For example to get help about the ``celery`` group
+command, you have to run the help command: ``airflow celery --help``.
 
 | Old command                   | New command                        |     Group          |
 |-------------------------------|------------------------------------|--------------------|
@@ -1862,14 +1882,13 @@ you have to run the help command: ``airflow celery --help``.
 
 Previously `TimeSensor` always compared the `target_time` with the current time in UTC.
 
-Now it will compare `target_time` with the current time in the timezone of the DAG,
-defaulting to the `default_timezone` in the global config.
+Now it will compare `target_time` with the current time in the timezone of the DAG, defaulting to the `default_timezone`
+in the global config.
 
 ### Removed Kerberos support for HDFS hook
 
-The HDFS hook's Kerberos support has been removed due to removed python-krbV dependency from PyPI
-and generally lack of support for SSL in Python3 (Snakebite-py3 we use as dependency has no
-support for SSL connection to HDFS).
+The HDFS hook's Kerberos support has been removed due to removed python-krbV dependency from PyPI and generally lack of
+support for SSL in Python3 (Snakebite-py3 we use as dependency has no support for SSL connection to HDFS).
 
 SSL support still works for WebHDFS hook.
 
@@ -1877,8 +1896,8 @@ SSL support still works for WebHDFS hook.
 
 In previous version of Airflow user session lifetime could be configured by
 `session_lifetime_days` and `force_log_out_after` options. In practise only `session_lifetime_days`
-had impact on session lifetime, but it was limited to values in day.
-We have removed mentioned options and introduced new `session_lifetime_minutes`
+had impact on session lifetime, but it was limited to values in day. We have removed mentioned options and introduced
+new `session_lifetime_minutes`
 option which simplify session lifetime configuration.
 
 Before
@@ -1901,21 +1920,22 @@ session_lifetime_minutes = 43200
 The ability to import Operators, Hooks and Sensors via the plugin mechanism has been deprecated and will raise warnings
 in Airflow 1.10.13 and will be removed completely in Airflow 2.0.
 
-Check https://airflow.apache.org/docs/1.10.13/howto/custom-operator.html to see how you can create and import
-Custom Hooks, Operators and Sensors.
+Check https://airflow.apache.org/docs/1.10.13/howto/custom-operator.html to see how you can create and import Custom
+Hooks, Operators and Sensors.
 
 ## Airflow 1.10.12
 
 ### Clearing tasks skipped by SkipMixin will skip them
 
-Previously, when tasks skipped by SkipMixin (such as BranchPythonOperator, BaseBranchOperator and ShortCircuitOperator) are cleared, they execute. Since 1.10.12, when such skipped tasks are cleared,
-they will be skipped again by the newly introduced NotPreviouslySkippedDep.
+Previously, when tasks skipped by SkipMixin (such as BranchPythonOperator, BaseBranchOperator and ShortCircuitOperator)
+are cleared, they execute. Since 1.10.12, when such skipped tasks are cleared, they will be skipped again by the newly
+introduced NotPreviouslySkippedDep.
 
 ### The pod_mutation_hook function will now accept a kubernetes V1Pod object
 
-As of airflow 1.10.12, using the `airflow.contrib.kubernetes.Pod` class in the `pod_mutation_hook` is now deprecated. Instead we recommend that users
-treat the `pod` parameter as a `kubernetes.client.models.V1Pod` object. This means that users now have access to the full Kubernetes API
-when modifying airflow pods
+As of airflow 1.10.12, using the `airflow.contrib.kubernetes.Pod` class in the `pod_mutation_hook` is now deprecated.
+Instead we recommend that users treat the `pod` parameter as a `kubernetes.client.models.V1Pod` object. This means that
+users now have access to the full Kubernetes API when modifying airflow pods
 
 ### pod_template_file option now available in the KubernetesPodOperator
 
@@ -1929,21 +1949,20 @@ Now use NULL as default value for dag.description in dag table
 
 ### Restrict editing DagRun State in the old UI (Flask-admin based UI)
 
-Before 1.10.11 it was possible to edit DagRun State in the `/admin/dagrun/` page
- to any text.
+Before 1.10.11 it was possible to edit DagRun State in the `/admin/dagrun/` page to any text.
 
 In Airflow 1.10.11+, the user can only choose the states from the list.
 
 ### Experimental API will deny all request by default.
 
-The previous default setting was to allow all API requests without authentication, but this poses security
-risks to users who miss this fact. This changes the default for new installs to deny all requests by default.
+The previous default setting was to allow all API requests without authentication, but this poses security risks to
+users who miss this fact. This changes the default for new installs to deny all requests by default.
 
 **Note**: This will not change the behavior for existing installs, please update check your airflow.cfg
 
 If you wish to have the experimental API work, and aware of the risks of enabling this without authentication
-(or if you have your own authentication layer in front of Airflow) you can get
-the previous behaviour on a new install by setting this in your airflow.cfg:
+(or if you have your own authentication layer in front of Airflow) you can get the previous behaviour on a new install
+by setting this in your airflow.cfg:
 
 ```
 [api]
@@ -1952,14 +1971,12 @@ auth_backend = airflow.api.auth.backend.default
 
 ### XCom Values can no longer be added or changed from the Webserver
 
-Since XCom values can contain pickled data, we would no longer allow adding or
-changing XCom values from the UI.
+Since XCom values can contain pickled data, we would no longer allow adding or changing XCom values from the UI.
 
 ### Default for `run_as_user` configured has been changed to 50000 from 0
 
 The UID to run the first process of the Worker PODs when using has been changed to `50000`
-from the previous default of `0`. The previous default was an empty string but the code used `0` if it was
-empty string.
+from the previous default of `0`. The previous default was an empty string but the code used `0` if it was empty string.
 
 **Before**:
 
@@ -1981,8 +1998,8 @@ This is done to avoid running the container as `root` user.
 
 ### Setting Empty string to a Airflow Variable will return an empty string
 
-Previously when you set an Airflow Variable with an empty string (`''`), the value you used to get
-back was ``None``. This will now return an empty string (`'''`)
+Previously when you set an Airflow Variable with an empty string (`''`), the value you used to get back was ``None``.
+This will now return an empty string (`'''`)
 
 Example:
 
@@ -1996,13 +2013,13 @@ The above code returned `None` previously, now it will return `''`.
 ### Make behavior of `none_failed` trigger rule consistent with documentation
 
 The behavior of the `none_failed` trigger rule is documented as "all parents have not failed (`failed` or
-    `upstream_failed`) i.e. all parents have succeeded or been skipped." As previously implemented, the actual behavior
-    would skip if all parents of a task had also skipped.
+`upstream_failed`) i.e. all parents have succeeded or been skipped." As previously implemented, the actual behavior
+would skip if all parents of a task had also skipped.
 
 ### Add new trigger rule `none_failed_or_skipped`
 
-The fix to `none_failed` trigger rule breaks workflows that depend on the previous behavior.
-    If you need the old behavior, you should change the tasks with `none_failed` trigger rule to `none_failed_or_skipped`.
+The fix to `none_failed` trigger rule breaks workflows that depend on the previous behavior. If you need the old
+behavior, you should change the tasks with `none_failed` trigger rule to `none_failed_or_skipped`.
 
 ### Success Callback will be called when a task in marked as success from UI
 
@@ -2016,7 +2033,8 @@ No breaking changes.
 
 ### Failure callback will be called when task is marked failed
 
-When task is marked failed by user or task fails due to system failures - on failure call back will be called as part of clean up
+When task is marked failed by user or task fails due to system failures - on failure call back will be called as part of
+clean up
 
 See [AIRFLOW-5621](https://jira.apache.org/jira/browse/AIRFLOW-5621) for details
 
@@ -2024,32 +2042,31 @@ See [AIRFLOW-5621](https://jira.apache.org/jira/browse/AIRFLOW-5621) for details
 
 ### Changes in experimental API execution_date microseconds replacement
 
-The default behavior was to strip the microseconds (and milliseconds, etc) off of all dag runs triggered by
-by the experimental REST API.  The default behavior will change when an explicit execution_date is
-passed in the request body.  It will also now be possible to have the execution_date generated, but
-keep the microseconds by sending `replace_microseconds=false` in the request body.  The default
-behavior can be overridden by sending `replace_microseconds=true` along with an explicit execution_date
+The default behavior was to strip the microseconds (and milliseconds, etc) off of all dag runs triggered by by the
+experimental REST API. The default behavior will change when an explicit execution_date is passed in the request body.
+It will also now be possible to have the execution_date generated, but keep the microseconds by
+sending `replace_microseconds=false` in the request body. The default behavior can be overridden by
+sending `replace_microseconds=true` along with an explicit execution_date
 
 ### Infinite pool size and pool size query optimisation
 
-Pool size can now be set to -1 to indicate infinite size (it also includes
-optimisation of pool query which lead to poor task n^2 performance of task
-pool queries in MySQL).
+Pool size can now be set to -1 to indicate infinite size (it also includes optimisation of pool query which lead to poor
+task n^2 performance of task pool queries in MySQL).
 
 ### Viewer won't have edit permissions on DAG view.
 
 ### Google Cloud Storage Hook
 
-The `GoogleCloudStorageDownloadOperator` can either write to a supplied `filename` or
-return the content of a file via xcom through `store_to_xcom_key` - both options are mutually exclusive.
+The `GoogleCloudStorageDownloadOperator` can either write to a supplied `filename` or return the content of a file via
+xcom through `store_to_xcom_key` - both options are mutually exclusive.
 
 ## Airflow 1.10.6
 
 ### BaseOperator::render_template function signature changed
 
-Previous versions of the `BaseOperator::render_template` function required an `attr` argument as the first
-positional argument, along with `content` and `context`. This function signature was changed in 1.10.6 and
-the `attr` argument is no longer required (or accepted).
+Previous versions of the `BaseOperator::render_template` function required an `attr` argument as the first positional
+argument, along with `content` and `context`. This function signature was changed in 1.10.6 and the `attr` argument is
+no longer required (or accepted).
 
 In order to use this function in subclasses of the `BaseOperator`, the `attr` argument must be removed:
 
@@ -2061,12 +2078,10 @@ result = self.render_template(self.myattr, context)  # Post-1.10.6 call
 
 ### Changes to `aws_default` Connection's default region
 
-The region of Airflow's default connection to AWS (`aws_default`) was previously
-set to `us-east-1` during installation.
+The region of Airflow's default connection to AWS (`aws_default`) was previously set to `us-east-1` during installation.
 
-The region now needs to be set manually, either in the connection screens in
-Airflow, via the `~/.aws` config files, or via the `AWS_DEFAULT_REGION` environment
-variable.
+The region now needs to be set manually, either in the connection screens in Airflow, via the `~/.aws` config files, or
+via the `AWS_DEFAULT_REGION` environment variable.
 
 ### Some DAG Processing metrics have been renamed
 
@@ -2086,31 +2101,41 @@ No breaking changes.
 
 ### Export MySQL timestamps as UTC
 
-`MySqlToGoogleCloudStorageOperator` now exports TIMESTAMP columns as UTC
-by default, rather than using the default timezone of the MySQL server.
-This is the correct behavior for use with BigQuery, since BigQuery
-assumes that TIMESTAMP columns without time zones are in UTC. To
-preserve the previous behavior, set `ensure_utc` to `False.`
+`MySqlToGoogleCloudStorageOperator` now exports TIMESTAMP columns as UTC by default, rather than using the default
+timezone of the MySQL server. This is the correct behavior for use with BigQuery, since BigQuery assumes that TIMESTAMP
+columns without time zones are in UTC. To preserve the previous behavior, set `ensure_utc` to `False.`
 
 ### Changes to DatastoreHook
 
-* removed argument `version` from `get_conn` function and added it to the hook's `__init__` function instead and renamed it to `api_version`
+* removed argument `version` from `get_conn` function and added it to the hook's `__init__` function instead and renamed
+  it to `api_version`
 * renamed the `partialKeys` argument of function `allocate_ids` to `partial_keys`
 
 ### Changes to GoogleCloudStorageHook
 
-* the discovery-based api (`googleapiclient.discovery`) used in `GoogleCloudStorageHook` is now replaced by the recommended client based api (`google-cloud-storage`). To know the difference between both the libraries, read https://cloud.google.com/apis/docs/client-libraries-explained. PR: [#5054](https://github.com/apache/airflow/pull/5054)
-* as a part of this replacement, the `multipart` & `num_retries` parameters for `GoogleCloudStorageHook.upload` method have been deprecated.
+* the discovery-based api (`googleapiclient.discovery`) used in `GoogleCloudStorageHook` is now replaced by the
+  recommended client based api (`google-cloud-storage`). To know the difference between both the libraries,
+  read https://cloud.google.com/apis/docs/client-libraries-explained.
+  PR: [#5054](https://github.com/apache/airflow/pull/5054)
+* as a part of this replacement, the `multipart` & `num_retries` parameters for `GoogleCloudStorageHook.upload` method
+  have been deprecated.
 
-  The client library uses multipart upload automatically if the object/blob size is more than 8 MB - [source code](https://github.com/googleapis/google-cloud-python/blob/11c543ce7dd1d804688163bc7895cf592feb445f/storage/google/cloud/storage/blob.py#L989-L997). The client also handles retries automatically
+  The client library uses multipart upload automatically if the object/blob size is more than 8 MB
+  - [source code](https://github.com/googleapis/google-cloud-python/blob/11c543ce7dd1d804688163bc7895cf592feb445f/storage/google/cloud/storage/blob.py#L989-L997)
+  . The client also handles retries automatically
 
-* the `generation` parameter is deprecated in `GoogleCloudStorageHook.delete` and `GoogleCloudStorageHook.insert_object_acl`.
+* the `generation` parameter is deprecated in `GoogleCloudStorageHook.delete`
+  and `GoogleCloudStorageHook.insert_object_acl`.
 
-Updating to `google-cloud-storage >= 1.16` changes the signature of the upstream `client.get_bucket()` method from `get_bucket(bucket_name: str)` to `get_bucket(bucket_or_name: Union[str, Bucket])`. This method is not directly exposed by the airflow hook, but any code accessing the connection directly (`GoogleCloudStorageHook().get_conn().get_bucket(...)` or similar) will need to be updated.
+Updating to `google-cloud-storage >= 1.16` changes the signature of the upstream `client.get_bucket()` method
+from `get_bucket(bucket_name: str)` to `get_bucket(bucket_or_name: Union[str, Bucket])`. This method is not directly
+exposed by the airflow hook, but any code accessing the connection
+directly (`GoogleCloudStorageHook().get_conn().get_bucket(...)` or similar) will need to be updated.
 
 ### Changes in writing Logs to Elasticsearch
 
-The `elasticsearch_` prefix has been removed from all config items under the `[elasticsearch]` section. For example `elasticsearch_host` is now just `host`.
+The `elasticsearch_` prefix has been removed from all config items under the `[elasticsearch]` section. For
+example `elasticsearch_host` is now just `host`.
 
 ### Removal of `non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`
 
@@ -2118,25 +2143,24 @@ The `elasticsearch_` prefix has been removed from all config items under the `[e
 are removed in favor of a real pool, e.g. `default_pool`.
 
 By default tasks are running in `default_pool`.
-`default_pool` is initialized with 128 slots and user can change the
-number of slots through UI/CLI. `default_pool` cannot be removed.
+`default_pool` is initialized with 128 slots and user can change the number of slots through UI/CLI. `default_pool`
+cannot be removed.
 
 ### `pool` config option in Celery section to support different Celery pool implementation
 
-The new `pool` config option allows users to choose different pool
-implementation. Default value is "prefork", while choices include "prefork" (default),
-"eventlet", "gevent" or "solo". This may help users achieve better concurrency performance
-in different scenarios.
+The new `pool` config option allows users to choose different pool implementation. Default value is "prefork", while
+choices include "prefork" (default),
+"eventlet", "gevent" or "solo". This may help users achieve better concurrency performance in different scenarios.
 
 For more details about Celery pool implementation, please refer to:
 
 - https://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency
 - https://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html
 
-
 ### Change to method signature in `BaseOperator` and `DAG` classes
 
-The signature of the `get_task_instances` method in the `BaseOperator` and `DAG` classes has changed. The change does not change the behavior of the method in either case.
+The signature of the `get_task_instances` method in the `BaseOperator` and `DAG` classes has changed. The change does
+not change the behavior of the method in either case.
 
 #### For `BaseOperator`
 
@@ -2159,7 +2183,7 @@ Old signature:
 
 ```python
 def get_task_instances(
-    self, session, start_date=None, end_date=None, state=None):
+  self, session, start_date=None, end_date=None, state=None):
 ```
 
 New signature:
@@ -2167,10 +2191,11 @@ New signature:
 ```python
 @provide_session
 def get_task_instances(
-    self, start_date=None, end_date=None, state=None, session=None):
+  self, start_date=None, end_date=None, state=None, session=None):
 ```
 
-In either case, it is necessary to rewrite calls to the `get_task_instances` method that currently provide the `session` positional argument. New calls to this method look like:
+In either case, it is necessary to rewrite calls to the `get_task_instances` method that currently provide the `session`
+positional argument. New calls to this method look like:
 
 ```python
 # if you can rely on @provide_session
@@ -2183,33 +2208,31 @@ dag.get_task_instances(session=your_session)
 
 ### New `dag_discovery_safe_mode` config option
 
-If `dag_discovery_safe_mode` is enabled, only check files for DAGs if
-they contain the strings "airflow" and "DAG". For backwards
-compatibility, this option is enabled by default.
+If `dag_discovery_safe_mode` is enabled, only check files for DAGs if they contain the strings "airflow" and "DAG". For
+backwards compatibility, this option is enabled by default.
 
 ### RedisPy dependency updated to v3 series
 
 If you are using the Redis Sensor or Hook you may have to update your code. See
-[redis-py porting instructions] to check if your code might be affected (MSET,
-MSETNX, ZADD, and ZINCRBY all were, but read the full doc).
+[redis-py porting instructions] to check if your code might be affected (MSET, MSETNX, ZADD, and ZINCRBY all were, but
+read the full doc).
 
 [redis-py porting instructions]: https://github.com/andymccurdy/redis-py/tree/3.2.0#upgrading-from-redis-py-2x-to-30
 
 ### SLUGIFY_USES_TEXT_UNIDECODE or AIRFLOW_GPL_UNIDECODE no longer required
 
-It is no longer required to set one of the environment variables to avoid
-a GPL dependency. Airflow will now always use text-unidecode if unidecode
-was not installed before.
+It is no longer required to set one of the environment variables to avoid a GPL dependency. Airflow will now always use
+text-unidecode if unidecode was not installed before.
 
 ### new `sync_parallelism` config option in celery section
 
-The new `sync_parallelism` config option will control how many processes CeleryExecutor will use to
-fetch celery task state in parallel. Default value is max(1, number of cores - 1)
+The new `sync_parallelism` config option will control how many processes CeleryExecutor will use to fetch celery task
+state in parallel. Default value is max(1, number of cores - 1)
 
 ### Rename of BashTaskRunner to StandardTaskRunner
 
-BashTaskRunner has been renamed to StandardTaskRunner. It is the default task runner
-so you might need to update your config.
+BashTaskRunner has been renamed to StandardTaskRunner. It is the default task runner so you might need to update your
+config.
 
 `task_runner = StandardTaskRunner`
 
@@ -2217,48 +2240,47 @@ so you might need to update your config.
 
 If the `AIRFLOW_CONFIG` environment variable was not set and the
 `~/airflow/airflow.cfg` file existed, airflow previously used
-`~/airflow/airflow.cfg` instead of `$AIRFLOW_HOME/airflow.cfg`. Now airflow
-will discover its config file using the `$AIRFLOW_CONFIG` and `$AIRFLOW_HOME`
+`~/airflow/airflow.cfg` instead of `$AIRFLOW_HOME/airflow.cfg`. Now airflow will discover its config file using
+the `$AIRFLOW_CONFIG` and `$AIRFLOW_HOME`
 environment variables rather than checking for the presence of a file.
 
 ### Changes in Google Cloud related operators
 
-Most GCP-related operators have now optional `PROJECT_ID` parameter. In case you do not specify it,
-the project id configured in
-[GCP Connection](https://airflow.apache.org/howto/manage-connections.html#connection-type-gcp) is used.
-There will be an `AirflowException` thrown in case `PROJECT_ID` parameter is not specified and the
-connection used has no project id defined. This change should be  backwards compatible as earlier version
-of the operators had `PROJECT_ID` mandatory.
+Most GCP-related operators have now optional `PROJECT_ID` parameter. In case you do not specify it, the project id
+configured in
+[GCP Connection](https://airflow.apache.org/howto/manage-connections.html#connection-type-gcp) is used. There will be
+an `AirflowException` thrown in case `PROJECT_ID` parameter is not specified and the connection used has no project id
+defined. This change should be backwards compatible as earlier version of the operators had `PROJECT_ID` mandatory.
 
 Operators involved:
 
-  * GCP Compute Operators
-    * GceInstanceStartOperator
-    * GceInstanceStopOperator
-    * GceSetMachineTypeOperator
-  * GCP Function Operators
-    * GcfFunctionDeployOperator
-  * GCP Cloud SQL Operators
-    * CloudSqlInstanceCreateOperator
-    * CloudSqlInstancePatchOperator
-    * CloudSqlInstanceDeleteOperator
-    * CloudSqlInstanceDatabaseCreateOperator
-    * CloudSqlInstanceDatabasePatchOperator
-    * CloudSqlInstanceDatabaseDeleteOperator
+* GCP Compute Operators
+  * GceInstanceStartOperator
+  * GceInstanceStopOperator
+  * GceSetMachineTypeOperator
+* GCP Function Operators
+  * GcfFunctionDeployOperator
+* GCP Cloud SQL Operators
+  * CloudSqlInstanceCreateOperator
+  * CloudSqlInstancePatchOperator
+  * CloudSqlInstanceDeleteOperator
+  * CloudSqlInstanceDatabaseCreateOperator
+  * CloudSqlInstanceDatabasePatchOperator
+  * CloudSqlInstanceDatabaseDeleteOperator
 
 Other GCP operators are unaffected.
 
 ### Changes in Google Cloud related hooks
 
-The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather
-than positional ones in all methods where `project_id` is used. The methods throw an explanatory exception
-in case they are called using positional parameters.
+The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather than
+positional ones in all methods where `project_id` is used. The methods throw an explanatory exception in case they are
+called using positional parameters.
 
 Hooks involved:
 
-  * GceHook
-  * GcfHook
-  * CloudSqlHook
+* GceHook
+* GcfHook
+* CloudSqlHook
 
 Other GCP hooks are unaffected.
 
@@ -2269,12 +2291,13 @@ It's now possible to use `None` as a default value with the `default_var` parame
 ```python
 foo = Variable.get("foo", default_var=None)
 if foo is None:
-    handle_missing_foo()
+  handle_missing_foo()
 ```
 
 (Note: there is already `Variable.setdefault()` which me be helpful in some cases.)
 
-This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects a `KeyError` to be thrown, then don't pass the `default_var` argument.
+This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects
+a `KeyError` to be thrown, then don't pass the `default_var` argument.
 
 ### Removal of `airflow_home` config setting
 
@@ -2282,13 +2305,11 @@ There were previously two ways of specifying the Airflow "home" directory
 (`~/airflow` by default): the `AIRFLOW_HOME` environment variable, and the
 `airflow_home` config setting in the `[core]` section.
 
-If they had two different values different parts of the code base would end up
-with different values. The config setting has been deprecated, and you should
-remove the value from the config file and set `AIRFLOW_HOME` environment
-variable if you need to use a non default value for this.
+If they had two different values different parts of the code base would end up with different values. The config setting
+has been deprecated, and you should remove the value from the config file and set `AIRFLOW_HOME` environment variable if
+you need to use a non default value for this.
 
-(Since this setting is used to calculate what config file to load, it is not
-possible to keep just the config option)
+(Since this setting is used to calculate what config file to load, it is not possible to keep just the config option)
 
 ### Change of two methods signatures in `GCPTransferServiceHook`
 
@@ -2335,7 +2356,7 @@ def wait_for_transfer_job(self, job):
 New signature:
 
 ```python
-def wait_for_transfer_job(self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS, )):
+def wait_for_transfer_job(self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS,)):
 ```
 
 The behavior of `wait_for_transfer_job` has changed:
@@ -2364,44 +2385,51 @@ The previous imports will continue to work until Airflow 2.0
 
 ### Fixed typo in --driver-class-path in SparkSubmitHook
 
-The `driver_classapth` argument  to SparkSubmit Hook and Operator was
-generating `--driver-classpath` on the spark command line, but this isn't a
-valid option to spark.
+The `driver_classapth` argument to SparkSubmit Hook and Operator was generating `--driver-classpath` on the spark
+command line, but this isn't a valid option to spark.
 
-The argument has been renamed to `driver_class_path`  and  the option it
-generates has been fixed.
+The argument has been renamed to `driver_class_path`  and the option it generates has been fixed.
 
 ## Airflow 1.10.2
 
 ### New `dag_processor_manager_log_location` config option
 
-The DAG parsing manager log now by default will be log into a file, where its location is
-controlled by the new `dag_processor_manager_log_location` config option in core section.
+The DAG parsing manager log now by default will be log into a file, where its location is controlled by the
+new `dag_processor_manager_log_location` config option in core section.
 
 ### DAG level Access Control for new RBAC UI
 
-Extend and enhance new Airflow RBAC UI to support DAG level ACL. Each dag now has two permissions(one for write, one for read) associated('can_dag_edit', 'can_dag_read').
-The admin will create new role, associate the dag permission with the target dag and assign that role to users. That user can only access / view the certain dags on the UI
-that he has permissions on. If a new role wants to access all the dags, the admin could associate dag permissions on an artificial view(``all_dags``) with that role.
+Extend and enhance new Airflow RBAC UI to support DAG level ACL. Each dag now has two permissions(one for write, one for
+read) associated('can_dag_edit', 'can_dag_read'). The admin will create new role, associate the dag permission with the
+target dag and assign that role to users. That user can only access / view the certain dags on the UI that he has
+permissions on. If a new role wants to access all the dags, the admin could associate dag permissions on an artificial
+view(``all_dags``) with that role.
 
 We also provide a new cli command(``sync_perm``) to allow admin to auto sync permissions.
 
 ### Modification to `ts_nodash` macro
 
-`ts_nodash` previously contained TimeZone information along with execution date. For Example: `20150101T000000+0000`. This is not user-friendly for file or folder names which was a popular use case for `ts_nodash`. Hence this behavior has been changed and using `ts_nodash` will no longer contain TimeZone information, restoring the pre-1.10 behavior of this macro. And a new macro `ts_nodash_with_tz` has been added which can be used to get a string with execution date and timezone info without dashes.
+`ts_nodash` previously contained TimeZone information along with execution date. For Example: `20150101T000000+0000`.
+This is not user-friendly for file or folder names which was a popular use case for `ts_nodash`. Hence this behavior has
+been changed and using `ts_nodash` will no longer contain TimeZone information, restoring the pre-1.10 behavior of this
+macro. And a new macro `ts_nodash_with_tz` has been added which can be used to get a string with execution date and
+timezone info without dashes.
 
 Examples:
 
-  * `ts_nodash`: `20150101T000000`
-  * `ts_nodash_with_tz`: `20150101T000000+0000`
+* `ts_nodash`: `20150101T000000`
+* `ts_nodash_with_tz`: `20150101T000000+0000`
 
 ### Semantics of next_ds/prev_ds changed for manually triggered runs
 
-next_ds/prev_ds now map to execution_date instead of the next/previous schedule-aligned execution date for DAGs triggered in the UI.
+next_ds/prev_ds now map to execution_date instead of the next/previous schedule-aligned execution date for DAGs
+triggered in the UI.
 
 ### User model changes
 
-This patch changes the `User.superuser` field from a hardcoded boolean to a `Boolean()` database column. `User.superuser` will default to `False`, which means that this privilege will have to be granted manually to any users that may require it.
+This patch changes the `User.superuser` field from a hardcoded boolean to a `Boolean()` database
+column. `User.superuser` will default to `False`, which means that this privilege will have to be granted manually to
+any users that may require it.
 
 For example, open a Python shell and
 
@@ -2421,10 +2449,10 @@ session.commit()
 
 ### Custom auth backends interface change
 
-We have updated the version of flask-login we depend upon, and as a result any
-custom auth backends might need a small change: `is_active`,
-`is_authenticated`, and `is_anonymous` should now be properties. What this means is if
-previously you had this in your user class
+We have updated the version of flask-login we depend upon, and as a result any custom auth backends might need a small
+change: `is_active`,
+`is_authenticated`, and `is_anonymous` should now be properties. What this means is if previously you had this in your
+user class
 
 ```python
 def is_active(self):
@@ -2441,16 +2469,18 @@ def is_active(self):
 
 ### Support autodetected schemas to GoogleCloudStorageToBigQueryOperator
 
-GoogleCloudStorageToBigQueryOperator is now support schema auto-detection is available when you load data into BigQuery. Unfortunately, changes can be required.
+GoogleCloudStorageToBigQueryOperator is now support schema auto-detection is available when you load data into BigQuery.
+Unfortunately, changes can be required.
 
-If BigQuery tables are created outside of airflow and the schema is not defined in the task, multiple options are available:
+If BigQuery tables are created outside of airflow and the schema is not defined in the task, multiple options are
+available:
 
 define a schema_fields:
 
 ```python
 gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
   ...
-  schema_fields={...})
+schema_fields = {...})
 ```
 
 or define a schema_object:
@@ -2458,7 +2488,7 @@ or define a schema_object:
 ```python
 gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
   ...
-  schema_object='path/to/schema/object')
+schema_object = 'path/to/schema/object')
 ```
 
 or enabled autodetect of schema:
@@ -2466,46 +2496,44 @@ or enabled autodetect of schema:
 ```python
 gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
   ...
-  autodetect=True)
+autodetect = True)
 ```
 
 ## Airflow 1.10.1
 
 ### min_file_parsing_loop_time config option temporarily disabled
 
-The scheduler.min_file_parsing_loop_time config option has been temporarily removed due to
-some bugs.
+The scheduler.min_file_parsing_loop_time config option has been temporarily removed due to some bugs.
 
 ### StatsD Metrics
 
-The `scheduler_heartbeat` metric has been changed from a gauge to a counter. Each loop of the scheduler will increment the counter by 1. This provides a higher degree of visibility and allows for better integration with Prometheus using the [StatsD Exporter](https://github.com/prometheus/statsd_exporter). The scheduler's activity status can be determined by graphing and alerting using a rate of change of the counter. If the scheduler goes down, the rate will drop to 0.
+The `scheduler_heartbeat` metric has been changed from a gauge to a counter. Each loop of the scheduler will increment
+the counter by 1. This provides a higher degree of visibility and allows for better integration with Prometheus using
+the [StatsD Exporter](https://github.com/prometheus/statsd_exporter). The scheduler's activity status can be determined
+by graphing and alerting using a rate of change of the counter. If the scheduler goes down, the rate will drop to 0.
 
 ### EMRHook now passes all of connection's extra to CreateJobFlow API
 
-EMRHook.create_job_flow has been changed to pass all keys to the create_job_flow API, rather than
-just specific known keys for greater flexibility.
+EMRHook.create_job_flow has been changed to pass all keys to the create_job_flow API, rather than just specific known
+keys for greater flexibility.
 
-However prior to this release the "emr_default" sample connection that was created had invalid
-configuration, so creating EMR clusters might fail until your connection is updated. (Ec2KeyName,
-Ec2SubnetId, TerminationProtection and KeepJobFlowAliveWhenNoSteps were all top-level keys when they
-should be inside the "Instances" dict)
+However prior to this release the "emr_default" sample connection that was created had invalid configuration, so
+creating EMR clusters might fail until your connection is updated. (Ec2KeyName, Ec2SubnetId, TerminationProtection and
+KeepJobFlowAliveWhenNoSteps were all top-level keys when they should be inside the "Instances" dict)
 
 ### LDAP Auth Backend now requires TLS
 
-Connecting to an LDAP server over plain text is not supported anymore. The
-certificate presented by the LDAP server must be signed by a trusted
-certificate, or you must provide the `cacert` option under `[ldap]` in the
-config file.
+Connecting to an LDAP server over plain text is not supported anymore. The certificate presented by the LDAP server must
+be signed by a trusted certificate, or you must provide the `cacert` option under `[ldap]` in the config file.
 
-If you want to use LDAP auth backend without TLS then you will have to create a
-custom-auth backend based on
+If you want to use LDAP auth backend without TLS then you will have to create a custom-auth backend based on
 https://github.com/apache/airflow/blob/1.10.0/airflow/contrib/auth/backends/ldap_auth.py
 
 ## Airflow 1.10
 
 Installation and upgrading requires setting `SLUGIFY_USES_TEXT_UNIDECODE=yes` in your environment or
-`AIRFLOW_GPL_UNIDECODE=yes`. In case of the latter a GPL runtime dependency will be installed due to a
-dependency (python-nvd3 -> python-slugify -> unidecode).
+`AIRFLOW_GPL_UNIDECODE=yes`. In case of the latter a GPL runtime dependency will be installed due to a dependency (
+python-nvd3 -> python-slugify -> unidecode).
 
 ### Replace DataProcHook.await calls to DataProcHook.wait
 
@@ -2515,43 +2543,61 @@ The method name was changed to be compatible with the Python 3.7 async/await key
 
 ### Add a configuration variable(default_dag_run_display_number) to control numbers of dag run for display
 
-Add a configuration variable(default_dag_run_display_number) under webserver section to control the number of dag runs to show in UI.
+Add a configuration variable(default_dag_run_display_number) under webserver section to control the number of dag runs
+to show in UI.
 
 ### Default executor for SubDagOperator is changed to SequentialExecutor
 
 ### New Webserver UI with Role-Based Access Control
 
-The current webserver UI uses the Flask-Admin extension. The new webserver UI uses the [Flask-AppBuilder (FAB)](https://github.com/dpgaspar/Flask-AppBuilder) extension. FAB has built-in authentication support and Role-Based Access Control (RBAC), which provides configurable roles and permissions for individual users.
+The current webserver UI uses the Flask-Admin extension. The new webserver UI uses
+the [Flask-AppBuilder (FAB)](https://github.com/dpgaspar/Flask-AppBuilder) extension. FAB has built-in authentication
+support and Role-Based Access Control (RBAC), which provides configurable roles and permissions for individual users.
 
-To turn on this feature, in your airflow.cfg file (under [webserver]), set the configuration variable `rbac = True`, and then run `airflow` command, which will generate the `webserver_config.py` file in your $AIRFLOW_HOME.
+To turn on this feature, in your airflow.cfg file (under [webserver]), set the configuration variable `rbac = True`, and
+then run `airflow` command, which will generate the `webserver_config.py` file in your $AIRFLOW_HOME.
 
 #### Setting up Authentication
 
-FAB has built-in authentication support for DB, OAuth, OpenID, LDAP, and REMOTE_USER. The default auth type is `AUTH_DB`.
+FAB has built-in authentication support for DB, OAuth, OpenID, LDAP, and REMOTE_USER. The default auth type is `AUTH_DB`
+.
 
-For any other authentication type (OAuth, OpenID, LDAP, REMOTE_USER), see the [Authentication section of FAB docs](http://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for how to configure variables in webserver_config.py file.
+For any other authentication type (OAuth, OpenID, LDAP, REMOTE_USER), see
+the [Authentication section of FAB docs](http://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods)
+for how to configure variables in webserver_config.py file.
 
-Once you modify your config file, run `airflow db init` to generate new tables for RBAC support (these tables will have the prefix `ab_`).
+Once you modify your config file, run `airflow db init` to generate new tables for RBAC support (these tables will have
+the prefix `ab_`).
 
 #### Creating an Admin Account
 
-Once configuration settings have been updated and new tables have been generated, create an admin account with `airflow create_user` command.
+Once configuration settings have been updated and new tables have been generated, create an admin account
+with `airflow create_user` command.
 
 #### Using your new UI
 
-Run `airflow webserver` to start the new UI. This will bring up a log in page, enter the recently created admin username and password.
+Run `airflow webserver` to start the new UI. This will bring up a log in page, enter the recently created admin username
+and password.
 
-There are five roles created for Airflow by default: Admin, User, Op, Viewer, and Public. To configure roles/permissions, go to the `Security` tab and click `List Roles` in the new UI.
+There are five roles created for Airflow by default: Admin, User, Op, Viewer, and Public. To configure
+roles/permissions, go to the `Security` tab and click `List Roles` in the new UI.
 
 #### Breaking changes
 
-- AWS Batch Operator renamed property queue to job_queue to prevent conflict with the internal queue from CeleryExecutor - AIRFLOW-2542
-- Users created and stored in the old users table will not be migrated automatically. FAB's built-in authentication support must be reconfigured.
+- AWS Batch Operator renamed property queue to job_queue to prevent conflict with the internal queue from CeleryExecutor
+  - AIRFLOW-2542
+- Users created and stored in the old users table will not be migrated automatically. FAB's built-in authentication
+  support must be reconfigured.
 - Airflow dag home page is now `/home` (instead of `/admin`).
-- All ModelViews in Flask-AppBuilder follow a different pattern from Flask-Admin. The `/admin` part of the URL path will no longer exist. For example: `/admin/connection` becomes `/connection/list`, `/admin/connection/new` becomes `/connection/add`, `/admin/connection/edit` becomes `/connection/edit`, etc.
-- Due to security concerns, the new webserver will no longer support the features in the `Data Profiling` menu of old UI, including `Ad Hoc Query`, `Charts`, and `Known Events`.
-- HiveServer2Hook.get_results() always returns a list of tuples, even when a single column is queried, as per Python API 2.
-- **UTC is now the default timezone**: Either reconfigure your workflows scheduling in UTC or set `default_timezone` as explained in https://airflow.apache.org/timezone.html#default-time-zone
+- All ModelViews in Flask-AppBuilder follow a different pattern from Flask-Admin. The `/admin` part of the URL path will
+  no longer exist. For example: `/admin/connection` becomes `/connection/list`, `/admin/connection/new`
+  becomes `/connection/add`, `/admin/connection/edit` becomes `/connection/edit`, etc.
+- Due to security concerns, the new webserver will no longer support the features in the `Data Profiling` menu of old
+  UI, including `Ad Hoc Query`, `Charts`, and `Known Events`.
+- HiveServer2Hook.get_results() always returns a list of tuples, even when a single column is queried, as per Python API
+  2.
+- **UTC is now the default timezone**: Either reconfigure your workflows scheduling in UTC or set `default_timezone` as
+  explained in https://airflow.apache.org/timezone.html#default-time-zone
 
 ### airflow.contrib.sensors.hdfs_sensors renamed to airflow.contrib.sensors.hdfs_sensor
 
@@ -2559,8 +2605,8 @@ We now rename airflow.contrib.sensors.hdfs_sensors to airflow.contrib.sensors.hd
 
 ### MySQL setting required
 
-We now rely on more strict ANSI SQL settings for MySQL in order to have sane defaults. Make sure
-to have specified `explicit_defaults_for_timestamp=1` in your my.cnf under `[mysqld]`
+We now rely on more strict ANSI SQL settings for MySQL in order to have sane defaults. Make sure to have
+specified `explicit_defaults_for_timestamp=1` in your my.cnf under `[mysqld]`
 
 ### Celery config
 
@@ -2579,28 +2625,33 @@ Resulting in the same config parameters as Celery 4, with more transparency.
 ### GCP Dataflow Operators
 
 Dataflow job labeling is now supported in Dataflow{Java,Python}Operator with a default
-"airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version
-to 2.2.0 or greater.
+"airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version to 2.2.0 or greater.
 
 ### BigQuery Hooks and Operator
 
-The `bql` parameter passed to `BigQueryOperator` and `BigQueryBaseCursor.run_query` has been deprecated and renamed to `sql` for consistency purposes. Using `bql` will still work (and raise a `DeprecationWarning`), but is no longer
+The `bql` parameter passed to `BigQueryOperator` and `BigQueryBaseCursor.run_query` has been deprecated and renamed
+to `sql` for consistency purposes. Using `bql` will still work (and raise a `DeprecationWarning`), but is no longer
 supported and will be removed entirely in Airflow 2.0
 
 ### Redshift to S3 Operator
 
-With Airflow 1.9 or lower, Unload operation always included header row. In order to include header row,
-we need to turn off parallel unload. It is preferred to perform unload operation using all nodes so that it is
-faster for larger tables. So, parameter called `include_header` is added and default is set to False.
-Header row will be added only if this parameter is set True and also in that case parallel will be automatically turned off (`PARALLEL OFF`)
+With Airflow 1.9 or lower, Unload operation always included header row. In order to include header row, we need to turn
+off parallel unload. It is preferred to perform unload operation using all nodes so that it is faster for larger tables.
+So, parameter called `include_header` is added and default is set to False. Header row will be added only if this
+parameter is set True and also in that case parallel will be automatically turned off (`PARALLEL OFF`)
 
 ### Google cloud connection string
 
-With Airflow 1.9 or lower, there were two connection strings for the Google Cloud operators, both `google_cloud_storage_default` and `google_cloud_default`. This can be confusing and therefore the `google_cloud_storage_default` connection id has been replaced with `google_cloud_default` to make the connection id consistent across Airflow.
+With Airflow 1.9 or lower, there were two connection strings for the Google Cloud operators,
+both `google_cloud_storage_default` and `google_cloud_default`. This can be confusing and therefore
+the `google_cloud_storage_default` connection id has been replaced with `google_cloud_default` to make the connection id
+consistent across Airflow.
 
 ### Logging Configuration
 
-With Airflow 1.9 or lower, `FILENAME_TEMPLATE`, `PROCESSOR_FILENAME_TEMPLATE`, `LOG_ID_TEMPLATE`, `END_OF_LOG_MARK` were configured in `airflow_local_settings.py`. These have been moved into the configuration file, and hence if you were using a custom configuration file the following defaults need to be added.
+With Airflow 1.9 or lower, `FILENAME_TEMPLATE`, `PROCESSOR_FILENAME_TEMPLATE`, `LOG_ID_TEMPLATE`, `END_OF_LOG_MARK` were
+configured in `airflow_local_settings.py`. These have been moved into the configuration file, and hence if you were
+using a custom configuration file the following defaults need to be added.
 
 ```
 [core]
@@ -2613,11 +2664,15 @@ elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_
 elasticsearch_end_of_log_mark = end_of_log
 ```
 
-The previous setting of `log_task_reader` is not needed in many cases now when using the default logging config with remote storages. (Previously it needed to be set to `s3.task` or similar. This is not needed with the default config anymore)
+The previous setting of `log_task_reader` is not needed in many cases now when using the default logging config with
+remote storages. (Previously it needed to be set to `s3.task` or similar. This is not needed with the default config
+anymore)
 
 #### Change of per-task log path
 
-With the change to Airflow core to be timezone aware the default log path for task instances will now include timezone information. This will by default mean all previous task logs won't be found. You can get the old behaviour back by setting the following config options:
+With the change to Airflow core to be timezone aware the default log path for task instances will now include timezone
+information. This will by default mean all previous task logs won't be found. You can get the old behaviour back by
+setting the following config options:
 
 ```
 [core]
@@ -2628,43 +2683,60 @@ log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ execution_date.strft
 
 ### SSH Hook updates, along with new SSH Operator & SFTP Operator
 
-SSH Hook now uses the Paramiko library to create an ssh client connection, instead of the sub-process based ssh command execution previously (<1.9.0), so this is backward incompatible.
+SSH Hook now uses the Paramiko library to create an ssh client connection, instead of the sub-process based ssh command
+execution previously (<1.9.0), so this is backward incompatible.
 
 - update SSHHook constructor
-- use SSHOperator class in place of SSHExecuteOperator which is removed now. Refer to test_ssh_operator.py for usage info.
-- SFTPOperator is added to perform secure file transfer from serverA to serverB. Refer to test_sftp_operator.py for usage info.
+- use SSHOperator class in place of SSHExecuteOperator which is removed now. Refer to test_ssh_operator.py for usage
+  info.
+- SFTPOperator is added to perform secure file transfer from serverA to serverB. Refer to test_sftp_operator.py for
+  usage info.
 - No updates are required if you are using ftpHook, it will continue to work as is.
 
 ### S3Hook switched to use Boto3
 
-The airflow.hooks.S3_hook.S3Hook has been switched to use boto3 instead of the older boto (a.k.a. boto2). This results in a few backwards incompatible changes to the following classes: S3Hook:
+The airflow.hooks.S3_hook.S3Hook has been switched to use boto3 instead of the older boto (a.k.a. boto2). This results
+in a few backwards incompatible changes to the following classes: S3Hook:
 
 - the constructors no longer accepts `s3_conn_id`. It is now called `aws_conn_id`.
 - the default connection is now "aws_default" instead of "s3_default"
 - the return type of objects returned by `get_bucket` is now boto3.s3.Bucket
 - the return type of `get_key`, and `get_wildcard_key` is now an boto3.S3.Object.
 
-If you are using any of these in your DAGs and specify a connection ID you will need to update the parameter name for the connection to "aws_conn_id": S3ToHiveTransfer, S3PrefixSensor, S3KeySensor, RedshiftToS3Transfer.
+If you are using any of these in your DAGs and specify a connection ID you will need to update the parameter name for
+the connection to "aws_conn_id": S3ToHiveTransfer, S3PrefixSensor, S3KeySensor, RedshiftToS3Transfer.
 
 ### Logging update
 
-The logging structure of Airflow has been rewritten to make configuration easier and the logging system more transparent.
+The logging structure of Airflow has been rewritten to make configuration easier and the logging system more
+transparent.
 
 #### A quick recap about logging
 
-A logger is the entry point into the logging system. Each logger is a named bucket to which messages can be written for processing. A logger is configured to have a log level. This log level describes the severity of the messages that the logger will handle. Python defines the following log levels: DEBUG, INFO, WARNING, ERROR or CRITICAL.
+A logger is the entry point into the logging system. Each logger is a named bucket to which messages can be written for
+processing. A logger is configured to have a log level. This log level describes the severity of the messages that the
+logger will handle. Python defines the following log levels: DEBUG, INFO, WARNING, ERROR or CRITICAL.
 
-Each message that is written to the logger is a Log Record. Each log record contains a log level indicating the severity of that specific message. A log record can also contain useful metadata that describes the event that is being logged. This can include details such as a stack trace or an error code.
+Each message that is written to the logger is a Log Record. Each log record contains a log level indicating the severity
+of that specific message. A log record can also contain useful metadata that describes the event that is being logged.
+This can include details such as a stack trace or an error code.
 
-When a message is given to the logger, the log level of the message is compared to the log level of the logger. If the log level of the message meets or exceeds the log level of the logger itself, the message will undergo further processing. If it doesn’t, the message will be ignored.
+When a message is given to the logger, the log level of the message is compared to the log level of the logger. If the
+log level of the message meets or exceeds the log level of the logger itself, the message will undergo further
+processing. If it doesn’t, the message will be ignored.
 
-Once a logger has determined that a message needs to be processed, it is passed to a Handler. This configuration is now more flexible and can be easily be maintained in a single file.
+Once a logger has determined that a message needs to be processed, it is passed to a Handler. This configuration is now
+more flexible and can be easily be maintained in a single file.
 
 #### Changes in Airflow Logging
 
-Airflow's logging mechanism has been refactored to use Python’s built-in `logging` module to perform logging of the application. By extending classes with the existing `LoggingMixin`, all the logging will go through a central logger. Also the `BaseHook` and `BaseOperator` already extend this class, so it is easily available to do logging.
+Airflow's logging mechanism has been refactored to use Python’s built-in `logging` module to perform logging of the
+application. By extending classes with the existing `LoggingMixin`, all the logging will go through a central logger.
+Also the `BaseHook` and `BaseOperator` already extend this class, so it is easily available to do logging.
 
-The main benefit is easier configuration of the logging by setting a single centralized python file. Disclaimer; there is still some inline configuration, but this will be removed eventually. The new logging class is defined by setting the dotted classpath in your `~/airflow/airflow.cfg` file:
+The main benefit is easier configuration of the logging by setting a single centralized python file. Disclaimer; there
+is still some inline configuration, but this will be removed eventually. The new logging class is defined by setting the
+dotted classpath in your `~/airflow/airflow.cfg` file:
 
 ```
 # Logging class
@@ -2673,9 +2745,12 @@ The main benefit is easier configuration of the logging by setting a single cent
 logging_config_class = my.path.default_local_settings.LOGGING_CONFIG
 ```
 
-The logging configuration file needs to be on the `PYTHONPATH`, for example `$AIRFLOW_HOME/config`. This directory is loaded by default. Any directory may be added to the `PYTHONPATH`, this might be handy when the config is in another directory or a volume is mounted in case of Docker.
+The logging configuration file needs to be on the `PYTHONPATH`, for example `$AIRFLOW_HOME/config`. This directory is
+loaded by default. Any directory may be added to the `PYTHONPATH`, this might be handy when the config is in another
+directory or a volume is mounted in case of Docker.
 
-The config can be taken from `airflow/config_templates/airflow_local_settings.py` as a starting point. Copy the contents to `${AIRFLOW_HOME}/config/airflow_local_settings.py`,  and alter the config as is preferred.
+The config can be taken from `airflow/config_templates/airflow_local_settings.py` as a starting point. Copy the contents
+to `${AIRFLOW_HOME}/config/airflow_local_settings.py`, and alter the config as is preferred.
 
 ```
 #
@@ -2790,7 +2865,9 @@ DEFAULT_LOGGING_CONFIG = {
 }
 ```
 
-To customize the logging (for example, use logging rotate), define one or more of the logging handles that [Python has to offer](https://docs.python.org/3/library/logging.handlers.html). For more details about the Python logging, please refer to the [official logging documentation](https://docs.python.org/3/library/logging.html).
+To customize the logging (for example, use logging rotate), define one or more of the logging handles
+that [Python has to offer](https://docs.python.org/3/library/logging.handlers.html). For more details about the Python
+logging, please refer to the [official logging documentation](https://docs.python.org/3/library/logging.html).
 
 Furthermore, this change also simplifies logging within the DAG itself:
 
@@ -2815,18 +2892,30 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 #### Template path of the file_task_handler
 
-The `file_task_handler` logger has been made more flexible. The default format can be changed, `{dag_id}/{task_id}/{execution_date}/{try_number}.log` by supplying Jinja templating in the `FILENAME_TEMPLATE` configuration variable. See the `file_task_handler` for more information.
+The `file_task_handler` logger has been made more flexible. The default format can be
+changed, `{dag_id}/{task_id}/{execution_date}/{try_number}.log` by supplying Jinja templating in the `FILENAME_TEMPLATE`
+configuration variable. See the `file_task_handler` for more information.
 
 #### I'm using S3Log or GCSLogs, what do I do!?
 
-If you are logging to Google cloud storage, please see the [Google cloud platform documentation](https://airflow.apache.org/integration.html#gcp-google-cloud-platform) for logging instructions.
+If you are logging to Google cloud storage, please see
+the [Google cloud platform documentation](https://airflow.apache.org/integration.html#gcp-google-cloud-platform) for
+logging instructions.
 
-If you are using S3, the instructions should be largely the same as the Google cloud platform instructions above. You will need a custom logging config. The `REMOTE_BASE_LOG_FOLDER` configuration key in your airflow config has been removed, therefore you will need to take the following steps:
+If you are using S3, the instructions should be largely the same as the Google cloud platform instructions above. You
+will need a custom logging config. The `REMOTE_BASE_LOG_FOLDER` configuration key in your airflow config has been
+removed, therefore you will need to take the following steps:
 
-- Copy the logging configuration from [`airflow/config_templates/airflow_logging_settings.py`](https://github.com/apache/airflow/blob/master/airflow/config_templates/airflow_local_settings.py).
-- Place it in a directory inside the Python import path `PYTHONPATH`. If you are using Python 2.7, ensuring that any `__init__.py` files exist so that it is importable.
-- Update the config by setting the path of `REMOTE_BASE_LOG_FOLDER` explicitly in the config. The `REMOTE_BASE_LOG_FOLDER` key is not used anymore.
-- Set the `logging_config_class` to the filename and dict. For example, if you place `custom_logging_config.py` on the base of your `PYTHONPATH`, you will need to set `logging_config_class = custom_logging_config.LOGGING_CONFIG` in your config as Airflow 1.8.
+- Copy the logging configuration
+  from [`airflow/config_templates/airflow_logging_settings.py`](https://github.com/apache/airflow/blob/master/airflow/config_templates/airflow_local_settings.py)
+  .
+- Place it in a directory inside the Python import path `PYTHONPATH`. If you are using Python 2.7, ensuring that
+  any `__init__.py` files exist so that it is importable.
+- Update the config by setting the path of `REMOTE_BASE_LOG_FOLDER` explicitly in the config.
+  The `REMOTE_BASE_LOG_FOLDER` key is not used anymore.
+- Set the `logging_config_class` to the filename and dict. For example, if you place `custom_logging_config.py` on the
+  base of your `PYTHONPATH`, you will need to set `logging_config_class = custom_logging_config.LOGGING_CONFIG` in your
+  config as Airflow 1.8.
 
 ### New Features
 
@@ -2839,32 +2928,34 @@ A new DaskExecutor allows Airflow tasks to be run in Dask Distributed clusters.
 These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
 supported and will be removed entirely in Airflow 2.0
 
-- If you're using the `google_cloud_conn_id` or `dataproc_cluster` argument names explicitly in `contrib.operators.Dataproc{*}Operator`(s), be sure to rename them to `gcp_conn_id` or `cluster_name`, respectively. We've renamed these arguments for consistency. (AIRFLOW-1323)
+- If you're using the `google_cloud_conn_id` or `dataproc_cluster` argument names explicitly
+  in `contrib.operators.Dataproc{*}Operator`(s), be sure to rename them to `gcp_conn_id` or `cluster_name`,
+  respectively. We've renamed these arguments for consistency. (AIRFLOW-1323)
 
 - `post_execute()` hooks now take two arguments, `context` and `result`
   (AIRFLOW-886)
 
   Previously, post_execute() only took one argument, `context`.
 
-- `contrib.hooks.gcp_dataflow_hook.DataFlowHook` starts to use `--runner=DataflowRunner` instead of `DataflowPipelineRunner`, which is removed from the package `google-cloud-dataflow-0.6.0`.
+- `contrib.hooks.gcp_dataflow_hook.DataFlowHook` starts to use `--runner=DataflowRunner` instead
+  of `DataflowPipelineRunner`, which is removed from the package `google-cloud-dataflow-0.6.0`.
 
-- The pickle type for XCom messages has been replaced by json to prevent RCE attacks.
-  Note that JSON serialization is stricter than pickling, so if you want to e.g. pass
-  raw bytes through XCom you must encode them using an encoding like base64.
-  By default pickling is still enabled until Airflow 2.0. To disable it
-  set enable_xcom_pickling = False in your Airflow config.
+- The pickle type for XCom messages has been replaced by json to prevent RCE attacks. Note that JSON serialization is
+  stricter than pickling, so if you want to e.g. pass raw bytes through XCom you must encode them using an encoding like
+  base64. By default pickling is still enabled until Airflow 2.0. To disable it set enable_xcom_pickling = False in your
+  Airflow config.
 
 ## Airflow 1.8.1
 
-The Airflow package name was changed from `airflow` to `apache-airflow` during this release. You must uninstall
-a previously installed version of Airflow before installing 1.8.1.
+The Airflow package name was changed from `airflow` to `apache-airflow` during this release. You must uninstall a
+previously installed version of Airflow before installing 1.8.1.
 
 ## Airflow 1.8
 
 ### Database
 
-The database schema needs to be upgraded. Make sure to shutdown Airflow and make a backup of your database. To
-upgrade the schema issue `airflow upgradedb`.
+The database schema needs to be upgraded. Make sure to shutdown Airflow and make a backup of your database. To upgrade
+the schema issue `airflow upgradedb`.
 
 ### Upgrade systemd unit files
 
@@ -2874,10 +2965,10 @@ Systemd unit files have been updated. If you use systemd please make sure to upd
 
 ### Tasks not starting although dependencies are met due to stricter pool checking
 
-Airflow 1.7.1 has issues with being able to over subscribe to a pool, ie. more slots could be used than were
-available. This is fixed in Airflow 1.8.0, but due to past issue jobs may fail to start although their
-dependencies are met after an upgrade. To workaround either temporarily increase the amount of slots above
-the amount of queued tasks or use a new pool.
+Airflow 1.7.1 has issues with being able to over subscribe to a pool, ie. more slots could be used than were available.
+This is fixed in Airflow 1.8.0, but due to past issue jobs may fail to start although their dependencies are met after
+an upgrade. To workaround either temporarily increase the amount of slots above the amount of queued tasks or use a new
+pool.
 
 ### Less forgiving scheduler on dynamic start_date
 
@@ -2892,16 +2983,16 @@ Please read through the new scheduler options, defaults have changed since 1.7.1
 
 #### child_process_log_directory
 
-In order to increase the robustness of the scheduler, DAGS are now processed in their own process. Therefore each
-DAG has its own log file for the scheduler. These log files are placed in `child_process_log_directory` which defaults to
+In order to increase the robustness of the scheduler, DAGS are now processed in their own process. Therefore each DAG
+has its own log file for the scheduler. These log files are placed in `child_process_log_directory` which defaults to
 `<AIRFLOW_HOME>/scheduler/latest`. You will need to make sure these log files are removed.
 
 > DAG logs or processor logs ignore and command line settings for log file locations.
 
 #### run_duration
 
-Previously the command line option `num_runs` was used to let the scheduler terminate after a certain amount of
-loops. This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
+Previously the command line option `num_runs` was used to let the scheduler terminate after a certain amount of loops.
+This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
 
 #### num_runs
 
@@ -2915,12 +3006,13 @@ After how much time should an updated DAG be picked up from the filesystem.
 
 #### min_file_parsing_loop_time
 
-CURRENTLY DISABLED DUE TO A BUG
-How many seconds to wait between file-parsing loops to prevent the logs from being spammed.
+CURRENTLY DISABLED DUE TO A BUG How many seconds to wait between file-parsing loops to prevent the logs from being
+spammed.
 
 #### dag_dir_list_interval
 
-The frequency with which the scheduler should relist the contents of the DAG directory. If while developing +dags, they are not being picked up, have a look at this number and decrease it when necessary.
+The frequency with which the scheduler should relist the contents of the DAG directory. If while developing +dags, they
+are not being picked up, have a look at this number and decrease it when necessary.
 
 #### catchup_by_default
 
@@ -2930,8 +3022,8 @@ This setting changes that behavior to only execute the latest interval. This can
 
 ### Faulty DAGs do not show an error in the Web UI
 
-Due to changes in the way Airflow processes DAGs the Web UI does not show an error when processing a faulty DAG. To
-find processing errors go the `child_process_log_directory` which defaults to `<AIRFLOW_HOME>/scheduler/latest`.
+Due to changes in the way Airflow processes DAGs the Web UI does not show an error when processing a faulty DAG. To find
+processing errors go the `child_process_log_directory` which defaults to `<AIRFLOW_HOME>/scheduler/latest`.
 
 ### New DAGs are paused by default
 
@@ -2944,18 +3036,17 @@ dags_are_paused_at_creation = False
 
 ### Airflow Context variable are passed to Hive config if conf is specified
 
-If you specify a hive conf to the run_cli command of the HiveHook, Airflow add some
-convenience variables to the config. In case you run a secure Hadoop setup it might be
-required to allow these variables by adjusting you hive configuration to add `airflow\.ctx\..*` to the regex
-of user-editable configuration properties. See
+If you specify a hive conf to the run_cli command of the HiveHook, Airflow add some convenience variables to the config.
+In case you run a secure Hadoop setup it might be required to allow these variables by adjusting you hive configuration
+to add `airflow\.ctx\..*` to the regex of user-editable configuration properties. See
 [the Hive docs on Configuration Properties][hive.security.authorization.sqlstd] for more info.
 
 [hive.security.authorization.sqlstd]: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903061#ConfigurationProperties-SQLStandardBasedAuthorization.1
 
 ### Google Cloud Operator and Hook alignment
 
-All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection
-type for all kinds of Google Cloud Operators.
+All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection type
+for all kinds of Google Cloud Operators.
 
 If you experience problems connecting with your operator make sure you set the connection type "Google Cloud".
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -19,7 +19,8 @@
 
 # Updating Airflow
 
-This file documents any backwards-incompatible changes in Airflow and assists users migrating to a new version.
+This file documents any backwards-incompatible changes in Airflow and
+assists users migrating to a new version.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -68,39 +69,42 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+
 ## Airflow 2.0.1
 
 ### Permission to view Airflow Configurations has been removed from `User` and `Viewer` role
 
-Previously, Users with `User` or `Viewer` role were able to get/view configurations using the REST API or in the
-Webserver. From Airflow 2.0.1, only users with `Admin` or `Op` role would be able to get/view Configurations.
+Previously, Users with `User` or `Viewer` role were able to get/view configurations using
+the REST API or in the Webserver. From Airflow 2.0.1, only users with `Admin` or `Op` role would be able
+to get/view Configurations.
 
 To allow users with other roles to view configuration, add `can read on Configurations` permissions to that role.
 
-Note that if `[webserver] expose_config` is set to `False`, the API will throw a `403` response even if the user has
-role with `can read on Configurations` permission.
+Note that if `[webserver] expose_config` is set to `False`, the API will throw a `403` response even if
+the user has role with `can read on Configurations` permission.
 
 ### Default `[celery] worker_concurrency` is changed to `16`
 
-The default value for `[celery] worker_concurrency` was `16` for Airflow <2.0.0. However, it was unintentionally changed
-to `8` in 2.0.0.
+The default value for `[celery] worker_concurrency` was `16` for Airflow <2.0.0.
+However, it was unintentionally changed to `8` in 2.0.0.
 
 From Airflow 2.0.1, we revert to the old default of `16`.
 
 ### Default `[scheduler] min_file_process_interval` is changed to `30`
 
-The default value for `[scheduler] min_file_process_interval` was `0`, due to which the CPU Usage mostly stayed around
-100% as the DAG files are parsed constantly.
+The default value for `[scheduler] min_file_process_interval` was `0`,
+due to which the CPU Usage mostly stayed around 100% as the DAG files are parsed
+constantly.
 
-From Airflow 2.0.0, the scheduling decisions have been moved from DagFileProcessor to Scheduler, so we can keep the
-default a bit higher: `30`.
+From Airflow 2.0.0, the scheduling decisions have been moved from
+DagFileProcessor to Scheduler, so we can keep the default a bit higher: `30`.
 
 ## Airflow 2.0.0
 
-The 2.0 release of the Airflow is a significant upgrade, and includes substantial major changes, and some of them may be
-breaking. Existing code written for earlier versions of this project will may require updates to use this version.
-Sometimes necessary configuration changes are also required. This document describes the changes that have been made,
-and what you need to do to update your usage.
+The 2.0 release of the Airflow is a significant upgrade, and includes substantial major changes,
+and some of them may be breaking. Existing code written for earlier versions of this project will may require updates
+to use this version. Sometimes necessary configuration changes are also required.
+This document describes the changes that have been made, and what you need to do to update your usage.
 
 If you experience issues or have questions, please file [an issue](https://github.com/apache/airflow/issues/new/choose).
 
@@ -110,29 +114,29 @@ This section describes the major changes that have been made in this release.
 
 ### The experimental REST API is disabled by default
 
-The experimental REST API is disabled by default. To restore these APIs while migrating to the stable REST API,
-set `enable_experimental_api` option in `[api]` section to `True`.
+The experimental REST API is disabled by default. To restore these APIs while migrating to
+the stable REST API, set `enable_experimental_api` option in `[api]` section to `True`.
 
-Please note that the experimental REST API do not have access control. The authenticated user has full access.
+Please note that the experimental REST API do not have access control.
+The authenticated user has full access.
 
 ### SparkJDBCHook default connection
 
 For SparkJDBCHook default connection was `spark-default`, and for SparkSubmitHook it was
-`spark_default`. Both hooks now use the `spark_default` which is a common pattern for the connection names used across
-all providers.
+`spark_default`. Both hooks now use the `spark_default` which is a common pattern for the connection
+names used across all providers.
 
 ### Changes to output argument in commands
 
-From Airflow 2.0, We are replacing [tabulate](https://pypi.org/project/tabulate/)
-with [rich](https://github.com/willmcgugan/rich) to render commands output. Due to this change, the `--output` argument
+From Airflow 2.0, We are replacing [tabulate](https://pypi.org/project/tabulate/) with [rich](https://github.com/willmcgugan/rich) to render commands output. Due to this change, the `--output` argument
 will no longer accept formats of tabulate tables. Instead, it now accepts:
 
 - `table` - will render the output in predefined table
 - `json` - will render the output as a json
 - `yaml` - will render the output as yaml
 
-By doing this we increased consistency and gave users possibility to manipulate the output programmatically (when using
-json or yaml).
+By doing this we increased consistency and gave users possibility to manipulate the
+output programmatically (when using json or yaml).
 
 Affected commands:
 
@@ -158,15 +162,17 @@ Affected commands:
 
 ### Azure Wasb Hook does not work together with Snowflake hook
 
-The WasbHook in Apache Airflow use a legacy version of Azure library. While the conflict is not significant for most of
-the Azure hooks, it is a problem for Wasb Hook because the `blob` folders for both libraries overlap. Installing both
-Snowflake and Azure extra will result in non-importable WasbHook.
+The WasbHook in Apache Airflow use a legacy version of Azure library. While the conflict is not
+significant for most of the Azure hooks, it is a problem for Wasb Hook because the `blob` folders
+for both libraries overlap. Installing both Snowflake and Azure extra will result in non-importable
+WasbHook.
 
 ### Rename `all` to `devel_all` extra
 
-The `all` extras were reduced to include only user-facing dependencies. This means that this extra does not contain
-development dependencies. If you were relying on
-`all` extra then you should use now `devel_all` or figure out if you need development extras at all.
+The `all` extras were reduced to include only user-facing dependencies. This means
+that this extra does not contain development dependencies. If you were relying on
+`all` extra then you should use now `devel_all` or figure out if you need development
+extras at all.
 
 ### Context variables `prev_execution_date_success` and `prev_execution_date_success` are now `pendulum.DateTime`
 
@@ -186,8 +192,7 @@ From Airflow 2, by default Airflow will retry 3 times to publish task to Celery 
 
 ### Adding Operators and Sensors via plugins is no longer supported
 
-Operators and Sensors should no longer be registered or imported via Airflow's plugin mechanism -- these types of
-classes are just treated as plain python classes by Airflow, so there is no need to register them with Airflow.
+Operators and Sensors should no longer be registered or imported via Airflow's plugin mechanism -- these types of classes are just treated as plain python classes by Airflow, so there is no need to register them with Airflow.
 
 If you previously had a `plugins/my_plugin.py` and you used it like this in a DAG:
 
@@ -201,15 +206,13 @@ You should instead import it as:
 from my_plugin import MyOperator
 ```
 
-The name under `airflow.operators.` was the plugin name, where as in the second example it is the python module name
-where the operator is defined.
+The name under `airflow.operators.` was the plugin name, where as in the second example it is the python module name where the operator is defined.
 
 See https://airflow.apache.org/docs/stable/howto/custom-operator.html for more info.
 
 ### Importing Hooks via plugins is no longer supported
 
-Importing hooks added in plugins via `airflow.hooks.<plugin_name>` is no longer supported, and hooks should just be
-imported as regular python modules.
+Importing hooks added in plugins via `airflow.hooks.<plugin_name>` is no longer supported, and hooks should just be imported as regular python modules.
 
 ```
 from airflow.hooks.my_plugin import MyHook
@@ -221,8 +224,7 @@ You should instead import it as:
 from my_plugin import MyHook
 ```
 
-It is still possible (but not required) to "register" hooks in plugins. This is to allow future support for dynamically
-populating the Connections form in the UI.
+It is still possible (but not required) to "register" hooks in plugins. This is to allow future support for dynamically populating the Connections form in the UI.
 
 See https://airflow.apache.org/docs/stable/howto/custom-operator.html for more info.
 
@@ -230,43 +232,39 @@ See https://airflow.apache.org/docs/stable/howto/custom-operator.html for more i
 
 ### The default value for `[core] enable_xcom_pickling` has been changed to `False`
 
-The pickle type for XCom messages has been replaced to JSON by default to prevent RCE attacks. Note that JSON
-serialization is stricter than pickling, so for example if you want to pass raw bytes through XCom you must encode them
-using an encoding like ``base64``. If you understand the risk and still want to
-use [pickling](https://docs.python.org/3/library/pickle.html), set `enable_xcom_pickling = True` in your Airflow
-config's `core` section.
+The pickle type for XCom messages has been replaced to JSON by default to prevent RCE attacks.
+Note that JSON serialization is stricter than pickling, so for example if you want to pass
+raw bytes through XCom you must encode them using an encoding like ``base64``.
+If you understand the risk and still want to use [pickling](https://docs.python.org/3/library/pickle.html),
+set `enable_xcom_pickling = True` in your Airflow config's `core` section.
 
 ### Airflowignore of base path
 
-There was a bug fixed in https://github.com/apache/airflow/pull/11993 that the "airflowignore" checked the base path of
-the dag folder for forbidden dags, not only the relative part. This had the effect that if the base path contained the
-excluded word the whole dag folder could have been excluded. For example if the airflowignore file contained x, and the
-dags folder was '/var/x/dags', then all dags in the folder would be excluded. The fix only matches the relative path
-only now which means that if you previously used full path as ignored, you should change it to relative one. For example
-if your dag folder was '/var/dags/' and your airflowignore contained '/var/dag/excluded/', you should change it to '
-excluded/'.
+There was a bug fixed in https://github.com/apache/airflow/pull/11993 that the "airflowignore" checked
+the base path of the dag folder for forbidden dags, not only the relative part. This had the effect
+that if the base path contained the excluded word the whole dag folder could have been excluded. For
+example if the airflowignore file contained x, and the dags folder was '/var/x/dags', then all dags in
+the folder would be excluded. The fix only matches the relative path only now which means that if you
+previously used full path as ignored, you should change it to relative one. For example if your dag
+folder was '/var/dags/' and your airflowignore contained '/var/dag/excluded/', you should change it
+to 'excluded/'.
 
 ### `ExternalTaskSensor` provides all task context variables to `execution_date_fn` as keyword arguments
 
-The old syntax of passing `context` as a dictionary will continue to work with the caveat that the argument must be
-named `context`. The following will break. To fix it, change `ctx` to `context`.
+The old syntax of passing `context` as a dictionary will continue to work with the caveat that the argument must be named `context`. The following will break. To fix it, change `ctx` to `context`.
 
 ```python
 def execution_date_fn(execution_date, ctx):
 ```
 
-`execution_date_fn` can take in any number of keyword arguments available in the task context dictionary. The following
-forms of `execution_date_fn` are all supported:
+`execution_date_fn` can take in any number of keyword arguments available in the task context dictionary. The following forms of `execution_date_fn` are all supported:
 
 ```python
 def execution_date_fn(dt):
 
-
 def execution_date_fn(execution_date):
 
-
 def execution_date_fn(execution_date, ds_nodash):
-
 
 def execution_date_fn(execution_date, ds_nodash, dag):
 ```
@@ -278,19 +276,22 @@ As [recommended](https://flask.palletsprojects.com/en/1.1.x/config/#SESSION_COOK
 
 #### Changes to import paths
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
-supported by the community. The project was passed to the Apache community and currently the entire code is maintained
-by the community, so now the division has no justification, and it is only due to historical reasons. In Airflow 2.0, we
-want to organize packages and move integrations with third party services to the ``airflow.providers`` package.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
+package was supported by the community. The project was passed to the Apache community and currently the
+entire code is maintained by the community, so now the division has no justification, and it is only due
+to historical reasons. In Airflow 2.0, we want to organize packages and move integrations
+with third party services to the ``airflow.providers`` package.
 
-All changes made are backward compatible, but if you use the old import paths you will see a deprecation warning. The
-old import paths can be abandoned in the future.
+All changes made are backward compatible, but if you use the old import paths you will
+see a deprecation warning. The old import paths can be abandoned in the future.
 
 According to [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths)
-`_operator` suffix has been removed from operators. A deprecation warning has also been raised for paths importing with
-the suffix.
+`_operator` suffix has been removed from operators. A deprecation warning has also been raised for paths
+importing with the suffix.
+
 
 The following table shows changes in import paths.
+
 
 | Old path                            | New path                   |
 |-------------------------------------|----------------------------|
@@ -308,45 +309,47 @@ The following table shows changes in import paths.
 | airflow.sensors.time_delta_sensor.TimeDeltaSensor | airflow.sensors.time_delta.TimeDeltaSensor |
 | airflow.contrib.sensors.weekday_sensor.DayOfWeekSensor | airflow.sensors.weekday.DayOfWeekSensor |
 
+
 ### Database schema changes
 
-In order to migrate the database, you should use the command `airflow db upgrade`, but in some cases manual steps are
-required.
+In order to migrate the database, you should use the command `airflow db upgrade`, but in
+some cases manual steps are required.
 
 #### Unique conn_id in connection table
 
-Previously, Airflow allowed users to add more than one connection with the same `conn_id` and on access it would choose
-one connection randomly. This acted as a basic load balancing and fault tolerance technique, when used in conjunction
-with retries.
+Previously, Airflow allowed users to add more than one connection with the same `conn_id` and on access it would choose one connection randomly. This acted as a basic load balancing and fault tolerance technique, when used in conjunction with retries.
 
 This behavior caused some confusion for users, and there was no clear evidence if it actually worked well or not.
 
-Now the `conn_id` will be unique. If you already have duplicates in your metadata database, you will have to manage
-those duplicate connections before upgrading the database.
+Now the `conn_id` will be unique. If you already have duplicates in your metadata database, you will have to manage those duplicate connections before upgrading the database.
 
 #### Not-nullable conn_type column in connection table
 
-The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced by application
-logic, but was not enforced by the database schema.
+The `conn_type` column in the `connection` table must contain content. Previously, this rule was enforced
+by application logic, but was not enforced by the database schema.
 
-If you made any modifications to the table directly, make sure you don't have null in the conn_type column.
+If you made any modifications to the table directly, make sure you don't have
+null in the conn_type column.
 
 ### Configuration changes
 
-This release contains many changes that require a change in the configuration of this application or other application
-that integrate with it.
+This release contains many changes that require a change in the configuration of this application or
+other application that integrate with it.
 
 This section describes the changes that have been made, and what you need to do to.
 
 #### airflow.contrib.utils.log has been moved
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
-supported by the community. The project was passed to the Apache community and currently the entire code is maintained
-by the community, so now the division has no justification, and it is only due to historical reasons. In Airflow 2.0, we
-want to organize packages and move integrations with third party services to the ``airflow.providers`` package.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
+package was supported by the community. The project was passed to the Apache community and currently the
+entire code is maintained by the community, so now the division has no justification, and it is only due
+to historical reasons. In Airflow 2.0, we want to organize packages and move integrations
+with third party services to the ``airflow.providers`` package.
 
 To clean up, the following packages were moved:
-| Old package | New package | |-|-| | ``airflow.contrib.utils.log`` | ``airflow.utils.log`` |
+| Old package | New package |
+|-|-|
+| ``airflow.contrib.utils.log`` | ``airflow.utils.log`` |
 | ``airflow.utils.log.gcs_task_handler`` | ``airflow.providers.google.cloud.log.gcs_task_handler`` |
 | ``airflow.utils.log.wasb_task_handler`` | ``airflow.providers.microsoft.azure.log.wasb_task_handler`` |
 | ``airflow.utils.log.stackdriver_task_handler`` | ``airflow.providers.google.cloud.log.stackdriver_task_handler`` |
@@ -354,14 +357,15 @@ To clean up, the following packages were moved:
 | ``airflow.utils.log.es_task_handler`` | ``airflow.providers.elasticsearch.log.es_task_handler`` |
 | ``airflow.utils.log.cloudwatch_task_handler`` | ``airflow.providers.amazon.aws.log.cloudwatch_task_handler`` |
 
-You should update the import paths if you are setting log configurations with the ``logging_config_class`` option. The
-old import paths still works but can be abandoned.
+You should update the import paths if you are setting log configurations with the ``logging_config_class`` option.
+The old import paths still works but can be abandoned.
 
 #### SendGrid emailer has been moved
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
-supported by the community. The project was passed to the Apache community and currently the entire code is maintained
-by the community, so now the division has no justification, and it is only due to historical reasons.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
+package was supported by the community. The project was passed to the Apache community and currently the
+entire code is maintained by the community, so now the division has no justification, and it is only due
+to historical reasons.
 
 To clean up, the `send_mail` function from the `airflow.contrib.utils.sendgrid` module has been moved.
 
@@ -387,15 +391,17 @@ The previous option used a colon(`:`) to split the module from function. Now the
 
 The change aims to unify the format of all options that refer to objects in the `airflow.cfg` file.
 
+
 #### Custom executors is loaded using full import path
 
-In previous versions of Airflow it was possible to use plugins to load custom executors. It is still possible, but the
-configuration has changed. Now you don't have to create a plugin to configure a custom executor, but you need to provide
-the full path to the module in the `executor` option in the `core` section. The purpose of this change is to simplify
-the plugin mechanism and make it easier to configure executor.
+In previous versions of Airflow it was possible to use plugins to load custom executors. It is still
+possible, but the configuration has changed. Now you don't have to create a plugin to configure a
+custom executor, but you need to provide the full path to the module in the `executor` option
+in the `core` section. The purpose of this change is to simplify the plugin mechanism and make
+it easier to configure executor.
 
-If your module was in the path `my_acme_company.executors.MyCustomExecutor`  and the plugin was called `my_plugin` then
-your configuration looks like this
+If your module was in the path `my_acme_company.executors.MyCustomExecutor`  and the plugin was
+called `my_plugin` then your configuration looks like this
 
 ```ini
 [core]
@@ -442,27 +448,25 @@ datamodel = CustomSQLAInterface(your_data_model)
 
 #### Drop plugin support for stat_name_handler
 
-In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use
-the `stat_name_handler`
+In previous version, you could use plugins mechanism to configure ``stat_name_handler``. You should now use the `stat_name_handler`
 option in `[scheduler]` section to achieve the same effect.
 
 If your plugin looked like this and was available through the `test_plugin` path:
 
 ```python
 def my_stat_name_handler(stat):
-  return stat
-
+    return stat
 
 class AirflowTestPlugin(AirflowPlugin):
-  name = "test_plugin"
-  stat_name_handler = my_stat_name_handler
+    name = "test_plugin"
+    stat_name_handler = my_stat_name_handler
 ```
 
 then your `airflow.cfg` file should look like this:
 
 ```ini
 [scheduler]
-stat_name_handler = test_plugin.my_stat_name_handler
+stat_name_handler=test_plugin.my_stat_name_handler
 ```
 
 This change is intended to simplify the statsd configuration.
@@ -506,8 +510,7 @@ The following configurations have been moved from `[scheduler]` to the new `[met
 
 #### Changes to Elasticsearch logging provider
 
-When JSON output to stdout is enabled, log lines will now contain the `log_id` & `offset` fields, this should make
-reading task logs from elasticsearch on the webserver work out of the box. Example configuration:
+When JSON output to stdout is enabled, log lines will now contain the `log_id` & `offset` fields, this should make reading task logs from elasticsearch on the webserver work out of the box. Example configuration:
 
 ```ini
 [logging]
@@ -522,24 +525,25 @@ Note that the webserver expects the log line data itself to be present in the `m
 
 #### Remove gcp_service_account_keys option in airflow.cfg file
 
-This option has been removed because it is no longer supported by the Google Kubernetes Engine. The new recommended
-service account keys for the Google Cloud management method is
+This option has been removed because it is no longer supported by the Google Kubernetes Engine. The new
+recommended service account keys for the Google Cloud management method is
 [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity).
 
 #### Fernet is enabled by default
 
-The fernet mechanism is enabled by default to increase the security of the default installation. In order to restore the
-previous behavior, the user must consciously set an empty key in the ``fernet_key`` option of section ``[core]`` in
-the ``airflow.cfg`` file.
+The fernet mechanism is enabled by default to increase the security of the default installation.  In order to
+restore the previous behavior, the user must consciously set an empty key in the ``fernet_key`` option of
+section ``[core]`` in the ``airflow.cfg`` file.
 
-At the same time, this means that the `apache-airflow[crypto]` extra-packages are always installed. However, this
-requires that your operating system has ``libffi-dev`` installed.
+At the same time, this means that the `apache-airflow[crypto]` extra-packages are always installed.
+However, this requires that your operating system has ``libffi-dev`` installed.
 
 #### Changes to propagating Kubernetes worker annotations
 
-`kubernetes_annotations` configuration section has been removed. A new key `worker_annotations` has been added to
-existing `kubernetes` section instead. That is to remove restriction on the character set for k8s annotation keys. All
-key/value pairs from `kubernetes_annotations` should now go to `worker_annotations` as a json. I.e. instead of e.g.
+`kubernetes_annotations` configuration section has been removed.
+A new key `worker_annotations` has been added to existing `kubernetes` section instead.
+That is to remove restriction on the character set for k8s annotation keys.
+All key/value pairs from `kubernetes_annotations` should now go to `worker_annotations` as a json. I.e. instead of e.g.
 
 ```
 [kubernetes_annotations]
@@ -556,61 +560,62 @@ worker_annotations = { "annotation_key" : "annotation_value", "annotation_key2" 
 
 #### Remove run_duration
 
-We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but
-right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an
-inconsistent state.
+We should not use the `run_duration` option anymore. This used to be for restarting the scheduler from time to time, but right now the scheduler is getting more stable and therefore using this setting is considered bad and might cause an inconsistent state.
 
 #### Rename pool statsd metrics
 
-Used slot has been renamed to running slot to make the name self-explanatory and the code more maintainable.
+Used slot has been renamed to running slot to make the name self-explanatory
+and the code more maintainable.
 
 This means `pool.used_slots.<pool_name>` metric has been renamed to
-`pool.running_slots.<pool_name>`. The `Used Slots` column in Pools Web UI view has also been changed to `Running Slots`.
+`pool.running_slots.<pool_name>`. The `Used Slots` column in Pools Web UI view
+has also been changed to `Running Slots`.
 
 #### Removal of Mesos Executor
 
-The Mesos Executor is removed from the code base as it was not widely used and not
-maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/thread.html/daa9500026b820c6aaadeffd66166eae558282778091ebbc68819fb7@%3Cdev.airflow.apache.org%3E)
-.
+The Mesos Executor is removed from the code base as it was not widely used and not maintained. [Mailing List Discussion on deleting it](https://lists.apache.org/thread.html/daa9500026b820c6aaadeffd66166eae558282778091ebbc68819fb7@%3Cdev.airflow.apache.org%3E).
 
 #### Change dag loading duration metric name
 
 Change DAG file loading duration metric from
-`dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to better handle the case when a DAG file
-has multiple DAGs.
+`dag.loading-duration.<dag_id>` to `dag.loading-duration.<dag_file>`. This is to
+better handle the case when a DAG file has multiple DAGs.
 
 #### Sentry is disabled by default
 
-Sentry is disabled by default. To enable these integrations, you need set ``sentry_on`` option in ``[sentry]`` section
-to ``"True"``.
+Sentry is disabled by default. To enable these integrations, you need set ``sentry_on`` option
+in ``[sentry]`` section to ``"True"``.
 
 #### Simplified GCSTaskHandler configuration
 
-In previous versions, in order to configure the service account key file, you had to create a connection entry. In the
-current version, you can configure ``google_key_path`` option in ``[logging]`` section to set the key file path.
+In previous versions, in order to configure the service account key file, you had to create a connection entry.
+In the current version, you can configure ``google_key_path`` option in ``[logging]`` section to set
+the key file path.
 
 Users using Application Default Credentials (ADC) need not take any action.
 
-The change aims to simplify the configuration of logging, to prevent corruption of the instance configuration by
-changing the value controlled by the user - connection entry. If you configure a backend secret, it also means the
-webserver doesn't need to connect to it. This simplifies setups with multiple GCP projects, because only one project
-will require the Secret Manager API to be enabled.
+The change aims to simplify the configuration of logging, to prevent corruption of
+the instance configuration by changing the value controlled by the user - connection entry. If you
+configure a backend secret, it also means the webserver doesn't need to connect to it. This
+simplifies setups with multiple GCP projects, because only one project will require the Secret Manager API
+to be enabled.
 
 ### Changes to the core operators/hooks
 
-We strive to ensure that there are no changes that may affect the end user and your files, but this release may contain
-changes that will require changes to your DAG files.
+We strive to ensure that there are no changes that may affect the end user and your files, but this
+release may contain changes that will require changes to your DAG files.
 
-This section describes the changes that have been made, and what you need to do to update your DAG File, if you use core
-operators or any other.
+This section describes the changes that have been made, and what you need to do to update your DAG File,
+if you use core operators or any other.
 
 #### BaseSensorOperator now respects the trigger_rule of downstream tasks
 
-Previously, BaseSensorOperator with setting `soft_fail=True` skips itself and skips all its downstream tasks
-unconditionally, when it fails i.e the trigger_rule of downstream tasks is not respected.
+Previously, BaseSensorOperator with setting `soft_fail=True` skips itself
+and skips all its downstream tasks unconditionally, when it fails i.e the trigger_rule of downstream tasks is not
+respected.
 
-In the new behavior, the trigger_rule of downstream tasks is respected. User can preserve/achieve the original behaviour
-by setting the trigger_rule of each downstream task to `all_success`.
+In the new behavior, the trigger_rule of downstream tasks is respected.
+User can preserve/achieve the original behaviour by setting the trigger_rule of each downstream task to `all_success`.
 
 #### BaseOperator uses metaclass
 
@@ -619,8 +624,8 @@ by setting the trigger_rule of each downstream task to `all_success`.
 
 #### Remove SQL support in BaseHook
 
-Remove ``get_records`` and ``get_pandas_df`` and ``run`` from BaseHook, which only apply for sql like hook, If want to
-use them, or your custom hook inherit them, please use ``airflow.hooks.dbapi.DbApiHook``
+Remove ``get_records`` and ``get_pandas_df`` and ``run`` from BaseHook, which only apply for sql like hook,
+If want to use them, or your custom hook inherit them, please use ``airflow.hooks.dbapi.DbApiHook``
 
 #### Assigning task to a DAG using bitwise shift (bit-shift) operators are no longer supported
 
@@ -637,7 +642,7 @@ This is no longer supported. Instead, we recommend using the DAG as context mana
 
 ```python
 with DAG('my_dag') as dag:
-  dummy = DummyOperator(task_id='dummy')
+    dummy = DummyOperator(task_id='dummy')
 ```
 
 #### Removed deprecated import mechanism
@@ -656,11 +661,11 @@ becomes `from airflow.sensors.base import BaseSensorOperator`
 
 #### Skipped tasks can satisfy wait_for_downstream
 
-Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of the previous task
-instance is successful. Meanwhile, a task instance with `depends_on_past=True`
-will run if the previous task instance is either successful or skipped. These two flags are close siblings yet they have
-different behavior. This inconsistency in behavior made the API less intuitive to users. To maintain consistent
-behavior, both successful or skipped downstream task can now satisfy the
+Previously, a task instance with `wait_for_downstream=True` will only run if the downstream task of
+the previous task instance is successful. Meanwhile, a task instance with `depends_on_past=True`
+will run if the previous task instance is either successful or skipped. These two flags are close siblings
+yet they have different behavior. This inconsistency in behavior made the API less intuitive to users.
+To maintain consistent behavior, both successful or skipped downstream task can now satisfy the
 `wait_for_downstream=True` flag.
 
 #### `airflow.utils.helpers.cross_downstream`
@@ -670,12 +675,13 @@ behavior, both successful or skipped downstream task can now satisfy the
 The `chain` and `cross_downstream` methods are now moved to airflow.models.baseoperator module from
 `airflow.utils.helpers` module.
 
-The baseoperator module seems to be a better choice to keep closely coupled methods together. Helpers module is supposed
-to contain standalone helper methods that can be imported by all classes.
+The baseoperator module seems to be a better choice to keep
+closely coupled methods together. Helpers module is supposed to contain standalone helper methods
+that can be imported by all classes.
 
-The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports any classes or
-functions from helpers module, then it automatically has an implicit dependency to BaseOperator. That can often lead to
-cyclic dependencies.
+The `chain` method and `cross_downstream` method both use BaseOperator. If any other package imports
+any classes or functions from helpers module, then it automatically has an
+implicit dependency to BaseOperator. That can often lead to cyclic dependencies.
 
 More information in [AIRFLOW-6392](https://issues.apache.org/jira/browse/AIRFLOW-6392)
 
@@ -695,82 +701,74 @@ from airflow.models.baseoperator import cross_downstream
 
 #### `airflow.operators.python.BranchPythonOperator`
 
-`BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch, where previously it returned
-None. Since it inherits from BaseOperator it will do an
+`BranchPythonOperator` will now return a value equal to the `task_id` of the chosen branch,
+where previously it returned None. Since it inherits from BaseOperator it will do an
 `xcom_push` of this value if `do_xcom_push=True`. This is useful for downstream decision-making.
 
 #### `airflow.sensors.sql_sensor.SqlSensor`
 
 SQLSensor now consistent with python `bool()` function and the `allow_null` parameter has been removed.
 
-It will resolve after receiving any value that is casted to `True` with python `bool(value)`. That changes the previous
-response receiving `NULL` or `'0'`. Earlier `'0'` has been treated as success criteria. `NULL` has been treated
-depending on value of `allow_null`parameter. But all the previous behaviour is still achievable setting param `success`
-to `lambda x: x is None or str(x) not in ('0', '')`.
+It will resolve after receiving any value  that is casted to `True` with python `bool(value)`. That
+changes the previous response receiving `NULL` or `'0'`. Earlier `'0'` has been treated as success
+criteria. `NULL` has been treated depending on value of `allow_null`parameter.  But all the previous
+behaviour is still achievable setting param `success` to `lambda x: x is None or str(x) not in ('0', '')`.
 
 #### `airflow.operators.trigger_dagrun.TriggerDagRunOperator`
 
-The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun. As a
-result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
+The TriggerDagRunOperator now takes a `conf` argument to which a dict can be provided as conf for the DagRun.
+As a result, the `python_callable` argument was removed. PR: https://github.com/apache/airflow/pull/6317.
 
 #### `airflow.operators.python.PythonOperator`
 
-`provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator
-is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not
-provide the context anymore. For example:
+`provide_context` argument on the PythonOperator was removed. The signature of the callable passed to the PythonOperator is now inferred and argument values are always automatically provided. There is no need to explicitly provide or not provide the context anymore. For example:
 
 ```python
 def myfunc(execution_date):
-  print(execution_date)
-
+    print(execution_date)
 
 python_operator = PythonOperator(task_id='mytask', python_callable=myfunc, dag=dag)
 ```
 
-Notice you don't have to set provide_context=True, variables from the task context are now automatically detected and
-provided.
+Notice you don't have to set provide_context=True, variables from the task context are now automatically detected and provided.
 
 All context variables can still be provided with a double-asterisk argument:
 
 ```python
 def myfunc(**context):
-  print(context)  # all variables will be provided to context
-
+    print(context)  # all variables will be provided to context
 
 python_operator = PythonOperator(task_id='mytask', python_callable=myfunc)
 ```
 
-The task context variable names are reserved names in the callable function, hence a clash with `op_args`
-and `op_kwargs` results in an exception:
+The task context variable names are reserved names in the callable function, hence a clash with `op_args` and `op_kwargs` results in an exception:
 
 ```python
 def myfunc(dag):
-
-
-# raises a ValueError because "dag" is a reserved name
-# valid signature example: myfunc(mydag)
+    # raises a ValueError because "dag" is a reserved name
+    # valid signature example: myfunc(mydag)
 
 python_operator = PythonOperator(
-  task_id='mytask',
-  op_args=[1],
-  python_callable=myfunc,
+    task_id='mytask',
+    op_args=[1],
+    python_callable=myfunc,
 )
 ```
 
-The change is backwards compatible, setting `provide_context` will add the `provide_context` variable to the `kwargs` (
-but won't do anything).
+The change is backwards compatible, setting `provide_context` will add the `provide_context` variable to the `kwargs` (but won't do anything).
 
 PR: [#5990](https://github.com/apache/airflow/pull/5990)
 
 #### `airflow.sensors.filesystem.FileSensor`
 
-FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in
-it then you should replace these with `[*]`, `[?]`, and `[[]`.
+FileSensor is now takes a glob pattern, not just a filename. If the filename you are looking for has `*`, `?`, or `[` in it then you should replace these with `[*]`, `[?]`, and `[[]`.
 
 #### `airflow.operators.subdag_operator.SubDagOperator`
 
-`SubDagOperator` is changed to use Airflow scheduler instead of backfill to schedule tasks in the subdag. User no longer
-need to specify the executor in `SubDagOperator`.
+`SubDagOperator` is changed to use Airflow scheduler instead of backfill
+to schedule tasks in the subdag. User no longer need to specify the executor
+in `SubDagOperator`.
+
 
 #### `airflow.providers.google.cloud.operators.datastore.CloudDatastoreExportEntitiesOperator`
 
@@ -790,9 +788,7 @@ need to specify the executor in `SubDagOperator`.
 
 #### `airflow.providers.http.operators.http.SimpleHttpOperator`
 
-The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different
-incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`)
-on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
+The `do_xcom_push` flag (a switch to push the result of an operator to xcom or not) was appearing in different incarnations in different operators. It's function has been unified under a common name (`do_xcom_push`) on `BaseOperator`. This way it is also easy to globally disable pushing results to xcom.
 
 The following operators were affected:
 
@@ -809,35 +805,30 @@ See [AIRFLOW-3249](https://jira.apache.org/jira/browse/AIRFLOW-3249) for details
 
 #### `airflow.operators.latest_only_operator.LatestOnlyOperator`
 
-In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own.
-From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any
-further downstream dependencies.
+In previous versions, the `LatestOnlyOperator` forcefully skipped all (direct and undirect) downstream tasks on its own. From this version on the operator will **only skip direct downstream** tasks and the scheduler will handle skipping any further downstream dependencies.
 
 No change is needed if only the default trigger rule `all_success` is being used.
 
-If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skipped by the `LatestOnlyOperator`,
-adjustments to the DAG need to be made to commodate the change in behaviour, i.e. with additional edges from
-the `LatestOnlyOperator`.
+If the DAG relies on tasks with other trigger rules (i.e. `all_done`) being skipped by the `LatestOnlyOperator`, adjustments to the DAG need to be made to commodate the change in behaviour, i.e. with additional edges from the `LatestOnlyOperator`.
 
-The goal of this change is to achieve a more consistent and configurale cascading behaviour based on
-the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923)
-and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
+The goal of this change is to achieve a more consistent and configurale cascading behaviour based on the `BaseBranchOperator` (see [AIRFLOW-2923](https://jira.apache.org/jira/browse/AIRFLOW-2923) and [AIRFLOW-1784](https://jira.apache.org/jira/browse/AIRFLOW-1784)).
 
 ### Changes to the core Python API
 
-We strive to ensure that there are no changes that may affect the end user, and your Python files, but this release may
-contain changes that will require changes to your plugins, DAG File or other integration.
+We strive to ensure that there are no changes that may affect the end user, and your Python files, but this
+release may contain changes that will require changes to your plugins, DAG File or other integration.
 
-Only changes unique to this provider are described here. You should still pay attention to the changes that have been
-made to the core (including core operators) as they can affect the integration behavior of this provider.
+Only changes unique to this provider are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
 
 This section describes the changes that have been made, and what you need to do to update your Python files.
 
 #### Removed sub-package imports from `airflow/__init__.py`
 
-The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`. All implicit
-references of these objects will no longer be valid. To migrate, all usages of each old path must be replaced with its
-corresponding new path.
+The imports `LoggingMixin`, `conf`, and `AirflowException` have been removed from `airflow/__init__.py`.
+All implicit references of these objects will no longer be valid. To migrate, all usages of each old path must be
+replaced with its corresponding new path.
 
 | Old Path (Implicit Import)   | New Path (Explicit Import)                       |
 |------------------------------|--------------------------------------------------|
@@ -853,11 +844,13 @@ The following variables were removed from the task instance context:
 - latest_date
 - tables
 
+
 #### `airflow.contrib.utils.Weekday`
 
-Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib package was
-supported by the community. The project was passed to the Apache community and currently the entire code is maintained
-by the community, so now the division has no justification, and it is only due to historical reasons.
+Formerly the core code was maintained by the original creators - Airbnb. The code that was in the contrib
+package was supported by the community. The project was passed to the Apache community and currently the
+entire code is maintained by the community, so now the division has no justification, and it is only due
+to historical reasons.
 
 To clean up, `Weekday` enum has been moved from `airflow.contrib.utils` into `airflow.utils` module.
 
@@ -884,16 +877,16 @@ conn_2.parse_uri(uri="mysql://AAA/")
 
 Now the second way is not supported.
 
-`Connection.log_info` and `Connection.debug_info` method have been deprecated. Read each Connection field individually
-or use the default representation (`__repr__`).
+`Connection.log_info` and `Connection.debug_info` method have been deprecated. Read each Connection field individually or use the
+default representation (`__repr__`).
 
-The old method is still works but can be abandoned at any time. The changes are intended to delete method that are
-rarely used.
+The old method is still works but can be abandoned at any time. The changes are intended to delete method
+that are rarely used.
 
 #### `airflow.models.dag.DAG.create_dagrun`
 
-DAG.create_dagrun accepts run_type and does not require run_id This change is caused by adding `run_type` column
-to `DagRun`.
+DAG.create_dagrun accepts run_type and does not require run_id
+This change is caused by adding `run_type` column to `DagRun`.
 
 Previous signature:
 
@@ -931,12 +924,13 @@ If user provides `run_type` and `execution_date` then `run_id` is constructed as
 Airflow should construct dagruns using `run_type` and `execution_date`, creation using
 `run_id` is preserved for user actions.
 
+
 #### `airflow.models.dagrun.DagRun`
 
 Use DagRunType.SCHEDULED.value instead of DagRun.ID_PREFIX
 
-All the run_id prefixes for different kind of DagRuns have been grouped into a single enum
-in `airflow.utils.types.DagRunType`.
+All the run_id prefixes for different kind of DagRuns have been grouped into a single
+enum in `airflow.utils.types.DagRunType`.
 
 Previously, there were defined in various places, example as `ID_PREFIX` class variables for
 `DagRun`, `BackfillJob` and in `_trigger_dag` function.
@@ -957,35 +951,38 @@ Replaced by:
 scheduled
 ```
 
+
 #### `airflow.utils.file.TemporaryDirectory`
 
-We remove airflow.utils.file.TemporaryDirectory Since Airflow dropped support for Python < 3.5 there's no need to have
-this custom implementation of `TemporaryDirectory` because the same functionality is provided by
+We remove airflow.utils.file.TemporaryDirectory
+Since Airflow dropped support for Python < 3.5 there's no need to have this custom
+implementation of `TemporaryDirectory` because the same functionality is provided by
 `tempfile.TemporaryDirectory`.
 
 Now users instead of `import from airflow.utils.files import TemporaryDirectory` should
-do `from tempfile import TemporaryDirectory`. Both context managers provide the same interface, thus no additional
-changes should be required.
+do `from tempfile import TemporaryDirectory`. Both context managers provide the same
+interface, thus no additional changes should be required.
 
 #### `airflow.AirflowMacroPlugin`
 
-We removed `airflow.AirflowMacroPlugin` class. The class was there in airflow package but it has not been used (
-apparently since 2015). It has been removed.
+We removed `airflow.AirflowMacroPlugin` class. The class was there in airflow package but it has not been used (apparently since 2015).
+It has been removed.
 
 #### `airflow.settings.CONTEXT_MANAGER_DAG`
 
 CONTEXT_MANAGER_DAG was removed from settings. It's role has been taken by `DagContext` in
-'airflow.models.dag'. One of the reasons was that settings should be rather static than store dynamic context from the
-DAG, but the main one is that moving the context out of settings allowed to untangle cyclic imports between DAG,
-BaseOperator, SerializedDAG, SerializedBaseOperator which was part of AIRFLOW-6010.
+'airflow.models.dag'. One of the reasons was that settings should be rather static than store
+dynamic context from the DAG, but the main one is that moving the context out of settings allowed to
+untangle cyclic imports between DAG, BaseOperator, SerializedDAG, SerializedBaseOperator which was
+part of AIRFLOW-6010.
 
 #### `airflow.utils.log.logging_mixin.redirect_stderr`
 
 #### `airflow.utils.log.logging_mixin.redirect_stdout`
 
-Function `redirect_stderr` and `redirect_stdout` from `airflow.utils.log.logging_mixin` module has been deleted because
-it can be easily replaced by the standard library. The functions of the standard library are more flexible and can be
-used in larger cases.
+Function `redirect_stderr` and `redirect_stdout` from `airflow.utils.log.logging_mixin` module has
+been deleted because it can be easily replaced by the standard library.
+The functions of the standard library are more flexible and can be used in larger cases.
 
 The code below
 
@@ -996,7 +993,7 @@ from airflow.utils.log.logging_mixin import redirect_stderr, redirect_stdout
 
 logger = logging.getLogger("custom-logger")
 with redirect_stdout(logger, logging.INFO), redirect_stderr(logger, logging.WARN):
-  print("I love Airflow")
+    print("I love Airflow")
 ```
 
 can be replaced by the following code:
@@ -1009,34 +1006,34 @@ from airflow.utils.log.logging_mixin import StreamLogWriter
 
 logger = logging.getLogger("custom-logger")
 
-with redirect_stdout(StreamLogWriter(logger, logging.INFO)),
-  redirect_stderr(StreamLogWriter(logger, logging.WARN)):
-  print("I Love Airflow")
+with redirect_stdout(StreamLogWriter(logger, logging.INFO)), \
+        redirect_stderr(StreamLogWriter(logger, logging.WARN)):
+    print("I Love Airflow")
 ```
 
 #### `airflow.models.baseoperator.BaseOperator`
 
-Now, additional arguments passed to BaseOperator cause an exception. Previous versions of Airflow took additional
-arguments and displayed a message on the console. When the message was not noticed by users, it caused very difficult to
-detect errors.
+Now, additional arguments passed to BaseOperator cause an exception. Previous versions of Airflow took additional arguments and displayed a message on the console. When the
+message was not noticed by users, it caused very difficult to detect errors.
 
-In order to restore the previous behavior, you must set an ``True`` in the ``allow_illegal_arguments``
-option of section ``[operators]`` in the ``airflow.cfg`` file. In the future it is possible to completely delete this
-option.
+In order to restore the previous behavior, you must set an ``True`` in  the ``allow_illegal_arguments``
+option of section ``[operators]`` in the ``airflow.cfg`` file. In the future it is possible to completely
+delete this option.
 
 #### `airflow.models.dagbag.DagBag`
 
-Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property are
-deprecated and will be removed in future versions.
+Passing `store_serialized_dags` argument to DagBag.__init__ and accessing `DagBag.store_serialized_dags` property
+are deprecated and will be removed in future versions.
+
 
 **Previous signature**:
 
 ```python
 DagBag(
-  dag_folder=None,
-  include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
-  safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
-  store_serialized_dags=False
+    dag_folder=None,
+    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
+    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+    store_serialized_dags=False
 ):
 ```
 
@@ -1044,78 +1041,79 @@ DagBag(
 
 ```python
 DagBag(
-  dag_folder=None,
-  include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
-  safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
-  read_dags_from_db=False
+    dag_folder=None,
+    include_examples=conf.getboolean('core', 'LOAD_EXAMPLES'),
+    safe_mode=conf.getboolean('core', 'DAG_DISCOVERY_SAFE_MODE'),
+    read_dags_from_db=False
 ):
 ```
 
-If you were using positional arguments, it requires no change but if you were using keyword arguments, please
-change `store_serialized_dags` to `read_dags_from_db`.
+If you were using positional arguments, it requires no change but if you were using keyword
+arguments, please change `store_serialized_dags` to `read_dags_from_db`.
 
 Similarly, if you were using `DagBag().store_serialized_dags` property, change it to
 `DagBag().read_dags_from_db`.
 
 ### Changes in `google` provider package
 
-We strive to ensure that there are no changes that may affect the end user and your Python files, but this release may
-contain changes that will require changes to your configuration, DAG Files or other integration e.g. custom operators.
+We strive to ensure that there are no changes that may affect the end user and your Python files, but this
+release may contain changes that will require changes to your configuration, DAG Files or other integration
+e.g. custom operators.
 
-Only changes unique to this provider are described here. You should still pay attention to the changes that have been
-made to the core (including core operators) as they can affect the integration behavior of this provider.
+Only changes unique to this provider are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
 
-This section describes the changes that have been made, and what you need to do to update your if you use operators or
-hooks which integrate with Google services (including Google Cloud - GCP).
+This section describes the changes that have been made, and what you need to do to update your if
+you use operators or hooks which integrate with Google services (including Google Cloud - GCP).
 
 #### Direct impersonation added to operators communicating with Google services
 
 [Directly impersonating a service account](https://cloud.google.com/iam/docs/understanding-service-accounts#directly_impersonating_a_service_account)
 has been made possible for operators communicating with Google services via new argument called `impersonation_chain`
-(`google_impersonation_chain` in case of operators that also communicate with services of other cloud providers). As a
-result, GCSToS3Operator no longer derivatives from GCSListObjectsOperator.
+(`google_impersonation_chain` in case of operators that also communicate with services of other cloud providers).
+As a result, GCSToS3Operator no longer derivatives from GCSListObjectsOperator.
 
 #### Normalize gcp_conn_id for Google Cloud
 
 Previously not all hooks and operators related to Google Cloud use
-`gcp_conn_id` as parameter for GCP connection. There is currently one parameter which apply to most services. Parameters
-like ``datastore_conn_id``, ``bigquery_conn_id``,
-``google_cloud_storage_conn_id`` and similar have been deprecated. Operators that require two connections are not
-changed.
+`gcp_conn_id` as parameter for GCP connection. There is currently one parameter
+which apply to most services. Parameters like ``datastore_conn_id``, ``bigquery_conn_id``,
+``google_cloud_storage_conn_id`` and similar have been deprecated. Operators that require two connections are not changed.
 
 Following components were affected by normalization:
 
-* airflow.providers.google.cloud.hooks.datastore.DatastoreHook
-* airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
-* airflow.providers.google.cloud.hooks.gcs.GoogleCloudStorageHook
-* airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryValueCheckOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryIntervalCheckOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryGetDataOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryDeleteDatasetOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyDatasetOperator
-* airflow.providers.google.cloud.operators.bigquery.BigQueryTableDeleteOperator
-* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageCreateBucketOperator
-* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageListOperator
-* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDownloadOperator
-* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDeleteOperator
-* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageBucketCreateAclEntryOperator
-* airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageObjectCreateAclEntryOperator
-* airflow.operators.sql_to_gcs.BaseSQLToGoogleCloudStorageOperator
-* airflow.operators.adls_to_gcs.AdlsToGoogleCloudStorageOperator
-* airflow.operators.gcs_to_s3.GoogleCloudStorageToS3Operator
-* airflow.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator
-* airflow.operators.bigquery_to_gcs.BigQueryToCloudStorageOperator
-* airflow.operators.local_to_gcs.FileToGoogleCloudStorageOperator
-* airflow.operators.cassandra_to_gcs.CassandraToGoogleCloudStorageOperator
-* airflow.operators.bigquery_to_bigquery.BigQueryToBigQueryOperator
+  * airflow.providers.google.cloud.hooks.datastore.DatastoreHook
+  * airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
+  * airflow.providers.google.cloud.hooks.gcs.GoogleCloudStorageHook
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryCheckOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryValueCheckOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryIntervalCheckOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryGetDataOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryDeleteDatasetOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyDatasetOperator
+  * airflow.providers.google.cloud.operators.bigquery.BigQueryTableDeleteOperator
+  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageCreateBucketOperator
+  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageListOperator
+  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDownloadOperator
+  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageDeleteOperator
+  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageBucketCreateAclEntryOperator
+  * airflow.providers.google.cloud.operators.gcs.GoogleCloudStorageObjectCreateAclEntryOperator
+  * airflow.operators.sql_to_gcs.BaseSQLToGoogleCloudStorageOperator
+  * airflow.operators.adls_to_gcs.AdlsToGoogleCloudStorageOperator
+  * airflow.operators.gcs_to_s3.GoogleCloudStorageToS3Operator
+  * airflow.operators.gcs_to_gcs.GoogleCloudStorageToGoogleCloudStorageOperator
+  * airflow.operators.bigquery_to_gcs.BigQueryToCloudStorageOperator
+  * airflow.operators.local_to_gcs.FileToGoogleCloudStorageOperator
+  * airflow.operators.cassandra_to_gcs.CassandraToGoogleCloudStorageOperator
+  * airflow.operators.bigquery_to_bigquery.BigQueryToBigQueryOperator
 
 #### Changes to import paths and names of GCP operators and hooks
 
 According to [AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths)
-operators related to Google Cloud has been moved from contrib to core. The following table shows changes in import
-paths.
+operators related to Google Cloud has been moved from contrib to core.
+The following table shows changes in import paths.
 
 |                                                     Old path                                                     |                                                 New path                                                                     |
 |------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
@@ -1300,11 +1298,13 @@ paths.
 #### Unify default conn_id for Google Cloud
 
 Previously not all hooks and operators related to Google Cloud use
-``google_cloud_default`` as a default conn_id. There is currently one default variant. Values
-like ``google_cloud_storage_default``, ``bigquery_default``,
-``google_cloud_datastore_default`` have been deprecated. The configuration of existing relevant connections in the
-database have been preserved. To use those deprecated GCP conn_id, you need to explicitly pass their conn_id into
-operators/hooks. Otherwise, ``google_cloud_default`` will be used as GCP's conn_id by default.
+``google_cloud_default`` as a default conn_id. There is currently one default
+variant. Values like ``google_cloud_storage_default``, ``bigquery_default``,
+``google_cloud_datastore_default`` have been deprecated. The configuration of
+existing relevant connections in the database have been preserved. To use those
+deprecated GCP conn_id, you need to explicitly pass their conn_id into
+operators/hooks. Otherwise, ``google_cloud_default`` will be used as GCP's conn_id
+by default.
 
 #### `airflow.providers.google.cloud.hooks.dataflow.DataflowHook`
 
@@ -1316,22 +1316,29 @@ operators/hooks. Otherwise, ``google_cloud_default`` will be used as GCP's conn_
 
 To use project_id argument consistently across GCP hooks and operators, we did the following changes:
 
-- Changed order of arguments in DataflowHook.start_python_dataflow. Uses with positional arguments may break.
-- Changed order of arguments in DataflowHook.is_job_dataflow_running. Uses with positional arguments may break.
-- Changed order of arguments in DataflowHook.cancel_job. Uses with positional arguments may break.
-- Added optional project_id argument to DataflowCreateJavaJobOperator constructor.
-- Added optional project_id argument to DataflowTemplatedJobStartOperator constructor.
-- Added optional project_id argument to DataflowCreatePythonJobOperator constructor.
+- Changed order of arguments in DataflowHook.start_python_dataflow. Uses
+    with positional arguments may break.
+- Changed order of arguments in DataflowHook.is_job_dataflow_running. Uses
+    with positional arguments may break.
+- Changed order of arguments in DataflowHook.cancel_job. Uses
+    with positional arguments may break.
+- Added optional project_id argument to DataflowCreateJavaJobOperator
+    constructor.
+- Added optional project_id argument to DataflowTemplatedJobStartOperator
+    constructor.
+- Added optional project_id argument to DataflowCreatePythonJobOperator
+    constructor.
 
 #### `airflow.providers.google.cloud.sensors.gcs.GCSUploadSessionCompleteSensor`
 
-To provide more precise control in handling of changes to objects in underlying GCS Bucket the constructor of this
-sensor now has changed.
+To provide more precise control in handling of changes to objects in
+underlying GCS Bucket the constructor of this sensor now has changed.
 
 - Old Behavior: This constructor used to optionally take ``previous_num_objects: int``.
 - New replacement constructor kwarg: ``previous_objects: Optional[Set[str]]``.
 
-Most users would not specify this argument because the bucket begins empty and the user wants to treat any files as new.
+Most users would not specify this argument because the bucket begins empty
+and the user wants to treat any files as new.
 
 Example of Updating usage of this sensor:
 Users who used to call:
@@ -1348,10 +1355,9 @@ Where '.keep' is a single file at your prefix that the sensor should not conside
 
 #### `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook`
 
-To simplify BigQuery operators (no need of `Cursor`) and standardize usage of hooks within all GCP integration methods
-from `BiqQueryBaseCursor`
-were moved to `BigQueryHook`. Using them by from `Cursor` object is still possible due to preserved backward
-compatibility but they will raise `DeprecationWarning`. The following methods were moved:
+To simplify BigQuery operators (no need of `Cursor`) and standardize usage of hooks within all GCP integration methods from `BiqQueryBaseCursor`
+were moved to `BigQueryHook`. Using them by from `Cursor` object is still possible due to preserved backward compatibility but they will raise `DeprecationWarning`.
+The following methods were moved:
 
 | Old path                                                                                       | New path                                                                                 |
 |------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
@@ -1382,23 +1388,20 @@ compatibility but they will raise `DeprecationWarning`. The following methods we
 
 #### `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor`
 
-Since BigQuery is the part of the GCP it was possible to simplify the code by handling the exceptions by usage of
-the `airflow.providers.google.common.hooks.base.GoogleBaseHook.catch_http_exception` decorator however it changes
+Since BigQuery is the part of the GCP it was possible to simplify the code by handling the exceptions
+by usage of the `airflow.providers.google.common.hooks.base.GoogleBaseHook.catch_http_exception` decorator however it changes
 exceptions raised by the following methods:
 
-* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.run_table_delete` raises `AirflowException` instead
-  of `Exception`.
-* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.create_empty_dataset` raises `AirflowException`
-  instead of `ValueError`.
-* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.get_dataset` raises `AirflowException` instead
-  of `ValueError`.
+* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.run_table_delete` raises `AirflowException` instead of `Exception`.
+* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.create_empty_dataset` raises `AirflowException` instead of `ValueError`.
+* `airflow.providers.google.cloud.hooks.bigquery.BigQueryBaseCursor.get_dataset` raises `AirflowException` instead of `ValueError`.
 
 #### `airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyTableOperator`
 
 #### `airflow.providers.google.cloud.operators.bigquery.BigQueryCreateEmptyDatasetOperator`
 
-Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`. But to achieve
-that try / except clause was removed from `create_empty_dataset` and `create_empty_table`
+Idempotency was added to `BigQueryCreateEmptyTableOperator` and `BigQueryCreateEmptyDatasetOperator`.
+But to achieve that try / except clause was removed from `create_empty_dataset` and `create_empty_table`
 methods of `BigQueryHook`.
 
 #### `airflow.providers.google.cloud.hooks.dataflow.DataflowHook`
@@ -1407,9 +1410,9 @@ methods of `BigQueryHook`.
 
 #### `airflow.providers.google.cloud.hooks.pubsub.PubSubHook`
 
-The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather than
-positional ones in all methods where `project_id` is used. The methods throw an explanatory exception in case they are
-called using positional parameters.
+The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather
+than positional ones in all methods where `project_id` is used. The methods throw an explanatory exception
+in case they are called using positional parameters.
 
 Other GCP hooks are unaffected.
 
@@ -1427,13 +1430,12 @@ Other GCP hooks are unaffected.
 
 #### `airflow.providers.google.cloud.sensors.pubsub.PubSubPullSensor`
 
-In the `PubSubPublishOperator` and `PubSubHook.publsh` method the data field in a message should be bytestring (utf-8
-encoded) rather than base64 encoded string.
+In the `PubSubPublishOperator` and `PubSubHook.publsh` method the data field in a message should be bytestring (utf-8 encoded) rather than base64 encoded string.
 
 Due to the normalization of the parameters within GCP operators and hooks a parameters like `project` or `topic_project`
-are deprecated and will be substituted by parameter `project_id`. In `PubSubHook.create_subscription` hook method in the
-parameter `subscription_project` is replaced by `subscription_project_id`. Template fields are updated accordingly and
-old ones may not work.
+are deprecated and will be substituted by parameter `project_id`.
+In `PubSubHook.create_subscription` hook method in the parameter `subscription_project` is replaced by `subscription_project_id`.
+Template fields are updated accordingly and old ones may not work.
 
 It is required now to pass key-word only arguments to `PubSub` hook.
 
@@ -1441,16 +1443,17 @@ These changes are not backward compatible.
 
 #### `airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator`
 
-The gcp_conn_id parameter in GKEPodOperator is required. In previous versions, it was possible to pass the `None` value
-to the `gcp_conn_id` in the GKEStartPodOperator operator, which resulted in credentials being determined according to
-the
+The gcp_conn_id parameter in GKEPodOperator is required. In previous versions, it was possible to pass
+the `None` value to the `gcp_conn_id` in the GKEStartPodOperator
+operator, which resulted in credentials being determined according to the
 [Application Default Credentials](https://cloud.google.com/docs/authentication/production) strategy.
 
-Now this parameter requires a value. To restore the previous behavior, configure the connection without specifying the
-service account.
+Now this parameter requires a value. To restore the previous behavior, configure the connection without
+specifying the service account.
 
 Detailed information about connection management is available:
 [Google Cloud Connection](https://airflow.apache.org/howto/connection/gcp.html).
+
 
 #### `airflow.providers.google.cloud.hooks.gcs.GCSHook`
 
@@ -1474,7 +1477,8 @@ Detailed information about connection management is available:
 
 The 'properties' and 'jars' properties for the Dataproc related operators (`DataprocXXXOperator`) have been renamed from
 `dataproc_xxxx_properties` and `dataproc_xxx_jars`  to `dataproc_properties`
-and `dataproc_jars`respectively. Arguments for dataproc_properties dataproc_jars
+and `dataproc_jars`respectively.
+Arguments for dataproc_properties dataproc_jars
 
 #### `airflow.providers.google.cloud.operators.cloud_storage_transfer_service.CloudDataTransferServiceCreateJobOperator`
 
@@ -1483,23 +1487,25 @@ has been renamed to `request_filter`.
 
 #### `airflow.providers.google.cloud.hooks.cloud_storage_transfer_service.CloudDataTransferServiceHook`
 
-To obtain pylint compatibility the `filter` argument in `CloudDataTransferServiceHook.list_transfer_job` and
-`CloudDataTransferServiceHook.list_transfer_operations` has been renamed to `request_filter`.
+ To obtain pylint compatibility the `filter` argument in `CloudDataTransferServiceHook.list_transfer_job` and
+ `CloudDataTransferServiceHook.list_transfer_operations` has been renamed to `request_filter`.
 
 #### `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook`
 
-In general all hook methods are decorated with `@GoogleBaseHook.fallback_to_default_project_id` thus parameters to hook
-can only be passed via keyword arguments.
+In general all hook methods are decorated with `@GoogleBaseHook.fallback_to_default_project_id` thus
+parameters to hook can only be passed via keyword arguments.
 
-- `create_empty_table` method accepts now `table_resource` parameter. If provided all other parameters are ignored.
-- `create_empty_dataset` will now use values from `dataset_reference` instead of raising error if parameters were passed
-  in `dataset_reference` and as arguments to method. Additionally validation of `dataset_reference` is done
-  using `Dataset.from_api_repr`. Exception and log messages has been changed.
+- `create_empty_table` method accepts now `table_resource` parameter. If provided all
+other parameters are ignored.
+- `create_empty_dataset` will now use values from `dataset_reference` instead of raising error
+if parameters were passed in `dataset_reference` and as arguments to method. Additionally validation
+of `dataset_reference` is done using `Dataset.from_api_repr`. Exception and log messages has been
+changed.
 - `update_dataset` requires now new `fields` argument (breaking change)
 - `delete_dataset` has new signature (dataset_id, project_id, ...)
-  previous one was (project_id, dataset_id, ...) (breaking change)
-- `get_tabledata` returns list of rows instead of API response in dict format. This method is deprecated in favor
-  of `list_rows`. (breaking change)
+previous one was (project_id, dataset_id, ...) (breaking change)
+- `get_tabledata` returns list of rows instead of API response in dict format. This method is deprecated in
+ favor of `list_rows`. (breaking change)
 
 #### `airflow.providers.google.cloud.hooks.dataflow.DataflowHook.start_python_dataflow`
 
@@ -1515,8 +1521,8 @@ Now the `py_interpreter` argument for DataFlow Hooks/Operators has been changed 
 
 To simplify the code, the decorator provide_gcp_credential_file has been moved from the inner-class.
 
-Instead of `@GoogleBaseHook._Decorators.provide_gcp_credential_file`, you should
-write `@GoogleBaseHook.provide_gcp_credential_file`
+Instead of `@GoogleBaseHook._Decorators.provide_gcp_credential_file`,
+you should write `@GoogleBaseHook.provide_gcp_credential_file`
 
 #### `airflow.providers.google.cloud.operators.dataproc.DataprocCreateClusterOperator`
 
@@ -1543,20 +1549,23 @@ BigQueryGetDatasetTablesOperator(dataset_resource: dict, dataset_id: Optional[st
 
 ### Changes in `amazon` provider package
 
-We strive to ensure that there are no changes that may affect the end user, and your Python files, but this release may
-contain changes that will require changes to your configuration, DAG Files or other integration e.g. custom operators.
+We strive to ensure that there are no changes that may affect the end user, and your Python files, but this
+release may contain changes that will require changes to your configuration, DAG Files or other integration
+e.g. custom operators.
 
-Only changes unique to this provider are described here. You should still pay attention to the changes that have been
-made to the core (including core operators) as they can affect the integration behavior of this provider.
+Only changes unique to this provider are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
 
-This section describes the changes that have been made, and what you need to do to update your if you use operators or
-hooks which integrate with Amazon services (including Amazon Web Service - AWS).
+This section describes the changes that have been made, and what you need to do to update your if
+you use operators or hooks which integrate with Amazon services (including Amazon Web Service - AWS).
 
 #### Migration of AWS components
 
 All AWS components (hooks, operators, sensors, example DAGs) will be grouped together as decided in
-[AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths). Migrated components
-remain backwards compatible but raise a `DeprecationWarning` when imported from the old module. Migrated are:
+[AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths). Migrated
+components remain backwards compatible but raise a `DeprecationWarning` when imported from the old module.
+Migrated are:
 
 | Old path                                                     | New path                                                 |
 | ------------------------------------------------------------ | -------------------------------------------------------- |
@@ -1583,26 +1592,28 @@ remain backwards compatible but raise a `DeprecationWarning` when imported from 
 
 #### `airflow.providers.amazon.aws.operators.emr_terminate_job_flow.EmrTerminateJobFlowOperator`
 
-The default value for the [aws_conn_id](https://airflow.apache.org/howto/manage-connections.html#amazon-web-services)
-was accidentally set to 's3_default' instead of 'aws_default' in some of the emr operators in previous versions. This
-was leading to EmrStepSensor not being able to find their corresponding emr cluster. With the new changes in the
-EmrAddStepsOperator, EmrTerminateJobFlowOperator and EmrCreateJobFlowOperator this issue is solved.
+The default value for the [aws_conn_id](https://airflow.apache.org/howto/manage-connections.html#amazon-web-services) was accidentally set to 's3_default' instead of 'aws_default' in some of the emr operators in previous
+versions. This was leading to EmrStepSensor not being able to find their corresponding emr cluster. With the new
+changes in the EmrAddStepsOperator, EmrTerminateJobFlowOperator and EmrCreateJobFlowOperator this issue is
+solved.
 
 #### `airflow.providers.amazon.aws.operators.batch.AwsBatchOperator`
 
-The `AwsBatchOperator` was refactored to extract an `AwsBatchClient` (and inherit from it). The changes are mostly
-backwards compatible and clarify the public API for these classes; some private methods on `AwsBatchOperator` for
-polling a job status were relocated and renamed to surface new public methods on `AwsBatchClient` (and via inheritance
-on `AwsBatchOperator`). A couple of job attributes are renamed on an instance of `AwsBatchOperator`; these were mostly
-used like private attributes but they were surfaced in the public API, so any use of them needs to be updated as
-follows:
+The `AwsBatchOperator` was refactored to extract an `AwsBatchClient` (and inherit from it).  The
+changes are mostly backwards compatible and clarify the public API for these classes; some
+private methods on `AwsBatchOperator` for polling a job status were relocated and renamed
+to surface new public methods on `AwsBatchClient` (and via inheritance on `AwsBatchOperator`).  A
+couple of job attributes are renamed on an instance of `AwsBatchOperator`; these were mostly
+used like private attributes but they were surfaced in the public API, so any use of them needs
+to be updated as follows:
 
 - `AwsBatchOperator().jobId` -> `AwsBatchOperator().job_id`
 - `AwsBatchOperator().jobName` -> `AwsBatchOperator().job_name`
 
 The `AwsBatchOperator` gets a new option to define a custom model for waiting on job status changes.
-The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBatchWaiters`, to specify that custom job
-waiters will be used to monitor a batch job. See the latest API documentation for details.
+The `AwsBatchOperator` can use a new `waiters` parameter, an instance of `AwsBatchWaiters`, to
+specify that custom job waiters will be used to monitor a batch job.  See the latest API
+documentation for details.
 
 #### `airflow.providers.amazon.aws.sensors.athena.AthenaSensor`
 
@@ -1610,25 +1621,28 @@ Replace parameter `max_retires` with `max_retries` to fix typo.
 
 #### `airflow.providers.amazon.aws.hooks.s3.S3Hook`
 
-Note: The order of arguments has changed for `check_for_prefix`. The `bucket_name` is now optional. It falls back to
-the `connection schema` attribute. The `delete_objects` now returns `None` instead of a response, since the method now
-makes multiple api requests when the keys list length is > 1000.
+Note: The order of arguments has changed for `check_for_prefix`.
+The `bucket_name` is now optional. It falls back to the `connection schema` attribute.
+The `delete_objects` now returns `None` instead of a response, since the method now makes multiple api requests when the keys list length is > 1000.
 
 ### Changes in other provider packages
 
-We strive to ensure that there are no changes that may affect the end user and your Python files, but this release may
-contain changes that will require changes to your configuration, DAG Files or other integration e.g. custom operators.
+We strive to ensure that there are no changes that may affect the end user and your Python files, but this
+release may contain changes that will require changes to your configuration, DAG Files or other integration
+e.g. custom operators.
 
-Only changes unique to providers are described here. You should still pay attention to the changes that have been made
-to the core (including core operators) as they can affect the integration behavior of this provider.
+Only changes unique to providers are described here. You should still pay attention to the changes that
+have been made to the core (including core operators) as they can affect the integration behavior
+of this provider.
 
-This section describes the changes that have been made, and what you need to do to update your if you use any code
-located in `airflow.providers` package.
+This section describes the changes that have been made, and what you need to do to update your if
+you use any code located in `airflow.providers` package.
 
 #### Changed return type of `list_prefixes` and `list_keys` methods in `S3Hook`
 
-Previously, the `list_prefixes` and `list_keys` methods returned `None` when there were no results. The behavior has
-been changed to return an empty list instead of `None` in this case.
+Previously, the `list_prefixes` and `list_keys` methods returned `None` when there were no
+results. The behavior has been changed to return an empty list instead of `None` in this
+case.
 
 #### Removed Hipchat integration
 
@@ -1645,13 +1659,11 @@ Rename `sign_in` function to `get_conn`.
 
 #### `airflow.providers.apache.pinot.hooks.pinot.PinotAdminHook.create_segment`
 
-Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint
-compatible
+Rename parameter name from ``format`` to ``segment_format`` in PinotAdminHook function create_segment fro pylint compatible
 
 #### `airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_partitions`
 
-Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint
-compatible
+Rename parameter name from ``filter`` to ``partition_filter`` in HiveMetastoreHook function get_partitions for pylint compatible
 
 #### `airflow.providers.ftp.hooks.ftp.FTPHook.list_directory`
 
@@ -1672,8 +1684,9 @@ Change parameter name from ``visibleTo`` to ``visible_to`` in OpsgenieAlertOpera
 ImapHook:
 
 * The order of arguments has changed for `has_mail_attachment`,
-  `retrieve_mail_attachments` and `download_mail_attachments`.
+`retrieve_mail_attachments` and `download_mail_attachments`.
 * A new `mail_filter` argument has been added to each of those.
+
 
 #### `airflow.providers.http.hooks.http.HttpHook`
 
@@ -1692,17 +1705,14 @@ For example:
 from airflow.providers.cloudant.hooks.cloudant import CloudantHook
 
 with CloudantHook().get_conn() as cloudant_session:
-  database = cloudant_session['database_name']
+    database = cloudant_session['database_name']
 ```
 
-See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant
-version.
+See the [docs](https://python-cloudant.readthedocs.io/en/latest/) for more information on how to use the new cloudant version.
 
 #### `airflow.providers.snowflake`
 
-When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`,
-regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched
-to `snowflake_default` for consistency and will be properly overridden when specified.
+When initializing a Snowflake hook or operator, the value used for `snowflake_conn_id` was always `snowflake_conn_id`, regardless of whether or not you specified a value for it. The default `snowflake_conn_id` value is now switched to `snowflake_default` for consistency and will be properly overridden when specified.
 
 ### Other changes
 
@@ -1740,13 +1750,15 @@ For example:
 If you want to install integration for Microsoft Azure, then instead of `pip install apache-airflow[atlas]`
 you should use `pip install apache-airflow[apache.atlas]`.
 
+
 NOTE!
 
-On November 2020, new version of PIP (20.3) has been released with a new, 2020 resolver. This resolver does not yet work
-with Apache Airflow and might lead to errors in installation - depends on your choice of extras. In order to install
-Airflow you need to either downgrade pip to version 20.2.4
+On November 2020, new version of PIP (20.3) has been released with a new, 2020 resolver. This resolver
+does not yet work with Apache Airflow and might lead to errors in installation - depends on your choice
+of extras. In order to install Airflow you need to either downgrade pip to version 20.2.4
 `pip install --upgrade pip==20.2.4` or, in case you use Pip 20.3, you need to add option
 `--use-deprecated legacy-resolver` to your pip install command.
+
 
 If you want to install integration for Microsoft Azure, then instead of
 
@@ -1763,27 +1775,26 @@ The deprecated extras will be removed in 3.0.
 
 #### Simplify the response payload of endpoints /dag_stats and /task_stats
 
-The response of endpoints `/dag_stats` and `/task_stats` help UI fetch brief statistics about DAGs and Tasks. The format
-was like
+The response of endpoints `/dag_stats` and `/task_stats` help UI fetch brief statistics about DAGs and Tasks. The format was like
 
 ```json
 {
-  "example_http_operator": [
-    {
-      "state": "success",
-      "count": 0,
-      "dag_id": "example_http_operator",
-      "color": "green"
-    },
-    {
-      "state": "running",
-      "count": 0,
-      "dag_id": "example_http_operator",
-      "color": "lime"
-    },
-    ...
-  ],
-  ...
+    "example_http_operator": [
+        {
+            "state": "success",
+            "count": 0,
+            "dag_id": "example_http_operator",
+            "color": "green"
+        },
+        {
+            "state": "running",
+            "count": 0,
+            "dag_id": "example_http_operator",
+            "color": "lime"
+        },
+        ...
+],
+...
 }
 ```
 
@@ -1793,20 +1804,20 @@ Now the `dag_id` will not appear repeated in the payload, and the response forma
 
 ```json
 {
-  "example_http_operator": [
-    {
-      "state": "success",
-      "count": 0,
-      "color": "green"
-    },
-    {
-      "state": "running",
-      "count": 0,
-      "color": "lime"
-    },
-    ...
-  ],
-  ...
+    "example_http_operator": [
+        {
+            "state": "success",
+            "count": 0,
+            "color": "green"
+        },
+        {
+            "state": "running",
+            "count": 0,
+            "color": "lime"
+        },
+        ...
+],
+...
 }
 ```
 
@@ -1821,27 +1832,25 @@ This is to align the name with the actual code where the Scheduler launches the 
 
 ### Airflow CLI changes in line with 2.0
 
-The Airflow CLI has been organized so that related commands are grouped together as subcommands, which means that if you
-use these commands in your scripts, they will now raise a DeprecationWarning and you have to make changes to them before
-you upgrade to Airflow 2.0.
+The Airflow CLI has been organized so that related commands are grouped together as subcommands,
+which means that if you use these commands in your scripts, they will now raise a DeprecationWarning and
+you have to make changes to them before you upgrade to Airflow 2.0.
 
 This section describes the changes that have been made, and what you need to do to update your script.
 
-The ability to manipulate users from the command line has been changed. ``airflow create_user``
-,  ``airflow delete_user``
-and ``airflow list_users`` has been grouped to a single command `airflow users` with optional flags `create`, `list`
-and `delete`.
+The ability to manipulate users from the command line has been changed. ``airflow create_user``,  ``airflow delete_user``
+ and ``airflow list_users`` has been grouped to a single command `airflow users` with optional flags `create`, `list` and `delete`.
 
 The `airflow list_dags` command is now `airflow dags list`, `airflow pause` is `airflow dags pause`, etc.
 
-In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a difference in behavior. In Airflow 1.10, it
-prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`. You
-can check other options by running the command `airflow config --help`
+In Airflow 1.10 and 2.0 there is an `airflow config` command but there is a difference in behavior. In Airflow 1.10,
+it prints all config options while in Airflow 2.0, it's a command group. `airflow config` is now `airflow config list`.
+You can check other options by running the command `airflow config --help`
 
 Compatibility with the old CLI has been maintained, but they will no longer appear in the help
 
-You can learn about the commands by running ``airflow --help``. For example to get help about the ``celery`` group
-command, you have to run the help command: ``airflow celery --help``.
+You can learn about the commands by running ``airflow --help``. For example to get help about the ``celery`` group command,
+you have to run the help command: ``airflow celery --help``.
 
 | Old command                   | New command                        |     Group          |
 |-------------------------------|------------------------------------|--------------------|
@@ -1882,13 +1891,14 @@ command, you have to run the help command: ``airflow celery --help``.
 
 Previously `TimeSensor` always compared the `target_time` with the current time in UTC.
 
-Now it will compare `target_time` with the current time in the timezone of the DAG, defaulting to the `default_timezone`
-in the global config.
+Now it will compare `target_time` with the current time in the timezone of the DAG,
+defaulting to the `default_timezone` in the global config.
 
 ### Removed Kerberos support for HDFS hook
 
-The HDFS hook's Kerberos support has been removed due to removed python-krbV dependency from PyPI and generally lack of
-support for SSL in Python3 (Snakebite-py3 we use as dependency has no support for SSL connection to HDFS).
+The HDFS hook's Kerberos support has been removed due to removed python-krbV dependency from PyPI
+and generally lack of support for SSL in Python3 (Snakebite-py3 we use as dependency has no
+support for SSL connection to HDFS).
 
 SSL support still works for WebHDFS hook.
 
@@ -1896,8 +1906,8 @@ SSL support still works for WebHDFS hook.
 
 In previous version of Airflow user session lifetime could be configured by
 `session_lifetime_days` and `force_log_out_after` options. In practise only `session_lifetime_days`
-had impact on session lifetime, but it was limited to values in day. We have removed mentioned options and introduced
-new `session_lifetime_minutes`
+had impact on session lifetime, but it was limited to values in day.
+We have removed mentioned options and introduced new `session_lifetime_minutes`
 option which simplify session lifetime configuration.
 
 Before
@@ -1920,22 +1930,21 @@ session_lifetime_minutes = 43200
 The ability to import Operators, Hooks and Sensors via the plugin mechanism has been deprecated and will raise warnings
 in Airflow 1.10.13 and will be removed completely in Airflow 2.0.
 
-Check https://airflow.apache.org/docs/1.10.13/howto/custom-operator.html to see how you can create and import Custom
-Hooks, Operators and Sensors.
+Check https://airflow.apache.org/docs/1.10.13/howto/custom-operator.html to see how you can create and import
+Custom Hooks, Operators and Sensors.
 
 ## Airflow 1.10.12
 
 ### Clearing tasks skipped by SkipMixin will skip them
 
-Previously, when tasks skipped by SkipMixin (such as BranchPythonOperator, BaseBranchOperator and ShortCircuitOperator)
-are cleared, they execute. Since 1.10.12, when such skipped tasks are cleared, they will be skipped again by the newly
-introduced NotPreviouslySkippedDep.
+Previously, when tasks skipped by SkipMixin (such as BranchPythonOperator, BaseBranchOperator and ShortCircuitOperator) are cleared, they execute. Since 1.10.12, when such skipped tasks are cleared,
+they will be skipped again by the newly introduced NotPreviouslySkippedDep.
 
 ### The pod_mutation_hook function will now accept a kubernetes V1Pod object
 
-As of airflow 1.10.12, using the `airflow.contrib.kubernetes.Pod` class in the `pod_mutation_hook` is now deprecated.
-Instead we recommend that users treat the `pod` parameter as a `kubernetes.client.models.V1Pod` object. This means that
-users now have access to the full Kubernetes API when modifying airflow pods
+As of airflow 1.10.12, using the `airflow.contrib.kubernetes.Pod` class in the `pod_mutation_hook` is now deprecated. Instead we recommend that users
+treat the `pod` parameter as a `kubernetes.client.models.V1Pod` object. This means that users now have access to the full Kubernetes API
+when modifying airflow pods
 
 ### pod_template_file option now available in the KubernetesPodOperator
 
@@ -1949,20 +1958,21 @@ Now use NULL as default value for dag.description in dag table
 
 ### Restrict editing DagRun State in the old UI (Flask-admin based UI)
 
-Before 1.10.11 it was possible to edit DagRun State in the `/admin/dagrun/` page to any text.
+Before 1.10.11 it was possible to edit DagRun State in the `/admin/dagrun/` page
+ to any text.
 
 In Airflow 1.10.11+, the user can only choose the states from the list.
 
 ### Experimental API will deny all request by default.
 
-The previous default setting was to allow all API requests without authentication, but this poses security risks to
-users who miss this fact. This changes the default for new installs to deny all requests by default.
+The previous default setting was to allow all API requests without authentication, but this poses security
+risks to users who miss this fact. This changes the default for new installs to deny all requests by default.
 
 **Note**: This will not change the behavior for existing installs, please update check your airflow.cfg
 
 If you wish to have the experimental API work, and aware of the risks of enabling this without authentication
-(or if you have your own authentication layer in front of Airflow) you can get the previous behaviour on a new install
-by setting this in your airflow.cfg:
+(or if you have your own authentication layer in front of Airflow) you can get
+the previous behaviour on a new install by setting this in your airflow.cfg:
 
 ```
 [api]
@@ -1971,12 +1981,14 @@ auth_backend = airflow.api.auth.backend.default
 
 ### XCom Values can no longer be added or changed from the Webserver
 
-Since XCom values can contain pickled data, we would no longer allow adding or changing XCom values from the UI.
+Since XCom values can contain pickled data, we would no longer allow adding or
+changing XCom values from the UI.
 
 ### Default for `run_as_user` configured has been changed to 50000 from 0
 
 The UID to run the first process of the Worker PODs when using has been changed to `50000`
-from the previous default of `0`. The previous default was an empty string but the code used `0` if it was empty string.
+from the previous default of `0`. The previous default was an empty string but the code used `0` if it was
+empty string.
 
 **Before**:
 
@@ -1998,8 +2010,8 @@ This is done to avoid running the container as `root` user.
 
 ### Setting Empty string to a Airflow Variable will return an empty string
 
-Previously when you set an Airflow Variable with an empty string (`''`), the value you used to get back was ``None``.
-This will now return an empty string (`'''`)
+Previously when you set an Airflow Variable with an empty string (`''`), the value you used to get
+back was ``None``. This will now return an empty string (`'''`)
 
 Example:
 
@@ -2013,13 +2025,13 @@ The above code returned `None` previously, now it will return `''`.
 ### Make behavior of `none_failed` trigger rule consistent with documentation
 
 The behavior of the `none_failed` trigger rule is documented as "all parents have not failed (`failed` or
-`upstream_failed`) i.e. all parents have succeeded or been skipped." As previously implemented, the actual behavior
-would skip if all parents of a task had also skipped.
+    `upstream_failed`) i.e. all parents have succeeded or been skipped." As previously implemented, the actual behavior
+    would skip if all parents of a task had also skipped.
 
 ### Add new trigger rule `none_failed_or_skipped`
 
-The fix to `none_failed` trigger rule breaks workflows that depend on the previous behavior. If you need the old
-behavior, you should change the tasks with `none_failed` trigger rule to `none_failed_or_skipped`.
+The fix to `none_failed` trigger rule breaks workflows that depend on the previous behavior.
+    If you need the old behavior, you should change the tasks with `none_failed` trigger rule to `none_failed_or_skipped`.
 
 ### Success Callback will be called when a task in marked as success from UI
 
@@ -2033,8 +2045,7 @@ No breaking changes.
 
 ### Failure callback will be called when task is marked failed
 
-When task is marked failed by user or task fails due to system failures - on failure call back will be called as part of
-clean up
+When task is marked failed by user or task fails due to system failures - on failure call back will be called as part of clean up
 
 See [AIRFLOW-5621](https://jira.apache.org/jira/browse/AIRFLOW-5621) for details
 
@@ -2042,31 +2053,32 @@ See [AIRFLOW-5621](https://jira.apache.org/jira/browse/AIRFLOW-5621) for details
 
 ### Changes in experimental API execution_date microseconds replacement
 
-The default behavior was to strip the microseconds (and milliseconds, etc) off of all dag runs triggered by by the
-experimental REST API. The default behavior will change when an explicit execution_date is passed in the request body.
-It will also now be possible to have the execution_date generated, but keep the microseconds by
-sending `replace_microseconds=false` in the request body. The default behavior can be overridden by
-sending `replace_microseconds=true` along with an explicit execution_date
+The default behavior was to strip the microseconds (and milliseconds, etc) off of all dag runs triggered by
+by the experimental REST API.  The default behavior will change when an explicit execution_date is
+passed in the request body.  It will also now be possible to have the execution_date generated, but
+keep the microseconds by sending `replace_microseconds=false` in the request body.  The default
+behavior can be overridden by sending `replace_microseconds=true` along with an explicit execution_date
 
 ### Infinite pool size and pool size query optimisation
 
-Pool size can now be set to -1 to indicate infinite size (it also includes optimisation of pool query which lead to poor
-task n^2 performance of task pool queries in MySQL).
+Pool size can now be set to -1 to indicate infinite size (it also includes
+optimisation of pool query which lead to poor task n^2 performance of task
+pool queries in MySQL).
 
 ### Viewer won't have edit permissions on DAG view.
 
 ### Google Cloud Storage Hook
 
-The `GoogleCloudStorageDownloadOperator` can either write to a supplied `filename` or return the content of a file via
-xcom through `store_to_xcom_key` - both options are mutually exclusive.
+The `GoogleCloudStorageDownloadOperator` can either write to a supplied `filename` or
+return the content of a file via xcom through `store_to_xcom_key` - both options are mutually exclusive.
 
 ## Airflow 1.10.6
 
 ### BaseOperator::render_template function signature changed
 
-Previous versions of the `BaseOperator::render_template` function required an `attr` argument as the first positional
-argument, along with `content` and `context`. This function signature was changed in 1.10.6 and the `attr` argument is
-no longer required (or accepted).
+Previous versions of the `BaseOperator::render_template` function required an `attr` argument as the first
+positional argument, along with `content` and `context`. This function signature was changed in 1.10.6 and
+the `attr` argument is no longer required (or accepted).
 
 In order to use this function in subclasses of the `BaseOperator`, the `attr` argument must be removed:
 
@@ -2078,10 +2090,12 @@ result = self.render_template(self.myattr, context)  # Post-1.10.6 call
 
 ### Changes to `aws_default` Connection's default region
 
-The region of Airflow's default connection to AWS (`aws_default`) was previously set to `us-east-1` during installation.
+The region of Airflow's default connection to AWS (`aws_default`) was previously
+set to `us-east-1` during installation.
 
-The region now needs to be set manually, either in the connection screens in Airflow, via the `~/.aws` config files, or
-via the `AWS_DEFAULT_REGION` environment variable.
+The region now needs to be set manually, either in the connection screens in
+Airflow, via the `~/.aws` config files, or via the `AWS_DEFAULT_REGION` environment
+variable.
 
 ### Some DAG Processing metrics have been renamed
 
@@ -2101,41 +2115,31 @@ No breaking changes.
 
 ### Export MySQL timestamps as UTC
 
-`MySqlToGoogleCloudStorageOperator` now exports TIMESTAMP columns as UTC by default, rather than using the default
-timezone of the MySQL server. This is the correct behavior for use with BigQuery, since BigQuery assumes that TIMESTAMP
-columns without time zones are in UTC. To preserve the previous behavior, set `ensure_utc` to `False.`
+`MySqlToGoogleCloudStorageOperator` now exports TIMESTAMP columns as UTC
+by default, rather than using the default timezone of the MySQL server.
+This is the correct behavior for use with BigQuery, since BigQuery
+assumes that TIMESTAMP columns without time zones are in UTC. To
+preserve the previous behavior, set `ensure_utc` to `False.`
 
 ### Changes to DatastoreHook
 
-* removed argument `version` from `get_conn` function and added it to the hook's `__init__` function instead and renamed
-  it to `api_version`
+* removed argument `version` from `get_conn` function and added it to the hook's `__init__` function instead and renamed it to `api_version`
 * renamed the `partialKeys` argument of function `allocate_ids` to `partial_keys`
 
 ### Changes to GoogleCloudStorageHook
 
-* the discovery-based api (`googleapiclient.discovery`) used in `GoogleCloudStorageHook` is now replaced by the
-  recommended client based api (`google-cloud-storage`). To know the difference between both the libraries,
-  read https://cloud.google.com/apis/docs/client-libraries-explained.
-  PR: [#5054](https://github.com/apache/airflow/pull/5054)
-* as a part of this replacement, the `multipart` & `num_retries` parameters for `GoogleCloudStorageHook.upload` method
-  have been deprecated.
+* the discovery-based api (`googleapiclient.discovery`) used in `GoogleCloudStorageHook` is now replaced by the recommended client based api (`google-cloud-storage`). To know the difference between both the libraries, read https://cloud.google.com/apis/docs/client-libraries-explained. PR: [#5054](https://github.com/apache/airflow/pull/5054)
+* as a part of this replacement, the `multipart` & `num_retries` parameters for `GoogleCloudStorageHook.upload` method have been deprecated.
 
-  The client library uses multipart upload automatically if the object/blob size is more than 8 MB
-  - [source code](https://github.com/googleapis/google-cloud-python/blob/11c543ce7dd1d804688163bc7895cf592feb445f/storage/google/cloud/storage/blob.py#L989-L997)
-  . The client also handles retries automatically
+  The client library uses multipart upload automatically if the object/blob size is more than 8 MB - [source code](https://github.com/googleapis/google-cloud-python/blob/11c543ce7dd1d804688163bc7895cf592feb445f/storage/google/cloud/storage/blob.py#L989-L997). The client also handles retries automatically
 
-* the `generation` parameter is deprecated in `GoogleCloudStorageHook.delete`
-  and `GoogleCloudStorageHook.insert_object_acl`.
+* the `generation` parameter is deprecated in `GoogleCloudStorageHook.delete` and `GoogleCloudStorageHook.insert_object_acl`.
 
-Updating to `google-cloud-storage >= 1.16` changes the signature of the upstream `client.get_bucket()` method
-from `get_bucket(bucket_name: str)` to `get_bucket(bucket_or_name: Union[str, Bucket])`. This method is not directly
-exposed by the airflow hook, but any code accessing the connection
-directly (`GoogleCloudStorageHook().get_conn().get_bucket(...)` or similar) will need to be updated.
+Updating to `google-cloud-storage >= 1.16` changes the signature of the upstream `client.get_bucket()` method from `get_bucket(bucket_name: str)` to `get_bucket(bucket_or_name: Union[str, Bucket])`. This method is not directly exposed by the airflow hook, but any code accessing the connection directly (`GoogleCloudStorageHook().get_conn().get_bucket(...)` or similar) will need to be updated.
 
 ### Changes in writing Logs to Elasticsearch
 
-The `elasticsearch_` prefix has been removed from all config items under the `[elasticsearch]` section. For
-example `elasticsearch_host` is now just `host`.
+The `elasticsearch_` prefix has been removed from all config items under the `[elasticsearch]` section. For example `elasticsearch_host` is now just `host`.
 
 ### Removal of `non_pooled_task_slot_count` and `non_pooled_backfill_task_slot_count`
 
@@ -2143,24 +2147,25 @@ example `elasticsearch_host` is now just `host`.
 are removed in favor of a real pool, e.g. `default_pool`.
 
 By default tasks are running in `default_pool`.
-`default_pool` is initialized with 128 slots and user can change the number of slots through UI/CLI. `default_pool`
-cannot be removed.
+`default_pool` is initialized with 128 slots and user can change the
+number of slots through UI/CLI. `default_pool` cannot be removed.
 
 ### `pool` config option in Celery section to support different Celery pool implementation
 
-The new `pool` config option allows users to choose different pool implementation. Default value is "prefork", while
-choices include "prefork" (default),
-"eventlet", "gevent" or "solo". This may help users achieve better concurrency performance in different scenarios.
+The new `pool` config option allows users to choose different pool
+implementation. Default value is "prefork", while choices include "prefork" (default),
+"eventlet", "gevent" or "solo". This may help users achieve better concurrency performance
+in different scenarios.
 
 For more details about Celery pool implementation, please refer to:
 
 - https://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency
 - https://docs.celeryproject.org/en/latest/userguide/concurrency/eventlet.html
 
+
 ### Change to method signature in `BaseOperator` and `DAG` classes
 
-The signature of the `get_task_instances` method in the `BaseOperator` and `DAG` classes has changed. The change does
-not change the behavior of the method in either case.
+The signature of the `get_task_instances` method in the `BaseOperator` and `DAG` classes has changed. The change does not change the behavior of the method in either case.
 
 #### For `BaseOperator`
 
@@ -2183,7 +2188,7 @@ Old signature:
 
 ```python
 def get_task_instances(
-  self, session, start_date=None, end_date=None, state=None):
+    self, session, start_date=None, end_date=None, state=None):
 ```
 
 New signature:
@@ -2191,11 +2196,10 @@ New signature:
 ```python
 @provide_session
 def get_task_instances(
-  self, start_date=None, end_date=None, state=None, session=None):
+    self, start_date=None, end_date=None, state=None, session=None):
 ```
 
-In either case, it is necessary to rewrite calls to the `get_task_instances` method that currently provide the `session`
-positional argument. New calls to this method look like:
+In either case, it is necessary to rewrite calls to the `get_task_instances` method that currently provide the `session` positional argument. New calls to this method look like:
 
 ```python
 # if you can rely on @provide_session
@@ -2208,31 +2212,33 @@ dag.get_task_instances(session=your_session)
 
 ### New `dag_discovery_safe_mode` config option
 
-If `dag_discovery_safe_mode` is enabled, only check files for DAGs if they contain the strings "airflow" and "DAG". For
-backwards compatibility, this option is enabled by default.
+If `dag_discovery_safe_mode` is enabled, only check files for DAGs if
+they contain the strings "airflow" and "DAG". For backwards
+compatibility, this option is enabled by default.
 
 ### RedisPy dependency updated to v3 series
 
 If you are using the Redis Sensor or Hook you may have to update your code. See
-[redis-py porting instructions] to check if your code might be affected (MSET, MSETNX, ZADD, and ZINCRBY all were, but
-read the full doc).
+[redis-py porting instructions] to check if your code might be affected (MSET,
+MSETNX, ZADD, and ZINCRBY all were, but read the full doc).
 
 [redis-py porting instructions]: https://github.com/andymccurdy/redis-py/tree/3.2.0#upgrading-from-redis-py-2x-to-30
 
 ### SLUGIFY_USES_TEXT_UNIDECODE or AIRFLOW_GPL_UNIDECODE no longer required
 
-It is no longer required to set one of the environment variables to avoid a GPL dependency. Airflow will now always use
-text-unidecode if unidecode was not installed before.
+It is no longer required to set one of the environment variables to avoid
+a GPL dependency. Airflow will now always use text-unidecode if unidecode
+was not installed before.
 
 ### new `sync_parallelism` config option in celery section
 
-The new `sync_parallelism` config option will control how many processes CeleryExecutor will use to fetch celery task
-state in parallel. Default value is max(1, number of cores - 1)
+The new `sync_parallelism` config option will control how many processes CeleryExecutor will use to
+fetch celery task state in parallel. Default value is max(1, number of cores - 1)
 
 ### Rename of BashTaskRunner to StandardTaskRunner
 
-BashTaskRunner has been renamed to StandardTaskRunner. It is the default task runner so you might need to update your
-config.
+BashTaskRunner has been renamed to StandardTaskRunner. It is the default task runner
+so you might need to update your config.
 
 `task_runner = StandardTaskRunner`
 
@@ -2240,47 +2246,48 @@ config.
 
 If the `AIRFLOW_CONFIG` environment variable was not set and the
 `~/airflow/airflow.cfg` file existed, airflow previously used
-`~/airflow/airflow.cfg` instead of `$AIRFLOW_HOME/airflow.cfg`. Now airflow will discover its config file using
-the `$AIRFLOW_CONFIG` and `$AIRFLOW_HOME`
+`~/airflow/airflow.cfg` instead of `$AIRFLOW_HOME/airflow.cfg`. Now airflow
+will discover its config file using the `$AIRFLOW_CONFIG` and `$AIRFLOW_HOME`
 environment variables rather than checking for the presence of a file.
 
 ### Changes in Google Cloud related operators
 
-Most GCP-related operators have now optional `PROJECT_ID` parameter. In case you do not specify it, the project id
-configured in
-[GCP Connection](https://airflow.apache.org/howto/manage-connections.html#connection-type-gcp) is used. There will be
-an `AirflowException` thrown in case `PROJECT_ID` parameter is not specified and the connection used has no project id
-defined. This change should be backwards compatible as earlier version of the operators had `PROJECT_ID` mandatory.
+Most GCP-related operators have now optional `PROJECT_ID` parameter. In case you do not specify it,
+the project id configured in
+[GCP Connection](https://airflow.apache.org/howto/manage-connections.html#connection-type-gcp) is used.
+There will be an `AirflowException` thrown in case `PROJECT_ID` parameter is not specified and the
+connection used has no project id defined. This change should be  backwards compatible as earlier version
+of the operators had `PROJECT_ID` mandatory.
 
 Operators involved:
 
-* GCP Compute Operators
-  * GceInstanceStartOperator
-  * GceInstanceStopOperator
-  * GceSetMachineTypeOperator
-* GCP Function Operators
-  * GcfFunctionDeployOperator
-* GCP Cloud SQL Operators
-  * CloudSqlInstanceCreateOperator
-  * CloudSqlInstancePatchOperator
-  * CloudSqlInstanceDeleteOperator
-  * CloudSqlInstanceDatabaseCreateOperator
-  * CloudSqlInstanceDatabasePatchOperator
-  * CloudSqlInstanceDatabaseDeleteOperator
+  * GCP Compute Operators
+    * GceInstanceStartOperator
+    * GceInstanceStopOperator
+    * GceSetMachineTypeOperator
+  * GCP Function Operators
+    * GcfFunctionDeployOperator
+  * GCP Cloud SQL Operators
+    * CloudSqlInstanceCreateOperator
+    * CloudSqlInstancePatchOperator
+    * CloudSqlInstanceDeleteOperator
+    * CloudSqlInstanceDatabaseCreateOperator
+    * CloudSqlInstanceDatabasePatchOperator
+    * CloudSqlInstanceDatabaseDeleteOperator
 
 Other GCP operators are unaffected.
 
 ### Changes in Google Cloud related hooks
 
-The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather than
-positional ones in all methods where `project_id` is used. The methods throw an explanatory exception in case they are
-called using positional parameters.
+The change in GCP operators implies that GCP Hooks for those operators require now keyword parameters rather
+than positional ones in all methods where `project_id` is used. The methods throw an explanatory exception
+in case they are called using positional parameters.
 
 Hooks involved:
 
-* GceHook
-* GcfHook
-* CloudSqlHook
+  * GceHook
+  * GcfHook
+  * CloudSqlHook
 
 Other GCP hooks are unaffected.
 
@@ -2291,13 +2298,12 @@ It's now possible to use `None` as a default value with the `default_var` parame
 ```python
 foo = Variable.get("foo", default_var=None)
 if foo is None:
-  handle_missing_foo()
+    handle_missing_foo()
 ```
 
 (Note: there is already `Variable.setdefault()` which me be helpful in some cases.)
 
-This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects
-a `KeyError` to be thrown, then don't pass the `default_var` argument.
+This changes the behaviour if you previously explicitly provided `None` as a default value. If your code expects a `KeyError` to be thrown, then don't pass the `default_var` argument.
 
 ### Removal of `airflow_home` config setting
 
@@ -2305,11 +2311,13 @@ There were previously two ways of specifying the Airflow "home" directory
 (`~/airflow` by default): the `AIRFLOW_HOME` environment variable, and the
 `airflow_home` config setting in the `[core]` section.
 
-If they had two different values different parts of the code base would end up with different values. The config setting
-has been deprecated, and you should remove the value from the config file and set `AIRFLOW_HOME` environment variable if
-you need to use a non default value for this.
+If they had two different values different parts of the code base would end up
+with different values. The config setting has been deprecated, and you should
+remove the value from the config file and set `AIRFLOW_HOME` environment
+variable if you need to use a non default value for this.
 
-(Since this setting is used to calculate what config file to load, it is not possible to keep just the config option)
+(Since this setting is used to calculate what config file to load, it is not
+possible to keep just the config option)
 
 ### Change of two methods signatures in `GCPTransferServiceHook`
 
@@ -2356,7 +2364,7 @@ def wait_for_transfer_job(self, job):
 New signature:
 
 ```python
-def wait_for_transfer_job(self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS,)):
+def wait_for_transfer_job(self, job, expected_statuses=(GcpTransferOperationStatus.SUCCESS, )):
 ```
 
 The behavior of `wait_for_transfer_job` has changed:
@@ -2385,51 +2393,44 @@ The previous imports will continue to work until Airflow 2.0
 
 ### Fixed typo in --driver-class-path in SparkSubmitHook
 
-The `driver_classapth` argument to SparkSubmit Hook and Operator was generating `--driver-classpath` on the spark
-command line, but this isn't a valid option to spark.
+The `driver_classapth` argument  to SparkSubmit Hook and Operator was
+generating `--driver-classpath` on the spark command line, but this isn't a
+valid option to spark.
 
-The argument has been renamed to `driver_class_path`  and the option it generates has been fixed.
+The argument has been renamed to `driver_class_path`  and  the option it
+generates has been fixed.
 
 ## Airflow 1.10.2
 
 ### New `dag_processor_manager_log_location` config option
 
-The DAG parsing manager log now by default will be log into a file, where its location is controlled by the
-new `dag_processor_manager_log_location` config option in core section.
+The DAG parsing manager log now by default will be log into a file, where its location is
+controlled by the new `dag_processor_manager_log_location` config option in core section.
 
 ### DAG level Access Control for new RBAC UI
 
-Extend and enhance new Airflow RBAC UI to support DAG level ACL. Each dag now has two permissions(one for write, one for
-read) associated('can_dag_edit', 'can_dag_read'). The admin will create new role, associate the dag permission with the
-target dag and assign that role to users. That user can only access / view the certain dags on the UI that he has
-permissions on. If a new role wants to access all the dags, the admin could associate dag permissions on an artificial
-view(``all_dags``) with that role.
+Extend and enhance new Airflow RBAC UI to support DAG level ACL. Each dag now has two permissions(one for write, one for read) associated('can_dag_edit', 'can_dag_read').
+The admin will create new role, associate the dag permission with the target dag and assign that role to users. That user can only access / view the certain dags on the UI
+that he has permissions on. If a new role wants to access all the dags, the admin could associate dag permissions on an artificial view(``all_dags``) with that role.
 
 We also provide a new cli command(``sync_perm``) to allow admin to auto sync permissions.
 
 ### Modification to `ts_nodash` macro
 
-`ts_nodash` previously contained TimeZone information along with execution date. For Example: `20150101T000000+0000`.
-This is not user-friendly for file or folder names which was a popular use case for `ts_nodash`. Hence this behavior has
-been changed and using `ts_nodash` will no longer contain TimeZone information, restoring the pre-1.10 behavior of this
-macro. And a new macro `ts_nodash_with_tz` has been added which can be used to get a string with execution date and
-timezone info without dashes.
+`ts_nodash` previously contained TimeZone information along with execution date. For Example: `20150101T000000+0000`. This is not user-friendly for file or folder names which was a popular use case for `ts_nodash`. Hence this behavior has been changed and using `ts_nodash` will no longer contain TimeZone information, restoring the pre-1.10 behavior of this macro. And a new macro `ts_nodash_with_tz` has been added which can be used to get a string with execution date and timezone info without dashes.
 
 Examples:
 
-* `ts_nodash`: `20150101T000000`
-* `ts_nodash_with_tz`: `20150101T000000+0000`
+  * `ts_nodash`: `20150101T000000`
+  * `ts_nodash_with_tz`: `20150101T000000+0000`
 
 ### Semantics of next_ds/prev_ds changed for manually triggered runs
 
-next_ds/prev_ds now map to execution_date instead of the next/previous schedule-aligned execution date for DAGs
-triggered in the UI.
+next_ds/prev_ds now map to execution_date instead of the next/previous schedule-aligned execution date for DAGs triggered in the UI.
 
 ### User model changes
 
-This patch changes the `User.superuser` field from a hardcoded boolean to a `Boolean()` database
-column. `User.superuser` will default to `False`, which means that this privilege will have to be granted manually to
-any users that may require it.
+This patch changes the `User.superuser` field from a hardcoded boolean to a `Boolean()` database column. `User.superuser` will default to `False`, which means that this privilege will have to be granted manually to any users that may require it.
 
 For example, open a Python shell and
 
@@ -2449,10 +2450,10 @@ session.commit()
 
 ### Custom auth backends interface change
 
-We have updated the version of flask-login we depend upon, and as a result any custom auth backends might need a small
-change: `is_active`,
-`is_authenticated`, and `is_anonymous` should now be properties. What this means is if previously you had this in your
-user class
+We have updated the version of flask-login we depend upon, and as a result any
+custom auth backends might need a small change: `is_active`,
+`is_authenticated`, and `is_anonymous` should now be properties. What this means is if
+previously you had this in your user class
 
 ```python
 def is_active(self):
@@ -2469,18 +2470,16 @@ def is_active(self):
 
 ### Support autodetected schemas to GoogleCloudStorageToBigQueryOperator
 
-GoogleCloudStorageToBigQueryOperator is now support schema auto-detection is available when you load data into BigQuery.
-Unfortunately, changes can be required.
+GoogleCloudStorageToBigQueryOperator is now support schema auto-detection is available when you load data into BigQuery. Unfortunately, changes can be required.
 
-If BigQuery tables are created outside of airflow and the schema is not defined in the task, multiple options are
-available:
+If BigQuery tables are created outside of airflow and the schema is not defined in the task, multiple options are available:
 
 define a schema_fields:
 
 ```python
 gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
   ...
-schema_fields = {...})
+  schema_fields={...})
 ```
 
 or define a schema_object:
@@ -2488,7 +2487,7 @@ or define a schema_object:
 ```python
 gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
   ...
-schema_object = 'path/to/schema/object')
+  schema_object='path/to/schema/object')
 ```
 
 or enabled autodetect of schema:
@@ -2496,44 +2495,46 @@ or enabled autodetect of schema:
 ```python
 gcs_to_bq.GoogleCloudStorageToBigQueryOperator(
   ...
-autodetect = True)
+  autodetect=True)
 ```
 
 ## Airflow 1.10.1
 
 ### min_file_parsing_loop_time config option temporarily disabled
 
-The scheduler.min_file_parsing_loop_time config option has been temporarily removed due to some bugs.
+The scheduler.min_file_parsing_loop_time config option has been temporarily removed due to
+some bugs.
 
 ### StatsD Metrics
 
-The `scheduler_heartbeat` metric has been changed from a gauge to a counter. Each loop of the scheduler will increment
-the counter by 1. This provides a higher degree of visibility and allows for better integration with Prometheus using
-the [StatsD Exporter](https://github.com/prometheus/statsd_exporter). The scheduler's activity status can be determined
-by graphing and alerting using a rate of change of the counter. If the scheduler goes down, the rate will drop to 0.
+The `scheduler_heartbeat` metric has been changed from a gauge to a counter. Each loop of the scheduler will increment the counter by 1. This provides a higher degree of visibility and allows for better integration with Prometheus using the [StatsD Exporter](https://github.com/prometheus/statsd_exporter). The scheduler's activity status can be determined by graphing and alerting using a rate of change of the counter. If the scheduler goes down, the rate will drop to 0.
 
 ### EMRHook now passes all of connection's extra to CreateJobFlow API
 
-EMRHook.create_job_flow has been changed to pass all keys to the create_job_flow API, rather than just specific known
-keys for greater flexibility.
+EMRHook.create_job_flow has been changed to pass all keys to the create_job_flow API, rather than
+just specific known keys for greater flexibility.
 
-However prior to this release the "emr_default" sample connection that was created had invalid configuration, so
-creating EMR clusters might fail until your connection is updated. (Ec2KeyName, Ec2SubnetId, TerminationProtection and
-KeepJobFlowAliveWhenNoSteps were all top-level keys when they should be inside the "Instances" dict)
+However prior to this release the "emr_default" sample connection that was created had invalid
+configuration, so creating EMR clusters might fail until your connection is updated. (Ec2KeyName,
+Ec2SubnetId, TerminationProtection and KeepJobFlowAliveWhenNoSteps were all top-level keys when they
+should be inside the "Instances" dict)
 
 ### LDAP Auth Backend now requires TLS
 
-Connecting to an LDAP server over plain text is not supported anymore. The certificate presented by the LDAP server must
-be signed by a trusted certificate, or you must provide the `cacert` option under `[ldap]` in the config file.
+Connecting to an LDAP server over plain text is not supported anymore. The
+certificate presented by the LDAP server must be signed by a trusted
+certificate, or you must provide the `cacert` option under `[ldap]` in the
+config file.
 
-If you want to use LDAP auth backend without TLS then you will have to create a custom-auth backend based on
+If you want to use LDAP auth backend without TLS then you will have to create a
+custom-auth backend based on
 https://github.com/apache/airflow/blob/1.10.0/airflow/contrib/auth/backends/ldap_auth.py
 
 ## Airflow 1.10
 
 Installation and upgrading requires setting `SLUGIFY_USES_TEXT_UNIDECODE=yes` in your environment or
-`AIRFLOW_GPL_UNIDECODE=yes`. In case of the latter a GPL runtime dependency will be installed due to a dependency (
-python-nvd3 -> python-slugify -> unidecode).
+`AIRFLOW_GPL_UNIDECODE=yes`. In case of the latter a GPL runtime dependency will be installed due to a
+dependency (python-nvd3 -> python-slugify -> unidecode).
 
 ### Replace DataProcHook.await calls to DataProcHook.wait
 
@@ -2543,61 +2544,43 @@ The method name was changed to be compatible with the Python 3.7 async/await key
 
 ### Add a configuration variable(default_dag_run_display_number) to control numbers of dag run for display
 
-Add a configuration variable(default_dag_run_display_number) under webserver section to control the number of dag runs
-to show in UI.
+Add a configuration variable(default_dag_run_display_number) under webserver section to control the number of dag runs to show in UI.
 
 ### Default executor for SubDagOperator is changed to SequentialExecutor
 
 ### New Webserver UI with Role-Based Access Control
 
-The current webserver UI uses the Flask-Admin extension. The new webserver UI uses
-the [Flask-AppBuilder (FAB)](https://github.com/dpgaspar/Flask-AppBuilder) extension. FAB has built-in authentication
-support and Role-Based Access Control (RBAC), which provides configurable roles and permissions for individual users.
+The current webserver UI uses the Flask-Admin extension. The new webserver UI uses the [Flask-AppBuilder (FAB)](https://github.com/dpgaspar/Flask-AppBuilder) extension. FAB has built-in authentication support and Role-Based Access Control (RBAC), which provides configurable roles and permissions for individual users.
 
-To turn on this feature, in your airflow.cfg file (under [webserver]), set the configuration variable `rbac = True`, and
-then run `airflow` command, which will generate the `webserver_config.py` file in your $AIRFLOW_HOME.
+To turn on this feature, in your airflow.cfg file (under [webserver]), set the configuration variable `rbac = True`, and then run `airflow` command, which will generate the `webserver_config.py` file in your $AIRFLOW_HOME.
 
 #### Setting up Authentication
 
-FAB has built-in authentication support for DB, OAuth, OpenID, LDAP, and REMOTE_USER. The default auth type is `AUTH_DB`
-.
+FAB has built-in authentication support for DB, OAuth, OpenID, LDAP, and REMOTE_USER. The default auth type is `AUTH_DB`.
 
-For any other authentication type (OAuth, OpenID, LDAP, REMOTE_USER), see
-the [Authentication section of FAB docs](http://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods)
-for how to configure variables in webserver_config.py file.
+For any other authentication type (OAuth, OpenID, LDAP, REMOTE_USER), see the [Authentication section of FAB docs](http://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for how to configure variables in webserver_config.py file.
 
-Once you modify your config file, run `airflow db init` to generate new tables for RBAC support (these tables will have
-the prefix `ab_`).
+Once you modify your config file, run `airflow db init` to generate new tables for RBAC support (these tables will have the prefix `ab_`).
 
 #### Creating an Admin Account
 
-Once configuration settings have been updated and new tables have been generated, create an admin account
-with `airflow create_user` command.
+Once configuration settings have been updated and new tables have been generated, create an admin account with `airflow create_user` command.
 
 #### Using your new UI
 
-Run `airflow webserver` to start the new UI. This will bring up a log in page, enter the recently created admin username
-and password.
+Run `airflow webserver` to start the new UI. This will bring up a log in page, enter the recently created admin username and password.
 
-There are five roles created for Airflow by default: Admin, User, Op, Viewer, and Public. To configure
-roles/permissions, go to the `Security` tab and click `List Roles` in the new UI.
+There are five roles created for Airflow by default: Admin, User, Op, Viewer, and Public. To configure roles/permissions, go to the `Security` tab and click `List Roles` in the new UI.
 
 #### Breaking changes
 
-- AWS Batch Operator renamed property queue to job_queue to prevent conflict with the internal queue from CeleryExecutor
-  - AIRFLOW-2542
-- Users created and stored in the old users table will not be migrated automatically. FAB's built-in authentication
-  support must be reconfigured.
+- AWS Batch Operator renamed property queue to job_queue to prevent conflict with the internal queue from CeleryExecutor - AIRFLOW-2542
+- Users created and stored in the old users table will not be migrated automatically. FAB's built-in authentication support must be reconfigured.
 - Airflow dag home page is now `/home` (instead of `/admin`).
-- All ModelViews in Flask-AppBuilder follow a different pattern from Flask-Admin. The `/admin` part of the URL path will
-  no longer exist. For example: `/admin/connection` becomes `/connection/list`, `/admin/connection/new`
-  becomes `/connection/add`, `/admin/connection/edit` becomes `/connection/edit`, etc.
-- Due to security concerns, the new webserver will no longer support the features in the `Data Profiling` menu of old
-  UI, including `Ad Hoc Query`, `Charts`, and `Known Events`.
-- HiveServer2Hook.get_results() always returns a list of tuples, even when a single column is queried, as per Python API
-  2.
-- **UTC is now the default timezone**: Either reconfigure your workflows scheduling in UTC or set `default_timezone` as
-  explained in https://airflow.apache.org/timezone.html#default-time-zone
+- All ModelViews in Flask-AppBuilder follow a different pattern from Flask-Admin. The `/admin` part of the URL path will no longer exist. For example: `/admin/connection` becomes `/connection/list`, `/admin/connection/new` becomes `/connection/add`, `/admin/connection/edit` becomes `/connection/edit`, etc.
+- Due to security concerns, the new webserver will no longer support the features in the `Data Profiling` menu of old UI, including `Ad Hoc Query`, `Charts`, and `Known Events`.
+- HiveServer2Hook.get_results() always returns a list of tuples, even when a single column is queried, as per Python API 2.
+- **UTC is now the default timezone**: Either reconfigure your workflows scheduling in UTC or set `default_timezone` as explained in https://airflow.apache.org/timezone.html#default-time-zone
 
 ### airflow.contrib.sensors.hdfs_sensors renamed to airflow.contrib.sensors.hdfs_sensor
 
@@ -2605,8 +2588,8 @@ We now rename airflow.contrib.sensors.hdfs_sensors to airflow.contrib.sensors.hd
 
 ### MySQL setting required
 
-We now rely on more strict ANSI SQL settings for MySQL in order to have sane defaults. Make sure to have
-specified `explicit_defaults_for_timestamp=1` in your my.cnf under `[mysqld]`
+We now rely on more strict ANSI SQL settings for MySQL in order to have sane defaults. Make sure
+to have specified `explicit_defaults_for_timestamp=1` in your my.cnf under `[mysqld]`
 
 ### Celery config
 
@@ -2625,33 +2608,28 @@ Resulting in the same config parameters as Celery 4, with more transparency.
 ### GCP Dataflow Operators
 
 Dataflow job labeling is now supported in Dataflow{Java,Python}Operator with a default
-"airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version to 2.2.0 or greater.
+"airflow-version" label, please upgrade your google-cloud-dataflow or apache-beam version
+to 2.2.0 or greater.
 
 ### BigQuery Hooks and Operator
 
-The `bql` parameter passed to `BigQueryOperator` and `BigQueryBaseCursor.run_query` has been deprecated and renamed
-to `sql` for consistency purposes. Using `bql` will still work (and raise a `DeprecationWarning`), but is no longer
+The `bql` parameter passed to `BigQueryOperator` and `BigQueryBaseCursor.run_query` has been deprecated and renamed to `sql` for consistency purposes. Using `bql` will still work (and raise a `DeprecationWarning`), but is no longer
 supported and will be removed entirely in Airflow 2.0
 
 ### Redshift to S3 Operator
 
-With Airflow 1.9 or lower, Unload operation always included header row. In order to include header row, we need to turn
-off parallel unload. It is preferred to perform unload operation using all nodes so that it is faster for larger tables.
-So, parameter called `include_header` is added and default is set to False. Header row will be added only if this
-parameter is set True and also in that case parallel will be automatically turned off (`PARALLEL OFF`)
+With Airflow 1.9 or lower, Unload operation always included header row. In order to include header row,
+we need to turn off parallel unload. It is preferred to perform unload operation using all nodes so that it is
+faster for larger tables. So, parameter called `include_header` is added and default is set to False.
+Header row will be added only if this parameter is set True and also in that case parallel will be automatically turned off (`PARALLEL OFF`)
 
 ### Google cloud connection string
 
-With Airflow 1.9 or lower, there were two connection strings for the Google Cloud operators,
-both `google_cloud_storage_default` and `google_cloud_default`. This can be confusing and therefore
-the `google_cloud_storage_default` connection id has been replaced with `google_cloud_default` to make the connection id
-consistent across Airflow.
+With Airflow 1.9 or lower, there were two connection strings for the Google Cloud operators, both `google_cloud_storage_default` and `google_cloud_default`. This can be confusing and therefore the `google_cloud_storage_default` connection id has been replaced with `google_cloud_default` to make the connection id consistent across Airflow.
 
 ### Logging Configuration
 
-With Airflow 1.9 or lower, `FILENAME_TEMPLATE`, `PROCESSOR_FILENAME_TEMPLATE`, `LOG_ID_TEMPLATE`, `END_OF_LOG_MARK` were
-configured in `airflow_local_settings.py`. These have been moved into the configuration file, and hence if you were
-using a custom configuration file the following defaults need to be added.
+With Airflow 1.9 or lower, `FILENAME_TEMPLATE`, `PROCESSOR_FILENAME_TEMPLATE`, `LOG_ID_TEMPLATE`, `END_OF_LOG_MARK` were configured in `airflow_local_settings.py`. These have been moved into the configuration file, and hence if you were using a custom configuration file the following defaults need to be added.
 
 ```
 [core]
@@ -2664,15 +2642,11 @@ elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_
 elasticsearch_end_of_log_mark = end_of_log
 ```
 
-The previous setting of `log_task_reader` is not needed in many cases now when using the default logging config with
-remote storages. (Previously it needed to be set to `s3.task` or similar. This is not needed with the default config
-anymore)
+The previous setting of `log_task_reader` is not needed in many cases now when using the default logging config with remote storages. (Previously it needed to be set to `s3.task` or similar. This is not needed with the default config anymore)
 
 #### Change of per-task log path
 
-With the change to Airflow core to be timezone aware the default log path for task instances will now include timezone
-information. This will by default mean all previous task logs won't be found. You can get the old behaviour back by
-setting the following config options:
+With the change to Airflow core to be timezone aware the default log path for task instances will now include timezone information. This will by default mean all previous task logs won't be found. You can get the old behaviour back by setting the following config options:
 
 ```
 [core]
@@ -2683,60 +2657,43 @@ log_filename_template = {{ ti.dag_id }}/{{ ti.task_id }}/{{ execution_date.strft
 
 ### SSH Hook updates, along with new SSH Operator & SFTP Operator
 
-SSH Hook now uses the Paramiko library to create an ssh client connection, instead of the sub-process based ssh command
-execution previously (<1.9.0), so this is backward incompatible.
+SSH Hook now uses the Paramiko library to create an ssh client connection, instead of the sub-process based ssh command execution previously (<1.9.0), so this is backward incompatible.
 
 - update SSHHook constructor
-- use SSHOperator class in place of SSHExecuteOperator which is removed now. Refer to test_ssh_operator.py for usage
-  info.
-- SFTPOperator is added to perform secure file transfer from serverA to serverB. Refer to test_sftp_operator.py for
-  usage info.
+- use SSHOperator class in place of SSHExecuteOperator which is removed now. Refer to test_ssh_operator.py for usage info.
+- SFTPOperator is added to perform secure file transfer from serverA to serverB. Refer to test_sftp_operator.py for usage info.
 - No updates are required if you are using ftpHook, it will continue to work as is.
 
 ### S3Hook switched to use Boto3
 
-The airflow.hooks.S3_hook.S3Hook has been switched to use boto3 instead of the older boto (a.k.a. boto2). This results
-in a few backwards incompatible changes to the following classes: S3Hook:
+The airflow.hooks.S3_hook.S3Hook has been switched to use boto3 instead of the older boto (a.k.a. boto2). This results in a few backwards incompatible changes to the following classes: S3Hook:
 
 - the constructors no longer accepts `s3_conn_id`. It is now called `aws_conn_id`.
 - the default connection is now "aws_default" instead of "s3_default"
 - the return type of objects returned by `get_bucket` is now boto3.s3.Bucket
 - the return type of `get_key`, and `get_wildcard_key` is now an boto3.S3.Object.
 
-If you are using any of these in your DAGs and specify a connection ID you will need to update the parameter name for
-the connection to "aws_conn_id": S3ToHiveTransfer, S3PrefixSensor, S3KeySensor, RedshiftToS3Transfer.
+If you are using any of these in your DAGs and specify a connection ID you will need to update the parameter name for the connection to "aws_conn_id": S3ToHiveTransfer, S3PrefixSensor, S3KeySensor, RedshiftToS3Transfer.
 
 ### Logging update
 
-The logging structure of Airflow has been rewritten to make configuration easier and the logging system more
-transparent.
+The logging structure of Airflow has been rewritten to make configuration easier and the logging system more transparent.
 
 #### A quick recap about logging
 
-A logger is the entry point into the logging system. Each logger is a named bucket to which messages can be written for
-processing. A logger is configured to have a log level. This log level describes the severity of the messages that the
-logger will handle. Python defines the following log levels: DEBUG, INFO, WARNING, ERROR or CRITICAL.
+A logger is the entry point into the logging system. Each logger is a named bucket to which messages can be written for processing. A logger is configured to have a log level. This log level describes the severity of the messages that the logger will handle. Python defines the following log levels: DEBUG, INFO, WARNING, ERROR or CRITICAL.
 
-Each message that is written to the logger is a Log Record. Each log record contains a log level indicating the severity
-of that specific message. A log record can also contain useful metadata that describes the event that is being logged.
-This can include details such as a stack trace or an error code.
+Each message that is written to the logger is a Log Record. Each log record contains a log level indicating the severity of that specific message. A log record can also contain useful metadata that describes the event that is being logged. This can include details such as a stack trace or an error code.
 
-When a message is given to the logger, the log level of the message is compared to the log level of the logger. If the
-log level of the message meets or exceeds the log level of the logger itself, the message will undergo further
-processing. If it doesn’t, the message will be ignored.
+When a message is given to the logger, the log level of the message is compared to the log level of the logger. If the log level of the message meets or exceeds the log level of the logger itself, the message will undergo further processing. If it doesn’t, the message will be ignored.
 
-Once a logger has determined that a message needs to be processed, it is passed to a Handler. This configuration is now
-more flexible and can be easily be maintained in a single file.
+Once a logger has determined that a message needs to be processed, it is passed to a Handler. This configuration is now more flexible and can be easily be maintained in a single file.
 
 #### Changes in Airflow Logging
 
-Airflow's logging mechanism has been refactored to use Python’s built-in `logging` module to perform logging of the
-application. By extending classes with the existing `LoggingMixin`, all the logging will go through a central logger.
-Also the `BaseHook` and `BaseOperator` already extend this class, so it is easily available to do logging.
+Airflow's logging mechanism has been refactored to use Python’s built-in `logging` module to perform logging of the application. By extending classes with the existing `LoggingMixin`, all the logging will go through a central logger. Also the `BaseHook` and `BaseOperator` already extend this class, so it is easily available to do logging.
 
-The main benefit is easier configuration of the logging by setting a single centralized python file. Disclaimer; there
-is still some inline configuration, but this will be removed eventually. The new logging class is defined by setting the
-dotted classpath in your `~/airflow/airflow.cfg` file:
+The main benefit is easier configuration of the logging by setting a single centralized python file. Disclaimer; there is still some inline configuration, but this will be removed eventually. The new logging class is defined by setting the dotted classpath in your `~/airflow/airflow.cfg` file:
 
 ```
 # Logging class
@@ -2745,12 +2702,9 @@ dotted classpath in your `~/airflow/airflow.cfg` file:
 logging_config_class = my.path.default_local_settings.LOGGING_CONFIG
 ```
 
-The logging configuration file needs to be on the `PYTHONPATH`, for example `$AIRFLOW_HOME/config`. This directory is
-loaded by default. Any directory may be added to the `PYTHONPATH`, this might be handy when the config is in another
-directory or a volume is mounted in case of Docker.
+The logging configuration file needs to be on the `PYTHONPATH`, for example `$AIRFLOW_HOME/config`. This directory is loaded by default. Any directory may be added to the `PYTHONPATH`, this might be handy when the config is in another directory or a volume is mounted in case of Docker.
 
-The config can be taken from `airflow/config_templates/airflow_local_settings.py` as a starting point. Copy the contents
-to `${AIRFLOW_HOME}/config/airflow_local_settings.py`, and alter the config as is preferred.
+The config can be taken from `airflow/config_templates/airflow_local_settings.py` as a starting point. Copy the contents to `${AIRFLOW_HOME}/config/airflow_local_settings.py`,  and alter the config as is preferred.
 
 ```
 #
@@ -2865,9 +2819,7 @@ DEFAULT_LOGGING_CONFIG = {
 }
 ```
 
-To customize the logging (for example, use logging rotate), define one or more of the logging handles
-that [Python has to offer](https://docs.python.org/3/library/logging.handlers.html). For more details about the Python
-logging, please refer to the [official logging documentation](https://docs.python.org/3/library/logging.html).
+To customize the logging (for example, use logging rotate), define one or more of the logging handles that [Python has to offer](https://docs.python.org/3/library/logging.handlers.html). For more details about the Python logging, please refer to the [official logging documentation](https://docs.python.org/3/library/logging.html).
 
 Furthermore, this change also simplifies logging within the DAG itself:
 
@@ -2892,30 +2844,18 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 #### Template path of the file_task_handler
 
-The `file_task_handler` logger has been made more flexible. The default format can be
-changed, `{dag_id}/{task_id}/{execution_date}/{try_number}.log` by supplying Jinja templating in the `FILENAME_TEMPLATE`
-configuration variable. See the `file_task_handler` for more information.
+The `file_task_handler` logger has been made more flexible. The default format can be changed, `{dag_id}/{task_id}/{execution_date}/{try_number}.log` by supplying Jinja templating in the `FILENAME_TEMPLATE` configuration variable. See the `file_task_handler` for more information.
 
 #### I'm using S3Log or GCSLogs, what do I do!?
 
-If you are logging to Google cloud storage, please see
-the [Google cloud platform documentation](https://airflow.apache.org/integration.html#gcp-google-cloud-platform) for
-logging instructions.
+If you are logging to Google cloud storage, please see the [Google cloud platform documentation](https://airflow.apache.org/integration.html#gcp-google-cloud-platform) for logging instructions.
 
-If you are using S3, the instructions should be largely the same as the Google cloud platform instructions above. You
-will need a custom logging config. The `REMOTE_BASE_LOG_FOLDER` configuration key in your airflow config has been
-removed, therefore you will need to take the following steps:
+If you are using S3, the instructions should be largely the same as the Google cloud platform instructions above. You will need a custom logging config. The `REMOTE_BASE_LOG_FOLDER` configuration key in your airflow config has been removed, therefore you will need to take the following steps:
 
-- Copy the logging configuration
-  from [`airflow/config_templates/airflow_logging_settings.py`](https://github.com/apache/airflow/blob/master/airflow/config_templates/airflow_local_settings.py)
-  .
-- Place it in a directory inside the Python import path `PYTHONPATH`. If you are using Python 2.7, ensuring that
-  any `__init__.py` files exist so that it is importable.
-- Update the config by setting the path of `REMOTE_BASE_LOG_FOLDER` explicitly in the config.
-  The `REMOTE_BASE_LOG_FOLDER` key is not used anymore.
-- Set the `logging_config_class` to the filename and dict. For example, if you place `custom_logging_config.py` on the
-  base of your `PYTHONPATH`, you will need to set `logging_config_class = custom_logging_config.LOGGING_CONFIG` in your
-  config as Airflow 1.8.
+- Copy the logging configuration from [`airflow/config_templates/airflow_logging_settings.py`](https://github.com/apache/airflow/blob/master/airflow/config_templates/airflow_local_settings.py).
+- Place it in a directory inside the Python import path `PYTHONPATH`. If you are using Python 2.7, ensuring that any `__init__.py` files exist so that it is importable.
+- Update the config by setting the path of `REMOTE_BASE_LOG_FOLDER` explicitly in the config. The `REMOTE_BASE_LOG_FOLDER` key is not used anymore.
+- Set the `logging_config_class` to the filename and dict. For example, if you place `custom_logging_config.py` on the base of your `PYTHONPATH`, you will need to set `logging_config_class = custom_logging_config.LOGGING_CONFIG` in your config as Airflow 1.8.
 
 ### New Features
 
@@ -2928,34 +2868,32 @@ A new DaskExecutor allows Airflow tasks to be run in Dask Distributed clusters.
 These features are marked for deprecation. They may still work (and raise a `DeprecationWarning`), but are no longer
 supported and will be removed entirely in Airflow 2.0
 
-- If you're using the `google_cloud_conn_id` or `dataproc_cluster` argument names explicitly
-  in `contrib.operators.Dataproc{*}Operator`(s), be sure to rename them to `gcp_conn_id` or `cluster_name`,
-  respectively. We've renamed these arguments for consistency. (AIRFLOW-1323)
+- If you're using the `google_cloud_conn_id` or `dataproc_cluster` argument names explicitly in `contrib.operators.Dataproc{*}Operator`(s), be sure to rename them to `gcp_conn_id` or `cluster_name`, respectively. We've renamed these arguments for consistency. (AIRFLOW-1323)
 
 - `post_execute()` hooks now take two arguments, `context` and `result`
   (AIRFLOW-886)
 
   Previously, post_execute() only took one argument, `context`.
 
-- `contrib.hooks.gcp_dataflow_hook.DataFlowHook` starts to use `--runner=DataflowRunner` instead
-  of `DataflowPipelineRunner`, which is removed from the package `google-cloud-dataflow-0.6.0`.
+- `contrib.hooks.gcp_dataflow_hook.DataFlowHook` starts to use `--runner=DataflowRunner` instead of `DataflowPipelineRunner`, which is removed from the package `google-cloud-dataflow-0.6.0`.
 
-- The pickle type for XCom messages has been replaced by json to prevent RCE attacks. Note that JSON serialization is
-  stricter than pickling, so if you want to e.g. pass raw bytes through XCom you must encode them using an encoding like
-  base64. By default pickling is still enabled until Airflow 2.0. To disable it set enable_xcom_pickling = False in your
-  Airflow config.
+- The pickle type for XCom messages has been replaced by json to prevent RCE attacks.
+  Note that JSON serialization is stricter than pickling, so if you want to e.g. pass
+  raw bytes through XCom you must encode them using an encoding like base64.
+  By default pickling is still enabled until Airflow 2.0. To disable it
+  set enable_xcom_pickling = False in your Airflow config.
 
 ## Airflow 1.8.1
 
-The Airflow package name was changed from `airflow` to `apache-airflow` during this release. You must uninstall a
-previously installed version of Airflow before installing 1.8.1.
+The Airflow package name was changed from `airflow` to `apache-airflow` during this release. You must uninstall
+a previously installed version of Airflow before installing 1.8.1.
 
 ## Airflow 1.8
 
 ### Database
 
-The database schema needs to be upgraded. Make sure to shutdown Airflow and make a backup of your database. To upgrade
-the schema issue `airflow upgradedb`.
+The database schema needs to be upgraded. Make sure to shutdown Airflow and make a backup of your database. To
+upgrade the schema issue `airflow upgradedb`.
 
 ### Upgrade systemd unit files
 
@@ -2965,10 +2903,10 @@ Systemd unit files have been updated. If you use systemd please make sure to upd
 
 ### Tasks not starting although dependencies are met due to stricter pool checking
 
-Airflow 1.7.1 has issues with being able to over subscribe to a pool, ie. more slots could be used than were available.
-This is fixed in Airflow 1.8.0, but due to past issue jobs may fail to start although their dependencies are met after
-an upgrade. To workaround either temporarily increase the amount of slots above the amount of queued tasks or use a new
-pool.
+Airflow 1.7.1 has issues with being able to over subscribe to a pool, ie. more slots could be used than were
+available. This is fixed in Airflow 1.8.0, but due to past issue jobs may fail to start although their
+dependencies are met after an upgrade. To workaround either temporarily increase the amount of slots above
+the amount of queued tasks or use a new pool.
 
 ### Less forgiving scheduler on dynamic start_date
 
@@ -2983,16 +2921,16 @@ Please read through the new scheduler options, defaults have changed since 1.7.1
 
 #### child_process_log_directory
 
-In order to increase the robustness of the scheduler, DAGS are now processed in their own process. Therefore each DAG
-has its own log file for the scheduler. These log files are placed in `child_process_log_directory` which defaults to
+In order to increase the robustness of the scheduler, DAGS are now processed in their own process. Therefore each
+DAG has its own log file for the scheduler. These log files are placed in `child_process_log_directory` which defaults to
 `<AIRFLOW_HOME>/scheduler/latest`. You will need to make sure these log files are removed.
 
 > DAG logs or processor logs ignore and command line settings for log file locations.
 
 #### run_duration
 
-Previously the command line option `num_runs` was used to let the scheduler terminate after a certain amount of loops.
-This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
+Previously the command line option `num_runs` was used to let the scheduler terminate after a certain amount of
+loops. This is now time bound and defaults to `-1`, which means run continuously. See also num_runs.
 
 #### num_runs
 
@@ -3006,13 +2944,12 @@ After how much time should an updated DAG be picked up from the filesystem.
 
 #### min_file_parsing_loop_time
 
-CURRENTLY DISABLED DUE TO A BUG How many seconds to wait between file-parsing loops to prevent the logs from being
-spammed.
+CURRENTLY DISABLED DUE TO A BUG
+How many seconds to wait between file-parsing loops to prevent the logs from being spammed.
 
 #### dag_dir_list_interval
 
-The frequency with which the scheduler should relist the contents of the DAG directory. If while developing +dags, they
-are not being picked up, have a look at this number and decrease it when necessary.
+The frequency with which the scheduler should relist the contents of the DAG directory. If while developing +dags, they are not being picked up, have a look at this number and decrease it when necessary.
 
 #### catchup_by_default
 
@@ -3022,8 +2959,8 @@ This setting changes that behavior to only execute the latest interval. This can
 
 ### Faulty DAGs do not show an error in the Web UI
 
-Due to changes in the way Airflow processes DAGs the Web UI does not show an error when processing a faulty DAG. To find
-processing errors go the `child_process_log_directory` which defaults to `<AIRFLOW_HOME>/scheduler/latest`.
+Due to changes in the way Airflow processes DAGs the Web UI does not show an error when processing a faulty DAG. To
+find processing errors go the `child_process_log_directory` which defaults to `<AIRFLOW_HOME>/scheduler/latest`.
 
 ### New DAGs are paused by default
 
@@ -3036,17 +2973,18 @@ dags_are_paused_at_creation = False
 
 ### Airflow Context variable are passed to Hive config if conf is specified
 
-If you specify a hive conf to the run_cli command of the HiveHook, Airflow add some convenience variables to the config.
-In case you run a secure Hadoop setup it might be required to allow these variables by adjusting you hive configuration
-to add `airflow\.ctx\..*` to the regex of user-editable configuration properties. See
+If you specify a hive conf to the run_cli command of the HiveHook, Airflow add some
+convenience variables to the config. In case you run a secure Hadoop setup it might be
+required to allow these variables by adjusting you hive configuration to add `airflow\.ctx\..*` to the regex
+of user-editable configuration properties. See
 [the Hive docs on Configuration Properties][hive.security.authorization.sqlstd] for more info.
 
 [hive.security.authorization.sqlstd]: https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=82903061#ConfigurationProperties-SQLStandardBasedAuthorization.1
 
 ### Google Cloud Operator and Hook alignment
 
-All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection type
-for all kinds of Google Cloud Operators.
+All Google Cloud Operators and Hooks are aligned and use the same client library. Now you have a single connection
+type for all kinds of Google Cloud Operators.
 
 If you experience problems connecting with your operator make sure you set the connection type "Google Cloud".
 


### PR DESCRIPTION
Upgrade check for use of CustomSQLAInterface
instead of SQLAInterface to create custom data model.

From Airflow 2.0, if you want to define your own Flask App Builder
models you need to use CustomSQLAInterface instead of SQLAInterface.

For Non-RBAC replace:

`from flask_appbuilder.models.sqla.interface import SQLAInterface`
`datamodel = SQLAInterface(your_data_model)`

with RBAC (in 1.10):

`from airflow.www_rbac.utils import CustomSQLAInterface`
`datamodel = CustomSQLAInterface(your_data_model)`

and in 2.0:

`from airflow.www.utils import CustomSQLAInterface`
`datamodel = CustomSQLAInterface(your_data_model)`

closes: #13226 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
