### PR TITLE
Sort and order REST API endpoints part2

### DIFF
--- a/airflow/api_connexion/endpoints/connection_endpoint.py
+++ b/airflow/api_connexion/endpoints/connection_endpoint.py
@@ -67,7 +67,8 @@ def get_connections(session, limit, sort, offset=0, order_by="id"):
     """Get all connection entries"""
     if order_by == "connection_id":
         order_by = 'id'
-    if not hasattr(Connection, order_by):
+    columns = [i.name for i in Connection.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"Connection has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -62,7 +62,8 @@ def get_dag_details(dag_id):
 @format_parameters({'limit': check_limit})
 def get_dags(limit, sort, offset=0, order_by='dag_id'):
     """Get all DAGs."""
-    if not hasattr(DagModel, order_by):
+    columns = [i.name for i in DagModel.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"DagModel has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -60,17 +60,17 @@ def get_dag_details(dag_id):
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 @format_parameters({'limit': check_limit})
-def get_dags(limit, sort, offset=0, order_by=None):
+def get_dags(limit, sort, offset=0, order_by='dag_id'):
     """Get all DAGs."""
-    if order_by and not hasattr(DagModel, order_by):
+    if not hasattr(DagModel, order_by):
         raise BadRequest(
             detail=f"DagModel has no attribute '{order_by}' specified in order_by parameter",
         )
     readable_dags = current_app.appbuilder.sm.get_readable_dags(g.user)
     if sort == "asc":
-        query = readable_dags.order_by(asc(order_by or DagModel.dag_id))
+        query = readable_dags.order_by(asc(order_by))
     else:
-        query = readable_dags.order_by(desc(order_by or DagModel.dag_id))
+        query = readable_dags.order_by(desc(order_by))
     dags = query.offset(offset).limit(limit).all()
     total_entries = readable_dags.count()
 

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -100,7 +100,8 @@ def get_dag_runs(
 ):  # pylint: disable=too-many-arguments
     """Get all DAG Runs."""
     # return early if order_by field do not exist
-    if order_by and not hasattr(DagRun, order_by):
+    columns = [i.name for i in DagRun.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"DagRun has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -102,8 +102,7 @@ def get_dag_runs(
     # return early if order_by field do not exist
     if order_by and not hasattr(DagRun, order_by):
         raise BadRequest(
-            title="Orderby column not found",
-            detail=f"The column `{order_by}` specified by order_by in query does not exist",
+            detail=f"DagRun has no attribute '{order_by}' specified in order_by parameter",
         )
     query = session.query(DagRun)
 

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -96,7 +96,7 @@ def get_dag_runs(
     offset=None,
     limit=None,
     sort=None,
-    order_by=None,
+    order_by='id',
 ):  # pylint: disable=too-many-arguments
     """Get all DAG Runs."""
     # return early if order_by field do not exist
@@ -156,9 +156,9 @@ def _fetch_dag_runs(
     total_entries = query.count()
     # sort
     if sort == 'asc':
-        query = query.order_by(asc(order_by or DagRun.id))
+        query = query.order_by(asc(order_by))
     elif sort == 'desc':
-        query = query.order_by(desc(order_by or DagRun.id))
+        query = query.order_by(desc(order_by))
     else:
         query = query.order_by(DagRun.id)
     # apply offset and limit

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -46,7 +46,8 @@ def get_event_log(event_log_id, session):
 @provide_session
 def get_event_logs(session, sort, limit, offset=None, order_by='id'):
     """Get all log entries from event log"""
-    if not hasattr(Log, order_by):
+    columns = [i.name for i in Log.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"Log has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/event_log_endpoint.py
+++ b/airflow/api_connexion/endpoints/event_log_endpoint.py
@@ -16,7 +16,7 @@
 # under the License.
 
 
-from sqlalchemy import func
+from sqlalchemy import asc, desc, func
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import NotFound
@@ -44,10 +44,15 @@ def get_event_log(event_log_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_AUDIT_LOG)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_event_logs(session, limit, offset=None):
+def get_event_logs(session, sort, limit, offset=None, order_by=None):
     """Get all log entries from event log"""
     total_entries = session.query(func.count(Log.id)).scalar()
-    event_logs = session.query(Log).order_by(Log.id).offset(offset).limit(limit).all()
+    query = session.query(Log)
+    if sort == 'asc':
+        query = query.order_by(asc(order_by or Log.id))
+    else:
+        query = query.order_by(desc(order_by or Log.id))
+    event_logs = query.offset(offset).limit(limit).all()
     return event_log_collection_schema.dump(
         EventLogCollection(event_logs=event_logs, total_entries=total_entries)
     )

--- a/airflow/api_connexion/endpoints/import_error_endpoint.py
+++ b/airflow/api_connexion/endpoints/import_error_endpoint.py
@@ -51,7 +51,8 @@ def get_import_errors(session, limit, sort, offset=None, order_by='id'):
     """Get all import errors"""
     if order_by == 'import_error_id':
         order_by = 'id'
-    if not hasattr(ImportError, order_by):
+    columns = [i.name for i in ImportError.__table__.columns]  # pylint: disable=no-member
+    if order_by not in columns:
         raise BadRequest(
             detail=f"ImportError has no attribute '{order_by}' specified in order_by parameter",
         )

--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -48,6 +48,8 @@ def get_roles(limit, sort, order_by='name', offset=None):
     appbuilder = current_app.appbuilder
     session = appbuilder.get_session
     total_entries = session.query(func.count(Role.id)).scalar()
+    if order_by == 'role_id':
+        order_by = 'id'
     columns = [i.name for i in Role.__table__.columns]  # pylint: disable=no-member
     if order_by not in columns:
         raise BadRequest(

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -51,7 +51,7 @@ def get_task(dag_id, task_id):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
     ]
 )
-def get_tasks(dag_id, sort: str, order_by=None):
+def get_tasks(dag_id, sort: str, order_by='task_id'):
     """Get tasks for DAG"""
     dag: DAG = current_app.dag_bag.get_dag(dag_id)
     if not dag:
@@ -59,12 +59,12 @@ def get_tasks(dag_id, sort: str, order_by=None):
     tasks = dag.tasks
     if sort == 'desc':
         try:
-            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"), reverse=True)
+            tasks = sorted(tasks, key=attrgetter(order_by), reverse=True)
         except AttributeError as err:
             raise BadRequest(detail=str(err))
     else:
         try:
-            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"))
+            tasks = sorted(tasks, key=attrgetter(order_by))
         except AttributeError as err:
             raise BadRequest(detail=str(err))
     task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))

--- a/airflow/api_connexion/endpoints/task_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_endpoint.py
@@ -14,11 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from operator import attrgetter
+
 from flask import current_app
 
 from airflow import DAG
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import NotFound
+from airflow.api_connexion.exceptions import BadRequest, NotFound
 from airflow.api_connexion.schemas.task_schema import TaskCollection, task_collection_schema, task_schema
 from airflow.exceptions import TaskNotFound
 from airflow.security import permissions
@@ -49,11 +51,21 @@ def get_task(dag_id, task_id):
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
     ]
 )
-def get_tasks(dag_id):
+def get_tasks(dag_id, sort: str, order_by=None):
     """Get tasks for DAG"""
     dag: DAG = current_app.dag_bag.get_dag(dag_id)
     if not dag:
         raise NotFound("DAG not found")
     tasks = dag.tasks
+    if sort == 'desc':
+        try:
+            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"), reverse=True)
+        except AttributeError as err:
+            raise BadRequest(detail=str(err))
+    else:
+        try:
+            tasks = sorted(tasks, key=attrgetter(order_by or "task_id"))
+        except AttributeError as err:
+            raise BadRequest(detail=str(err))
     task_collection = TaskCollection(tasks=tasks, total_entries=len(tasks))
     return task_collection_schema.dump(task_collection)

--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -47,6 +47,8 @@ def get_users(limit, sort, order_by='id', offset=None):
     session = appbuilder.get_session
     total_entries = session.query(func.count(User.id)).scalar()
     columns = [i.name for i in User.__table__.columns]  # pylint: disable=no-member
+    if order_by == 'user_id':
+        order_by = 'id'
     if order_by not in columns:
         raise BadRequest(
             detail=f"User model has no attribute '{order_by}' specified in order_by parameter",

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -648,6 +648,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -260,6 +260,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.
@@ -696,6 +698,9 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
+
       responses:
         '200':
           description: Success.
@@ -711,7 +716,6 @@ paths:
   /importErrors/{import_error_id}:
     parameters:
       - $ref: '#/components/parameters/ImportErrorID'
-
     get:
       summary: Get an import error
       x-openapi-router-controller: airflow.api_connexion.endpoints.import_error_endpoint

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1211,6 +1211,8 @@ paths:
   /dags/{dag_id}/tasks:
     parameters:
       - $ref: '#/components/parameters/DAGID'
+      - $ref: '#/components/parameters/SortBy'
+      - $ref: '#/components/parameters/OrderBy'
 
     get:
       summary: Get tasks for DAG

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1405,6 +1405,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.
@@ -1470,6 +1472,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -376,6 +376,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -960,6 +960,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: Success.

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -526,6 +526,8 @@ paths:
         - $ref: '#/components/parameters/FilterStartDateLTE'
         - $ref: '#/components/parameters/FilterEndDateGTE'
         - $ref: '#/components/parameters/FilterEndDateLTE'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: List of DAG runs.
@@ -3165,6 +3167,27 @@ components:
           type: string
       description:
         The value can be repeated to retrieve multiple matching values (OR condition).
+
+    # Sort/Order parameters
+    SortBy:
+      in: query
+      name: sort
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+        default: desc
+      required: false
+      description: The direction to order results
+
+    OrderBy:
+      in: query
+      name: order_by
+      schema:
+        type: string
+      required: false
+      description: The name of the field to order results
 
     # Other parameters
     FileToken:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -744,6 +744,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/PageLimit'
         - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/SortBy'
+        - $ref: '#/components/parameters/OrderBy'
       responses:
         '200':
           description: List of pools.

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -278,6 +278,15 @@ class TestGetDagRuns(TestDagRunEndpoint):
             "total_entries": 2,
         }
 
+    def test_invalid_order_by_raises_400(self):
+        self._create_test_dag_run()
+
+        response = self.client.get(
+            "api/v1/dags/TEST_DAG_ID/dagRuns?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == "DagRun has no attribute 'invalid' specified in order_by parameter"
+
     def test_return_correct_results_with_order_by(self, session):
         self._create_test_dag_run()
         result = session.query(DagRun).all()

--- a/tests/api_connexion/endpoints/test_event_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_event_log_endpoint.py
@@ -321,6 +321,17 @@ class TestGetEventLogPagination(TestEventLogEndpoint):
         assert response.json["total_entries"] == 200
         assert len(response.json["event_logs"]) == 100  # default 100
 
+    def test_should_raise_400_for_invalid_order_by_name(self, session):
+        log_models = self._create_event_logs(200)
+        session.add_all(log_models)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/eventLogs?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == "Log has no attribute 'invalid' specified in order_by parameter"
+
     @provide_session
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self, session):

--- a/tests/api_connexion/endpoints/test_import_error_endpoint.py
+++ b/tests/api_connexion/endpoints/test_import_error_endpoint.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from datetime import timedelta
 
 import pytest
 from parameterized import parameterized
@@ -131,7 +132,7 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
         session.add_all(import_error)
         session.commit()
 
-        response = self.client.get("/api/v1/importErrors", environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get("/api/v1/importErrors?sort=asc", environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
         response_data = response.json
@@ -153,6 +154,64 @@ class TestGetImportErrorsEndpoint(TestBaseImportError):
             ],
             "total_entries": 2,
         } == response_data
+
+    def test_get_import_errors_order_by(self, session):
+        import_error = [
+            ImportError(
+                filename=f"Lorem_ipsum{i}.py",
+                stacktrace="Lorem ipsum",
+                timestamp=timezone.parse(self.timestamp, timezone="UTC") + timedelta(days=-i),
+            )
+            for i in range(1, 3)
+        ]
+        session.add_all(import_error)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/importErrors?order_by=timestamp&sort=asc", environ_overrides={'REMOTE_USER': "test"}
+        )
+
+        assert response.status_code == 200
+        response_data = response.json
+        self._normalize_import_errors(response_data['import_errors'])
+        assert {
+            "import_errors": [
+                {
+                    "filename": "Lorem_ipsum2.py",
+                    "import_error_id": 1,  # id normalized with self._normalize_import_errors
+                    "stack_trace": "Lorem ipsum",
+                    "timestamp": "2020-06-08T12:00:00+00:00",
+                },
+                {
+                    "filename": "Lorem_ipsum1.py",
+                    "import_error_id": 2,
+                    "stack_trace": "Lorem ipsum",
+                    "timestamp": "2020-06-09T12:00:00+00:00",
+                },
+            ],
+            "total_entries": 2,
+        } == response_data
+
+    def test_order_by_raises_400_for_invalid_attr(self, session):
+        import_error = [
+            ImportError(
+                filename="Lorem_ipsum.py",
+                stacktrace="Lorem ipsum",
+                timestamp=timezone.parse(self.timestamp, timezone="UTC"),
+            )
+            for _ in range(2)
+        ]
+        session.add_all(import_error)
+        session.commit()
+
+        response = self.client.get(
+            "/api/v1/importErrors?order_by=timest", environ_overrides={'REMOTE_USER': "test"}
+        )
+
+        assert response.status_code == 400
+        assert (
+            response.json['detail'] == "ImportError has no attribute 'timest' specified in order_by parameter"
+        )
 
     def test_should_raises_401_unauthenticated(self, session):
         import_error = [
@@ -197,7 +256,7 @@ class TestGetImportErrorsEndpointPagination(TestBaseImportError):
         session.add_all(import_errors)
         session.commit()
 
-        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
 
         assert response.status_code == 200
         import_ids = [pool["filename"] for pool in response.json["import_errors"]]

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -92,6 +92,15 @@ class TestGetRolesEndpoint(TestRoleEndpoint):
         response = self.client.get("/api/v1/roles")
         assert_401(response)
 
+    def test_should_raises_400_for_invalid_order_by(self):
+        response = self.client.get(
+            "/api/v1/roles?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert (
+            response.json['detail'] == "Role model has no attribute 'invalid' specified in order_by parameter"
+        )
+
     def test_should_raise_403_forbidden(self):
         response = self.client.get("/api/v1/roles", environ_overrides={'REMOTE_USER': "test_no_permissions"})
         assert response.status_code == 403
@@ -119,7 +128,7 @@ class TestGetRolesEndpointPaginationandFilter(TestRoleEndpoint):
         ]
     )
     def test_can_handle_limit_and_offset(self, url, expected_roles):
-        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
+        response = self.client.get(url + "&sort=asc", environ_overrides={'REMOTE_USER': "test"})
         assert response.status_code == 200
         existing_roles = set(EXISTING_ROLES)
         existing_roles.update(['Test', 'TestNoPermissions'])

--- a/tests/api_connexion/endpoints/test_task_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_endpoint.py
@@ -53,12 +53,17 @@ def configured_app(minimal_app_for_api):
 class TestTaskEndpoint:
     dag_id = "test_dag"
     task_id = "op1"
+    task_id2 = 'op2'
+    task1_start_date = datetime(2020, 6, 15)
+    task2_start_date = datetime(2020, 6, 16)
 
     @pytest.fixture(scope="class")
     def setup_dag(self, configured_app):
-        with DAG(self.dag_id, start_date=datetime(2020, 6, 15), doc_md="details") as dag:
-            DummyOperator(task_id=self.task_id)
+        with DAG(self.dag_id, start_date=self.task1_start_date, doc_md="details") as dag:
+            task1 = DummyOperator(task_id=self.task_id)
+            task2 = DummyOperator(task_id=self.task_id2, start_date=self.task2_start_date)
 
+        task1 >> task2
         dag_bag = DagBag(os.devnull, include_examples=False)
         dag_bag.dags = {dag.dag_id: dag}
         configured_app.dag_bag = dag_bag  # type:ignore
@@ -87,7 +92,7 @@ class TestGetTask(TestTaskEndpoint):
                 "module_path": "airflow.operators.dummy",
             },
             "depends_on_past": False,
-            "downstream_task_ids": [],
+            "downstream_task_ids": [self.task_id2],
             "end_date": None,
             "execution_timeout": None,
             "extra_links": [],
@@ -129,7 +134,7 @@ class TestGetTask(TestTaskEndpoint):
                 "module_path": "airflow.operators.dummy",
             },
             "depends_on_past": False,
-            "downstream_task_ids": [],
+            "downstream_task_ids": [self.task_id2],
             "end_date": None,
             "execution_timeout": None,
             "extra_links": [],
@@ -198,6 +203,33 @@ class TestGetTasks(TestTaskEndpoint):
                     "retries": 0.0,
                     "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
                     "retry_exponential_backoff": False,
+                    "start_date": "2020-06-16T00:00:00+00:00",
+                    "task_id": self.task_id2,
+                    "template_fields": [],
+                    "trigger_rule": "all_success",
+                    "ui_color": "#e8f7e4",
+                    "ui_fgcolor": "#000",
+                    "wait_for_downstream": False,
+                    "weight_rule": "downstream",
+                },
+                {
+                    "class_ref": {
+                        "class_name": "DummyOperator",
+                        "module_path": "airflow.operators.dummy",
+                    },
+                    "depends_on_past": False,
+                    "downstream_task_ids": [self.task_id2],
+                    "end_date": None,
+                    "execution_timeout": None,
+                    "extra_links": [],
+                    "owner": "airflow",
+                    "pool": "default_pool",
+                    "pool_slots": 1.0,
+                    "priority_weight": 1.0,
+                    "queue": "default",
+                    "retries": 0.0,
+                    "retry_delay": {"__type": "TimeDelta", "days": 0, "seconds": 300, "microseconds": 0},
+                    "retry_exponential_backoff": False,
                     "start_date": "2020-06-15T00:00:00+00:00",
                     "task_id": "op1",
                     "template_fields": [],
@@ -206,15 +238,43 @@ class TestGetTasks(TestTaskEndpoint):
                     "ui_fgcolor": "#000",
                     "wait_for_downstream": False,
                     "weight_rule": "downstream",
-                }
+                },
             ],
-            "total_entries": 1,
+            "total_entries": 2,
         }
         response = self.client.get(
             f"/api/v1/dags/{self.dag_id}/tasks", environ_overrides={'REMOTE_USER': "test"}
         )
         assert response.status_code == 200
         assert response.json == expected
+
+    def test_should_respond_200_ascending_order_by_start_date(self):
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/tasks?sort=asc&order_by=start_date",
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 200
+        assert self.task1_start_date < self.task2_start_date
+        assert response.json['tasks'][0]['task_id'] == self.task_id
+        assert response.json['tasks'][1]['task_id'] == self.task_id2
+
+    def test_should_respond_200_descending_order_by_start_date(self):
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/tasks?order_by=start_date", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 200
+        # Default sort order is descending
+        assert self.task1_start_date < self.task2_start_date
+        assert response.json['tasks'][0]['task_id'] == self.task_id2
+        assert response.json['tasks'][1]['task_id'] == self.task_id
+
+    def test_should_raise_400_for_invalid_order_by_name(self):
+        response = self.client.get(
+            f"/api/v1/dags/{self.dag_id}/tasks?order_by=invalid_task_colume_name",
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == "'DummyOperator' object has no attribute 'invalid_task_colume_name'"
 
     def test_should_respond_404(self):
         dag_id = "xxxx_not_existing"

--- a/tests/api_connexion/endpoints/test_variable_endpoint.py
+++ b/tests/api_connexion/endpoints/test_variable_endpoint.py
@@ -129,7 +129,7 @@ class TestGetVariables(TestVariableEndpoint):
     @parameterized.expand(
         [
             (
-                "/api/v1/variables?limit=2&offset=0",
+                "/api/v1/variables?limit=2&offset=0&sort=asc",
                 {
                     "variables": [
                         {"key": "var1", "value": "1"},
@@ -139,7 +139,7 @@ class TestGetVariables(TestVariableEndpoint):
                 },
             ),
             (
-                "/api/v1/variables?limit=2&offset=1",
+                "/api/v1/variables?limit=2&offset=1&sort=asc",
                 {
                     "variables": [
                         {"key": "var2", "value": "foo"},
@@ -149,7 +149,7 @@ class TestGetVariables(TestVariableEndpoint):
                 },
             ),
             (
-                "/api/v1/variables?limit=1&offset=2",
+                "/api/v1/variables?limit=1&offset=2&sort=asc",
                 {
                     "variables": [
                         {"key": "var3", "value": "[100, 101]"},
@@ -174,6 +174,18 @@ class TestGetVariables(TestVariableEndpoint):
         assert response.status_code == 200
         assert response.json["total_entries"] == 101
         assert len(response.json["variables"]) == 100
+
+    def test_should_raise_400_for_invalid_order_by(self):
+        for i in range(101):
+            Variable.set(f"var{i}", i)
+        response = self.client.get(
+            "/api/v1/variables?order_by=invalid", environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert (
+            response.json["detail"]
+            == "Variable model has no attribute 'invalid' specified in order_by parameter"
+        )
 
     @conf_vars({("api", "maximum_page_limit"): "150"})
     def test_should_return_conf_max_if_req_max_above_conf(self):


### PR DESCRIPTION
This change adds sort and order_by to the following endpoints:
1. Get Users endpoint
2. Get roles endpoint
3. Get variables endpoint
4. Get Import errors endpoint

This change depends on #14895. With this, it now remains Get taskinstances endpoint which will be done in a separate PR


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
