### PR TITLE
`logging.exception` redundancy.

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -346,7 +346,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
         if self.extra:
             try:
                 obj = json.loads(self.extra)
-            except JSONDecodeError as e:
+            except JSONDecodeError:
                 self.log.exception("Failed parsing the json for conn_id %s", self.conn_id)
 
         return obj

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -347,8 +347,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
             try:
                 obj = json.loads(self.extra)
             except JSONDecodeError as e:
-                self.log.exception(e)
-                self.log.error("Failed parsing the json for conn_id %s", self.conn_id)
+                self.log.exception("Failed parsing the json for conn_id %s", self.conn_id)
 
         return obj
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1295,7 +1295,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                 registered = False
                 try:
                     registered = task_copy.register_in_sensor_service(self, context)
-                except Exception as e:
+                except Exception:
                     self.log.warning(
                         "Failed to register in sensor service."
                         "Continue to run task in non smart sensor mode.",
@@ -1349,7 +1349,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         try:
             if task.on_execute_callback:
                 task.on_execute_callback(context)
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.log.exception("Failed when executing execute callback")
 
     def _run_finished_callback(self, error: Optional[Union[str, Exception]] = None) -> None:
@@ -1533,7 +1533,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         if email_for_state and task.email:
             try:
                 self.email_alert(error)
-            except Exception as exec2:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.log.exception('Failed to send email to: %s', task.email)
 
         if not test_mode:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1295,11 +1295,11 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                 registered = False
                 try:
                     registered = task_copy.register_in_sensor_service(self, context)
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     self.log.warning(
                         "Failed to register in sensor service."
-                        "Continue to run task in non smart sensor mode.",
-                        exc_info=True
+                        " Continue to run task in non smart sensor mode.",
+                        exc_info=True,
                     )
 
                 if registered:

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1297,9 +1297,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                     registered = task_copy.register_in_sensor_service(self, context)
                 except Exception as e:
                     self.log.warning(
-                        "Failed to register in sensor service.Continue to run task in non smart sensor mode."
+                        "Failed to register in sensor service."
+                        "Continue to run task in non smart sensor mode.",
+                        exc_info=True
                     )
-                    self.log.exception(e, exc_info=True)
 
                 if registered:
                     # Will raise AirflowSmartSensorException to avoid long running execution.
@@ -1349,8 +1350,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             if task.on_execute_callback:
                 task.on_execute_callback(context)
         except Exception as exc:  # pylint: disable=broad-except
-            self.log.error("Failed when executing execute callback")
-            self.log.exception(exc)
+            self.log.exception("Failed when executing execute callback")
 
     def _run_finished_callback(self, error: Optional[Union[str, Exception]] = None) -> None:
         """
@@ -1534,8 +1534,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             try:
                 self.email_alert(error)
             except Exception as exec2:  # pylint: disable=broad-except
-                self.log.error('Failed to send email to: %s', task.email)
-                self.log.exception(exec2)
+                self.log.exception('Failed to send email to: %s', task.email)
 
         if not test_mode:
             session.merge(self)

--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -244,8 +244,7 @@ def load_plugins_from_plugin_directory():
                 plugin_instance.source = PluginsDirectorySource(file_path)
                 register_plugin(plugin_instance)
         except Exception as e:  # pylint: disable=broad-except
-            log.exception(e)
-            log.error('Failed to import plugin %s', file_path)
+            log.exception('Failed to import plugin %s', file_path)
             import_errors[file_path] = str(e)
 
 

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -185,7 +185,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
             if append and self.s3_log_exists(remote_log_location):
                 old_log = self.s3_read(remote_log_location)
                 log = '\n'.join([old_log, log]) if old_log else log
-        except Exception as error:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.log.exception('Could not verify previous log to append')
 
         try:

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -120,8 +120,9 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         try:
             log_exists = self.s3_log_exists(remote_loc)
         except Exception as error:  # pylint: disable=broad-except
-            self.log.exception(error)
-            log = f'*** Failed to verify remote log exists {remote_loc}.\n{str(error)}\n'
+            log = f'*** Failed to verify remote log exists {remote_loc}.'
+            self.log.exception(log)
+            log += f'\n{error}\n'
 
         if log_exists:
             # If S3 remote file exists, we do not fetch logs from task instance
@@ -185,7 +186,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
                 old_log = self.s3_read(remote_log_location)
                 log = '\n'.join([old_log, log]) if old_log else log
         except Exception as error:  # pylint: disable=broad-except
-            self.log.exception('Could not verify previous log to append: %s', str(error))
+            self.log.exception('Could not verify previous log to append')
 
         try:
             self.hook.load_string(

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -120,9 +120,8 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         try:
             log_exists = self.s3_log_exists(remote_loc)
         except Exception as error:  # pylint: disable=broad-except
-            log = f'*** Failed to verify remote log exists {remote_loc}.'
-            self.log.exception(log)
-            log += f'\n{error}\n'
+            self.log.exception("Failed to verify remote log exists %s.", remote_loc)
+            log = f'*** Failed to verify remote log exists {remote_loc}.\n{error}\n'
 
         if log_exists:
             # If S3 remote file exists, we do not fetch logs from task instance

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -688,5 +688,5 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
                     self.log.info("Spark on K8s killed with response: %s", api_response)
 
-                except kube_client.ApiException as e:
+                except kube_client.ApiException:
                     self.log.exception("Exception when attempting to kill Spark on K8s")

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -689,5 +689,4 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                     self.log.info("Spark on K8s killed with response: %s", api_response)
 
                 except kube_client.ApiException as e:
-                    self.log.error("Exception when attempting to kill Spark on K8s:")
-                    self.log.exception(e)
+                    self.log.exception("Exception when attempting to kill Spark on K8s")

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -246,7 +246,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
 
                 logs = search[self.MAX_LINE_PER_PAGE * self.PAGE : self.MAX_LINE_PER_PAGE].execute()
             except Exception as e:  # pylint: disable=broad-except
-                self.log.exception('Could not read log with log_id: %s, error: %s', log_id, str(e))
+                self.log.exception('Could not read log with log_id: %s', log_id)
 
         return logs
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -245,7 +245,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             try:
 
                 logs = search[self.MAX_LINE_PER_PAGE * self.PAGE : self.MAX_LINE_PER_PAGE].execute()
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.log.exception('Could not read log with log_id: %s', log_id)
 
         return logs

--- a/airflow/providers/jira/sensors/jira.py
+++ b/airflow/providers/jira/sensors/jira.py
@@ -137,8 +137,7 @@ class JiraTicketSensor(JiraSensor):
         except JIRAError as jira_error:
             self.log.error("Jira error while checking with expected value: %s", jira_error)
         except Exception as e:  # pylint: disable=broad-except
-            self.log.error("Error while checking with expected value %s:", self.expected_value)
-            self.log.exception(e)
+            self.log.exception("Error while checking with expected value %s:", self.expected_value)
         if result is True:
             self.log.info(
                 "Issue field %s has expected value %s, returning success", self.field, self.expected_value

--- a/airflow/providers/jira/sensors/jira.py
+++ b/airflow/providers/jira/sensors/jira.py
@@ -136,7 +136,7 @@ class JiraTicketSensor(JiraSensor):
 
         except JIRAError as jira_error:
             self.log.error("Jira error while checking with expected value: %s", jira_error)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.log.exception("Error while checking with expected value %s:", self.expected_value)
         if result is True:
             self.log.info(

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -70,6 +70,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
                 ' and the Wasb connection exists.',
                 remote_conn_id,
             )
+            return None
 
     def set_context(self, ti) -> None:
         super().set_context(ti)

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -160,7 +160,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         """
         try:
             return self.hook.read_file(self.wasb_container, remote_log_location)
-        except AzureHttpError as e:
+        except AzureHttpError:
             msg = f'Could not read logs from {remote_log_location}'
             self.log.exception(msg)
             # return error if needed

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -162,7 +162,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             return self.hook.read_file(self.wasb_container, remote_log_location)
         except AzureHttpError as e:
             msg = f'Could not read logs from {remote_log_location}'
-            self.log.exception("Message: '%s', exception '%s'", msg, e)
+            self.log.exception(msg)
             # return error if needed
             if return_error:
                 return msg

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -63,15 +63,13 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
             from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
             return WasbHook(remote_conn_id)
-        except AzureHttpError as e:
-            self.log.error(
-                'Could not create an WasbHook with connection id "%s". '
-                'Please make sure that airflow[azure] is installed and '
-                'the Wasb connection exists. Exception "%s"',
+        except AzureHttpError:
+            self.log.exception(
+                'Could not create an WasbHook with connection id "%s".'
+                ' Please make sure that airflow[azure] is installed'
+                ' and the Wasb connection exists.',
                 remote_conn_id,
-                e,
             )
-            return None
 
     def set_context(self, ti) -> None:
         super().set_context(ti)

--- a/airflow/sensors/smart_sensor.py
+++ b/airflow/sensors/smart_sensor.py
@@ -465,7 +465,9 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
 
         except Exception:  # pylint: disable=broad-except
             self.log.warning(
-                "Exception _mark_multi_state in smart sensor for hashcode %s", poke_hash, exc_info=True,
+                "Exception _mark_multi_state in smart sensor for hashcode %s",
+                str(poke_hash),  # cast to str in advance for highlighting
+                exc_info=True,
             )
         self.log.info("Marked %s tasks out of %s to state %s", count_marked, len(query_result), state)
 

--- a/airflow/sensors/smart_sensor.py
+++ b/airflow/sensors/smart_sensor.py
@@ -464,7 +464,9 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
             session.commit()
 
         except Exception:  # pylint: disable=broad-except
-            self.log.warning("Exception _mark_multi_state in smart sensor for hashcode %s", str(poke_hash), exc_info=True)
+            self.log.warning(
+                "Exception _mark_multi_state in smart sensor for hashcode %s", poke_hash, exc_info=True,
+            )
         self.log.info("Marked %s tasks out of %s to state %s", count_marked, len(query_result), state)
 
     @provide_session

--- a/airflow/sensors/smart_sensor.py
+++ b/airflow/sensors/smart_sensor.py
@@ -366,7 +366,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
         for ti in tis:
             try:
                 sensor_works.append(SensorWork(ti))
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 self.log.exception("Exception at creating sensor work for ti %s", ti.key)
 
         self.log.info("%d tasks detected.", len(sensor_works))
@@ -463,7 +463,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
 
             session.commit()
 
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.log.warning("Exception _mark_multi_state in smart sensor for hashcode %s", str(poke_hash), exc_info=True)
         self.log.info("Marked %s tasks out of %s to state %s", count_marked, len(query_result), state)
 
@@ -487,7 +487,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
                 email = sensor_work.execution_context.get('email')
 
                 send_email(email, subject, html_content)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception:  # pylint: disable=broad-except
                 sensor_work.log.warning("Exception alerting email.", exc_info=True)
 
         def handle_failure(sensor_work, ti):
@@ -548,7 +548,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
                 )
                 sensor_work.close_sensor_logger()
 
-        except AirflowException as e:
+        except AirflowException:
             sensor_work.log.warning("Exception on failing %s", sensor_work.ti_key, exc_info=True)
 
     def _check_and_handle_ti_timeout(self, sensor_work):
@@ -718,7 +718,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
             Stats.gauge("smart_sensor_operator.poked_exception", count_poke_exception)
             Stats.gauge("smart_sensor_operator.exception_failures", count_exception_failures)
             Stats.gauge("smart_sensor_operator.infra_failures", count_infra_failure)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.log.exception("Exception at getting loop stats %s")
 
     def execute(self, context):

--- a/airflow/sensors/smart_sensor.py
+++ b/airflow/sensors/smart_sensor.py
@@ -368,7 +368,6 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
                 sensor_works.append(SensorWork(ti))
             except Exception as e:  # pylint: disable=broad-except
                 self.log.exception("Exception at creating sensor work for ti %s", ti.key)
-                self.log.exception(e, exc_info=True)
 
         self.log.info("%d tasks detected.", len(sensor_works))
 
@@ -465,8 +464,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
             session.commit()
 
         except Exception as e:  # pylint: disable=broad-except
-            self.log.warning("Exception _mark_multi_state in smart sensor for hashcode %s", str(poke_hash))
-            self.log.exception(e, exc_info=True)
+            self.log.warning("Exception _mark_multi_state in smart sensor for hashcode %s", str(poke_hash), exc_info=True)
         self.log.info("Marked %s tasks out of %s to state %s", count_marked, len(query_result), state)
 
     @provide_session
@@ -490,8 +488,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
 
                 send_email(email, subject, html_content)
             except Exception as e:  # pylint: disable=broad-except
-                sensor_work.log.warning("Exception alerting email.")
-                sensor_work.log.exception(e, exc_info=True)
+                sensor_work.log.warning("Exception alerting email.", exc_info=True)
 
         def handle_failure(sensor_work, ti):
             if sensor_work.execution_context.get('retries') and ti.try_number <= ti.max_tries:
@@ -552,8 +549,7 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
                 sensor_work.close_sensor_logger()
 
         except AirflowException as e:
-            sensor_work.log.warning("Exception on failing %s", sensor_work.ti_key)
-            sensor_work.log.exception(e, exc_info=True)
+            sensor_work.log.warning("Exception on failing %s", sensor_work.ti_key, exc_info=True)
 
     def _check_and_handle_ti_timeout(self, sensor_work):
         """
@@ -724,7 +720,6 @@ class SmartSensorOperator(BaseOperator, SkipMixin):
             Stats.gauge("smart_sensor_operator.infra_failures", count_infra_failure)
         except Exception as e:  # pylint: disable=broad-except
             self.log.exception("Exception at getting loop stats %s")
-            self.log.exception(e, exc_info=True)
 
     def execute(self, context):
         started_at = timezone.utcnow()

--- a/airflow/utils/timeout.py
+++ b/airflow/utils/timeout.py
@@ -40,11 +40,11 @@ class timeout(LoggingMixin):  # pylint: disable=invalid-name
         try:
             signal.signal(signal.SIGALRM, self.handle_timeout)
             signal.setitimer(signal.ITIMER_REAL, self.seconds)
-        except ValueError as e:
+        except ValueError:
             self.log.warning("timeout can't be used in the current context", exc_info=True)
 
     def __exit__(self, type_, value, traceback):
         try:
             signal.setitimer(signal.ITIMER_REAL, 0)
-        except ValueError as e:
+        except ValueError:
             self.log.warning("timeout can't be used in the current context", exc_info=True)

--- a/airflow/utils/timeout.py
+++ b/airflow/utils/timeout.py
@@ -41,12 +41,10 @@ class timeout(LoggingMixin):  # pylint: disable=invalid-name
             signal.signal(signal.SIGALRM, self.handle_timeout)
             signal.setitimer(signal.ITIMER_REAL, self.seconds)
         except ValueError as e:
-            self.log.warning("timeout can't be used in the current context")
-            self.log.exception(e)
+            self.log.warning("timeout can't be used in the current context", exc_info=True)
 
     def __exit__(self, type_, value, traceback):
         try:
             signal.setitimer(signal.ITIMER_REAL, 0)
         except ValueError as e:
-            self.log.warning("timeout can't be used in the current context")
-            self.log.exception(e)
+            self.log.warning("timeout can't be used in the current context", exc_info=True)

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -71,11 +71,11 @@ class TestWasbTaskHandler(unittest.TestCase):
                 handler.hook
 
             mock_error.assert_called_once_with(
-                'Could not create an WasbHook with connection id "%s". '
-                'Please make sure that airflow[azure] is installed and '
-                'the Wasb connection exists. Exception "%s"',
-                "wasb_default",
-                ANY,
+                'Could not create an WasbHook with connection id "%s".'
+                ' Please make sure that airflow[azure] is installed'
+                ' and the Wasb connection exists.',
+                'wasb_default',
+                exc_info=True,
             )
 
     def test_set_context_raw(self):
@@ -123,9 +123,7 @@ class TestWasbTaskHandler(unittest.TestCase):
 
                 handler.wasb_read(self.remote_log_location, return_error=True)
             mock_error.assert_called_once_with(
-                "Message: '%s', exception '%s'",
                 'Could not read logs from remote/log/location/1.log',
-                ANY,
                 exc_info=True,
             )
 

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -18,7 +18,6 @@
 import unittest
 from datetime import datetime
 from unittest import mock
-from unittest.mock import ANY
 
 from azure.common import AzureHttpError
 


### PR DESCRIPTION
Having both `logging.exception` and any other `logging` methods side by side seems unnecessary, and may lead to misread.
- Per [doc](https://docs.python.org/3/library/logging.html#logging.Logger.exception), the first argument of `logging.exception` is a string-like `msg`.
- `logging.exception(msg)` ≡ `logging.error(msg, exc_info=True)`
- `exc_info=True` will add `str(exception)` at the end of trace anyway.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
