### PR TITLE
Fixed runs-on for non-apache repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,13 +164,11 @@ jobs:
       - name: Set runs-on
         id: set-runs-on
         run: |
-          echo "::set-output name=runsOn::$(jq -n '
-            if env.AIRFLOW_SELF_HOSTED_RUNNER or (["push", "schedule"] | index(env.GITHUB_EVENT_NAME)) then
-              "self-hosted"
-            else
-              "ubuntu-20.04"
-            end
-          ')"
+          if [[ ${AIRFLOW_SELF_HOSTED_RUNNER} != "" ]]; then
+            echo "::set-output name=runsOn::\"self-hosted\""
+          else
+            echo "::set-output name=runsOn::\"ubuntu-20.04\""
+          fi
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The change #14718 by mistake left the 'self-hosted" runs-on in case of
push or schedule. This caused failures on non-apache repositories.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
