### PR TITLE
hostAliases support for workers in helm chart

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -75,6 +75,10 @@ spec:
 {{ toYaml $affinity | indent 8 }}
       tolerations:
 {{ toYaml $tolerations | indent 8 }}
+{{- if .Values.workers.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.workers.hostAliases | indent 8 }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.workers.terminationGracePeriodSeconds }}
       restartPolicy: Always
       serviceAccountName: {{ .Release.Name }}-worker

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -58,3 +58,17 @@ class WorkerTest(unittest.TestCase):
         assert "test-volume" == jmespath.search(
             "spec.template.spec.containers[0].volumeMounts[0].name", docs[0]
         )
+
+    def test_workers_host_aliases(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "hostAliases": [{"ip": "127.0.0.2", "hostnames": ["test.hostname"]}],
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert "127.0.0.2" == jmespath.search("spec.template.spec.hostAliases[0].ip", docs[0])
+        assert "test.hostname" == jmespath.search("spec.template.spec.hostAliases[0].hostnames[0]", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -658,6 +658,10 @@
                 "tolerations": {
                     "description": "Select certain nodes for airflow pods.",
                     "type": "array"
+                },
+                "hostAliases": {
+                    "description": "Specify hostAliases for workers.",
+                    "type": "array"
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -367,6 +367,16 @@ workers:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+  # hostAliases to use in worker pods.
+  # See:
+  # https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+  hostAliases: []
+  # - ip: "127.0.0.2"
+  #   hostnames:
+  #   - "test.hostname.one"
+  # - ip: "127.0.0.3"
+  #   hostnames:
+  #   - "test.hostname.two"
 
 # Airflow scheduler settings
 scheduler:

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -276,6 +276,9 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``workers.tolerations``
      - Toleration labels for pod assignment
      - ``1``
+   * - ``workers.hostAliases``
+     - HostAliases to use in Celery workers
+     - ``[]``
    * - ``scheduler.podDisruptionBudget.enabled``
      - Enable PDB on Airflow scheduler
      - ``1``


### PR DESCRIPTION
This PR adds `workers.hostAliases` parameter in helm chart in order to use [kubernetes HostAliases](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) in worker pods.