### PR TITLE
`task_type` should be respected as it is supposed to be overridden.

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -776,7 +776,10 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         if plugins_manager.operator_extra_links is None:
             raise AirflowException("Can't load operators")
         for ope in plugins_manager.operator_extra_links:
-            if ope.operators and self.__class__ in ope.operators:
+            if ope.operators and (
+                self.__class__ in ope.operators
+                or self.task_type in ope.operators
+            ):
                 op_extra_links_from_plugin.update({ope.name: ope})
 
         operator_extra_links_all = {link.name: link for link in self.operator_extra_links}
@@ -1497,7 +1500,7 @@ def cross_downstream(
 class BaseOperatorLink(metaclass=ABCMeta):
     """Abstract base class that defines how we get an operator link."""
 
-    operators: ClassVar[List[Type[BaseOperator]]] = []
+    operators: ClassVar[List[Union[Type[BaseOperator], str]]] = []
     """
     This property will be used by Airflow Plugins to find the Operators to which you want
     to assign this Operator Link

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1520,3 +1520,7 @@ class BaseOperatorLink(metaclass=ABCMeta):
         :param dttm: datetime
         :return: link to external system
         """
+
+    @classmethod
+    def import_path(cls):
+        return f"{cls.__module__}.{cls.__name__}"

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -372,7 +372,7 @@ def initialize_extra_operators_links_plugins():
 
         registered_operator_link_classes.update(
             {
-                f"{link.__class__.__module__}.{link.__class__.__name__}": link.__class__
+                link.import_path(): link.__class__
                 for link in plugin.operator_extra_links
             }
         )

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -588,9 +588,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
                 op_link_arguments = {}
             serialize_operator_extra_links.append(
                 {
-                    "{}.{}".format(
-                        operator_extra_link.__class__.__module__, operator_extra_link.__class__.__name__
-                    ): op_link_arguments
+                    operator_extra_link.import_path(): op_link_arguments
                 }
             )
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -426,20 +426,11 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         if cls._load_operator_extra_links:  # pylint: disable=too-many-nested-blocks
             from airflow import plugins_manager
 
-            plugins_manager.initialize_extra_operators_links_plugins()
-
-            if plugins_manager.operator_extra_links is None:
-                raise AirflowException("Can not load plugins")
-
-            for ope in plugins_manager.operator_extra_links:
-                for operator in ope.operators:
-                    if ((
-                        operator.__name__ == encoded_op["_task_type"]
-                        and operator.__module__ == encoded_op["_task_module"]
-                    ) if not isinstance(operator, str) else (
-                        operator == encoded_op['_task_type']
-                    )):
-                        op_extra_links_from_plugin.update({ope.name: ope})
+            plugins_manager.collect_operator_extra_links(
+                op_extra_links_from_plugin,
+                encoded_op["_task_module"],
+                encoded_op["_task_type"],
+            )
 
             # If OperatorLinks are defined in Plugins but not in the Operator that is being Serialized
             # set the Operator links attribute

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -433,10 +433,12 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
 
             for ope in plugins_manager.operator_extra_links:
                 for operator in ope.operators:
-                    if (
+                    if ((
                         operator.__name__ == encoded_op["_task_type"]
                         and operator.__module__ == encoded_op["_task_module"]
-                    ):
+                    ) if not isinstance(operator, str) else (
+                        operator == encoded_op['_task_type']
+                    )):
                         op_extra_links_from_plugin.update({ope.name: ope})
 
             # If OperatorLinks are defined in Plugins but not in the Operator that is being Serialized

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -372,7 +372,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
     def serialize_operator(cls, op: BaseOperator) -> Dict[str, Any]:
         """Serializes operator into a JSON object."""
         serialize_op = cls.serialize_to_json(op, cls._decorated_fields)
-        serialize_op['_task_type'] = op.__class__.__name__
+        serialize_op['_task_type'] = op.task_type
         serialize_op['_task_module'] = op.__class__.__module__
 
         # Used to determine if an Operator is inherited from DummyOperator


### PR DESCRIPTION
```py
class BaseOperator(...):
    @property
    def task_type(self) -> str: ...
```
The `task_type` property is designed to show customized name (*for human to distinguish, not to import code*)
and is allowed to override in sub-class, if I understand correctly.

---
### My Use Case

I need to distinguish operators by connection type, something likes:
```py
from airflow.providers.jdbc.operators.jdbc import JdbcOperator

class DistinctJdbcOperator(JdbcOperator):
    @property
    def task_type(self):
        return self.conn.conn_type.capitalize() + 'JdbcOperator'
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
