### PR TITLE
Use click for building prepare_provider_packages.py CLI

### DIFF
--- a/dev/provider_packages/README.md
+++ b/dev/provider_packages/README.md
@@ -333,8 +333,9 @@ pip install -e ".[devel_all]"
 3) Run update documentation (version suffix might be empty):
 
 ```shell script
-./dev/provider_packages/prepare_provider_packages.py --version-suffix <SUFFIX> \
-    update-package-documentation <PACKAGE>
+./dev/provider_packages/prepare_provider_packages.py update-package-documentation \
+    --version-suffix <SUFFIX> \
+    <PACKAGE>
 ```
 
 This script will fetch the latest version of airflow from Airflow's repo (it will automatically add
@@ -394,8 +395,9 @@ last time it was generated. In the CI we always add 'dev' suffix, and we never c
 TAG for it, so in the CI the setup.py is generated and should never fail.
 
 ```shell script
-./dev/provider_packages/prepare_provider_packages.py --version-suffix "<SUFFIX>" \
-  generate-setup-files <PACKAGE>
+./dev/provider_packages/prepare_provider_packages.py generate-setup-files \
+    --version-suffix "<SUFFIX>" \
+    <PACKAGE>
 ```
 
 ## Debugging preparing the packages
@@ -424,8 +426,9 @@ pip install -e ".[devel_all]"
 3) Run update documentation (version suffix might be empty):
 
 ```shell script
-./dev/provider_packages/prepare_provider_packages.py --version-suffix <SUFFIX> \
-    build-provider-packages <PACKAGE>
+./dev/provider_packages/prepare_provider_packages.py build-provider-packages \
+    --version-suffix <SUFFIX> \
+    <PACKAGE>
 ```
 
 In case version being prepared is already tagged in the repo documentation preparation returns immediately

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -606,8 +606,8 @@ function get_providers_to_act_on() {
     if [[ -z "$*" ]]; then
         while IFS='' read -r line; do PROVIDER_PACKAGES+=("$line"); done < <(
             python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
-                "${OPTIONAL_BACKPORT_FLAG[@]}" \
-                list-providers-packages
+                list-providers-packages \
+                "${OPTIONAL_BACKPORT_FLAG[@]}"
         )
         if [[ "$BACKPORT_PACKAGES" != "true" ]]; then
             # Don't check for missing packages when we are building backports -- we have filtered some out,
@@ -622,8 +622,9 @@ function get_providers_to_act_on() {
             echo "You can provide list of packages to build out of:"
             echo
             python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
+                list-providers-packages \
                 "${OPTIONAL_BACKPORT_FLAG[@]}" \
-                list-providers-packages | tr '\n ' ' ' | fold -w 100 -s
+                | tr '\n ' ' ' | fold -w 100 -s
             echo
             echo
             exit

--- a/scripts/in_container/run_prepare_provider_documentation.sh
+++ b/scripts/in_container/run_prepare_provider_documentation.sh
@@ -26,8 +26,8 @@ function import_all_provider_classes() {
 
 function verify_provider_packages_named_properly() {
     python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
-        "${OPTIONAL_BACKPORT_FLAG[@]}" \
-        verify-provider-classes
+        verify-provider-classes \
+        "${OPTIONAL_BACKPORT_FLAG[@]}"
 }
 
 function run_prepare_documentation() {
@@ -45,11 +45,11 @@ function run_prepare_documentation() {
         local res
         # There is a separate group created in logs for each provider package
         python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
+            update-package-documentation \
             --version-suffix "${TARGET_VERSION_SUFFIX}" \
             --no-git-update \
             "${OPTIONAL_BACKPORT_FLAG[@]}" \
             "${OPTIONAL_RELEASE_VERSION_ARGUMENT[@]}" \
-            update-package-documentation \
             "${provider_package}"
         res=$?
         if [[ ${res} == "64" ]]; then

--- a/scripts/in_container/run_prepare_provider_packages.sh
+++ b/scripts/in_container/run_prepare_provider_packages.sh
@@ -86,10 +86,11 @@ function build_provider_packages() {
         local res
         set +e
         python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
+            generate-setup-files \
             "${OPTIONAL_BACKPORT_FLAG[@]}" \
             --no-git-update \
             --version-suffix "${VERSION_SUFFIX_FOR_PYPI}" \
-            generate-setup-files "${provider_package}"
+            "${provider_package}"
         res=$?
         set -e
         if [[ ${res} == "64" ]]; then
@@ -110,11 +111,11 @@ function build_provider_packages() {
             package_suffix="${VERSION_SUFFIX_FOR_PYPI}"
         fi
         python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
+            build-provider-packages \
             "${OPTIONAL_BACKPORT_FLAG[@]}" \
             --no-git-update \
             --version-suffix "${package_suffix}" \
             "${package_format_args[@]}" \
-            build-provider-packages \
             "${provider_package}"
         res=$?
         set -e


### PR DESCRIPTION
Click is already a dev dependency and handles a lot of the CLI we need
nicely.

One change I have made here is to only have the various options only
apply to the subcommands that use them, i.e. `list-providers-packages
--release-version 2020.10.10` would be an error now.

This does mean that the command has to come before the options -- all
the automated uses have been updated.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
