### PR TITLE
Improve readability of Sensor Schedule Mode table

### DIFF
--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -515,6 +515,7 @@ There are currently 3 different modes for how a sensor operates:
 
 .. list-table::
    :header-rows: 1
+   :widths: "auto"
 
    * - Schedule Mode
      - Description


### PR DESCRIPTION
* Change Sensor Schedule Mode table to use width: "auto", so it doesn't scroll horizontally.
  * Currently horizontally scrolls more than one extra page width for me, on a fairly wide viewport.