### PR TITLE
Do not suppress error in airflow plugins cli

### DIFF
--- a/airflow/cli/commands/plugins_command.py
+++ b/airflow/cli/commands/plugins_command.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import inspect
+import logging
 from typing import Any, Dict, List, Union
 
 from airflow import plugins_manager
@@ -36,7 +37,7 @@ def _join_plugins_names(value: Union[List[Any], Any]) -> str:
     return ",".join(_get_name(v) for v in value)
 
 
-@suppress_logs_and_warning
+@suppress_logs_and_warning(level=logging.WARNING)
 def dump_plugins(args):
     """Dump plugins information"""
     plugins_info: List[Dict[str, str]] = get_plugin_info()

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -239,6 +239,7 @@ def load_plugins_from_plugin_directory():
                 plugins.append(plugin_instance)
 
         except Exception as e:  # pylint: disable=broad-except
+            print("exception", e)
             log.exception(e)
             log.error('Failed to import plugin %s', file_path)
             import_errors[file_path] = str(e)

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -293,26 +293,34 @@ def should_use_colors(args) -> bool:
     return is_terminal_support_colors()
 
 
-def suppress_logs_and_warning(f: T) -> T:
+def suppress_logs_and_warning(level=logging.CRITICAL):
     """
-    Decorator to suppress logging and warning messages
+    Configurable decorator to suppress logging and warning messages
     in cli functions.
     """
 
-    @functools.wraps(f)
-    def _wrapper(*args, **kwargs):
-        _check_cli_args(args)
-        if args[0].verbose:
-            f(*args, **kwargs)
-        else:
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                logging.disable(logging.CRITICAL)
-                try:
-                    f(*args, **kwargs)
-                finally:
-                    # logging output again depends on the effective
-                    # levels of individual loggers
-                    logging.disable(logging.NOTSET)
+    def decorator(f: T) -> T:
+        """
+        Decorator to suppress logging and warning messages
+        in cli functions.
+        """
 
-    return cast(T, _wrapper)
+        @functools.wraps(f)
+        def _wrapper(*args, **kwargs):
+            _check_cli_args(args)
+            if args[0].verbose:
+                f(*args, **kwargs)
+            else:
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    logging.disable(level)
+                    try:
+                        f(*args, **kwargs)
+                    finally:
+                        # logging output again depends on the effective
+                        # levels of individual loggers
+                        logging.disable(logging.NOTSET)
+
+        return cast(T, _wrapper)
+
+    return decorator


### PR DESCRIPTION
Currently `airflow plugins` with suppress all errors, and warnings, so for example if the plugins contain errors, the output will simply show 
```
airflow plugins
No plugins loaded
```

There is the flag `--verbose`  that will preserve the log output: 
```
airflow plugins --verbose
[2021-03-04 17:46:38,569] {plugins_manager.py:243} ERROR - No module named 'nonexisting'
Traceback (most recent call last):
  File "/Users/ecerulm/git/airflow/airflow/plugins_manager.py", line 233, in load_plugins_from_plugin_directory
    loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/ecerulm/git/airflow/plugins/errored_plugin.py", line 13, in <module>
    import nonexisting
ModuleNotFoundError: No module named 'nonexisting'
[2021-03-04 17:46:38,570] {plugins_manager.py:244} ERROR - Failed to import plugin /Users/ecerulm/git/airflow/plugins/errored_plugin.py
No plugins loaded
```

This PR aims to change the default suppression level so that errors are shown by default on `airflow plugins` by introducing a parameter to the `@suppress_logs_and_warnings` decorator to set the supression level. 

so `@suppress_log_and_warnings()` will supress all logs but `@suppress_log_and_warnings(level=logging.WARNING)` will still show `ERROR` and `CRITICAL` logs.

