### PR TITLE
Add REST API query sort and order to some endpoints

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -67,7 +67,8 @@ def get_connections(session, limit, sort, offset=0, order_by="id"):
     """Get all connection entries"""
     if order_by == "connection_id":
         order_by = 'id'
-    if not hasattr(Connection, order_by):
+    columns = [i.name for i in Connection.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"Connection has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -65,12 +65,12 @@ def get_connection(connection_id, session):
 @provide_session
 def get_connections(session, limit, offset=0, order_by="id"):
     """Get all connection entries"""
-    to_replace = {"connection_id": "conn_id", "-connection_id": "-conn_id"}
+    to_replace = {"connection_id": "conn_id"}
     allowed_filter_attrs = ['connection_id', 'conn_type', 'description', 'host', 'port', 'id']
 
     total_entries = session.query(func.count(Connection.id)).scalar()
     query = session.query(Connection)
-    query = apply_sorting(Connection, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     connections = query.offset(offset).limit(limit).all()
     return connection_collection_schema.dump(
         ConnectionCollection(connections=connections, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -66,11 +66,11 @@ def get_connection(connection_id, session):
 def get_connections(session, limit, offset=0, order_by="id"):
     """Get all connection entries"""
     to_replace = {"connection_id": "conn_id", "-connection_id": "-conn_id"}
-    allowed_attrs = ['connection_id', 'conn_type', 'description', 'host', 'port']
+    allowed_filter_attrs = ['connection_id', 'conn_type', 'description', 'host', 'port', 'id']
 
     total_entries = session.query(func.count(Connection.id)).scalar()
     query = session.query(Connection)
-    query = apply_sorting(Connection, query, order_by, to_replace, allowed_attrs)
+    query = apply_sorting(Connection, query, order_by, to_replace, allowed_filter_attrs)
     connections = query.offset(offset).limit(limit).all()
     return connection_collection_schema.dump(
         ConnectionCollection(connections=connections, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -65,11 +65,12 @@ def get_connection(connection_id, session):
 @provide_session
 def get_connections(session, limit, offset=0, order_by="id"):
     """Get all connection entries"""
-    to_replace = {"connection_id": "id", "-connection_id": "-id"}
+    to_replace = {"connection_id": "conn_id", "-connection_id": "-conn_id"}
+    allowed_attrs = ['connection_id', 'conn_type', 'description', 'host', 'port']
 
     total_entries = session.query(func.count(Connection.id)).scalar()
     query = session.query(Connection)
-    query = apply_sorting(Connection, query, order_by, to_replace)
+    query = apply_sorting(Connection, query, order_by, to_replace, allowed_attrs)
     connections = query.offset(offset).limit(limit).all()
     return connection_collection_schema.dump(
         ConnectionCollection(connections=connections, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -62,7 +62,8 @@ def get_dag_details(dag_id):
 @format_parameters({'limit': check_limit})
 def get_dags(limit, sort, offset=0, order_by='dag_id'):
     """Get all DAGs."""
-    if not hasattr(DagModel, order_by):
+    columns = [i.name for i in DagModel.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"DagModel has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -60,17 +60,17 @@ def get_dag_details(dag_id):
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 @format_parameters({'limit': check_limit})
-def get_dags(limit, sort, offset=0, order_by=None):
+def get_dags(limit, sort, offset=0, order_by='dag_id'):
     """Get all DAGs."""
-    if order_by and not hasattr(DagModel, order_by):
+    if not hasattr(DagModel, order_by):
         raise BadRequest(
             detail=f"DagModel has no attribute '{order_by}' specified in order_by parameter",
         )
     readable_dags = current_app.appbuilder.sm.get_readable_dags(g.user)
     if sort == "asc":
-        query = readable_dags.order_by(asc(order_by or DagModel.dag_id))
+        query = readable_dags.order_by(asc(order_by))
     else:
-        query = readable_dags.order_by(desc(order_by or DagModel.dag_id))
+        query = readable_dags.order_by(desc(order_by))
     dags = query.offset(offset).limit(limit).all()
     total_entries = readable_dags.count()
 

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -20,7 +20,7 @@ from marshmallow import ValidationError
 from airflow import DAG
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound
-from airflow.api_connexion.parameters import apply_sorting, check_limit, format_parameters
+from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.dag_schema import (
     DAGCollection,
     dag_detail_schema,
@@ -59,11 +59,10 @@ def get_dag_details(dag_id):
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 @format_parameters({'limit': check_limit})
-def get_dags(limit, offset=0, order_by='dag_id'):
+def get_dags(limit, offset=0):
     """Get all DAGs."""
     readable_dags = current_app.appbuilder.sm.get_readable_dags(g.user)
-    query = apply_sorting(DagModel, readable_dags, order_by)
-    dags = query.offset(offset).limit(limit).all()
+    dags = readable_dags.order_by(DagModel.dag_id).offset(offset).limit(limit).all()
     total_entries = readable_dags.count()
 
     return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -100,7 +100,8 @@ def get_dag_runs(
 ):  # pylint: disable=too-many-arguments
     """Get all DAG Runs."""
     # return early if order_by field do not exist
-    if order_by and not hasattr(DagRun, order_by):
+    columns = [i.name for i in DagRun.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"DagRun has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -102,8 +102,7 @@ def get_dag_runs(
     # return early if order_by field do not exist
     if order_by and not hasattr(DagRun, order_by):
         raise BadRequest(
-            title="Orderby column not found",
-            detail=f"The column `{order_by}` specified by order_by in query does not exist",
+            detail=f"DagRun has no attribute '{order_by}' specified in order_by parameter",
         )
     query = session.query(DagRun)
 

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -96,7 +96,7 @@ def get_dag_runs(
     offset=None,
     limit=None,
     sort=None,
-    order_by=None,
+    order_by='id',
 ):  # pylint: disable=too-many-arguments
     """Get all DAG Runs."""
     # return early if order_by field do not exist
@@ -156,9 +156,9 @@ def _fetch_dag_runs(
     total_entries = query.count()
     # sort
     if sort == 'asc':
-        query = query.order_by(asc(order_by or DagRun.id))
+        query = query.order_by(asc(order_by))
     elif sort == 'desc':
-        query = query.order_by(desc(order_by or DagRun.id))
+        query = query.order_by(desc(order_by))
     else:
         query = query.order_by(DagRun.id)
     # apply offset and limit

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -146,7 +146,7 @@ def _fetch_dag_runs(
     # Count items
     total_entries = query.count()
     # sort
-    to_replace = {"dag_run_id": "run_id", "-dag_run_id": "dag_run_id"}
+    to_replace = {"dag_run_id": "run_id"}
     allowed_filter_attrs = [
         "id",
         "state",
@@ -158,7 +158,7 @@ def _fetch_dag_runs(
         "external_trigger",
         "conf",
     ]
-    query = apply_sorting(DagRun, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     # apply offset and limit
     dag_run = query.offset(offset).limit(limit).all()
     return dag_run, total_entries

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -147,7 +147,8 @@ def _fetch_dag_runs(
     total_entries = query.count()
     # sort
     to_replace = {"dag_run_id": "run_id", "-dag_run_id": "dag_run_id"}
-    allowed_attrs = [
+    allowed_filter_attrs = [
+        "id",
         "state",
         "dag_id",
         "execution_date",
@@ -157,7 +158,7 @@ def _fetch_dag_runs(
         "external_trigger",
         "conf",
     ]
-    query = apply_sorting(DagRun, query, order_by, to_replace, allowed_attrs)
+    query = apply_sorting(DagRun, query, order_by, to_replace, allowed_filter_attrs)
     # apply offset and limit
     dag_run = query.offset(offset).limit(limit).all()
     return dag_run, total_entries

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -146,7 +146,18 @@ def _fetch_dag_runs(
     # Count items
     total_entries = query.count()
     # sort
-    query = apply_sorting(DagRun, query, order_by)
+    to_replace = {"dag_run_id": "run_id", "-dag_run_id": "dag_run_id"}
+    allowed_attrs = [
+        "state",
+        "dag_id",
+        "execution_date",
+        "dag_run_id",
+        "start_date",
+        "end_date",
+        "external_trigger",
+        "conf",
+    ]
+    query = apply_sorting(DagRun, query, order_by, to_replace, allowed_attrs)
     # apply offset and limit
     dag_run = query.offset(offset).limit(limit).all()
     return dag_run, total_entries

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -132,7 +132,7 @@ def _fetch_dag_runs(
     start_date_lte,
     limit,
     offset,
-    order_by='id',
+    order_by,
 ):  # pylint: disable=too-many-arguments
     query = _apply_date_filters_to_query(
         query,
@@ -219,6 +219,7 @@ def get_dag_runs_batch(session):
         data["start_date_lte"],
         data["page_limit"],
         data["page_offset"],
+        order_by=data.get('order_by', "id"),
     )
 
     return dagrun_collection_schema.dump(DAGRunCollection(dag_runs=dag_runs, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -46,7 +46,8 @@ def get_event_log(event_log_id, session):
 @provide_session
 def get_event_logs(session, sort, limit, offset=None, order_by='id'):
     """Get all log entries from event log"""
-    if not hasattr(Log, order_by):
+    columns = [i.name for i in Log.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"Log has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-from sqlalchemy import func
+from sqlalchemy import asc, desc, func
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import NotFound
@@ -44,10 +44,15 @@ def get_event_log(event_log_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_event_logs(session, limit, offset=None):
+def get_event_logs(session, sort, limit, offset=None, order_by=None):
     """Get all log entries from event log"""
     total_entries = session.query(func.count(Log.id)).scalar()
-    event_logs = session.query(Log).order_by(Log.id).offset(offset).limit(limit).all()
+    query = session.query(Log)
+    if sort == 'asc':
+        query = query.order_by(asc(order_by or Log.id))
+    else:
+        query = query.order_by(desc(order_by or Log.id))
+    event_logs = query.offset(offset).limit(limit).all()
     return event_log_collection_schema.dump(
         EventLogCollection(event_logs=event_logs, total_entries=total_entries)
     )

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -44,13 +44,22 @@ def get_event_log(event_log_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_event_logs(session, limit, offset=None, order_by='id'):
+def get_event_logs(session, limit, offset=None, order_by='event_log_id'):
     """Get all log entries from event log"""
     to_replace = {"event_log_id": "id", "-event_log_id": "-id", "when": "dttm", "-when": "-dttm"}
-    allowed_attrs = ['event_log_id', "when", "dag_id", "task_id", "event", "execution_date", "owner", "extra"]
+    allowed_filter_attrs = [
+        'event_log_id',
+        "when",
+        "dag_id",
+        "task_id",
+        "event",
+        "execution_date",
+        "owner",
+        "extra",
+    ]
     total_entries = session.query(func.count(Log.id)).scalar()
     query = session.query(Log)
-    query = apply_sorting(Log, query, order_by, to_replace, allowed_attrs)
+    query = apply_sorting(Log, query, order_by, to_replace, allowed_filter_attrs)
     event_logs = query.offset(offset).limit(limit).all()
     return event_log_collection_schema.dump(
         EventLogCollection(event_logs=event_logs, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -46,7 +46,7 @@ def get_event_log(event_log_id, session):
 @provide_session
 def get_event_logs(session, limit, offset=None, order_by='event_log_id'):
     """Get all log entries from event log"""
-    to_replace = {"event_log_id": "id", "-event_log_id": "-id", "when": "dttm", "-when": "-dttm"}
+    to_replace = {"event_log_id": "id", "when": "dttm"}
     allowed_filter_attrs = [
         'event_log_id',
         "when",
@@ -59,7 +59,7 @@ def get_event_logs(session, limit, offset=None, order_by='event_log_id'):
     ]
     total_entries = session.query(func.count(Log.id)).scalar()
     query = session.query(Log)
-    query = apply_sorting(Log, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     event_logs = query.offset(offset).limit(limit).all()
     return event_log_collection_schema.dump(
         EventLogCollection(event_logs=event_logs, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -16,11 +16,11 @@
 # under the License.
 
 
-from sqlalchemy import asc, desc, func
+from sqlalchemy import func
 
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import BadRequest, NotFound
-from airflow.api_connexion.parameters import check_limit, format_parameters
+from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import apply_sorting, check_limit, format_parameters
 from airflow.api_connexion.schemas.event_log_schema import (
     EventLogCollection,
     event_log_collection_schema,
@@ -44,19 +44,11 @@ def get_event_log(event_log_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_event_logs(session, sort, limit, offset=None, order_by='id'):
+def get_event_logs(session, limit, offset=None, order_by='id'):
     """Get all log entries from event log"""
-    columns = [i.name for i in Log.__table__.columns]  # pylint: disable=no-member
-    if order_by not in columns:
-        raise BadRequest(
-            detail=f"Log has no attribute '{order_by}' specified in order_by parameter",
-        )
     total_entries = session.query(func.count(Log.id)).scalar()
     query = session.query(Log)
-    if sort == 'asc':
-        query = query.order_by(asc(order_by))
-    else:
-        query = query.order_by(desc(order_by))
+    query = apply_sorting(Log, query, order_by)
     event_logs = query.offset(offset).limit(limit).all()
     return event_log_collection_schema.dump(
         EventLogCollection(event_logs=event_logs, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -46,9 +46,11 @@ def get_event_log(event_log_id, session):
 @provide_session
 def get_event_logs(session, limit, offset=None, order_by='id'):
     """Get all log entries from event log"""
+    to_replace = {"event_log_id": "id", "-event_log_id": "-id", "when": "dttm", "-when": "-dttm"}
+    allowed_attrs = ['event_log_id', "when", "dag_id", "task_id", "event", "execution_date", "owner", "extra"]
     total_entries = session.query(func.count(Log.id)).scalar()
     query = session.query(Log)
-    query = apply_sorting(Log, query, order_by)
+    query = apply_sorting(Log, query, order_by, to_replace, allowed_attrs)
     event_logs = query.offset(offset).limit(limit).all()
     return event_log_collection_schema.dump(
         EventLogCollection(event_logs=event_logs, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -51,7 +51,8 @@ def get_import_errors(session, limit, sort, offset=None, order_by='id'):
     """Get all import errors"""
     if order_by == 'import_error_id':
         order_by = 'id'
-    if not hasattr(ImportError, order_by):
+    columns = [i.name for i in ImportError.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"ImportError has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -15,17 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from sqlalchemy import asc, desc, func
+from sqlalchemy import func
 
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import BadRequest, NotFound
-from airflow.api_connexion.parameters import check_limit, format_parameters
+from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import apply_sorting, check_limit, format_parameters
 from airflow.api_connexion.schemas.error_schema import (
     ImportErrorCollection,
     import_error_collection_schema,
     import_error_schema,
 )
-from airflow.models.errors import ImportError  # pylint: disable=redefined-builtin
+from airflow.models.errors import ImportError as ImportErrorModel
 from airflow.security import permissions
 from airflow.utils.session import provide_session
 
@@ -34,7 +34,7 @@ from airflow.utils.session import provide_session
 @provide_session
 def get_import_error(import_error_id, session):
     """Get an import error"""
-    error = session.query(ImportError).filter(ImportError.id == import_error_id).one_or_none()
+    error = session.query(ImportErrorModel).filter(ImportErrorModel.id == import_error_id).one_or_none()
 
     if error is None:
         raise NotFound(
@@ -47,21 +47,13 @@ def get_import_error(import_error_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_IMPORT_ERROR)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_import_errors(session, limit, sort, offset=None, order_by='id'):
+def get_import_errors(session, limit, offset=None, order_by='id'):
     """Get all import errors"""
-    if order_by == 'import_error_id':
-        order_by = 'id'
-    columns = [i.name for i in ImportError.__table__.columns]  # pylint: disable=no-member
-    if order_by not in columns:
-        raise BadRequest(
-            detail=f"ImportError has no attribute '{order_by}' specified in order_by parameter",
-        )
-    total_entries = session.query(func.count(ImportError.id)).scalar()
-    query = session.query(ImportError)
-    if sort == 'asc':
-        query = query.order_by(asc(order_by))
-    else:
-        query = query.order_by(desc(order_by))
+    to_replace = {"import_error_id": 'id', "-import_error_id": "-id"}
+
+    total_entries = session.query(func.count(ImportErrorModel.id)).scalar()
+    query = session.query(ImportErrorModel)
+    query = apply_sorting(ImportErrorModel, query, order_by, to_replace)
     import_errors = query.offset(offset).limit(limit).all()
     return import_error_collection_schema.dump(
         ImportErrorCollection(import_errors=import_errors, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -47,13 +47,13 @@ def get_import_error(import_error_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_IMPORT_ERROR)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_import_errors(session, limit, offset=None, order_by='id'):
+def get_import_errors(session, limit, offset=None, order_by='import_error_id'):
     """Get all import errors"""
     to_replace = {"import_error_id": 'id', "-import_error_id": "-id"}
-
+    allowed_filter_attrs = ['import_error_id', "timestamp", "filename"]
     total_entries = session.query(func.count(ImportErrorModel.id)).scalar()
     query = session.query(ImportErrorModel)
-    query = apply_sorting(ImportErrorModel, query, order_by, to_replace)
+    query = apply_sorting(ImportErrorModel, query, order_by, to_replace, allowed_filter_attrs)
     import_errors = query.offset(offset).limit(limit).all()
     return import_error_collection_schema.dump(
         ImportErrorCollection(import_errors=import_errors, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -49,11 +49,11 @@ def get_import_error(import_error_id, session):
 @provide_session
 def get_import_errors(session, limit, offset=None, order_by='import_error_id'):
     """Get all import errors"""
-    to_replace = {"import_error_id": 'id', "-import_error_id": "-id"}
+    to_replace = {"import_error_id": 'id'}
     allowed_filter_attrs = ['import_error_id', "timestamp", "filename"]
     total_entries = session.query(func.count(ImportErrorModel.id)).scalar()
     query = session.query(ImportErrorModel)
-    query = apply_sorting(ImportErrorModel, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     import_errors = query.offset(offset).limit(limit).all()
     return import_error_collection_schema.dump(
         ImportErrorCollection(import_errors=import_errors, total_entries=total_entries)

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -55,9 +55,11 @@ def get_pool(pool_name, session):
 @provide_session
 def get_pools(session, limit, order_by='id', offset=None):
     """Get all pools"""
+    to_replace = {"name": "pool", "-name": "-pool"}
+    allowed_filter_attrs = ['name', 'slots', "id"]
     total_entries = session.query(func.count(Pool.id)).scalar()
     query = session.query(Pool)
-    query = apply_sorting(Pool, query, order_by)
+    query = apply_sorting(Pool, query, order_by, to_replace, allowed_filter_attrs)
     pools = query.offset(offset).limit(limit).all()
     return pool_collection_schema.dump(PoolCollection(pools=pools, total_entries=total_entries))
 

--- a/airflow/api_connexion/endpoints/pool_endpoint.py
+++ b/airflow/api_connexion/endpoints/pool_endpoint.py
@@ -55,11 +55,11 @@ def get_pool(pool_name, session):
 @provide_session
 def get_pools(session, limit, order_by='id', offset=None):
     """Get all pools"""
-    to_replace = {"name": "pool", "-name": "-pool"}
+    to_replace = {"name": "pool"}
     allowed_filter_attrs = ['name', 'slots', "id"]
     total_entries = session.query(func.count(Pool.id)).scalar()
     query = session.query(Pool)
-    query = apply_sorting(Pool, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     pools = query.offset(offset).limit(limit).all()
     return pool_collection_schema.dump(PoolCollection(pools=pools, total_entries=total_entries))
 

--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -48,6 +48,8 @@ def get_roles(limit, sort, order_by='name', offset=None):
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(Role.id)).scalar()
+    if order_by == 'role_id':
+        order_by = 'id'
     columns = [i.name for i in Role.__table__.columns]  # pylint: disable=no-member
     if order_by not in columns:
         raise BadRequest(

--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -16,11 +16,11 @@
 # under the License.
 from flask import current_app
 from flask_appbuilder.security.sqla.models import Permission, Role
-from sqlalchemy import asc, desc, func
+from sqlalchemy import func
 
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import BadRequest, NotFound
-from airflow.api_connexion.parameters import check_limit, format_parameters
+from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.parameters import apply_sorting, check_limit, format_parameters
 from airflow.api_connexion.schemas.role_and_permission_schema import (
     ActionCollection,
     RoleCollection,
@@ -43,23 +43,14 @@ def get_role(role_name):
 
 @security.requires_access([(permissions.ACTION_CAN_LIST, permissions.RESOURCE_ROLE_MODEL_VIEW)])
 @format_parameters({'limit': check_limit})
-def get_roles(limit, sort, order_by='name', offset=None):
+def get_roles(limit, order_by='name', offset=None):
     """Get roles"""
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(Role.id)).scalar()
-    if order_by == 'role_id':
-        order_by = 'id'
-    columns = [i.name for i in Role.__table__.columns]  # pylint: disable=no-member
-    if order_by not in columns:
-        raise BadRequest(
-            detail=f"Role model has no attribute '{order_by}' specified in order_by parameter",
-        )
+    to_replace = {"role_id": "id", "-role_id": "-id"}
     query = session.query(Role)
-    if sort == 'asc':
-        query = query.order_by(asc(order_by))
-    else:
-        query = query.order_by(desc(order_by))
+    query = apply_sorting(Role, query, order_by, to_replace)
     roles = query.offset(offset).limit(limit).all()
 
     return role_collection_schema.dump(RoleCollection(roles=roles, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -49,8 +49,9 @@ def get_roles(limit, order_by='name', offset=None):
     session = appbuilder.get_session
     total_entries = session.query(func.count(Role.id)).scalar()
     to_replace = {"role_id": "id", "-role_id": "-id"}
+    allowed_filter_attrs = ['role_id', 'name']
     query = session.query(Role)
-    query = apply_sorting(Role, query, order_by, to_replace)
+    query = apply_sorting(Role, query, order_by, to_replace, allowed_filter_attrs)
     roles = query.offset(offset).limit(limit).all()
 
     return role_collection_schema.dump(RoleCollection(roles=roles, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -48,10 +48,10 @@ def get_roles(limit, order_by='name', offset=None):
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(Role.id)).scalar()
-    to_replace = {"role_id": "id", "-role_id": "-id"}
+    to_replace = {"role_id": "id"}
     allowed_filter_attrs = ['role_id', 'name']
     query = session.query(Role)
-    query = apply_sorting(Role, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     roles = query.offset(offset).limit(limit).all()
 
     return role_collection_schema.dump(RoleCollection(roles=roles, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -51,7 +51,7 @@ def get_task(dag_id, task_id):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
     ]
 )
-def get_tasks(dag_id, sort: str, order_by=None):
+def get_tasks(dag_id, sort: str, order_by='task_id'):
     """Get tasks for DAG"""
     dag: DAG = current_app.dag_bag.get_dag(dag_id)
     if not dag:
@@ -59,12 +59,12 @@ def get_tasks(dag_id, sort: str, order_by=None):
     tasks = dag.tasks
     if sort == 'desc':
         try:
-            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"), reverse=True)
+            tasks = sorted(tasks, key=attrgetter(order_by), reverse=True)
         except AttributeError as err:
             raise BadRequest(detail=str(err))
     else:
         try:
-            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"))
+            tasks = sorted(tasks, key=attrgetter(order_by))
         except AttributeError as err:
             raise BadRequest(detail=str(err))
     task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -14,11 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from operator import attrgetter
+
 from flask import current_app
 
 from airflow import DAG
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.exceptions import BadRequest, NotFound
 from airflow.api_connexion.schemas.task_schema import TaskCollection, task_collection_schema, task_schema
 from airflow.exceptions import TaskNotFound
 from airflow.security import permissions
@@ -49,11 +51,21 @@ def get_task(dag_id, task_id):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
     ]
 )
-def get_tasks(dag_id):
+def get_tasks(dag_id, sort: str, order_by=None):
     """Get tasks for DAG"""
     dag: DAG = current_app.dag_bag.get_dag(dag_id)
     if not dag:
         raise NotFound("DAG not found")
     tasks = dag.tasks
+    if sort == 'desc':
+        try:
+            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"), reverse=True)
+        except AttributeError as err:
+            raise BadRequest(detail=str(err))
+    else:
+        try:
+            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"))
+        except AttributeError as err:
+            raise BadRequest(detail=str(err))
     task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))
     return task_collection_schema.dump(task_collection)

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -59,7 +59,7 @@ def get_tasks(dag_id, order_by='task_id'):
     tasks = dag.tasks
 
     try:
-        tasks = sorted(tasks, key=attrgetter(order_by.lstrip('-')), reverse=(order_by[0] == '-'))
+        tasks = sorted(tasks, key=attrgetter(order_by.lstrip('-')), reverse=(order_by[0:1] == '-'))
     except AttributeError as err:
         raise BadRequest(detail=str(err))
     task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -57,15 +57,10 @@ def get_tasks(dag_id, order_by='task_id'):
     if not dag:
         raise NotFound("DAG not found")
     tasks = dag.tasks
-    if '-' in order_by:
-        try:
-            tasks = sorted(tasks, key=attrgetter(order_by.strip('-')), reverse=True)
-        except AttributeError as err:
-            raise BadRequest(detail=str(err))
-    else:
-        try:
-            tasks = sorted(tasks, key=attrgetter(order_by))
-        except AttributeError as err:
-            raise BadRequest(detail=str(err))
+
+    try:
+        tasks = sorted(tasks, key=attrgetter(order_by.lstrip('-')), reverse=(order_by[0] == '-'))
+    except AttributeError as err:
+        raise BadRequest(detail=str(err))
     task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))
     return task_collection_schema.dump(task_collection)

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -51,15 +51,15 @@ def get_task(dag_id, task_id):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
     ]
 )
-def get_tasks(dag_id, sort: str, order_by='task_id'):
+def get_tasks(dag_id, order_by='task_id'):
     """Get tasks for DAG"""
     dag: DAG = current_app.dag_bag.get_dag(dag_id)
     if not dag:
         raise NotFound("DAG not found")
     tasks = dag.tasks
-    if sort == 'desc':
+    if '-' in order_by:
         try:
-            tasks = sorted(tasks, key=attrgetter(order_by), reverse=True)
+            tasks = sorted(tasks, key=attrgetter(order_by.strip('-')), reverse=True)
         except AttributeError as err:
             raise BadRequest(detail=str(err))
     else:

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -47,6 +47,8 @@ def get_users(limit, sort, order_by='id', offset=None):
     session = appbuilder.get_session
     total_entries = session.query(func.count(User.id)).scalar()
     columns = [i.name for i in User.__table__.columns]  # pylint: disable=no-member
+    if order_by == 'user_id':
+        order_by = 'id'
     if order_by not in columns:
         raise BadRequest(
             detail=f"User model has no attribute '{order_by}' specified in order_by parameter",

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -41,14 +41,15 @@ def get_user(username):
 
 @security.requires_access([(permissions.ACTION_CAN_LIST, permissions.RESOURCE_USER_DB_MODELVIEW)])
 @format_parameters({'limit': check_limit})
-def get_users(limit, order_by='id', offset=None):
+def get_users(limit, order_by='user_id', offset=None):
     """Get users"""
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(User.id)).scalar()
     to_replace = {"user_id": "id", "-user_id": "-id"}
+    allowed_filter_attrs = ["user_id", "first_name", "last_name", "user_name", "email", "is_active", "role"]
     query = session.query(User)
-    query = apply_sorting(User, query, order_by, to_replace)
+    query = apply_sorting(User, query, order_by, to_replace, allowed_filter_attrs)
     users = query.offset(offset).limit(limit).all()
 
     return user_collection_schema.dump(UserCollection(users=users, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -41,15 +41,24 @@ def get_user(username):
 
 @security.requires_access([(permissions.ACTION_CAN_LIST, permissions.RESOURCE_USER_DB_MODELVIEW)])
 @format_parameters({'limit': check_limit})
-def get_users(limit, order_by='user_id', offset=None):
+def get_users(limit, order_by='id', offset=None):
     """Get users"""
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(User.id)).scalar()
-    to_replace = {"user_id": "id", "-user_id": "-id"}
-    allowed_filter_attrs = ["user_id", "first_name", "last_name", "user_name", "email", "is_active", "role"]
+    to_replace = {"user_id": "id"}
+    allowed_filter_attrs = [
+        "user_id",
+        'id',
+        "first_name",
+        "last_name",
+        "user_name",
+        "email",
+        "is_active",
+        "role",
+    ]
     query = session.query(User)
-    query = apply_sorting(User, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     users = query.offset(offset).limit(limit).all()
 
     return user_collection_schema.dump(UserCollection(users=users, total_entries=total_entries))

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -55,10 +55,10 @@ def get_variables(
 ) -> Response:
     """Get all variable values"""
     total_entries = session.query(func.count(Variable.id)).scalar()
-    to_replace = {"value": "val", "-value": "-val"}
-    allowed_filter_attrs = ['value', 'id']
+    to_replace = {"value": "val"}
+    allowed_filter_attrs = ['value', 'key', 'id']
     query = session.query(Variable)
-    query = apply_sorting(Variable, query, order_by, to_replace, allowed_filter_attrs)
+    query = apply_sorting(query, order_by, to_replace, allowed_filter_attrs)
     variables = query.offset(offset).limit(limit).all()
     return variable_collection_schema.dump(
         {

--- a/airflow/api_connexion/endpoints/variable_endpoint.py
+++ b/airflow/api_connexion/endpoints/variable_endpoint.py
@@ -56,8 +56,9 @@ def get_variables(
     """Get all variable values"""
     total_entries = session.query(func.count(Variable.id)).scalar()
     to_replace = {"value": "val", "-value": "-val"}
+    allowed_filter_attrs = ['value', 'id']
     query = session.query(Variable)
-    query = apply_sorting(Variable, query, order_by, to_replace)
+    query = apply_sorting(Variable, query, order_by, to_replace, allowed_filter_attrs)
     variables = query.offset(offset).limit(limit).all()
     return variable_collection_schema.dump(
         {

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -648,6 +648,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -260,6 +260,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.
@@ -696,6 +698,9 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
+
       responses:
         '200':
           description: Success.
@@ -711,7 +716,6 @@ paths:
   /importErrors/{import_error_id}:
     parameters:
       - $ref: '#/components/parameters/ImportErrorID'
-
     get:
       summary: Get an import error
       x-openapi-router-controller: airflow.api_connexion.endpoints.import_error_endpoint

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1211,6 +1211,8 @@ paths:
   /dags/{dag_id}/tasks:
     parameters:
       - $ref: '#/components/parameters/DAGID'
+      - $ref: '#/components/parameters/SortBy'
+      - $ref: '#/components/parameters/OrderBy'
 
     get:
       summary: Get tasks for DAG

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1405,6 +1405,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.
@@ -1470,6 +1472,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -376,6 +376,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -960,6 +960,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -526,6 +526,8 @@ paths:
         - $ref: '#/components/parameters/FilterStartDateLTE'
         - $ref: '#/components/parameters/FilterEndDateGTE'
         - $ref: '#/components/parameters/FilterEndDateLTE'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: List of DAG runs.
@@ -3165,6 +3167,27 @@ components:
           type: string
       description:
         The value can be repeated to retrieve multiple matching values (OR condition).
+
+    # Sort/Order parameters
+    SortBy:
+      in: query
+      name: sort
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+        default: desc
+      required: false
+      description: The direction to order results
+
+    OrderBy:
+      in: query
+      name: order_by
+      schema:
+        type: string
+      required: false
+      description: The name of the field to order results
 
     # Other parameters
     FileToken:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -744,6 +744,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: List of pools.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -260,7 +260,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -378,7 +377,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -530,7 +528,6 @@ paths:
         - $ref: '#/components/parameters/FilterStartDateLTE'
         - $ref: '#/components/parameters/FilterEndDateGTE'
         - $ref: '#/components/parameters/FilterEndDateLTE'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -652,7 +649,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -698,7 +694,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
 
       responses:
@@ -744,7 +739,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -960,7 +954,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -1223,7 +1216,6 @@ paths:
   /dags/{dag_id}/tasks:
     parameters:
       - $ref: '#/components/parameters/DAGID'
-      - $ref: '#/components/parameters/SortBy'
       - $ref: '#/components/parameters/OrderBy'
 
     get:
@@ -1407,7 +1399,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -1474,7 +1465,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
-        - $ref: '#/components/parameters/SortBy'
         - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
@@ -3186,19 +3176,6 @@ components:
       description:
         The value can be repeated to retrieve multiple matching values (OR condition).
 
-    # Sort/Order parameters
-    SortBy:
-      in: query
-      name: sort
-      schema:
-        type: string
-        enum:
-          - asc
-          - desc
-        default: desc
-      required: false
-      description: The direction to order results
-
     OrderBy:
       in: query
       name: order_by
@@ -3208,6 +3185,7 @@ components:
       description: The name of the field to order results
 
     # Other parameters
+
     FileToken:
       in: path
       name: file_token

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2574,6 +2574,11 @@ components:
     ListDagRunsForm:
       type: object
       properties:
+        order_by:
+          type: string
+          description: |
+            The name of the field to order the results by. Prefix a field name
+            with `-` to reverse the sort order.
         page_offset:
           type: integer
           minimum: 0
@@ -3182,7 +3187,9 @@ components:
       schema:
         type: string
       required: false
-      description: The name of the field to order the results by. Prefix a field name with `-` to reverse the sort order.
+      description: |
+        The name of the field to order the results by.
+        Prefix a field name with `-` to reverse the sort order.
 
     # Other parameters
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3182,7 +3182,7 @@ components:
       schema:
         type: string
       required: false
-      description: The name of the field to order results
+      description: The name of the field to order the results by. Prefix a field name with `-` to reverse the sort order.
 
     # Other parameters
 

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -89,13 +89,16 @@ def format_parameters(params_formatters: Dict[str, Callable[..., bool]]) -> Call
     return format_parameters_decorator
 
 
-def apply_sorting(model, query, order_by, to_replace=None):
+def apply_sorting(model, query, order_by, to_replace=None, allowed_attrs=None):
     """Apply sorting to query"""
+    lstriped_orderby = order_by.lstrip('-')
+    if allowed_attrs and lstriped_orderby not in allowed_attrs:
+        raise BadRequest(detail=f"Filtering with this attribute '{lstriped_orderby}' is disallowed")
     if to_replace:
         for key, value in to_replace.items():
             if key == order_by:
                 order_by = value
-    if order_by.strip('-') not in (i.name for i in model.__table__.columns):
+    if lstriped_orderby not in (i.name for i in model.__table__.columns):
         modelname = model.__tablename__.capitalize()
         model_mapping = {
             "Ab_user": 'User',
@@ -108,11 +111,11 @@ def apply_sorting(model, query, order_by, to_replace=None):
         if model_mapping.get(modelname, None):
             modelname = model_mapping[modelname]
         raise BadRequest(
-            detail=f"{modelname} model has no attribute '{order_by.strip('-')}' "
+            detail=f"{modelname} model has no attribute '{lstriped_orderby}' "
             f"specified in order_by parameter",
         )
 
     if '-' in order_by:
-        return query.order_by(desc(order_by.strip('-')))
+        return query.order_by(desc(lstriped_orderby))
     else:
         return query.order_by(asc(order_by))

--- a/airflow/api_connexion/parameters.py
+++ b/airflow/api_connexion/parameters.py
@@ -93,12 +93,6 @@ def apply_sorting(model, query, order_by, to_replace=None, allowed_attrs=None):
     """Apply sorting to query"""
     lstriped_orderby = order_by.lstrip('-')
     if allowed_attrs and lstriped_orderby not in allowed_attrs:
-        raise BadRequest(detail=f"Filtering with this attribute '{lstriped_orderby}' is disallowed")
-    if to_replace:
-        for key, value in to_replace.items():
-            if key == order_by:
-                order_by = value
-    if lstriped_orderby not in (i.name for i in model.__table__.columns):
         modelname = model.__tablename__.capitalize()
         model_mapping = {
             "Ab_user": 'User',
@@ -111,10 +105,13 @@ def apply_sorting(model, query, order_by, to_replace=None, allowed_attrs=None):
         if model_mapping.get(modelname, None):
             modelname = model_mapping[modelname]
         raise BadRequest(
-            detail=f"{modelname} model has no attribute '{lstriped_orderby}' "
-            f"specified in order_by parameter",
+            detail=f"Ordering with '{lstriped_orderby}' is disallowed or "
+            f"the attribute does not exist on {modelname} model"
         )
-
+    if to_replace:
+        for key, value in to_replace.items():
+            if key == order_by:
+                order_by = value
     if '-' in order_by:
         return query.order_by(desc(lstriped_orderby))
     else:

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -101,6 +101,7 @@ class DagRunsBatchFormSchema(Schema):
         datetimeformat = 'iso'
         strict = True
 
+    order_by = fields.String()
     page_offset = fields.Int(missing=0, min=0)
     page_limit = fields.Int(missing=100, min=1)
     dag_ids = fields.List(fields.Str(), missing=None)

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -161,7 +161,7 @@ class TestGetConnections(TestConnectionEndpoint):
         session.commit()
         result = session.query(Connection).all()
         assert len(result) == 2
-        response = self.client.get("/api/v1/connections?sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/connections", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert response.json == {
             'connections': [
@@ -194,10 +194,10 @@ class TestGetConnections(TestConnectionEndpoint):
         result = session.query(Connection).all()
         assert len(result) == 2
         response = self.client.get(
-            "/api/v1/connections?order_by=connection_id", environ_overrides={'REMOTE_USER': "test"}
+            "/api/v1/connections?order_by=-connection_id", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
-        # This also tests desc since sort is descending by default
+        # Using - means descending
         assert response.json == {
             'connections': [
                 {
@@ -269,7 +269,7 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
         connections = self._create_connections(10)
         session.add_all(connections)
         session.commit()
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert response.json["total_entries"] == 10
         conn_ids = [conn["connection_id"] for conn in response.json["connections"] if conn]
@@ -296,7 +296,8 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
         )
         assert response.status_code == 400
         assert (
-            response.json['detail'] == "Connection has no attribute 'invalid' specified in order_by parameter"
+            response.json['detail']
+            == "Connection model has no attribute 'invalid' specified in order_by parameter"
         )
 
     def test_limit_of_zero_should_return_default(self, session):

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -296,8 +296,8 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
         )
         assert response.status_code == 400
         assert (
-            response.json['detail']
-            == "Connection model has no attribute 'invalid' specified in order_by parameter"
+            response.json['detail'] == "Ordering with 'invalid' is disallowed or"
+            " the attribute does not exist on Connection model"
         )
 
     def test_limit_of_zero_should_return_default(self, session):

--- a/tests/api_connexion/endpoints/test_connection_endpoint.py
+++ b/tests/api_connexion/endpoints/test_connection_endpoint.py
@@ -297,7 +297,7 @@ class TestGetConnectionsPagination(TestConnectionEndpoint):
         assert response.status_code == 400
         assert (
             response.json['detail'] == "Ordering with 'invalid' is disallowed or"
-            " the attribute does not exist on Connection model"
+            " the attribute does not exist on the model"
         )
 
     def test_limit_of_zero_should_return_default(self, session):

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -428,59 +428,6 @@ class TestGetDags(TestDagEndpoint):
             "total_entries": 2,
         } == response.json
 
-    def test_order_by_id_descending(self):
-        self._create_dag_models(2)
-
-        response = self.client.get("api/v1/dags?order_by=-dag_id", environ_overrides={'REMOTE_USER': "test"})
-        file_token = SERIALIZER.dumps("/tmp/dag_1.py")
-        file_token2 = SERIALIZER.dumps("/tmp/dag_2.py")
-        assert response.status_code == 200
-        assert {
-            "dags": [
-                {
-                    "dag_id": "TEST_DAG_2",
-                    "description": None,
-                    "fileloc": "/tmp/dag_2.py",
-                    "file_token": file_token2,
-                    "is_paused": False,
-                    "is_subdag": False,
-                    "owners": [],
-                    "root_dag_id": None,
-                    "schedule_interval": {
-                        "__type": "CronExpression",
-                        "value": "2 2 * * *",
-                    },
-                    "tags": [],
-                },
-                {
-                    "dag_id": "TEST_DAG_1",
-                    "description": None,
-                    "fileloc": "/tmp/dag_1.py",
-                    "file_token": file_token,
-                    "is_paused": False,
-                    "is_subdag": False,
-                    "owners": [],
-                    "root_dag_id": None,
-                    "schedule_interval": {
-                        "__type": "CronExpression",
-                        "value": "2 2 * * *",
-                    },
-                    "tags": [],
-                },
-            ],
-            "total_entries": 2,
-        } == response.json
-
-    def test_invalid_order_by_raises_400(self):
-        self._create_dag_models(2)
-
-        response = self.client.get("api/v1/dags?order_by=invalid", environ_overrides={'REMOTE_USER': "test"})
-        assert response.status_code == 400
-        assert (
-            response.json['detail']
-            == "DagModel model has no attribute 'invalid' specified in order_by parameter"
-        )
-
     def test_should_respond_200_with_granular_dag_access(self):
         self._create_dag_models(3)
         response = self.client.get(

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -388,7 +388,7 @@ class TestGetDags(TestDagEndpoint):
     def test_should_respond_200(self):
         self._create_dag_models(2)
 
-        response = self.client.get("api/v1/dags?sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("api/v1/dags", environ_overrides={'REMOTE_USER': "test"})
         file_token = SERIALIZER.dumps("/tmp/dag_1.py")
         file_token2 = SERIALIZER.dumps("/tmp/dag_2.py")
         assert response.status_code == 200
@@ -431,7 +431,7 @@ class TestGetDags(TestDagEndpoint):
     def test_order_by_id_descending(self):
         self._create_dag_models(2)
 
-        response = self.client.get("api/v1/dags?order_by=dag_id", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("api/v1/dags?order_by=-dag_id", environ_overrides={'REMOTE_USER': "test"})
         file_token = SERIALIZER.dumps("/tmp/dag_1.py")
         file_token2 = SERIALIZER.dumps("/tmp/dag_2.py")
         assert response.status_code == 200
@@ -477,7 +477,8 @@ class TestGetDags(TestDagEndpoint):
         response = self.client.get("api/v1/dags?order_by=invalid", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 400
         assert (
-            response.json['detail'] == "DagModel has no attribute 'invalid' specified in order_by parameter"
+            response.json['detail']
+            == "DagModel model has no attribute 'invalid' specified in order_by parameter"
         )
 
     def test_should_respond_200_with_granular_dag_access(self):
@@ -520,7 +521,7 @@ class TestGetDags(TestDagEndpoint):
     def test_should_respond_200_and_handle_pagination(self, url, expected_dag_ids):
         self._create_dag_models(10)
 
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
 

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -278,6 +278,15 @@ class TestGetDagRuns(TestDagRunEndpoint):
             "total_entries": 2,
         }
 
+    def test_invalid_order_by_raises_400(self):
+        self._create_test_dag_run()
+
+        response = self.client.get(
+            "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == "DagRun has no attribute 'invalid' specified in order_by parameter"
+
     def test_return_correct_results_with_order_by(self, session):
         self._create_test_dag_run()
         result = session.query(DagRun).all()

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -249,7 +249,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
         result = session.query(DagRun).all()
         assert len(result) == 2
         response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns?sort=asc", environ_overrides={'REMOTE_USER': "test"}
+            "api/v1/dags/TEST_DAG_ID/dagRuns", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
         assert response.json == {
@@ -285,20 +285,23 @@ class TestGetDagRuns(TestDagRunEndpoint):
             "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert response.json['detail'] == "DagRun has no attribute 'invalid' specified in order_by parameter"
+        assert (
+            response.json['detail']
+            == "DagRun model has no attribute 'invalid' specified in order_by parameter"
+        )
 
     def test_return_correct_results_with_order_by(self, session):
         self._create_test_dag_run()
         result = session.query(DagRun).all()
         assert len(result) == 2
         response = self.client.get(
-            "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=execution_date",
+            "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=-execution_date",
             environ_overrides={'REMOTE_USER': "test"},
         )
 
         assert response.status_code == 200
         assert self.default_time < self.default_time_2
-        # Sort is descending by default
+        # - means descending
         assert response.json == {
             "dag_runs": [
                 {
@@ -327,7 +330,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
 
     def test_should_return_all_with_tilde_as_dag_id_and_all_dag_permissions(self):
         self._create_test_dag_run(extra_dag=True)
-        expected_dag_run_ids = ['TEST_DAG_ID_4', 'TEST_DAG_ID_3', "TEST_DAG_ID", "TEST_DAG_ID"]
+        expected_dag_run_ids = ['TEST_DAG_ID', 'TEST_DAG_ID', "TEST_DAG_ID_3", "TEST_DAG_ID_4"]
         response = self.client.get("api/v1/dags/~/dagRuns", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         dag_run_ids = [dag_run["dag_id"] for dag_run in response.json["dag_runs"]]
@@ -394,7 +397,7 @@ class TestGetDagRunsPagination(TestDagRunEndpoint):
     )
     def test_handle_limit_and_offset(self, url, expected_dag_run_ids):
         self._create_dag_runs(10)
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
 
         assert response.json["total_entries"] == 10
@@ -485,7 +488,7 @@ class TestGetDagRunsPaginationFilters(TestDagRunEndpoint):
         session.add_all(dagrun_models)
         session.commit()
 
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert response.json["total_entries"] == len(expected_dag_run_ids)
         dag_run_ids = [dag_run["dag_run_id"] for dag_run in response.json["dag_runs"]]

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -285,10 +285,8 @@ class TestGetDagRuns(TestDagRunEndpoint):
             "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert (
-            response.json['detail']
-            == "DagRun model has no attribute 'invalid' specified in order_by parameter"
-        )
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on DagRun model"
+        assert response.json['detail'] == msg
 
     def test_return_correct_results_with_order_by(self, session):
         self._create_test_dag_run()

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -285,7 +285,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
             "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on DagRun model"
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
     def test_return_correct_results_with_order_by(self, session):

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -321,6 +321,17 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
         assert response.json["total_entries"] == 200
         assert len(response.json["event_logs"]) == 100  # default 100
 
+    def test_should_raise_400_for_invalid_order_by_name(self, session):
+        log_models = self._create_event_logs(200)
+        session.add_all(log_models)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/eventLogs?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == "Log has no attribute 'invalid' specified in order_by parameter"
+
     @provide_session
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self, session):

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -330,9 +330,8 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
             "/api/v1/eventLogs?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert (
-            response.json['detail'] == "Log model has no attribute 'invalid' specified in order_by parameter"
-        )
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on Log model"
+        assert response.json['detail'] == msg
 
     @provide_session
     @conf_vars({("api", "maximum_page_limit"): "150"})

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -330,7 +330,7 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
             "/api/v1/eventLogs?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on Log model"
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
     @provide_session

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -148,7 +148,7 @@ class TestGetEventLogs(TestEventLogEndpoint):
         log_model_3.dttm = timezone.parse(self.default_time_2)
         session.add_all([log_model_1, log_model_2, log_model_3])
         session.commit()
-        response = self.client.get("/api/v1/eventLogs?sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/eventLogs", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert response.json == {
             "event_logs": [
@@ -199,7 +199,7 @@ class TestGetEventLogs(TestEventLogEndpoint):
         session.add_all([log_model_1, log_model_2, log_model_3])
         session.commit()
         response = self.client.get(
-            "/api/v1/eventLogs?order_by=owner", environ_overrides={'REMOTE_USER': "test"}
+            "/api/v1/eventLogs?order_by=-owner", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
         assert response.json == {
@@ -210,7 +210,7 @@ class TestGetEventLogs(TestEventLogEndpoint):
                     "dag_id": "TEST_DAG_ID",
                     "task_id": "TEST_TASK_ID",
                     "execution_date": self.default_time,
-                    "owner": 'zsh',  # Order by name, sort order is descending(default)
+                    "owner": 'zsh',  # Order by name, sort order is descending(-)
                     "when": self.default_time_2,
                     "extra": None,
                 },
@@ -302,7 +302,7 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
         session.add_all(log_models)
         session.commit()
 
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
 
         assert response.json["total_entries"] == 10
@@ -330,7 +330,9 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
             "/api/v1/eventLogs?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert response.json['detail'] == "Log has no attribute 'invalid' specified in order_by parameter"
+        assert (
+            response.json['detail'] == "Log model has no attribute 'invalid' specified in order_by parameter"
+        )
 
     @provide_session
     @conf_vars({("api", "maximum_page_limit"): "150"})

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import timedelta
 
 import pytest
 from parameterized import parameterized
@@ -131,7 +132,7 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         session.add_all(import_error)
         session.commit()
 
-        response = self.client.get("/api/v1/importErrors", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/importErrors?sort=asc", environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
         response_data = response.json
@@ -153,6 +154,64 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
             ],
             "total_entries": 2,
         } == response_data
+
+    def test_get_import_errors_order_by(self, session):
+        import_error = [
+            ImportError(
+                filename=f"Lorem_ipsum{i}.py",
+                stacktrace="Lorem ipsum",
+                timestamp=timezone.parse(self.timestamp, timezone="UTC") + timedelta(days=-i),
+            )
+            for i in range(1, 3)
+        ]
+        session.add_all(import_error)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/importErrors?order_by=timestamp&sort=asc", environ_overrides={'REMOTE_USER': "test"}
+        )
+
+        assert response.status_code == 200
+        response_data = response.json
+        self._normalize_import_errors(response_data['import_errors'])
+        assert {
+            "import_errors": [
+                {
+                    "filename": "Lorem_ipsum2.py",
+                    "import_error_id": 1,  # id normalized with self._normalize_import_errors
+                    "stack_trace": "Lorem ipsum",
+                    "timestamp": "2020-06-08T12:00:00+00:00",
+                },
+                {
+                    "filename": "Lorem_ipsum1.py",
+                    "import_error_id": 2,
+                    "stack_trace": "Lorem ipsum",
+                    "timestamp": "2020-06-09T12:00:00+00:00",
+                },
+            ],
+            "total_entries": 2,
+        } == response_data
+
+    def test_order_by_raises_400_for_invalid_attr(self, session):
+        import_error = [
+            ImportError(
+                filename="Lorem_ipsum.py",
+                stacktrace="Lorem ipsum",
+                timestamp=timezone.parse(self.timestamp, timezone="UTC"),
+            )
+            for _ in range(2)
+        ]
+        session.add_all(import_error)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/importErrors?order_by=timest", environ_overrides={'REMOTE_USER': "test"}
+        )
+
+        assert response.status_code == 400
+        assert (
+            response.json['detail'] == "ImportError has no attribute 'timest' specified in order_by parameter"
+        )
 
     def test_should_raises_401_unauthenticated(self, session):
         import_error = [
@@ -197,7 +256,7 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         session.add_all(import_errors)
         session.commit()
 
-        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
         import_ids = [pool["filename"] for pool in response.json["import_errors"]]

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -132,7 +132,7 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         session.add_all(import_error)
         session.commit()
 
-        response = self.client.get("/api/v1/importErrors?sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/importErrors", environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
         response_data = response.json
@@ -168,7 +168,7 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         session.commit()
 
         response = self.client.get(
-            "/api/v1/importErrors?order_by=timestamp&sort=asc", environ_overrides={'REMOTE_USER': "test"}
+            "/api/v1/importErrors?order_by=-timestamp", environ_overrides={'REMOTE_USER': "test"}
         )
 
         assert response.status_code == 200
@@ -177,16 +177,16 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         assert {
             "import_errors": [
                 {
-                    "filename": "Lorem_ipsum2.py",
+                    "filename": "Lorem_ipsum1.py",
                     "import_error_id": 1,  # id normalized with self._normalize_import_errors
                     "stack_trace": "Lorem ipsum",
-                    "timestamp": "2020-06-08T12:00:00+00:00",
+                    "timestamp": "2020-06-09T12:00:00+00:00",
                 },
                 {
-                    "filename": "Lorem_ipsum1.py",
+                    "filename": "Lorem_ipsum2.py",
                     "import_error_id": 2,
                     "stack_trace": "Lorem ipsum",
-                    "timestamp": "2020-06-09T12:00:00+00:00",
+                    "timestamp": "2020-06-08T12:00:00+00:00",
                 },
             ],
             "total_entries": 2,
@@ -210,7 +210,8 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
 
         assert response.status_code == 400
         assert (
-            response.json['detail'] == "ImportError has no attribute 'timest' specified in order_by parameter"
+            response.json['detail']
+            == "ImportError model has no attribute 'timest' specified in order_by parameter"
         )
 
     def test_should_raises_401_unauthenticated(self, session):
@@ -256,7 +257,7 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         session.add_all(import_errors)
         session.commit()
 
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
         import_ids = [pool["filename"] for pool in response.json["import_errors"]]

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -209,7 +209,7 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         )
 
         assert response.status_code == 400
-        msg = "Ordering with 'timest' is disallowed or the attribute does not exist on ImportError model"
+        msg = "Ordering with 'timest' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
     def test_should_raises_401_unauthenticated(self, session):

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -209,10 +209,8 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         )
 
         assert response.status_code == 400
-        assert (
-            response.json['detail']
-            == "ImportError model has no attribute 'timest' specified in order_by parameter"
-        )
+        msg = "Ordering with 'timest' is disallowed or the attribute does not exist on ImportError model"
+        assert response.json['detail'] == msg
 
     def test_should_raises_401_unauthenticated(self, session):
         import_error = [

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -185,10 +185,8 @@ class TestGetPoolsPagination(TestBasePoolEndpoints):
             "/api/v1/pools?order_by=open_slots", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert (
-            response.json['detail']
-            == "Pool model has no attribute 'open_slots' specified in order_by parameter"
-        )
+        msg = "Ordering with 'open_slots' is disallowed or the attribute does not exist on Pool model"
+        assert response.json['detail'] == msg
 
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self, session):

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -185,7 +185,7 @@ class TestGetPoolsPagination(TestBasePoolEndpoints):
             "/api/v1/pools?order_by=open_slots", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        msg = "Ordering with 'open_slots' is disallowed or the attribute does not exist on Pool model"
+        msg = "Ordering with 'open_slots' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
     @conf_vars({("api", "maximum_page_limit"): "150"})

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -68,7 +68,7 @@ class TestGetPools(TestBasePoolEndpoints):
         session.commit()
         result = session.query(Pool).all()
         assert len(result) == 2  # accounts for the default pool as well
-        response = self.client.get("/api/v1/pools?sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/pools", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert {
             "pools": [
@@ -98,9 +98,7 @@ class TestGetPools(TestBasePoolEndpoints):
         session.commit()
         result = session.query(Pool).all()
         assert len(result) == 2  # accounts for the default pool as well
-        response = self.client.get(
-            "/api/v1/pools?order_by=slots&sort=asc", environ_overrides={'REMOTE_USER': "test"}
-        )
+        response = self.client.get("/api/v1/pools?order_by=slots", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert {
             "pools": [
@@ -162,7 +160,7 @@ class TestGetPoolsPagination(TestBasePoolEndpoints):
         session.commit()
         result = session.query(Pool).count()
         assert result == 121  # accounts for default pool as well
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         pool_ids = [pool["name"] for pool in response.json["pools"]]
         assert pool_ids == expected_pool_ids

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -92,6 +92,15 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
         response = self.client.get("/api/v1/roles")
         assert_401(response)
 
+    def test_should_raises_400_for_invalid_order_by(self):
+        response = self.client.get(
+            "/api/v1/roles?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert (
+            response.json['detail'] == "Role model has no attribute 'invalid' specified in order_by parameter"
+        )
+
     def test_should_raise_403_forbidden(self):
         response = self.client.get("/api/v1/roles", environ_overrides={'REMOTE_USER': "test_no_permissions"})
         assert response.status_code == 403
@@ -119,7 +128,7 @@ class TestGetRolesEndpointPaginationandFilter(TestRoleEndpoint):
         ]
     )
     def test_can_handle_limit_and_offset(self, url, expected_roles):
-        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         existing_roles = set(EXISTING_ROLES)
         existing_roles.update(['Test', 'TestNoPermissions'])

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -97,9 +97,8 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
             "/api/v1/roles?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert (
-            response.json['detail'] == "Role model has no attribute 'invalid' specified in order_by parameter"
-        )
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on Role model"
+        assert response.json['detail'] == msg
 
     def test_should_raise_403_forbidden(self):
         response = self.client.get("/api/v1/roles", environ_overrides={'REMOTE_USER': "test_no_permissions"})

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -128,7 +128,7 @@ class TestGetRolesEndpointPaginationandFilter(TestRoleEndpoint):
         ]
     )
     def test_can_handle_limit_and_offset(self, url, expected_roles):
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         existing_roles = set(EXISTING_ROLES)
         existing_roles.update(['Test', 'TestNoPermissions'])

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -97,7 +97,7 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
             "/api/v1/roles?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on Role model"
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
     def test_should_raise_403_forbidden(self):

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -53,12 +53,17 @@ def configured_app(minimal_app_for_api):
 class TestTaskEndpoint:
     dag_id = "test_dag"
     task_id = "op1"
+    task_id2 = 'op2'
+    task1_start_date = datetime(2020, 6, 15)
+    task2_start_date = datetime(2020, 6, 16)
 
     @pytest.fixture(scope="class")
     def setup_dag(self, configured_app):
-        with DAG(self.dag_id, start_date=datetime(2020, 6, 15), doc_md="details") as dag:
-            DummyOperator(task_id=self.task_id)
+        with DAG(self.dag_id, start_date=self.task1_start_date, doc_md="details") as dag:
+            task1 = DummyOperator(task_id=self.task_id)
+            task2 = DummyOperator(task_id=self.task_id2, start_date=self.task2_start_date)
 
+        task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {dag.dag_id: dag}
         configured_app.dag_bag = dag_bag  # type:ignore
@@ -87,7 +92,7 @@ class TestGetTask(TestTaskEndpoint):
                 "module_path": "airflow.operators.dummy",
             },
             "depends_on_past": False,
-            "downstream_task_ids": [],
+            "downstream_task_ids": [self.task_id2],
             "end_date": None,
             "execution_timeout": None,
             "extra_links": [],
@@ -129,7 +134,7 @@ class TestGetTask(TestTaskEndpoint):
                 "module_path": "airflow.operators.dummy",
             },
             "depends_on_past": False,
-            "downstream_task_ids": [],
+            "downstream_task_ids": [self.task_id2],
             "end_date": None,
             "execution_timeout": None,
             "extra_links": [],
@@ -198,6 +203,33 @@ class TestGetTasks(TestTaskEndpoint):
                     "retries": 0.0,
                     "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
                     "retry_exponential_backoff": False,
+                    "start_date": "2020-06-16T00:00:00+00:00",
+                    "task_id": self.task_id2,
+                    "template_fields": [],
+                    "trigger_rule": "all_success",
+                    "ui_color": "#e8f7e4",
+                    "ui_fgcolor": "#000",
+                    "wait_for_downstream": False,
+                    "weight_rule": "downstream",
+                },
+                {
+                    "class_ref": {
+                        "class_name": "DummyOperator",
+                        "module_path": "airflow.operators.dummy",
+                    },
+                    "depends_on_past": False,
+                    "downstream_task_ids": [self.task_id2],
+                    "end_date": None,
+                    "execution_timeout": None,
+                    "extra_links": [],
+                    "owner": "airflow",
+                    "pool": "default_pool",
+                    "pool_slots": 1.0,
+                    "priority_weight": 1.0,
+                    "queue": "default",
+                    "retries": 0.0,
+                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+                    "retry_exponential_backoff": False,
                     "start_date": "2020-06-15T00:00:00+00:00",
                     "task_id": "op1",
                     "template_fields": [],
@@ -206,15 +238,43 @@ class TestGetTasks(TestTaskEndpoint):
                     "ui_fgcolor": "#000",
                     "wait_for_downstream": False,
                     "weight_rule": "downstream",
-                }
+                },
             ],
-            "total_entries": 1,
+            "total_entries": 2,
         }
         response = self.client.get(
             f"/api/v1/dags/{self.dag_id}/tasks", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
         assert response.json == expected
+
+    def test_should_respond_200_ascending_order_by_start_date(self):
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/tasks?sort=asc&order_by=start_date",
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 200
+        assert self.task1_start_date < self.task2_start_date
+        assert response.json['tasks'][0]['task_id'] == self.task_id
+        assert response.json['tasks'][1]['task_id'] == self.task_id2
+
+    def test_should_respond_200_descending_order_by_start_date(self):
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/tasks?order_by=start_date", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 200
+        # Default sort order is descending
+        assert self.task1_start_date < self.task2_start_date
+        assert response.json['tasks'][0]['task_id'] == self.task_id2
+        assert response.json['tasks'][1]['task_id'] == self.task_id
+
+    def test_should_raise_400_for_invalid_order_by_name(self):
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/tasks?order_by=invalid_task_colume_name",
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == "'DummyOperator' object has no attribute 'invalid_task_colume_name'"
 
     def test_should_respond_404(self):
         dag_id = "xxxx_not_existing"

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -191,33 +191,6 @@ class TestGetTasks(TestTaskEndpoint):
                         "module_path": "airflow.operators.dummy",
                     },
                     "depends_on_past": False,
-                    "downstream_task_ids": [],
-                    "end_date": None,
-                    "execution_timeout": None,
-                    "extra_links": [],
-                    "owner": "airflow",
-                    "pool": "default_pool",
-                    "pool_slots": 1.0,
-                    "priority_weight": 1.0,
-                    "queue": "default",
-                    "retries": 0.0,
-                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
-                    "retry_exponential_backoff": False,
-                    "start_date": "2020-06-16T00:00:00+00:00",
-                    "task_id": self.task_id2,
-                    "template_fields": [],
-                    "trigger_rule": "all_success",
-                    "ui_color": "#e8f7e4",
-                    "ui_fgcolor": "#000",
-                    "wait_for_downstream": False,
-                    "weight_rule": "downstream",
-                },
-                {
-                    "class_ref": {
-                        "class_name": "DummyOperator",
-                        "module_path": "airflow.operators.dummy",
-                    },
-                    "depends_on_past": False,
                     "downstream_task_ids": [self.task_id2],
                     "end_date": None,
                     "execution_timeout": None,
@@ -239,6 +212,33 @@ class TestGetTasks(TestTaskEndpoint):
                     "wait_for_downstream": False,
                     "weight_rule": "downstream",
                 },
+                {
+                    "class_ref": {
+                        "class_name": "DummyOperator",
+                        "module_path": "airflow.operators.dummy",
+                    },
+                    "depends_on_past": False,
+                    "downstream_task_ids": [],
+                    "end_date": None,
+                    "execution_timeout": None,
+                    "extra_links": [],
+                    "owner": "airflow",
+                    "pool": "default_pool",
+                    "pool_slots": 1.0,
+                    "priority_weight": 1.0,
+                    "queue": "default",
+                    "retries": 0.0,
+                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+                    "retry_exponential_backoff": False,
+                    "start_date": "2020-06-16T00:00:00+00:00",
+                    "task_id": self.task_id2,
+                    "template_fields": [],
+                    "trigger_rule": "all_success",
+                    "ui_color": "#e8f7e4",
+                    "ui_fgcolor": "#000",
+                    "wait_for_downstream": False,
+                    "weight_rule": "downstream",
+                },
             ],
             "total_entries": 2,
         }
@@ -250,7 +250,7 @@ class TestGetTasks(TestTaskEndpoint):
 
     def test_should_respond_200_ascending_order_by_start_date(self):
         response = self.client.get(
-            f"/api/v1/dags/{self.dag_id}/tasks?sort=asc&order_by=start_date",
+            f"/api/v1/dags/{self.dag_id}/tasks?order_by=start_date",
             environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 200
@@ -260,10 +260,11 @@ class TestGetTasks(TestTaskEndpoint):
 
     def test_should_respond_200_descending_order_by_start_date(self):
         response = self.client.get(
-            f"/api/v1/dags/{self.dag_id}/tasks?order_by=start_date", environ_overrides={'REMOTE_USER': "test"}
+            f"/api/v1/dags/{self.dag_id}/tasks?order_by=-start_date",
+            environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 200
-        # Default sort order is descending
+        # - means is descending
         assert self.task1_start_date < self.task2_start_date
         assert response.json['tasks'][0]['task_id'] == self.task_id2
         assert response.json['tasks'][1]['task_id'] == self.task_id

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -209,7 +209,7 @@ class TestGetUsersPagination(TestUserEndpoint):
         self.session.commit()
         response = self.client.get("/api/v1/users?order_by=myname", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 400
-        msg = "Ordering with 'myname' is disallowed or the attribute does not exist on User model"
+        msg = "Ordering with 'myname' is disallowed or the attribute does not exist on the model"
         assert response.json['detail'] == msg
 
     def test_limit_of_zero_should_return_default(self):

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -209,9 +209,8 @@ class TestGetUsersPagination(TestUserEndpoint):
         self.session.commit()
         response = self.client.get("/api/v1/users?order_by=myname", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 400
-        assert (
-            response.json['detail'] == "User model has no attribute 'myname' specified in order_by parameter"
-        )
+        msg = "Ordering with 'myname' is disallowed or the attribute does not exist on User model"
+        assert response.json['detail'] == msg
 
     def test_limit_of_zero_should_return_default(self):
         users = self._create_users(200)

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -125,7 +125,7 @@ class TestGetUser(TestUserEndpoint):
 
 class TestGetUsers(TestUserEndpoint):
     def test_should_response_200(self):
-        response = self.client.get("/api/v1/users?sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/users", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert response.json["total_entries"] == 2
         usernames = [user["username"] for user in response.json["users"] if user]
@@ -186,7 +186,7 @@ class TestGetUsersPagination(TestUserEndpoint):
         users = self._create_users(10)
         self.session.add_all(users)
         self.session.commit()
-        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         assert response.json["total_entries"] == 12
         usernames = [user["username"] for user in response.json["users"] if user]

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -129,7 +129,7 @@ class TestGetVariables(TestVariableEndpoint):
     @parameterized.expand(
         [
             (
-                "/api/v1/variables?limit=2&offset=0",
+                "/api/v1/variables?limit=2&offset=0&sort=asc",
                 {
                     "variables": [
                         {"key": "var1", "value": "1"},
@@ -139,7 +139,7 @@ class TestGetVariables(TestVariableEndpoint):
                 },
             ),
             (
-                "/api/v1/variables?limit=2&offset=1",
+                "/api/v1/variables?limit=2&offset=1&sort=asc",
                 {
                     "variables": [
                         {"key": "var2", "value": "foo"},
@@ -149,7 +149,7 @@ class TestGetVariables(TestVariableEndpoint):
                 },
             ),
             (
-                "/api/v1/variables?limit=1&offset=2",
+                "/api/v1/variables?limit=1&offset=2&sort=asc",
                 {
                     "variables": [
                         {"key": "var3", "value": "[100, 101]"},
@@ -174,6 +174,18 @@ class TestGetVariables(TestVariableEndpoint):
         assert response.status_code == 200
         assert response.json["total_entries"] == 101
         assert len(response.json["variables"]) == 100
+
+    def test_should_raise_400_for_invalid_order_by(self):
+        for i in range(101):
+            Variable.set(f"var{i}", i)
+        response = self.client.get(
+            "/api/v1/variables?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert (
+            response.json["detail"]
+            == "Variable model has no attribute 'invalid' specified in order_by parameter"
+        )
 
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self):

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -182,10 +182,8 @@ class TestGetVariables(TestVariableEndpoint):
             "/api/v1/variables?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        assert (
-            response.json["detail"]
-            == "Variable model has no attribute 'invalid' specified in order_by parameter"
-        )
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on Variable model"
+        assert response.json["detail"] == msg
 
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self):

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -182,7 +182,7 @@ class TestGetVariables(TestVariableEndpoint):
             "/api/v1/variables?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 400
-        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on Variable model"
+        msg = "Ordering with 'invalid' is disallowed or the attribute does not exist on the model"
         assert response.json["detail"] == msg
 
     @conf_vars({("api", "maximum_page_limit"): "150"})

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -129,7 +129,7 @@ class TestGetVariables(TestVariableEndpoint):
     @parameterized.expand(
         [
             (
-                "/api/v1/variables?limit=2&offset=0&sort=asc",
+                "/api/v1/variables?limit=2&offset=0",
                 {
                     "variables": [
                         {"key": "var1", "value": "1"},
@@ -139,7 +139,7 @@ class TestGetVariables(TestVariableEndpoint):
                 },
             ),
             (
-                "/api/v1/variables?limit=2&offset=1&sort=asc",
+                "/api/v1/variables?limit=2&offset=1",
                 {
                     "variables": [
                         {"key": "var2", "value": "foo"},
@@ -149,7 +149,7 @@ class TestGetVariables(TestVariableEndpoint):
                 },
             ),
             (
-                "/api/v1/variables?limit=1&offset=2&sort=asc",
+                "/api/v1/variables?limit=1&offset=2",
                 {
                     "variables": [
                         {"key": "var3", "value": "[100, 101]"},


### PR DESCRIPTION
This change adds ordering to the REST API endpoints. 

The get taskinstances and dags endpoint are excluded in this PR

Part of https://github.com/apache/airflow/issues/14803

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
