### PR TITLE
Add ability to specify api group and version for Spark operators

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -36,6 +36,10 @@ class SparkKubernetesOperator(BaseOperator):
     :type namespace: str
     :param kubernetes_conn_id: the connection to Kubernetes cluster
     :type kubernetes_conn_id: str
+    :param api_group: kubernetes api group of sparkApplication
+    :type api_group: str
+    :param api_version: kubernetes api version of sparkApplication
+    :type api_version: str
     """
 
     template_fields = ['application_file', 'namespace']
@@ -49,19 +53,23 @@ class SparkKubernetesOperator(BaseOperator):
         application_file: str,
         namespace: Optional[str] = None,
         kubernetes_conn_id: str = 'kubernetes_default',
+        api_group: str = 'sparkoperator.k8s.io',
+        api_version: str = 'v1beta2',
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.application_file = application_file
         self.namespace = namespace
         self.kubernetes_conn_id = kubernetes_conn_id
+        self.api_group = api_group
+        self.api_version = api_version
 
     def execute(self, context):
         self.log.info("Creating sparkApplication")
         hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
         response = hook.create_custom_object(
-            group="sparkoperator.k8s.io",
-            version="v1beta2",
+            group=self.api_group,
+            version=self.api_version,
             plural="sparkapplications",
             body=self.application_file,
             namespace=self.namespace,

--- a/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -41,6 +41,10 @@ class SparkKubernetesSensor(BaseSensorOperator):
     :type kubernetes_conn_id: str
     :param attach_log: determines whether logs for driver pod should be appended to the sensor log
     :type attach_log: bool
+    :param api_group: kubernetes api group of sparkApplication
+    :type api_group: str
+    :param api_version: kubernetes api version of sparkApplication
+    :type api_version: str
     """
 
     template_fields = ("application_name", "namespace")
@@ -55,6 +59,8 @@ class SparkKubernetesSensor(BaseSensorOperator):
         attach_log: bool = False,
         namespace: Optional[str] = None,
         kubernetes_conn_id: str = "kubernetes_default",
+        api_group: str = 'sparkoperator.k8s.io',
+        api_version: str = 'v1beta2',
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -63,6 +69,8 @@ class SparkKubernetesSensor(BaseSensorOperator):
         self.namespace = namespace
         self.kubernetes_conn_id = kubernetes_conn_id
         self.hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
+        self.api_group = api_group
+        self.api_version = api_version
 
     def _log_driver(self, application_state: str, response: dict) -> None:
         if not self.attach_log:
@@ -93,8 +101,8 @@ class SparkKubernetesSensor(BaseSensorOperator):
     def poke(self, context: Dict) -> bool:
         self.log.info("Poking: %s", self.application_name)
         response = self.hook.get_custom_object(
-            group="sparkoperator.k8s.io",
-            version="v1beta2",
+            group=self.api_group,
+            version=self.api_version,
             plural="sparkapplications",
             name=self.application_name,
             namespace=self.namespace,

--- a/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/operators/test_spark_kubernetes.py
@@ -213,6 +213,30 @@ class TestSparkKubernetesOperator(unittest.TestCase):
         )
 
     @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
+    def test_create_application_from_json_with_api_group_and_version(
+        self, mock_create_namespaced_crd, mock_kubernetes_hook
+    ):
+        api_group = 'sparkoperator.example.com'
+        api_version = 'v1alpha1'
+        op = SparkKubernetesOperator(
+            application_file=TEST_VALID_APPLICATION_JSON,
+            dag=self.dag,
+            kubernetes_conn_id='kubernetes_default_kube_config',
+            task_id='test_task_id',
+            api_group=api_group,
+            api_version=api_version,
+        )
+        op.execute(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_create_namespaced_crd.assert_called_with(
+            body=TEST_APPLICATION_DICT,
+            group=api_group,
+            namespace='default',
+            plural='sparkapplications',
+            version=api_version,
+        )
+
+    @patch('kubernetes.client.api.custom_objects_api.CustomObjectsApi.create_namespaced_custom_object')
     def test_namespace_from_operator(self, mock_create_namespaced_crd, mock_kubernetes_hook):
         op = SparkKubernetesOperator(
             application_file=TEST_VALID_APPLICATION_JSON,

--- a/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
+++ b/tests/providers/cncf/kubernetes/sensors/test_spark_kubernetes.py
@@ -664,6 +664,31 @@ class TestSparkKubernetesSensor(unittest.TestCase):
         "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
         return_value=TEST_COMPLETED_APPLICATION,
     )
+    def test_api_group_and_version_from_sensor(self, mock_get_namespaced_crd, mock_kubernetes_hook):
+        api_group = 'sparkoperator.example.com'
+        api_version = 'v1alpha1'
+        sensor = SparkKubernetesSensor(
+            application_name="spark_pi",
+            dag=self.dag,
+            kubernetes_conn_id="kubernetes_with_namespace",
+            task_id="test_task_id",
+            api_group=api_group,
+            api_version=api_version,
+        )
+        sensor.poke(None)
+        mock_kubernetes_hook.assert_called_once_with()
+        mock_get_namespaced_crd.assert_called_once_with(
+            group=api_group,
+            name="spark_pi",
+            namespace="mock_namespace",
+            plural="sparkapplications",
+            version=api_version,
+        )
+
+    @patch(
+        "kubernetes.client.api.custom_objects_api.CustomObjectsApi.get_namespaced_custom_object",
+        return_value=TEST_COMPLETED_APPLICATION,
+    )
     def test_namespace_from_connection(self, mock_get_namespaced_crd, mock_kubernetes_hook):
         sensor = SparkKubernetesSensor(
             application_name="spark_pi",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #14897
There were added two parameters for `SparkKubernetesOperator` and `SparkKubernetesSensor`. I've placed them in the end and provided default values, so there will be backward compatibility. 
Also added description and tests.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
