### PR TITLE
Fixes broken asset compilation in Docker images

### DIFF
--- a/scripts/ci/libraries/_md5sum.sh
+++ b/scripts/ci/libraries/_md5sum.sh
@@ -40,7 +40,13 @@ function md5sum::calculate_file_md5sum {
         diff "${MD5SUM_FILE_NEW}" "${MD5SUM_FILE}" >/dev/null
         RES=$?
         if [[ "${RES}" != "0" ]]; then
-            verbosity::print_info "The md5sum changed for ${FILE}"
+            verbosity::print_info "The md5sum changed for ${FILE}: was $(cat "${MD5SUM_FILE}") now it is $(cat "${MD5SUM_FILE_NEW}")"
+            if [[ ${CI} == "true" ]]; then
+                echo "${COLOR_RED}The file has changed: ${FILE}${COLOR_RESET}"
+                echo "${COLOR_BLUE}==============================${COLOR_RESET}"
+                cat "${FILE}"
+                echo "${COLOR_BLUE}==============================${COLOR_RESET}"
+            fi
             RET_CODE=1
         fi
     fi
@@ -61,7 +67,7 @@ function md5sum::move_file_md5sum {
     MD5SUM_FILE_NEW=${CACHE_TMP_FILE_DIR}/$(basename "$(dirname "${FILE}")")-$(basename "${FILE}").md5sum.new
     if [[ -f "${MD5SUM_FILE_NEW}" ]]; then
         mv "${MD5SUM_FILE_NEW}" "${MD5SUM_FILE}"
-        verbosity::print_info "Updated md5sum file ${MD5SUM_FILE} for ${FILE}."
+        verbosity::print_info "Updated md5sum file ${MD5SUM_FILE} for ${FILE}: $(cat "${MD5SUM_FILE}")"
     fi
 }
 

--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -99,6 +99,15 @@ function verify_image::verify_ci_image_dependencies() {
     start_end::group_end
 }
 
+function verify_image::verify_ci_image_has_dist_folder() {
+    start_end::group_start "Verify CI image dist folder (compiled www assets): ${DOCKER_IMAGE}"
+
+    verify_image::check_command "Dist folder" '[ -f /opt/airflow/airflow/www/static/dist/manifest.json ] || exit 1'
+
+    start_end::group_end
+}
+
+
 function verify_image::verify_prod_image_dependencies() {
     start_end::group_start "Checking if Airflow dependencies are non-conflicting in ${DOCKER_IMAGE} image."
 
@@ -241,6 +250,14 @@ function verify_image::verify_prod_image_as_root() {
     set -e
 }
 
+function verify_image::verify_production_image_has_dist_folder() {
+    start_end::group_start "Verify prod image has dist folder (compiled www assets): ${DOCKER_IMAGE}"
+    # shellcheck disable=SC2016
+    verify_image::check_command "Dist folder" '[ -f $(python -m site --user-site)/airflow/www/static/dist/manifest.json ] || exit 1'
+
+    start_end::group_end
+}
+
 function verify_image::display_result {
     if [[ ${IMAGE_VALID} == "true" ]]; then
         echo
@@ -265,6 +282,8 @@ function verify_image::verify_prod_image {
 
     verify_image::verify_prod_image_as_root
 
+    verify_image::verify_production_image_has_dist_folder
+
     verify_image::display_result
 }
 
@@ -272,6 +291,8 @@ function verify_image::verify_ci_image {
     IMAGE_VALID="true"
     DOCKER_IMAGE="${1}"
     verify_image::verify_ci_image_dependencies
+
+    verify_image::verify_ci_image_has_dist_folder
 
     verify_image::display_result
 }

--- a/scripts/docker/compile_www_assets.sh
+++ b/scripts/docker/compile_www_assets.sh
@@ -28,22 +28,20 @@ function compile_www_assets() {
     md5sum_file="static/dist/sum.md5"
     readonly md5sum_file
     local airflow_site_package
-    airflow_site_package="$(python -m site --user-site)"
+    airflow_site_package="$(python -m site --user-site)/airflow"
     local www_dir=""
     if [[ -f "${airflow_site_package}/www_rbac/package.json" ]]; then
         www_dir="${airflow_site_package}/www_rbac"
     elif [[ -f "${airflow_site_package}/www/package.json" ]]; then
         www_dir="${airflow_site_package}/www"
     fi
-    if [[ -n "${www_dir}" ]]; then
-        pushd ${www_dir} || exit 1
-        yarn install --frozen-lockfile --no-cache
-        yarn run prod
-        find package.json yarn.lock static/css static/js -type f | sort | xargs md5sum > "${md5sum_file}"
-        rm -rf "${www_dir}/node_modules"
-        rm -vf "${www_dir}"/{package.json,yarn.lock,.eslintignore,.eslintrc,.stylelintignore,.stylelintrc,compile_assets.sh,webpack.config.js}
-        popd || exit 1
-    fi
+    pushd ${www_dir} || exit 1
+    yarn install --frozen-lockfile --no-cache
+    yarn run prod
+    find package.json yarn.lock static/css static/js -type f | sort | xargs md5sum > "${md5sum_file}"
+    rm -rf "${www_dir}/node_modules"
+    rm -vf "${www_dir}"/{package.json,yarn.lock,.eslintignore,.eslintrc,.stylelintignore,.stylelintrc,compile_assets.sh,webpack.config.js}
+    popd || exit 1
 }
 
 compile_www_assets


### PR DESCRIPTION
The change #14911 had a bug - when PYTHON_MINOR_MAJOR_VERSION
was removed from the imge args, the replacement `python -m site`
expression missed `/airflow/` suffix. Unfortunately it was not
flagged as an error because the recompiling script silently
skipped recompilation step in such case.

This change:

* fixes the error
* removes the silent-skipping if check (the recompilation will
  fail in case it is wrongly set)
* adds check at image verification whether dist/manifest.json is
  present.

Fixes: #14991

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
