### PR TITLE
Add readonly REST API endpoints for users

### DIFF
--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -18,6 +18,7 @@ from flask import current_app
 from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import func
 
+from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.user_schema import (
@@ -25,8 +26,10 @@ from airflow.api_connexion.schemas.user_schema import (
     user_collection_item_schema,
     user_collection_schema,
 )
+from airflow.security import permissions
 
 
+@security.requires_access([(permissions.ACTION_CAN_SHOW, permissions.RESOURCE_USER_DB_MODELVIEW)])
 def get_user(username):
     """Get a user"""
     ab_security_manager = current_app.appbuilder.sm
@@ -36,6 +39,7 @@ def get_user(username):
     return user_collection_item_schema.dump(user)
 
 
+@security.requires_access([(permissions.ACTION_CAN_LIST, permissions.RESOURCE_USER_DB_MODELVIEW)])
 @format_parameters({'limit': check_limit})
 def get_users(limit=None, offset=None):
     """Get users"""

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from flask import current_app
+from flask_appbuilder.security.sqla.models import User
+from sqlalchemy import func
+
+from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.schemas.user_schema import (
+    UserCollection,
+    user_collection_item_schema,
+    user_collection_schema,
+)
+
+
+def get_user(username):
+    """Get a user"""
+    ab_security_manager = current_app.appbuilder.sm
+    user = ab_security_manager.find_user(username=username)
+    if not user:
+        raise NotFound(title="User not found", detail=f"The User with username `{username}` was not found")
+    return user_collection_item_schema.dump(user)
+
+
+def get_users(limit=None, offset=None):
+    """Get users"""
+    appbuilder = current_app.appbuilder
+    session = appbuilder.get_session
+    total_entries = session.query(func.count(User.id)).scalar()
+    query = session.query(User)
+
+    users = query.order_by(User.id).offset(offset).limit(limit).all()
+
+    return user_collection_schema.dump(UserCollection(users=users, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -46,8 +46,6 @@ def get_users(limit=None, offset=None):
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(User.id)).scalar()
-    query = session.query(User)
-
-    users = query.order_by(User.id).offset(offset).limit(limit).all()
+    users = session.query(User).order_by(User.id).offset(offset).limit(limit).all()
 
     return user_collection_schema.dump(UserCollection(users=users, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -19,6 +19,7 @@ from flask_appbuilder.security.sqla.models import User
 from sqlalchemy import func
 
 from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.user_schema import (
     UserCollection,
     user_collection_item_schema,
@@ -35,6 +36,7 @@ def get_user(username):
     return user_collection_item_schema.dump(user)
 
 
+@format_parameters({'limit': check_limit})
 def get_users(limit=None, offset=None):
     """Get users"""
     appbuilder = current_app.appbuilder

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1447,11 +1447,140 @@ paths:
         '403':
           $ref: '#/components/responses/PermissionDenied'
 
+  /users:
+    get:
+      summary: List users
+      x-openapi-router-controller: airflow.api_connexion.endpoints.user_endpoint
+      operationId: get_users
+      tags: [User]
+      parameters:
+        - $ref: '#/components/parameters/PageLimit'
+        - $ref: '#/components/parameters/PageOffset'
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCollection'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+
+  /users/{username}:
+    parameters:
+      - $ref: '#/components/parameters/Username'
+    get:
+      summary: Get a user
+      x-openapi-router-controller: airflow.api_connexion.endpoints.user_endpoint
+      operationId: get_user
+      tags: [User]
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserCollectionItem'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
 components:
   # Reusable schemas (data models)
   schemas:
     # Database entities
+    UserCollectionItem:
+      description: >
+        A user object
+      type: object
+      properties:
+        user_id:
+          type: integer
+          description: The user id
+          readOnly: true
+        first_name:
+          type: string
+          description: The user firstname
+        last_name:
+          type: string
+          description: The user lastname
+        username:
+          type: string
+          description: The username
+        email:
+          type: string
+          description: The user's email
+        active:
+          type: boolean
+          description: Whether the user is active
+          readOnly: true
+          nullable: true
+        last_login:
+          type: string
+          format: datetime
+          description: The last user login
+          readOnly: true
+          nullable: true
+        login_count:
+          type: integer
+          description: The login count
+          readOnly: true
+          nullable: true
+        failed_login_count:
+          type: integer
+          description: The number of times the login failed
+          readOnly: true
+          nullable: true
+        roles:
+          type: array
+          description: User roles
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+            nullable: true
+          readOnly: true
+        created_on:
+          type: string
+          format: datetime
+          description: The date user was created
+          readOnly: true
+          nullable: true
+        changed_on:
+          type: string
+          format: datetime
+          description: The date user was changed
+          readOnly: true
+          nullable: true
+    User:
+      type: object
+      description: A user object with sensitive data
+      allOf:
+        - $ref: '#/components/schemas/UserCollectionItem'
+        - type: object
+          properties:
+            password:
+              type: string
+              writeOnly: true
+
+    UserCollection:
+      type: object
+      description: Collection of users.
+      allOf:
+        - type: object
+          properties:
+            users:
+              type: array
+              items:
+                $ref: '#/components/schemas/UserCollectionItem'
+        - $ref: '#/components/schemas/CollectionInfo'
+
     ConnectionCollectionItem:
       description: >
         Connection collection item.
@@ -2805,6 +2934,13 @@ components:
       description: The numbers of items to return.
 
     # Database entity fields
+    Username:
+      in: path
+      name: username
+      schema:
+        type: string
+      required: true
+      description: The username of the user
     RoleName:
       in: path
       name: role_name
@@ -3159,6 +3295,7 @@ tags:
   - name: Plugin
   - name: Role
   - name: Permission
+  - name: User
 
 externalDocs:
   url: https://airflow.apache.org/docs/apache-airflow/stable/

--- a/airflow/api_connexion/schemas/user_schema.py
+++ b/airflow/api_connexion/schemas/user_schema.py
@@ -21,7 +21,7 @@ from marshmallow import Schema, fields
 from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.parameters import validate_istimezone
-from airflow.api_connexion.schemas.role_and_permission_schema import RoleCollectionItemSchema
+from airflow.api_connexion.schemas.role_and_permission_schema import RoleSchema
 
 
 class UserCollectionItemSchema(SQLAlchemySchema):
@@ -42,7 +42,7 @@ class UserCollectionItemSchema(SQLAlchemySchema):
     last_login = auto_field(dump_only=True)
     login_count = auto_field(dump_only=True)
     fail_login_count = auto_field(dump_only=True)
-    roles = fields.List(fields.Nested(RoleCollectionItemSchema, only=('name',)))
+    roles = fields.List(fields.Nested(RoleSchema, only=('name',)))
     created_on = auto_field(validate=validate_istimezone, dump_only=True)
     changed_on = auto_field(validate=validate_istimezone, dump_only=True)
 

--- a/airflow/api_connexion/schemas/user_schema.py
+++ b/airflow/api_connexion/schemas/user_schema.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import List, NamedTuple
+
+from flask_appbuilder.security.sqla.models import User
+from marshmallow import Schema, fields
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
+
+from airflow.api_connexion.parameters import validate_istimezone
+from airflow.api_connexion.schemas.role_and_permission_schema import RoleCollectionItemSchema
+
+
+class UserCollectionItemSchema(SQLAlchemySchema):
+    """user collection item schema"""
+
+    class Meta:
+        """Meta"""
+
+        model = User
+        dateformat = "iso"
+
+    user_id = auto_field('id', dump_only=True)
+    first_name = auto_field()
+    last_name = auto_field()
+    username = auto_field()
+    active = auto_field(dump_only=True)
+    email = auto_field()
+    last_login = auto_field(dump_only=True)
+    login_count = auto_field(dump_only=True)
+    fail_login_count = auto_field(dump_only=True)
+    roles = fields.List(fields.Nested(RoleCollectionItemSchema, only=('name',)))
+    created_on = auto_field(validate=validate_istimezone, dump_only=True)
+    changed_on = auto_field(validate=validate_istimezone, dump_only=True)
+
+
+class UserSchema(UserCollectionItemSchema):
+    """User schema"""
+
+    password = auto_field(load_only=True)
+
+
+class UserCollection(NamedTuple):
+    """User collection"""
+
+    users: List[User]
+    total_entries: int
+
+
+class UserCollectionSchema(Schema):
+    """User collection schema"""
+
+    users = fields.List(fields.Nested(UserCollectionItemSchema))
+    total_entries = fields.Int()
+
+
+user_collection_item_schema = UserCollectionItemSchema()
+user_schema = UserSchema()
+user_collection_schema = UserCollectionSchema()

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -143,8 +143,8 @@ class TestGetUsers(TestUserEndpoint):
 class TestGetUsersPagination(TestUserEndpoint):
     @parameterized.expand(
         [
-            ("/api/v1/users?limit=1", ['test']),
-            ("/api/v1/users?limit=2", ['test', "test_no_permissions"]),
+            ("/api/v1/users?limit=1", ["test"]),
+            ("/api/v1/users?limit=2", ["test", "test_no_permissions"]),
             (
                 "/api/v1/users?offset=5",
                 [

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -1,0 +1,234 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from flask_appbuilder.security.sqla.models import User
+from parameterized import parameterized
+
+from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
+from airflow.utils import timezone
+from airflow.utils.session import provide_session
+from airflow.www import app
+from tests.test_utils.config import conf_vars
+from tests.test_utils.decorators import dont_initialize_flask_app_submodules
+
+DEFAULT_TIME = "2020-06-11T18:00:00+00:00"
+
+
+class TestUserEndpoint(unittest.TestCase):
+    @classmethod
+    @dont_initialize_flask_app_submodules(
+        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
+    )
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
+            cls.app = app.create_app(testing=True)  # type:ignore
+        cls.client = cls.app.test_client()  # type:ignore
+
+    @provide_session
+    def tearDown(self, session) -> None:
+        self.delete_users(session)
+
+    def _create_users(self, count, roles=None):
+        # create users with defined created_on and changed_on date
+        # for easy testing
+        if roles is None:
+            roles = []
+        return [
+            User(
+                first_name=f'test{i}',
+                last_name=f'test{i}',
+                username=f'TEST_USER{i}',
+                email=f'mytest@test{i}.org',
+                roles=roles or [],
+                created_on=timezone.parse(DEFAULT_TIME),
+                changed_on=timezone.parse(DEFAULT_TIME),
+            )
+            for i in range(1, count + 1)
+        ]
+
+    @provide_session
+    def delete_users(self, session):
+        # Delete users that have our custom default time
+        users = session.query(User).filter(User.changed_on == timezone.parse(DEFAULT_TIME)).all()
+        for user in users:
+            session.delete(user)
+        session.commit()
+
+
+class TestGetUser(TestUserEndpoint):
+    @provide_session
+    def test_should_respond_200(self, session):
+        users = self._create_users(1)
+        session.add_all(users)
+        session.commit()
+        response = self.client.get("/api/v1/users/TEST_USER1")
+        assert response.status_code == 200
+        assert response.json == {
+            'active': None,
+            'changed_on': DEFAULT_TIME,
+            'created_on': DEFAULT_TIME,
+            'email': 'mytest@test1.org',
+            'fail_login_count': None,
+            'first_name': 'test1',
+            'last_login': None,
+            'last_name': 'test1',
+            'login_count': None,
+            'roles': [],
+            'user_id': users[0].id,
+            'username': 'TEST_USER1',
+        }
+
+    def test_should_respond_404(self):
+        response = self.client.get("/api/v1/users/invalid-user")
+        assert response.status_code == 404
+        assert {
+            'detail': "The User with username `invalid-user` was not found",
+            'status': 404,
+            'title': 'User not found',
+            'type': EXCEPTIONS_LINK_MAP[404],
+        } == response.json
+
+
+class TestGetUsers(TestUserEndpoint):
+    @provide_session
+    def test_should_response_200(self, session):
+        users = self._create_users(2)
+        session.add_all(users)
+        session.commit()
+        response = self.client.get("/api/v1/users")
+        assert response.status_code == 200
+        assert response.json == {
+            'total_entries': 2,
+            'users': [
+                {
+                    'active': None,
+                    'changed_on': '2020-06-11T18:00:00+00:00',
+                    'created_on': '2020-06-11T18:00:00+00:00',
+                    'email': 'mytest@test1.org',
+                    'fail_login_count': None,
+                    'first_name': 'test1',
+                    'last_login': None,
+                    'last_name': 'test1',
+                    'login_count': None,
+                    'roles': [],
+                    'user_id': users[0].id,
+                    'username': 'TEST_USER1',
+                },
+                {
+                    'active': None,
+                    'changed_on': '2020-06-11T18:00:00+00:00',
+                    'created_on': '2020-06-11T18:00:00+00:00',
+                    'email': 'mytest@test2.org',
+                    'fail_login_count': None,
+                    'first_name': 'test2',
+                    'last_login': None,
+                    'last_name': 'test2',
+                    'login_count': None,
+                    'roles': [],
+                    'user_id': users[1].id,
+                    'username': 'TEST_USER2',
+                },
+            ],
+        }
+
+
+class TestGetUsersPagination(TestUserEndpoint):
+    @parameterized.expand(
+        [
+            ("/api/v1/users?limit=1", ['TEST_USER1']),
+            ("/api/v1/users?limit=2", ['TEST_USER1', "TEST_USER2"]),
+            (
+                "/api/v1/users?offset=5",
+                [
+                    "TEST_USER6",
+                    "TEST_USER7",
+                    "TEST_USER8",
+                    "TEST_USER9",
+                    "TEST_USER10",
+                ],
+            ),
+            (
+                "/api/v1/users?offset=0",
+                [
+                    "TEST_USER1",
+                    "TEST_USER2",
+                    "TEST_USER3",
+                    "TEST_USER4",
+                    "TEST_USER5",
+                    "TEST_USER6",
+                    "TEST_USER7",
+                    "TEST_USER8",
+                    "TEST_USER9",
+                    "TEST_USER10",
+                ],
+            ),
+            ("/api/v1/users?limit=1&offset=5", ["TEST_USER6"]),
+            ("/api/v1/users?limit=1&offset=1", ["TEST_USER2"]),
+            (
+                "/api/v1/users?limit=2&offset=2",
+                ["TEST_USER3", "TEST_USER4"],
+            ),
+        ]
+    )
+    @provide_session
+    def test_handle_limit_offset(self, url, expected_usernames, session):
+        users = self._create_users(10)
+        session.add_all(users)
+        session.commit()
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.json["total_entries"] == 10
+        usernames = [user["username"] for user in response.json["users"] if user]
+        assert usernames == expected_usernames
+
+    @provide_session
+    def test_should_respect_page_size_limit_default(self, session):
+        users = self._create_users(200)
+        session.add_all(users)
+        session.commit()
+
+        response = self.client.get("/api/v1/users")
+        assert response.status_code == 200
+
+        assert response.json["total_entries"] == 200
+        assert len(response.json["users"]) == 100
+
+    @provide_session
+    def test_limit_of_zero_should_return_default(self, session):
+        users = self._create_users(200)
+        session.add_all(users)
+        session.commit()
+
+        response = self.client.get("/api/v1/users?limit=0")
+        assert response.status_code == 200
+
+        assert response.json["total_entries"] == 200
+        assert len(response.json["users"]) == 100
+
+    @provide_session
+    @conf_vars({("api", "maximum_page_limit"): "150"})
+    def test_should_return_conf_max_if_req_max_above_conf(self, session):
+        users = self._create_users(200)
+        session.add_all(users)
+        session.commit()
+
+        response = self.client.get("/api/v1/users?limit=180")
+        assert response.status_code == 200
+        assert len(response.json['users']) == 150

--- a/tests/api_connexion/schemas/test_user_schema.py
+++ b/tests/api_connexion/schemas/test_user_schema.py
@@ -1,0 +1,140 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from flask_appbuilder.security.sqla.models import User
+
+from airflow.api_connexion.schemas.user_schema import user_collection_item_schema, user_schema
+from airflow.utils import timezone
+from airflow.utils.session import provide_session
+from airflow.www import app
+from tests.test_utils.api_connexion_utils import create_role, delete_role
+
+TEST_EMAIL = "test@example.org"
+
+DEFAULT_TIME = "2021-01-09T13:59:56.336000+00:00"
+
+
+class TestUserBase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        cls.app = app.create_app(testing=True)  # type:ignore
+        cls.role = create_role(
+            cls.app,
+            name="TestRole",
+            permissions=[],
+        )
+
+    def tearDown(self) -> None:
+        delete_role(self.app, 'Test')
+
+    @provide_session
+    def setUp(self, session) -> None:
+        self.delete_user(session)
+
+    def delete_user(self, session):
+        user = session.query(User).filter(User.email == TEST_EMAIL).first()
+        if user:
+            session.delete(user)
+
+
+class TestUserCollectionItemSchema(TestUserBase):
+    @provide_session
+    def test_serialize(self, session):
+        user_model = User(
+            first_name="Foo",
+            last_name="Bar",
+            username="test",
+            password="test",
+            email=TEST_EMAIL,
+            roles=[self.role],
+            created_on=timezone.parse(DEFAULT_TIME),
+            changed_on=timezone.parse(DEFAULT_TIME),
+        )
+        session.add(user_model)
+        session.commit()
+        user = session.query(User).filter(User.email == TEST_EMAIL).first()
+        deserialized_user = user_collection_item_schema.dump(user)
+        # No password in dump
+        assert deserialized_user == {
+            'created_on': DEFAULT_TIME,
+            'email': 'test@example.org',
+            'changed_on': DEFAULT_TIME,
+            'user_id': user.id,
+            'active': None,
+            'last_login': None,
+            'last_name': 'Bar',
+            'fail_login_count': None,
+            'first_name': 'Foo',
+            'username': 'test',
+            'login_count': None,
+            'roles': [{'name': 'TestRole'}],
+        }
+
+
+class TestUserSchema(TestUserBase):
+    @provide_session
+    def test_serialize(self, session):
+        user_model = User(
+            first_name="Foo",
+            last_name="Bar",
+            username="test",
+            password="test",
+            email=TEST_EMAIL,
+            created_on=timezone.parse(DEFAULT_TIME),
+            changed_on=timezone.parse(DEFAULT_TIME),
+        )
+        session.add(user_model)
+        session.commit()
+        user = session.query(User).filter(User.email == TEST_EMAIL).first()
+        deserialized_user = user_schema.dump(user)
+        # No password in dump
+        assert deserialized_user == {
+            'roles': [],
+            'created_on': DEFAULT_TIME,
+            'email': 'test@example.org',
+            'changed_on': DEFAULT_TIME,
+            'user_id': user.id,
+            'active': None,
+            'last_login': None,
+            'last_name': 'Bar',
+            'fail_login_count': None,
+            'first_name': 'Foo',
+            'username': 'test',
+            'login_count': None,
+        }
+
+    def test_deserialize_user(self):
+        user_dump = {
+            'roles': [{'name': 'TestRole'}],
+            'email': 'test@example.org',
+            'last_name': 'Bar',
+            'first_name': 'Foo',
+            'username': 'test',
+            'password': 'test',  # loads password
+        }
+        result = user_schema.load(user_dump)
+        assert result == {
+            'roles': [{'name': "TestRole"}],
+            'email': 'test@example.org',
+            'last_name': 'Bar',
+            'first_name': 'Foo',
+            'username': 'test',
+            'password': 'test',  # Password loaded
+        }


### PR DESCRIPTION
This PR adds readonly user endpoints.
Depends on #14664 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
