### PR TITLE
Due to rate limits of Docker we copy imaages for CI to apache/*

### DIFF
--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -29,7 +29,7 @@ services:
         condition: service_healthy
 
   mysql:
-    image: mysql:${MYSQL_VERSION}
+    image: apache/airflow:mysql-${MYSQL_VERSION}
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=true
       - MYSQL_ROOT_HOST=%

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -28,7 +28,7 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:${POSTGRES_VERSION}
+    image: apache/airflow:postgres-${POSTGRES_VERSION}
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=airflow

--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -18,7 +18,7 @@
 version: "2.2"
 services:
   cassandra:
-    image: cassandra:3.0
+    image: apache/airflow:cassandra-3.0
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - cassandra-db-volume:/var/lib/cassandra

--- a/scripts/ci/docker-compose/integration-mongo.yml
+++ b/scripts/ci/docker-compose/integration-mongo.yml
@@ -18,7 +18,7 @@
 version: "2.2"
 services:
   mongo:
-    image: mongo:3
+    image: apache/airflow:mongo-3
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - mongo-db-volume:/data/db

--- a/scripts/ci/docker-compose/integration-pinot.yml
+++ b/scripts/ci/docker-compose/integration-pinot.yml
@@ -18,7 +18,7 @@
 version: "2.2"
 services:
   pinot:
-    image: apachepinot/pinot:latest
+    image: apache/airflow:pinot-latest
     ports:
       - "9080:9080"
     volumes:

--- a/scripts/ci/docker-compose/integration-rabbitmq.yml
+++ b/scripts/ci/docker-compose/integration-rabbitmq.yml
@@ -18,7 +18,7 @@
 version: "2.2"
 services:
   rabbitmq:
-    image: rabbitmq:3.7
+    image: apache/airflow:rabbitmq-3.7
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - rabbitmq-db-volume:/var/lib/rabbitmq

--- a/scripts/ci/docker-compose/integration-redis.yml
+++ b/scripts/ci/docker-compose/integration-redis.yml
@@ -18,7 +18,7 @@
 version: "2.2"
 services:
   redis:
-    image: redis:5.0.1
+    image: apache/airflow:redis-5.0.1
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - redis-db-volume:/data/presto


### PR DESCRIPTION
Docker introduced rate limits for image pulls:

https://www.docker.com/increase-rate-limits

We are using a number of images which we do not have to build
ourselves and used them from official images such as mongo or
rabbit or cassndra, postgres, mysql, but we started to hit the limits
where a lot of builds are run in quick succession (with #14531 it will
become even worse because our builds will run faster).

Therefore we pushed the images to apache/airflow-* prefixed
images - apache/* images are exempted from pull rate limit.

Example failed build:

https://github.com/apache/airflow/runs/2117788455?check_suite_focus=true#step:6:378

Pulling postgres (postgres:13)...
  toomanyrequests: You have reached your pull rate limit. You may
increase the limit by authenticating and upgrading:
https://www.docker.com/increase-rate-limit

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
