### PR TITLE
Remove dags_folder path from dag.fileloc

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1100,7 +1100,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                 ignore_task_deps=False,
                 ignore_ti_state=False,
                 pool=ti.pool,
-                file_path=ti.dag_model.fileloc,
+                file_path=ti.dag_model.file_path,
                 pickle_id=ti.dag_model.pickle_id,
             )
 

--- a/tests/utils/test_file.py
+++ b/tests/utils/test_file.py
@@ -20,7 +20,8 @@ import os.path
 import unittest
 from unittest import mock
 
-from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
+from airflow.settings import DAGS_FOLDER
+from airflow.utils.file import clean_dag_fileloc, correct_maybe_zipped, expand_fileloc, open_maybe_zipped
 from tests.models import TEST_DAGS_FOLDER
 
 
@@ -75,3 +76,29 @@ class TestOpenMaybeZipped(unittest.TestCase):
         with open_maybe_zipped(test_file_path, 'r') as test_file:
             content = test_file.read()
         assert isinstance(content, str)
+
+
+class TestCleanDagFileloc(unittest.TestCase):
+    def test_dag_in_dags_folder(self):
+        path = DAGS_FOLDER + '/no_dags.py'
+        cleaned_path = clean_dag_fileloc(path)
+        assert cleaned_path == 'no_dags.py'
+
+    def test_dag_not_in_dags_folder(self):
+        # such as an example dag
+        path = '/path/to/fake/dag.py'
+        cleaned_path = clean_dag_fileloc(path)
+        assert cleaned_path == path
+
+
+class TestExpandDagFileloc(unittest.TestCase):
+    def test_dag_in_dags_folder(self):
+        path = DAGS_FOLDER + '/no_dags.py'
+        expanded_path = expand_fileloc('no_dags.py')
+        assert path == expanded_path
+
+    def test_dag_not_in_dags_folder(self):
+        # such as an example dag
+        path = '/path/to/fake/dag.py'
+        expanded_path = expand_fileloc(path)
+        assert expanded_path == path


### PR DESCRIPTION
Removes the dags_filepath from the fileloc that is saved to the database. This is to support deployments where for one reason or another the scheduler and workers are unable to have dags in the same path.

closes: https://github.com/apache/airflow/issues/8061


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
