### PR TITLE
Fix breeze no --log-out option in script

### DIFF
--- a/breeze
+++ b/breeze
@@ -27,7 +27,7 @@ if [[ ${BREEZE_REDIRECT=} == "" ]]; then
     if [[ "$(uname)" == "Darwin" ]]; then
       exec script -q "${AIRFLOW_SOURCES}"/logs/breeze.out "$BASH" -c "$(printf "%q " "${0}" "${@}")"
     else
-      exec script --return --quiet --log-out "${AIRFLOW_SOURCES}"/logs/breeze.out -c "$(printf "%q " "${0}" "${@}")"
+      exec script --return --quiet -c "$(printf "%q " "${0}" "${@}")" | tee "${AIRFLOW_SOURCES}"/logs/breeze.out
     fi
 fi
 


### PR DESCRIPTION
I tried starting breeze after a rebase and I couldn't.
I had this error:
```
script: unrecognized option '--log-out'
Try 'script --help' for more information.
```
when I tried `script --help` I got :
```
Usage:
 script [options] [file]

Make a typescript of a terminal session.

Options:
 -a, --append                  append the output
 -c, --command <command>       run command rather than interactive shell
 -e, --return                  return exit code of the child process
 -f, --flush                   run flush after each write
     --force                   use output file even when it is a link
 -o, --output-limit <size>     terminate if output files exceed size
 -q, --quiet                   be quiet
 -t[<file>], --timing[=<file>] output timing data to stderr or to FILE
 -h, --help                    display this help
 -V, --version                 display version

For more details see script(1).
```
When I ran `script --version` I got:
```
script from util-linux 2.34
```
This PR is what I did to have breeze running.



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
