### PR TITLE
Simplify cleaning string passed to origin param (#14738)

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -129,18 +129,14 @@ def get_safe_url(url):
 
     parsed = urlparse(url)
 
-    # If the url is relative & it contains semicolon, redirect it to homepage to avoid
+    # If the url contains semicolon, redirect it to homepage to avoid
     # potential XSS. (Similar to https://github.com/python/cpython/pull/24297/files (bpo-42967))
-    if parsed.netloc == '' and parsed.scheme == '' and ';' in unquote(url):
+    if ';' in unquote(url):
         return url_for('Airflow.index')
 
     query = parse_qsl(parsed.query, keep_blank_values=True)
 
-    # Remove all the query elements containing semicolon
-    # As part of https://github.com/python/cpython/pull/24297/files (bpo-42967)
-    # semicolon was already removed as a separator for query arguments by default
-    sanitized_query = [query_arg for query_arg in query if ';' not in query_arg[1]]
-    url = parsed._replace(query=urlencode(sanitized_query)).geturl()
+    url = parsed._replace(query=urlencode(query)).geturl()
 
     if parsed.scheme in valid_schemes and parsed.netloc in valid_netlocs:
         return url

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -3353,15 +3353,15 @@ class TestHelperFunctions(TestBase):
             ("36539'%3balert(1)%2f%2f166", "/home"),
             (
                 "http://localhost:8080/trigger?dag_id=test&origin=36539%27%3balert(1)%2f%2f166&abc=2",
-                "http://localhost:8080/trigger?dag_id=test&abc=2",
+                "/home",
             ),
             (
                 "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%test_dag';alert(33)//",
-                "http://localhost:8080/trigger?dag_id=test_dag",
+                "/home",
             ),
             (
-                "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%test_dag",
-                "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%25test_dag",
+                "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%3Dtest_dag",
+                "http://localhost:8080/trigger?dag_id=test_dag&origin=%2Ftree%3Fdag_id%3Dtest_dag",
             ),
         ]
     )


### PR DESCRIPTION
Looks like "trying to be smart approach" in https://github.com/apache/airflow/pull/14738
does not work on old Python versions. The "smart" part being if semicolon exists in URL
only those specific query argument were removed. While this solves the issue for Py 3.6.13
 it didn't fix for 3.6.12 (although it minimzed it).

Python 3.6.12:

```python
>>> parse_qsl("r=3;a=b")
[('r', '3'), ('a', 'b')]
```

Python 3.6.13:

```python
>>> parse_qsl("r=3;a=b")
[('r', '3;a=b')]
```

This commit simplifies it and check if the url contains `;`, it just redirects to
`/home`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
