### PR TITLE
Add CLI check for scheduler(s)

### DIFF
--- a/airflow/cli/commands/jobs_command.py
+++ b/airflow/cli/commands/jobs_command.py
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List
+
+from airflow.jobs.base_job import BaseJob
+from airflow.utils.session import provide_session
+from airflow.utils.state import State
+
+
+@provide_session
+def check(args, session=None):
+    """Checks if job(s) are still alive"""
+    if args.allow_multiple and not args.limit > 1:
+        raise SystemExit("To use option --allow-multiple, you must set the limit to a value greater than 1.")
+    query = (
+        session.query(BaseJob)
+        .filter(BaseJob.state == State.RUNNING)
+        .order_by(BaseJob.latest_heartbeat.desc())
+    )
+    if args.job_type:
+        query = query.filter(BaseJob.job_type == args.job_type)
+    if args.hostname:
+        query = query.filter(BaseJob.hostname == args.hostname)
+    if args.limit > 0:
+        query = query.limit(args.limit)
+
+    jobs: List[BaseJob] = query.all()
+    alive_jobs = [job for job in jobs if job.is_alive()]
+
+    count_alive_jobs = len(alive_jobs)
+    if count_alive_jobs == 0:
+        raise SystemExit("No alive jobs found.")
+    if count_alive_jobs > 1 and not args.allow_multiple:
+        raise SystemExit(f"Found {count_alive_jobs} alive jobs. Expected only one.")
+    if count_alive_jobs == 1:
+        print("Found one alive job.")
+    else:
+        print(f"Found {count_alive_jobs} alive jobs.")

--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -102,6 +102,11 @@ services:
   airflow-scheduler:
     <<: *airflow-common
     command: scheduler
+    healthcheck:
+      test: ["CMD-SHELL", 'airflow jobs check --job-type SchedulerJob --hostname "$${HOSTNAME}"']
+      interval: 10s
+      timeout: 10s
+      retries: 5
     restart: always
 
   airflow-worker:

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -105,7 +105,7 @@ In the second terminal you can check the condition of the containers and make su
     $ docker ps
     CONTAINER ID   IMAGE                             COMMAND                  CREATED          STATUS                    PORTS                              NAMES
     247ebe6cf87a   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    8080/tcp                           compose_airflow-worker_1
-    ed9b09fc84b1   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes              8080/tcp                           compose_airflow-scheduler_1
+    ed9b09fc84b1   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    8080/tcp                           compose_airflow-scheduler_1
     65ac1da2c219   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    0.0.0.0:5555->5555/tcp, 8080/tcp   compose_flower_1
     7cb1fb603a98   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    0.0.0.0:8080->8080/tcp             compose_airflow-webserver_1
     74f3bbe506eb   postgres:13                       "docker-entrypoint.s…"   18 minutes ago   Up 17 minutes (healthy)   5432/tcp                           compose_postgres_1

--- a/tests/cli/commands/test_jobs_command.py
+++ b/tests/cli/commands/test_jobs_command.py
@@ -1,0 +1,128 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import contextlib
+import io
+import unittest
+
+import pytest
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import jobs_command
+from airflow.jobs.scheduler_job import SchedulerJob
+from airflow.utils.session import create_session
+from airflow.utils.state import State
+from tests.test_utils.db import clear_db_jobs
+
+
+class TestCliConfigList(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    def setUp(self) -> None:
+        clear_db_jobs()
+
+    def tearDown(self) -> None:
+        clear_db_jobs()
+
+    def test_should_report_success_for_one_working_scheduler(self):
+        with create_session() as session:
+            job = SchedulerJob()
+            job.state = State.RUNNING
+            session.add(job)
+            session.commit()
+            job.heartbeat()
+
+        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            jobs_command.check(self.parser.parse_args(['jobs', 'check', '--job-type', 'SchedulerJob']))
+        self.assertIn("Found one alive job.", temp_stdout.getvalue())
+
+    def test_should_report_success_for_one_working_scheduler_with_hostname(self):
+        with create_session() as session:
+            job = SchedulerJob()
+            job.state = State.RUNNING
+            job.hostname = 'HOSTNAME'
+            session.add(job)
+            session.commit()
+            job.heartbeat()
+
+        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            jobs_command.check(
+                self.parser.parse_args(
+                    ['jobs', 'check', '--job-type', 'SchedulerJob', '--hostname', 'HOSTNAME']
+                )
+            )
+        self.assertIn("Found one alive job.", temp_stdout.getvalue())
+
+    def test_should_report_success_for_ha_schedulers(self):
+        with create_session() as session:
+            for _ in range(3):
+                job = SchedulerJob()
+                job.state = State.RUNNING
+                session.add(job)
+            session.commit()
+            job.heartbeat()
+
+        with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            jobs_command.check(
+                self.parser.parse_args(
+                    ['jobs', 'check', '--job-type', 'SchedulerJob', '--limit', '100', '--allow-multiple']
+                )
+            )
+        self.assertIn("Found 3 alive jobs.", temp_stdout.getvalue())
+
+    def test_should_ignore_not_running_jobs(self):
+        with create_session() as session:
+            for _ in range(3):
+                job = SchedulerJob()
+                job.state = State.SHUTDOWN
+                session.add(job)
+            session.commit()
+        # No alive jobs found.
+        with pytest.raises(SystemExit, match=r"No alive jobs found."):
+            jobs_command.check(self.parser.parse_args(['jobs', 'check']))
+
+    def test_should_raise_exception_for_multiple_scheduler_on_one_host(self):
+        with create_session() as session:
+            for _ in range(3):
+                job = SchedulerJob()
+                job.state = State.RUNNING
+                job.hostname = 'HOSTNAME'
+                session.add(job)
+            session.commit()
+            job.heartbeat()
+
+        with pytest.raises(SystemExit, match=r"Found 3 alive jobs. Expected only one."):
+            jobs_command.check(
+                self.parser.parse_args(
+                    [
+                        'jobs',
+                        'check',
+                        '--job-type',
+                        'SchedulerJob',
+                        '--limit',
+                        '100',
+                    ]
+                )
+            )
+
+    def test_should_raise_exception_for_allow_multiple_and_limit_1(self):
+        with pytest.raises(
+            SystemExit,
+            match=r"To use option --allow-multiple, you must set the limit to a value greater than 1.",
+        ):
+            jobs_command.check(self.parser.parse_args(['jobs', 'check', '--allow-multiple']))

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -161,8 +161,9 @@ class TestCli(TestCase):
                 parser.parse_args([*cmd_args, '--help'])
 
     def test_positive_int(self):
-        assert 1 == cli_parser.positive_int('1')
+        assert 1 == cli_parser.positive_int(allow_zero=True)('1')
+        assert 0 == cli_parser.positive_int(allow_zero=True)('0')
 
         with pytest.raises(argparse.ArgumentTypeError):
-            cli_parser.positive_int('0')
-            cli_parser.positive_int('-1')
+            cli_parser.positive_int(allow_zero=False)('0')
+            cli_parser.positive_int(allow_zero=True)('-1')


### PR DESCRIPTION
Part of: https://github.com/apache/airflow/issues/11161

I miss a simple method to check if the scheduler is in good health, so I added a command that allows me to do it. Additionally, I updated `docker-compose.yaml` to take use it

For now, we've been doing without this command because we had a Python script implemented that did similar behavior, but that doesn't look right.
https://github.com/apache/airflow/blob/7d181508ef5383d36eae584ceedb9845b7467776/chart/templates/scheduler/scheduler-deployment.yaml#L126-L143
I am not updating the Helm Chart yet to keep compatibilityy with Airflow 1.10, but when we drop support for Aiirflow 1.10, we will be able to use it. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
