### PR TITLE
Bugfix: Fix TypeError in monitor_pod

### DIFF
--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -140,9 +140,10 @@ class PodLauncher(LoggingMixin):
                     break
 
                 self.log.warning('Pod %s log read interrupted', pod.metadata.name)
-                delta = pendulum.now() - last_log_time
-                # Prefer logs duplication rather than loss
-                read_logs_since_sec = math.ceil(delta.total_seconds())
+                if last_log_time:
+                    delta = pendulum.now() - last_log_time
+                    # Prefer logs duplication rather than loss
+                    read_logs_since_sec = math.ceil(delta.total_seconds())
         result = None
         if self.extract_xcom:
             while self.base_container_is_running(pod):


### PR DESCRIPTION
We have seen several task failures because of this issue.

If the log read is interrupted before any logs are produced then
`last_log_time` will not be set and the line
`delta = pendulum.now() - last_log_time` will fail with
```
TypeError: unsupported operand type(s) for -: 'DateTime' and 'NoneType'
```

This commit fix this issue by only updating `read_logs_since_sec` if
`last_log_time` has been set.