### PR TITLE
Remove duplicated WORKDIR in CI Dockerfile

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -415,8 +415,6 @@ RUN if [[ -n "${ADDITIONAL_PYTHON_DEPS}" ]]; then \
         pip install --no-cache-dir ${ADDITIONAL_PYTHON_DEPS}; \
     fi
 
-WORKDIR ${AIRFLOW_SOURCES}
-
 ENV PATH "/files/bin/:/opt/airflow/scripts/in_container/bin/:${HOME}:${PATH}"
 
 # Needed to stop Gunicorn from crashing when /tmp is now mounted from host


### PR DESCRIPTION
Having it doesn't cause any harm, but it was already set five commands
further up to the same value (on L401)
