### PR TITLE
Make script_args templated in AwsGlueJobOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -39,7 +39,7 @@ class AwsGlueJobOperator(BaseOperator):
     :type job_desc: Optional[str]
     :param concurrent_run_limit: The maximum number of concurrent runs allowed for a job
     :type concurrent_run_limit: Optional[int]
-    :param script_args: etl script arguments and AWS Glue arguments
+    :param script_args: etl script arguments and AWS Glue arguments (templated)
     :type script_args: dict
     :param retry_limit: The maximum number of times to retry this job if it fails
     :type retry_limit: Optional[int]
@@ -55,7 +55,7 @@ class AwsGlueJobOperator(BaseOperator):
     :type create_job_kwargs: Optional[dict]
     """
 
-    template_fields = ()
+    template_fields = ('script_args',)
     template_ext = ()
     ui_color = '#ededed'
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This makes `script_args` a templated field in AwsGlueJobOperator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
