### PR TITLE
Fix import cycle in cluster policy examples

### DIFF
--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -1350,6 +1350,12 @@ Here is what it may look like:
       :start-after: [START example_dag_cluster_policy]
       :end-before: [END example_dag_cluster_policy]
 
+
+.. note::
+
+    To avoid import cycles, if using ``DAG`` in type annotations in your cluster policy, be sure to import from ``airflow.models`` and not from ``airflow``.
+
+
 Task level cluster policy
 -----------------------------
 For example, this function could apply a specific queue property when

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -18,10 +18,9 @@
 from datetime import timedelta
 from typing import Callable, List
 
-from airflow import DAG
 from airflow.configuration import conf
 from airflow.exceptions import AirflowClusterPolicyViolation
-from airflow.models import TaskInstance
+from airflow.models import DAG, TaskInstance
 from airflow.models.baseoperator import BaseOperator
 
 


### PR DESCRIPTION
If you import anything directly from `airflow` in cluster policy file, an import cycle will prevent the policy from getting loaded.

This PR fixes the import in the example and adds a small note warning about this.

closes: #14945
