### PR TITLE
Fix `sync-perm` to work correctly when update_fab_perms = False

### DIFF
--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -26,9 +26,9 @@ def sync_perm(args):
     """Updates permissions for existing roles and DAGs"""
     appbuilder = cached_app().appbuilder  # pylint: disable=no-member
     print('Updating permission, view-menu for all existing roles')
-    appbuilder.sm.sync_roles()
-    # Add missing permissions for all the Base Views
+    # Add missing permissions for all the Base Views _before_ syncing/creating roles
     appbuilder.add_permissions(update_perms=True)
+    appbuilder.sm.sync_roles()
     print('Updating permission on all DAG views')
     dagbag = DagBag(read_dags_from_db=True)
     dagbag.collect_dags_from_db()


### PR DESCRIPTION
If Airflow is configured with update_fab_perms config setting to False,
then the Op, User and Viewer roles are created _before_ the permissions
objects are written to the database, meaning that these roles did not
correctly get assigned all the permissions we asked for (the missing
permissions are just silently not created.)

Because of the "migrate to resource permission" migration this problem
is not "disasterous" as all most of the Permissions et al. we use are
created by a migration.

This changes it so that the permissions are always created/synced before
we look at the roles.

(Re-running sync-perm wouldn't fix this, as although the second time
around the Permissions will exist in the DB, we see that Op role already
has permissions and don't make any changes, assuming that the site
operators made such changes.)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).