### PR TITLE
Bump redoc version to match node dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -536,4 +536,4 @@ if PACKAGE_NAME == 'apache-airflow':
     ]
 
     # Options for script updater
-    redoc_script_url = "https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.30/bundles/redoc.standalone.js"
+    redoc_script_url = "https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.48/bundles/redoc.standalone.js"


### PR DESCRIPTION
Follow up to #14608. Keep this docs version in-sync with the node dependency.