### PR TITLE
Remove broken and undocumented "demo mode" feature

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1065,14 +1065,6 @@
       type: string
       example: ~
       default: "LR"
-    - name: demo_mode
-      description: |
-        Puts the webserver in demonstration mode; blurs the names of Operators for
-        privacy.
-      version_added: ~
-      type: string
-      example: ~
-      default: "False"
     - name: log_fetch_timeout_sec
       description: |
         The amount of time (in secs) webserver will wait for initial handshake

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -538,10 +538,6 @@ dag_default_view = tree
 # ``LR`` (Left->Right), ``TB`` (Top->Bottom), ``RL`` (Right->Left), ``BT`` (Bottom->Top)
 dag_orientation = LR
 
-# Puts the webserver in demonstration mode; blurs the names of Operators for
-# privacy.
-demo_mode = False
-
 # The amount of time (in secs) webserver will wait for initial handshake
 # while fetching logs from other worker machine
 log_fetch_timeout_sec = 5

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -255,10 +255,6 @@ body div.panel {
   padding: 0;
 }
 
-.blur {
-  filter: url(#blur-effect-1);
-}
-
 .legend-row {
   display: flex;
   align-items: center;

--- a/airflow/www/static/js/dag_code.js
+++ b/airflow/www/static/js/dag_code.js
@@ -19,18 +19,7 @@
 
 import getMetaValue from './meta_value';
 
-const isDemoMode = getMetaValue('demo_mode');
 const isWrapped = getMetaValue('wrapped');
-
-document.addEventListener('DOMContentLoaded', () => {
-  // We blur task_ids in demo mode
-  if (isDemoMode) {
-    $('pre span.s').css({
-      'text-shadow': '0 0 10px red',
-      color: 'transparent',
-    });
-  }
-});
 
 // pygments generates the HTML so set wrap toggle via js
 if (isWrapped) {

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -259,9 +259,6 @@ document.addEventListener('DOMContentLoaded', () => {
       .attr('dx', barHeight / 2)
       .text((d) => d.name);
 
-    const isBlur = getMetaValue('blur');
-    if (isBlur === 'True') text.attr('class', 'blur');
-
     nodeEnter.append('g')
       .attr('class', 'stateboxes')
       .attr('transform',

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -23,7 +23,6 @@
 
 {% block head_meta %}
   {{ super() }}
-  <meta name="demo_mode" content="{{ demo_mode }}">
   <meta name="wrapped" content="{{ wrapped }}">
 {% endblock %}
 

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -109,9 +109,6 @@
     <div class="graph-svg-wrap">
       <svg id="graph-svg" width="{{ width }}" height="{{ height }}">
         <g id="dig" transform="translate(20,20)"></g>
-        <filter id="blur-effect-1">
-          <feGaussianBlur stdDeviation="3"></feGaussianBlur>
-        </filter>
       </svg>
     </div>
   </div>
@@ -288,11 +285,6 @@
                   .style("stroke-width", stroke_width) ;
           })
       }
-
-
-      {% if blur %}
-      d3.selectAll("text").attr("class", "blur");
-      {% endif %}
 
       d3.selectAll('.js-state-legend-item')
           .style("cursor", "pointer")

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -20,11 +20,6 @@
 {% extends "airflow/dag.html" %}
 {% block page_title %}{{ dag.dag_id }} - Tree - {{ appbuilder.app_name }}{% endblock %}
 
-{% block head_meta %}
-  {{ super() }}
-  <meta name="blur" content="{{ blur }}">
-{% endblock %}
-
 {% block head_css %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('tree.css') }}">
@@ -80,11 +75,7 @@
   <hr>
   <div id="svg_container">
     <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
-    <svg id="tree-svg" class='tree' width="100%">
-      <filter id="blur-effect-1">
-        <feGaussianBlur stdDeviation="3"></feGaussianBlur>
-      </filter>
-    </svg>
+    <svg id="tree-svg" class='tree' width="100%"></svg>
   </div>
 {% endblock %}
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -841,7 +841,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag_orm,
             title=dag_id,
             root=request.args.get('root'),
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             wrapped=conf.getboolean('webserver', 'default_wrap'),
         )
 
@@ -1870,7 +1869,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
     def tree(self):
         """Get Dag as tree."""
         dag_id = request.args.get('dag_id')
-        blur = conf.getboolean('webserver', 'demo_mode')
         dag = current_app.dag_bag.get_dag(dag_id)
         if not dag:
             flash(f'DAG "{dag_id}" seems to be missing from DagBag.', "error")
@@ -2015,7 +2013,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag,
             doc_md=doc_md,
             data=data,
-            blur=blur,
             num_runs=num_runs,
             show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name,
@@ -2035,7 +2032,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
     def graph(self, session=None):
         """Get DAG as Graph."""
         dag_id = request.args.get('dag_id')
-        blur = conf.getboolean('webserver', 'demo_mode')
         dag = current_app.dag_bag.get_dag(dag_id)
         if not dag:
             flash(f'DAG "{dag_id}" seems to be missing.', "error")
@@ -2101,7 +2097,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             doc_md=doc_md,
             arrange=arrange,
             operators=sorted({op.task_type: op for op in dag.tasks}.values(), key=lambda x: x.task_type),
-            blur=blur,
             root=root or '',
             task_instances=task_instances,
             tasks=tasks,
@@ -2234,7 +2229,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         return self.render_template(
             'airflow/duration_chart.html',
             dag=dag,
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
             chart=Markup(chart.htmlcontent),
@@ -2306,7 +2300,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         return self.render_template(
             'airflow/chart.html',
             dag=dag,
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
             chart=Markup(chart.htmlcontent),
@@ -2392,7 +2385,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag,
             chart=Markup(chart.htmlcontent),
             height=str(chart_height + 100) + "px",
-            demo_mode=conf.getboolean('webserver', 'demo_mode'),
             root=root,
             form=form,
             tab_title='Landing times',
@@ -2467,7 +2459,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         """Show GANTT chart."""
         dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
-        demo_mode = conf.getboolean('webserver', 'demo_mode')
 
         root = request.args.get('root')
         if root:
@@ -2546,7 +2537,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             form=form,
             data=data,
             base_date='',
-            demo_mode=demo_mode,
             root=root,
         )
 


### PR DESCRIPTION
After fixing and refactoring the "demo mode" feature in #14595, I feel that it would be more productive to replace that PR with this one that removes the feature instead. 

- It has very little documentation
- It has been largely broken for an unknown period of time without any issue reports. I only encountered it because I wanted to refactor its implementation.
- [As illustrated by @ashb](https://github.com/apache/airflow/pull/14595#issuecomment-790581682) it doesn't do a really great job if someone were to capture a screenshot from remote demonstration.
- As pointed out by @HaloKo4, only being able to activate it from the config doesn't make it a very convenient feature that can easily be enabled/disabled.

If this is a feature people would like to see, I think it would be better to see a new implementation proposed that addresses these shortcomings.