### PR TITLE
Adds option to set extraVolumeMounts for git-sync container

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -185,6 +185,9 @@
     subPath: known_hosts
   {{- end }}
   {{- end }}
+{{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.extraVolumeMounts }}
+{{ toYaml .Values.dags.gitSync.extraVolumeMounts | indent 2 }}
+{{- end }}
 {{- end }}
 
 # This helper will change when customers deploy a new image.

--- a/chart/tests/test_git_sync_scheduler.py
+++ b/chart/tests/test_git_sync_scheduler.py
@@ -209,9 +209,9 @@ class GitSyncSchedulerTest(unittest.TestCase):
         assert {"name": "test-volume", "emptyDir": {}} in jmespath.search(
             "spec.template.spec.volumes", docs[0]
         )
-        assert {'mountPath': '/git', 'name': 'dags'}  in jmespath.search(
+        assert {'mountPath': '/git', 'name': 'dags'} in jmespath.search(
             "spec.template.spec.containers[1].volumeMounts", docs[0]
         )
-        assert {"name": "test-volume", "mountPath": "/opt/test"}  in jmespath.search(
+        assert {"name": "test-volume", "mountPath": "/opt/test"} in jmespath.search(
             "spec.template.spec.containers[1].volumeMounts", docs[0]
         )

--- a/chart/tests/test_git_sync_scheduler.py
+++ b/chart/tests/test_git_sync_scheduler.py
@@ -188,3 +188,30 @@ class GitSyncSchedulerTest(unittest.TestCase):
         assert {"name": "test-volume", "mountPath": "/opt/test"} in jmespath.search(
             "spec.template.spec.containers[0].volumeMounts", docs[0]
         )
+
+    def test_extra_volume_and_git_sync_extra_volume_mount(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "scheduler": {
+                    "extraVolumes": [{"name": "test-volume", "emptyDir": {}}],
+                },
+                "dags": {
+                    "gitSync": {
+                        "enabled": True,
+                        "extraVolumeMounts": [{"mountPath": "/opt/test", "name": "test-volume"}],
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert {"name": "test-volume", "emptyDir": {}} in jmespath.search(
+            "spec.template.spec.volumes", docs[0]
+        )
+        assert {'mountPath': '/git', 'name': 'dags'}  in jmespath.search(
+            "spec.template.spec.containers[1].volumeMounts", docs[0]
+        )
+        assert {"name": "test-volume", "mountPath": "/opt/test"}  in jmespath.search(
+            "spec.template.spec.containers[1].volumeMounts", docs[0]
+        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1446,6 +1446,10 @@
                             "description": "Git sync container run as user parameter.",
                             "type": "integer"
                         },
+                        "extraVolumeMounts": {
+                            "description": "Mount additional volumes into git sync container.",
+                            "type": "array"
+                        },
                         "credentialsSecret": {
                             "description": "TODO",
                             "type": ["string", "null"]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -838,3 +838,4 @@ dags:
     wait: 60
     containerName: git-sync
     uid: 65533
+    extraVolumeMounts: []


### PR DESCRIPTION
This allows users to add additional `VolumeMounts` to the `gitSync` container. I put the test into the `git-sync` related file for the scheduler, but can move it somewhere else if deemed more appropriate.
