### PR TITLE
Increases timeout for docs build.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,7 +422,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           VERBOSE: false
 
   docs:
-    timeout-minutes: 45
+    timeout-minutes: 80
     name: "Build docs"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]


### PR DESCRIPTION
It looks like docs build takes longer and longer. we need to fix
it eventually but for now the docs build started to fail because
the docs build takes > 45 minutes allocated for it.

Example here: https://github.com/apache/airflow/runs/1990835562?check_suite_focus=true

This increases the timeout to 80 minutes.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
