### PR TITLE
New UI GitHub integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 /airflow/api/ @mik-laj @kaxil
 /airflow/api_connexion/ @mik-laj @kaxil @ephraimbuddy
 
+# UI
+/airflow/ui/ @ryanahamilton @ashb
+
 # WWW
 /airflow/www/ @ryanahamilton @ashb
 

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -122,6 +122,7 @@ labelPRBasedOnFilePath:
     - airflow/www/webpack.config.js
     - airflow/www/yarn.lock
     - docs/apache-airflow/ui.rst
+    - airflow/ui/**/*
 
   area:CLI:
     - airflow/bin/cli.py


### PR DESCRIPTION
Adds initial GitHub code owners and label automation for the new UI directory being added (#14691) for AIP-38.
