### PR TITLE
Make skip_exit_code configurable in BashOperator

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -21,7 +21,6 @@
 from datetime import timedelta
 
 from airflow import DAG
-from airflow.hooks.subprocess import EXIT_CODE_SKIP
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.dates import days_ago
@@ -71,7 +70,7 @@ with DAG(
 # [START howto_operator_bash_skip]
 this_will_skip = BashOperator(
     task_id='this_will_skip',
-    bash_command=f'echo "hello world"; exit {EXIT_CODE_SKIP};',
+    bash_command='echo "hello world"; exit 99;',
     dag=dag,
 )
 # [END howto_operator_bash_skip]

--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -24,8 +24,6 @@ from typing import Dict, List, Optional
 
 from airflow.hooks.base import BaseHook
 
-EXIT_CODE_SKIP = 127
-
 SubprocessResult = namedtuple('SubprocessResult', ['exit_code', 'output'])
 
 

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -24,7 +24,7 @@ except ImportError:
     from cached_property import cached_property
 
 from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.hooks.subprocess import EXIT_CODE_SKIP, SubprocessHook
+from airflow.hooks.subprocess import SubprocessHook
 from airflow.models import BaseOperator
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.operator_helpers import context_to_airflow_vars
@@ -51,20 +51,25 @@ class BashOperator(BaseOperator):
     :type env: dict
     :param output_encoding: Output encoding of bash command
     :type output_encoding: str
+    :param skip_exit_code: If task exits with this exit code, leave the task
+        in ``skipped`` state (default: 99). If set to ``None``, any non-zero
+        exit code will be treated as a failure.
+    :type skip_exit_code: int
 
-    Airflow will evaluate the exit code of the bash command.  In general, a non-zero exit code will result in
-    task failure and zero will result in task success.  Exit code ``127`` will throw an
-    :class:`airflow.exceptions.AirflowSkipException`, which will leave the task in ``skipped`` state.
+    Airflow will evaluate the exit code of the bash command. In general, a non-zero exit code will result in
+    task failure and zero will result in task success. Exit code ``99`` (or another set in ``skip_exit_code``)
+    will throw an :class:`airflow.exceptions.AirflowSkipException`, which will leave the task in ``skipped``
+    state. You can have all non-zero exit codes be treated as a failure by setting ``skip_exit_code=None``.
 
     .. list-table::
        :widths: 25 25
        :header-rows: 1
 
-       * - Exit code range
+       * - Exit code
          - Behavior
        * - 0
          - success
-       * - 127
+       * - `skip_exit_code` (default: 99)
          - raise :class:`airflow.exceptions.AirflowSkipException`
        * - otherwise
          - raise :class:`airflow.exceptions.AirflowException`
@@ -134,12 +139,14 @@ class BashOperator(BaseOperator):
         bash_command: str,
         env: Optional[Dict[str, str]] = None,
         output_encoding: str = 'utf-8',
+        skip_exit_code: int = 99,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
         self.bash_command = bash_command
         self.env = env
         self.output_encoding = output_encoding
+        self.skip_exit_code = skip_exit_code
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
         self.sub_process = None
@@ -170,8 +177,8 @@ class BashOperator(BaseOperator):
             env=env,
             output_encoding=self.output_encoding,
         )
-        if result.exit_code == EXIT_CODE_SKIP:
-            raise AirflowSkipException(f"Bash command returned exit code {EXIT_CODE_SKIP}. Skipping.")
+        if self.skip_exit_code is not None and result.exit_code == self.skip_exit_code:
+            raise AirflowSkipException(f"Bash command returned exit code {self.skip_exit_code}. Skipping.")
         elif result.exit_code != 0:
             raise AirflowException('Bash command failed. The command returned a non-zero exit code.')
         return result.output

--- a/docs/apache-airflow/howto/operator/bash.rst
+++ b/docs/apache-airflow/howto/operator/bash.rst
@@ -78,7 +78,8 @@ Skipping
 --------
 
 In general a non-zero exit code produces an AirflowException and thus a task failure.  In cases where it is desirable
-to instead have the task end in a ``skipped`` state, you can exit with code ``127``.
+to instead have the task end in a ``skipped`` state, you can exit with code ``99`` (or with another exit code if you
+pass ``skip_exit_code``).
 
 .. exampleinclude:: /../../airflow/example_dags/example_bash_operator.py
     :language: python


### PR DESCRIPTION
Exit code 127 is used when a command is not found and we don't want to
skip those tasks. Exit code 100 was arbitrarily chosen, however, most
importantly it isn't used as a standard exit code:

https://tldp.org/LDP/abs/html/exitcodes.html

