### PR TITLE
Ensure we use ti.queued_by_job_id

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -652,7 +652,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
 
     def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
         tis_to_flush = [ti for ti in tis if not ti.queued_by_job_id]
-        scheduler_job_ids = [ti.queued_by_job_id for ti in tis]
+        scheduler_job_ids = {ti.queued_by_job_id for ti in tis}
         pod_ids = {
             create_pod_id(
                 dag_id=pod_generator.make_safe_label_value(ti.dag_id),

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -651,15 +651,15 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
         self.event_buffer[key] = state, None
 
     def try_adopt_task_instances(self, tis: List[TaskInstance]) -> List[TaskInstance]:
-        tis_to_flush = [ti for ti in tis if not ti.external_executor_id]
-        scheduler_job_ids = [ti.external_executor_id for ti in tis]
+        tis_to_flush = [ti for ti in tis if not ti.queued_by_job_id]
+        scheduler_job_ids = [ti.queued_by_job_id for ti in tis]
         pod_ids = {
             create_pod_id(
                 dag_id=pod_generator.make_safe_label_value(ti.dag_id),
                 task_id=pod_generator.make_safe_label_value(ti.task_id),
             ): ti
             for ti in tis
-            if ti.external_executor_id
+            if ti.queued_by_job_id
         }
         kube_client: client.CoreV1Api = self.kube_client
         for scheduler_job_id in scheduler_job_ids:


### PR DESCRIPTION
Ensure that we use ti.queued_by_job_id when searching for pods.

When a task is adopted by a new scheduler, the id of the current task is used:
https://github.com/apache/airflow/blob/feb6b8107e1e01aa1dae152f7b3861fe668b3008/airflow/executors/kubernetes_executor.py#L620-L623

When this is successful the task instance is updated, and `queued_by_job_id` is updated with the id of the current scheduler:
https://github.com/apache/airflow/blob/feb6b8107e1e01aa1dae152f7b3861fe668b3008/airflow/jobs/scheduler_job.py#L1877-L1878

Therefore when we search for the pod labels on subsequent scheduler relaunches, we must search for pods using the `queued_by_job_id` and not `external_executor_id`, as we are currently doing:
https://github.com/apache/airflow/blob/feb6b8107e1e01aa1dae152f7b3861fe668b3008/airflow/executors/kubernetes_executor.py#L592

`external_executor_id` is static and never appears to be updated when tasks are adopted. 

This relates to https://github.com/apache/airflow/issues/13808

