### PR TITLE
Print proper provider version in airflow info command

### DIFF
--- a/airflow/cli/commands/info_command.py
+++ b/airflow/cli/commands/info_command.py
@@ -277,8 +277,8 @@ class ProvidersInfo(_BaseInfo):
         table = SimpleTable(title="Providers info")
         table.add_column()
         table.add_column(width=150)
-        for _, provider in ProvidersManager().providers.values():
-            table.add_row(provider['package-name'], provider['versions'][0])
+        for provider_value in ProvidersManager().providers.values():
+            table.add_row(provider_value.provider_info['package-name'], provider_value.version)
         console.print(table)
 
 


### PR DESCRIPTION
This changes the output of `airflow info` from 

```
Providers info
apache-airflow-providers-amazon           | 1.2.0
```

to

``` 
Providers info
apache-airflow-providers-amazon           | 1.2.0rc1
```

to better reflect the actual package version in use. 