### PR TITLE
Drop third-party lazy proxy.

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -339,7 +339,6 @@ COPY airflow/__init__.py ${AIRFLOW_SOURCES}/airflow/__init__.py
 # Those are additional constraints that are needed for some extras but we do not want to
 # force them on the main Airflow package. Those limitations are:
 # * chardet,<4: required by snowflake provider
-# * lazy-object-proxy<1.5.0: required by astroid
 # * pytz<2021.0: required by snowflake provider
 # * pyOpenSSL: required by snowflake provider https://github.com/snowflakedb/snowflake-connector-python/blob/v2.3.6/setup.py#L201
 # * urllib3<1.26: Required to keep boto3 happy

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -32,7 +32,6 @@ from urllib.parse import quote
 
 import dill
 import jinja2
-import lazy_object_proxy
 import pendulum
 from jinja2 import TemplateAssertionError, UndefinedError
 from sqlalchemy import Column, Float, Index, Integer, PickleType, String, and_, func, or_
@@ -68,6 +67,7 @@ from airflow.utils.helpers import is_container
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
 from airflow.utils.operator_helpers import context_to_airflow_vars
+from airflow.utils.proxy import cached_getter, cached_proxy
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, with_row_locks
 from airflow.utils.state import State
@@ -1706,10 +1706,16 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             'prev_ds': prev_ds,
             'prev_ds_nodash': prev_ds_nodash,
             'prev_execution_date': prev_execution_date,
-            'prev_execution_date_success': lazy_object_proxy.Proxy(
+            'prev_execution_date_success': cached_proxy(
                 lambda: self.get_previous_execution_date(state=State.SUCCESS)
             ),
-            'prev_start_date_success': lazy_object_proxy.Proxy(
+            'prev_start_date_success': cached_proxy(
+                lambda: self.get_previous_start_date(state=State.SUCCESS)
+            ),
+            'get_prev_execution_date_success': cached_getter(
+                lambda: self.get_previous_execution_date(state=State.SUCCESS)
+            ),
+            'get_prev_start_date_success': cached_getter(
                 lambda: self.get_previous_start_date(state=State.SUCCESS)
             ),
             'run_id': run_id,

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -544,7 +544,7 @@ class PythonVirtualenvOperator(PythonOperator):
             return self.system_site_packages or 'apache-airflow' in self.requirements
 
         def _is_pendulum_env():
-            return 'pendulum' in self.requirements and 'lazy_object_proxy' in self.requirements
+            return 'pendulum' in self.requirements
 
         serializable_context_keys = self.BASE_SERIALIZABLE_CONTEXT_KEYS.copy()
         if _is_airflow_env():

--- a/airflow/utils/proxy.py
+++ b/airflow/utils/proxy.py
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import functools
+from typing import Any, Callable
+
+from werkzeug.local import LocalProxy
+
+
+class _Miss:
+    pass
+
+
+_miss = _Miss()
+
+
+def cached_getter(getter: Callable[[], Any]) -> Callable[[], Any]:
+    """Return cached version of getter function."""
+    cached = _miss
+    @functools.wraps(getter)
+    def wrapped():
+        nonlocal cached
+        if cached is _miss:
+            cached = getter()
+        return cached
+    return wrapped
+
+
+def cached_proxy(getter: Callable[[], Any]) -> LocalProxy:
+    """Return cached proxy of getter function."""
+    return LocalProxy(cached_getter(getter))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -31,7 +31,6 @@ from operator import itemgetter
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import parse_qsl, unquote, urlencode, urlparse
 
-import lazy_object_proxy
 import nvd3
 import sqlalchemy as sqla
 import yaml
@@ -90,6 +89,7 @@ from airflow.utils.dates import infer_time_unit, scale_time_units
 from airflow.utils.docs import get_docs_url
 from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils.log.log_reader import TaskLogReader
+from airflow.utils.proxy import cached_proxy
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.version import version
@@ -404,7 +404,7 @@ class AirflowBaseView(BaseView):  # noqa: D101
         return super().render_template(
             *args,
             # Cache this at most once per request, not for the lifetime of the view instance
-            scheduler_job=lazy_object_proxy.Proxy(SchedulerJob.most_recent_job),
+            scheduler_job=cached_proxy(SchedulerJob.most_recent_job),
             **kwargs,
         )
 

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -77,8 +77,7 @@ Unfortunately we currently do not support to serialize ``var`` and ``ti`` / ``ta
 with the underlying library. For airflow context variables make sure that you either have access to Airflow through
 setting ``system_site_packages`` to ``True`` or add ``apache-airflow`` to the ``requirements`` argument.
 Otherwise you won't have access to the most context variables of Airflow in ``op_kwargs``.
-If you want the context related to datetime objects like ``execution_date`` you can add ``pendulum`` and
-``lazy_object_proxy``.
+If you want the context related to datetime objects like ``execution_date`` you can add ``pendulum``.
 
 Templating
 ^^^^^^^^^^

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,6 @@ install_requires =
     itsdangerous>=1.1.0
     jinja2>=2.10.1, <2.12.0
     jsonschema~=3.0
-    lazy-object-proxy
     lockfile>=0.12.2
     markdown>=2.5.2, <4.0
     markupsafe>=1.1.1, <2.0


### PR DESCRIPTION
We already get a local object proxy from werkzeug, and it's trivial to
add memoization with the standard library, so we can drop the
third-party dependency without losing functionality. This patch also
adds explicit getters to the template context for fields that require a
database lookup for explicitness.