### PR TITLE
Support all terminus task states in Docker Swarm Operator

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -144,10 +144,10 @@ class DockerSwarmOperator(DockerOperator):
                 self.log.info('Service status before exiting: %s', self._service_status())
                 break
 
-        if self.service and self._service_status() == 'failed':
+        if self.service and self._service_status() != 'complete':
             if self.auto_remove:
                 self.cli.remove_service(self.service['ID'])
-            raise AirflowException('Service failed: ' + repr(self.service))
+            raise AirflowException('Service did not complete: ' + repr(self.service))
         elif self.auto_remove:
             if not self.service:
                 raise Exception("The 'service' should be initialized before!")
@@ -160,7 +160,7 @@ class DockerSwarmOperator(DockerOperator):
 
     def _has_service_terminated(self) -> bool:
         status = self._service_status()
-        return status in ['failed', 'complete']
+        return status in ['complete', 'failed', 'shutdown', 'rejected', 'orphaned', 'remove']
 
     def _stream_logs_to_output(self) -> None:
         if not self.cli:

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 import requests
 from docker import APIClient
+from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator
@@ -146,9 +147,10 @@ class TestDockerSwarmOperator(unittest.TestCase):
             client_mock.remove_service.call_count == 0
         ), 'Docker service being removed even when `auto_remove` set to `False`'
 
+    @parameterized.expand([('failed',), ('shutdown',), ('rejected',), ('orphaned',), ('remove',)])
     @mock.patch('airflow.providers.docker.operators.docker.APIClient')
     @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_failed_service_raises_error(self, types_mock, client_class_mock):
+    def test_non_complete_service_raises_error(self, status, types_mock, client_class_mock):
 
         mock_obj = mock.Mock()
 
@@ -156,7 +158,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         client_mock.create_service.return_value = {'ID': 'some_id'}
         client_mock.images.return_value = []
         client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.return_value = [{'Status': {'State': 'failed'}}]
+        client_mock.tasks.return_value = [{'Status': {'State': status}}]
         types_mock.TaskTemplate.return_value = mock_obj
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -165,7 +165,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         client_class_mock.return_value = client_mock
 
         operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest', enable_logging=False)
-        msg = "Service failed: {'ID': 'some_id'}"
+        msg = "Service did not complete: {'ID': 'some_id'}"
         with pytest.raises(AirflowException) as ctx:
             operator.execute(None)
         assert str(ctx.value) == msg


### PR DESCRIPTION
Docker reference for task states - https://docs.docker.com/engine/swarm/how-swarm-mode-works/swarm-task-states/

In case of existing issue, reference it using one of the following:

closes: https://github.com/apache/airflow/issues/14959
