### PR TITLE
Allow override of project_id in DataprocJobBaseOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -858,6 +858,9 @@ class DataprocJobBaseOperator(BaseOperator):
     :type job_name: str
     :param cluster_name: The name of the DataProc cluster.
     :type cluster_name: str
+    :param project_id: The ID of the Google Cloud project the cluster belongs to,
+        if not specified the project will be inferred from the provided GCP connection.
+    :type project_id: str
     :param dataproc_properties: Map for the Hive properties. Ideal to put in
         default arguments (templated)
     :type dataproc_properties: dict
@@ -912,6 +915,7 @@ class DataprocJobBaseOperator(BaseOperator):
         *,
         job_name: str = '{{task.task_id}}_{{ds_nodash}}',
         cluster_name: str = "cluster-1",
+        project_id: Optional[str] = None,
         dataproc_properties: Optional[Dict] = None,
         dataproc_jars: Optional[List[str]] = None,
         gcp_conn_id: str = 'google_cloud_default',
@@ -943,9 +947,8 @@ class DataprocJobBaseOperator(BaseOperator):
 
         self.job_error_states = job_error_states if job_error_states is not None else {'ERROR'}
         self.impersonation_chain = impersonation_chain
-
         self.hook = DataprocHook(gcp_conn_id=gcp_conn_id, impersonation_chain=impersonation_chain)
-        self.project_id = self.hook.project_id
+        self.project_id = self.hook.project_id if project_id is None else project_id
         self.job_template = None
         self.job = None
         self.dataproc_job_id = None

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -781,6 +781,12 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
         "labels": {"airflow-version": AIRFLOW_VERSION},
         "spark_sql_job": {"query_list": {"queries": [query]}, "script_variables": variables},
     }
+    other_project_job = {
+        "reference": {"project_id": "other-project", "job_id": "{{task.task_id}}_{{ds_nodash}}_" + job_id},
+        "placement": {"cluster_name": "cluster-1"},
+        "labels": {"airflow-version": AIRFLOW_VERSION},
+        "spark_sql_job": {"query_list": {"queries": [query]}, "script_variables": variables},
+    }
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
     def test_deprecation_warning(self, mock_hook):
@@ -811,6 +817,32 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
             job_id=self.job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+        )
+
+    @mock.patch(DATAPROC_PATH.format("uuid.uuid4"))
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_execute_override_project_id(self, mock_hook, mock_uuid):
+        mock_uuid.return_value = self.job_id
+        mock_hook.return_value.project_id = GCP_PROJECT
+        mock_hook.return_value.wait_for_job.return_value = None
+        mock_hook.return_value.submit_job.return_value.reference.job_id = self.job_id
+
+        op = DataprocSubmitSparkSqlJobOperator(
+            project_id="other-project",
+            task_id=TASK_ID,
+            region=GCP_LOCATION,
+            gcp_conn_id=GCP_CONN_ID,
+            query=self.query,
+            variables=self.variables,
+            impersonation_chain=IMPERSONATION_CHAIN,
+        )
+        op.execute(context={})
+        mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
+        mock_hook.return_value.submit_job.assert_called_once_with(
+            project_id="other-project", job=self.other_project_job, location=GCP_LOCATION
+        )
+        mock_hook.return_value.wait_for_job.assert_called_once_with(
+            job_id=self.job_id, location=GCP_LOCATION, project_id="other-project"
         )
 
     @mock.patch(DATAPROC_PATH.format("uuid.uuid4"))


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Operators extending the DataprocSubmitJobOperator currently infer the project_id from the GCP connection, which isn't always correct (for example, when using a service account from one Project to submit jobs to a dataproc cluster in a different project).

In our case, this led to 404s when trying to submit jobs, as the operator incorrectly assumed that the dataproc cluster was in the same project as the service account used to submit the job. 

Adding an optional override, if the project_id is left unspecified it will fallback to the old behaviour. 

I also understand that these operators are now deprecated, so if you don't want to make changes to them you can close this PR. 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
