### PR TITLE
Add tests for python & pythonvenv operators execute method.

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -347,9 +347,7 @@ class PythonVirtualenvOperator(PythonOperator):
         self.pickling_library = dill if self.use_dill else pickle
 
     def execute(self, context: Dict):
-        serializable_context = {
-            key: context[key] for key in self._get_serializable_context_keys() if context.get(key) is not None
-        }
+        serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
         return super().execute(context=serializable_context)
 
     def execute_callable(self):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -347,7 +347,9 @@ class PythonVirtualenvOperator(PythonOperator):
         self.pickling_library = dill if self.use_dill else pickle
 
     def execute(self, context: Dict):
-        serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
+        serializable_context = {
+            key: context[key] for key in self._get_serializable_context_keys() if context.get(key) is not None
+        }
         return super().execute(context=serializable_context)
 
     def execute_callable(self):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1041,7 +1041,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         return_value = f()
 
         task = PythonVirtualenvOperator(task_id='task', python_callable=f, dag=self.dag)
-        assert task.execute({}) == return_value
+        assert task.execute(unittest.mock.MagicMock()) == return_value
 
 
 DEFAULT_ARGS = {

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -314,6 +314,15 @@ class TestPythonOperator(TestPythonBase):
         )
         python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    def test_execute_return(self):
+        def f():
+            return 'execute_return'
+
+        return_value = f()
+
+        task = PythonOperator(task_id='task', python_callable=f, dag=self.dag)
+        assert task.execute({}) == return_value
+
 
 class TestBranchOperator(unittest.TestCase):
     @classmethod
@@ -1024,6 +1033,15 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             pass
 
         self._run_as_operator(f, use_dill=True, system_site_packages=False, requirements=None)
+
+    def test_execute_return(self):
+        def f():
+            return 'execute_return'
+
+        return_value = f()
+
+        task = PythonVirtualenvOperator(task_id='task', python_callable=f, dag=self.dag)
+        assert task.execute({}) == return_value
 
 
 DEFAULT_ARGS = {


### PR DESCRIPTION
See original PR (https://github.com/apache/airflow/pull/14061)

Add some tests to make sure the PythonOperator & PythonVirtualenvOperator return their execute method results. Had to make some slight modifications to be able to unit test the execute method in the PythonVirtualenvOperator.