### PR TITLE
Docs: Clarify behavior of delete_worker_pods_on_failure

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2021,6 +2021,8 @@
       description: |
         If False (and delete_worker_pods is True),
         failed worker pods will not be deleted so users can investigate them.
+        This only prevents removal of worker pods where the worker itself failed,
+        not when the task it ran failed.
       version_added: 1.10.11
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -989,6 +989,8 @@ delete_worker_pods = True
 
 # If False (and delete_worker_pods is True),
 # failed worker pods will not be deleted so users can investigate them.
+# This only prevents removal of worker pods where the worker itself failed,
+# not when the task it ran failed.
 delete_worker_pods_on_failure = False
 
 # Number of Kubernetes Worker Pod creation calls per scheduler loop.


### PR DESCRIPTION
Clarify that the `delete_worker_pods_on_failure` flag only applies to worker failures, not task failures as well.