### PR TITLE
Fix functionality of "Demo Mode", refactor/simplify naming

### DIFF
--- a/airflow/www/extensions/init_jinja_globals.py
+++ b/airflow/www/extensions/init_jinja_globals.py
@@ -66,6 +66,7 @@ def init_jinja_globals(app):
             'airflow_version': airflow_version,
             'git_version': git_version,
             'k8s_or_k8scelery_executor': IS_K8S_OR_K8SCELERY_EXECUTOR,
+            'is_demo_mode': conf.getboolean('webserver', 'demo_mode'),
         }
 
         if 'analytics_tool' in conf.getsection('webserver'):

--- a/airflow/www/static/css/dag-code.css
+++ b/airflow/www/static/css/dag-code.css
@@ -1,0 +1,15 @@
+.code-wrap {
+  position: relative;
+  margin-top: 30px;
+}
+
+.code-wrap-toggle {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+}
+
+.hide-sensitive-code {
+  text-shadow: 0 0 10px red;
+  color: transparent;
+}

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -255,7 +255,7 @@ body div.panel {
   padding: 0;
 }
 
-.blur {
+.blur-sensitive-info {
   filter: url(#blur-effect-1);
 }
 
@@ -403,17 +403,6 @@ label[for="timezone-other"],
   margin: 16px 0;
   padding: 16px 0;
   background-color: #f0f0f0;
-}
-
-.code-wrap {
-  position: relative;
-  margin-top: 30px;
-}
-
-.code-wrap-toggle {
-  position: absolute;
-  top: 15px;
-  right: 15px;
 }
 
 .search-input {

--- a/airflow/www/static/js/dag_code.js
+++ b/airflow/www/static/js/dag_code.js
@@ -19,16 +19,13 @@
 
 import getMetaValue from './meta_value';
 
-const isDemoMode = getMetaValue('demo_mode');
+const isDemoMode = getMetaValue('is_demo_mode');
 const isWrapped = getMetaValue('wrapped');
 
 document.addEventListener('DOMContentLoaded', () => {
   // We blur task_ids in demo mode
   if (isDemoMode) {
-    $('pre span.s').css({
-      'text-shadow': '0 0 10px red',
-      color: 'transparent',
-    });
+    $('pre .s1, pre .s2').addClass('hide-sensitive-code');
   }
 });
 

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -259,8 +259,8 @@ document.addEventListener('DOMContentLoaded', () => {
       .attr('dx', barHeight / 2)
       .text((d) => d.name);
 
-    const isBlur = getMetaValue('blur');
-    if (isBlur === 'True') text.attr('class', 'blur');
+    const isDemoMode = getMetaValue('is_demo_mode');
+    if (isDemoMode === 'True') svg.attr('class', 'blur-sensitive-info');
 
     nodeEnter.append('g')
       .attr('class', 'stateboxes')

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -22,6 +22,11 @@
 
 {% block page_title %}{{ dag.dag_id }} - {{ appbuilder.app_name }}{% endblock %}
 
+{% block head_meta %}
+  {{ super() }}
+  <meta name="is_demo_mode" content="{{ is_demo_mode }}">
+{% endblock %}
+
 {% block head_css %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('switch.css') }}">

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -23,8 +23,12 @@
 
 {% block head_meta %}
   {{ super() }}
-  <meta name="demo_mode" content="{{ demo_mode }}">
   <meta name="wrapped" content="{{ wrapped }}">
+{% endblock %}
+
+{% block head_css %}
+  {{ super() }}
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('dagCode.css') }}">
 {% endblock %}
 
 {% block content %}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -290,8 +290,8 @@
       }
 
 
-      {% if blur %}
-      d3.selectAll("text").attr("class", "blur");
+      {% if is_demo_mode %}
+        svg.attr('class', 'blur-sensitive-info');
       {% endif %}
 
       d3.selectAll('.js-state-legend-item')

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -20,11 +20,6 @@
 {% extends "airflow/dag.html" %}
 {% block page_title %}{{ dag.dag_id }} - Tree - {{ appbuilder.app_name }}{% endblock %}
 
-{% block head_meta %}
-  {{ super() }}
-  <meta name="blur" content="{{ blur }}">
-{% endblock %}
-
 {% block head_css %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('tree.css') }}">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -841,7 +841,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag_orm,
             title=dag_id,
             root=request.args.get('root'),
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             wrapped=conf.getboolean('webserver', 'default_wrap'),
         )
 
@@ -1870,7 +1869,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
     def tree(self):
         """Get Dag as tree."""
         dag_id = request.args.get('dag_id')
-        blur = conf.getboolean('webserver', 'demo_mode')
         dag = current_app.dag_bag.get_dag(dag_id)
         if not dag:
             flash(f'DAG "{dag_id}" seems to be missing from DagBag.', "error")
@@ -2015,7 +2013,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag,
             doc_md=doc_md,
             data=data,
-            blur=blur,
             num_runs=num_runs,
             show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name,
@@ -2035,7 +2032,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
     def graph(self, session=None):
         """Get DAG as Graph."""
         dag_id = request.args.get('dag_id')
-        blur = conf.getboolean('webserver', 'demo_mode')
         dag = current_app.dag_bag.get_dag(dag_id)
         if not dag:
             flash(f'DAG "{dag_id}" seems to be missing.', "error")
@@ -2101,7 +2097,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             doc_md=doc_md,
             arrange=arrange,
             operators=sorted({op.task_type: op for op in dag.tasks}.values(), key=lambda x: x.task_type),
-            blur=blur,
             root=root or '',
             task_instances=task_instances,
             tasks=tasks,
@@ -2234,7 +2229,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         return self.render_template(
             'airflow/duration_chart.html',
             dag=dag,
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
             chart=Markup(chart.htmlcontent),
@@ -2306,7 +2300,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         return self.render_template(
             'airflow/chart.html',
             dag=dag,
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
             chart=Markup(chart.htmlcontent),
@@ -2392,7 +2385,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag,
             chart=Markup(chart.htmlcontent),
             height=str(chart_height + 100) + "px",
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
             tab_title='Landing times',
@@ -2467,7 +2459,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         """Show GANTT chart."""
         dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
-        demo_mode = conf.getboolean('webserver', 'demo_mode')
 
         root = request.args.get('root')
         if root:
@@ -2546,7 +2537,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             form=form,
             data=data,
             base_date='',
-            demo_mode=demo_mode,
             root=root,
         )
 

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -39,7 +39,7 @@ const config = {
   entry: {
     airflowDefaultTheme: `${CSS_DIR}/bootstrap-theme.css`,
     connectionForm: `${JS_DIR}/connection_form.js`,
-    dagCode: `${JS_DIR}/dag_code.js`,
+    dagCode: [`${CSS_DIR}/dag-code.css`, `${JS_DIR}/dag_code.js`],
     dags: `${CSS_DIR}/dags.css`,
     flash: `${CSS_DIR}/flash.css`,
     gantt: [`${CSS_DIR}/gantt.css`, `${JS_DIR}/gantt.js`],


### PR DESCRIPTION
"Demo Mode" wasn't functioning properly (obfuscating sensitive info). This update fixes the implementation so the Tree, Graph, and Code view blur contents as expected.

- Refactored the instrumentation of the "demo mode" to use a global jinja variable instead of repeating individual view variables
- Used more instructive variable naming. eg. `is_demo_mode` instead of `blur`.

_Side note:_ I'm interested in the genesis of this feature, but wasn't able to track down a PR in my initial searching. Curious how widely something like this would actually be used—if it's worth the overhead?

| Before | After |
|---|---|
|  <img width="1110" alt="Image 2021-03-03 at 10 16 38 PM" src="https://user-images.githubusercontent.com/3267/109906388-694f8d00-7c6e-11eb-8ecf-1a0d91424ebd.png"> | <img width="1170" alt="Image 2021-03-03 at 10 14 29 PM" src="https://user-images.githubusercontent.com/3267/109906550-b469a000-7c6e-11eb-932c-c4fafd9b3200.png">  |

| Before | After |
|---|---|
|  <img width="581" alt="Image 2021-03-03 at 10 16 53 PM" src="https://user-images.githubusercontent.com/3267/109906386-6785c980-7c6e-11eb-896d-f29418387438.png"> | <img width="753" alt="Image 2021-03-03 at 10 14 13 PM" src="https://user-images.githubusercontent.com/3267/109906418-73718b80-7c6e-11eb-8218-cd685f05eab8.png">  |

| Before | After |
|---|---|
|  <img width="1246" alt="Image 2021-03-03 at 10 17 10 PM" src="https://user-images.githubusercontent.com/3267/109906380-63f24280-7c6e-11eb-84a2-4677b9bf0db7.png"> |  <img width="1303" alt="Image 2021-03-03 at 10 13 56 PM" src="https://user-images.githubusercontent.com/3267/109906425-753b4f00-7c6e-11eb-92d5-a030836b5a2d.png"> |
