### PR TITLE
Fix typo in Helm chart tests

### DIFF
--- a/chart/tests/test_git_sync_scheduler.py
+++ b/chart/tests/test_git_sync_scheduler.py
@@ -57,7 +57,7 @@ class GitSyncSchedulerTest(unittest.TestCase):
                     "gitSync": {
                         "repository": "test-registry/test-repo",
                         "tag": "test-tag",
-                        "pullPolicy": "Allways",
+                        "pullPolicy": "Always",
                     }
                 },
                 "dags": {
@@ -87,7 +87,7 @@ class GitSyncSchedulerTest(unittest.TestCase):
             "name": "git-sync-test",
             "securityContext": {"runAsUser": 65533},
             "image": "test-registry/test-repo:test-tag",
-            "imagePullPolicy": "Allways",
+            "imagePullPolicy": "Always",
             "env": [
                 {"name": "GIT_SYNC_REV", "value": "HEAD"},
                 {"name": "GIT_SYNC_BRANCH", "value": "test-branch"},

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -55,7 +55,7 @@ class PodTemplateFileTest(unittest.TestCase):
                     "gitSync": {
                         "repository": "test-registry/test-repo",
                         "tag": "test-tag",
-                        "pullPolicy": "Allways",
+                        "pullPolicy": "Always",
                     }
                 },
                 "dags": {
@@ -85,7 +85,7 @@ class PodTemplateFileTest(unittest.TestCase):
             "name": "git-sync-test",
             "securityContext": {"runAsUser": 65533},
             "image": "test-registry/test-repo:test-tag",
-            "imagePullPolicy": "Allways",
+            "imagePullPolicy": "Always",
             "env": [
                 {"name": "GIT_SYNC_REV", "value": "HEAD"},
                 {"name": "GIT_SYNC_BRANCH", "value": "test-branch"},


### PR DESCRIPTION
Fix typo `Allways` to `Always` for docker `imagePullPolicy`.
I found it in Helm Chart tests.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
