### PR TITLE
When `breeze stop` is called all integrations are enabled

### DIFF
--- a/breeze
+++ b/breeze
@@ -1419,6 +1419,11 @@ function breeze::parse_arguments() {
             command_to_run="run_docker_compose"
             docker_compose_command="down"
             EXTRA_DC_OPTIONS+=("--remove-orphans")
+            for INTEGRATION in ${_breeze_allowed_integrations}; do
+                if [[ ${INTEGRATION} != "all" ]]; then
+                    INTEGRATIONS+=("${INTEGRATION}")
+                fi
+            done
             shift
             ;;
         restart)


### PR DESCRIPTION
Sometimes when an integration got broken, it could be broken
permanently due to left-over volume. This was because when
breeze stop was called the integration were not enabled and
some volumes were not deleted.

As result, breeze sometimes could not start with integrations, due to
misterious 'unhealthy' condition of one of the integrations.

This change enables all integrations automatically when
breeze stop is called so that all volumes are removed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
