### PR TITLE
Fix celery executor bug trying to call len on map

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -551,6 +551,7 @@ class BulkStateFetcher(LoggingMixin):
         if isinstance(app.backend, DatabaseBackend):
             result = self._get_many_from_db_backend(async_results)
             return result
+        async_results = list(async_results)
         result = self._get_many_using_multiprocessing(async_results)
         self.log.debug("Fetched %d states for %d task", len(result), len(async_results))
         return result

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -547,12 +547,12 @@ class BulkStateFetcher(LoggingMixin):
         """Gets status for many Celery tasks using the best method available."""
         if isinstance(app.backend, BaseKeyValueStoreBackend):
             result = self._get_many_from_kv_backend(async_results)
-            return result
-        if isinstance(app.backend, DatabaseBackend):
+        elif isinstance(app.backend, DatabaseBackend):
             result = self._get_many_from_db_backend(async_results)
-            return result
-        async_results = list(async_results)
-        result = self._get_many_using_multiprocessing(async_results)
+        else:
+            async_results = list(async_results)
+            result = self._get_many_using_multiprocessing(async_results)
+        async_results = list(async_results) if isinstance(async_results, map) else async_results
         self.log.debug("Fetched %d states for %d task", len(result), len(async_results))
         return result
 

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -476,7 +476,7 @@ class CeleryExecutor(BaseExecutor):
             return tis
 
         states_by_celery_task_id = self.bulk_state_fetcher.get_many(
-            map(operator.itemgetter(0), celery_tasks.values())
+            list(map(operator.itemgetter(0), celery_tasks.values()))
         )
 
         adopted = []
@@ -549,13 +549,8 @@ class BulkStateFetcher(LoggingMixin):
         elif isinstance(app.backend, DatabaseBackend):
             result = self._get_many_from_db_backend(async_results)
         else:
-            async_results = list(async_results) if isinstance(async_results, map) else async_results
             result = self._get_many_using_multiprocessing(async_results)
-        if logging.getLevelName(self.log.level) == "DEBUG":
-            if isinstance(async_results, map):
-                self.log.debug("Fetched state for %d task(s)", len(result))
-            else:
-                self.log.debug("Fetched %d state(s) for %d task(s)", len(result), len(async_results))
+        self.log.debug("Fetched %d state(s) for %d task(s)", len(result), len(async_results))
         return result
 
     def _get_many_from_kv_backend(self, async_tasks) -> Mapping[str, EventBufferValueType]:

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -550,10 +550,11 @@ class BulkStateFetcher(LoggingMixin):
         elif isinstance(app.backend, DatabaseBackend):
             result = self._get_many_from_db_backend(async_results)
         else:
-            async_results = list(async_results)
+            async_results = list(async_results) if isinstance(async_results, map) else async_results
             result = self._get_many_using_multiprocessing(async_results)
-        async_results = list(async_results) if isinstance(async_results, map) else async_results
-        self.log.debug("Fetched %d states for %d task", len(result), len(async_results))
+        if isinstance(async_results, map) and self.log.level == "DEBUG":
+            async_results = list(async_results)
+            self.log.debug("Fetched %d states for %d task", len(result), len(async_results))
         return result
 
     def _get_many_from_kv_backend(self, async_tasks) -> Mapping[str, EventBufferValueType]:

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -413,7 +413,9 @@ class TestBulkStateFetcher(unittest.TestCase):
     def test_should_support_kv_backend(self, mock_mget):
         with _prepare_app():
             mock_backend = BaseKeyValueStoreBackend(app=celery_executor.app)
-            with mock.patch.object(celery_executor.app, 'backend', mock_backend):
+            with mock.patch.object(celery_executor.app, 'backend', mock_backend), self.assertLogs(
+                "airflow.executors.celery_executor.BulkStateFetcher", level="DEBUG"
+            ) as cm:
                 fetcher = BulkStateFetcher()
                 result = fetcher.get_many(
                     [
@@ -428,6 +430,9 @@ class TestBulkStateFetcher(unittest.TestCase):
         mock_mget.assert_called_once_with(mock.ANY)
 
         assert result == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
+        assert [
+            'DEBUG:airflow.executors.celery_executor.BulkStateFetcher:Fetched 2 state(s) for 2 task(s)'
+        ] == cm.output
 
     @mock.patch("celery.backends.database.DatabaseBackend.ResultSession")
     @pytest.mark.integration("redis")
@@ -437,21 +442,26 @@ class TestBulkStateFetcher(unittest.TestCase):
         with _prepare_app():
             mock_backend = DatabaseBackend(app=celery_executor.app, url="sqlite3://")
 
-            with mock.patch.object(celery_executor.app, 'backend', mock_backend):
+            with mock.patch.object(celery_executor.app, 'backend', mock_backend), self.assertLogs(
+                "airflow.executors.celery_executor.BulkStateFetcher", level="DEBUG"
+            ) as cm:
                 mock_session = mock_backend.ResultSession.return_value  # pylint: disable=no-member
                 mock_session.query.return_value.filter.return_value.all.return_value = [
                     mock.MagicMock(**{"to_dict.return_value": {"status": "SUCCESS", "task_id": "123"}})
                 ]
 
-        fetcher = BulkStateFetcher()
-        result = fetcher.get_many(
-            [
-                mock.MagicMock(task_id="123"),
-                mock.MagicMock(task_id="456"),
-            ]
-        )
+                fetcher = BulkStateFetcher()
+                result = fetcher.get_many(
+                    [
+                        mock.MagicMock(task_id="123"),
+                        mock.MagicMock(task_id="456"),
+                    ]
+                )
 
         assert result == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
+        assert [
+            'DEBUG:airflow.executors.celery_executor.BulkStateFetcher:Fetched 2 state(s) for 2 task(s)'
+        ] == cm.output
 
     @pytest.mark.integration("redis")
     @pytest.mark.integration("rabbitmq")
@@ -460,7 +470,9 @@ class TestBulkStateFetcher(unittest.TestCase):
         with _prepare_app():
             mock_backend = mock.MagicMock(autospec=BaseBackend)
 
-            with mock.patch.object(celery_executor.app, 'backend', mock_backend):
+            with mock.patch.object(celery_executor.app, 'backend', mock_backend), self.assertLogs(
+                "airflow.executors.celery_executor.BulkStateFetcher", level="DEBUG"
+            ) as cm:
                 fetcher = BulkStateFetcher(1)
                 result = fetcher.get_many(
                     [
@@ -470,11 +482,15 @@ class TestBulkStateFetcher(unittest.TestCase):
                 )
 
         assert result == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
+        assert [
+            'DEBUG:airflow.executors.celery_executor.BulkStateFetcher:Fetched 2 state(s) for 2 task(s)'
+        ] == cm.output
 
     @pytest.mark.integration("redis")
     @pytest.mark.integration("rabbitmq")
     @pytest.mark.backend("mysql", "postgres")
     def test_should_support_base_backend_from_try_adopt_task_instances(self):
+
         celery_tasks = {
             123: (ClassWithCustomAttributes(task_id="123", state='SUCCESS'), None),
             456: (ClassWithCustomAttributes(task_id="456", state="PENDING"), None),
@@ -482,11 +498,15 @@ class TestBulkStateFetcher(unittest.TestCase):
         with _prepare_app():
             mock_backend = mock.MagicMock(autospec=BaseBackend)
 
-            with mock.patch.object(celery_executor.app, 'backend', mock_backend):
-
+            with mock.patch.object(celery_executor.app, 'backend', mock_backend), self.assertLogs(
+                "airflow.executors.celery_executor.BulkStateFetcher", level="DEBUG"
+            ) as cm:
                 fetcher = BulkStateFetcher(1)
                 states_by_celery_task_id = fetcher.get_many(
                     map(operator.itemgetter(0), celery_tasks.values())
                 )
 
         assert states_by_celery_task_id == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
+        assert [
+            'DEBUG:airflow.executors.celery_executor.BulkStateFetcher:Fetched 2 state(s) for 2 task(s)'
+        ] == cm.output

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -17,7 +17,6 @@
 # under the License.
 import contextlib
 import json
-import operator
 import os
 import sys
 import unittest
@@ -482,31 +481,6 @@ class TestBulkStateFetcher(unittest.TestCase):
                 )
 
         assert result == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
-        assert [
-            'DEBUG:airflow.executors.celery_executor.BulkStateFetcher:Fetched 2 state(s) for 2 task(s)'
-        ] == cm.output
-
-    @pytest.mark.integration("redis")
-    @pytest.mark.integration("rabbitmq")
-    @pytest.mark.backend("mysql", "postgres")
-    def test_should_support_base_backend_from_try_adopt_task_instances(self):
-
-        celery_tasks = {
-            123: (ClassWithCustomAttributes(task_id="123", state='SUCCESS'), None),
-            456: (ClassWithCustomAttributes(task_id="456", state="PENDING"), None),
-        }
-        with _prepare_app():
-            mock_backend = mock.MagicMock(autospec=BaseBackend)
-
-            with mock.patch.object(celery_executor.app, 'backend', mock_backend), self.assertLogs(
-                "airflow.executors.celery_executor.BulkStateFetcher", level="DEBUG"
-            ) as cm:
-                fetcher = BulkStateFetcher(1)
-                states_by_celery_task_id = fetcher.get_many(
-                    map(operator.itemgetter(0), celery_tasks.values())
-                )
-
-        assert states_by_celery_task_id == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
         assert [
             'DEBUG:airflow.executors.celery_executor.BulkStateFetcher:Fetched 2 state(s) for 2 task(s)'
         ] == cm.output

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -17,6 +17,7 @@
 # under the License.
 import contextlib
 import json
+import operator
 import os
 import sys
 import unittest
@@ -469,3 +470,23 @@ class TestBulkStateFetcher(unittest.TestCase):
                 )
 
         assert result == {'123': ('SUCCESS', None), '456': ("PENDING", None)}
+
+    @pytest.mark.integration("redis")
+    @pytest.mark.integration("rabbitmq")
+    @pytest.mark.backend("mysql", "postgres")
+    def test_should_support_base_backend_from_try_adopt_task_instances(self):
+        celery_tasks = {
+            123: (ClassWithCustomAttributes(task_id="123", state='SUCCESS'), None),
+            456: (ClassWithCustomAttributes(task_id="456", state="PENDING"), None),
+        }
+        with _prepare_app():
+            mock_backend = mock.MagicMock(autospec=BaseBackend)
+
+            with mock.patch.object(celery_executor.app, 'backend', mock_backend):
+
+                fetcher = BulkStateFetcher(1)
+                states_by_celery_task_id = fetcher.get_many(
+                    map(operator.itemgetter(0), celery_tasks.values())
+                )
+
+        assert states_by_celery_task_id == {'123': ('SUCCESS', None), '456': ("PENDING", None)}


### PR DESCRIPTION
When the celery executor tries to adopt task instances, and there are indeed task instances to adopt, `bulk_state_fetcher.get_many` [is called](https://github.com/apache/airflow/blob/90ab60bba877c65cb93871b97db13a179820d28b/airflow/executors/celery_executor.py#L478-L480), passing a map object. If the celery `result_backend` is not  an instance of BaseKeyValueStoreBackend or DatabaseBackend, the method `_get_many_using_multiprocessing` will be called. This method attempts to get the len of its parameter, but you can't take the length of a map object. So, it needs to be converted to a list (or perhaps another iterable?) first. Since there is a debug statement that first takes the len before `_get_many_using_multiprocessing` [is called](https://github.com/apache/airflow/blob/90ab60bba877c65cb93871b97db13a179820d28b/airflow/executors/celery_executor.py#L555), it makes sense to convert the map object to a list immediately prior even if it wasn't handled in the `else` block. 

I wasn't able to actually reproduce the issue with Airflow, but I was able to reproduce it with the [test_try_adopt_task_instances](https://github.com/apache/airflow/blob/90ab60bba877c65cb93871b97db13a179820d28b/tests/executors/test_celery_executor.py#L319-L353) test by setting the celery result backend to `rpc://` and the broker to redis.

closes: #14163