### PR TITLE
Don't use author_association for self-hosted vs public runner decision.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         (
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
-          contains(fromJSON(env.AIRFLOW_COMMITERS), github.actor)
+          contains(['ashb'], github.actor)
         ) && github.repository == 'apache/airflow'
       ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
@@ -87,7 +87,7 @@ jobs:
           (
             github.event_name == 'push' ||
             github.event_name == 'schedule' ||
-            contains(fromJSON(env.AIRFLOW_COMMITERS), github.actor)
+            contains(['ashb'], github.actor)
           ) && github.repository == 'apache/airflow'
         ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,9 @@ jobs:
       # Avoid having to specify the runs-on logic every time
       - name: debug dump
         run: |
-          echo "${{toJSON(runner)"
-          echo "${{toJSON(job)"
-          echo "${{toJSON(env)"
+          echo "${{toJSON(runner) }}"
+          echo "${{toJSON(job) }}"
+          echo "${{toJSON(env) }}"
       - name: Set runs-on
         id: set-runs-on
         run: echo "::set-output name=runsOn::$(jq -n 'env.RUNS_ON')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,7 @@ jobs:
         (
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'MEMBER'
+          contains(secrets.AIRFLOW_COMMITERS, github.actor)
         ) && github.repository == 'apache/airflow'
       ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
@@ -88,8 +87,7 @@ jobs:
           (
             github.event_name == 'push' ||
             github.event_name == 'schedule' ||
-            github.event.pull_request.author_association == 'OWNER' ||
-            github.event.pull_request.author_association == 'MEMBER'
+            contains(secrets.AIRFLOW_COMMITERS, github.actor)
           ) && github.repository == 'apache/airflow'
         ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,21 +73,94 @@ jobs:
 
   build-info:
     name: "Build info"
+    # The runs-on cannot refer to env. or secrets. context, so we have no
+    # option but to specify a hard-coded list here. This is "safe", as the list
+    # is checked again by the runner using it's own list, so a PR author cannot
+    # change this and get access to our self-hosted runners
     runs-on: >-
       ${{ (
         (
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
-          contains(fromJSON('["ashb"]'), github.actor)
+          contains(fromJSON('[
+            "BasPH",
+            "Fokko",
+            "KevinYang21",
+            "XD-DENG",
+            "aijamalnk",
+            "alexvanboxel",
+            "aoen",
+            "artwr",
+            "ashb",
+            "bolkedebruin",
+            "criccomini",
+            "dimberman",
+            "feng-tao",
+            "houqp",
+            "jghoman",
+            "jmcarp",
+            "kaxil",
+            "leahecole",
+            "mik-laj",
+            "milton0825",
+            "mistercrunch",
+            "msumit",
+            "potiuk",
+            "r39132",
+            "ryanahamilton",
+            "ryw",
+            "saguziel",
+            "sekikn",
+            "turbaszek",
+            "zhongjiajie",
+            "ephraimbuddy",
+            "jhtimmins",
+            "dstandish"
+          ]'), github.actor)
         ) && github.repository == 'apache/airflow'
       ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
+      # Sadly we have to duplicate this list _again_ :(. There is no way to refer
       RUNS_ON: ${{ (
           (
             github.event_name == 'push' ||
             github.event_name == 'schedule' ||
-            contains(fromJSON('["ashb"]'), github.actor)
+          contains(fromJSON('[
+            "BasPH",
+            "Fokko",
+            "KevinYang21",
+            "XD-DENG",
+            "aijamalnk",
+            "alexvanboxel",
+            "aoen",
+            "artwr",
+            "ashb",
+            "bolkedebruin",
+            "criccomini",
+            "dimberman",
+            "feng-tao",
+            "houqp",
+            "jghoman",
+            "jmcarp",
+            "kaxil",
+            "leahecole",
+            "mik-laj",
+            "milton0825",
+            "mistercrunch",
+            "msumit",
+            "potiuk",
+            "r39132",
+            "ryanahamilton",
+            "ryw",
+            "saguziel",
+            "sekikn",
+            "turbaszek",
+            "zhongjiajie",
+            "ephraimbuddy",
+            "jhtimmins",
+            "dstandish"
+          ]'), github.actor)
           ) && github.repository == 'apache/airflow'
         ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:
@@ -128,9 +201,7 @@ jobs:
       # Avoid having to specify the runs-on logic every time
       - name: debug dump
         run: |
-          echo "${{toJSON(runner) }}"
-          echo "${{toJSON(job) }}"
-          echo "${{toJSON(env) }}"
+          env | sort
       - name: Set runs-on
         id: set-runs-on
         run: echo "::set-output name=runsOn::$(jq -n 'env.RUNS_ON')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     steps:
       # Avoid having to specify the runs-on logic every time
       - name: debug dump
-        runs: |
+        run: |
           echo "${{toJSON(runner)"
           echo "${{toJSON(job)"
           echo "${{toJSON(env)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,11 @@ jobs:
       runsOn: ${{ steps.set-runs-on.outputs.runsOn }}
     steps:
       # Avoid having to specify the runs-on logic every time
+      - name: debug dump
+        runs: |
+          echo "${{toJSON(runner)"
+          echo "${{toJSON(job)"
+          echo "${{toJSON(env)"
       - name: Set runs-on
         id: set-runs-on
         run: echo "::set-output name=runsOn::$(jq -n 'env.RUNS_ON')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,17 +165,13 @@ jobs:
       - name: Set runs-on
         id: set-runs-on
         run: |
-          set -x
-          echo "$AIRFLOW_SELF_HOSTED_RUNNER"
-          echo "$GITHUB_EVENT_NAME"
           echo "::set-output name=runsOn::$(jq -n '
-            if env.AIRFLOW_SELF_HOSTED_RUNNER and (["push", "schedule"] | index(env.GITHUB_EVENT_NAME)) then
+            if env.AIRFLOW_SELF_HOSTED_RUNNER or (["push", "schedule"] | index(env.GITHUB_EVENT_NAME)) then
               "self-hosted"
             else
               "ubuntu-20.04"
             end
           ')"
-          env | sort
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
     # option but to specify a hard-coded list here. This is "safe", as the list
     # is checked again by the runner using it's own list, so a PR author cannot
     # change this and get access to our self-hosted runners
+    #
+    # When changing this list, ensure that it is kept in sync with the
+    # configOverride parameter in AWS SSM (which is what the runner uses)
     runs-on: >-
       ${{ (
         (
@@ -162,6 +165,9 @@ jobs:
       - name: Set runs-on
         id: set-runs-on
         run: |
+          set -x
+          echo "$AIRFLOW_SELF_HOSTED_RUNNER"
+          echo "$GITHUB_EVENT_NAME"
           echo "::set-output name=runsOn::$(jq -n '
             if env.AIRFLOW_SELF_HOSTED_RUNNER and (["push", "schedule"] | index(env.GITHUB_EVENT_NAME)) then
               "self-hosted"
@@ -169,6 +175,7 @@ jobs:
               "ubuntu-20.04"
             end
           ')"
+          env | sort
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,48 +121,6 @@ jobs:
       ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
-      # Sadly we have to duplicate this list _again_ :(. There is no way to refer
-      RUNS_ON: ${{ (
-          (
-            github.event_name == 'push' ||
-            github.event_name == 'schedule' ||
-          contains(fromJSON('[
-            "BasPH",
-            "Fokko",
-            "KevinYang21",
-            "XD-DENG",
-            "aijamalnk",
-            "alexvanboxel",
-            "aoen",
-            "artwr",
-            "ashb",
-            "bolkedebruin",
-            "criccomini",
-            "dimberman",
-            "feng-tao",
-            "houqp",
-            "jghoman",
-            "jmcarp",
-            "kaxil",
-            "leahecole",
-            "mik-laj",
-            "milton0825",
-            "mistercrunch",
-            "msumit",
-            "potiuk",
-            "r39132",
-            "ryanahamilton",
-            "ryw",
-            "saguziel",
-            "sekikn",
-            "turbaszek",
-            "zhongjiajie",
-            "ephraimbuddy",
-            "jhtimmins",
-            "dstandish"
-          ]'), github.actor)
-          ) && github.repository == 'apache/airflow'
-        ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:
       waitForImage: ${{ steps.wait-for-image.outputs.wait-for-image }}
       upgradeToNewerDependencies: ${{ steps.selective-checks.outputs.upgrade-to-newer-dependencies }}
@@ -198,13 +156,19 @@ jobs:
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
       runsOn: ${{ steps.set-runs-on.outputs.runsOn }}
     steps:
-      # Avoid having to specify the runs-on logic every time
-      - name: debug dump
-        run: |
-          env | sort
+      # Avoid having to specify the runs-on logic every time. We use the custom
+      # env var AIRFLOW_SELF_HOSTED_RUNNER set only on our runners, but never
+      # on the public runners
       - name: Set runs-on
         id: set-runs-on
-        run: echo "::set-output name=runsOn::$(jq -n 'env.RUNS_ON')"
+        run: |
+          echo "::set-output name=runsOn::$(jq -n '
+            if env.AIRFLOW_SELF_HOSTED_RUNNER and (["push", "schedule"] | index(env.GITHUB_EVENT_NAME)) then
+              "self-hosted"
+            else
+              "ubuntu-20.04"
+            end
+          ')"
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ on:  # yamllint disable-line rule:truthy
     branches: ['master', 'v1-10-test', 'v1-10-stable', 'v2-0-test']
 
 env:
-
+  AIRFLOW_COMMITERS: ${{ secrets.AIRFLOW_COMMITERS }}
   MOUNT_SELECTED_LOCAL_SOURCES: "false"
   FORCE_ANSWER_TO_QUESTIONS: "yes"
   FORCE_PULL_IMAGES: "true"
@@ -78,7 +78,7 @@ jobs:
         (
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
-          contains(secrets.AIRFLOW_COMMITERS, github.actor)
+          contains(fromJSON(env.AIRFLOW_COMMITERS), github.actor)
         ) && github.repository == 'apache/airflow'
       ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
@@ -87,7 +87,7 @@ jobs:
           (
             github.event_name == 'push' ||
             github.event_name == 'schedule' ||
-            contains(secrets.AIRFLOW_COMMITERS, github.actor)
+            contains(fromJSON(env.AIRFLOW_COMMITERS), github.actor)
           ) && github.repository == 'apache/airflow'
         ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
         (
           github.event_name == 'push' ||
           github.event_name == 'schedule' ||
-          contains(['ashb'], github.actor)
+          contains(fromJSON('["ashb"]'), github.actor)
         ) && github.repository == 'apache/airflow'
       ) && 'self-hosted' || 'ubuntu-20.04' }}
     env:
@@ -87,7 +87,7 @@ jobs:
           (
             github.event_name == 'push' ||
             github.event_name == 'schedule' ||
-            contains(['ashb'], github.actor)
+            contains(fromJSON('["ashb"]'), github.actor)
           ) && github.repository == 'apache/airflow'
         ) && 'self-hosted' || 'ubuntu-20.04' }}
     outputs:


### PR DESCRIPTION
Using this has two draw-backs for us.

1. MEMBER applies to _anyone in the org_, not just members/commiters to this repo
2. The value of this setting depends upon the user's "visiblity" in the org. I.e. if they hide their membership of the org, the author_association will show up as "CONTRIBUTOR" instead.

Both of these combined mean we should instead use an alternative list.  Airflow committers is a scret that contains a list of GH user ids, such as `["ashb", "..."]` etc.