### PR TITLE
Use OpenAPI validation and only use updateable fields in request body for PATCH endpoints of DAG and Variable.

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 from flask import current_app, g, request
-from marshmallow import ValidationError
 
 from airflow import DAG
 from airflow.api_connexion import security
@@ -75,10 +74,7 @@ def patch_dag(session, dag_id, update_mask=None):
     dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one_or_none()
     if not dag:
         raise NotFound(f"Dag with id: '{dag_id}' not found")
-    try:
-        patch_body = dag_schema.load(request.json, session=session)
-    except ValidationError as err:
-        raise BadRequest("Invalid Dag schema", detail=str(err.messages))
+    patch_body = request.json
     if update_mask:
         patch_body_ = {}
         if len(update_mask) > 1:

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -70,22 +70,14 @@ def get_variables(session, limit: Optional[int], offset: Optional[int] = None) -
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_VARIABLE)])
 def patch_variable(variable_key: str, update_mask: Optional[List[str]] = None) -> Response:
     """Update a variable by key"""
-    try:
-        data = variable_schema.load(request.json)
-    except ValidationError as err:
-        raise BadRequest("Invalid Variable schema", detail=str(err.messages))
-
-    if data["key"] != variable_key:
-        raise BadRequest("Invalid post body", detail="key from request body doesn't match uri parameter")
-
+    data = request.json
     if update_mask:
         if "key" in update_mask:
             raise BadRequest("key is a ready only field")
         if "value" not in update_mask:
             raise BadRequest("No field to update")
-
-    Variable.set(data["key"], data["val"])
-    return variable_schema.dump(data)
+    Variable.set(variable_key, data["value"])
+    return variable_schema.dump({"key": variable_key, "val": data['value']})
 
 
 @security.requires_access([(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)])

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -425,7 +425,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DAG'
+              type: object
+              properties:
+                is_paused:
+                  type: boolean
+                  description: Whether to pause or unpause the dag
+              additionalProperties: false
       responses:
         '200':
           description: Success.
@@ -988,7 +993,6 @@ paths:
   /variables/{variable_key}:
     parameters:
       - $ref: '#/components/parameters/VariableKey'
-
     get:
       summary: Get a variable
       description: Get a variable by key.
@@ -1022,7 +1026,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Variable'
+              type: object
+              properties:
+                value:
+                  type: string
+              additionalProperties: false
 
       responses:
         '200':

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -553,7 +553,7 @@ class TestPatchDag(TestDagEndpoint):
         response = self.client.patch(f"/api/v1/dags/{dag_model.dag_id}", json=patch_body)
         assert response.status_code == 400
         assert response.json == {
-            'detail': "Property is read-only - 'schedule_interval'",
+            'detail': "Additional properties are not allowed ('schedule_interval' was unexpected)",
             'status': 400,
             'title': 'Bad Request',
             'type': EXCEPTIONS_LINK_MAP[400],

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -198,7 +198,6 @@ class TestPatchVariable(TestVariableEndpoint):
         response = self.client.patch(
             "/api/v1/variables/var1",
             json={
-                "key": "var1",
                 "value": "updated",
             },
             environ_overrides={'REMOTE_USER': "test"},
@@ -221,10 +220,10 @@ class TestPatchVariable(TestVariableEndpoint):
         )
         assert response.status_code == 400
         assert response.json == {
-            "title": "Invalid post body",
+            "title": "Bad Request",
             "status": 400,
             "type": EXCEPTIONS_LINK_MAP[400],
-            "detail": "key from request body doesn't match uri parameter",
+            "detail": "Additional properties are not allowed ('key' was unexpected)",
         }
 
         response = self.client.patch(
@@ -235,10 +234,10 @@ class TestPatchVariable(TestVariableEndpoint):
             environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.json == {
-            "title": "Invalid Variable schema",
+            "title": "Bad Request",
             "status": 400,
             "type": EXCEPTIONS_LINK_MAP[400],
-            "detail": "{'value': ['Missing data for required field.']}",
+            "detail": "Additional properties are not allowed ('key' was unexpected)",
         }
 
     def test_should_raises_401_unauthenticated(self):
@@ -247,7 +246,6 @@ class TestPatchVariable(TestVariableEndpoint):
         response = self.client.patch(
             "/api/v1/variables/var1",
             json={
-                "key": "var1",
                 "value": "updated",
             },
         )


### PR DESCRIPTION
Closes: #14635 
This two endpoints DAG `PATCH` and Variable `PATCH` allows only a single field to be updated and were being given the DAG and Variable objects in the requestBody respectively. This causes confusion and I feel we should let users know that they don't need the DAG or Variable object for their updates

This PR changes the behaviour and also switch to using Openapi for validation in the requestBody instead of schema validation

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
