### PR TITLE
Suppress LOG/WARNING for a few tasks CLI for better CLI experience

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -930,7 +930,7 @@ TASKS_COMMANDS = (
         name='list',
         help="List the tasks within a DAG",
         func=lazy_load_command('airflow.cli.commands.task_command.task_list'),
-        args=(ARG_DAG_ID, ARG_TREE, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_TREE, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='clear',
@@ -956,7 +956,7 @@ TASKS_COMMANDS = (
         name='state',
         help="Get the status of a task instance",
         func=lazy_load_command('airflow.cli.commands.task_command.task_state'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='failed-deps',
@@ -973,7 +973,7 @@ TASKS_COMMANDS = (
         name='render',
         help="Render a task instance's template(s)",
         func=lazy_load_command('airflow.cli.commands.task_command.task_render'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='run',

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -263,6 +263,7 @@ def task_failed_deps(args):
 
 
 @cli_utils.action_logging
+@suppress_logs_and_warning
 def task_state(args):
     """
     Returns the state of a TaskInstance at the command line.
@@ -276,6 +277,7 @@ def task_state(args):
 
 
 @cli_utils.action_logging
+@suppress_logs_and_warning
 def task_list(args, dag=None):
     """Lists the tasks within a DAG at the command line"""
     dag = dag or get_dag(args.subdir, args.dag_id)
@@ -397,6 +399,7 @@ def task_test(args, dag=None):
 
 
 @cli_utils.action_logging
+@suppress_logs_and_warning
 def task_render(args):
     """Renders and displays templated fields for a given task"""
     dag = get_dag(args.subdir, args.dag_id)


### PR DESCRIPTION
For `state`/`list`/`render`, more likely users would like to rely on the CLI output for some work, and the Python LOG/WARNING prints cause inconvenience, for example

<img width="1238" alt="Default__-zsh_" src="https://user-images.githubusercontent.com/11539188/109709972-66d13280-7b9d-11eb-98d6-d9209a4c34d4.png">


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
