### PR TITLE
GCS to BigQuery Transfer Operator with Labels and Description parameter

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -531,6 +531,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         encoding: str = "UTF-8",
         src_fmt_configs: Optional[Dict] = None,
         labels: Optional[Dict] = None,
+        description: Optional[str] = None,
         encryption_configuration: Optional[Dict] = None,
         location: Optional[str] = None,
         project_id: Optional[str] = None,
@@ -601,6 +602,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :type src_fmt_configs: dict
         :param labels: a dictionary containing labels for the table, passed to BigQuery
         :type labels: dict
+        :param description: a string containing description for the table, passed to BigQuery
+        :type descriptin: str
         :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
             **Example**: ::
 
@@ -668,6 +671,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         table.external_data_configuration = external_config
         if labels:
             table.labels = labels
+
+        if description:
+            table.description = description
 
         if encryption_configuration:
             table.encryption_configuration = EncryptionConfiguration.from_api_repr(encryption_configuration)
@@ -1560,6 +1566,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         cluster_fields: Optional[List] = None,
         autodetect: bool = False,
         encryption_configuration: Optional[Dict] = None,
+        labels: Optional[Dict] = None,
+        description: Optional[str] = None
     ) -> str:
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
@@ -1741,6 +1749,13 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
         if encryption_configuration:
             configuration["load"]["destinationEncryptionConfiguration"] = encryption_configuration
+
+        if labels:
+            configuration['load']['destinationTableProperties']['labels'] = labels
+
+        if description:
+            configuration['load']['destinationTableProperties']['description'] = description
+
 
         src_fmt_to_configs_mapping = {
             'CSV': [

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1750,11 +1750,14 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         if encryption_configuration:
             configuration["load"]["destinationEncryptionConfiguration"] = encryption_configuration
 
-        if labels:
-            configuration['load']['destinationTableProperties']['labels'] = labels
+        if labels or description:
+            configuration['load'].update({'destinationTableProperties': {}})
 
-        if description:
-            configuration['load']['destinationTableProperties']['description'] = description
+            if labels:
+                configuration['load']['destinationTableProperties']['labels'] = labels
+
+            if description:
+                configuration['load']['destinationTableProperties']['description'] = description
 
 
         src_fmt_to_configs_mapping = {

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -600,9 +600,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :type encoding: str
         :param src_fmt_configs: configure optional fields specific to the source format
         :type src_fmt_configs: dict
-        :param labels: a dictionary containing labels for the table, passed to BigQuery
+        :param labels: A dictionary containing labels for the BiqQuery table.
         :type labels: dict
-        :param description: a string containing description for the table, passed to BigQuery
+        :param description: A string containing the description for the BigQuery table.
         :type descriptin: str
         :param encryption_configuration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
             **Example**: ::
@@ -1650,6 +1650,10 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
                     "kmsKeyName": "projects/testp/locations/us/keyRings/test-kr/cryptoKeys/test-key"
                 }
         :type encryption_configuration: dict
+        :param labels: A dictionary containing labels for the BiqQuery table.
+        :type labels: dict
+        :param description: A string containing the description for the BigQuery table.
+        :type descriptin: str
         """
         warnings.warn(
             "This method is deprecated. Please use `BigQueryHook.insert_job` method.", DeprecationWarning

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -1567,7 +1567,7 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         autodetect: bool = False,
         encryption_configuration: Optional[Dict] = None,
         labels: Optional[Dict] = None,
-        description: Optional[str] = None
+        description: Optional[str] = None,
     ) -> str:
         """
         Executes a BigQuery load command to load data from Google Cloud Storage
@@ -1762,7 +1762,6 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
             if description:
                 configuration['load']['destinationTableProperties']['description'] = description
-
 
         src_fmt_to_configs_mapping = {
             'CSV': [

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -157,9 +157,9 @@ class GCSToBigQueryOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :type impersonation_chain: Union[str, Sequence[str]]
-    :param labels: dict
-    :type labels: [Optional] Labels for BQ table.
-    :param description: [Optional] Description for BQ table.
+    :param labels: [Optional] Labels for the BiqQuery table.
+    :type labels: dict
+    :param description: [Optional] Description for the BigQuery table.
     :type description: str
     """
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -157,6 +157,9 @@ class GCSToBigQueryOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :type impersonation_chain: Union[str, Sequence[str]]
+    :type labels: dict
+    :param description: [Optional] Description for BQ table.
+    :type description: str
     """
 
     template_fields = (
@@ -204,6 +207,8 @@ class GCSToBigQueryOperator(BaseOperator):
         encryption_configuration=None,
         location=None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        labels=None,
+        description=None,
         **kwargs,
     ):
 
@@ -248,6 +253,9 @@ class GCSToBigQueryOperator(BaseOperator):
         self.encryption_configuration = encryption_configuration
         self.location = location
         self.impersonation_chain = impersonation_chain
+
+        self.labels = labels
+        self.description = description
 
     def execute(self, context):
         bq_hook = BigQueryHook(
@@ -300,6 +308,8 @@ class GCSToBigQueryOperator(BaseOperator):
                 encoding=self.encoding,
                 src_fmt_configs=self.src_fmt_configs,
                 encryption_configuration=self.encryption_configuration,
+                labels=self.labels,
+                description=self.description
             )
         else:
             cursor.run_load(

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -157,7 +157,8 @@ class GCSToBigQueryOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :type impersonation_chain: Union[str, Sequence[str]]
-    :type labels: dict
+    :param labels: dict
+    :type labels: [Optional] Labels for BQ table.
     :param description: [Optional] Description for BQ table.
     :type description: str
     """
@@ -333,6 +334,8 @@ class GCSToBigQueryOperator(BaseOperator):
                 time_partitioning=self.time_partitioning,
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration,
+                labels=self.labels,
+                description=self.description
             )
 
         if cursor.use_legacy_sql:

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -310,7 +310,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 src_fmt_configs=self.src_fmt_configs,
                 encryption_configuration=self.encryption_configuration,
                 labels=self.labels,
-                description=self.description
+                description=self.description,
             )
         else:
             cursor.run_load(
@@ -335,7 +335,7 @@ class GCSToBigQueryOperator(BaseOperator):
                 cluster_fields=self.cluster_fields,
                 encryption_configuration=self.encryption_configuration,
                 labels=self.labels,
-                description=self.description
+                description=self.description,
             )
 
         if cursor.use_legacy_sql:

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1813,7 +1813,6 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
     def test_create_external_table_labels(self, mock_create):
 
         labels = {'label1': 'test1', 'label2': 'test2'}
-        
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
@@ -1828,7 +1827,6 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
     def test_create_external_table_description(self, mock_create):
 
         description = "Test Description"
-        
         self.hook.create_external_table(
             external_project_dataset_table='my_dataset.my_table',
             schema_fields=[],

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1779,3 +1779,62 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning(unittest.TestCase):
 
         mocked_func.assert_called_once_with(*args, **kwargs)
         assert re.search(f".*{new_path}.*", func.__doc__)
+
+class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
+    def test_run_load_labels(self, mock_insert):
+
+        labels = {'label1': 'test1', 'label2': 'test2'}
+        self.hook.run_load(
+            destination_project_dataset_table='my_dataset.my_table',
+            schema_fields=[],
+            source_uris=[],
+            labels=labels
+        )
+
+        _, kwargs = mock_insert.call_args
+        assert kwargs["configuration"]['load']['destinationTableProperties']['labels'] is labels
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
+    def test_run_load_description(self, mock_insert):
+
+        description = "Test Description"
+        self.hook.run_load(
+            destination_project_dataset_table='my_dataset.my_table',
+            schema_fields=[],
+            source_uris=[],
+            description=description
+        )
+
+        _, kwargs = mock_insert.call_args
+        assert kwargs["configuration"]['load']['destinationTableProperties']['description'] is description
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
+    def test_create_external_table_labels(self, mock_create):
+
+        labels = {'label1': 'test1', 'label2': 'test2'}
+        
+        self.hook.create_external_table(
+            external_project_dataset_table='my_dataset.my_table',
+            schema_fields=[],
+            source_uris=[],
+            labels=labels
+        )
+
+        _, kwargs = mock_create.call_args
+        self.assertDictEqual(kwargs['table_resource']['labels'], labels)
+
+    @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table")
+    def test_create_external_table_description(self, mock_create):
+
+        description = "Test Description"
+        
+        self.hook.create_external_table(
+            external_project_dataset_table='my_dataset.my_table',
+            schema_fields=[],
+            source_uris=[],
+            description=description
+        )
+
+        _, kwargs = mock_create.call_args
+        assert kwargs['table_resource']['description'] is  description

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -1780,6 +1780,7 @@ class TestBigQueryBaseCursorMethodsDeprecationWarning(unittest.TestCase):
         mocked_func.assert_called_once_with(*args, **kwargs)
         assert re.search(f".*{new_path}.*", func.__doc__)
 
+
 class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job")
     def test_run_load_labels(self, mock_insert):
@@ -1789,7 +1790,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
             destination_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
-            labels=labels
+            labels=labels,
         )
 
         _, kwargs = mock_insert.call_args
@@ -1803,7 +1804,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
             destination_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
-            description=description
+            description=description,
         )
 
         _, kwargs = mock_insert.call_args
@@ -1817,7 +1818,7 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
             external_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
-            labels=labels
+            labels=labels,
         )
 
         _, kwargs = mock_create.call_args
@@ -1831,8 +1832,8 @@ class TestBigQueryWithLabelsAndDescription(_BigQueryBaseTestClass):
             external_project_dataset_table='my_dataset.my_table',
             schema_fields=[],
             source_uris=[],
-            description=description
+            description=description,
         )
 
         _, kwargs = mock_create.call_args
-        assert kwargs['table_resource']['description'] is  description
+        assert kwargs['table_resource']['description'] is description

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -159,24 +159,25 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
         operator.execute(None)
 
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
-            external_project_dataset_table=mock.ANY,
-            schema_fields=mock.ANY,
-            source_uris=mock.ANY,
-            source_format=mock.ANY,
-            compression=mock.ANY,
-            skip_leading_rows=mock.ANY,
-            field_delimiter=mock.ANY,
-            max_bad_records=mock.ANY,
-            quote_character=mock.ANY,
-            ignore_unknown_values=mock.ANY,
-            allow_quoted_newlines=mock.ANY,
-            allow_jagged_rows=mock.ANY,
-            encoding=mock.ANY,
-            src_fmt_configs=mock.ANY,
-            encryption_configuration=mock.ANY,
-            labels=LABELS,
-            description=mock.ANY
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table \
+            .assert_called_once_with(
+                external_project_dataset_table=mock.ANY,
+                schema_fields=mock.ANY,
+                source_uris=mock.ANY,
+                source_format=mock.ANY,
+                compression=mock.ANY,
+                skip_leading_rows=mock.ANY,
+                field_delimiter=mock.ANY,
+                max_bad_records=mock.ANY,
+                quote_character=mock.ANY,
+                ignore_unknown_values=mock.ANY,
+                allow_quoted_newlines=mock.ANY,
+                allow_jagged_rows=mock.ANY,
+                encoding=mock.ANY,
+                src_fmt_configs=mock.ANY,
+                encryption_configuration=mock.ANY,
+                labels=LABELS,
+                description=mock.ANY
         )
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
@@ -193,22 +194,23 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
         operator.execute(None)
 
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
-            external_project_dataset_table=mock.ANY,
-            schema_fields=mock.ANY,
-            source_uris=mock.ANY,
-            source_format=mock.ANY,
-            compression=mock.ANY,
-            skip_leading_rows=mock.ANY,
-            field_delimiter=mock.ANY,
-            max_bad_records=mock.ANY,
-            quote_character=mock.ANY,
-            ignore_unknown_values=mock.ANY,
-            allow_quoted_newlines=mock.ANY,
-            allow_jagged_rows=mock.ANY,
-            encoding=mock.ANY,
-            src_fmt_configs=mock.ANY,
-            encryption_configuration=mock.ANY,
-            labels=mock.ANY,
-            description=DESCRIPTION
+        bq_hook.return_value.get_conn.return_value.cursor.return_value \
+            .create_external_table.assert_called_once_with(
+                external_project_dataset_table=mock.ANY,
+                schema_fields=mock.ANY,
+                source_uris=mock.ANY,
+                source_format=mock.ANY,
+                compression=mock.ANY,
+                skip_leading_rows=mock.ANY,
+                field_delimiter=mock.ANY,
+                max_bad_records=mock.ANY,
+                quote_character=mock.ANY,
+                ignore_unknown_values=mock.ANY,
+                allow_quoted_newlines=mock.ANY,
+                allow_jagged_rows=mock.ANY,
+                encoding=mock.ANY,
+                src_fmt_configs=mock.ANY,
+                encryption_configuration=mock.ANY,
+                labels=mock.ANY,
+                description=DESCRIPTION
         )

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -26,7 +26,7 @@ TEST_EXPLICIT_DEST = 'test-project.dataset.table'
 TEST_BUCKET = 'test-bucket'
 MAX_ID_KEY = 'id'
 TEST_SOURCE_OBJECTS = ['test/objects/*']
-LABELS = {'test': 'label'}
+LABELS = {'k1': 'v1'}
 DESCRIPTION = "Test Description"
 
 
@@ -70,41 +70,145 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
         )
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
-    def test_execute_labels(self, bq_hook):
+    def test_labels(self, bq_hook):
+
         operator = GCSToBigQueryOperator(
             task_id=TASK_ID,
             bucket=TEST_BUCKET,
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            max_id_key=MAX_ID_KEY,
             labels=LABELS
         )
 
-        # using non-legacy SQL
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = False
-
         operator.execute(None)
 
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.execute.assert_called_once_with(
-            "SELECT MAX(id) FROM `test-project.dataset.table`"
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.run_load.assert_called_once_with(
+                destination_project_dataset_table=mock.ANY,
+                schema_fields=mock.ANY,
+                source_uris=mock.ANY,
+                source_format=mock.ANY,
+                autodetect=mock.ANY,
+                create_disposition=mock.ANY,
+                skip_leading_rows=mock.ANY,
+                write_disposition=mock.ANY,
+                field_delimiter=mock.ANY,
+                max_bad_records=mock.ANY,
+                quote_character=mock.ANY,
+                ignore_unknown_values=mock.ANY,
+                allow_quoted_newlines=mock.ANY,
+                allow_jagged_rows=mock.ANY,
+                encoding=mock.ANY,
+                schema_update_options=mock.ANY,
+                src_fmt_configs=mock.ANY,
+                time_partitioning=mock.ANY,
+                cluster_fields=mock.ANY,
+                encryption_configuration=mock.ANY,
+                labels=LABELS,
+                description=mock.ANY
         )
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
-    def test_execute_description(self, bq_hook):
+    def test_description(self, bq_hook):
+
         operator = GCSToBigQueryOperator(
             task_id=TASK_ID,
             bucket=TEST_BUCKET,
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            max_id_key=MAX_ID_KEY,
-            description=DESCRIPTION
+            description=DESCRIPTION,
         )
-
-        # using non-legacy SQL
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = False
 
         operator.execute(None)
 
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.execute.assert_called_once_with(
-            "SELECT MAX(id) FROM `test-project.dataset.table`"
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.run_load.assert_called_once_with(
+            destination_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=mock.ANY,
+            source_format=mock.ANY,
+            autodetect=mock.ANY,
+            create_disposition=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            write_disposition=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            schema_update_options=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            time_partitioning=mock.ANY,
+            cluster_fields=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=mock.ANY,
+            description=DESCRIPTION
+        )
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
+    def test_labels_external_table(self, bq_hook):
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            labels=LABELS,
+            external_table=True
+        )
+
+        operator.execute(None)
+
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
+            external_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=mock.ANY,
+            source_format=mock.ANY,
+            compression=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=LABELS,
+            description=mock.ANY
+        )
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
+    def test_description_external_table(self, bq_hook):
+
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            description=DESCRIPTION,
+            external_table=True
+        )
+
+        operator.execute(None)
+
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
+            external_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=mock.ANY,
+            source_format=mock.ANY,
+            compression=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=mock.ANY,
+            description=DESCRIPTION
         )

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -26,6 +26,8 @@ TEST_EXPLICIT_DEST = 'test-project.dataset.table'
 TEST_BUCKET = 'test-bucket'
 MAX_ID_KEY = 'id'
 TEST_SOURCE_OBJECTS = ['test/objects/*']
+LABELS = {'test': 'label'}
+DESCRIPTION = "Test Description"
 
 
 class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
@@ -56,6 +58,46 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
             max_id_key=MAX_ID_KEY,
+        )
+
+        # using non-legacy SQL
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = False
+
+        operator.execute(None)
+
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.execute.assert_called_once_with(
+            "SELECT MAX(id) FROM `test-project.dataset.table`"
+        )
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
+    def test_execute_labels(self, bq_hook):
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            max_id_key=MAX_ID_KEY,
+            labels=LABELS
+        )
+
+        # using non-legacy SQL
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.use_legacy_sql = False
+
+        operator.execute(None)
+
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.execute.assert_called_once_with(
+            "SELECT MAX(id) FROM `test-project.dataset.table`"
+        )
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
+    def test_execute_description(self, bq_hook):
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+            max_id_key=MAX_ID_KEY,
+            description=DESCRIPTION
         )
 
         # using non-legacy SQL

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -159,8 +159,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
         operator.execute(None)
 
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table \
-            .assert_called_once_with(
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
                 external_project_dataset_table=mock.ANY,
                 schema_fields=mock.ANY,
                 source_uris=mock.ANY,
@@ -194,23 +193,22 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
 
         operator.execute(None)
 
-        bq_hook.return_value.get_conn.return_value.cursor.return_value \
-            .create_external_table.assert_called_once_with(
-                external_project_dataset_table=mock.ANY,
-                schema_fields=mock.ANY,
-                source_uris=mock.ANY,
-                source_format=mock.ANY,
-                compression=mock.ANY,
-                skip_leading_rows=mock.ANY,
-                field_delimiter=mock.ANY,
-                max_bad_records=mock.ANY,
-                quote_character=mock.ANY,
-                ignore_unknown_values=mock.ANY,
-                allow_quoted_newlines=mock.ANY,
-                allow_jagged_rows=mock.ANY,
-                encoding=mock.ANY,
-                src_fmt_configs=mock.ANY,
-                encryption_configuration=mock.ANY,
-                labels=mock.ANY,
-                description=DESCRIPTION
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
+            external_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=mock.ANY,
+            source_format=mock.ANY,
+            compression=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=mock.ANY,
+            description=DESCRIPTION
         )

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -77,34 +77,34 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             bucket=TEST_BUCKET,
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
-            labels=LABELS
+            labels=LABELS,
         )
 
         operator.execute(None)
 
         bq_hook.return_value.get_conn.return_value.cursor.return_value.run_load.assert_called_once_with(
-                destination_project_dataset_table=mock.ANY,
-                schema_fields=mock.ANY,
-                source_uris=mock.ANY,
-                source_format=mock.ANY,
-                autodetect=mock.ANY,
-                create_disposition=mock.ANY,
-                skip_leading_rows=mock.ANY,
-                write_disposition=mock.ANY,
-                field_delimiter=mock.ANY,
-                max_bad_records=mock.ANY,
-                quote_character=mock.ANY,
-                ignore_unknown_values=mock.ANY,
-                allow_quoted_newlines=mock.ANY,
-                allow_jagged_rows=mock.ANY,
-                encoding=mock.ANY,
-                schema_update_options=mock.ANY,
-                src_fmt_configs=mock.ANY,
-                time_partitioning=mock.ANY,
-                cluster_fields=mock.ANY,
-                encryption_configuration=mock.ANY,
-                labels=LABELS,
-                description=mock.ANY
+            destination_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=mock.ANY,
+            source_format=mock.ANY,
+            autodetect=mock.ANY,
+            create_disposition=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            write_disposition=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            schema_update_options=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            time_partitioning=mock.ANY,
+            cluster_fields=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=LABELS,
+            description=mock.ANY,
         )
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
@@ -142,7 +142,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             cluster_fields=mock.ANY,
             encryption_configuration=mock.ANY,
             labels=mock.ANY,
-            description=DESCRIPTION
+            description=DESCRIPTION,
         )
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
@@ -154,29 +154,29 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
             labels=LABELS,
-            external_table=True
+            external_table=True,
         )
 
         operator.execute(None)
 
         bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
-                external_project_dataset_table=mock.ANY,
-                schema_fields=mock.ANY,
-                source_uris=mock.ANY,
-                source_format=mock.ANY,
-                compression=mock.ANY,
-                skip_leading_rows=mock.ANY,
-                field_delimiter=mock.ANY,
-                max_bad_records=mock.ANY,
-                quote_character=mock.ANY,
-                ignore_unknown_values=mock.ANY,
-                allow_quoted_newlines=mock.ANY,
-                allow_jagged_rows=mock.ANY,
-                encoding=mock.ANY,
-                src_fmt_configs=mock.ANY,
-                encryption_configuration=mock.ANY,
-                labels=LABELS,
-                description=mock.ANY
+            external_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=mock.ANY,
+            source_format=mock.ANY,
+            compression=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=LABELS,
+            description=mock.ANY,
         )
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
@@ -188,7 +188,7 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             source_objects=TEST_SOURCE_OBJECTS,
             destination_project_dataset_table=TEST_EXPLICIT_DEST,
             description=DESCRIPTION,
-            external_table=True
+            external_table=True,
         )
 
         operator.execute(None)
@@ -210,5 +210,5 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
             src_fmt_configs=mock.ANY,
             encryption_configuration=mock.ANY,
             labels=mock.ANY,
-            description=DESCRIPTION
+            description=DESCRIPTION,
         )

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -158,26 +158,28 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
         )
 
         operator.execute(None)
-
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
-            external_project_dataset_table=mock.ANY,
-            schema_fields=mock.ANY,
-            source_uris=mock.ANY,
-            source_format=mock.ANY,
-            compression=mock.ANY,
-            skip_leading_rows=mock.ANY,
-            field_delimiter=mock.ANY,
-            max_bad_records=mock.ANY,
-            quote_character=mock.ANY,
-            ignore_unknown_values=mock.ANY,
-            allow_quoted_newlines=mock.ANY,
-            allow_jagged_rows=mock.ANY,
-            encoding=mock.ANY,
-            src_fmt_configs=mock.ANY,
-            encryption_configuration=mock.ANY,
-            labels=LABELS,
-            description=mock.ANY,
-        )
+        # fmt: off
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table. \
+            assert_called_once_with(
+                external_project_dataset_table=mock.ANY,
+                schema_fields=mock.ANY,
+                source_uris=mock.ANY,
+                source_format=mock.ANY,
+                compression=mock.ANY,
+                skip_leading_rows=mock.ANY,
+                field_delimiter=mock.ANY,
+                max_bad_records=mock.ANY,
+                quote_character=mock.ANY,
+                ignore_unknown_values=mock.ANY,
+                allow_quoted_newlines=mock.ANY,
+                allow_jagged_rows=mock.ANY,
+                encoding=mock.ANY,
+                src_fmt_configs=mock.ANY,
+                encryption_configuration=mock.ANY,
+                labels=LABELS,
+                description=mock.ANY,
+            )
+        # fmt: on
 
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
     def test_description_external_table(self, bq_hook):
@@ -192,23 +194,25 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
         )
 
         operator.execute(None)
-
-        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table.assert_called_once_with(
-            external_project_dataset_table=mock.ANY,
-            schema_fields=mock.ANY,
-            source_uris=mock.ANY,
-            source_format=mock.ANY,
-            compression=mock.ANY,
-            skip_leading_rows=mock.ANY,
-            field_delimiter=mock.ANY,
-            max_bad_records=mock.ANY,
-            quote_character=mock.ANY,
-            ignore_unknown_values=mock.ANY,
-            allow_quoted_newlines=mock.ANY,
-            allow_jagged_rows=mock.ANY,
-            encoding=mock.ANY,
-            src_fmt_configs=mock.ANY,
-            encryption_configuration=mock.ANY,
-            labels=mock.ANY,
-            description=DESCRIPTION,
-        )
+        # fmt: off
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.create_external_table. \
+            assert_called_once_with(
+                external_project_dataset_table=mock.ANY,
+                schema_fields=mock.ANY,
+                source_uris=mock.ANY,
+                source_format=mock.ANY,
+                compression=mock.ANY,
+                skip_leading_rows=mock.ANY,
+                field_delimiter=mock.ANY,
+                max_bad_records=mock.ANY,
+                quote_character=mock.ANY,
+                ignore_unknown_values=mock.ANY,
+                allow_quoted_newlines=mock.ANY,
+                allow_jagged_rows=mock.ANY,
+                encoding=mock.ANY,
+                src_fmt_configs=mock.ANY,
+                encryption_configuration=mock.ANY,
+                labels=mock.ANY,
+                description=DESCRIPTION,
+            )
+        # fmt: on


### PR DESCRIPTION
This adds the following optional parameters to the GCS to BQ transfer operator:

1. labels
2. description

These can be set by users to update labels and/or description information in the destination BigQuery table.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
