### PR TITLE
Fix failing doc build on Master

### DIFF
--- a/docs/exts/docs_build/fetch_inventories.py
+++ b/docs/exts/docs_build/fetch_inventories.py
@@ -123,8 +123,8 @@ def fetch_inventories():
             (path for _, _, path in to_download),
         )
     failed, success = partition(lambda d: d[1], download_results)
-    failed, success = list(failed), list(failed)
-    print(f"Result: {len(success)}, success {len(failed)} failed")
+    failed, success = list(failed), list(success)
+    print(f"Result: {len(success)} success, {len(failed)} failed")
     if failed:
         print("Failed packages:")
         for pkg_no, (pkg_name, _) in enumerate(failed, start=1):

--- a/docs/exts/docs_build/third_party_inventories.py
+++ b/docs/exts/docs_build/third_party_inventories.py
@@ -20,7 +20,7 @@ THIRD_PARTY_INDEXES = {
     'celery': 'https://docs.celeryproject.org/en/stable',
     'hdfs': 'https://hdfscli.readthedocs.io/en/latest',
     'jinja2': 'https://jinja.palletsprojects.com/en/master',
-    'mongodb': 'https://pymongo.readthedocs.io/en/stable/',
+    'mongodb': 'https://pymongo.readthedocs.io/en/3.11.3',
     'pandas': 'https://pandas.pydata.org/pandas-docs/stable',
     'python': 'https://docs.python.org/3',
     'requests': 'https://requests.readthedocs.io/en/master',


### PR DESCRIPTION
- For some reason pymongo's stable inventory fetch is redirecting, I can reproduce it locally too if I try to access https://pymongo.readthedocs.io/en/stable/objects.inv from my browser.

![image](https://user-images.githubusercontent.com/8811558/112351105-80a7f600-8cc1-11eb-9a98-1b9346045460.png)

This PR also does minor logging improvements.

closes https://github.com/apache/airflow/issues/14985


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
