### PR TITLE
Fix running "upgrade_check" command in a PTY.

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -158,7 +158,8 @@ def should_use_colors(args):
 def get_terminal_size(fallback=(80, 20)):
     """Return a tuple of (terminal height, terminal width)."""
     try:
-        return struct.unpack('hhhh', ioctl(sys.__stdout__, TIOCGWINSZ, '\000' * 8))[0:2]
+        width, height = struct.unpack('hhhh', ioctl(sys.__stdout__, TIOCGWINSZ, '\000' * 8))[0:2]
+        return width or fallback[0], height or fallback[1]
     except IOError:
         # when the output stream or init descriptor is not a tty, such
         # as when when stdout is piped to another program


### PR DESCRIPTION
In case of running in a PTY, the get_terminal_size() call can return (0, 0).
Related issue for native shutil.get_terminal_size method https://bugs.python.org/issue42174.

As a consequence "upgrade_check" command fails during formatting of output.
"""
File "/usr/local/lib/airflow/airflow/upgrade/formatters.py", line 109, in on_next_rule_status
    print(status_line_fmt.format(rule_status.rule.title, status))
ValueError: Sign not allowed in string format specifier
"""

This change is to fallback in case of (0, 0) and prevent command from failing.

Addresses https://github.com/apache/airflow/issues/15003

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
