### PR TITLE
Fix asset recompilation message

### DIFF
--- a/airflow/www/ask_for_recompile_assets_if_needed.sh
+++ b/airflow/www/ask_for_recompile_assets_if_needed.sh
@@ -23,6 +23,7 @@ cd "$( dirname "${BASH_SOURCE[0]}" )"
 MD5SUM_FILE="static/dist/sum.md5"
 readonly MD5SUM_FILE
 
+GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NO_COLOR='\033[0m'
 
@@ -36,5 +37,7 @@ if [[ ${old_md5sum} != "${md5sum}" ]]; then
     echo "   ./airflow/www/compile_assets.sh"
     echo ""
 else
-    echo "No need to recompile www assets"
+    echo
+    echo -e "${GREEN}No need for www assets recompilation.${NO_COLOR}"
+    echo
 fi

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -69,7 +69,9 @@ if [[ -z ${INSTALL_AIRFLOW_VERSION=} ]]; then
     echo
     echo "Using already installed airflow version"
     echo
-    "${AIRFLOW_SOURCES}/airflow/www/ask_for_recompile_assets_if_needed.sh"
+    pushd "${AIRFLOW_SOURCES}/airflow/www/" >/dev/null
+    ./ask_for_recompile_assets_if_needed.sh
+    popd >/dev/null
     # Cleanup the logs, tmp when entering the environment
     sudo rm -rf "${AIRFLOW_SOURCES}"/logs/*
     sudo rm -rf "${AIRFLOW_SOURCES}"/tmp/*


### PR DESCRIPTION
The asset recompilation message did not work well in case of the
tests - where we did not mount local sources. It was always
showign the instructions to recompile the assets.

This is now fixed and the "OK" message is green.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
