### PR TITLE
Remove un-needed/left over environment variables in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ on:  # yamllint disable-line rule:truthy
     branches: ['master', 'v1-10-test', 'v1-10-stable', 'v2-0-test']
 
 env:
-  AIRFLOW_COMMITERS: ${{ secrets.AIRFLOW_COMMITERS }}
   MOUNT_SELECTED_LOCAL_SOURCES: "false"
   FORCE_ANSWER_TO_QUESTIONS: "yes"
   FORCE_PULL_IMAGES: "true"
@@ -208,13 +207,11 @@ jobs:
       - name: Selective checks
         id: selective-checks
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          TARGET_COMMIT_SHA: ${{ github.sha }}
           PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
         run: |
-          if [[ ${EVENT_NAME} == "pull_request" ]]; then
+          if [[ ${GITHUB_EVENT_NAME} == "pull_request" ]]; then
             # Run selective checks
-            ./scripts/ci/selective_ci_checks.sh "${TARGET_COMMIT_SHA}"
+            ./scripts/ci/selective_ci_checks.sh "${GITHUB_SHA}"
           else
             # Run all checks
             ./scripts/ci/selective_ci_checks.sh

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -45,7 +45,7 @@ fi
 function check_upgrade_to_newer_dependencies_needed() {
     # shellcheck disable=SC2153
     if [[ "${UPGRADE_TO_NEWER_DEPENDENCIES}" != "false" ||
-            ${EVENT_NAME} == 'push' || ${EVENT_NAME} == "scheduled" ]]; then
+            ${GITHUB_EVENT_NAME} == 'push' || ${GITHUB_EVENT_NAME} == "scheduled" ]]; then
         # Trigger upgrading to latest constraints where label is set or when
         # SHA of the merge commit triggers rebuilding layer in the docker image
         # Each build that upgrades to latest constraints will get truly latest constraints, not those


### PR DESCRIPTION
AIRFLOW_COMMITERS was left over from a #14718  PR and should have never been included in that merge.

EVENT_NAME isn't needed as GitHub already provide us a GITHUB_EVENT_NAME with the same value.