### PR TITLE
Fix: Mysql 5.7 id utf8mb3

### DIFF
--- a/airflow/migrations/versions/03afc6b6f902_increase_length_of_fab_ab_view_menu_.py
+++ b/airflow/migrations/versions/03afc6b6f902_increase_length_of_fab_ab_view_menu_.py
@@ -28,6 +28,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine.reflection import Inspector
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = '03afc6b6f902'
 down_revision = '92c57b58940d'
@@ -59,7 +61,10 @@ def upgrade():
             op.execute("PRAGMA foreign_keys=on")
         else:
             op.alter_column(
-                table_name='ab_view_menu', column_name='name', type_=sa.String(length=250), nullable=False
+                table_name='ab_view_menu',
+                column_name='name',
+                type_=sa.String(length=250, **COLLATION_ARGS),
+                nullable=False,
             )
 
 

--- a/airflow/migrations/versions/0a2a5b66e19d_add_task_reschedule_table.py
+++ b/airflow/migrations/versions/0a2a5b66e19d_add_task_reschedule_table.py
@@ -26,9 +26,9 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
 
-# revision identifiers, used by Alembic.
 from airflow.models.base import COLLATION_ARGS
 
+# revision identifiers, used by Alembic.
 revision = '0a2a5b66e19d'
 down_revision = '9635ae0956e7'
 branch_labels = None

--- a/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
+++ b/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
@@ -27,6 +27,8 @@ Create Date: 2015-10-27 08:31:48.475140
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = '1b38cef5b76e'
 down_revision = '502898887f84'
@@ -38,10 +40,10 @@ def upgrade():
     op.create_table(
         'dag_run',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('dag_id', sa.String(length=250), nullable=True),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
         sa.Column('execution_date', sa.DateTime(), nullable=True),
         sa.Column('state', sa.String(length=50), nullable=True),
-        sa.Column('run_id', sa.String(length=250), nullable=True),
+        sa.Column('run_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
         sa.Column('external_trigger', sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('dag_id', 'execution_date'),

--- a/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
+++ b/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
@@ -26,9 +26,9 @@ Create Date: 2016-08-03 14:02:59.203021
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
 from airflow.models.base import COLLATION_ARGS
 
+# revision identifiers, used by Alembic.
 revision = '64de9cddf6c9'
 down_revision = '211e584da130'
 branch_labels = None

--- a/airflow/migrations/versions/7939bcff74ba_add_dagtags_table.py
+++ b/airflow/migrations/versions/7939bcff74ba_add_dagtags_table.py
@@ -27,6 +27,8 @@ Create Date: 2020-01-07 19:39:01.247442
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = '7939bcff74ba'
 down_revision = 'fe461863935f'
@@ -39,7 +41,7 @@ def upgrade():
     op.create_table(
         'dag_tag',
         sa.Column('name', sa.String(length=100), nullable=False),
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
         sa.ForeignKeyConstraint(
             ['dag_id'],
             ['dag.dag_id'],

--- a/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
+++ b/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
@@ -27,6 +27,8 @@ Create Date: 2020-03-10 22:19:18.034961
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = '852ae6c715af'
 down_revision = 'a4c2fd67d16b'
@@ -51,8 +53,8 @@ def upgrade():
 
     op.create_table(
         TABLE_NAME,
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
-        sa.Column('task_id', sa.String(length=250), nullable=False),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
         sa.Column('execution_date', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('rendered_fields', json_type(), nullable=False),
         sa.PrimaryKeyConstraint('dag_id', 'task_id', 'execution_date'),

--- a/airflow/migrations/versions/8646922c8a04_change_default_pool_slots_to_1.py
+++ b/airflow/migrations/versions/8646922c8a04_change_default_pool_slots_to_1.py
@@ -28,13 +28,12 @@ import dill
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import Column, Float, Integer, PickleType, String
-
-# revision identifiers, used by Alembic.
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow.models.base import COLLATION_ARGS
 from airflow.utils.sqlalchemy import UtcDateTime
 
+# revision identifiers, used by Alembic.
 revision = '8646922c8a04'
 down_revision = '449b4072c2da'
 branch_labels = None

--- a/airflow/migrations/versions/8d48763f6d53_add_unique_constraint_to_conn_id.py
+++ b/airflow/migrations/versions/8d48763f6d53_add_unique_constraint_to_conn_id.py
@@ -27,6 +27,8 @@ Create Date: 2020-05-03 16:55:01.834231
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = '8d48763f6d53'
 down_revision = '8f966b9c467a'
@@ -38,7 +40,7 @@ def upgrade():
     """Apply add unique constraint to conn_id and set it as non-nullable"""
     try:
         with op.batch_alter_table('connection') as batch_op:
-            batch_op.alter_column("conn_id", nullable=False, existing_type=sa.String(250))
+            batch_op.alter_column("conn_id", nullable=False, existing_type=sa.String(250, **COLLATION_ARGS))
             batch_op.create_unique_constraint(constraint_name="unique_conn_id", columns=["conn_id"])
 
     except sa.exc.IntegrityError:

--- a/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
+++ b/airflow/migrations/versions/952da73b5eff_add_dag_code_table.py
@@ -27,9 +27,9 @@ Create Date: 2020-03-12 12:39:01.797462
 import sqlalchemy as sa
 from alembic import op
 
-# revision identifiers, used by Alembic.
 from airflow.models.dagcode import DagCode
 
+# revision identifiers, used by Alembic.
 revision = '952da73b5eff'
 down_revision = '852ae6c715af'
 branch_labels = None

--- a/airflow/migrations/versions/b25a55525161_increase_length_of_pool_name.py
+++ b/airflow/migrations/versions/b25a55525161_increase_length_of_pool_name.py
@@ -27,6 +27,8 @@ Create Date: 2020-03-09 08:48:14.534700
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = 'b25a55525161'
 down_revision = 'bbf4a7ad0465'
@@ -38,7 +40,7 @@ def upgrade():
     """Increase column length of pool name from 50 to 256 characters"""
     # use batch_alter_table to support SQLite workaround
     with op.batch_alter_table('slot_pool', table_args=sa.UniqueConstraint('pool')) as batch_op:
-        batch_op.alter_column('pool', type_=sa.String(256))
+        batch_op.alter_column('pool', type_=sa.String(256, **COLLATION_ARGS))
 
 
 def downgrade():

--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -31,10 +31,9 @@ from sqlalchemy.ext.declarative import declarative_base
 
 from airflow import settings
 from airflow.models import DagBag
-
-# revision identifiers, used by Alembic.
 from airflow.models.base import COLLATION_ARGS
 
+# revision identifiers, used by Alembic.
 revision = 'cc1e65623dc7'
 down_revision = '127d2bf2dfa7'
 branch_labels = None

--- a/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
+++ b/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
@@ -27,6 +27,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = 'd38e04c12aa2'
 down_revision = '6e96a59344a4'
@@ -49,7 +51,7 @@ def upgrade():
 
     op.create_table(
         'serialized_dag',
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
         sa.Column('fileloc', sa.String(length=2000), nullable=False),
         sa.Column('fileloc_hash', sa.Integer(), nullable=False),
         sa.Column('data', json_type(), nullable=False),

--- a/airflow/migrations/versions/e38be357a868_update_schema_for_smart_sensor.py
+++ b/airflow/migrations/versions/e38be357a868_update_schema_for_smart_sensor.py
@@ -29,6 +29,8 @@ from sqlalchemy import func
 from sqlalchemy.dialects import mysql
 from sqlalchemy.engine.reflection import Inspector
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = 'e38be357a868'
 down_revision = '8d48763f6d53'
@@ -66,8 +68,8 @@ def upgrade():
     op.create_table(
         'sensor_instance',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('task_id', sa.String(length=250), nullable=False),
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
         sa.Column('execution_date', timestamp(), nullable=False),
         sa.Column('state', sa.String(length=20), nullable=True),
         sa.Column('try_number', sa.Integer(), nullable=True),

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -29,9 +29,9 @@ from alembic import op
 from sqlalchemy import func
 from sqlalchemy.engine.reflection import Inspector
 
-# revision identifiers, used by Alembic.
 from airflow.models.base import COLLATION_ARGS
 
+# revision identifiers, used by Alembic.
 revision = 'e3a246e0dc1'
 down_revision = None
 branch_labels = None
@@ -47,7 +47,7 @@ def upgrade():
         op.create_table(
             'connection',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('conn_id', sa.String(length=250), nullable=True),
+            sa.Column('conn_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
             sa.Column('conn_type', sa.String(length=500), nullable=True),
             sa.Column('host', sa.String(length=500), nullable=True),
             sa.Column('schema', sa.String(length=500), nullable=True),
@@ -60,7 +60,7 @@ def upgrade():
     if 'dag' not in tables:
         op.create_table(
             'dag',
-            sa.Column('dag_id', sa.String(length=250), nullable=False),
+            sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
             sa.Column('is_paused', sa.Boolean(), nullable=True),
             sa.Column('is_subdag', sa.Boolean(), nullable=True),
             sa.Column('is_active', sa.Boolean(), nullable=True),
@@ -134,7 +134,7 @@ def upgrade():
         op.create_table(
             'slot_pool',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('pool', sa.String(length=50), nullable=True),
+            sa.Column('pool', sa.String(length=50, **COLLATION_ARGS), nullable=True),
             sa.Column('slots', sa.Integer(), nullable=True),
             sa.Column('description', sa.Text(), nullable=True),
             sa.PrimaryKeyConstraint('id'),
@@ -169,7 +169,7 @@ def upgrade():
         op.create_table(
             'user',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('username', sa.String(length=250), nullable=True),
+            sa.Column('username', sa.String(length=250, **COLLATION_ARGS), nullable=True),
             sa.Column('email', sa.String(length=500), nullable=True),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('username'),
@@ -178,7 +178,7 @@ def upgrade():
         op.create_table(
             'variable',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('key', sa.String(length=250), nullable=True),
+            sa.Column('key', sa.String(length=250, **COLLATION_ARGS), nullable=True),
             sa.Column('val', sa.Text(), nullable=True),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('key'),

--- a/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
+++ b/airflow/migrations/versions/f2ca10b85618_add_dag_stats_table.py
@@ -26,6 +26,8 @@ Create Date: 2016-07-20 15:08:28.247537
 import sqlalchemy as sa
 from alembic import op
 
+from airflow.models.base import COLLATION_ARGS
+
 # revision identifiers, used by Alembic.
 revision = 'f2ca10b85618'
 down_revision = '64de9cddf6c9'
@@ -36,7 +38,7 @@ depends_on = None
 def upgrade():
     op.create_table(
         'dag_stats',
-        sa.Column('dag_id', sa.String(length=250), nullable=False),
+        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
         sa.Column('state', sa.String(length=50), nullable=False),
         sa.Column('count', sa.Integer(), nullable=False, default=0),
         sa.Column('dirty', sa.Boolean(), nullable=False, default=False),


### PR DESCRIPTION
This may not be a ready PR. The code diff best expresses my ideas.

I'm initializing a mysql 5.7 db from empty using `hub.docker.com, apache/airflow:2.0.1-python3.8`. The migration scripts throw errors of `(1071, 'Specified key was too long; max key length is 767 bytes')`. `AIRFLOW__CORE__SQL_ENGINE_COLLATION_FOR_IDS: utf8mb3_general_ci` does not work. (ref #7570).

After go through the issues and code, I had an assumption that `utf8mb3` config was not applied to all places that it should. I applied those migration scripts manually, then it works.

I'm not confident about how the migration scripts work.

1. Should it be generated by some tools and not modified manually?
2. Some scripts modify existed columns. Can I directly fix the `create table` scripts and skip the `modify table` ones? How does this affect the old users wants to upgrade?

~~Another question.~~

~~I cannot fix the line `bop.create_primary_key('pk_xcom', ['dag_id', 'task_id', 'key', 'execution_date'])`. My DBA always told me not to use too many columns for keys. Why in this case `dag_id` and `task_id` is not enough?~~

EDIT: Fixed in master.