### PR TITLE
Update add-dag-tags.rst info about tag filtering only works in RBAC UI

### DIFF
--- a/docs/apache-airflow/howto/add-dag-tags.rst
+++ b/docs/apache-airflow/howto/add-dag-tags.rst
@@ -42,3 +42,5 @@ In your Dag file, pass a list of tags you want to add to DAG object:
 **Screenshot**:
 
 .. image:: ../img/add-dag-tags.png
+
+Note: This feature is only available for the RBAC UI (enabled using rbac=True in [webserver] section in your airflow.cfg).


### PR DESCRIPTION
Added at the end:
Note: This feature is only available for the RBAC UI (enabled using rbac=True in [webserver] section in your airflow.cfg).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
