### PR TITLE
Fixes unbound variable on MacOS

### DIFF
--- a/breeze
+++ b/breeze
@@ -22,6 +22,7 @@ set -euo pipefail
 AIRFLOW_SOURCES="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ ${BREEZE_REDIRECT=} == "" ]]; then
+    set +u
     mkdir -p "${AIRFLOW_SOURCES}"/logs
     export BREEZE_REDIRECT="true"
     if [[ "$(uname)" == "Darwin" ]]; then
@@ -29,6 +30,7 @@ if [[ ${BREEZE_REDIRECT=} == "" ]]; then
     else
       exec script --return --quiet "${AIRFLOW_SOURCES}"/logs/breeze.out -c "$(printf "%q " "${0}" "${@}")"
     fi
+    set -u
 fi
 
 export AIRFLOW_SOURCES


### PR DESCRIPTION
Without it I get:

```
$ ./breeze
./breeze: line 28: @: unbound variable
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
