### PR TITLE
Fixes default group of Airflow user.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -483,6 +483,8 @@ WORKDIR ${AIRFLOW_HOME}
 
 EXPOSE 8080
 
+RUN usermod -g 0 airflow
+
 USER ${AIRFLOW_UID}
 
 # Having the variable in final image allows to disable providers manager warnings when

--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -28,6 +28,21 @@ The recommended way to update your DAGs with this chart is to build a new docker
 .. code-block:: bash
 
     docker build --tag "my-company/airflow:8a0da78" . -f - <<EOF
+    FROM apache/airflow
+
+    COPY ./dags/ \${AIRFLOW_HOME}/dags/
+
+    EOF
+
+.. note::
+
+   In airflow images prior to version 2.0.2, there was a bug that required you to use
+   a bit longer Dockerfile, to make sure the image remains OpenShift-compatible (i.e dag
+   has root group similarly as other files). In 2.0.2 this has been fixed.
+
+.. code-block:: bash
+
+    docker build --tag "my-company/airflow:8a0da78" . -f - <<EOF
     FROM apache/airflow:2.0.1
 
     USER root
@@ -37,6 +52,7 @@ The recommended way to update your DAGs with this chart is to build a new docker
     USER airflow
 
     EOF
+
 
 Then publish it in the accessible registry:
 

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -255,13 +255,9 @@ function kind::build_image_for_kubernetes_tests() {
     docker build --tag "${AIRFLOW_PROD_IMAGE_KUBERNETES}" . -f - <<EOF
 FROM ${AIRFLOW_PROD_IMAGE}
 
-USER root
+COPY airflow/example_dags/ \${AIRFLOW_HOME}/dags/
 
-COPY --chown=airflow:root airflow/example_dags/ \${AIRFLOW_HOME}/dags/
-
-COPY --chown=airflow:root airflow/kubernetes_executor_templates/ \${AIRFLOW_HOME}/pod_templates/
-
-USER airflow
+COPY airflow/kubernetes_executor_templates/ \${AIRFLOW_HOME}/pod_templates/
 
 EOF
     echo "The ${AIRFLOW_PROD_IMAGE_KUBERNETES} is prepared for test kubernetes deployment."


### PR DESCRIPTION
The production image did not have root group set as default for
the airflow user. This was not a big problem unless you extended
the image - in which case you had to change the group manually
when copying the images in order to keep the image OpenShift
compatible (i.e. runnable with any user and root group).

This PR fixes it by changing default group of airflow user
to root, which also works when you extend the image.

```
Connected.
airflow@53f70b1e3675:/opt/airflow$ ls
dags  logs
airflow@53f70b1e3675:/opt/airflow$ cd dags/
airflow@53f70b1e3675:/opt/airflow/dags$ ls -l
total 4
-rw-r--r-- 1 airflow root 1648 Mar 22 23:16 test_dag.py
airflow@53f70b1e3675:/opt/airflow/dags$
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
