### PR TITLE
Add links to 2.0 Blog post in Changelog

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -143,6 +143,12 @@ Doc only changes
 - Add deprecated config options to docs (#13883)
 - Added a FAQ section to the Upgrading to 2 doc (#13979)
 
+Airflow 2.0.0, 2020-12-18
+----------------------------
+
+The full changelog is about 3,000 lines long (already excluding everything backported to 1.10)
+so please check `Airflow 2.0.0 Highligths Blog Post <https://airflow.apache.org/blog/airflow-two-point-oh-is-here/>`_
+instead.
 
 Airflow 1.10.14, 2020-12-10
 ----------------------------


### PR DESCRIPTION
We currently don't have anything mentioned about 2.0.0 in the changelog,
 this commit should help users get to our blog post highlighting 2.0 features.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
