### PR TITLE
Update python openapi gen script to generate code in a submodule

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -22,7 +22,7 @@
 Supported languages:
 
 * [Golang](https://github.com/apache/airflow-client-go) generated through `./gen/go.sh`.
-
+* [Python](https://github.com/apache/airflow-client-python) generated through `./gen/python.sh`.
 
 ## Dependencies
 

--- a/clients/gen/common.sh
+++ b/clients/gen/common.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OPENAPI_GENERATOR_CLI_VER=5.0.1
+OPENAPI_GENERATOR_CLI_VER=5.1.0
 readonly OPENAPI_GENERATOR_CLI_VER
 
 GIT_USER=${GIT_USER:-apache}
@@ -45,10 +45,23 @@ function validate_input {
     OUTPUT_DIR=$(realpath "$2")
     readonly OUTPUT_DIR
 
+    # cleanup the existing generated code, otherwise generator would skip them
+    for dir in "${CLEANUP_DIRS[@]}"
+    do
+        echo "Cleaning up ${OUTPUT_DIR}/${dir}"
+        rm -rf "${OUTPUT_DIR}/${dir}"
+    done
+
     # create openapi ignore file to keep generated code clean
     cat <<EOF > "${OUTPUT_DIR}/.openapi-generator-ignore"
 .travis.yml
 git_push.sh
+.gitlab-ci.yml
+requirements.txt
+setup.cfg
+setup.py
+test-requirements.txt
+tox.ini
 EOF
 }
 

--- a/clients/gen/common.sh
+++ b/clients/gen/common.sh
@@ -48,8 +48,9 @@ function validate_input {
     # cleanup the existing generated code, otherwise generator would skip them
     for dir in "${CLEANUP_DIRS[@]}"
     do
-        echo "Cleaning up ${OUTPUT_DIR}/${dir}"
-        rm -rf "${OUTPUT_DIR}/${dir}"
+        local dirToClean="${OUTPUT_DIR}/${dir}"
+        echo "Cleaning up ${dirToClean}"
+        rm -rf "${dirToClean:?}"
     done
 
     # create openapi ignore file to keep generated code clean

--- a/clients/gen/go.sh
+++ b/clients/gen/go.sh
@@ -19,6 +19,9 @@
 CLIENTS_GEN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly CLIENTS_GEN_DIR
 
+CLEANUP_DIRS=(api docs)
+readonly CLEANUP_DIRS
+
 # shellcheck source=./clients/gen/common.sh
 source "${CLIENTS_GEN_DIR}/common.sh"
 

--- a/clients/gen/python.sh
+++ b/clients/gen/python.sh
@@ -19,6 +19,9 @@
 CLIENTS_GEN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 readonly CLIENTS_GEN_DIR
 
+CLEANUP_DIRS=(client docs test README.md)
+readonly CLEANUP_DIRS
+
 # shellcheck source=./clients/gen/common.sh
 source "${CLIENTS_GEN_DIR}/common.sh"
 
@@ -39,6 +42,7 @@ gen_client python \
 echo "--- Patching generated code..."
 
 # Post-processing of the generated Python wrapper.
+
 touch "${OUTPUT_DIR}/__init__.py"
 find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i '' -e 's/client/airflow_client.client/g' {} +
 find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/# client/# Apache Airflow Python Client/g' {} +

--- a/clients/gen/python.sh
+++ b/clients/gen/python.sh
@@ -32,8 +32,23 @@ python_config=(
 validate_input "$@"
 
 gen_client python \
-    --package-name airflow_client \
-    --git-repo-id airflow-client-python/airflow \
+    --package-name client \
+    --git-repo-id airflow-client-python \
     --additional-properties "${python_config[*]}"
+
+echo "--- Patching generated code..."
+
+# Post-processing of the generated Python wrapper.
+touch "${OUTPUT_DIR}/__init__.py"
+find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i '' -e 's/client/airflow_client.client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/# client/# Apache Airflow Python Client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/import client/import airflow_client.client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/from client/from airflow_client.client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
+
+# fix imports
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i '' -e 's/import client\./import airflow_client.client./g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i '' -e 's/from client/from airflow_client.client/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i '' -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
 
 run_pre_commit


### PR DESCRIPTION
Some changes required in the OpenApi3 generator script to support the auto-generated code as a submodule to the airflow_client we'd created previously. 

Related PR -> https://github.com/apache/airflow-client-python/pull/2
