### PR TITLE
Fix running child tasks in a subdag after clearing a successful subdag

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1112,11 +1112,11 @@ class DAG(LoggingMixin):
     @provide_session
     def set_dag_runs_state(
         self,
-        dag_ids: List[str] = None,
         state: str = State.RUNNING,
         session: Session = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
+        dag_ids: List[str] = None,
     ) -> None:
         dag_ids = dag_ids or [self.dag_id]
         query = session.query(DagRun).filter(DagRun.dag_id.in_(dag_ids))
@@ -1333,11 +1333,11 @@ class DAG(LoggingMixin):
             )
 
             self.set_dag_runs_state(
-                dag_ids=dag_ids,
                 session=session,
                 start_date=start_date,
                 end_date=end_date,
                 state=dag_run_state,
+                dag_ids=dag_ids,
             )
         else:
             count = 0

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1124,7 +1124,7 @@ class DAG(LoggingMixin):
             query = query.filter(DagRun.execution_date >= start_date)
         if end_date:
             query = query.filter(DagRun.execution_date <= end_date)
-        query.update({DagRun.state: state}, synchronize_session=False)
+        query.update({DagRun.state: state}, synchronize_session='fetch')
 
     @provide_session
     def clear(

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1306,6 +1306,60 @@ class TestDag(unittest.TestCase):
         assert dagrun.state == dag_run_state
 
     @parameterized.expand(
+        [
+            (State.NONE,),
+            (State.RUNNING,),
+        ]
+    )
+    def test_clear_set_dagrun_state_for_subdag(self, dag_run_state):
+        dag_id = 'test_clear_set_dagrun_state_subdag'
+        self._clean_up(dag_id)
+        task_id = 't1'
+        dag = DAG(dag_id, start_date=DEFAULT_DATE, max_active_runs=1)
+        t_1 = DummyOperator(task_id=task_id, dag=dag)
+        subdag = DAG(dag_id + '.test', start_date=DEFAULT_DATE, max_active_runs=1)
+        SubDagOperator(task_id='test', subdag=subdag, dag=dag)
+        t_2 = DummyOperator(task_id='task', dag=subdag)
+
+        session = settings.Session()
+        dagrun_1 = dag.create_dagrun(
+            run_type=DagRunType.BACKFILL_JOB,
+            state=State.FAILED,
+            start_date=DEFAULT_DATE,
+            execution_date=DEFAULT_DATE,
+        )
+        session.merge(dagrun_1)
+
+        task_instance_1 = TI(t_1, execution_date=DEFAULT_DATE, state=State.RUNNING)
+        task_instance_2 = TI(t_2, execution_date=DEFAULT_DATE, state=State.RUNNING)
+        session.merge(task_instance_1)
+        session.merge(task_instance_2)
+        session.commit()
+
+        dag.clear(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=1),
+            dag_run_state=dag_run_state,
+            include_subdags=True,
+            include_parentdag=False,
+            session=session,
+        )
+
+        dagruns = (
+            session.query(
+                DagRun,
+            )
+            .filter(
+                DagRun.dag_id.in_([dag_id, dag_id + '.test']),
+            )
+            .all()
+        )
+
+        assert len(dagruns) == 1
+        dagrun = dagruns[0]  # type: DagRun
+        assert dagrun.state == dag_run_state
+
+    @parameterized.expand(
         [(state, State.NONE) for state in State.task_states if state != State.RUNNING]
         + [(State.RUNNING, State.SHUTDOWN)]
     )  # type: ignore

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1328,8 +1328,14 @@ class TestDag(unittest.TestCase):
             start_date=DEFAULT_DATE,
             execution_date=DEFAULT_DATE,
         )
+        dagrun_2 = subdag.create_dagrun(
+            run_type=DagRunType.BACKFILL_JOB,
+            state=State.FAILED,
+            start_date=DEFAULT_DATE,
+            execution_date=DEFAULT_DATE,
+        )
         session.merge(dagrun_1)
-
+        session.merge(dagrun_2)
         task_instance_1 = TI(t_1, execution_date=DEFAULT_DATE, state=State.RUNNING)
         task_instance_2 = TI(t_2, execution_date=DEFAULT_DATE, state=State.RUNNING)
         session.merge(task_instance_1)
@@ -1345,18 +1351,13 @@ class TestDag(unittest.TestCase):
             session=session,
         )
 
-        dagruns = (
+        dagrun = (
             session.query(
                 DagRun,
             )
-            .filter(
-                DagRun.dag_id.in_([dag_id, dag_id + '.test']),
-            )
-            .all()
+            .filter(DagRun.dag_id == subdag.dag_id)
+            .one()
         )
-
-        assert len(dagruns) == 1
-        dagrun = dagruns[0]  # type: DagRun
         assert dagrun.state == dag_run_state
 
     @parameterized.expand(


### PR DESCRIPTION
Closes: #13295

After successfully running a SUBDAG, clearing it
(including downstream+recursive) doesn't trigger the inner tasks.
Instead, the subdag is marked successful and the inner tasks all
stay cleared and aren't re-run.

The above problem is because the DagRun state of the subdags are not updated
after clearing. This PR solves it by updating the DagRun state of all DAGs
including subdags when include_subdags is True

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
