### PR TITLE
Disable in-container health checks for ad-hoc containers

### DIFF
--- a/docs/apache-airflow/production-deployment.rst
+++ b/docs/apache-airflow/production-deployment.rst
@@ -810,6 +810,7 @@ available. This happens always when you use the default entrypoint.
 The script detects backend type depending on the URL schema and assigns default port numbers if not specified
 in the URL. Then it loops until the connection to the host/port specified can be established
 It tries ``CONNECTION_CHECK_MAX_COUNT`` times and sleeps ``CONNECTION_CHECK_SLEEP_TIME`` between checks
+To disable check, set ``CONNECTION_CHECK_MAX_COUNT=0``.
 
 Supported schemes:
 
@@ -894,7 +895,8 @@ commands are used the entrypoint will wait until the celery broker DB connection
 
 The script detects backend type depending on the URL schema and assigns default port numbers if not specified
 in the URL. Then it loops until connection to the host/port specified can be established
-It tries ``CONNECTION_CHECK_MAX_COUNT`` times and sleeps ``CONNECTION_CHECK_SLEEP_TIME`` between checks
+It tries ``CONNECTION_CHECK_MAX_COUNT`` times and sleeps ``CONNECTION_CHECK_SLEEP_TIME`` between checks.
+To disable check, set ``CONNECTION_CHECK_MAX_COUNT=0``.
 
 Supported schemes:
 

--- a/docs/apache-airflow/start/airflow.sh
+++ b/docs/apache-airflow/start/airflow.sh
@@ -25,4 +25,4 @@ PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set -euo pipefail
 
 export COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yaml"
-exec docker-compose run airflow-worker "${@}"
+exec docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=0 airflow-worker "${@}"

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -253,7 +253,9 @@ readonly CONNECTION_CHECK_SLEEP_TIME
 
 create_system_user_if_missing
 set_pythonpath_for_root_user
-wait_for_airflow_db
+if [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
+    wait_for_airflow_db
+fi
 
 if [[ -n "${_AIRFLOW_DB_UPGRADE=}" ]] ; then
     upgrade_db
@@ -279,7 +281,8 @@ if [[ ${AIRFLOW_COMMAND} == "airflow" ]]; then
 fi
 
 # Note: the broker backend configuration concerns only a subset of Airflow components
-if [[ ${AIRFLOW_COMMAND} =~ ^(scheduler|celery|worker|flower)$ ]]; then
+if [[ ${AIRFLOW_COMMAND} =~ ^(scheduler|celery|worker|flower)$ ]] \
+    && [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
     wait_for_celery_backend "${@}"
 fi
 


### PR DESCRIPTION
This slows things down a bit if we're trying to write scripts that can sometimes run multiple containers. The health of the containers is already checked by Docker, so we don't have to check it on our side every time.

Comparision:
```
$ time docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=0 airflow-worker airflow celery
0.66s user 0.14s system 23% cpu 3.396 total
$ time docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=0 airflow-worker airflow celery
0.66s user 0.14s system 22% cpu 3.576 total
$ time docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=0 airflow-worker airflow celery
0.61s user 0.13s system 22% cpu 3.210 total
```
```
$ time docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=1 airflow-worker airflow celery
0.67s user 0.18s system 19% cpu 4.456 total
$ time docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=1 airflow-worker airflow celery
0.63s user 0.14s system 18% cpu 4.182 total
$ time docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=1 airflow-worker airflow celery
0.65s user 0.15s system 18% cpu 4.373 total
```

Part of: https://github.com/apache/airflow/issues/11161
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
