### PR TITLE
Add Airflow 2.0.1 to `breeze-complete` and BREEZE.rst

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1313,7 +1313,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 2.0.0 1.10.15 1.10.14 1.10.12 1.10.11 1.10.10 1.10.9 none wheel sdist
+                 2.0.1 2.0.0 1.10.15 1.10.14 1.10.12 1.10.11 1.10.10 1.10.9 none wheel sdist
 
           When 'none' is used, you can install airflow from local packages. When building image,
           airflow package should be added to 'docker-context-files' and
@@ -2556,7 +2556,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 2.0.0 1.10.15 1.10.14 1.10.12 1.10.11 1.10.10 1.10.9 none wheel sdist
+                 2.0.1 2.0.0 1.10.15 1.10.14 1.10.12 1.10.11 1.10.10 1.10.9 none wheel sdist
 
           When 'none' is used, you can install airflow from local packages. When building image,
           airflow package should be added to 'docker-context-files' and

--- a/breeze-complete
+++ b/breeze-complete
@@ -57,6 +57,7 @@ _breeze_allowed_installation_methods=". apache-airflow"
 }
 
 _breeze_allowed_install_airflow_versions=$(cat <<-EOF
+2.0.1
 2.0.0
 1.10.15
 1.10.14


### PR DESCRIPTION
2.0.1 was missing from the breeze-complete list and the docs

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
