### PR TITLE
Remove unused usage of logging module

### DIFF
--- a/airflow/api_connexion/endpoints/dag_source_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_source_endpoint.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import logging
 
 from flask import Response, current_app, request
 from itsdangerous import BadSignature, URLSafeSerializer
@@ -24,8 +23,6 @@ from airflow.api_connexion.exceptions import NotFound
 from airflow.api_connexion.schemas.dag_source_schema import dag_source_schema
 from airflow.models.dagcode import DagCode
 from airflow.security import permissions
-
-log = logging.getLogger(__name__)
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_CODE)])

--- a/airflow/api_connexion/endpoints/version_endpoint.py
+++ b/airflow/api_connexion/endpoints/version_endpoint.py
@@ -15,14 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import logging
 from typing import NamedTuple, Optional
 
 import airflow
 from airflow.api_connexion.schemas.version_schema import version_info_schema
 from airflow.utils.platform import get_airflow_git_version
-
-log = logging.getLogger(__name__)
 
 
 class VersionInfo(NamedTuple):


### PR DESCRIPTION
Unless I am missing something the logging module was imported in the following files but was not used:

- airflow/api_connexion/endpoints/dag_source_endpoint.py
- airflow/api_connexion/endpoints/version_endpoint.py

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
