### PR TITLE
Restore correct terminal with to interactive breeze usage

### DIFF
--- a/breeze
+++ b/breeze
@@ -24,7 +24,11 @@ AIRFLOW_SOURCES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ ${BREEZE_REDIRECT=} == "" ]]; then
     mkdir -p "${AIRFLOW_SOURCES}"/logs
     export BREEZE_REDIRECT="true"
-    exec script --return --quiet --log-out "${AIRFLOW_SOURCES}"/logs/breeze.out -c "$(printf "%q " "${0}" "${@}")"
+    if [[ "$(uname)" == "Darwin" ]]; then
+      exec script -q "${AIRFLOW_SOURCES}"/logs/breeze.out "$BASH" -c "$(printf "%q " "${0}" "${@}")"
+    else
+      exec script --return --quiet --log-out "${AIRFLOW_SOURCES}"/logs/breeze.out -c "$(printf "%q " "${0}" "${@}")"
+    fi
 fi
 
 export AIRFLOW_SOURCES

--- a/breeze
+++ b/breeze
@@ -24,10 +24,7 @@ AIRFLOW_SOURCES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ ${BREEZE_REDIRECT=} == "" ]]; then
     mkdir -p "${AIRFLOW_SOURCES}"/logs
     export BREEZE_REDIRECT="true"
-    set +u
-    "${0}" "${@}" 2>&1 | tee "${AIRFLOW_SOURCES}"/logs/breeze.out
-    set -u
-    exit
+    exec script --return --quiet --log-out "${AIRFLOW_SOURCES}"/logs/breeze.out -c "$(printf "%q " "${0}" "${@}")"
 fi
 
 export AIRFLOW_SOURCES

--- a/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.sh
+++ b/scripts/ci/pre_commit/pre_commit_breeze_cmd_line.sh
@@ -49,6 +49,8 @@ readonly FORCE_SCREEN_WIDTH
 export VERBOSE="false"
 readonly VERBOSE
 
+export BREEZE_REDIRECT="false"
+
 ./breeze help-all | sed 's/^/  /' | sed 's/ *$//' >>"${TMP_FILE}"
 
 MAX_LEN_FOUND=$(awk '{ print length($0); }' "${TMP_FILE}" | sort -n | tail -1 )


### PR DESCRIPTION
The change to redirect all breeze output to a file (#14470) had the effect of making stdin no longer a TTY, which meant that the docker container had a fixed with of 80 columns.

The fix is to replace the use of `tee` with `scripts`, which does what we want -- captures stdout+stderr, but makes the running program believe that it is still attached to a terminal (if it ever was).

Tested with `./breeze -n shell -- -c 'set -x; [[ $(tput cols) -gt 80 ]]'`