### PR TITLE
Fix broken endpoints due to dagrun id being quoted in url path

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -20,7 +20,7 @@ from marshmallow import ValidationError
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
-from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_datetime, format_parameters, return_plus
 from airflow.api_connexion.schemas.dag_run_schema import (
     DAGRunCollection,
     dagrun_collection_schema,
@@ -33,6 +33,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.types import DagRunType
 
 
+@format_parameters({"dag_run_id": return_plus})
 @security.requires_access(
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
@@ -47,6 +48,7 @@ def delete_dag_run(dag_id, dag_run_id, session):
     return NoContent, 204
 
 
+@format_parameters({"dag_run_id": return_plus})
 @security.requires_access(
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),

--- a/airflow/api_connexion/endpoints/extra_link_endpoint.py
+++ b/airflow/api_connexion/endpoints/extra_link_endpoint.py
@@ -20,6 +20,7 @@ from flask import current_app
 from airflow import DAG
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import format_parameters, return_plus
 from airflow.exceptions import TaskNotFound
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun as DR
@@ -27,6 +28,7 @@ from airflow.security import permissions
 from airflow.utils.session import provide_session
 
 
+@format_parameters({"dag_run_id": return_plus})
 @security.requires_access(
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),

--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -21,6 +21,7 @@ from itsdangerous.url_safe import URLSafeSerializer
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound
+from airflow.api_connexion.parameters import format_parameters, return_plus
 from airflow.api_connexion.schemas.log_schema import LogResponseObject, logs_schema
 from airflow.exceptions import TaskNotFound
 from airflow.models import DagRun
@@ -29,6 +30,7 @@ from airflow.utils.log.log_reader import TaskLogReader
 from airflow.utils.session import provide_session
 
 
+@format_parameters({"dag_run_id": return_plus})
 @security.requires_access(
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -23,7 +23,7 @@ from sqlalchemy import and_, func
 from airflow.api.common.experimental.mark_tasks import set_state
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound
-from airflow.api_connexion.parameters import format_datetime, format_parameters
+from airflow.api_connexion.parameters import format_datetime, format_parameters, return_plus
 from airflow.api_connexion.schemas.task_instance_schema import (
     TaskInstanceCollection,
     TaskInstanceReferenceCollection,
@@ -43,6 +43,7 @@ from airflow.utils.session import provide_session
 from airflow.utils.state import State
 
 
+@format_parameters({"dag_run_id": return_plus})
 @security.requires_access(
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
@@ -99,6 +100,7 @@ def _apply_range_filter(query, key, value_range: Tuple[Any, Any]):
         "start_date_lte": format_datetime,
         "end_date_gte": format_datetime,
         "end_date_lte": format_datetime,
+        "dag_run_id": return_plus,
     }
 )
 @security.requires_access(
@@ -111,8 +113,8 @@ def _apply_range_filter(query, key, value_range: Tuple[Any, Any]):
 @provide_session
 def get_task_instances(
     limit: int,
-    dag_id: Optional[str] = None,
-    dag_run_id: Optional[str] = None,
+    dag_id: str,
+    dag_run_id: str,
     execution_date_gte: Optional[str] = None,
     execution_date_lte: Optional[str] = None,
     start_date_gte: Optional[str] = None,

--- a/airflow/api_connexion/endpoints/xcom_endpoint.py
+++ b/airflow/api_connexion/endpoints/xcom_endpoint.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm.session import Session
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import NotFound
-from airflow.api_connexion.parameters import check_limit, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_parameters, return_plus
 from airflow.api_connexion.schemas.xcom_schema import (
     XComCollection,
     XComCollectionItemSchema,
@@ -43,7 +43,7 @@ from airflow.utils.session import provide_session
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_XCOM),
     ]
 )
-@format_parameters({'limit': check_limit})
+@format_parameters({'limit': check_limit, "dag_run_id": return_plus})
 @provide_session
 def get_xcom_entries(
     dag_id: str,
@@ -74,6 +74,7 @@ def get_xcom_entries(
     return xcom_collection_schema.dump(XComCollection(xcom_entries=query.all(), total_entries=total_entries))
 
 
+@format_parameters({"dag_run_id": return_plus})
 @security.requires_access(
     [
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -16,12 +16,18 @@
 # under the License.
 from functools import wraps
 from typing import Callable, Dict, TypeVar, cast
+from urllib.parse import unquote
 
 from pendulum.parsing import ParserError
 
 from airflow.api_connexion.exceptions import BadRequest
 from airflow.configuration import conf
 from airflow.utils import timezone
+
+
+def return_plus(value: str):
+    """Unquote double quoted + for dag_run_id in url"""
+    return unquote(value)
 
 
 def validate_istimezone(value):

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -102,7 +102,7 @@ class TestDagRunEndpoint:
         dags = [DagModel(dag_id="TEST_DAG_ID")]
         dagrun_model_1 = DagRun(
             dag_id="TEST_DAG_ID",
-            run_id="TEST_DAG_RUN_ID_1",
+            run_id="TEST_DAG_RUN_ID_1+00:00",
             run_type=DagRunType.MANUAL,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
@@ -144,12 +144,14 @@ class TestDeleteDagRun(TestDagRunEndpoint):
         session.add_all(self._create_test_dag_run())
         session.commit()
         response = self.client.delete(
-            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID_1", environ_overrides={'REMOTE_USER': "test"}
+            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID_1%252B00:00",
+            environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 204
         # Check if the Dag Run is deleted from the database
         response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID_1", environ_overrides={'REMOTE_USER': "test"}
+            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID_1%252B00:00",
+            environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 404
 
@@ -170,7 +172,7 @@ class TestDeleteDagRun(TestDagRunEndpoint):
         session.commit()
 
         response = self.client.delete(
-            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID_1",
+            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID_1+00:00",
         )
 
         assert_401(response)
@@ -187,7 +189,7 @@ class TestGetDagRun(TestDagRunEndpoint):
     def test_should_respond_200(self, session):
         dagrun_model = DagRun(
             dag_id="TEST_DAG_ID",
-            run_id="TEST_DAG_RUN_ID",
+            run_id="TEST_DAG_RUN_ID+00:00",
             run_type=DagRunType.MANUAL,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
@@ -198,12 +200,13 @@ class TestGetDagRun(TestDagRunEndpoint):
         result = session.query(DagRun).all()
         assert len(result) == 1
         response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID", environ_overrides={'REMOTE_USER': "test"}
+            "api/v1/dags/TEST_DAG_ID/dagRuns/TEST_DAG_RUN_ID%252B00:00",
+            environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 200
         expected_response = {
             'dag_id': 'TEST_DAG_ID',
-            'dag_run_id': 'TEST_DAG_RUN_ID',
+            'dag_run_id': 'TEST_DAG_RUN_ID+00:00',
             'end_date': None,
             'state': 'running',
             'execution_date': self.default_time,
@@ -256,7 +259,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
             "dag_runs": [
                 {
                     'dag_id': 'TEST_DAG_ID',
-                    'dag_run_id': 'TEST_DAG_RUN_ID_1',
+                    'dag_run_id': 'TEST_DAG_RUN_ID_1+00:00',
                     'end_date': None,
                     'state': 'running',
                     'execution_date': self.default_time,
@@ -483,7 +486,7 @@ class TestGetDagRunsEndDateFilters(TestDagRunEndpoint):
             (
                 f"api/v1/dags/TEST_DAG_ID/dagRuns?end_date_lte="
                 f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}",
-                ["TEST_DAG_RUN_ID_1"],
+                ["TEST_DAG_RUN_ID_1+00:00"],
             ),
         ]
     )
@@ -509,7 +512,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
             "dag_runs": [
                 {
                     'dag_id': 'TEST_DAG_ID',
-                    'dag_run_id': 'TEST_DAG_RUN_ID_1',
+                    'dag_run_id': 'TEST_DAG_RUN_ID_1+00:00',
                     'end_date': None,
                     'state': 'running',
                     'execution_date': self.default_time,
@@ -543,7 +546,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
             "dag_runs": [
                 {
                     'dag_id': 'TEST_DAG_ID',
-                    'dag_run_id': 'TEST_DAG_RUN_ID_1',
+                    'dag_run_id': 'TEST_DAG_RUN_ID_1+00:00',
                     'end_date': None,
                     'state': 'running',
                     'execution_date': self.default_time,
@@ -790,7 +793,7 @@ class TestGetDagRunBatchDateFilters(TestDagRunEndpoint):
             ),
             (
                 {"end_date_lte": f"{(timezone.utcnow() + timedelta(days=1)).isoformat()}"},
-                ["TEST_DAG_RUN_ID_1"],
+                ["TEST_DAG_RUN_ID_1+00:00"],
             ),
         ]
     )
@@ -906,7 +909,7 @@ class TestPostDagRun(TestDagRunEndpoint):
         response = self.client.post(
             "api/v1/dags/TEST_DAG_ID/dagRuns",
             json={
-                "dag_run_id": "TEST_DAG_RUN_ID_1",
+                "dag_run_id": "TEST_DAG_RUN_ID_1+00:00",
                 "execution_date": self.default_time,
             },
             environ_overrides={'REMOTE_USER': "test"},
@@ -914,7 +917,7 @@ class TestPostDagRun(TestDagRunEndpoint):
         assert response.status_code == 409, response.data
         assert response.json == {
             "detail": "DAGRun with DAG ID: 'TEST_DAG_ID' and "
-            "DAGRun ID: 'TEST_DAG_RUN_ID_1' already exists",
+            "DAGRun ID: 'TEST_DAG_RUN_ID_1+00:00' already exists",
             "status": 409,
             "title": "Conflict",
             "type": EXCEPTIONS_LINK_MAP[409],


### PR DESCRIPTION
The endpoints accepting dag_run_id are broken when you make a call
against them using tools like postman.

 This is because the dagrun id is being quoted in the url.

A dagrun id "manual__2021-03-12T09:40:00.745000+00:00" changes to
"manual__2021-03-12T09:40:00.745000%252B00:00" on the url and then
we cannot find the dagrun that has the ID. 

This started recently and I can't pin it to any library.

This commit resolves this issue by unquoting it. Tests were also modified
to have quoted dagrun id in the url

Would appreciate a suggestion on a better way to resolve this

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
