### PR TITLE
Allow function wrappers for @task operator

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -271,7 +271,7 @@ def task(
         Defaults to False.
     :type multiple_outputs: bool
     :param wrapper_func: Allows users to add a wrapper around the python function. This will make the
-    @task wrapper easier to extend
+        task wrapper easier to extend
     :type wrapper_func: Optional[Callable]
 
     """

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -177,6 +177,30 @@ is automatically set to true.
 Note, If you manually set the ``multiple_outputs`` parameter the inference is disabled and
 the parameter value is used.
 
+Adding function wrappers around the @task decorator
+---------------------------------------------------
+
+For those who want to extend the functionality of a TaskFlow task decorator, we offer the ability to provide a wrapper
+function to perform setup and teardown before and after each function. This could be setting up a spark cluster,
+establishing a database connection, or any other number of other environment setup steps.
+
+In the basic example below, we create a wrapper that adds one to the output of the task.
+
+.. code-block:: python
+        def add_one_wrapper(f):
+            @functools.wraps(f)
+            def add_one(*args, **kwargs):
+                initial_result = f(*args, **kwargs)
+                print(f"Adding one to result {initial_result}")
+                return  initial_result + 1
+            return add_one
+
+        @task(wrapper_func=add_one_wrapper)
+        def return_one():
+            return 1
+
+        should_be_two = return_one()
+
 Adding dependencies to decorated tasks from regular tasks
 ---------------------------------------------------------
 The above tutorial shows how to create dependencies between python-based tasks. However, it is

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -187,19 +187,19 @@ establishing a database connection, or any other number of other environment set
 In the basic example below, we create a wrapper that adds one to the output of the task.
 
 .. code-block:: python
-        def add_one_wrapper(f):
-            @functools.wraps(f)
-            def add_one(*args, **kwargs):
-                initial_result = f(*args, **kwargs)
-                print(f"Adding one to result {initial_result}")
-                return  initial_result + 1
-            return add_one
+    def add_one_wrapper(f):
+        @functools.wraps(f)
+        def add_one(*args, **kwargs):
+            initial_result = f(*args, **kwargs)
+            print(f"Adding one to result {initial_result}")
+            return  initial_result + 1
+        return add_one
 
-        @task(wrapper_func=add_one_wrapper)
-        def return_one():
-            return 1
+    @task(wrapper_func=add_one_wrapper)
+    def return_one():
+        return 1
 
-        should_be_two = return_one()
+    should_be_two = return_one()
 
 Adding dependencies to decorated tasks from regular tasks
 ---------------------------------------------------------


### PR DESCRIPTION
Make the @task decorator easily extensible by allowing users to add
custom wrapper functions for setup/teardown of environments

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
