### PR TITLE
Increase default `worker_refresh_interval` to `6000` seconds

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -70,6 +70,16 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Default `[webserver] worker_refresh_interval` is changed to `6000` seconds
+
+The default value for `[webserver] worker_refresh_interval` was `30` seconds for
+Airflow <=2.0.1. However, since Airflow 2.0 DAG Serialization is a hard requirement
+and the Webserver used the serialized DAGs, there is no need to kill an existing
+worker and create a new one as frequently as `30` seconds.
+
+This setting can be raised to an even higher value, currently it is
+set to `6000` seconds (10 minutes) to
+serve as a DagBag cache burst time.
 
 ## Airflow 2.0.1
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -974,7 +974,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "30"
+      default: "6000"
     - name: reload_on_plugin_change
       description: |
         If set to True, Airflow will track files in plugins_folder directory. When it detects changes,

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -495,7 +495,7 @@ web_server_worker_timeout = 120
 worker_refresh_batch_size = 1
 
 # Number of seconds to wait before refreshing a batch of workers.
-worker_refresh_interval = 30
+worker_refresh_interval = 6000
 
 # If set to True, Airflow will track files in plugins_folder directory. When it detects changes,
 # then reload the gunicorn.


### PR DESCRIPTION
The default value for `[webserver] worker_refresh_interval` was `30` seconds for
Airflow <=2.0.1. However, since Airflow 2.0 DAG Serialization is a hard requirement
and the Webserver used the serialized DAGs, there is no need to kill an existing
worker and create a new one as frequently as `30` seconds.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
