### PR TITLE
Suggest using $http_host instead of $host

### DIFF
--- a/docs/apache-airflow/howto/run-behind-proxy.rst
+++ b/docs/apache-airflow/howto/run-behind-proxy.rst
@@ -47,7 +47,7 @@ Your reverse proxy (ex: nginx) should be configured as follow:
 
         location /myorg/airflow/ {
             proxy_pass http://localhost:8080;
-            proxy_set_header Host $host;
+            proxy_set_header Host $http_host;
             proxy_redirect off;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
@@ -64,7 +64,7 @@ Your reverse proxy (ex: nginx) should be configured as follow:
           location /myorg/flower/ {
               rewrite ^/myorg/flower/(.*)$ /$1 break;  # remove prefix from http header
               proxy_pass http://localhost:5555;
-              proxy_set_header Host $host;
+              proxy_set_header Host $http_host;
               proxy_redirect off;
               proxy_http_version 1.1;
               proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

If the reverse proxy is not running in port 80, using $host won't forward the port in the HTTP request to airflow and it won't build the correct redirect URL.

E.g.
I have nginx and airflow running in docker in the default ports. My mapping for nginx x is 7003:80.
The request http://myserver:7003/myorg/airflow/ will redirect to http://myserver/myorg/airflow/admin/ instead of http://myserver:7003/myorg/airflow/admin/.
