### PR TITLE
Wrapping create-user-job by double quote for Helm Chart

### DIFF
--- a/chart/templates/create-user-job.yaml
+++ b/chart/templates/create-user-job.yaml
@@ -81,7 +81,7 @@ spec:
             - "-l"
             - {{ .Values.webserver.defaultUser.lastName }}
             - "-p"
-            - {{ .Values.webserver.defaultUser.password }}
+            - "{{ .Values.webserver.defaultUser.password }}"
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:


### PR DESCRIPTION
When UI default user password includes a special character like `$`, occurs an error in Helm.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
