### PR TITLE
Fix broken docs build on Master

### DIFF
--- a/docs/exts/airflow_intersphinx.py
+++ b/docs/exts/airflow_intersphinx.py
@@ -53,6 +53,10 @@ def _generate_provider_intersphinx_mapping():
         doc_inventory = f'{DOCS_DIR}/_build/docs/{package_name}/{current_version}/objects.inv'
         cache_inventory = f'{DOCS_DIR}/_inventory_cache/{package_name}/objects.inv'
 
+        # Skip adding the mapping if the path does not exist
+        if not os.path.exists(doc_inventory) and not os.path.exists(cache_inventory):
+            continue
+
         airflow_mapping[package_name] = (
             # base URI
             provider_base_url,


### PR DESCRIPTION
Currently docs build are broken, example: https://github.com/apache/airflow/runs/1991279427

because of the following error:

```
  sphinx.errors.SphinxWarning: failed to reach any of the inventories with the following issues:
  intersphinx inventory '/opt/airflow/docs/_inventory_cache/apache-airflow-providers-tableau/objects.inv' not fetchable due to <class 'FileNotFoundError'>: [Errno 2] No such file or directory: '/opt/airflow/docs/_inventory_cache/apache-airflow-providers-tableau/objects.inv'
```

This PR fixes it and takes care of the case when inventory is not present, which happens when. a new provider is added. Once the docs are built the objects.env file is uploaded successfully.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
