### PR TITLE
Allow ExternalTaskSensor to wait for taskgroup

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -831,7 +831,7 @@ class DAG(LoggingMixin):
 
     @property
     def task_group_dict(self) -> Dict[str, "TaskGroup"]:
-        return {k: v for k, v in self._task_group.get_task_group_dict().items() if k is not None}
+        return {k: v for k, v in self.task_group.get_task_group_dict().items() if k is not None}
 
     @property
     def task_group(self) -> "TaskGroup":

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -830,8 +830,16 @@ class DAG(LoggingMixin):
         return list(self.task_dict.keys())
 
     @property
+    def task_group_dict(self) -> Dict[str, "TaskGroup"]:
+        return {k: v for k, v in self._task_group.get_task_group_dict().items() if k is not None}
+
+    @property
     def task_group(self) -> "TaskGroup":
         return self._task_group
+
+    @property
+    def task_groups(self) -> List["TaskGroup"]:
+        return list(self.task_group_dict.values())
 
     @property
     def filepath(self) -> str:
@@ -1883,8 +1891,11 @@ class DAG(LoggingMixin):
 
         return dag
 
+    def has_task_group(self, group_id: str):
+        return group_id in self.task_group_dict
+
     def has_task(self, task_id: str):
-        return task_id in (t.task_id for t in self.tasks)
+        return task_id in self.task_dict
 
     def get_task(self, task_id: str, include_subdags: bool = False) -> BaseOperator:
         if task_id in self.task_dict:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1891,7 +1891,7 @@ class DAG(LoggingMixin):
 
         return dag
 
-    def has_task_group(self, group_id: str):
+    def has_task_group(self, group_id: str) -> bool:
         return group_id in self.task_group_dict
 
     def has_task(self, task_id: str):

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -160,7 +160,7 @@ class TaskGroup(TaskMixin):
         """Returns True if this TaskGroup is the root TaskGroup. Otherwise False"""
         return not self.group_id
 
-    def __iter__(self):
+    def __iter__(self) -> "BaseOperator":
         for child in self.children.values():
             if isinstance(child, TaskGroup):
                 yield from child
@@ -342,6 +342,9 @@ class TaskGroup(TaskMixin):
     def get_child_by_label(self, label: str) -> Union["BaseOperator", "TaskGroup"]:
         """Get a child task/TaskGroup by its label (i.e. task_id/group_id without the group_id prefix)"""
         return self.children[self.child_id(label)]
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}: {self.group_id}>"
 
 
 class TaskGroupContext:

--- a/tests/sensors/test_external_task.py
+++ b/tests/sensors/test_external_task.py
@@ -152,6 +152,8 @@ class TestExternalTaskSensor:
 
     def test_external_dag_sensor(self):
         other_dag = DAG('other_dag', default_args=self.args, end_date=DEFAULT_DATE, schedule_interval='@once')
+
+        clear_db_runs()
         other_dag.create_dagrun(
             run_id='test', start_date=DEFAULT_DATE, execution_date=DEFAULT_DATE, state=State.SUCCESS
         )

--- a/tests/sensors/test_external_task.py
+++ b/tests/sensors/test_external_task.py
@@ -15,8 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import logging
-import unittest
 from datetime import time, timedelta
 
 import pytest
@@ -41,13 +39,8 @@ TEST_TASK_ID_ALTERNATE = 'time_sensor_check_alternate'
 DEV_NULL = '/dev/null'
 
 
-@pytest.fixture(autouse=True)
-def clean_db():
-    clear_db_runs()
-
-
-class TestExternalTaskSensor(unittest.TestCase):
-    def setUp(self):
+class TestExternalTaskSensor:
+    def setup_method(self):
         self.dagbag = DagBag(dag_folder=DEV_NULL, include_examples=True)
         self.args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
         self.dag = DAG(TEST_DAG_ID, default_args=self.args)
@@ -417,7 +410,7 @@ exit 0
             op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
 
-class TestExternalTaskMarker(unittest.TestCase):
+class TestExternalTaskMarker:
     def test_serialized_fields(self):
         assert {"recursion_depth"}.issubset(ExternalTaskMarker.get_serialized_fields())
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #14563

This PR enables ExternalTaskSensor to also wait for the external task_group. 

The implementation is to retrieve the external DAG from the DagBag and then check if the TaskGroup exists. If so, query and wait for the states of all tasks within that TaskGroup during the poking cycle.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
