### PR TITLE
docs: sample pod_mutation_hook adjusted to new API

### DIFF
--- a/docs/apache-airflow/kubernetes.rst
+++ b/docs/apache-airflow/kubernetes.rst
@@ -46,5 +46,7 @@ to every worker pod launched by KubernetesExecutor or KubernetesPodOperator.
 
 .. code-block:: python
 
-    def pod_mutation_hook(pod: Pod):
-      pod.annotations['airflow.apache.org/launched-by'] = 'Tests'
+    from kubernetes.client.models import V1Pod
+
+    def pod_mutation_hook(pod: V1Pod):
+        pod.metadata.annotations['airflow.apache.org/launched-by'] = 'Tests'


### PR DESCRIPTION
The current documentation presents example of `pod_mutation_hook` that uses old API. The change presents same functionality, but using new API (direct Kubernetes objects)