### PR TITLE
Add new kubernetes.proxy_url configuration option.

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2133,7 +2133,7 @@
     - name: proxy_url
       description: |
         Configure the Kubernetes Python client configuration proxy parameter. Useful
-        if the Kubernetes API is sitting behind something like privoxy or a load balancer.
+        if the Kubernetes API is sitting behind something like Privoxy or a load balancer.
       version_added: ~
       type: string
       example: "http://10.245.35.252:8118"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2130,6 +2130,14 @@
       type: boolean
       example: ~
       default: "True"
+    - name: proxy_url
+      description: |
+        Configure the Kubernetes Python client configuration proxy parameter. Useful
+        if the Kubernetes API is sitting behind something like privoxy or a load balancer.
+      version_added: ~
+      type: string
+      example: "http://10.245.35.252:8118"
+      default: ""
 - name: smart_sensor
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1051,7 +1051,8 @@ verify_ssl = True
 
 # Configure the Kubernetes Python client configuration proxy parameter. Useful
 # if the Kubernetes API is sitting behind something like privoxy or a load balancer.
-proxy_url = 
+# Example: proxy_url = http://10.245.35.252:8118
+proxy_url =
 
 [smart_sensor]
 # When `use_smart_sensor` is True, Airflow redirects multiple qualified sensor tasks to

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1050,7 +1050,7 @@ tcp_keep_cnt = 6
 verify_ssl = True
 
 # Configure the Kubernetes Python client configuration proxy parameter. Useful
-# if the Kubernetes API is sitting behind something like privoxy or a load balancer.
+# if the Kubernetes API is sitting behind something like Privoxy or a load balancer.
 # Example: proxy_url = http://10.245.35.252:8118
 proxy_url =
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1049,6 +1049,10 @@ tcp_keep_cnt = 6
 # Set this to false to skip verifying SSL certificate of Kubernetes python client.
 verify_ssl = True
 
+# Configure the Kubernetes Python client configuration proxy parameter. Useful
+# if the Kubernetes API is sitting behind something like privoxy or a load balancer.
+proxy_url = 
+
 [smart_sensor]
 # When `use_smart_sensor` is True, Airflow redirects multiple qualified sensor tasks to
 # smart sensor task.

--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -17,8 +17,6 @@
 """Client for kubernetes communication"""
 from typing import Optional
 
-from kubernetes.client import configuration
-
 from airflow.configuration import conf
 
 try:

--- a/airflow/kubernetes/kube_client.py
+++ b/airflow/kubernetes/kube_client.py
@@ -17,6 +17,8 @@
 """Client for kubernetes communication"""
 from typing import Optional
 
+from kubernetes.client import configuration
+
 from airflow.configuration import conf
 
 try:
@@ -61,6 +63,11 @@ try:
     def _disable_verify_ssl() -> None:
         configuration = Configuration()
         configuration.verify_ssl = False
+        Configuration.set_default(configuration)
+
+    def _set_proxy(proxy_url) -> None:
+        configuration = Configuration()
+        configuration.proxy = proxy_url
         Configuration.set_default(configuration)
 
 
@@ -130,6 +137,8 @@ def get_kube_client(
 
     if not conf.getboolean('kubernetes', 'verify_ssl', fallback=True):
         _disable_verify_ssl()
+
+    _set_proxy(conf.get('kubernetes', 'proxy_url', fallback=None))
 
     client_conf = _get_kube_config(in_cluster, cluster_context, config_file)
     return _get_client_with_patched_configuration(client_conf)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -291,6 +291,7 @@ Pre
 Precommit
 PredictionServiceClient
 Preprocessed
+Privoxy
 Proc
 ProductSearchClient
 Protobuf

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -19,7 +19,7 @@ import socket
 import unittest
 from unittest import mock
 
-from kubernetes.client import Configuration, configuration
+from kubernetes.client import Configuration
 from urllib3.connection import HTTPConnection, HTTPSConnection
 
 from airflow.kubernetes.kube_client import (


### PR DESCRIPTION
closes: #14904

Allows for the specification of a `proxy_url` option to which the Kubernetes Python client should proxy its requests through.