### PR TITLE
Make app creation session- or class-wide when possible to make tests faster

### DIFF
--- a/tests/api_connexion/schemas/test_role_and_permission_schema.py
+++ b/tests/api_connexion/schemas/test_role_and_permission_schema.py
@@ -23,9 +23,7 @@ from airflow.api_connexion.schemas.role_and_permission_schema import (
     role_schema,
 )
 from airflow.security import permissions
-from airflow.www import app
 from tests.test_utils.api_connexion_utils import create_role, delete_role
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 
 class TestRoleCollectionItemSchema:

--- a/tests/api_connexion/schemas/test_role_and_permission_schema.py
+++ b/tests/api_connexion/schemas/test_role_and_permission_schema.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
+import pytest
 
 from airflow.api_connexion.schemas.role_and_permission_schema import (
     RoleCollection,
@@ -28,24 +28,22 @@ from tests.test_utils.api_connexion_utils import create_role, delete_role
 from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 
-class TestRoleCollectionItemSchema(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(skip_all_except=["init_appbuilder"])
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls.app = app.create_app(testing=True)  # type:ignore
-        cls.role = create_role(
-            cls.app,  # type: ignore
+class TestRoleCollectionItemSchema:
+    @pytest.fixture(scope="class")
+    def role(self, minimal_app_for_api):
+        yield create_role(
+            minimal_app_for_api,  # type: ignore
             name="Test",
             permissions=[
                 (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION),
             ],
         )
+        delete_role(minimal_app_for_api, "Test")
 
-    @classmethod
-    @dont_initialize_flask_app_submodules(skip_all_except=["init_appbuilder"])
-    def tearDownClass(cls) -> None:
-        delete_role(cls.app, 'Test')
+    @pytest.fixture(autouse=True)
+    def _set_attrs(self, minimal_app_for_api, role):
+        self.app = minimal_app_for_api
+        self.role = role
 
     def test_serialize(self):
         deserialized_role = role_schema.dump(self.role)
@@ -66,35 +64,31 @@ class TestRoleCollectionItemSchema(unittest.TestCase):
         }
 
 
-class TestRoleCollectionSchema(unittest.TestCase):
-    @classmethod
-    @dont_initialize_flask_app_submodules(skip_all_except=["init_appbuilder"])
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls.app = app.create_app(testing=True)  # type:ignore
-        cls.role1 = create_role(
-            cls.app,  # type: ignore
+class TestRoleCollectionSchema:
+    @pytest.fixture(scope="class")
+    def role1(self, minimal_app_for_api):
+        yield create_role(
+            minimal_app_for_api,  # type: ignore
             name="Test1",
             permissions=[
                 (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_CONNECTION),
             ],
         )
-        cls.role2 = create_role(
-            cls.app,  # type: ignore
+        delete_role(minimal_app_for_api, 'Test1')
+
+    @pytest.fixture(scope="class")
+    def role2(self, minimal_app_for_api):
+        yield create_role(
+            minimal_app_for_api,  # type: ignore
             name="Test2",
             permissions=[
                 (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             ],
         )
+        delete_role(minimal_app_for_api, 'Test2')        
 
-    @classmethod
-    @dont_initialize_flask_app_submodules(skip_all_except=["init_appbuilder"])
-    def tearDownClass(cls) -> None:
-        delete_role(cls.app, 'Test1')
-        delete_role(cls.app, 'Test2')
-
-    def test_serialize(self):
-        instance = RoleCollection([self.role1, self.role2], total_entries=2)
+    def test_serialize(self, role1, role2):
+        instance = RoleCollection([role1, role2], total_entries=2)
         deserialized = role_collection_schema.dump(instance)
         assert deserialized == {
             'roles': [

--- a/tests/api_connexion/schemas/test_role_and_permission_schema.py
+++ b/tests/api_connexion/schemas/test_role_and_permission_schema.py
@@ -83,7 +83,7 @@ class TestRoleCollectionSchema:
                 (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             ],
         )
-        delete_role(minimal_app_for_api, 'Test2')        
+        delete_role(minimal_app_for_api, 'Test2')
 
     def test_serialize(self, role1, role2):
         instance = RoleCollection([role1, role2], total_entries=2)

--- a/tests/api_connexion/test_error_handling.py
+++ b/tests/api_connexion/test_error_handling.py
@@ -14,39 +14,26 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest
+def test_incorrect_endpoint_should_return_json(minimal_app_for_api):
+    client = minimal_app_for_api.test_client()
 
-from airflow.www import app
+    # Given we have application with Connexion added
+    # When we hitting incorrect endpoint in API path
 
+    resp_json = client.get("/api/v1/incorrect_endpoint").json
 
-class TestErrorHandling(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        super().setUpClass()
-        cls.app = app.create_app(testing=True)  # type:ignore
+    # Then we have parsable JSON as output
 
-    def setUp(self) -> None:
-        self.client = self.app.test_client()  # type:ignore
+    assert 404 == resp_json["status"]
 
-    def test_incorrect_endpoint_should_return_json(self):
+    # When we are hitting non-api incorrect endpoint
 
-        # Given we have application with Connexion added
-        # When we hitting incorrect endpoint in API path
+    resp_json = client.get("/incorrect_endpoint").json
 
-        resp_json = self.client.get("/api/v1/incorrect_endpoint").json
+    # Then we do not have JSON as response, rather standard HTML
 
-        # Then we have parsable JSON as output
+    assert resp_json is None
 
-        assert 404 == resp_json["status"]
+    resp_json = client.put("/api/v1/variables").json
 
-        # When we are hitting non-api incorrect endpoint
-
-        resp_json = self.client.get("/incorrect_endpoint").json
-
-        # Then we do not have JSON as response, rather standard HTML
-
-        assert resp_json is None
-
-        resp_json = self.client.put("/api/v1/variables").json
-
-        assert 'Method Not Allowed' == resp_json["title"]
+    assert 'Method Not Allowed' == resp_json["title"]

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -21,7 +21,6 @@ from contextlib import redirect_stdout
 
 import pytest
 
-
 from airflow.cli.commands import role_command
 
 TEST_USER1_EMAIL = 'test-user1@example.com'

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -17,31 +17,26 @@
 # under the License.
 #
 import io
-import unittest
 from contextlib import redirect_stdout
 
-from airflow import models
-from airflow.cli import cli_parser
+import pytest
+
+
 from airflow.cli.commands import role_command
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
 TEST_USER2_EMAIL = 'test-user2@example.com'
 
 
-class TestCliRoles(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
-        cls.parser = cli_parser.get_parser()
-
-    def setUp(self):
-        from airflow.www import app as application
-
-        self.app = application.create_app(testing=True)
+class TestCliRoles:
+    @pytest.fixture(autouse=True)
+    def _set_attrs(self, app, dagbag, parser):
+        self.app = app
+        self.dagbag = dagbag
+        self.parser = parser
         self.appbuilder = self.app.appbuilder  # pylint: disable=no-member
         self.clear_roles_and_roles()
-
-    def tearDown(self):
+        yield
         self.clear_roles_and_roles()
 
     def clear_roles_and_roles(self):

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -19,11 +19,10 @@ import io
 import json
 import os
 import tempfile
-import unittest
 from contextlib import redirect_stdout
 
-from airflow import models
-from airflow.cli import cli_parser
+import pytest
+
 from airflow.cli.commands import user_command
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
@@ -39,20 +38,15 @@ def _does_user_belong_to_role(appbuilder, email, rolename):
     return False
 
 
-class TestCliUsers(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.dagbag = models.DagBag(include_examples=True)
-        cls.parser = cli_parser.get_parser()
-
-    def setUp(self):
-        from airflow.www import app as application
-
-        self.app = application.create_app(testing=True)
+class TestCliUsers:
+    @pytest.fixture(autouse=True)
+    def _set_attrs(self, app, dagbag, parser):
+        self.app = app
+        self.dagbag = dagbag
+        self.parser = parser
         self.appbuilder = self.app.appbuilder  # pylint: disable=no-member
         self.clear_roles_and_roles()
-
-    def tearDown(self):
+        yield
         self.clear_roles_and_roles()
 
     def clear_roles_and_roles(self):

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -239,8 +239,7 @@ class TestCliUsers:
 
         def find_by_username(username):
             matches = [u for u in retrieved_users if u['username'] == username]
-            if not matches:
-                self.fail(f"Couldn't find user with username {username}")
+            assert matches, f"Couldn't find user with username {username}"
             matches[0].pop('id')  # this key not required for import
             return matches[0]
 

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import pytest
+
+from airflow import models
+from airflow.cli import cli_parser
+from airflow.www import app as application
+
+
+@pytest.fixture(scope="session")
+def app():
+    return application.create_app(testing=True)
+
+
+@pytest.fixture(scope="session")
+def dagbag():
+    return models.DagBag(include_examples=True)
+
+
+@pytest.fixture(scope="session")
+def parser():
+    return cli_parser.get_parser()

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -20,12 +20,6 @@ import pytest
 
 from airflow import models
 from airflow.cli import cli_parser
-from airflow.www import app as application
-
-
-@pytest.fixture(scope="session")
-def app():
-    return application.create_app(testing=True)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -418,3 +418,10 @@ def frozen_sleep(monkeypatch):
 
     if freezegun_control is not None:
         freezegun_control.stop()
+
+
+@pytest.fixture(scope="session")
+def app():
+    from airflow.www import app
+
+    return app.create_app(testing=True)

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -31,9 +31,10 @@ importlib_metadata = 'importlib.metadata' if py39 else 'importlib_metadata'
 
 
 class TestPluginsRBAC(unittest.TestCase):
-    def setUp(self):
-        self.app = application.create_app(testing=True)
-        self.appbuilder = self.app.appbuilder  # pylint: disable=no-member
+    @classmethod
+    def setUpClass(cls):
+        cls.app = application.create_app(testing=True)
+        cls.appbuilder = cls.app.appbuilder  # pylint: disable=no-member
 
     def test_flaskappbuilder_views(self):
         from tests.plugins.test_plugin import v_appbuilder_package

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -60,23 +60,6 @@ class TestPluginsRBAC(unittest.TestCase):
         assert link.name == v_appbuilder_package['category']
         assert link.childs[0].name == v_appbuilder_package['name']
 
-    def test_flaskappbuilder_nomenu_views(self):
-        from tests.plugins.test_plugin import v_nomenu_appbuilder_package
-
-        class AirflowNoMenuViewsPlugin(AirflowPlugin):
-            appbuilder_views = [v_nomenu_appbuilder_package]
-
-        appbuilder_class_name = str(v_nomenu_appbuilder_package['view'].__class__.__name__)
-
-        with mock_plugin_manager(plugins=[AirflowNoMenuViewsPlugin()]):
-            appbuilder = application.create_app(testing=True).appbuilder  # pylint: disable=no-member
-
-            plugin_views = [
-                view for view in appbuilder.baseviews if view.blueprint.name == appbuilder_class_name
-            ]
-
-            assert len(plugin_views) == 1
-
     def test_flaskappbuilder_menu_links(self):
         from tests.plugins.test_plugin import appbuilder_mitem, appbuilder_mitem_toplevel
 
@@ -111,6 +94,24 @@ class TestPluginsRBAC(unittest.TestCase):
         # Blueprint should be present in the app
         assert 'test_plugin' in self.app.blueprints
         assert self.app.blueprints['test_plugin'].name == bp.name
+
+
+def test_flaskappbuilder_nomenu_views():
+    from tests.plugins.test_plugin import v_nomenu_appbuilder_package
+
+    class AirflowNoMenuViewsPlugin(AirflowPlugin):
+        appbuilder_views = [v_nomenu_appbuilder_package]
+
+    appbuilder_class_name = str(v_nomenu_appbuilder_package['view'].__class__.__name__)
+
+    with mock_plugin_manager(plugins=[AirflowNoMenuViewsPlugin()]):
+        appbuilder = application.create_app(testing=True).appbuilder  # pylint: disable=no-member
+
+        plugin_views = [
+            view for view in appbuilder.baseviews if view.blueprint.name == appbuilder_class_name
+        ]
+
+        assert len(plugin_views) == 1
 
 
 class TestPluginsManager:

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -108,9 +108,7 @@ def test_flaskappbuilder_nomenu_views():
     with mock_plugin_manager(plugins=[AirflowNoMenuViewsPlugin()]):
         appbuilder = application.create_app(testing=True).appbuilder  # pylint: disable=no-member
 
-        plugin_views = [
-            view for view in appbuilder.baseviews if view.blueprint.name == appbuilder_class_name
-        ]
+        plugin_views = [view for view in appbuilder.baseviews if view.blueprint.name == appbuilder_class_name]
 
         assert len(plugin_views) == 1
 

--- a/tests/plugins/test_plugins_manager.py
+++ b/tests/plugins/test_plugins_manager.py
@@ -18,8 +18,9 @@
 import importlib
 import logging
 import sys
-import unittest
 from unittest import mock
+
+import pytest
 
 from airflow.hooks.base import BaseHook
 from airflow.plugins_manager import AirflowPlugin
@@ -30,11 +31,11 @@ py39 = sys.version_info >= (3, 9)
 importlib_metadata = 'importlib.metadata' if py39 else 'importlib_metadata'
 
 
-class TestPluginsRBAC(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.app = application.create_app(testing=True)
-        cls.appbuilder = cls.app.appbuilder  # pylint: disable=no-member
+class TestPluginsRBAC:
+    @pytest.fixture(autouse=True)
+    def _set_attrs(self, app):
+        self.app = app
+        self.appbuilder = app.appbuilder  # pylint: disable=no-member
 
     def test_flaskappbuilder_views(self):
         from tests.plugins.test_plugin import v_appbuilder_package
@@ -289,7 +290,7 @@ class TestPluginsManager:
             assert hasattr(macros, MacroPlugin.name)
 
 
-class TestPluginsDirectorySource(unittest.TestCase):
+class TestPluginsDirectorySource:
     def test_should_return_correct_path_name(self):
         from airflow import plugins_manager
 

--- a/tests/providers/google/common/auth_backend/test_google_openid.py
+++ b/tests/providers/google/common/auth_backend/test_google_openid.py
@@ -18,7 +18,6 @@
 from unittest import mock
 
 import pytest
-
 from flask_login import current_user
 from google.auth.exceptions import GoogleAuthError
 from parameterized import parameterized

--- a/tests/providers/google/common/auth_backend/test_google_openid.py
+++ b/tests/providers/google/common/auth_backend/test_google_openid.py
@@ -28,20 +28,21 @@ from tests.test_utils.db import clear_db_pools
 
 
 class TestGoogleOpenID(unittest.TestCase):
-    def setUp(self) -> None:
+    @classmethod
+    def setUpClass(cls) -> None:
         with conf_vars(
             {
                 ("api", "auth_backend"): "airflow.providers.google.common.auth_backend.google_openid",
                 ('api', 'enable_experimental_api'): 'true',
             }
         ):
-            self.app = create_app(testing=True)
+            cls.app = create_app(testing=True)
 
-        self.appbuilder = self.app.appbuilder  # pylint: disable=no-member
-        role_admin = self.appbuilder.sm.find_role("Admin")
-        tester = self.appbuilder.sm.find_user(username="test")
+        cls.appbuilder = cls.app.appbuilder  # pylint: disable=no-member
+        role_admin = cls.appbuilder.sm.find_role("Admin")
+        tester = cls.appbuilder.sm.find_user(username="test")
         if not tester:
-            self.appbuilder.sm.add_user(
+            cls.appbuilder.sm.add_user(
                 username="test",
                 first_name="test",
                 last_name="test",

--- a/tests/providers/google/common/auth_backend/test_google_openid.py
+++ b/tests/providers/google/common/auth_backend/test_google_openid.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 from unittest import mock
+
+import pytest
 
 from flask_login import current_user
 from google.auth.exceptions import GoogleAuthError
@@ -27,29 +28,38 @@ from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_pools
 
 
-class TestGoogleOpenID(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls) -> None:
-        with conf_vars(
-            {
-                ("api", "auth_backend"): "airflow.providers.google.common.auth_backend.google_openid",
-                ('api', 'enable_experimental_api'): 'true',
-            }
-        ):
-            cls.app = create_app(testing=True)
+@pytest.fixture(scope="module")
+def google_openid_app():
+    confs = {
+        ("api", "auth_backend"): "airflow.providers.google.common.auth_backend.google_openid",
+        ('api', 'enable_experimental_api'): 'true',
+    }
+    with conf_vars(confs):
+        return create_app(testing=True)
 
-        cls.appbuilder = cls.app.appbuilder  # pylint: disable=no-member
-        role_admin = cls.appbuilder.sm.find_role("Admin")
-        tester = cls.appbuilder.sm.find_user(username="test")
-        if not tester:
-            cls.appbuilder.sm.add_user(
-                username="test",
-                first_name="test",
-                last_name="test",
-                email="test@fab.org",
-                role=role_admin,
-                password="test",
-            )
+
+@pytest.fixture(scope="module")
+def admin_user(google_openid_app):
+    appbuilder = google_openid_app.appbuilder  # pylint: disable=no-member
+    role_admin = appbuilder.sm.find_role("Admin")
+    tester = appbuilder.sm.find_user(username="test")
+    if not tester:
+        appbuilder.sm.add_user(
+            username="test",
+            first_name="test",
+            last_name="test",
+            email="test@fab.org",
+            role=role_admin,
+            password="test",
+        )
+    return role_admin
+
+
+class TestGoogleOpenID:
+    @pytest.fixture(autouse=True)
+    def _set_attrs(self, google_openid_app, admin_user) -> None:
+        self.app = google_openid_app
+        self.admin_user = admin_user
 
     @mock.patch("google.oauth2.id_token.verify_token")
     def test_success(self, mock_verify_token):

--- a/tests/www/api/experimental/conftest.py
+++ b/tests/www/api/experimental/conftest.py
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import pytest
+
+from airflow.www import app as application
+from tests.test_utils.config import conf_vars
+from tests.test_utils.decorators import dont_initialize_flask_app_submodules
+
+
+@pytest.fixture(scope="session")
+def experiemental_api_app():
+    @conf_vars({('api', 'enable_experimental_api'): 'true'})
+    @dont_initialize_flask_app_submodules(
+        skip_all_except=[
+            "init_api_experimental_auth",
+            "init_appbuilder_views",
+            "init_api_experimental",
+            "init_appbuilder",
+        ]
+    )
+    def factory():
+        app = application.create_app(testing=True)
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
+        app.config['SECRET_KEY'] = 'secret_key'
+        app.config['CSRF_ENABLED'] = False
+        app.config['WTF_CSRF_ENABLED'] = False
+        return app
+
+    return factory()

--- a/tests/www/api/experimental/test_dag_runs_endpoint.py
+++ b/tests/www/api/experimental/test_dag_runs_endpoint.py
@@ -23,26 +23,6 @@ from airflow.api.common.experimental.trigger_dag import trigger_dag
 from airflow.models import DagBag, DagRun
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.settings import Session
-from airflow.www import app as application
-from tests.test_utils.config import conf_vars
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
-
-
-@pytest.fixture(scope="module")
-def app():
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=[
-            "init_api_experimental_auth",
-            "init_appbuilder_views",
-            "init_api_experimental",
-            "init_appbuilder",
-        ]
-    )
-    def factory():
-        with conf_vars({('api', 'enable_experimental_api'): 'true'}):
-            return application.create_app(testing=True)
-
-    return factory()
 
 
 class TestDagRunsEndpoint:
@@ -58,8 +38,8 @@ class TestDagRunsEndpoint:
             SerializedDagModel.write_dag(dag)
 
     @pytest.fixture(autouse=True)
-    def _reset_test_session(self, app):
-        self.app = app.test_client()
+    def _reset_test_session(self, experiemental_api_app):
+        self.app = experiemental_api_app.test_client()
         yield
         session = Session()
         session.query(DagRun).delete()

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -31,10 +31,7 @@ from airflow.models.serialized_dag import SerializedDagModel
 from airflow.settings import Session
 from airflow.utils.timezone import datetime, parse as parse_datetime, utcnow
 from airflow.version import version
-from airflow.www import app as application
-from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_pools
-from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 
 ROOT_FOLDER = os.path.realpath(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, os.pardir, os.pardir, os.pardir)

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -42,23 +42,6 @@ ROOT_FOLDER = os.path.realpath(
 
 
 @pytest.fixture(scope="module")
-def app():
-    @conf_vars({('api', 'enable_experimental_api'): 'true'})
-    @dont_initialize_flask_app_submodules(
-        skip_all_except=["init_api_experimental_auth", "init_api_experimental", "init_appbuilder"]
-    )
-    def factory():
-        app = application.create_app(testing=True)
-        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///'
-        app.config['SECRET_KEY'] = 'secret_key'
-        app.config['CSRF_ENABLED'] = False
-        app.config['WTF_CSRF_ENABLED'] = False
-        return app
-
-    return factory()
-
-
-@pytest.fixture(scope="module")
 def configured_session():
     settings.configure_orm()
     return Session
@@ -66,10 +49,10 @@ def configured_session():
 
 class TestBase:
     @pytest.fixture(autouse=True)
-    def _setup_attrs_base(self, app, configured_session):
-        self.app = app
-        self.appbuilder = app.appbuilder  # pylint: disable=no-member
-        self.client = app.test_client()
+    def _setup_attrs_base(self, experiemental_api_app, configured_session):
+        self.app = experiemental_api_app
+        self.appbuilder = self.app.appbuilder  # pylint: disable=no-member
+        self.client = self.app.test_client()
         self.session = configured_session
 
     def assert_deprecated(self, resp):


### PR DESCRIPTION
More free-ish speedup.

Can this `app` fixture be merged with the one in #14875? They have very slightly different configs (this one does not have `init_appbuilder_views`). That would be able to further save some more time.