### PR TITLE
Make pytest collection warnings errors

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,3 +30,5 @@ norecursedirs =
     tests/dags
 faulthandler_timeout = 480
 log_level = INFO
+filterwarnings =
+    error::pytest.PytestCollectionWarning


### PR DESCRIPTION
In a previous PR I introduced a mistake that made some test classes not
be collected (and thus were never run) -- this ensures that we don't
have this mistake again.

@ephraimbuddy fixed it in #14826, and this PR makes sure it doesn't come back.

Example output before Ephraim's fix:


```
________________________________ ERROR collecting tests/api_connexion/endpoints/test_dag_endpoint.py ________________________________
../../../.virtualenvs/airflow/lib/python3.7/site-packages/_pytest/runner.py:311: in from_call
    result: Optional[TResult] = func()
../../../.virtualenvs/airflow/lib/python3.7/site-packages/_pytest/runner.py:341: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
../../../.virtualenvs/airflow/lib/python3.7/site-packages/_pytest/python.py:770: in collect
    % (self.obj.__name__, self.parent.nodeid)
../../../.virtualenvs/airflow/lib/python3.7/site-packages/_pytest/nodes.py:231: in warn
    warning, category=None, filename=str(path), lineno=lineno + 1,
E   pytest.PytestCollectionWarning: cannot collect test class 'TestPatchDag' because it has a __init__ constructor (from: tests/api_connexion/endpoints/test_dag_endpoint.py)
====================================================== short test summary info ======================================================
ERROR tests/api_connexion/endpoints/test_dag_endpoint.py::TestDagEndpoint - pytest.PytestCollectionWarning: cannot collect test class 'TestDagEndpoint' because it has a __init__ constructor (from: tests/api_connexion/endpoints/test_dag_endpoint.py)
ERROR tests/api_connexion/endpoints/test_dag_endpoint.py::TestGetDag - pytest.PytestCollectionWarning: cannot collect test class 'TestGetDag' because it has a __init__ constructor (from: tests/api_connexion/endpoints/test_dag_endpoint.py)
ERROR tests/api_connexion/endpoints/test_dag_endpoint.py::TestGetDagDetails - pytest.PytestCollectionWarning: cannot collect test class 'TestGetDagDetails' because it has a __init__ constructor (from: tests/api_connexion/endpoints/test_dag_endpoint.py)
ERROR tests/api_connexion/endpoints/test_dag_endpoint.py::TestGetDags - pytest.PytestCollectionWarning: cannot collect test class 'TestGetDags' because it has a __init__ constructor (from: tests/api_connexion/endpoints/test_dag_endpoint.py)
ERROR tests/api_connexion/endpoints/test_dag_endpoint.py::TestPatchDag - pytest.PytestCollectionWarning: cannot collect test class 'TestPatchDag' because it has a __init__ constructor (from: tests/api_connexion/endpoints/test_dag_endpoint.py)
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 5 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
=============================================== no tests collected, 5 errors in 0.62s ===============================================
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).