### PR TITLE
Fix breeze redirect on macOS

### DIFF
--- a/breeze
+++ b/breeze
@@ -24,7 +24,9 @@ AIRFLOW_SOURCES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ ${BREEZE_REDIRECT=} == "" ]]; then
     mkdir -p "${AIRFLOW_SOURCES}"/logs
     export BREEZE_REDIRECT="true"
+    set +u
     "${0}" "${@}" 2>&1 | tee "${AIRFLOW_SOURCES}"/logs/breeze.out
+    set -u
     exit
 fi
 


### PR DESCRIPTION
Without the fix the breeze command fails on macOS:

```
$ ./breeze
./breeze: line 28: @: unbound variable 
```