### PR TITLE
`sync_resource_permissions` should be called during initialization.

### DIFF
--- a/airflow/api_connexion/security.py
+++ b/airflow/api_connexion/security.py
@@ -36,13 +36,12 @@ def check_authentication() -> None:
 
 def requires_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Callable[[T], T]:
     """Factory for decorator that checks current user's permissions against required permissions."""
-    appbuilder = current_app.appbuilder
-    appbuilder.sm.sync_resource_permissions(permissions)
 
     def requires_access_decorator(func: T):
         @wraps(func)
         def decorated(*args, **kwargs):
             check_authentication()
+            appbuilder = current_app.appbuilder
             if appbuilder.sm.check_authorization(permissions, kwargs.get('dag_id')):
                 return func(*args, **kwargs)
             raise PermissionDenied()

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -63,7 +63,12 @@ def sync_appbuilder_roles(flask_app):
     if conf.getboolean('webserver', 'UPDATE_FAB_PERMS'):
         security_manager = flask_app.appbuilder.sm
         security_manager.sync_roles()
-        security_manager.sync_resource_permissions()
+        security_manager.sync_resource_permissions(
+            security_manager.VIEWER_PERMISSIONS +
+            security_manager.USER_PERMISSIONS +
+            security_manager.OP_PERMISSIONS +
+            security_manager.ADMIN_PERMISSIONS
+        )
 
 
 def create_app(config=None, testing=False):

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -64,10 +64,10 @@ def sync_appbuilder_roles(flask_app):
         security_manager = flask_app.appbuilder.sm
         security_manager.sync_roles()
         security_manager.sync_resource_permissions(
-            security_manager.VIEWER_PERMISSIONS +
-            security_manager.USER_PERMISSIONS +
-            security_manager.OP_PERMISSIONS +
-            security_manager.ADMIN_PERMISSIONS
+            security_manager.VIEWER_PERMISSIONS
+            + security_manager.USER_PERMISSIONS
+            + security_manager.OP_PERMISSIONS
+            + security_manager.ADMIN_PERMISSIONS
         )
 
 


### PR DESCRIPTION
- Call it in decorator declaration wastes performance,
  and will raise error when not in an `app_context`.
- It needs `perms` (otherwise it's a no-op).
- 'Admin' should have all predefined (*known*) perms,
  apply them is good enough (I guess).

@jhtimmins please have a review. Thanks!

---
### My Use Case

I made a plugin (_in `$AIRFLOW_HOME/plugins/`_), which mixed with web entry and RESTful API.
```py
from airflow.api_connexion import security
from airflow.www import auth
from airflow.www.app import csrf
from airflow.www.views import AirflowModelView

class MyModalView(AirflowModelView):
    @auth.has_access([...])
    @expose('/my/modal')
    def some_web_entry(self): ...

    @csrf.exempt
    @security.requires_access([...])
    @expose('/my/modal/rest-api-for-robot/')
    def some_bot_api(self): ...
```
Then I found airflow **worker** cannot start when it load the plugin,
the `security.requires_access` failed because not in an app context.

I'd prefer `@security.requires_access` can be safely used like `@auth.has_access`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
