### PR TITLE
Upgrade rule to suggest to rename max_threads to parsing_processes

### DIFF
--- a/airflow/upgrade/rules/parsing_processes_configuration_rule.py
+++ b/airflow/upgrade/rules/parsing_processes_configuration_rule.py
@@ -36,5 +36,6 @@ class ParsingProcessesConfigurationRule(BaseRule):
             old_config_value = conf.get("scheduler", "max_threads")
             if old_config_value == default:
                 return None
-            return ["Please rename the max_threads configuration in the [scheduler] section to parsing_processes."]
+            return ["Please rename the max_threads configuration in the "
+                    "[scheduler] section to parsing_processes."]
         return None

--- a/airflow/upgrade/rules/parsing_processes_configuration_rule.py
+++ b/airflow/upgrade/rules/parsing_processes_configuration_rule.py
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.base_rule import BaseRule
+
+
+class ParsingProcessesConfigurationRule(BaseRule):
+    title = "Rename max_threads to parsing_processes"
+
+    description = "The max_threads configuration in the [scheduler] section was renamed to parsing_processes."
+
+    def check(self):
+        default = 2
+
+        old_config_exists = conf.has_option("scheduler", "max_threads")
+        new_config_exists = conf.has_option("scheduler", "parsing_processes")
+
+        if old_config_exists and not new_config_exists:
+            old_config_value = conf.get("scheduler", "max_threads")
+            if old_config_value == default:
+                return None
+            return ["Please rename the max_threads configuration in the [scheduler] section to parsing_processes."]
+        return None

--- a/tests/upgrade/rules/test_parsing_processes_configuration_rule.py
+++ b/tests/upgrade/rules/test_parsing_processes_configuration_rule.py
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.configuration import conf
+from airflow.upgrade.rules.parsing_processes_configuration_rule import ParsingProcessesConfigurationRule
+from tests.test_utils.config import conf_vars
+
+
+class TestParsingProcessesConfigurationRule(TestCase):
+    @conf_vars(
+        {
+            ("scheduler", "parsing_processes"): "DUMMY",
+        }
+    )
+    def test_check_new_config(self):
+        rule = ParsingProcessesConfigurationRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        # Remove the fallback option
+        conf.deprecated_options.get("scheduler", {}).pop("parsing_processes", "")
+        conf.remove_option("scheduler", "parsing_processes")
+
+        response = rule.check()
+        assert response is None
+
+    @conf_vars(
+        {
+            ("scheduler", "max_threads"): "DUMMY",
+        }
+    )
+    def test_check_old_config(self):
+        rule = ParsingProcessesConfigurationRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        # Remove the fallback option
+        conf.deprecated_options.get("scheduler", {}).pop("parsing_processes", "")
+        conf.remove_option("scheduler", "parsing_processes")
+
+        response = rule.check()
+        assert response == \
+               ["Please rename the max_threads configuration in the [scheduler] section to parsing_processes."]

--- a/tests/upgrade/rules/test_parsing_processes_configuration_rule.py
+++ b/tests/upgrade/rules/test_parsing_processes_configuration_rule.py
@@ -57,4 +57,5 @@ class TestParsingProcessesConfigurationRule(TestCase):
 
         response = rule.check()
         assert response == \
-               ["Please rename the max_threads configuration in the [scheduler] section to parsing_processes."]
+               ["Please rename the max_threads configuration in the "
+                "[scheduler] section to parsing_processes."]


### PR DESCRIPTION
This adds an upgrade rule as described in #12672 to rename the max_threads configuration to parsing_processes.

I created this rule on the example of the `LoggingConfigurationRule`, which doesn't suggest any changes if the old configuration exists but has the default value. I assume, that the idea behind this is, that if the configuration is not set by the user, a default configuration is taken. However, if a user explicitly copied the default configuration in his or her own configuration, in my opinion, a change should be suggested but isn't. But maybe I misunderstood something.