### PR TITLE
Fix false warning about class that was not used in a dag file

### DIFF
--- a/airflow/upgrade/rules/import_changes.py
+++ b/airflow/upgrade/rules/import_changes.py
@@ -53,6 +53,10 @@ class ImportChange(
         return ".".join(part)
 
     @cached_property
+    def old_class(self):
+        return self.old_path.split(".")[-1]
+
+    @cached_property
     def new_class(self):
         return self.new_path.split(".")[-1]
 
@@ -116,7 +120,7 @@ class ImportChangesRule(BaseRule):
             try:
                 content = file.read()
                 for change in ImportChangesRule.ALL_CHANGES:
-                    if change.old_path_without_classname in content:
+                    if change.old_path_without_classname in content and change.old_class in content:
                         problems.append(change.info(file_path))
                         if change.providers_package:
                             providers.add(change.providers_package)


### PR DESCRIPTION
Running upgrade_check with this import in a dag:
from airflow.operators.slack_operator import SlackAPIPostOperator

Causes these warnings:
[1] Using `airflow.operators.slack_operator.SlackAPIPostOperator` should be replaced by `airflow.providers.slack.operators.slack.SlackAPIPostOperator`.
[2] Using `airflow.operators.slack_operator.SlackAPIOperator` should be replaced by `airflow.providers.slack.operators.slack.SlackAPIOperator`

Only 1 above is correct.
This PR fixes it by checking that both the old import part and class name exists in the dag before issuing warning

Related slack conversation: https://apache-airflow.slack.com/archives/CCPRP7943/p1615388292013900

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
