### PR TITLE
Further speed up Connexion API tests with pytest session fixtures

### DIFF
--- a/pylintrc-tests
+++ b/pylintrc-tests
@@ -160,7 +160,9 @@ disable=print-statement,
         missing-docstring,
         no-self-use,
         too-many-public-methods,
-        protected-access
+        protected-access,
+        redefined-outer-name, # Gets confused about file-scoped pytest fixtures
+        attribute-defined-outside-init,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/api_connexion/endpoints/conftest.py
+++ b/tests/api_connexion/endpoints/conftest.py
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+from airflow.www import app
+from tests.test_utils.config import conf_vars
+from tests.test_utils.decorators import dont_initialize_flask_app_submodules
+
+
+@pytest.fixture(scope="session")
+def minimal_app_for_api():
+    @dont_initialize_flask_app_submodules(
+        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
+    )
+    def factory():
+        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
+            return app.create_app(testing=True)  # type:ignore
+
+    return factory()
+
+
+@pytest.fixture
+def session():
+    from airflow.utils.session import create_session
+
+    with create_session() as session:
+        yield session

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -15,9 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
-import unittest
+import unittest.mock
 from datetime import datetime
 
+import pytest
 from itsdangerous import URLSafeSerializer
 from parameterized import parameterized
 
@@ -29,17 +30,43 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.operators.dummy import DummyOperator
 from airflow.security import permissions
 from airflow.utils.session import provide_session
-from airflow.www import app
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 SERIALIZER = URLSafeSerializer(conf.get('webserver', 'secret_key'))
 FILE_TOKEN = SERIALIZER.dumps(__file__)
 
 
-class TestDagEndpoint(unittest.TestCase):
+@pytest.fixture(scope="module")
+def configured_app(minimal_app_for_api):
+    app = minimal_app_for_api
+    create_user(
+        app,  # type: ignore
+        username="test",
+        role_name="Test",
+        permissions=[
+            (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG),
+        ],
+    )
+    create_user(app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
+    create_user(app, username="test_granular_permissions", role_name="TestGranularDag")  # type: ignore
+    app.appbuilder.sm.sync_perm_for_dag(  # type: ignore  # pylint: disable=no-member
+        "TEST_DAG_1",
+        access_control={'TestGranularDag': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]},
+    )
+
+    yield app
+
+    delete_user(app, username="test")  # type: ignore
+    delete_user(app, username="test_no_permissions")  # type: ignore
+    delete_user(app, username="test_granular_permissions")  # type: ignore
+
+
+class TestDagEndpoint:
     dag_id = "test_dag"
     task_id = "op1"
     dag2_id = "test_dag2"
@@ -51,69 +78,45 @@ class TestDagEndpoint(unittest.TestCase):
         clear_db_dags()
         clear_db_serialized_dags()
 
-    @classmethod
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
-    )
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
-            cls.app = app.create_app(testing=True)  # type:ignore
-        create_user(
-            cls.app,  # type: ignore
-            username="test",
-            role_name="Test",
-            permissions=[
-                (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
-                (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
-                (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG),
-            ],
-        )
-        create_user(cls.app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
-        create_user(
-            cls.app, username="test_granular_permissions", role_name="TestGranularDag"  # type: ignore
-        )
-        cls.app.appbuilder.sm.sync_perm_for_dag(  # type: ignore  # pylint: disable=no-member
+    def __init__(self, configured_app):
+
+        app = configured_app
+        app.appbuilder.sm.sync_perm_for_dag(  # type: ignore  # pylint: disable=no-member
             "TEST_DAG_1",
             access_control={'TestGranularDag': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]},
         )
 
         with DAG(
-            cls.dag_id,
+            self.dag_id,
             start_date=datetime(2020, 6, 15),
             doc_md="details",
             params={"foo": 1},
             tags=['example'],
         ) as dag:
-            DummyOperator(task_id=cls.task_id)
+            DummyOperator(task_id=self.task_id)
 
-        with DAG(cls.dag2_id, start_date=datetime(2020, 6, 15)) as dag2:  # no doc_md
-            DummyOperator(task_id=cls.task_id)
+        with DAG(self.dag2_id, start_date=datetime(2020, 6, 15)) as dag2:  # no doc_md
+            DummyOperator(task_id=self.task_id)
 
-        with DAG(cls.dag3_id) as dag3:  # DAG start_date set to None
-            DummyOperator(task_id=cls.task_id, start_date=datetime(2019, 6, 12))
+        with DAG(self.dag3_id) as dag3:  # DAG start_date set to None
+            DummyOperator(task_id=self.task_id, start_date=datetime(2019, 6, 12))
 
-        cls.dag = dag  # type:ignore
-        cls.dag2 = dag2  # type: ignore
-        cls.dag3 = dag3  # tupe: ignore
+        self.dag = dag  # type:ignore
+        self.dag2 = dag2  # type: ignore
+        self.dag3 = dag3  # tupe: ignore
 
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {dag.dag_id: dag, dag2.dag_id: dag2, dag3.dag_id: dag3}
 
-        cls.app.dag_bag = dag_bag  # type:ignore
+        configured_app.dag_bag = dag_bag  # type:ignore
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        delete_user(cls.app, username="test")  # type: ignore
-        delete_user(cls.app, username="test_no_permissions")  # type: ignore
-        delete_user(cls.app, username="test_granular_permissions")  # type: ignore
-
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup_attrs(self, configured_app) -> None:
         self.clean_db()
+        self.app = configured_app
         self.client = self.app.test_client()  # type:ignore
 
-    def tearDown(self) -> None:
+    def teardown_method(self) -> None:
         self.clean_db()
 
     @provide_session
@@ -147,8 +150,7 @@ class TestGetDag(TestDagEndpoint):
         } == response.json
 
     @conf_vars({("webserver", "secret_key"): "mysecret"})
-    @provide_session
-    def test_should_respond_200_with_schedule_interval_none(self, session=None):
+    def test_should_respond_200_with_schedule_interval_none(self, session):
         dag_model = DagModel(
             dag_id="TEST_DAG_1",
             fileloc="/tmp/dag_1.py",
@@ -300,18 +302,14 @@ class TestGetDagDetails(TestDagEndpoint):
         }
         assert response.json == expected
 
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
-    )
     def test_should_respond_200_serialized(self):
-        # Create empty app with empty dagbag to check if DAG is read from db
-        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
-            app_serialized = app.create_app(testing=True)
-        dag_bag = DagBag(os.devnull, include_examples=False, read_dags_from_db=True)
-        app_serialized.dag_bag = dag_bag
-        client = app_serialized.test_client()
+        # Get the dag out of the dagbag before we patch it to an empty one
+        SerializedDagModel.write_dag(self.app.dag_bag.get_dag(self.dag_id))
 
-        SerializedDagModel.write_dag(self.dag)
+        # Create empty app with empty dagbag to check if DAG is read from db
+        dag_bag = DagBag(os.devnull, include_examples=False, read_dags_from_db=True)
+        patcher = unittest.mock.patch.object(self.app, 'dag_bag', dag_bag)
+        patcher.start()
 
         expected = {
             "catchup": True,
@@ -338,12 +336,14 @@ class TestGetDagDetails(TestDagEndpoint):
             "tags": [{'name': 'example'}],
             "timezone": "Timezone('UTC')",
         }
-        response = client.get(
+        response = self.client.get(
             f"/api/v1/dags/{self.dag_id}/details", environ_overrides={'REMOTE_USER': "test"}
         )
 
         assert response.status_code == 200
         assert response.json == expected
+
+        patcher.stop()
 
         response = self.client.get(
             f"/api/v1/dags/{self.dag_id}/details", environ_overrides={'REMOTE_USER': "test"}

--- a/tests/api_connexion/endpoints/test_health_endpoint.py
+++ b/tests/api_connexion/endpoints/test_health_endpoint.py
@@ -14,37 +14,29 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest
 from datetime import timedelta
 from unittest import mock
+
+import pytest
 
 from airflow.jobs.base_job import BaseJob
 from airflow.utils import timezone
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
-from airflow.www import app
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 HEALTHY = "healthy"
 UNHEALTHY = "unhealthy"
 
 
-class TestHealthTestBase(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
-    )
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls.app = app.create_app(testing=True)  # type:ignore
-
-    def setUp(self) -> None:
+class TestHealthTestBase:
+    @pytest.fixture(autouse=True)
+    def setup_attrs(self, minimal_app_for_api) -> None:
+        self.app = minimal_app_for_api
         self.client = self.app.test_client()  # type:ignore
         with create_session() as session:
             session.query(BaseJob).delete()
 
-    def tearDown(self):
-        super().tearDown()
+    def teardown_method(self):
         with create_session() as session:
             session.query(BaseJob).delete()
 

--- a/tests/api_connexion/endpoints/test_plugin_endpoint.py
+++ b/tests/api_connexion/endpoints/test_plugin_endpoint.py
@@ -15,43 +15,42 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 
+import pytest
 from parameterized import parameterized
 
 from airflow.plugins_manager import AirflowPlugin
 from airflow.security import permissions
-from airflow.www import app
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
 from tests.test_utils.config import conf_vars
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 from tests.test_utils.mock_plugins import mock_plugin_manager
 
 
-class TestPluginsEndpoint(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
+@pytest.fixture(scope="module")
+def configured_app(minimal_app_for_api):
+    app = minimal_app_for_api
+    create_user(
+        app,  # type: ignore
+        username="test",
+        role_name="Test",
+        permissions=[(permissions.ACTION_CAN_READ, permissions.RESOURCE_PLUGIN)],
     )
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
-            cls.app = app.create_app(testing=True)  # type:ignore
-        create_user(
-            cls.app,  # type: ignore
-            username="test",
-            role_name="Test",
-            permissions=[(permissions.ACTION_CAN_READ, permissions.RESOURCE_PLUGIN)],
-        )
-        create_user(cls.app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
+    create_user(app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
 
-    def setUp(self) -> None:
+    yield app
+
+    delete_user(app, username="test")  # type: ignore
+    delete_user(app, username="test_no_permissions")  # type: ignore
+
+
+class TestPluginsEndpoint:
+    @pytest.fixture(autouse=True)
+    def setup_attrs(self, configured_app) -> None:
+        """
+        Setup For XCom endpoint TC
+        """
+        self.app = configured_app
         self.client = self.app.test_client()  # type:ignore
-
-    @classmethod
-    def tearDownClass(cls) -> None:
-        delete_user(cls.app, username="test")  # type: ignore
-        delete_user(cls.app, username="test_no_permissions")  # type: ignore
 
 
 class TestGetPlugins(TestPluginsEndpoint):

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -16,9 +16,9 @@
 # under the License.
 import datetime as dt
 import getpass
-import unittest
 from unittest import mock
 
+import pytest
 from parameterized import parameterized
 
 from airflow.models import DagBag, DagRun, SlaMiss, TaskInstance
@@ -27,44 +27,38 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.types import DagRunType
-from airflow.www import app
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
-from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_runs, clear_db_sla_miss
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 DEFAULT_DATETIME_1 = datetime(2020, 1, 1)
 DEFAULT_DATETIME_STR_1 = "2020-01-01T00:00:00+00:00"
 DEFAULT_DATETIME_STR_2 = "2020-01-02T00:00:00+00:00"
 
 
-class TestTaskInstanceEndpoint(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
+@pytest.fixture(scope="module")
+def configured_app(minimal_app_for_api):
+    app = minimal_app_for_api
+    create_user(
+        app,  # type: ignore
+        username="test",
+        role_name="Test",
+        permissions=[
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
+        ],
     )
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
-            cls.app = app.create_app(testing=True)  # type:ignore
-        create_user(
-            cls.app,  # type: ignore
-            username="test",
-            role_name="Test",
-            permissions=[
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
-                (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
-            ],
-        )
-        create_user(cls.app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
+    create_user(app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        delete_user(cls.app, username="test")  # type: ignore
+    yield app
 
-    def setUp(self) -> None:
+    delete_user(app, username="test")  # type: ignore
+
+
+class TestTaskInstanceEndpoint:
+    @pytest.fixture(autouse=True)
+    def setup_attrs(self, configured_app) -> None:
         self.default_time = DEFAULT_DATETIME_1
         self.ti_init = {
             "execution_date": self.default_time,
@@ -79,6 +73,7 @@ class TestTaskInstanceEndpoint(unittest.TestCase):
             "queue": "default_queue",
             "job_id": 0,
         }
+        self.app = configured_app
         self.client = self.app.test_client()  # type:ignore
         clear_db_runs()
         clear_db_sla_miss()
@@ -138,7 +133,6 @@ class TestTaskInstanceEndpoint(unittest.TestCase):
 
 
 class TestGetTaskInstance(TestTaskInstanceEndpoint):
-    @provide_session
     def test_should_respond_200(self, session):
         self.create_task_instances(session)
         response = self.client.get(
@@ -169,7 +163,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "unixname": getpass.getuser(),
         }
 
-    @provide_session
     def test_should_respond_200_with_task_state_in_removed(self, session):
         self.create_task_instances(session, task_instances=[{"state": State.REMOVED}], update_extras=True)
         response = self.client.get(
@@ -200,7 +193,6 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "unixname": getpass.getuser(),
         }
 
-    @provide_session
     def test_should_respond_200_task_instance_with_sla(self, session):
         self.create_task_instances(session)
         session.query()
@@ -439,7 +431,6 @@ class TestGetTaskInstances(TestTaskInstanceEndpoint):
         assert response.json["total_entries"] == expected_ti
         assert len(response.json["task_instances"]) == expected_ti
 
-    @provide_session
     def test_should_respond_200_for_dag_id_filter(self, session):
         self.create_task_instances(session)
         self.create_task_instances(session, dag_id="example_skip_dag")
@@ -846,7 +837,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
         assert response.status_code == 200
         assert len(response.json["task_instances"]) == expected_ti
 
-    @provide_session
     def test_should_respond_200_with_reset_dag_run(self, session):
         dag_id = "example_python_operator"
         payload = {
@@ -993,7 +983,6 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
 
 
 class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
-    @provide_session
     @mock.patch('airflow.api_connexion.endpoints.task_instance_endpoint.set_state')
     def test_should_assert_call_mocked_api(self, mock_set_state, session):
         self.create_task_instances(session)

--- a/tests/api_connexion/endpoints/test_version_endpoint.py
+++ b/tests/api_connexion/endpoints/test_version_endpoint.py
@@ -14,23 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest
 from unittest import mock
 
-from airflow.www import app
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
+import pytest
 
 
-class TestGetHealthTest(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
-    )
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls.app = app.create_app(testing=True)  # type:ignore
-
-    def setUp(self) -> None:
+class TestGetHealthTest:
+    @pytest.fixture(autouse=True)
+    def setup_attrs(self, minimal_app_for_api) -> None:
+        """
+        Setup For XCom endpoint TC
+        """
+        self.app = minimal_app_for_api
         self.client = self.app.test_client()  # type:ignore
 
     @mock.patch("airflow.api_connexion.endpoints.version_endpoint.airflow.__version__", "MOCK_VERSION")

--- a/tests/api_connexion/endpoints/test_xcom_endpoint.py
+++ b/tests/api_connexion/endpoints/test_xcom_endpoint.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest
 from datetime import timedelta
 
+import pytest
 from parameterized import parameterized
 
 from airflow.models import DagModel, DagRun as DR, XCom
@@ -24,70 +24,65 @@ from airflow.security import permissions
 from airflow.utils.dates import parse_execution_date
 from airflow.utils.session import provide_session
 from airflow.utils.types import DagRunType
-from airflow.www import app
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_user
-from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_xcom
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 
-class TestXComEndpoint(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_appbuilder", "init_api_experimental_auth", "init_api_connexion"]
+@pytest.fixture(scope="module")
+def configured_app(minimal_app_for_api):
+    app = minimal_app_for_api
+
+    create_user(
+        app,  # type: ignore
+        username="test",
+        role_name="Test",
+        permissions=[
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
+        ],
     )
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        with conf_vars({("api", "auth_backend"): "tests.test_utils.remote_user_api_auth_backend"}):
-            cls.app = app.create_app(testing=True)  # type:ignore
+    create_user(
+        app,  # type: ignore
+        username="test_granular_permissions",
+        role_name="TestGranularDag",
+        permissions=[
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
+        ],
+    )
+    app.appbuilder.sm.sync_perm_for_dag(  # type: ignore  # pylint: disable=no-member
+        "test-dag-id-1",
+        access_control={'TestGranularDag': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]},
+    )
+    create_user(app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
 
-        create_user(
-            cls.app,  # type: ignore
-            username="test",
-            role_name="Test",
-            permissions=[
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
-            ],
-        )
-        create_user(
-            cls.app,  # type: ignore
-            username="test_granular_permissions",
-            role_name="TestGranularDag",
-            permissions=[
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
-                (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
-            ],
-        )
-        cls.app.appbuilder.sm.sync_perm_for_dag(  # type: ignore  # pylint: disable=no-member
-            "test-dag-id-1",
-            access_control={'TestGranularDag': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]},
-        )
-        create_user(cls.app, username="test_no_permissions", role_name="TestNoPermissions")  # type: ignore
+    yield app
 
-    @classmethod
-    def tearDownClass(cls) -> None:
-        delete_user(cls.app, username="test")  # type: ignore
-        delete_user(cls.app, username="test_no_permissions")  # type: ignore
+    delete_user(app, username="test")  # type: ignore
+    delete_user(app, username="test_no_permissions")  # type: ignore
 
+
+class TestXComEndpoint:
     @staticmethod
     def clean_db():
         clear_db_dags()
         clear_db_runs()
         clear_db_xcom()
 
-    def setUp(self) -> None:
+    @pytest.fixture(autouse=True)
+    def setup_attrs(self, configured_app) -> None:
         """
         Setup For XCom endpoint TC
         """
+        self.app = configured_app
         self.client = self.app.test_client()  # type:ignore
         # clear existing xcoms
         self.clean_db()
 
-    def tearDown(self) -> None:
+    def teardown_method(self) -> None:
         """
         Clear Hanging XComs
         """
@@ -377,8 +372,7 @@ class TestGetXComEntries(TestXComEndpoint):
 
 
 class TestPaginationGetXComEntries(TestXComEndpoint):
-    def setUp(self):
-        super().setUp()
+    def setup_method(self):
         self.dag_id = 'test-dag-id'
         self.task_id = 'test-task-id'
         self.execution_date = '2005-04-02T00:00:00+00:00'


### PR DESCRIPTION
Creating the Flask API and Connexion take a significant amount of time
to create, and each of these test modules creates the Flask app with the
same set up "initializers".

To make this work we had to switch away from `unittest.TestCase`, as
pytest fixtures won't work with TestCase subclasses.

The `configured_app` fixture is defined at the module level, otherwise
each _subclass_ would have it's "own" module scope fixture.

This takes the test time for api_connexion/endpoints down to sub-1 minute
for me.