### PR TITLE
Adds initial router, routes, and placeholder views 

### DIFF
--- a/airflow/ui/.neutrinorc.js
+++ b/airflow/ui/.neutrinorc.js
@@ -37,6 +37,7 @@ module.exports = {
       // Aliases for internal modules
       neutrino.config.resolve.alias.set('root', resolve(__dirname));
       neutrino.config.resolve.alias.set('src', resolve(__dirname, 'src'));
+      neutrino.config.resolve.alias.set('views', resolve(__dirname, 'src/views'));
     },
     typescript(),
     // Modify typescript config in .tsconfig.json

--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -16,7 +16,8 @@
     "framer-motion": "^3.10.0",
     "react": "^16",
     "react-dom": "^16",
-    "react-hot-loader": "^4"
+    "react-hot-loader": "^4",
+    "react-router-dom": "^5.2.0"
   },
   "devDependencies": {
     "@neutrinojs/eslint": "^9.5.0",
@@ -27,8 +28,10 @@
     "@types/jest": "^26.0.20",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.2",
+    "@types/react-router-dom": "^5.1.7",
     "eslint": "^7",
     "eslint-config-airbnb-typescript": "^12.3.1",
+    "history": "^5.0.0",
     "jest": "^26",
     "neutrino": "^9.5.0",
     "neutrinojs-typescript": "^1.1.6",

--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -40,8 +40,5 @@
     "webpack": "^4",
     "webpack-cli": "^3",
     "webpack-dev-server": "^3"
-  },
-  "resolutions": {
-    "framer-motion": "3.6.7"
   }
 }

--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -40,5 +40,8 @@
     "webpack": "^4",
     "webpack-cli": "^3",
     "webpack-dev-server": "^3"
+  },
+  "resolutions": {
+    "framer-motion": "3.6.7"
   }
 }

--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -31,6 +31,8 @@
     "@types/react-router-dom": "^5.1.7",
     "eslint": "^7",
     "eslint-config-airbnb-typescript": "^12.3.1",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
     "history": "^5.0.0",
     "jest": "^26",
     "neutrino": "^9.5.0",

--- a/airflow/ui/src/App.tsx
+++ b/airflow/ui/src/App.tsx
@@ -19,12 +19,43 @@
 
 import { hot } from 'react-hot-loader';
 import React from 'react';
-import { Center, Heading } from '@chakra-ui/react';
+import { Route, Redirect, Switch } from 'react-router-dom';
+
+import Pipelines from 'views/Pipelines';
+import Pipeline from 'views/Pipeline';
+
+import EventLogs from 'views/Activity/EventLogs';
+
+import Config from 'views/Config';
+
+import Access from 'views/Access';
+import Users from 'views/Access/Users';
+import Roles from 'views/Access/Roles';
+
+import Docs from 'views/Docs';
+import NotFound from 'views/NotFound';
 
 const App = () => (
-  <Center height="100vh">
-    <Heading>Apache Airflow new UI</Heading>
-  </Center>
+  <Switch>
+    <Redirect exact path="/" to="/pipelines" />
+    <Route exact path="/pipelines" component={Pipelines} />
+    <Route exact path="/pipelines/:dagId" component={Pipeline} />
+
+    <Route exact path="/activity/event-logs" component={EventLogs} />
+
+    <Route exact path="/config" component={Config} />
+
+    <Route exact path="/access" component={Access} />
+    <Route exact path="/access/users" component={Users} />
+    <Route exact path="/access/users/new" component={Users} />
+    <Route exact path="/access/users/:id" component={Users} />
+    <Route exact path="/access/users/:id/edit" component={Users} />
+    <Route exact path="/access/roles" component={Roles} />
+
+    <Route exact path="/docs" component={Docs} />
+
+    <Route component={NotFound} />
+  </Switch>
 );
 
 export default hot(module)(App);

--- a/airflow/ui/src/App.tsx
+++ b/airflow/ui/src/App.tsx
@@ -48,8 +48,8 @@ const App = () => (
     <Route exact path="/access" component={Access} />
     <Route exact path="/access/users" component={Users} />
     <Route exact path="/access/users/new" component={Users} />
-    <Route exact path="/access/users/:id" component={Users} />
-    <Route exact path="/access/users/:id/edit" component={Users} />
+    <Route exact path="/access/users/:username" component={Users} />
+    <Route exact path="/access/users/:username/edit" component={Users} />
     <Route exact path="/access/roles" component={Roles} />
 
     <Route exact path="/docs" component={Docs} />

--- a/airflow/ui/src/index.tsx
+++ b/airflow/ui/src/index.tsx
@@ -19,14 +19,17 @@
 
 import React from 'react';
 import { render } from 'react-dom';
+import { BrowserRouter } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
 
 import App from './App';
 import theme from './theme';
 
 render(
-  <ChakraProvider theme={theme}>
-    <App />
-  </ChakraProvider>,
+  <BrowserRouter basename="/">
+    <ChakraProvider theme={theme}>
+      <App />
+    </ChakraProvider>
+  </BrowserRouter>,
   document.getElementById('root'),
 );

--- a/airflow/ui/src/views/Access/Roles.tsx
+++ b/airflow/ui/src/views/Access/Roles.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Roles: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Roles</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Roles;

--- a/airflow/ui/src/views/Access/Users.tsx
+++ b/airflow/ui/src/views/Access/Users.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Users: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Users</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Users;

--- a/airflow/ui/src/views/Access/index.tsx
+++ b/airflow/ui/src/views/Access/index.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Access: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Access</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Access;

--- a/airflow/ui/src/views/Activity/EventLogs.tsx
+++ b/airflow/ui/src/views/Activity/EventLogs.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const EventLogs: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Event Logs</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default EventLogs;

--- a/airflow/ui/src/views/Config/index.tsx
+++ b/airflow/ui/src/views/Config/index.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Config: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Config</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Config;

--- a/airflow/ui/src/views/Docs.tsx
+++ b/airflow/ui/src/views/Docs.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Docs: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Docs</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Docs;

--- a/airflow/ui/src/views/NotFound.tsx
+++ b/airflow/ui/src/views/NotFound.tsx
@@ -18,34 +18,27 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Link as RouterLink } from 'react-router-dom';
+import {
+  Center,
+  Box,
+  Heading,
+  Link,
+} from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const NotFound: React.FC = () => (
+  <Center mt="50px">
+    <Box textAlign="center">
+      <Heading>Page not found</Heading>
+      <Link
+        as={RouterLink}
+        to="/"
+        color="teal.500"
+      >
+        Return to the main page
+      </Link>
+    </Box>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default NotFound;

--- a/airflow/ui/src/views/Pipeline/index.tsx
+++ b/airflow/ui/src/views/Pipeline/index.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Pipeline: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Pipeline</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Pipeline;

--- a/airflow/ui/src/views/Pipelines.tsx
+++ b/airflow/ui/src/views/Pipelines.tsx
@@ -18,34 +18,12 @@
  */
 
 import React from 'react';
-import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
-import { createMemoryHistory } from 'history';
+import { Center, Heading } from '@chakra-ui/react';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+const Pipelines: React.FC = () => (
+  <Center height="100vh">
+    <Heading>Pipelines</Heading>
+  </Center>
+);
 
-test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
-  const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
-  );
-
-  expect(getByText('Pipelines')).toBeInTheDocument();
-});
-
-test('Bad route', () => {
-  const history = createMemoryHistory();
-  history.push('/invalid-path');
-  const { getByText } = render(
-    <Router history={history}>
-      <NotFound />
-    </Router>,
-  );
-
-  expect(getByText('Page not found')).toBeInTheDocument();
-});
+export default Pipelines;

--- a/airflow/ui/test/App.test.tsx
+++ b/airflow/ui/test/App.test.tsx
@@ -19,33 +19,34 @@
 
 import React from 'react';
 import '@testing-library/jest-dom';
-import { Router } from 'react-router-dom';
+import { Router, BrowserRouter } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 
-import Pipelines from 'views/Pipelines';
-import NotFound from 'views/NotFound';
+import App from 'App';
 
 test('Root path redirects to Pipelines view', () => {
-  const history = createMemoryHistory();
-  history.push('/');
+  // Redirect is not working in <Router /> for some reason
   const { getByText } = render(
-    <Router history={history}>
-      <Pipelines />
-    </Router>,
+    <BrowserRouter basename="/">
+      <App />
+    </BrowserRouter>,
   );
 
   expect(getByText('Pipelines')).toBeInTheDocument();
 });
 
-test('Bad route', () => {
+test('App displays 404 page on a bad route', () => {
   const history = createMemoryHistory();
-  history.push('/invalid-path');
+  history.push('/pipelines');
   const { getByText } = render(
     <Router history={history}>
-      <NotFound />
+      <App />
     </Router>,
   );
 
+  expect(getByText('Pipelines')).toBeInTheDocument();
+
+  history.push('/invalid-path');
   expect(getByText('Page not found')).toBeInTheDocument();
 });

--- a/airflow/ui/tsconfig.json
+++ b/airflow/ui/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "jsx": "preserve",
     // baseUrl allows to absolute paths but you also have to add the alias in .neutrinorc.js
     "baseUrl": "src",

--- a/airflow/ui/yarn.lock
+++ b/airflow/ui/yarn.lock
@@ -4960,6 +4960,19 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+framer-motion@3.6.7:
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-3.6.7.tgz#b9b40db52ecb2390757f7c556846e3b4bf949330"
+  integrity sha512-3DqvW+Ab69dL54gn0YvrWz4+Gg8PCgvXH9Rknx4OXJ226vYzpSjc3imHBM4h974ndVvb8C4/Z3/PyZigEh8m2A==
+  dependencies:
+    framesync "^5.1.0"
+    hey-listen "^1.0.8"
+    popmotion "9.2.1"
+    style-value-types "4.0.3"
+    tslib "^1.10.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
+
 framer-motion@^3.10.0:
   version "3.10.6"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-3.10.6.tgz#67737ef05ed0408860751d81c919770ac831b394"
@@ -4973,7 +4986,12 @@ framer-motion@^3.10.0:
   optionalDependencies:
     "@emotion/is-prop-valid" "^0.8.2"
 
-framesync@5.2.0:
+framesync@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/framesync/-/framesync-5.1.0.tgz#b22639be6e83cf170e5cb3d0497e3e50100a01ef"
+  integrity sha512-31sDH8LxSFoLKDYENzKdI+YJD4vV8sMBpwcAW0/6Es2jZBQBdlqbFnqrYczpsnzpqG+y6EqYPvgFMI2ZDdlnyQ==
+
+framesync@5.2.0, framesync@^5.1.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/framesync/-/framesync-5.2.0.tgz#f14480654cd05a6af4c72c9890cad93556841643"
   integrity sha512-dcl92w5SHc0o6pRK3//VBVNvu6WkYkiXmHG6ZIXrVzmgh0aDYMDAaoA3p3LH71JIdN5qmhDcfONFA4Lmq22tNA==
@@ -7687,6 +7705,16 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+popmotion@9.2.1:
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.2.1.tgz#8bc19214a4f0ba7925a901455d0996131cbec6dc"
+  integrity sha512-kplHK5z2LwYkUXNMCC4+tSYuuAXcG3oatKdsEzJzc1r0I2wM5UnYKITO1ZUnmmFy84VJqIZuoBXwJrWuZuAKkg==
+  dependencies:
+    framesync "5.1.0"
+    hey-listen "^1.0.8"
+    style-value-types "4.0.3"
+    tslib "^1.10.0"
+
 popmotion@9.3.1:
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.3.1.tgz#134319ed4b9b8e3ec506c99064f7b2f14bc05781"
@@ -9109,6 +9137,14 @@ style-loader@^1.3.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
+
+style-value-types@4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-4.0.3.tgz#3e2e46c50e876757cba02f442c8a0b0dd970c118"
+  integrity sha512-Yk2kpwC88W2HRlJXegWlT0pfLzjKWMjj8DI4s6m2VsZsL1Ht2oUyHl1EgTYIRlFiAnC4rBSQO+EEn0YiYAxQDw==
+  dependencies:
+    hey-listen "^1.0.8"
+    tslib "^1.10.0"
 
 style-value-types@4.1.1:
   version "4.1.1"

--- a/airflow/ui/yarn.lock
+++ b/airflow/ui/yarn.lock
@@ -898,7 +898,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -2094,6 +2094,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/lodash.mergewith@4.6.6":
   version "4.6.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.6.tgz#c4698f5b214a433ff35cb2c75ee6ec7f99d79f10"
@@ -2727,6 +2732,15 @@ array-unique@^0.3.2:
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
+array.prototype.flat@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
+  integrity sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
+
 array.prototype.flatmap@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
@@ -2771,6 +2785,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
 ast-types@0.9.6:
   version "0.9.6"
@@ -2818,6 +2837,16 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axe-core@^4.0.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.3.tgz#64a4c85509e0991f5168340edc4bedd1ceea6966"
+  integrity sha512-vwPpH4Aj4122EW38mxO/fxhGKtwWTMLDIJfZ1He0Edbtjcfna/R3YB67yVhezUMzqc3Jr3+Ii50KRntlENL4xQ==
+
+axobject-query@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
+  integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
 babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
@@ -3597,6 +3626,11 @@ constants-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
+
 content-disposition@0.5.3:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.3.tgz#e130caf7e7279087c5616c2007d0485698984fbd"
@@ -3852,6 +3886,11 @@ cyclist@^1.0.1:
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
+damerau-levenshtein@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
+  integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -3868,7 +3907,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
+debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -4077,6 +4116,14 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
@@ -4217,6 +4264,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.0.0:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
 emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
@@ -4267,7 +4319,7 @@ errno@^0.1.3, errno@~0.1.7:
   dependencies:
     prr "~1.0.1"
 
-error-ex@^1.3.1:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
@@ -4377,6 +4429,14 @@ eslint-config-airbnb@^18.2.0:
     object.assign "^4.1.2"
     object.entries "^1.1.2"
 
+eslint-import-resolver-node@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.13.1"
+
 eslint-loader@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-4.0.2.tgz#386a1e21bcb613b3cf2d252a3b708023ccfb41ec"
@@ -4388,6 +4448,14 @@ eslint-loader@^4.0.2:
     object-hash "^2.0.3"
     schema-utils "^2.6.5"
 
+eslint-module-utils@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
+  integrity sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
+  dependencies:
+    debug "^2.6.9"
+    pkg-dir "^2.0.0"
+
 eslint-plugin-babel@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz#75a2413ffbf17e7be57458301c60291f2cfbf560"
@@ -4395,12 +4463,48 @@ eslint-plugin-babel@^5.3.1:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
+eslint-plugin-import@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz#0896c7e6a0cf44109a2d97b95903c2bb689d7702"
+  integrity sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
+  dependencies:
+    array-includes "^3.1.1"
+    array.prototype.flat "^1.2.3"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.4"
+    eslint-module-utils "^2.6.0"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.1"
+    read-pkg-up "^2.0.0"
+    resolve "^1.17.0"
+    tsconfig-paths "^3.9.0"
+
 eslint-plugin-jest@^23.20.0:
   version "23.20.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz#e1d69c75f639e99d836642453c4e75ed22da4099"
   integrity sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
+
+eslint-plugin-jsx-a11y@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz#a2d84caa49756942f42f1ffab9002436391718fd"
+  integrity sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    aria-query "^4.2.2"
+    array-includes "^3.1.1"
+    ast-types-flow "^0.0.7"
+    axe-core "^4.0.2"
+    axobject-query "^2.2.0"
+    damerau-levenshtein "^1.0.6"
+    emoji-regex "^9.0.0"
+    has "^1.0.3"
+    jsx-ast-utils "^3.1.0"
+    language-tags "^1.0.5"
 
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
@@ -4863,6 +4967,13 @@ find-root@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
   integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -6558,7 +6669,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-"jsx-ast-utils@^2.4.1 || ^3.0.0":
+"jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz#41108d2cec408c3453c1bbe8a4aae9e1e2bd8f82"
   integrity sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==
@@ -6600,6 +6711,18 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+language-subtag-registry@~0.3.2:
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz#04ac218bea46f04cb039084602c6da9e788dd45a"
+  integrity sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
+  dependencies:
+    language-subtag-registry "~0.3.2"
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-3.1.0.tgz#77891de834064cccba82ae7842bb6b14a13ed7f2"
@@ -6626,6 +6749,16 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -6648,6 +6781,14 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -7165,7 +7306,7 @@ node-releases@^1.1.70:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.71.tgz#cb1334b179896b1c89ecfdd4b725fb7bbdfc7dbb"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
 
-normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -7419,12 +7560,26 @@ p-finally@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -7451,6 +7606,11 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -7503,6 +7663,13 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
+
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  integrity sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=
+  dependencies:
+    error-ex "^1.2.0"
 
 parse-json@^5.0.0:
   version "5.2.0"
@@ -7599,6 +7766,13 @@ path-to-regexp@^1.7.0:
   dependencies:
     isarray "0.0.1"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+  dependencies:
+    pify "^2.0.0"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -7665,6 +7839,13 @@ pirates@^4.0.1:
   integrity sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
   dependencies:
     node-modules-regexp "^1.0.0"
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
 
 pkg-dir@^3.0.0:
   version "3.0.0"
@@ -8103,6 +8284,14 @@ react@^16:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -8111,6 +8300,15 @@ read-pkg-up@^7.0.1:
     find-up "^4.1.0"
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read-pkg@^5.2.0:
   version "5.2.0"
@@ -8387,7 +8585,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.18.1:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -9068,6 +9266,11 @@ strip-ansi@^6.0.0:
   dependencies:
     ansi-regex "^5.0.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
 strip-bom@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
@@ -9336,6 +9539,16 @@ tr46@^2.0.2:
   integrity sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
   dependencies:
     punycode "^2.1.1"
+
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"

--- a/airflow/ui/yarn.lock
+++ b/airflow/ui/yarn.lock
@@ -898,17 +898,17 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.13", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
-  version "7.13.9"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
-  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
+  version "7.13.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.9.tgz#97dbe2116e2630c489f22e0656decd60aaa1fcee"
+  integrity sha512-aY2kU+xgJ3dJ1eU6FMB9EH8dIe8dmusF1xEku52joLvw6eAFN0AI+WxCLDnpev2LEejWBAy2sBvBOBAjI3zmvA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -950,498 +950,496 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@chakra-ui/accordion@1.1.3":
+"@chakra-ui/accordion@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.1.4.tgz#7f114ee546185a9cfc3fc0dfbbb63daaae2af8cb"
+  integrity sha512-8SBSZlxtGuZEi9iXeVF+V9ziM7RH1MW1WJ0K6AcQQVU8uyMa6Ld+FWzsROawwkEJgVCrrd3tFH9coY/0ZXlZRQ==
+  dependencies:
+    "@chakra-ui/descendant" "1.0.9"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/transition" "1.1.0"
+    "@chakra-ui/utils" "1.4.0"
+
+"@chakra-ui/alert@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/accordion/-/accordion-1.1.3.tgz#bfe4901aab137bd08e0796d09c4b4baeb54d3e4e"
-  integrity sha512-if61BesRBHK5kmqfS0FesTtsmoYcpSYdgcn2cQ0nk9vEc2RvK6H8FTPlFvu64ycpbD73sa9unpdNdxTtzZp7bw==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.1.3.tgz#05b86d62b4a20d5e0b4c88be788a79cd5666e071"
+  integrity sha512-Q/A2K6m/FqN4W/bNh+OAPzrwNGGGS9yxznPTQMHC0Map34t0/pP2A/luKC00B0oDHhF9AAcLosjn3NXhphT2pw==
   dependencies:
-    "@chakra-ui/descendant" "1.0.8"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/transition" "1.0.9"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/alert@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/alert/-/alert-1.1.2.tgz#78a1693e405464784bef83922a26b63782c5d0ef"
-  integrity sha512-paJyY9S7EvYPZVqpvP3EyzzqXRRQDsEbR62ohfpFQg6C5+S5YWgjos/0YJNPEHDDj/XSQ/4RuAis78CcfivzwQ==
+"@chakra-ui/avatar@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.1.4.tgz#63a41624fabee5cad35380f4cd1ced3bc8a4d413"
+  integrity sha512-/l7ibd8at75gIW3WzU9cis0+o5lWfwgUO4oI9yevFgllSyyPgwgZhdR/lcTQmJlmEuA0eaawQPM3GN8LsJfFnQ==
   dependencies:
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/image" "1.0.9"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/avatar@1.1.3":
+"@chakra-ui/breadcrumb@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/avatar/-/avatar-1.1.3.tgz#ebdbf90a0a1d51c98a523341b684e0301b6bfd79"
-  integrity sha512-fM5yzEUd7zyFs+bdFnfDEafQoSlt84AdbWoJ9jG55WwFnJ5CWV2kXb0CRe9MADj2V11EKXzQFT/YYeEg00Jb+Q==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.1.3.tgz#956f58ac2e349a51dae47cad8139df2534c6ce3e"
+  integrity sha512-FpHlrJiheSQ6SAXvvZMp7juMOnaYeGFtmz4FK1n4sDaaim6jy7haMxbxY6yINOhMC/FGjpdpLLjdK0lPKUuZPw==
   dependencies:
-    "@chakra-ui/image" "1.0.8"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/breadcrumb@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/breadcrumb/-/breadcrumb-1.1.2.tgz#875200b383ef24f1c262c712f041e73bad9e234e"
-  integrity sha512-spKkKKd8z738ExOGa5zCg8f1YSou8DEYpB5FHbfdQDzyI0VAuwsxZHy4WPPqWf+V7Tgsjnn/gUEYCQIayHcJcw==
+"@chakra-ui/button@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.1.4.tgz#6b474f56f51d46115894342a8a06a2f5321faedc"
+  integrity sha512-xLrISCqC/oe+QuBfhfTmdxCNbgad2dz5lu2BZ9TE6d1ppeP13RtFArQHaJ9/0wUVs3Oke6+ksSr1oCvGXvDadA==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/spinner" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/button@1.1.3":
+"@chakra-ui/checkbox@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.3.0.tgz#51874dcdbc038ac2d896ddd9c327f966619a3353"
+  integrity sha512-erZxnK7ybI7ruyAQaDaDzPEV4eL+AJgP0dWQBzssLwOUhLqYkLG5km/tmgZZzfwg5A62WaBf9QT0tZymWTJ+ng==
+  dependencies:
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
+    "@chakra-ui/visually-hidden" "1.0.6"
+
+"@chakra-ui/clickable@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.0.6.tgz#9ab45fbbfe01ac484f5a3d6f5c26e13000353d52"
+  integrity sha512-k4+mS2l3GbYbJbdIVpZzAB3xQ9EiECUoMmlZKp+NHh9pUR2XZWSmjVhfedVyk7WuOfpXWxAhwhgCVrM5+hRd9w==
+  dependencies:
+    "@chakra-ui/utils" "1.4.0"
+
+"@chakra-ui/close-button@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/button/-/button-1.1.3.tgz#d41514efb2cee211a5b9564aac303d3b0234b842"
-  integrity sha512-KfBLKCl7QDwZjVkSo7UEU0zU0u/j8TImU2571L9AVwIrzatQXGuyx4m4PYxrEgU4lb+YhbDwNWNnHgTPNzcdVw==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.1.3.tgz#db0a0c62549a14c529deae8184d20466170fe3e8"
+  integrity sha512-pLj5E2or8VdQ69w/ZZ/B09E446B6wbmJFQ8fuqnaxOeBZKp3VtvOLXWDg23SsijKKgw71EBq0O7qUOKvQRygKA==
   dependencies:
-    "@chakra-ui/spinner" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/checkbox@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/checkbox/-/checkbox-1.2.4.tgz#b1743fafe591c20482bdc9e58d33e397480e82e7"
-  integrity sha512-4GgkRAPFWHyat6tFfhmdzBeF7W+C0MEsMiSNmF5dsp13/6txsOaUiIg0sy6VzoGAp9rIBEr0IaXjVR3MmSTWsw==
-  dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
-    "@chakra-ui/visually-hidden" "1.0.5"
-
-"@chakra-ui/clickable@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/clickable/-/clickable-1.0.5.tgz#b9f42c06955eb7d52a7e9dd8baf97a1ea819cc61"
-  integrity sha512-bymyXqh3/NTYobgF7ea3o5TaxMo0O7yD97Osj756sLhMl8mbovnKDdPsFO2uL6Y/v+BAvlBUftQVOnwXgMMJkQ==
-  dependencies:
-    "@chakra-ui/utils" "1.3.0"
-
-"@chakra-ui/close-button@1.1.2":
+"@chakra-ui/color-mode@1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/close-button/-/close-button-1.1.2.tgz#eb212e4439bfd43c8af400819e037871be3aadd2"
-  integrity sha512-jLDhVMV5s7BTHDhwZMEPNLlHG8cI5Pw4y0dWrrnGWi3XQIFWYvAfLDhApn7W1cF1ijch000Heloq9WcN/WxilA==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.1.2.tgz#824ea170b04152021bc5c39a7f17f7f0b6d59801"
+  integrity sha512-RnJvLFNmLyC9bnYgzunJ19pwr7chc3T6mvZJG4Goqxdn8jPQ3QJPh6A0vA5tvIIgbXqvIPn8imknBntHq1P0kw==
   dependencies:
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/color-mode@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/color-mode/-/color-mode-1.1.1.tgz#762da845c24c9ca01114b5b2c99cc78852b44b19"
-  integrity sha512-vTT7SNjYie5O2EucJ+rQvta2srLUHXxY2J0mfOVRIvMzpMr4l49DYAqZmRHFie7rTvV+e0h5JaA3qwdHUsBu/w==
+"@chakra-ui/control-box@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.6.tgz#aa6f2b385fb22cf2033e1e567db87321a70bfb6e"
+  integrity sha512-5Tkwre9BF3wifx6pe5cgBlpcAZaJWhLF2KGs29lsmjOHV14JvLff9sPNaqNIaugRZY25bF4JVgMXg42aIfS17Q==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/control-box@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/control-box/-/control-box-1.0.5.tgz#a2c0bbf329d47b17b6ce0321c8a76d7a263401ea"
-  integrity sha512-gwmWfobqeNjMlHNG4ATj0yg7p/WYIONwFhLU0l85qLsfSs+GkX5xTBV+ssrnD9l2ADG8lALmDAxgPFOOhLZMvg==
+"@chakra-ui/counter@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.0.9.tgz#e0a107293c433856e17de8ec6d755b891fc60e9f"
+  integrity sha512-D1iXgA2rjHhZx2Gm3Tp3BD6fCX+LMvI0D/SkWGnJ5ES4n/0QXk1AoEAaz7jIrk6nEY1Sv/U4GxErRTV3KtSOzw==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
-
-"@chakra-ui/counter@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/counter/-/counter-1.0.8.tgz#6ff32914e7eba25408eed421db6b4b9edc4d4c31"
-  integrity sha512-TynFTt6JmYqg5EreZuv619ePUqXEj6a/zVPGXA3QPgJBEOcNwbhqX/SRaQ1vMD+Cv9xVbxjWFV6J2na5j3E3yQ==
-  dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
 "@chakra-ui/css-reset@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@chakra-ui/css-reset/-/css-reset-1.0.0.tgz#8395921b35ef27bee0579a4d730c5ab7f7b39734"
   integrity sha512-UaPsImGHvCgFO3ayp6Ugafu2/3/EG8wlW/8Y9Ihfk1UFv8cpV+3BfWKmuZ7IcmxcBL9dkP6E8p3/M1T0FB92hg==
 
-"@chakra-ui/descendant@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/descendant/-/descendant-1.0.8.tgz#50e809b82b5a54e77c1b3d3291afc1ec6b8ebbf4"
-  integrity sha512-amKxOoFJ2uiQxJqAw5XZOI5nwVdUQ4BxZAY2Y7kM9Ml5qATxzRiVv8eoyJ0uQ/VksFRfECFxyudFtLm0VwO8hQ==
+"@chakra-ui/descendant@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/descendant/-/descendant-1.0.9.tgz#acc0470c42d5ec962586a91e7165c8e654377f5f"
+  integrity sha512-N/s5+mr7SfDHdMDKcXaJsISYxtIoUTy+Wj9fYbVO2ABx5TrMWc/6Y+3sIlEHzobpsAGfaPTLUhTUYT9P82zGSw==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
+    "@chakra-ui/hooks" "1.2.0"
 
-"@chakra-ui/editable@1.1.2":
+"@chakra-ui/editable@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.1.3.tgz#7abaa3ebc5bcd2402d2a39d47948c437aa959eae"
+  integrity sha512-jH38V+LQveXAxB80GAw5kXkB4Q0BbV+1YU/u5fyxYjoQ2GSkTe34kUiWXzCtYdnHska8xaZ08qtkfEcS5eDZsQ==
+  dependencies:
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
+
+"@chakra-ui/focus-lock@1.1.2":
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/editable/-/editable-1.1.2.tgz#ae4adee0e1dcd2c1aad74a2d7273ba1a90fd6b5b"
-  integrity sha512-uWt0I8Oo9prs5rDYF2Yqairq2Wl1MMaAU6y2NTSLLq0Un2RTVtyW29TkHFpx7SF1mlrtClyKmh0yk0qEiEMcWQ==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.1.2.tgz#2e8fda42887372b39b440c1b90b9fa380dcc0376"
+  integrity sha512-t9CYCX+E/9rqVCpFq7emIWMkTYPSl5fBJtuTUoWBNVXeyDBHB+Kfg7miM2ET0Re2By4ZFTCofcCs5sTYHGbeQA==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
-
-"@chakra-ui/focus-lock@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/focus-lock/-/focus-lock-1.1.1.tgz#46292f52e6140cbffa94cc6610354ad926c4f843"
-  integrity sha512-fscXuFgaxbf1GnRB3/a7KMwYwcmSGT61XmF5yUOw8PflkBl/4a8u+UuSZMuzw8blD5/fK9thWNJK2Nqq/24aOA==
-  dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
     react-focus-lock "2.5.0"
 
-"@chakra-ui/form-control@1.2.2":
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.2.2.tgz#88d75491e59f0791dabfdaf032e09360a59e7d67"
-  integrity sha512-p/tLw25/0NZBeuv6WG9NzRfPkS1EfIcs60IWu7ehxvNrNo4TAzTNkp9eEeSDAgpEin1hlAEBWdi2ZzgvK28qEA==
+"@chakra-ui/form-control@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/form-control/-/form-control-1.2.3.tgz#8ee931d769c22afbcdf62e304751de9a440130f2"
+  integrity sha512-FwT+Bet7wHg4yPZBjcJd08TVtHMgVc33iNT1gUKluMskHH1dPiXvgH0+bNLlQcjO3869qP6rqG0ul4BuWga/XA==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/hooks@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.1.5.tgz#54d22fc1f291b085ba431c9f9ec59b2ddfdbeb4a"
-  integrity sha512-JBBeQ5woByVRV0yuc318ogyjjIHJJSujdBhOZUmB+nAjlmx5lpFoAm59IAKuH8ZIqZBEzjwcnhKNw67wXjoowQ==
+"@chakra-ui/hooks@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/hooks/-/hooks-1.2.0.tgz#4faedf2840c9c8bfad6dac289cdd13ffbb36e6a5"
+  integrity sha512-un6FuNRVtX4YKT842otuthOPvsBMsRfiDFSu0afoOZHcxfUPmtPFdE0mWQGlyAcolaj5wkL7zxXR6tbY47FnBA==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
     compute-scroll-into-view "1.0.14"
     copy-to-clipboard "3.3.1"
 
-"@chakra-ui/icon@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.2.tgz#b57f53c801b515301f26bc829957f32b7ca5fb8d"
-  integrity sha512-Gp/G0CZ8X8RWJWrs8jUm1dfA+5lS4zgNd078zQAj+yppnyhRGEGuZ6jAVJowtF+gbljZttmZwfXUgV3WpKnT/A==
-  dependencies:
-    "@chakra-ui/utils" "1.3.0"
-
-"@chakra-ui/image@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.8.tgz#3e20c89966c651859d95728f9d4987ae2f8cd8a9"
-  integrity sha512-WSVFFvx0bJ7qdJslBrj9FGFJvOLXk05rQC+tL+lPI8/jqhzj6EwUzsQ4qXlwcjo8KR5LviMA8zZsaoEZ+kAUqw==
-  dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
-
-"@chakra-ui/input@1.1.3":
+"@chakra-ui/icon@1.1.3":
   version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.1.3.tgz#d40ab036332d1eef1f9a5225bb9e329eff63b5ad"
-  integrity sha512-WwTx6jPTqoXPXMYCftcnIPhJjZqmbcUlju2Oyt32+M1jc1uFa+uUUd2zBfNQVK2KrbzWISquCzYVF5WVehHVtA==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/icon/-/icon-1.1.3.tgz#5fbc310652fa20da973ea9422ed5e1a654596d23"
+  integrity sha512-XZ9RTU0J/qB5bZawUK5yk6YN3P2fi74aTLap1qygmodAPo5sIroRzfuXndezjAYFhuRjI62zfSs/FVhwJyhmsw==
   dependencies:
-    "@chakra-ui/form-control" "1.2.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/layout@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.3.2.tgz#59524b4971bf299e9b439f8669abd2064976cec2"
-  integrity sha512-L2dM3yRu2RKkENpuTiuBxz9Vq07LDhIWLo3aeB7uSbjWNi4kD8pVsHUw4489xEUVnVplC1T4XryM4gDck7jIVg==
+"@chakra-ui/image@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/image/-/image-1.0.9.tgz#bd301f6028000d9dc3370c897868b465edc39ed5"
+  integrity sha512-GpfwgXzVC/IVkcFGUX0I4/NcQafjdCCSVNkdTRxYo0v368VrXb4087i2ypx+7w4PgRqZv3ABunM2BbbXE35U0w==
   dependencies:
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/live-region@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.5.tgz#9862e16f7d9c128fb6af98d26c7ee2ed419bdda2"
-  integrity sha512-2DBI1wgTcXILW+pEceZwWDK1DbzIS/dNBCZVjkiE2ZT17rxjkl1/olq/em4jaNvlXGcZ9V0EjmiVO3NFM3mFmA==
+"@chakra-ui/input@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/input/-/input-1.1.4.tgz#c4a7ada280df66fc0fc3e1fa1edb2bb4a4d286e0"
+  integrity sha512-dk2JD7tfRmQLqbQXpDLrkRjVpdZeVIqNKPqzQFOTApzQPxyF0/wHVbrPtipQCzlqwGuzhF0WDVc+G/KAQ+3SmA==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/form-control" "1.2.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/media-query@1.0.6":
+"@chakra-ui/layout@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/layout/-/layout-1.3.3.tgz#837d2d7be4d2c8f57b3aee2eb9288f740ffbb0d4"
+  integrity sha512-PvJSNAkTNmeYv10J0tD1oBZdKSeWDkrb0hrF8IrGtmLztL+gA5fGMIkNN4/bWq25mqI7mCRHqwYei4PhhZKYXg==
+  dependencies:
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
+
+"@chakra-ui/live-region@1.0.6":
   version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.0.6.tgz#c86fce1fdeb5b660050de88d9017e7e72b14a59d"
-  integrity sha512-CRav7owkwkLBJC96vwZjlOpU4igQoZvDFd7aH/u9KivGg3saICtSfHwWPl58WIrowTIkvV5ycHyo0efzcB1S1Q==
+  resolved "https://registry.yarnpkg.com/@chakra-ui/live-region/-/live-region-1.0.6.tgz#85d20b273d35a27ebe35e98cc9f6c9d66500e38e"
+  integrity sha512-pLtOXsb4H0+WNtxro3KGjaoTmruvXy7uedcf61lm3d3QaRAmA+R5nCjnGayvSGK9ex8Wr+CJQSzTUUijNzKiwg==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/menu@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.1.3.tgz#03cb360e9d3e10dd4983b711c424131af40f2d59"
-  integrity sha512-tO98inArQCg0nlMgl+9uL9YwN09AClmP3HZtGk/kINTvFD/eqKI/UDh/IcBhlHw5DczPKQtBBWO8yg2z7PqGPg==
+"@chakra-ui/media-query@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/media-query/-/media-query-1.0.7.tgz#08d9011ef7a5dcb238026fd35549257e21f1fcac"
+  integrity sha512-loonqcxL4Buqt6c558D8fR6zwQiL4yRqTG3LZZMP3UtFo4ja9tyFI0bFtmnP1PYMgOrlITkty82KuLshppwuFg==
   dependencies:
-    "@chakra-ui/clickable" "1.0.5"
-    "@chakra-ui/descendant" "1.0.8"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/popper" "1.1.5"
-    "@chakra-ui/transition" "1.0.9"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/modal@1.6.1":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.6.1.tgz#40faefe2b94f7da630ef774e8ba5f99b51090862"
-  integrity sha512-Eu2jp2aXrrmaLe+xAqdRQRXdmsMmQMu52gvunYRDoR94oGlKyhixMrxTZrATjq5+JNCV1D1QbwFhh+GvZhjbcg==
+"@chakra-ui/menu@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/menu/-/menu-1.2.0.tgz#489738547f69d2d36a67cb3863cb620b0454fd97"
+  integrity sha512-OYVlc1F2QNtCMWdrs611DnfqbLNTkKtpKUDJnaxGB8lzHY4aN0rPrYo0eIiY+10TCDLXCm7o4jWd+vHn1zqBGA==
   dependencies:
-    "@chakra-ui/close-button" "1.1.2"
-    "@chakra-ui/focus-lock" "1.1.1"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/portal" "1.1.2"
-    "@chakra-ui/transition" "1.0.9"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/clickable" "1.0.6"
+    "@chakra-ui/descendant" "1.0.9"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/popper" "2.0.0"
+    "@chakra-ui/transition" "1.1.0"
+    "@chakra-ui/utils" "1.4.0"
+
+"@chakra-ui/modal@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/modal/-/modal-1.7.0.tgz#801ff8dbb27e4f740739768500973e6097536ba4"
+  integrity sha512-TxXcGbMdNkiD4WU55FLshAk4XlHvoUraKAJ1rcI5AcNc/DXuW8wy9P1t8Ho0iGgq1xRWQjzDgDfgBOh98fO7fQ==
+  dependencies:
+    "@chakra-ui/close-button" "1.1.3"
+    "@chakra-ui/focus-lock" "1.1.2"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/portal" "1.1.3"
+    "@chakra-ui/transition" "1.1.0"
+    "@chakra-ui/utils" "1.4.0"
     aria-hidden "^1.1.1"
     react-remove-scroll "2.4.1"
 
-"@chakra-ui/number-input@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.1.2.tgz#fd330133769db8fdf64f869d0cde720a19bc13cc"
-  integrity sha512-bSiX1cgE7tTJpuaYAqzhheU3F6S+WjlxY7tsJ842KoN8aooMFaB6VClkkjZAQfvCeXLXyYNlDi+FZwlwQq8j3Q==
+"@chakra-ui/number-input@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/number-input/-/number-input-1.1.3.tgz#6035270af9e9177cb64521a94f9ab76b067e4eb3"
+  integrity sha512-vISd0obMse4EWVkowIyTE4JUfhzrPCjQkzdv9PgLEk1b5F5TVcKMCDAwPlsHhQGciaKnXRaMcOCTVeRS8oUoUQ==
   dependencies:
-    "@chakra-ui/counter" "1.0.8"
-    "@chakra-ui/form-control" "1.2.2"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/counter" "1.0.9"
+    "@chakra-ui/form-control" "1.2.3"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/pin-input@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.4.1.tgz#3e676c5707b58d2f166ea7dc2445830d64cbe4bf"
-  integrity sha512-0DY+q71VBbjmLh/soUcibj9Mi5+Jr0eKugRP8hzx1ywoSqmNVa4hhw12cC4xeEaO242Ec3752D7TLGCSZFD04Q==
+"@chakra-ui/pin-input@1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/pin-input/-/pin-input-1.4.2.tgz#01b461210eca8b7878b2a49b9cdf5c96a1f9082d"
+  integrity sha512-7aS2IP67hfV1agnji8FemBJl1M7zqu2X5DTIy2NxuTNqU3/H8douMwVnNUrjavSltve4OYycxY8gPK/h9u4/uQ==
   dependencies:
-    "@chakra-ui/descendant" "1.0.8"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/descendant" "1.0.9"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/popover@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.2.3.tgz#7e2f64169276c318b092de3ad1b632289eeabe8e"
-  integrity sha512-hA44W7GwDpQWep5R+4lRkN9C3FE7zW+cTYuJXNNx2CwpUOWCdTAaPwx4LJb+yLmTMbRXDKSR1KrkzWK3C6Abcg==
+"@chakra-ui/popover@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popover/-/popover-1.3.0.tgz#df32ede440f36c26fadc3dcc754955aa9ddbd462"
+  integrity sha512-iVDe1A8BU4kImXKdOnaHnA0swcMXkkBYMxuTyhXVqvJwb+8uZgZ1OUdvYOgSEk/dA+idMQX7pINE0snw0W7USg==
   dependencies:
-    "@chakra-ui/close-button" "1.1.2"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/popper" "1.1.5"
-    "@chakra-ui/portal" "1.1.2"
-    "@chakra-ui/transition" "1.0.9"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/close-button" "1.1.3"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/popper" "2.0.0"
+    "@chakra-ui/portal" "1.1.3"
+    "@chakra-ui/transition" "1.1.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/popper@1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-1.1.5.tgz#0284969e5755a5faab27da446791b2bdef1ae0ac"
-  integrity sha512-Z7NpOMoycnELII8TTEC1FmMqAIO69xJ8pyNL4lo/ifNyTngIuEQw4o40U7rfA4E7A6AM24WmlgwH0lxFOfOqqg==
+"@chakra-ui/popper@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/popper/-/popper-2.0.0.tgz#48cf74a434cd4e292b9304b65ef8a391b149ddd9"
+  integrity sha512-7qm1Zms9YOhtx48Zo8TvZ5pw0Uz91gK7D+2B2Lu9W3hNovDUA0/UuHcSnDf9iBZAQqwNkyYakXtJsYPOEdhbkw==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
     "@popperjs/core" "2.4.4"
-    dequal "2.0.2"
 
-"@chakra-ui/portal@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.1.2.tgz#b1da6d6d91a7e34033ae74aa7d53760470cbc702"
-  integrity sha512-cGZgevVcSC59egLn++nJ2RifrDGzVSZfY8DDpDaoeb7hLqa9w+zWjcMq54+BTHDIJ4PeRjZtnk1gl16KG4V8iQ==
+"@chakra-ui/portal@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/portal/-/portal-1.1.3.tgz#a74f4f98540c3b6c3fbcb143831292374664af14"
+  integrity sha512-8CvC7YCFcvJV+LyuEP6EDMEZKl+C0u4A6L6JeUbkGNMqY3QcWhg+7+v0jrnq4ZvpZdpBSlzqRYX+dvZTJkZYjg==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/progress@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.1.2.tgz#8e6c9f963672c915ae422c980bf4658b6620345a"
-  integrity sha512-ndxmLq5SF/yaOmDaGPeBuaDelDu3mtf0nzJcCKTVGjLIksTNUt71puQNsTEHGXp089wJlFKJLKAx2i0UqgasWA==
+"@chakra-ui/progress@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/progress/-/progress-1.1.3.tgz#80d61c3dbbb35a1e692d209fb370583b584c2ddf"
+  integrity sha512-SLxLfDAFQ1kiIp8SKwTUPaCldiHKgLg8F9exOt0KDX0nUen/u1PLvpeFKh+rX850ahn+/3tpIUOg1gPq4S9USw==
   dependencies:
-    "@chakra-ui/theme-tools" "1.1.0"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/theme-tools" "1.1.1"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/radio@1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.2.4.tgz#377471a9ee002158977a8920c432689f0c3277f7"
-  integrity sha512-nf9haPcD2jX50XbaiSP5mJUZUUP0wKJSeHeCgMsPtTSMjmQcsr8V8qZ3s31uvy3K17KfPhxChtH7MvDHBNDHsQ==
+"@chakra-ui/radio@1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/radio/-/radio-1.2.5.tgz#0ef48110c702616cbd15949082b462e21029a7d7"
+  integrity sha512-GtcNlDaD3cWBCY8Yr6S5AZgryY/w2rxL4b+uli2l3X1dlh1313IyOGR4HHpBKDGa+vr2tGUJA9f9oO4bhfGLPg==
   dependencies:
-    "@chakra-ui/form-control" "1.2.2"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
-    "@chakra-ui/visually-hidden" "1.0.5"
+    "@chakra-ui/form-control" "1.2.3"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
+    "@chakra-ui/visually-hidden" "1.0.6"
 
 "@chakra-ui/react@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.3.4.tgz#4701feddffc6d632a1b5bb16302c71057759609e"
-  integrity sha512-RLj+PswKfJ14TTxhmqQeXmCREwoF36QivH0hKt6mu9BeGux5su8hbxcRwfZc+QW7pqyHIy17w0AqVGn79U7uDA==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/react/-/react-1.4.1.tgz#95caaaea65373dce2d64ad9803dad56bfdcf0315"
+  integrity sha512-jbFWV++0yhTJF92CulRDgkNkoMe589fdrc3YUyAh5ZqadNVB3qJoJxaTZLFV8gl8EUMCOu0Fu+EQkSoqkpzKGw==
   dependencies:
-    "@chakra-ui/accordion" "1.1.3"
-    "@chakra-ui/alert" "1.1.2"
-    "@chakra-ui/avatar" "1.1.3"
-    "@chakra-ui/breadcrumb" "1.1.2"
-    "@chakra-ui/button" "1.1.3"
-    "@chakra-ui/checkbox" "1.2.4"
-    "@chakra-ui/close-button" "1.1.2"
-    "@chakra-ui/control-box" "1.0.5"
-    "@chakra-ui/counter" "1.0.8"
+    "@chakra-ui/accordion" "1.1.4"
+    "@chakra-ui/alert" "1.1.3"
+    "@chakra-ui/avatar" "1.1.4"
+    "@chakra-ui/breadcrumb" "1.1.3"
+    "@chakra-ui/button" "1.1.4"
+    "@chakra-ui/checkbox" "1.3.0"
+    "@chakra-ui/close-button" "1.1.3"
+    "@chakra-ui/control-box" "1.0.6"
+    "@chakra-ui/counter" "1.0.9"
     "@chakra-ui/css-reset" "1.0.0"
-    "@chakra-ui/editable" "1.1.2"
-    "@chakra-ui/form-control" "1.2.2"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/image" "1.0.8"
-    "@chakra-ui/input" "1.1.3"
-    "@chakra-ui/layout" "1.3.2"
-    "@chakra-ui/live-region" "1.0.5"
-    "@chakra-ui/media-query" "1.0.6"
-    "@chakra-ui/menu" "1.1.3"
-    "@chakra-ui/modal" "1.6.1"
-    "@chakra-ui/number-input" "1.1.2"
-    "@chakra-ui/pin-input" "1.4.1"
-    "@chakra-ui/popover" "1.2.3"
-    "@chakra-ui/popper" "1.1.5"
-    "@chakra-ui/portal" "1.1.2"
-    "@chakra-ui/progress" "1.1.2"
-    "@chakra-ui/radio" "1.2.4"
-    "@chakra-ui/select" "1.1.2"
-    "@chakra-ui/skeleton" "1.1.4"
-    "@chakra-ui/slider" "1.1.2"
-    "@chakra-ui/spinner" "1.1.2"
-    "@chakra-ui/stat" "1.1.2"
-    "@chakra-ui/switch" "1.1.4"
-    "@chakra-ui/system" "1.4.0"
-    "@chakra-ui/table" "1.1.2"
-    "@chakra-ui/tabs" "1.2.0"
-    "@chakra-ui/tag" "1.1.2"
-    "@chakra-ui/textarea" "1.1.2"
-    "@chakra-ui/theme" "1.7.0"
-    "@chakra-ui/toast" "1.1.12"
-    "@chakra-ui/tooltip" "1.1.3"
-    "@chakra-ui/transition" "1.0.9"
-    "@chakra-ui/utils" "1.3.0"
-    "@chakra-ui/visually-hidden" "1.0.5"
+    "@chakra-ui/editable" "1.1.3"
+    "@chakra-ui/form-control" "1.2.3"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/image" "1.0.9"
+    "@chakra-ui/input" "1.1.4"
+    "@chakra-ui/layout" "1.3.3"
+    "@chakra-ui/live-region" "1.0.6"
+    "@chakra-ui/media-query" "1.0.7"
+    "@chakra-ui/menu" "1.2.0"
+    "@chakra-ui/modal" "1.7.0"
+    "@chakra-ui/number-input" "1.1.3"
+    "@chakra-ui/pin-input" "1.4.2"
+    "@chakra-ui/popover" "1.3.0"
+    "@chakra-ui/popper" "2.0.0"
+    "@chakra-ui/portal" "1.1.3"
+    "@chakra-ui/progress" "1.1.3"
+    "@chakra-ui/radio" "1.2.5"
+    "@chakra-ui/select" "1.1.3"
+    "@chakra-ui/skeleton" "1.1.6"
+    "@chakra-ui/slider" "1.1.3"
+    "@chakra-ui/spinner" "1.1.3"
+    "@chakra-ui/stat" "1.1.3"
+    "@chakra-ui/switch" "1.1.5"
+    "@chakra-ui/system" "1.5.1"
+    "@chakra-ui/table" "1.1.3"
+    "@chakra-ui/tabs" "1.2.1"
+    "@chakra-ui/tag" "1.1.3"
+    "@chakra-ui/textarea" "1.1.3"
+    "@chakra-ui/theme" "1.7.1"
+    "@chakra-ui/toast" "1.2.0"
+    "@chakra-ui/tooltip" "1.2.0"
+    "@chakra-ui/transition" "1.1.0"
+    "@chakra-ui/utils" "1.4.0"
+    "@chakra-ui/visually-hidden" "1.0.6"
 
-"@chakra-ui/select@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.1.2.tgz#bd7bbe7be19a68b7d28eb4c809a1e6f1f271c635"
-  integrity sha512-iN1oarmhBGdLc/MuExyymPsbGBKXTcw/ubkhTgYydGbiyOo8LkYtpzK4tfXyAJEI1banH5kZ7/DxLACqplaamw==
+"@chakra-ui/select@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/select/-/select-1.1.3.tgz#9ca61436a2881960b576f4968ffedb7a77d499cb"
+  integrity sha512-t5x7rM29aSc0LHMIvXMRvyNhufG5t+MNhZZZyxCnV8ySN/8IfpA01umGGn7Pz1qmME3gUw1Jz1paMvik0WTFsA==
   dependencies:
-    "@chakra-ui/form-control" "1.2.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/form-control" "1.2.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/skeleton@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.1.4.tgz#0eaf47d3be25a33c767346e383d721e7a4c06e92"
-  integrity sha512-Dp4dmZ1TJRcqoXmRoGQxWI8q2yEPpTCeJquKmmJlca1pHghu9iIfLNdeJ0uZTw5xvm/PO0LIlNc8Kkyw1thMxQ==
+"@chakra-ui/skeleton@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/skeleton/-/skeleton-1.1.6.tgz#2a3cceb101574a7dfaad4489bb73714a17a0a1d2"
+  integrity sha512-wzm9fCaLhTTO0i0bjlEc2PrVRgZcOEpxvJth9sFHOwd1aYGDigMhmi3azOzfWMeVcAoAkHBOkwa4o1BosD69rQ==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/media-query" "1.0.6"
-    "@chakra-ui/system" "1.4.0"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/media-query" "1.0.7"
+    "@chakra-ui/system" "1.5.1"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/slider@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.1.2.tgz#2ba4995660b4ae60523c67c2399dba8c651607f1"
-  integrity sha512-ag5Dr6sXeakcQa+XLtpCM7GVwcZIjhFJt+DkdbxO2dVjUmtJSsAvCBdCUzM63HFzsZTD61RaOXSMWWLcyZ6Rrw==
+"@chakra-ui/slider@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/slider/-/slider-1.1.3.tgz#e55740fff98269d2dccd03b8b8542389cf0b0122"
+  integrity sha512-stEzjnJBd2r3XAKOPSnufHHKAHrsuU2BQelJUzCpGxJtFYFSGvfNLMgQj3LjuqaIDjbOxSU4mkJYZ/KS+kXwFA==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/spinner@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.1.2.tgz#65214402a6ff7761318a2eddb4a0d65661e75a6f"
-  integrity sha512-WZj+XcxXjWPWSjoJoeFupy2RDVqAVqIxFAylFolQ3mhmIAYDSBN6t1lUsSKxl8fWK1lSOAGxTOlvsI6eobMM/w==
+"@chakra-ui/spinner@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/spinner/-/spinner-1.1.3.tgz#97e96acfe4fdb2b3e41d2ddd01e14ca923b1cb37"
+  integrity sha512-kJZ7PhJ3wQdwSvfcUHUf3w8xULO3xepjKQZ3GV+p/F+xxl1/i+kvBIvDqGpDNHK3Fke27DW9jfOUMVqFa3Jrpw==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
-    "@chakra-ui/visually-hidden" "1.0.5"
+    "@chakra-ui/utils" "1.4.0"
+    "@chakra-ui/visually-hidden" "1.0.6"
 
-"@chakra-ui/stat@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.1.2.tgz#212b0a68a6dde42cbf5fb6abb226bc7b104463ae"
-  integrity sha512-Iw61iJY8ffx1miB+BOOw6Mnnuic3lD8tepxn8GdUrr+6liBreYbbEe9+VGZeaeU5qx9FDpjr8EtwzzHjKe/X7g==
+"@chakra-ui/stat@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/stat/-/stat-1.1.3.tgz#9d7418bb0240c7401b39dc14303cc97ff244745a"
+  integrity sha512-ewEuymCAIKs9g+gS5s+kXmxdggrP5rBaFEIcQ/EPEO4zXFkTbPPPf1ZbUECfq53qrGnNzYZSIx2hqGaW2k0c3w==
   dependencies:
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
-    "@chakra-ui/visually-hidden" "1.0.5"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
+    "@chakra-ui/visually-hidden" "1.0.6"
 
-"@chakra-ui/styled-system@1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.8.0.tgz#b34f561b9c5e0acc495ca4c6b45da69cd690b329"
-  integrity sha512-EKtVaZSW3drOxNBV/Cl3Int3YN9o7BJ9WOsPBcXfdXjAsk5XORN74Mw8HVHPvcheW0ERTlOFWlTSv4Ot/U8GXg==
+"@chakra-ui/styled-system@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/styled-system/-/styled-system-1.9.1.tgz#4541a3944c64fc2c2705685abe76faaf1591c7f3"
+  integrity sha512-LS/1oW2BP1/wY+GbBpoMTdb1ezVx1P32zR52OUn4ANogsDcB/7/DMMj6tuS4yaZEZ9AKliORI+p0CD9P/ETyQA==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
     csstype "^3.0.6"
 
-"@chakra-ui/switch@1.1.4":
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.1.4.tgz#f42f061dd10dbc0fd71b5132d27410dc5d129097"
-  integrity sha512-fqGq7s9Pn4r5o0h9PMM2U60ScJF/6tWefCYqftIiWYNAQek+Iak0sug/JRo2/tbKJq1Vd2kheHVo4eVYRqUVCQ==
+"@chakra-ui/switch@1.1.5":
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/switch/-/switch-1.1.5.tgz#9d7ae9f20047cdeafbd3ed01f8432e7e2e659b37"
+  integrity sha512-zezIVpoAIKaspZShnkMkveT6wa7N8VIhlZhcLl32zaBr5W865t8eGM0uFcNpGu6FU881bMR9dRvK/S7OXnzqTw==
   dependencies:
-    "@chakra-ui/checkbox" "1.2.4"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/checkbox" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/system@1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.4.0.tgz#d459656c3009b6339bb8992cf900712d8de73731"
-  integrity sha512-AvfrF/eVMYJEw5im6sXFcbkxCYQP6RrFcpSjcQ4aD71tfnqDCrlr6oQ8P+fugbrUpGSERoVWpQs1rK4LMTWNLg==
+"@chakra-ui/system@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/system/-/system-1.5.1.tgz#ab668a5b5d8f8899cd18c14d59546dff7df4537f"
+  integrity sha512-rbuCWqWHYvZ4Y89WsSkMvTPFP8usz3JN0/a36nsLzQ0YLG0Ehi6jUhjDSTbm9pQXh8cUpojGGNFtKW79HyIoXQ==
   dependencies:
-    "@chakra-ui/color-mode" "1.1.1"
-    "@chakra-ui/styled-system" "1.8.0"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/color-mode" "1.1.2"
+    "@chakra-ui/styled-system" "1.9.1"
+    "@chakra-ui/utils" "1.4.0"
     react-fast-compare "3.2.0"
 
-"@chakra-ui/table@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/table/-/table-1.1.2.tgz#13fd5de1b4ce1befe096f0db75278856ddec1119"
-  integrity sha512-buaWwNS8VCx3T6izWjmULuIIQKDitI6kObthGIhmG3OsJgkSuzKk5xypK4Oa1b2H03gQT/jGeuwfv8ejjzjITw==
+"@chakra-ui/table@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/table/-/table-1.1.3.tgz#d7463c59afa3d702d5e93a22ebdf803d4da4601c"
+  integrity sha512-vP4AJ+rXtB9l3YnlCvhdfbGzrs18lq9Nq9fDRNf8p8u2vtuiSTVar/kHXUO/JBI0NCpUfdAkELTxH3LonO7z4w==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/tabs@1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.2.0.tgz#65d83dde70668cc64d8b0016d0fed44b7f062c45"
-  integrity sha512-9yorwUbbEqL6b+vDGvbAmOJTucLpC+pHxKCWFHub1DuZNXHKfqVZcBYYKWPVs0ydzVHCwxd0RRmhqtWAP8n0vQ==
+"@chakra-ui/tabs@1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tabs/-/tabs-1.2.1.tgz#606168281ff8fe9916ccf2f79fa454136d5d2ae0"
+  integrity sha512-+nzHORo+obsZ3582qp8585WdCc9tRGu9I21edsaPwaYy3HJJNYh3/qXIaqW9xKbMuQmdPjGJlPN+sLWlda0gbw==
   dependencies:
-    "@chakra-ui/clickable" "1.0.5"
-    "@chakra-ui/descendant" "1.0.8"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/clickable" "1.0.6"
+    "@chakra-ui/descendant" "1.0.9"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/tag@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.1.2.tgz#bd8056f70106e7b84baf3e251d6364de444c7f9c"
-  integrity sha512-oEGQSll4is63lulTkRwsL4QAOo6iHYaOL0gqSRQmHmHfeDBVNdxvaedN3mnxPPP8oFO8pKGJ9LqcaHe1pj7rTg==
+"@chakra-ui/tag@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tag/-/tag-1.1.3.tgz#bacda9ad0890028a4f31247b380942049a9c1467"
+  integrity sha512-qc4AfYDobBp7JhRcbIzmJal5BruJCZlvbcS/Ee8RPHUFIj9ZuaYB3OiZzGyScJxEzNch6kTxOSl5hooj+UYvig==
   dependencies:
-    "@chakra-ui/icon" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/icon" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/textarea@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.1.2.tgz#41ef1a26b77d087d7191b80302acbb26c9582434"
-  integrity sha512-yltPY89AbFYKIvyVhj3h2yb5sglkxF6WigNmV/vn3LB2ZTxM0ozTj1rdgPC6LW48UIzRcW9F70L5N77SW0UfAQ==
+"@chakra-ui/textarea@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/textarea/-/textarea-1.1.3.tgz#fa029bdb8ac917d061f2ef5fd2c55c67868c62d1"
+  integrity sha512-/lWWBP3JBhiQMjdthKi4kRiMz7M22xZPshaWFYJJ/SNKZVdSExhQDQmG6ytUcSvI4nNRV8N5kFkZMP8MZ7j35g==
   dependencies:
-    "@chakra-ui/form-control" "1.2.2"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/form-control" "1.2.3"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/theme-tools@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.1.0.tgz#3f3599aae6fe1b7e0d28d6e518b25e1247270897"
-  integrity sha512-o1rJBJj3vbhq4C02Ld9Ay1xXKrfphQAqDacowKQlRu8G5DL+EvH/v0RGLkdJQd1ORoUsUZrZBvOcXO9dQt9DeQ==
+"@chakra-ui/theme-tools@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme-tools/-/theme-tools-1.1.1.tgz#c5e2fda87fb9602f637ea8360e4084503faa4f2c"
+  integrity sha512-ECW8IF0DxMxQgwgn4SPKPbHXhp1fnz50WtInNTvyXHvFZSst0ANn8k+WRAMb9qXolzuZw0sFjhd8U59rtIIpwA==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
     "@types/tinycolor2" "1.4.2"
     tinycolor2 "1.4.2"
 
-"@chakra-ui/theme@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.7.0.tgz#a341ff46aa7d3c5c15e6f9969689d01383827d06"
-  integrity sha512-3GqSBOfKrgyq2SZ+Rv6YEFOvhKlyUPh4yCsPq0JpT5fbZjaVPS4zkcoUSqcNzEOyDI4Fb5NYtqhdGWVnLOPDcg==
+"@chakra-ui/theme@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/theme/-/theme-1.7.1.tgz#71491d9610cfe3558b56ec92c4037e2a5de9528a"
+  integrity sha512-O1bAt9mbVdSF8u2QGewtA//rr4Vldo6p7tm3zFXm4vRfY0gQdvx3oEDxBWZX/KFRZbWV8c2IPmP0/fy4LWM0Ig==
   dependencies:
-    "@chakra-ui/theme-tools" "1.1.0"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/theme-tools" "1.1.1"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/toast@1.1.12":
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.1.12.tgz#465d9a74bdd54cdc981371d7513830a8c3999992"
-  integrity sha512-mLc8mB5mp34UXGD+XKmBYUUiB1dIZtD9AXkLbfeTwMPIsm52vCMk73CnZByr26G8HZM1wXLQF3/UO/1PzeWOug==
+"@chakra-ui/toast@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/toast/-/toast-1.2.0.tgz#ebe43c611b81bfb5ed67ba462630f75e96610f1b"
+  integrity sha512-KbCofqnZRmCGaOtdctI8Q3GUXy5nzpnv+hKCWApC0i3GQononcXU5b/FYre+MM+egp9nqtds9u8/NhC1CCn4xg==
   dependencies:
-    "@chakra-ui/alert" "1.1.2"
-    "@chakra-ui/close-button" "1.1.2"
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/theme" "1.7.0"
-    "@chakra-ui/transition" "1.0.9"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/alert" "1.1.3"
+    "@chakra-ui/close-button" "1.1.3"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/theme" "1.7.1"
+    "@chakra-ui/transition" "1.1.0"
+    "@chakra-ui/utils" "1.4.0"
     "@reach/alert" "0.13.0"
 
-"@chakra-ui/tooltip@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.1.3.tgz#531d598e8df2e5515164b568b2997f036f6541ff"
-  integrity sha512-wYEezJnMkYT23mwV+NS4cwG5+xOgoPdQ2YBDaOAOHGmX5wX4gZ9YjC9t17MunvFt4hknvjMhtujUSjaYHMSqxA==
+"@chakra-ui/tooltip@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/tooltip/-/tooltip-1.2.0.tgz#4d5d784a954b33c3be05e2277c0b1d97e6ab1ff3"
+  integrity sha512-u6PA8amBTmUNbeCs73+A/BEhJwvK7BJz9UlPA3IwAXup2upzQlRWqgb1fYYME+fl4S7UZNGmjExBlanLq4ZxSQ==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/popper" "1.1.5"
-    "@chakra-ui/portal" "1.1.2"
-    "@chakra-ui/utils" "1.3.0"
-    "@chakra-ui/visually-hidden" "1.0.5"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/popper" "2.0.0"
+    "@chakra-ui/portal" "1.1.3"
+    "@chakra-ui/utils" "1.4.0"
+    "@chakra-ui/visually-hidden" "1.0.6"
 
-"@chakra-ui/transition@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.0.9.tgz#a842f1ccfce24c585394084d93778bbf9cb9b694"
-  integrity sha512-ry7i3VY8xhfWxrOcHs4W7hpyT4HsL3P4qe8jbZICzVxuWL7rtYb26P+yItGJeeujE53m2wKjXqrE8kdSivaMVg==
+"@chakra-ui/transition@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/transition/-/transition-1.1.0.tgz#7ac05f7dd2e817f321099b54d654cb1ce82b9035"
+  integrity sha512-cCOTfxvRF8zNfXF9R4CYBiCx24fzWvpAVbQrkjA+A4oUSFYwuqIt72H9fnCOCAh/q84NNKVFuXqtUCawuFjxcg==
   dependencies:
-    "@chakra-ui/hooks" "1.1.5"
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/hooks" "1.2.0"
+    "@chakra-ui/utils" "1.4.0"
 
-"@chakra-ui/utils@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.3.0.tgz#7bfe8ffd4a8613ec562f51d27a08c4c430b88132"
-  integrity sha512-MezHglxjRaAZIQDVAi1uOMVNd4a0zKGmV4cvp8+r3xTmGMU/XJCC5J49qufEqLLJbR31Y7UiCRTz86O66s1r5A==
+"@chakra-ui/utils@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/utils/-/utils-1.4.0.tgz#4b20c522141d68dc62b5c7be929bb6d1596db190"
+  integrity sha512-ND7NIilpncnkzcNBnAySGBFpOXb3urO1X9esSY0+M5zXiq+VSSfK9JuoJd3ilvV4Dbwgzil7hMAELBuHme4uTg==
   dependencies:
     "@types/lodash.mergewith" "4.6.6"
     "@types/object-assign" "4.0.30"
     css-box-model "1.2.1"
     lodash.mergewith "4.6.2"
 
-"@chakra-ui/visually-hidden@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.5.tgz#dcbd32a1eacb19e9636d2242e55aca5914dc3011"
-  integrity sha512-EIRZ081CgfFqhnOuhTfoluoqaKtx1id3/oCLk9QrJcB3s3r3PWexg41/z0WUaQzeQSPobw3hz5M5QxymmrZ4UQ==
+"@chakra-ui/visually-hidden@1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@chakra-ui/visually-hidden/-/visually-hidden-1.0.6.tgz#c47578afbbd9396996c4ee3d7ce05d91f00a43c1"
+  integrity sha512-PM1QOGabhMAQyfNUq05GKSUr85dJdQGeQZVO6Gw8QOJ29+J/xS6Qpyvvn358OrWVYQjw3eEQ15ALEGXb/HJfeA==
   dependencies:
-    "@chakra-ui/utils" "1.3.0"
+    "@chakra-ui/utils" "1.4.0"
 
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
@@ -3998,11 +3996,6 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
-dequal@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
-  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
-
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -4026,10 +4019,10 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node-es@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.0.0.tgz#c0318b9e539a5256ca780dd9575c9345af05b8ed"
-  integrity sha512-S4AHriUkTX9FoFvL4G8hXDcx6t3gp2HpfCza3Q0v6S78gul2hKWifLQbeW+ZF89+hSm2ZIc/uF3J97ZgytgTRg==
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 detect-node@^2.0.4:
   version "2.0.4"
@@ -9591,11 +9584,11 @@ use-callback-ref@^1.2.1, use-callback-ref@^1.2.3:
   integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
 use-sidecar@^1.0.1:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.4.tgz#38398c3723727f9f924bed2343dfa3db6aaaee46"
-  integrity sha512-A5ggIS3/qTdxCAlcy05anO2/oqXOfpmxnpRE1Jm+fHHtCvUvNSZDGqgOSAXPriBVAcw2fMFFkh5v5KqrFFhCMA==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.5.tgz#ffff2a17c1df42e348624b699ba6e5c220527f2b"
+  integrity sha512-k9jnrjYNwN6xYLj1iaGhonDghfvmeTmYjAiGvOr7clwKfPjMXJf4/HOr7oT5tJwYafgp2tG2l3eZEOfoELiMcA==
   dependencies:
-    detect-node-es "^1.0.0"
+    detect-node-es "^1.1.0"
     tslib "^1.9.3"
 
 use@^3.1.0:

--- a/airflow/ui/yarn.lock
+++ b/airflow/ui/yarn.lock
@@ -4960,19 +4960,6 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-framer-motion@3.6.7:
-  version "3.6.7"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-3.6.7.tgz#b9b40db52ecb2390757f7c556846e3b4bf949330"
-  integrity sha512-3DqvW+Ab69dL54gn0YvrWz4+Gg8PCgvXH9Rknx4OXJ226vYzpSjc3imHBM4h974ndVvb8C4/Z3/PyZigEh8m2A==
-  dependencies:
-    framesync "^5.1.0"
-    hey-listen "^1.0.8"
-    popmotion "9.2.1"
-    style-value-types "4.0.3"
-    tslib "^1.10.0"
-  optionalDependencies:
-    "@emotion/is-prop-valid" "^0.8.2"
-
 framer-motion@^3.10.0:
   version "3.10.6"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-3.10.6.tgz#67737ef05ed0408860751d81c919770ac831b394"
@@ -4986,12 +4973,7 @@ framer-motion@^3.10.0:
   optionalDependencies:
     "@emotion/is-prop-valid" "^0.8.2"
 
-framesync@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-5.1.0.tgz#b22639be6e83cf170e5cb3d0497e3e50100a01ef"
-  integrity sha512-31sDH8LxSFoLKDYENzKdI+YJD4vV8sMBpwcAW0/6Es2jZBQBdlqbFnqrYczpsnzpqG+y6EqYPvgFMI2ZDdlnyQ==
-
-framesync@5.2.0, framesync@^5.1.0:
+framesync@5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/framesync/-/framesync-5.2.0.tgz#f14480654cd05a6af4c72c9890cad93556841643"
   integrity sha512-dcl92w5SHc0o6pRK3//VBVNvu6WkYkiXmHG6ZIXrVzmgh0aDYMDAaoA3p3LH71JIdN5qmhDcfONFA4Lmq22tNA==
@@ -7705,16 +7687,6 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-popmotion@9.2.1:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.2.1.tgz#8bc19214a4f0ba7925a901455d0996131cbec6dc"
-  integrity sha512-kplHK5z2LwYkUXNMCC4+tSYuuAXcG3oatKdsEzJzc1r0I2wM5UnYKITO1ZUnmmFy84VJqIZuoBXwJrWuZuAKkg==
-  dependencies:
-    framesync "5.1.0"
-    hey-listen "^1.0.8"
-    style-value-types "4.0.3"
-    tslib "^1.10.0"
-
 popmotion@9.3.1:
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-9.3.1.tgz#134319ed4b9b8e3ec506c99064f7b2f14bc05781"
@@ -9137,14 +9109,6 @@ style-loader@^1.3.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
-
-style-value-types@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-4.0.3.tgz#3e2e46c50e876757cba02f442c8a0b0dd970c118"
-  integrity sha512-Yk2kpwC88W2HRlJXegWlT0pfLzjKWMjj8DI4s6m2VsZsL1Ht2oUyHl1EgTYIRlFiAnC4rBSQO+EEn0YiYAxQDw==
-  dependencies:
-    hey-listen "^1.0.8"
-    tslib "^1.10.0"
 
 style-value-types@4.1.1:
   version "4.1.1"

--- a/airflow/ui/yarn.lock
+++ b/airflow/ui/yarn.lock
@@ -905,7 +905,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.6", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
@@ -2046,6 +2046,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.8.tgz#49348387983075705fe8f4e02fb67f7daaec4934"
+  integrity sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz#3c9ee980f1a10d6021ae6632ca3e79ca2ec4fb50"
@@ -2143,6 +2148,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.2.tgz#35654cf6c49ae162d5bc90843d5437dc38008d43"
   integrity sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.1.7":
+  version "5.1.7"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.7.tgz#a126d9ea76079ffbbdb0d9225073eb5797ab7271"
+  integrity sha512-D5mHD6TbdV/DNHYsnwBTv+y73ei+mMjrkGrla86HthE4/PVvL1J94Bu3qABU+COXzpL23T1EZapVVpwHuBXiUg==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.12"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.12.tgz#0f300e09468e7aed86e18241c90238c18c377e51"
+  integrity sha512-0bhXQwHYfMeJlCh7mGhc0VJTRm0Gk+Z8T00aiP4702mDUuLs9SMhnd2DitpjWFjdOecx2UXtICK14H9iMnziGA==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^17.0.3":
@@ -5309,6 +5331,25 @@ hey-listen@^1.0.8:
   resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
   integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
+history@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/history/-/history-5.0.0.tgz#0cabbb6c4bbf835addb874f8259f6d25101efd08"
+  integrity sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==
+  dependencies:
+    "@babel/runtime" "^7.7.6"
+
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5318,7 +5359,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5941,6 +5982,11 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -6660,7 +6706,7 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -6855,6 +6901,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@^0.12.0:
   version "0.12.0"
@@ -7545,6 +7599,13 @@ path-to-regexp@0.1.7:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
 
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -7968,7 +8029,7 @@ react-hot-loader@^4:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8001,6 +8062,35 @@ react-remove-scroll@2.4.1:
     tslib "^1.0.0"
     use-callback-ref "^1.2.3"
     use-sidecar "^1.0.1"
+
+react-router-dom@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-style-singleton@^2.1.0:
   version "2.1.1"
@@ -8293,6 +8383,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -9153,10 +9248,15 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tiny-invariant@^1.0.6:
+tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tinycolor2@1.4.2:
   version "1.4.2"
@@ -9571,6 +9671,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -202,6 +202,8 @@ function initialization::initialize_files_for_rebuild_check() {
         "airflow/www/package.json"
         "airflow/www/yarn.lock"
         "airflow/www/webpack.config.js"
+        "airflow/ui/package.json"
+        "airflow/ui/yarn.lock"
     )
 }
 


### PR DESCRIPTION
Replacing #14862 with this identical PR ~to circumvent a NPM packaging caching issue in GitHub Actions causing static checks to fail~. (checks were removed temporarily by #14984)

Resolves #14802.

This adds `react-router-dom` with an initial collection of Routes and corresponding placeholder view components.