### PR TITLE
Bugfix: Fix wrong output of tags and owners in dag detail API endpoint

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1940,39 +1940,84 @@ components:
 
         For details see:
         (airflow.models.DAG)[https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/index.html#airflow.models.DAG]
-      allOf:
-        - $ref: '#/components/schemas/DAG'
-        - type: object
-          properties:
-            timezone:
-              $ref: '#/components/schemas/Timezone'
-            catchup:
-              type: boolean
-              readOnly: true
-            orientation:
-              type: string
-              readOnly: true
-            concurrency:
-              type: number
-              readOnly: true
-            start_date:
-              type: string
-              format: 'date-time'
-              readOnly: true
-              nullable: true
-            dag_run_timeout:
-              nullable: true
-              $ref: '#/components/schemas/TimeDelta'
-            doc_md:
-              type: string
-              readOnly: true
-              nullable: true
-            default_view:
-              type: string
-              readOnly: true
-            params:
-              type: object
-              readOnly: true
+      properties:
+        dag_id:
+          type: string
+          readOnly: true
+          description: The ID of the DAG.
+        root_dag_id:
+          type: string
+          readOnly: true
+          nullable: true
+          description: If the DAG is SubDAG then it is the top level DAG identifier. Otherwise, nulll.
+        is_paused:
+          type: boolean
+          nullable: true
+          description: Whether the DAG is paused.
+        is_subdag:
+          description: Whether the DAG is SubDAG.
+          type: boolean
+          readOnly: true
+        fileloc:
+          description: The absolute path to the file.
+          type: string
+          readOnly: true
+        file_token:
+          type: string
+          readOnly: true
+          description: >
+            The key containing the encrypted path to the file. Encryption and decryption take place only on
+            the server. This prevents the client from reading an non-DAG file. This also ensures API
+            extensibility, because the format of encrypted data may change.
+        owner:
+          type: string
+          nullable: true
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+          nullable: true
+          description: >
+            User-provided DAG description, which can consist of several sentences or paragraphs that
+            describe DAG contents.
+        schedule_interval:
+          $ref: '#/components/schemas/ScheduleInterval'
+        tags:
+          description: List of tags.
+          type: array
+          items:
+            type: string
+          readOnly: true
+          nullable: true
+        timezone:
+          $ref: '#/components/schemas/Timezone'
+        catchup:
+          type: boolean
+          readOnly: true
+        orientation:
+          type: string
+          readOnly: true
+        concurrency:
+          type: number
+          readOnly: true
+        start_date:
+          type: string
+          format: 'date-time'
+          readOnly: true
+          nullable: true
+        dag_run_timeout:
+          nullable: true
+          $ref: '#/components/schemas/TimeDelta'
+        doc_md:
+          type: string
+          readOnly: true
+          nullable: true
+        default_view:
+          type: string
+          readOnly: true
+        params:
+          type: object
+          readOnly: true
 
     ExtraLink:
       type: object

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1940,84 +1940,39 @@ components:
 
         For details see:
         (airflow.models.DAG)[https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/index.html#airflow.models.DAG]
-      properties:
-        dag_id:
-          type: string
-          readOnly: true
-          description: The ID of the DAG.
-        root_dag_id:
-          type: string
-          readOnly: true
-          nullable: true
-          description: If the DAG is SubDAG then it is the top level DAG identifier. Otherwise, nulll.
-        is_paused:
-          type: boolean
-          nullable: true
-          description: Whether the DAG is paused.
-        is_subdag:
-          description: Whether the DAG is SubDAG.
-          type: boolean
-          readOnly: true
-        fileloc:
-          description: The absolute path to the file.
-          type: string
-          readOnly: true
-        file_token:
-          type: string
-          readOnly: true
-          description: >
-            The key containing the encrypted path to the file. Encryption and decryption take place only on
-            the server. This prevents the client from reading an non-DAG file. This also ensures API
-            extensibility, because the format of encrypted data may change.
-        owner:
-          type: string
-          nullable: true
-          readOnly: true
-        description:
-          type: string
-          readOnly: true
-          nullable: true
-          description: >
-            User-provided DAG description, which can consist of several sentences or paragraphs that
-            describe DAG contents.
-        schedule_interval:
-          $ref: '#/components/schemas/ScheduleInterval'
-        tags:
-          description: List of tags.
-          type: array
-          items:
-            type: string
-          readOnly: true
-          nullable: true
-        timezone:
-          $ref: '#/components/schemas/Timezone'
-        catchup:
-          type: boolean
-          readOnly: true
-        orientation:
-          type: string
-          readOnly: true
-        concurrency:
-          type: number
-          readOnly: true
-        start_date:
-          type: string
-          format: 'date-time'
-          readOnly: true
-          nullable: true
-        dag_run_timeout:
-          nullable: true
-          $ref: '#/components/schemas/TimeDelta'
-        doc_md:
-          type: string
-          readOnly: true
-          nullable: true
-        default_view:
-          type: string
-          readOnly: true
-        params:
-          type: object
-          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/DAG'
+        - type: object
+          properties:
+            timezone:
+              $ref: '#/components/schemas/Timezone'
+            catchup:
+              type: boolean
+              readOnly: true
+            orientation:
+              type: string
+              readOnly: true
+            concurrency:
+              type: number
+              readOnly: true
+            start_date:
+              type: string
+              format: 'date-time'
+              readOnly: true
+              nullable: true
+            dag_run_timeout:
+              nullable: true
+              $ref: '#/components/schemas/TimeDelta'
+            doc_md:
+              type: string
+              readOnly: true
+              nullable: true
+            default_view:
+              type: string
+              readOnly: true
+            params:
+              type: object
+              readOnly: true
 
     ExtraLink:
       type: object

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -70,18 +70,34 @@ class DAGSchema(SQLAlchemySchema):
         return serializer.dumps(obj.fileloc)
 
 
-class DAGDetailSchema(DAGSchema):
+class DAGDetailSchema(Schema):
     """DAG details"""
 
-    timezone = TimezoneField(dump_only=True)
-    catchup = fields.Boolean(dump_only=True)
-    orientation = fields.String(dump_only=True)
-    concurrency = fields.Integer(dump_only=True)
-    start_date = fields.DateTime(dump_only=True)
-    dag_run_timeout = fields.Nested(TimeDeltaSchema, dump_only=True, attribute="dagrun_timeout")
-    doc_md = fields.String(dump_only=True)
-    default_view = fields.String(dump_only=True)
-    params = fields.Dict(dump_only=True)
+    dag_id = fields.String()
+    root_dag_id = fields.String()
+    is_paused = fields.Boolean()
+    is_subdag = fields.Boolean()
+    fileloc = fields.String()
+    file_token = fields.Method("get_token", dump_only=True)
+    description = fields.String()
+    schedule_interval = fields.Nested(ScheduleIntervalSchema)
+    timezone = TimezoneField()
+    catchup = fields.Boolean()
+    orientation = fields.String()
+    concurrency = fields.Integer()
+    start_date = fields.DateTime()
+    dag_run_timeout = fields.Nested(TimeDeltaSchema, attribute="dagrun_timeout")
+    doc_md = fields.String()
+    default_view = fields.String()
+    params = fields.Dict()
+    owner = fields.String()
+    tags = fields.List(fields.String())
+
+    @staticmethod
+    def get_token(obj: DagModel):
+        """Return file token"""
+        serializer = URLSafeSerializer(conf.get('webserver', 'secret_key'))
+        return serializer.dumps(obj.fileloc)
 
 
 class DAGCollection(NamedTuple):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -212,7 +212,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owners": [],
+            "owner": 'airflow',
             "params": {"foo": 1},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -244,7 +244,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owners": [],
+            "owner": 'airflow',
             "params": {},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -276,7 +276,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owners": [],
+            "owner": 'airflow',
             "params": {},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -313,7 +313,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owners": [],
+            "owner": 'airflow',
             "params": {"foo": 1},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -349,7 +349,7 @@ class TestGetDagDetails(TestDagEndpoint):
             'is_paused': None,
             'is_subdag': False,
             'orientation': 'LR',
-            'owners': [],
+            'owner': 'airflow',
             "params": {"foo": 1},
             'schedule_interval': {'__type': 'TimeDelta', 'days': 1, 'microseconds': 0, 'seconds': 0},
             'start_date': '2020-06-15T00:00:00+00:00',

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -75,7 +75,13 @@ class TestDagEndpoint(unittest.TestCase):
             access_control={'TestGranularDag': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]},
         )
 
-        with DAG(cls.dag_id, start_date=datetime(2020, 6, 15), doc_md="details", params={"foo": 1}) as dag:
+        with DAG(
+            cls.dag_id,
+            start_date=datetime(2020, 6, 15),
+            doc_md="details",
+            params={"foo": 1},
+            tags=['example'],
+        ) as dag:
             DummyOperator(task_id=cls.task_id)
 
         with DAG(cls.dag2_id, start_date=datetime(2020, 6, 15)) as dag2:  # no doc_md
@@ -212,7 +218,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owner": 'airflow',
+            "owners": ['airflow'],
             "params": {"foo": 1},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -221,7 +227,7 @@ class TestGetDagDetails(TestDagEndpoint):
                 "seconds": 0,
             },
             "start_date": "2020-06-15T00:00:00+00:00",
-            "tags": None,
+            "tags": [{'name': 'example'}],
             "timezone": "Timezone('UTC')",
         }
         assert response.json == expected
@@ -244,7 +250,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owner": 'airflow',
+            "owners": ['airflow'],
             "params": {},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -253,7 +259,7 @@ class TestGetDagDetails(TestDagEndpoint):
                 "seconds": 0,
             },
             "start_date": "2020-06-15T00:00:00+00:00",
-            "tags": None,
+            "tags": [],
             "timezone": "Timezone('UTC')",
         }
         assert response.json == expected
@@ -276,7 +282,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owner": 'airflow',
+            "owners": ['airflow'],
             "params": {},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -285,7 +291,7 @@ class TestGetDagDetails(TestDagEndpoint):
                 "seconds": 0,
             },
             "start_date": None,
-            "tags": None,
+            "tags": [],
             "timezone": "Timezone('UTC')",
         }
         assert response.json == expected
@@ -313,7 +319,7 @@ class TestGetDagDetails(TestDagEndpoint):
             "is_paused": None,
             "is_subdag": False,
             "orientation": "LR",
-            "owner": 'airflow',
+            "owners": ['airflow'],
             "params": {"foo": 1},
             "schedule_interval": {
                 "__type": "TimeDelta",
@@ -322,7 +328,7 @@ class TestGetDagDetails(TestDagEndpoint):
                 "seconds": 0,
             },
             "start_date": "2020-06-15T00:00:00+00:00",
-            "tags": None,
+            "tags": [{'name': 'example'}],
             "timezone": "Timezone('UTC')",
         }
         response = client.get(
@@ -349,11 +355,11 @@ class TestGetDagDetails(TestDagEndpoint):
             'is_paused': None,
             'is_subdag': False,
             'orientation': 'LR',
-            'owner': 'airflow',
+            'owners': ['airflow'],
             "params": {"foo": 1},
             'schedule_interval': {'__type': 'TimeDelta', 'days': 1, 'microseconds': 0, 'seconds': 0},
             'start_date': '2020-06-15T00:00:00+00:00',
-            'tags': None,
+            'tags': [{'name': 'example'}],
             'timezone': "Timezone('UTC')",
         }
         assert response.json == expected

--- a/tests/api_connexion/schemas/test_dag_schema.py
+++ b/tests/api_connexion/schemas/test_dag_schema.py
@@ -107,6 +107,7 @@ class TestDAGDetailSchema:
             orientation="LR",
             default_view="duration",
             params={"foo": 1},
+            tags=["example1", "example2"],
         )
         schema = DAGDetailSchema()
         expected = {
@@ -122,11 +123,11 @@ class TestDAGDetailSchema:
             'is_paused': None,
             'is_subdag': False,
             'orientation': 'LR',
-            'owners': [],
+            'owner': '',
             'params': {'foo': 1},
             'schedule_interval': {'__type': 'TimeDelta', 'days': 1, 'seconds': 0, 'microseconds': 0},
             'start_date': '2020-06-19T00:00:00+00:00',
-            'tags': None,
+            'tags': ["example1", "example2"],
             'timezone': "Timezone('UTC')",
         }
         assert schema.dump(dag) == expected

--- a/tests/api_connexion/schemas/test_dag_schema.py
+++ b/tests/api_connexion/schemas/test_dag_schema.py
@@ -107,7 +107,6 @@ class TestDAGDetailSchema:
             orientation="LR",
             default_view="duration",
             params={"foo": 1},
-            tags=["example1", "example2"],
         )
         schema = DAGDetailSchema()
         expected = {
@@ -123,11 +122,11 @@ class TestDAGDetailSchema:
             'is_paused': None,
             'is_subdag': False,
             'orientation': 'LR',
-            'owner': '',
+            'owners': [],
             'params': {'foo': 1},
             'schedule_interval': {'__type': 'TimeDelta', 'days': 1, 'seconds': 0, 'microseconds': 0},
             'start_date': '2020-06-19T00:00:00+00:00',
-            'tags': ["example1", "example2"],
+            'tags': [],
             'timezone': "Timezone('UTC')",
         }
         assert schema.dump(dag) == expected

--- a/tests/api_connexion/schemas/test_dag_schema.py
+++ b/tests/api_connexion/schemas/test_dag_schema.py
@@ -107,6 +107,7 @@ class TestDAGDetailSchema:
             orientation="LR",
             default_view="duration",
             params={"foo": 1},
+            tags=['example1', 'example2'],
         )
         schema = DAGDetailSchema()
         expected = {
@@ -126,7 +127,7 @@ class TestDAGDetailSchema:
             'params': {'foo': 1},
             'schedule_interval': {'__type': 'TimeDelta', 'days': 1, 'seconds': 0, 'microseconds': 0},
             'start_date': '2020-06-19T00:00:00+00:00',
-            'tags': [],
+            'tags': [{'name': "example1"}, {'name': "example2"}],
             'timezone': "Timezone('UTC')",
         }
         assert schema.dump(dag) == expected


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/14481

The dag detail endpoint is a python object and was modelled as a database schema object. This caused the tags output to be empty because the tags attribute of DAG object is just a string while DagModel tags attribute is a list of TagModel object.

Also, DAG object doesn't have `owners` attribute but `owner` which is a string containing the owners e.g `owner = 'airflow, Anotherowner'`.

This PR fixes this by modeling the DagDetail schema as a python object.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
