### PR TITLE
Bugfix: Fix False alarm in import changes rule

### DIFF
--- a/airflow/upgrade/rules/import_changes.py
+++ b/airflow/upgrade/rules/import_changes.py
@@ -47,8 +47,10 @@ class ImportChange(
         return msg
 
     @cached_property
-    def old_class(self):
-        return self.old_path.split(".")[-1]
+    def old_path_without_classname(self):
+        part = self.old_path.split(".")
+        part.pop()
+        return ".".join(part)
 
     @cached_property
     def new_class(self):
@@ -113,9 +115,8 @@ class ImportChangesRule(BaseRule):
         with open(file_path, "r") as file:
             try:
                 content = file.read()
-
                 for change in ImportChangesRule.ALL_CHANGES:
-                    if change.old_class in content:
+                    if change.old_path_without_classname in content:
                         problems.append(change.info(file_path))
                         if change.providers_package:
                             providers.add(change.providers_package)

--- a/airflow/upgrade/rules/renamed_classes.py
+++ b/airflow/upgrade/rules/renamed_classes.py
@@ -1729,4 +1729,11 @@ TRANSFERS = [
     ),
 ]
 
-ALL = OPERATORS + HOOKS + SECRETS + SENSORS + TRANSFERS
+UTILS = [
+    (
+        'airflow.providers.sendgrid.utils.emailer.send_email',
+        'airflow.contrib.utils.sendgrid.send_email'
+    )
+]
+
+ALL = OPERATORS + HOOKS + SECRETS + SENSORS + TRANSFERS + UTILS

--- a/tests/upgrade/rules/test_import_changes.py
+++ b/tests/upgrade/rules/test_import_changes.py
@@ -25,6 +25,7 @@ NEW_CLASS = "NewOperator"
 PROVIDER = "dummy"
 OLD_PATH = "airflow.contrib." + OLD_CLASS
 NEW_PATH = "airflow.providers." + PROVIDER + "." + NEW_CLASS
+OLD_PATH_WITHOUT_CLASS_NAME = "airflow.contrib"
 
 
 class TestImportChange:
@@ -35,7 +36,7 @@ class TestImportChange:
         assert change.info(
             "file.py"
         ) == "Using `{}` should be replaced by `{}`. Affected file: file.py".format(OLD_PATH, NEW_PATH)
-        assert change.old_class == OLD_CLASS
+        assert change.old_path_without_classname == OLD_PATH_WITHOUT_CLASS_NAME
         assert change.new_class == NEW_CLASS
 
     def test_from_new_old_paths(self):


### PR DESCRIPTION
Closes: #14295

Currently, the ImportChangesRule only checks for the existence of a class name and issue a warning, this causes false warning. This PR addresses it by checking for the old import path instead of the class name

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
