### PR TITLE
Fix too specific parsing of `False` in LegacyUIDeprecated

### DIFF
--- a/airflow/upgrade/rules/legacy_ui_deprecated.py
+++ b/airflow/upgrade/rules/legacy_ui_deprecated.py
@@ -28,8 +28,8 @@ class LegacyUIDeprecated(BaseRule):
 
     def check(self):
         if conf.has_option("webserver", "rbac"):
-            rbac = conf.get("webserver", "rbac")
-            if rbac == "false":
+            rbac = conf.get("webserver", "rbac").strip().lower()
+            if rbac in ("f", "false", "0"):
                 return (
                     "rbac in airflow.cfg must be explicitly set empty as"
                     " RBAC mechanism is enabled by default."

--- a/tests/upgrade/rules/test_legacy_ui_deprecated.py
+++ b/tests/upgrade/rules/test_legacy_ui_deprecated.py
@@ -21,7 +21,7 @@ from tests.test_utils.config import conf_vars
 
 
 class TestLegacyUIDeprecated(TestCase):
-    @conf_vars({("webserver", "rbac"): "false"})
+    @conf_vars({("webserver", "rbac"): "False"})
     def test_invalid_check(self):
         rule = LegacyUIDeprecated()
 

--- a/tests/upgrade/rules/test_legacy_ui_deprecated.py
+++ b/tests/upgrade/rules/test_legacy_ui_deprecated.py
@@ -15,14 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 from unittest import TestCase
+from unittest.mock import patch
 
 from airflow.upgrade.rules.legacy_ui_deprecated import LegacyUIDeprecated
 from tests.test_utils.config import conf_vars
 
 
 class TestLegacyUIDeprecated(TestCase):
-    @conf_vars({("webserver", "rbac"): "False"})
-    def test_invalid_check(self):
+    @patch('airflow.configuration.conf.get')
+    def test_invalid_check(self, conf_get):
         rule = LegacyUIDeprecated()
 
         assert isinstance(rule.description, str)
@@ -32,8 +33,10 @@ class TestLegacyUIDeprecated(TestCase):
             "rbac in airflow.cfg must be explicitly set empty as"
             " RBAC mechanism is enabled by default."
         )
-        response = rule.check()
-        assert response == msg
+        for false_value in ("False", "false", "f", "0"):
+            conf_get.return_value = false_value
+            response = rule.check()
+            assert response == msg
 
     @conf_vars({("webserver", "rbac"): ""})
     def test_valid_check(self):


### PR DESCRIPTION
This is one of two issues mentioned in #13287 . The issue is trivial one: only `false` case sensitive was taken into account, however, the Airflow config allows many more options for the boolean False.
This fix is basically a replacement of the case sensitive check for `false` by the same logic `getboolean()` uses. Using `getboolean()` itself seems not to be a good solution, since it throws an Exception if there is a blank value in the field.