### PR TITLE
Don't exit upgrade_check with code 1 if there are no problems

### DIFF
--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -116,7 +116,7 @@ def run(args):
     logging.disable(logging.ERROR)
 
     all_rule_statuses = check_upgrade(formatter, rules)
-    any_problems = any([rule.is_problem for rule in all_rule_statuses])
+    any_problems = any(rule.is_problem for rule in all_rule_statuses)
     if any_problems:
         sys.exit(1)
 

--- a/airflow/upgrade/checker.py
+++ b/airflow/upgrade/checker.py
@@ -115,8 +115,9 @@ def run(args):
     # We want to show only output of upgrade_check command
     logging.disable(logging.ERROR)
 
-    all_problems = check_upgrade(formatter, rules)
-    if all_problems:
+    all_rule_statuses = check_upgrade(formatter, rules)
+    any_problems = any([rule.is_problem for rule in all_rule_statuses])
+    if any_problems:
         sys.exit(1)
 
 

--- a/airflow/upgrade/problem.py
+++ b/airflow/upgrade/problem.py
@@ -33,6 +33,10 @@ class RuleStatus(NamedTuple(
     def is_success(self):
         return len(self.messages) == 0
 
+    @property
+    def is_problem(self):
+        return not self.skipped and not self.is_success
+
     @classmethod
     def from_rule(cls, rule):
         # type: (BaseRule) -> RuleStatus

--- a/tests/upgrade/test_problem.py
+++ b/tests/upgrade/test_problem.py
@@ -25,6 +25,11 @@ class TestRuleStatus:
         assert RuleStatus(rule=mock.MagicMock(), messages=[], skipped=False).is_success is True
         assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"], skipped=False).is_success is False
 
+    def test_is_problem(self):
+        assert RuleStatus(rule=mock.MagicMock(), messages=[], skipped=False).is_problem is False
+        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"], skipped=False).is_problem is True
+        assert RuleStatus(rule=mock.MagicMock(), messages=["aaa"], skipped=True).is_problem is False
+
     def test_rule_status_from_rule(self):
         msgs = ["An interesting problem to solve"]
         rule = mock.MagicMock()


### PR DESCRIPTION
`airflow upgrade` check exits with code 1, even if there are no problem. If I understand https://github.com/apache/airflow/blob/995e4b9ba4bffed9f3b721b52592257ea7752b72/airflow/upgrade/checker.py#L118-L120 correctly, as long as any check is performed, it will always exit with code 1.

I extended the `Rule` object by an `is_problem` property and replace the current check _if there are any Rules_ by _if there are any problems_, where a skipped Rule doesn't count as a problem.