### PR TITLE
Pin SQLAlchemy to <1.4 due to breakage of sqlalchemy-utils

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -130,7 +130,8 @@ install_requires =
     requests>=2.20.0
     rich==9.2.0
     setproctitle>=1.1.8, <2
-    sqlalchemy>=1.3.18, <2
+    # SQLAlchemy 1.4 breaks sqlalchemy-utils https://github.com/kvesteri/sqlalchemy-utils/issues/505
+    sqlalchemy>=1.3.18, <1.4
     sqlalchemy_jsonfield~=1.0
     tabulate>=0.7.5, <0.9
     tenacity~=6.2.0


### PR DESCRIPTION
The 1.4 releae of SQLAlchemy breaks sqlalchemy-utils.

This change pins it to < 1.4

Fixes #14811

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
