### PR TITLE
remove duplicate assert in TestS3KeysUnchangedSensor

### DIFF
--- a/tests/providers/amazon/aws/sensors/test_s3_keys_unchanged.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_keys_unchanged.py
@@ -107,5 +107,4 @@ class TestS3KeysUnchangedSensor(TestCase):
     def test_poke_succeeds_on_upload_complete(self, mock_hook):
         mock_hook.return_value.list_keys.return_value = {'a'}
         assert not self.sensor.poke(dict())
-        assert not self.sensor.poke(dict())
         assert self.sensor.poke(dict())


### PR DESCRIPTION
`test_poke_succeeds_on_upload_complete` in `TestS3KeysUnchangedSensor` has the same assert twice.
The duplication exist since the sensor was added https://github.com/apache/airflow/pull/9817. This PR removes the duplication.