### PR TITLE
Remember expanded task groups in localStorage

### DIFF
--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -185,6 +185,8 @@
 
         // When an expanded group is clicked, collapse it.
         d3.selectAll("g.cluster").on("click", function (node_id) {
+          d3.event.stopPropagation();
+
           if (d3.event.defaultPrevented) // Ignore dragging actions.
               return;
           node = g.node(node_id)
@@ -192,6 +194,7 @@
         })
         // When a node is clicked, action depends on the node type.
         d3.selectAll("g.node").on("click", function (node_id) {
+          d3.event.stopPropagation();
           node = g.node(node_id)
           if (node.children != undefined && Object.keys(node.children).length > 0) {
             // A group node
@@ -408,6 +411,8 @@
               .style("opacity", 1);
           d3.selectAll('.js-state-legend-item')
               .style("background-color", null);
+
+          localStorage.setItem(focused_group_key(dag_id), undefined)
       }
 
       function focusState(state, node, color){
@@ -617,6 +622,16 @@
         return "no_status"
       }
 
+      // Returns the key used to store expanded task group ids in localStorage
+      function expanded_groups_key(dag_id) {
+          return `expanded_groups_${dag_id}`
+      }
+
+      // Returns the key used to store the focused task group id in localStorage
+      function focused_group_key(dag_id) {
+          return `focused_group_${dag_id}`
+      }
+
       // Focus the graph on the expanded/collapsed node
       function focus_group(node_id) {
         if(node_id != null && zoom != null) {
@@ -659,6 +674,8 @@
                       .style("opacity", 0.2).duration(duration)
               }
             });
+
+            localStorage.setItem(focused_group_key(dag_id), node_id)
         }
       }
 
@@ -698,6 +715,8 @@
 
         draw()
         focus_group(node_id)
+
+        save_expanded_group(node_id)
     }
 
     // Remove the node with this node_id from g.
@@ -736,10 +755,67 @@
 
         draw()
         focus_group(node_id)
+
+        remove_expanded_group(node_id)
       }
 
-      expand_group(null, nodes)
+    function get_saved_groups(dag_id) {
+        // expanded_groups is a Set
+        try {
+            var expanded_groups = new Set(JSON.parse(localStorage.getItem(expanded_groups_key(dag_id))));
+        } catch {
+            var expanded_groups = new Set();
+        }
 
-      initRefresh();
+        return expanded_groups;
+    }
+
+    // Remember the expanded groups in local storage so that refreshing the page doesn't reset
+    // the graph state.
+    function save_expanded_group(node_id) {
+        // expanded_groups is a Set
+        var expanded_groups = get_saved_groups(dag_id);
+        expanded_groups.add(node_id)
+        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)))
+    }
+
+    // Remove the node_id from the expanded state
+    function remove_expanded_group(node_id) {
+        var expanded_groups = get_saved_groups(dag_id);
+        expanded_groups.delete(node_id)
+        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)))
+    }
+
+    // Restore previously expanded task groups
+    function expand_saved_groups(expanded_groups, node) {
+        if (node.children == undefined) {
+            return;
+        }
+
+        node.children.forEach(function (child_node) {
+            if(expanded_groups.has(child_node.id)) {
+                expand_group(child_node.id, g.node(child_node.id))
+
+                expand_saved_groups(expanded_groups, child_node)
+            }
+        })
+    }
+
+    svg.node().onclick = clearFocus
+
+    const focus_node_id = localStorage.getItem(focused_group_key(dag_id))
+    const expanded_groups = get_saved_groups(dag_id)
+
+    // Always expand the root node
+    expand_group(null, nodes)
+
+    // Expand the node that were previously expanded
+    expand_saved_groups(expanded_groups, nodes)
+
+    // Focus the node that was previously in focus
+    if (focus_node_id != undefined && g.hasNode(focus_node_id))
+        focus_group(focus_node_id)
+
+    initRefresh();
   </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -185,8 +185,6 @@
 
         // When an expanded group is clicked, collapse it.
         d3.selectAll("g.cluster").on("click", function (node_id) {
-          d3.event.stopPropagation();
-
           if (d3.event.defaultPrevented) // Ignore dragging actions.
               return;
           node = g.node(node_id)
@@ -194,7 +192,6 @@
         })
         // When a node is clicked, action depends on the node type.
         d3.selectAll("g.node").on("click", function (node_id) {
-          d3.event.stopPropagation();
           node = g.node(node_id)
           if (node.children != undefined && Object.keys(node.children).length > 0) {
             // A group node
@@ -235,7 +232,7 @@
         });
 
         d3.selectAll("g.node").on("mouseout", function (d) {
-          d3.select(this).selectAll("rect").style("stroke", null);
+          d3.select(this).selectAll("rect,circle").style("stroke", null);
           highlight_nodes(g.predecessors(d), null, initialStrokeWidth)
           highlight_nodes(g.successors(d), null, initialStrokeWidth)
           d3.selectAll("g.node")
@@ -244,6 +241,7 @@
             .style("stroke-width", initialStrokeWidth);
           d3.selectAll("g.edgePath")
             .style("opacity", 1);
+          localStorage.removeItem(focused_group_key(dag_id))
         });
         updateNodesStates(task_instances);
         setUpZoomSupport();
@@ -412,7 +410,7 @@
           d3.selectAll('.js-state-legend-item')
               .style("background-color", null);
 
-          localStorage.setItem(focused_group_key(dag_id), undefined)
+          localStorage.removeItem(focused_group_key(dag_id))
       }
 
       function focusState(state, node, color){
@@ -587,6 +585,22 @@
         return children
       }
 
+      // Return list of all task group ids in the given task group including the given group itself.
+      function get_all_group_ids(group) {
+        var children = [group.id]
+
+        for(const [key, val] of Object.entries(group.children)) {
+          if(val.children != undefined) {
+            // group
+            const sub_group_children = get_all_group_ids(val)
+            for(const id of sub_group_children) {
+              children.push(id)
+            }
+          }
+        }
+        return children
+      }
+
 
       // Return the state for the node based on the state of its taskinstance or that of its
       // children if it's a group node
@@ -680,7 +694,7 @@
       }
 
       // Expands a group node
-      function expand_group(node_id, node) {
+      function expand_group(node_id, node, focus=true) {
         node.children.forEach(function (val) {
           // Set children nodes
           g.setNode(val.id, val.value)
@@ -714,7 +728,9 @@
         })
 
         draw()
-        focus_group(node_id)
+
+        if (focus)
+          focus_group(node_id)
 
         save_expanded_group(node_id)
     }
@@ -756,7 +772,7 @@
         draw()
         focus_group(node_id)
 
-        remove_expanded_group(node_id)
+        remove_expanded_group(node_id, node)
       }
 
     function get_saved_groups(dag_id) {
@@ -770,8 +786,17 @@
         return expanded_groups;
     }
 
-    // Remember the expanded groups in local storage so that refreshing the page doesn't reset
-    // the graph state.
+    // Clean up invalid group_ids from saved_group_ids (e.g. due to DAG changes)
+    function prune_invalid_saved_group_ids() {
+        // All the group_ids in the whole DAG
+        const all_group_ids = new Set(get_all_group_ids(nodes))
+        var expanded_groups = get_saved_groups(dag_id);
+        expanded_groups = Array.from(expanded_groups).filter(group_id => all_group_ids.has(group_id))
+        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(expanded_groups))
+    }
+
+    // Remember the expanded groups in local storage so that it can be used to restore the expanded state
+    // of task groups.
     function save_expanded_group(node_id) {
         // expanded_groups is a Set
         var expanded_groups = get_saved_groups(dag_id);
@@ -780,9 +805,10 @@
     }
 
     // Remove the node_id from the expanded state
-    function remove_expanded_group(node_id) {
+    function remove_expanded_group(node_id, node) {
         var expanded_groups = get_saved_groups(dag_id);
-        expanded_groups.delete(node_id)
+        const child_group_ids = get_all_group_ids(node)
+        child_group_ids.forEach(child_id => expanded_groups.delete(child_id))
         localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)))
     }
 
@@ -794,15 +820,14 @@
 
         node.children.forEach(function (child_node) {
             if(expanded_groups.has(child_node.id)) {
-                expand_group(child_node.id, g.node(child_node.id))
+                expand_group(child_node.id, g.node(child_node.id), false)
 
                 expand_saved_groups(expanded_groups, child_node)
             }
         })
     }
 
-    svg.node().onclick = clearFocus
-
+    prune_invalid_saved_group_ids()
     const focus_node_id = localStorage.getItem(focused_group_key(dag_id))
     const expanded_groups = get_saved_groups(dag_id)
 
@@ -812,9 +837,9 @@
     // Expand the node that were previously expanded
     expand_saved_groups(expanded_groups, nodes)
 
-    // Focus the node that was previously in focus
-    if (focus_node_id != undefined && g.hasNode(focus_node_id))
-        focus_group(focus_node_id)
+    // Restore focus (if available)
+    if(g.hasNode(focus_node_id))
+      focus_group(focus_node_id)
 
     initRefresh();
   </script>

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -241,7 +241,7 @@
             .style("stroke-width", initialStrokeWidth);
           d3.selectAll("g.edgePath")
             .style("opacity", 1);
-          localStorage.removeItem(focused_group_key(dag_id))
+          localStorage.removeItem(focused_group_key(dag_id));
         });
         updateNodesStates(task_instances);
         setUpZoomSupport();
@@ -410,7 +410,7 @@
           d3.selectAll('.js-state-legend-item')
               .style("background-color", null);
 
-          localStorage.removeItem(focused_group_key(dag_id))
+          localStorage.removeItem(focused_group_key(dag_id));
       }
 
       function focusState(state, node, color){
@@ -587,18 +587,18 @@
 
       // Return list of all task group ids in the given task group including the given group itself.
       function get_all_group_ids(group) {
-        var children = [group.id]
+        var children = [group.id];
 
-        for(const [key, val] of Object.entries(group.children)) {
-          if(val.children != undefined) {
+        for (const [key, val] of Object.entries(group.children)) {
+          if (val.children != undefined) {
             // group
             const sub_group_children = get_all_group_ids(val)
-            for(const id of sub_group_children) {
-              children.push(id)
+            for (const id of sub_group_children) {
+              children.push(id);
             }
           }
         }
-        return children
+        return children;
       }
 
 
@@ -638,12 +638,12 @@
 
       // Returns the key used to store expanded task group ids in localStorage
       function expanded_groups_key(dag_id) {
-          return `expanded_groups_${dag_id}`
+          return `expanded_groups_${dag_id}`;
       }
 
       // Returns the key used to store the focused task group id in localStorage
       function focused_group_key(dag_id) {
-          return `focused_group_${dag_id}`
+          return `focused_group_${dag_id}`;
       }
 
       // Focus the graph on the expanded/collapsed node
@@ -689,7 +689,7 @@
               }
             });
 
-            localStorage.setItem(focused_group_key(dag_id), node_id)
+            localStorage.setItem(focused_group_key(dag_id), node_id);
         }
       }
 
@@ -729,20 +729,21 @@
 
         draw()
 
-        if (focus)
-          focus_group(node_id)
+        if (focus) {
+          focus_group(node_id);
+        }
 
         save_expanded_group(node_id)
     }
 
     // Remove the node with this node_id from g.
     function remove_node(node_id) {
-      if(g.hasNode(node_id)) {
+      if (g.hasNode(node_id)) {
           node = g.node(node_id)
           if(node.children != undefined) {
             // If the child is an expanded group node, remove children too.
             node.children.forEach(function (child) {
-              remove_node(child.id)
+              remove_node(child.id);
             })
           }
       }
@@ -772,7 +773,7 @@
         draw()
         focus_group(node_id)
 
-        remove_expanded_group(node_id, node)
+        remove_expanded_group(node_id, node);
       }
 
     function get_saved_groups(dag_id) {
@@ -789,10 +790,10 @@
     // Clean up invalid group_ids from saved_group_ids (e.g. due to DAG changes)
     function prune_invalid_saved_group_ids() {
         // All the group_ids in the whole DAG
-        const all_group_ids = new Set(get_all_group_ids(nodes))
+        const all_group_ids = new Set(get_all_group_ids(nodes));
         var expanded_groups = get_saved_groups(dag_id);
-        expanded_groups = Array.from(expanded_groups).filter(group_id => all_group_ids.has(group_id))
-        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(expanded_groups))
+        expanded_groups = Array.from(expanded_groups).filter(group_id => all_group_ids.has(group_id));
+        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(expanded_groups));
     }
 
     // Remember the expanded groups in local storage so that it can be used to restore the expanded state
@@ -801,15 +802,15 @@
         // expanded_groups is a Set
         var expanded_groups = get_saved_groups(dag_id);
         expanded_groups.add(node_id)
-        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)))
+        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)));
     }
 
     // Remove the node_id from the expanded state
     function remove_expanded_group(node_id, node) {
         var expanded_groups = get_saved_groups(dag_id);
-        const child_group_ids = get_all_group_ids(node)
-        child_group_ids.forEach(child_id => expanded_groups.delete(child_id))
-        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)))
+        const child_group_ids = get_all_group_ids(node);
+        child_group_ids.forEach(child_id => expanded_groups.delete(child_id));
+        localStorage.setItem(expanded_groups_key(dag_id), JSON.stringify(Array.from(expanded_groups)));
     }
 
     // Restore previously expanded task groups
@@ -820,26 +821,27 @@
 
         node.children.forEach(function (child_node) {
             if(expanded_groups.has(child_node.id)) {
-                expand_group(child_node.id, g.node(child_node.id), false)
+                expand_group(child_node.id, g.node(child_node.id), false);
 
-                expand_saved_groups(expanded_groups, child_node)
+                expand_saved_groups(expanded_groups, child_node);
             }
-        })
+        });
     }
 
-    prune_invalid_saved_group_ids()
-    const focus_node_id = localStorage.getItem(focused_group_key(dag_id))
-    const expanded_groups = get_saved_groups(dag_id)
+    prune_invalid_saved_group_ids();
+    const focus_node_id = localStorage.getItem(focused_group_key(dag_id));
+    const expanded_groups = get_saved_groups(dag_id);
 
     // Always expand the root node
-    expand_group(null, nodes)
+    expand_group(null, nodes);
 
     // Expand the node that were previously expanded
-    expand_saved_groups(expanded_groups, nodes)
+    expand_saved_groups(expanded_groups, nodes);
 
     // Restore focus (if available)
-    if(g.hasNode(focus_node_id))
-      focus_group(focus_node_id)
+    if(g.hasNode(focus_node_id)) {
+      focus_group(focus_node_id);
+    }
 
     initRefresh();
   </script>


### PR DESCRIPTION
This PR makes the web UI restore previously expanded TaskGroups when the page is refreshed or re-opened. This is to preserve the look of the DAG across sessions. This is done by storing the list of expanded group_ids in `localStorage`.

## Previous behaviour:
When the page is refreshed, the Graph View resets to the initial view (with all the TaskGroup collapsed by default).

## Behaviour after this PR:
When the page is refreshed, the Graph View expands previously expanded TaskGroups, and puts the previously focused TaskGroup back in focus.