### PR TITLE
Pass queue in BaseExecutor.execute_async like in airflow 1.10

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -182,10 +182,10 @@ class BaseExecutor(LoggingMixin):
         sorted_queue = self.order_queued_tasks_by_priority()
 
         for _ in range(min((open_slots, len(self.queued_tasks)))):
-            key, (command, _, _, ti) = sorted_queue.pop(0)
+            key, (command, _, queue, ti) = sorted_queue.pop(0)
             self.queued_tasks.pop(key)
             self.running.add(key)
-            self.execute_async(key=key, command=command, queue=None, executor_config=ti.executor_config)
+            self.execute_async(key=key, command=command, queue=queue, executor_config=ti.executor_config)
 
     def change_state(self, key: TaskInstanceKey, state: str, info=None) -> None:
         """


### PR DESCRIPTION
[1.10](https://github.com/apache/airflow/blob/1.10.15/airflow/executors/base_executor.py#L153) passes the Task Instance queue, but the refactor in [2.0](https://github.com/apache/airflow/blob/2.0.1/airflow/executors/base_executor.py#L188) looks to have missed this.

Any schedulers depending on the queue functionality that haven't overridden `trigger_tasks` will see queue functionality break when upgrading to 2.0