### PR TITLE
Fix Failing tests on v1-10-stable

### DIFF
--- a/tests/upgrade/rules/test_chain_between_dag_and_operator_not_allowed_rule.py
+++ b/tests/upgrade/rules/test_chain_between_dag_and_operator_not_allowed_rule.py
@@ -14,10 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
 from contextlib import contextmanager
 from unittest import TestCase
 
 from tempfile import NamedTemporaryFile
+
+import pytest
+
 from tests.compat import mock
 
 from airflow.upgrade.rules.chain_between_dag_and_operator_not_allowed_rule import \
@@ -124,6 +128,10 @@ class TestChainBetweenDAGAndOperatorNotAllowedRule(TestCase):
             msgs = rule.check()
             assert msgs == []
 
+    @pytest.mark.skipif(
+        sys.version_info.major == 2,
+        reason="Test is irrelevant in Python 2.7 because of unicode differences"
+    )
     def test_decode_errors_are_handled(self, mock_list_files):
 
         with NamedTemporaryFile("wb+", suffix=".py") as temp_file:

--- a/tests/upgrade/rules/test_import_changes.py
+++ b/tests/upgrade/rules/test_import_changes.py
@@ -15,7 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import sys
 from tempfile import NamedTemporaryFile
+
+import pytest
+
 from tests.compat import mock
 
 from airflow.upgrade.rules.import_changes import ImportChange, ImportChangesRule
@@ -85,6 +89,10 @@ class TestImportChangesRule:
     @mock.patch(
         "airflow.upgrade.rules.import_changes.ImportChangesRule.ALL_CHANGES",
         [ImportChange.from_new_old_paths(NEW_PATH, OLD_PATH)],
+    )
+    @pytest.mark.skipif(
+        sys.version_info.major == 2,
+        reason="Test is irrelevant in Python 2.7 because of unicode differences"
     )
     def test_decode_error_are_handled(self, mock_list_files):
         with NamedTemporaryFile("wb+", suffix=".py") as temp:


### PR DESCRIPTION
Some of the tests were irrelevant in Python 2.7 because of unicode differences

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
