### PR TITLE
Fixed default XCom deserialization.

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -19,7 +19,6 @@
 import json
 import logging
 import pickle
-from json import JSONDecodeError
 from typing import Any, Iterable, Optional, Union
 
 import pendulum
@@ -245,7 +244,7 @@ class BaseXCom(Base, LoggingMixin):
         else:
             try:
                 return json.loads(result.value.decode('UTF-8'))
-            except JSONDecodeError:
+            except (json.JSONDecodeError, UnicodeDecodeError):
                 return pickle.loads(result.value)
 
     def orm_deserialize_value(self) -> Any:

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -62,13 +62,7 @@ class BaseXCom(Base, LoggingMixin):
         Called by the ORM after the instance has been loaded from the DB or otherwise reconstituted
         i.e automatically deserialize Xcom value when loading from DB.
         """
-        try:
-            self.value = self.orm_deserialize_value()
-        except (UnicodeEncodeError, ValueError):
-            # For backward-compatibility.
-            # Preventing errors in webserver
-            # due to XComs mixed with pickled and unpickled.
-            self.value = pickle.loads(self.value)
+        self.value = self.orm_deserialize_value()
 
     def __repr__(self):
         return f'<XCom "{self.key}" ({self.task_id} @ {self.execution_date})>'
@@ -233,32 +227,25 @@ class BaseXCom(Base, LoggingMixin):
             return json.dumps(value).encode('UTF-8')
         except (ValueError, TypeError):
             log.error(
-                "Could not serialize the XCom value into JSON. "
-                "If you are using pickles instead of JSON "
-                "for XCom, then you need to enable pickle "
-                "support for XCom in your airflow config."
+                "Could not serialize the XCom value into JSON."
+                " If you are using pickles instead of JSON for XCom,"
+                " then you need to enable pickle support for XCom"
+                " in your airflow config."
             )
             raise
 
     @staticmethod
     def deserialize_value(result: "XCom") -> Any:
         """Deserialize XCom value from str or pickle object"""
-        enable_pickling = conf.getboolean('core', 'enable_xcom_pickling')
-        if enable_pickling:
+        if not conf.getboolean('core', 'enable_xcom_pickling'):
             try:
-                return pickle.loads(result.value)
-            except pickle.UnpicklingError:
                 return json.loads(result.value.decode('UTF-8'))
-        try:
-            return json.loads(result.value.decode('UTF-8'))
-        except JSONDecodeError:
-            log.error(
-                "Could not deserialize the XCom value from JSON. "
-                "If you are using pickles instead of JSON "
-                "for XCom, then you need to enable pickle "
-                "support for XCom in your airflow config."
-            )
-            raise
+            except JSONDecodeError:
+                # For backward-compatibility.
+                # As 'enable_xcom_pickling' changed default from True to False,
+                # pickled (old) and JSON (new) are both existing.
+                pass
+        return pickle.loads(result.value)
 
     def orm_deserialize_value(self) -> Any:
         """


### PR DESCRIPTION
This is a fix for migrating with the default `enable_xcom_pickling` (*before & after*).
I.e. `pickle`-d (_old_) and `JSON` (_new_) data both existing in database.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
