### PR TITLE
HttpHook. Use request factory and respect defaults

### DIFF
--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -126,20 +126,15 @@ class HttpHook(BaseHook):
         else:
             url = (self.base_url or '') + (endpoint or '')
 
-        request_parameters = dict(method=self.method.upper(), url=url, headers=headers)
-        request_parameters.update(request_kwargs)
-
         if self.method == 'GET':
             # GET uses params
-            request_parameters["params"] = data
+            req = requests.Request(self.method, url, params=data, headers=headers, **request_kwargs)
         elif self.method == 'HEAD':
             # HEAD doesn't use params
-            pass
+            req = requests.Request(self.method, url, headers=headers, **request_kwargs)
         else:
             # Others use data
-            request_parameters["data"] = data
-
-        req = requests.Request(**request_parameters)
+            req = requests.Request(self.method, url, data=data, headers=headers, **request_kwargs)
 
         prepped_request = session.prepare_request(req)
         self.log.info("Sending '%s' to url: %s", self.method, url)

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -76,9 +76,7 @@ class TestHttpHook(unittest.TestCase):
                 except MissingSchema:
                     pass
 
-                request_mock.assert_called_once_with(
-                    method=mock.ANY, url=expected_url, headers=mock.ANY, params=mock.ANY
-                )
+                request_mock.assert_called_once_with(mock.ANY, expected_url, mock.ANY, mock.ANY)
 
                 request_mock.reset_mock()
 
@@ -117,7 +115,7 @@ class TestHttpHook(unittest.TestCase):
                 self.get_lowercase_hook.run('v1/test', data=data)
             except (MissingSchema, InvalidURL):
                 pass
-            request_mock.assert_called_once_with(method=mock.ANY, url=mock.ANY, headers=mock.ANY, params=data)
+            request_mock.assert_called_once_with(mock.ANY, mock.ANY, headers=mock.ANY, params=data)
 
     @requests_mock.mock()
     def test_hook_uses_provided_header(self, mock_requests):

--- a/tests/providers/http/hooks/test_http.py
+++ b/tests/providers/http/hooks/test_http.py
@@ -76,7 +76,9 @@ class TestHttpHook(unittest.TestCase):
                 except MissingSchema:
                     pass
 
-                request_mock.assert_called_once_with(mock.ANY, expected_url, mock.ANY, mock.ANY)
+                request_mock.assert_called_once_with(
+                    mock.ANY, expected_url, headers=mock.ANY, params=mock.ANY
+                )
 
                 request_mock.reset_mock()
 

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -201,6 +201,9 @@ class FakeSession:
             self.response._content += ('/' + request.params['date']).encode('ascii', 'ignore')
         return self.response
 
+    def merge_environment_settings(self, _url, **kwargs):
+        return kwargs
+
 
 class TestHttpOpSensor(unittest.TestCase):
     def setUp(self):

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -138,7 +138,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         except MissingSchema:
             pass
         mock_request.assert_called_once_with(
-            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
+            method=self.expected_method, url=self.expected_url, headers=mock.ANY, data=mock.ANY
         )
         mock_request.reset_mock()
 
@@ -151,7 +151,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         except MissingSchema:
             pass
         mock_request.assert_called_once_with(
-            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
+            method=self.expected_method, url=self.expected_url, headers=mock.ANY, data=mock.ANY
         )
         mock_request.reset_mock()
 
@@ -164,6 +164,6 @@ class TestSlackWebhookHook(unittest.TestCase):
         except MissingSchema:
             pass
         mock_request.assert_called_once_with(
-            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
+            method=self.expected_method, url=self.expected_url, headers=mock.ANY, data=mock.ANY
         )
         mock_request.reset_mock()

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -138,7 +138,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         except MissingSchema:
             pass
         mock_request.assert_called_once_with(
-            method=self.expected_method, url=self.expected_url, headers=mock.ANY, data=mock.ANY
+            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
         )
         mock_request.reset_mock()
 
@@ -151,7 +151,7 @@ class TestSlackWebhookHook(unittest.TestCase):
         except MissingSchema:
             pass
         mock_request.assert_called_once_with(
-            method=self.expected_method, url=self.expected_url, headers=mock.ANY, data=mock.ANY
+            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
         )
         mock_request.reset_mock()
 
@@ -164,6 +164,6 @@ class TestSlackWebhookHook(unittest.TestCase):
         except MissingSchema:
             pass
         mock_request.assert_called_once_with(
-            method=self.expected_method, url=self.expected_url, headers=mock.ANY, data=mock.ANY
+            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
         )
         mock_request.reset_mock()


### PR DESCRIPTION
Use Request's `session.request` factory for HTTP request initiation, this will use environment variables and sensible defaults for requests.
Also use `verify` option only if it is provided to `run` method, as requests library already defaults to `True`.

---

Backstory for this PR:
 Our organization uses firewalls and custom SSL certificates to communicate between systems, this can be achieved via `CURL_CA_BUNDLE` and `REQUESTS_CA_BUNDLE` environment variables.
Requests library takes both into account and uses them as default value for `verify` option when sending request to remote system.

 Current implementation is setting `verify` to True, which overwrites defaults and as results requests can not be made due to SSL verification issues. This PR is fixing the problem.