### PR TITLE
Remove the default config from the Configuration View, show only running configuration

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -69,6 +69,16 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Configuration View only shows running configuration
+
+Previously, the Configuration View showed two things:
+
+1. airflow.cfg content
+2. Table with the running configuration, displaying the active values and their source (e.g. env vars)
+
+Since values in airflow.cfg can be overridden by environment variables, this led to confusion because airflow.cfg did
+not represent the currently active configuration. Therefore, the airflow.cfg content was removed from the Configuration
+View and only the table with running configuration is displayed.
 
 ## Airflow 2.0.1
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -80,10 +80,8 @@ Since values in airflow.cfg can be overridden by environment variables, this led
 not represent the currently active configuration. Therefore, the airflow.cfg content was removed from the Configuration
 View and only the table with running configuration is displayed.
 
-The `raw` argument (`http://airflow/configuration?raw=true`) was given slightly different behaviour:
-
-- In case `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=False`: returns HTTP 204 (with a header `Reason`)
-- In case `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True`: returns running configuration in JSON format
+In the process, the `raw` argument (`http://airflow/configuration?raw=true`) was removed. It is substituted by Config
+endpoint of the REST API.
 
 ## Airflow 2.0.1
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -69,7 +69,7 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
-### Configuration View only shows running configuration
+### Configuration View only returns running configuration
 
 Previously, the Configuration View showed two things:
 
@@ -79,6 +79,11 @@ Previously, the Configuration View showed two things:
 Since values in airflow.cfg can be overridden by environment variables, this led to confusion because airflow.cfg did
 not represent the currently active configuration. Therefore, the airflow.cfg content was removed from the Configuration
 View and only the table with running configuration is displayed.
+
+The `raw` argument (`http://airflow/configuration?raw=true`) was given slightly different behaviour:
+
+- In case `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=False`: returns HTTP 204 (with a header `Reason`)
+- In case `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True`: returns running configuration in JSON format
 
 ## Airflow 2.0.1
 

--- a/airflow/www/templates/airflow/config.html
+++ b/airflow/www/templates/airflow/config.html
@@ -31,17 +31,11 @@
         <pre>{{ pre_subtitle }}</pre>
     {% endif %}
 
-    {% if subtitle %}
-        <h5>{{ subtitle }}</h5>
-    {% endif %}
-
-    {% if code_html %}
-        {{ code_html }}
-    {% endif %}
-
-    <hr>
-
-    {% if table %}
+    {% if not expose_config %}
+        <div class="alert alert-info">
+            <p>Your Airflow administrator chose not to expose the configuration, most likely for security reasons.</p>
+        </div>
+    {% elif expose_config and table %}
         <br>
         <h3>Running Configuration</h3>
         <br>

--- a/airflow/www/templates/airflow/config.html
+++ b/airflow/www/templates/airflow/config.html
@@ -27,10 +27,6 @@
     {{ super() }}
     <h2>{{ title }}</h2>
 
-    {% if pre_subtitle %}
-        <pre>{{ pre_subtitle }}</pre>
-    {% endif %}
-
     {% if hide_config_msg is defined %}
         <div class="alert alert-info">
             <p>{{ hide_config_msg }}</p>

--- a/airflow/www/templates/airflow/config.html
+++ b/airflow/www/templates/airflow/config.html
@@ -31,7 +31,7 @@
         <pre>{{ pre_subtitle }}</pre>
     {% endif %}
 
-    {% if hide_config_msg %}
+    {% if hide_config_msg is defined %}
         <div class="alert alert-info">
             <p>{{ hide_config_msg }}</p>
         </div>

--- a/airflow/www/templates/airflow/config.html
+++ b/airflow/www/templates/airflow/config.html
@@ -31,14 +31,11 @@
         <pre>{{ pre_subtitle }}</pre>
     {% endif %}
 
-    {% if not expose_config %}
+    {% if hide_config_msg %}
         <div class="alert alert-info">
-            <p>Your Airflow administrator chose not to expose the configuration, most likely for security reasons.</p>
+            <p>{{ hide_config_msg }}</p>
         </div>
-    {% elif expose_config and table %}
-        <br>
-        <h3>Running Configuration</h3>
-        <br>
+    {% elif table %}
         <div>
             <table class="table table-striped table-bordered">
                 <tr>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2653,42 +2653,29 @@ class ConfigurationView(AirflowBaseView):
     )
     def conf(self):
         """Shows configuration."""
-        raw = request.args.get('raw') == "true"
         title = "Airflow Configuration"
-        subtitle = AIRFLOW_CONFIG
         # Don't show config when expose_config variable is False in airflow config
-        if conf.getboolean("webserver", "expose_config"):
-            with open(AIRFLOW_CONFIG) as file:
-                config = file.read()
+        expose_config = conf.getboolean("webserver", "expose_config")
+        if expose_config:
             table = [
                 (section, key, value, source)
                 for section, parameters in conf.as_dict(True, True).items()
                 for key, (value, source) in parameters.items()
             ]
         else:
-            config = (
-                "# Your Airflow administrator chose not to expose the "
-                "configuration, most likely for security reasons."
-            )
             table = None
 
-        if raw:
+        if request.args.get('raw') == "true" and expose_config:
+            with open(AIRFLOW_CONFIG) as file:
+                config = file.read()
             return Response(response=config, status=200, mimetype="application/text")
         else:
-            code_html = Markup(
-                highlight(
-                    config,
-                    lexers.IniLexer(),  # Lexer call pylint: disable=no-member
-                    HtmlFormatter(noclasses=True),
-                )
-            )
             return self.render_template(
                 'airflow/config.html',
                 pre_subtitle=settings.HEADER + "  v" + airflow.__version__,
-                code_html=code_html,
                 title=title,
-                subtitle=subtitle,
                 table=table,
+                expose_config=expose_config,
             )
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -71,7 +71,7 @@ from airflow.api.common.experimental.mark_tasks import (
     set_dag_run_state_to_failed,
     set_dag_run_state_to_success,
 )
-from airflow.configuration import AIRFLOW_CONFIG, conf
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2661,31 +2661,16 @@ class ConfigurationView(AirflowBaseView):
                 for section, parameters in conf.as_dict(True, True).items()
                 for key, (value, source) in parameters.items()
             ]
-
-            if request.args.get('raw') == "true":
-                return Response(response=json.dumps(table), status=200, mimetype="application/json")
-
-            return self.render_template(
-                'airflow/config.html',
-                title=title,
-                pre_subtitle=settings.HEADER + "  v" + airflow.__version__,
-                table=table,
-            )
+            return self.render_template('airflow/config.html', title=title, table=table)
 
         else:
-            hide_config_msg = (
-                "Your Airflow administrator chose not to expose the configuration, "
-                "most likely for security reasons."
-            )
-
-            if request.args.get('raw') == "true":
-                return Response(headers={"Reason": hide_config_msg}, status=204, mimetype="application/text")
-
             return self.render_template(
                 'airflow/config.html',
                 title=title,
-                pre_subtitle=settings.HEADER + "  v" + airflow.__version__,
-                hide_config_msg=hide_config_msg,
+                hide_config_msg=(
+                    "Your Airflow administrator chose not to expose the configuration, "
+                    "most likely for security reasons."
+                ),
             )
 
 

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1168,7 +1168,7 @@ class TestConfigurationView(TestBase):
         self.check_content_in_response(
             [
                 'Airflow Configuration',
-                '# Your Airflow administrator chose not to expose the configuration, '
+                'Your Airflow administrator chose not to expose the configuration, '
                 'most likely for security reasons.',
             ],
             resp,
@@ -1179,7 +1179,7 @@ class TestConfigurationView(TestBase):
         self.login()
         with conf_vars({('webserver', 'expose_config'): 'True'}):
             resp = self.client.get('configuration', follow_redirects=True)
-        self.check_content_in_response(['Airflow Configuration', 'Running Configuration'], resp)
+        self.check_content_in_response(['Airflow Configuration', 'Section', 'Key', 'Value', 'Source'], resp)
 
 
 class TestRedocView(TestBase):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR removes airflow.cfg from the Airflow Configuration view, and shows _only_ the rendered view, with the goal to remove confusion about which configuration is currently active.

My motivation is that I often encounter people not knowing that you can scroll down to see the active configuration, thinking the airflow.cfg (which is displayed first) is the configuration currently active (which are defaults that might be overridden by env vars).

Summary of changes:

- UI shows only rendered config
- UI shows an info message in case `AIRFLOW__WEBSERVER__EXPOSE_CONFIG=False`
- Removed argument `raw=true`, this can be substituted by the Config endpoint of the REST API
- Removed `pre_subtitle` (the ascii art thing + version)

Screenshots of old & new behaviours:

### **`AIRFLOW__WEBSERVER__EXPOSE_CONFIG=False`**

- Previously:

![image](https://user-images.githubusercontent.com/6249654/110203331-e2690300-7e6d-11eb-980b-4c8a18e40836.png)

- New:

![image](https://user-images.githubusercontent.com/6249654/110173893-97180b80-7dff-11eb-9d96-066c85c1b8d6.png)

### **`AIRFLOW__WEBSERVER__EXPOSE_CONFIG=True`**

- Previously:

![image](https://user-images.githubusercontent.com/6249654/110203504-ea757280-7e6e-11eb-8da1-a9488d1e6021.png)

- New: Displays only running configuration, no more (non active) defaults in airflow.cfg

![image](https://user-images.githubusercontent.com/6249654/110536579-eae96400-8121-11eb-9727-a897ef1cb20c.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
