### PR TITLE
Add label area:providers to boring cyborg

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -44,6 +44,15 @@ labelPRBasedOnFilePath:
     - docs/howto/operator/snowflake/*
     - tests/providers/snowflake/**/*
 
+  area:providers:
+    - airflow/providers/**/*
+    - docs/apache-airflow-providers-*/**/*
+    - tests/providers/**/*
+    - scripts/docker-compose/ci/integration-*.yml
+    - tests/core/test_providers_manager.py
+    - scripts/in_container/run_install_and_test_provider_packages.sh
+    - scripts/in_container/run_prepare_provider_documentation.sh
+
   area:kubernetes:
     - airflow/**/kubernetes_*.py
     - airflow/example_dags/example_kubernetes_executor.py

--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -48,10 +48,6 @@ labelPRBasedOnFilePath:
     - airflow/providers/**/*
     - docs/apache-airflow-providers-*/**/*
     - tests/providers/**/*
-    - scripts/docker-compose/ci/integration-*.yml
-    - tests/core/test_providers_manager.py
-    - scripts/in_container/run_install_and_test_provider_packages.sh
-    - scripts/in_container/run_prepare_provider_documentation.sh
 
   area:kubernetes:
     - airflow/**/kubernetes_*.py

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -93,7 +93,6 @@ class AirbyteHook(HttpHook):
             endpoint=f"api/{self.api_version}/connections/sync",
             json={"connectionId": connection_id},
             headers={"accept": "application/json"},
-            extra_options={'allow_redirects': False}
         )
 
     def get_job(self, job_id: int) -> Any:

--- a/airflow/providers/airbyte/hooks/airbyte.py
+++ b/airflow/providers/airbyte/hooks/airbyte.py
@@ -93,6 +93,7 @@ class AirbyteHook(HttpHook):
             endpoint=f"api/{self.api_version}/connections/sync",
             json={"connectionId": connection_id},
             headers={"accept": "application/json"},
+            extra_options={'allow_redirects': False}
         )
 
     def get_job(self, job_id: int) -> Any:


### PR DESCRIPTION
Boring Cyborg now only allows labeling using a basic path. When someone changes a big provider (Apache, Google, AWS) the boring cyborg is going to apply two labels: `area:providers` and `provider:Google` for example, which is not a problem IMHO.

Resolves #14879 @kaxil and @mik-laj can take a look?

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
