### PR TITLE
BugFix: fix DAG doc display (especially for TaskFlow DAGs)

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -337,6 +337,8 @@ def wrapped_markdown(s, css_class=None):
     if s is None:
         return None
 
+    s = '\n'.join(line.lstrip() for line in s.split('\n'))
+
     return Markup(f'<div class="{css_class}" >' + markdown.markdown(s, extensions=['tables']) + "</div>")
 
 

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -245,3 +245,16 @@ class TestWrappedMarkdown(unittest.TestCase):
             '</td>\n<td>14m</td>\n</tr>\n</tbody>\n'
             '</table></div>'
         ) == rendered
+
+    def test_wrapped_markdown_with_indented_lines(self):
+        rendered = wrapped_markdown(
+            """
+                # header
+                1st line
+                2nd line
+            """
+        )
+
+        assert (
+            '<div class="None" ><h1>header</h1>\n<p>1st line\n2nd line</p></div>'
+        ) == rendered

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -255,6 +255,4 @@ class TestWrappedMarkdown(unittest.TestCase):
             """
         )
 
-        assert (
-            '<div class="None" ><h1>header</h1>\n<p>1st line\n2nd line</p></div>'
-        ) == rendered
+        assert '<div class="None" ><h1>header</h1>\n<p>1st line\n2nd line</p></div>' == rendered


### PR DESCRIPTION
### Issue and Background

Let's take the example DAG `tutorial_taskflow_api_etl` as example. In **2.0.1**, the DAG doc in Markdown format is not rendered properly.

![tutorial_taskflow_api_etl_-_Tree_-_Airflow](https://user-images.githubusercontent.com/11539188/109669625-91f25c80-7b72-11eb-87e4-6e745de27837.png)

If it's rendered properly, it should look like the DAG Docs of another example DAG, `tutorial`,

![tutorial_-_Tree_-_Airflow](https://user-images.githubusercontent.com/11539188/109669825-cc5bf980-7b72-11eb-8ae2-a8ef9f9a24ed.png)


### Why

Because of how TaskFlow DAGs are constructed, their `__doc__` lines may start with spaces. This fails `markdown.markdown()`, and the doc in Markdown format cannot be transformed into HTML properly, and further fails the doc display in the UI.

Actually this also affects the non-TaskFlow DAGs (if users accidentally add a space in the beginning of any line in the `__doc__`)

```python
def x(x):
    """
    ### Header
    XD's test
    2nd line
    """
    return x * 2

import markdown

print('Case-1')
print(markdown.markdown(x.__doc__))

print('Case-2')
print(markdown.markdown('\n'.join(line.lstrip() for line in x.__doc__.split('\n'))))
```

Output:
```
Case-1
<pre><code>### Header
XD's test
2nd line
</code></pre>

Case-2
<h3>Header</h3>
<p>XD's test
2nd line</p>
```

### Solution

This commit fixes this by always doing left strip for each line of the doc md.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
