### PR TITLE
Update Flask-AppBuilder dependency to allow 3.2 (and all 3.x series)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ install_requires =
     cryptography>=0.9.3
     dill>=0.2.2, <0.4
     flask>=1.1.0, <2.0
-    flask-appbuilder~=3.1.1
+    flask-appbuilder~=3.1,>=3.1.1
     flask-caching>=1.5.0, <2.0.0
     flask-login>=0.3, <0.5
     flask-wtf>=0.14.3, <0.15


### PR DESCRIPTION
Closes #14469

