### PR TITLE
Add workers extraVolumes to Kubernetes pod template for Helm Chart

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -72,6 +72,9 @@ spec:
           readOnly: true
           subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
+{{- if .Values.workers.extraVolumeMounts }}
+{{ toYaml .Values.workers.extraVolumeMounts | indent 8 }}
+{{- end }}
   hostNetwork: false
   {{- if or .Values.registry.secretName .Values.registry.connection }}
   imagePullSecrets:
@@ -108,3 +111,6 @@ spec:
   - configMap:
       name: {{ include "airflow_config" . }}
     name: config
+{{- if .Values.workers.extraVolumes }}
+{{ toYaml .Values.workers.extraVolumes | indent 2 }}
+{{- end }}

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -272,7 +272,6 @@ class PodTemplateFileTest(unittest.TestCase):
     def test_should_create_valid_volume_mount_and_volume(self):
         docs = render_chart(
             values={
-                "executor": "KubernetesExecutor",
                 "workers": {
                     "extraVolumes": [{"name": "test-volume", "emptyDir": {}}],
                     "extraVolumeMounts": [{"name": "test-volume", "mountPath": "/opt/test"}],
@@ -281,7 +280,7 @@ class PodTemplateFileTest(unittest.TestCase):
             show_only=["templates/pod-template-file.yaml"],
         )
 
-        assert "test-volume" == jmespath.search("spec.template.spec.volumes[3].name", docs[0])
+        assert "test-volume" == jmespath.search("spec.volumes[2].name", docs[0])
         assert "test-volume" == jmespath.search(
-            "spec.template.spec.containers[0].volumeMounts[3].name", docs[0]
+            "spec.containers[0].volumeMounts[2].name", docs[0]
         )

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -268,3 +268,20 @@ class PodTemplateFileTest(unittest.TestCase):
         )
 
         self.assertEqual(5000, jmespath.search("spec.securityContext.fsGroup", docs[0]))
+
+    def test_should_create_valid_volume_mount_and_volume(self):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                "workers": {
+                    "extraVolumes": [{"name": "test-volume", "emptyDir": {}}],
+                    "extraVolumeMounts": [{"name": "test-volume", "mountPath": "/opt/test"}],
+                }
+            },
+            show_only=["templates/pod-template-file.yaml"],
+        )
+
+        assert "test-volume" == jmespath.search("spec.template.spec.volumes[0].name", docs[0])
+        assert "test-volume" == jmespath.search(
+            "spec.template.spec.containers[0].volumeMounts[0].name", docs[0]
+        )

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -281,6 +281,4 @@ class PodTemplateFileTest(unittest.TestCase):
         )
 
         assert "test-volume" == jmespath.search("spec.volumes[2].name", docs[0])
-        assert "test-volume" == jmespath.search(
-            "spec.containers[0].volumeMounts[2].name", docs[0]
-        )
+        assert "test-volume" == jmespath.search("spec.containers[0].volumeMounts[2].name", docs[0])

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -281,7 +281,7 @@ class PodTemplateFileTest(unittest.TestCase):
             show_only=["templates/pod-template-file.yaml"],
         )
 
-        assert "test-volume" == jmespath.search("spec.template.spec.volumes[0].name", docs[0])
+        assert "test-volume" == jmespath.search("spec.template.spec.volumes[3].name", docs[0])
         assert "test-volume" == jmespath.search(
-            "spec.template.spec.containers[0].volumeMounts[0].name", docs[0]
+            "spec.template.spec.containers[0].volumeMounts[3].name", docs[0]
         )

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -280,5 +280,11 @@ class PodTemplateFileTest(unittest.TestCase):
             show_only=["templates/pod-template-file.yaml"],
         )
 
-        assert "test-volume" == jmespath.search("spec.volumes[2].name", docs[0])
-        assert "test-volume" == jmespath.search("spec.containers[0].volumeMounts[2].name", docs[0])
+        assert "test-volume" == jmespath.search(
+            "spec.volumes[2].name",
+            docs[0],
+        )
+        assert "test-volume" == jmespath.search(
+            "spec.containers[0].volumeMounts[2].name",
+            docs[0],
+        )


### PR DESCRIPTION
As far as I know, the pod_template is a worker template for creating workers by Kubernetes Executor.
We already have the extraVolumes value for workers, I think it can apply to the pod_template.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
