### PR TITLE
Skips provider package builds and provider tests for non-master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
       needs-helm-tests: ${{ steps.selective-checks.outputs.needs-helm-tests }}
       needs-api-tests: ${{ steps.selective-checks.outputs.needs-api-tests }}
       needs-api-codegen: ${{ steps.selective-checks.outputs.needs-api-codegen }}
+      default-branch: ${{ steps.selective-checks.outputs.default-branch }}
       pullRequestNumber: ${{ steps.source-run-info.outputs.pullRequestNumber }}
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
       runsOn: ${{ steps.set-runs-on.outputs.runsOn }}
@@ -504,12 +505,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     strategy:
       matrix:
         package-format: ['wheel', 'sdist']
-    if: needs.build-info.outputs.image-build == 'true'
+    if: needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'master'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+        if: needs.build-info.outputs.default-branch == 'master'
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
@@ -551,7 +553,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     strategy:
       matrix:
         package-format: ['wheel', 'sdist']
-    if: needs.build-info.outputs.image-build == 'true'
+    if: needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'master'
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
@@ -1033,8 +1035,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - tests-postgres
       - tests-mysql
       - tests-kubernetes
-      - prepare-provider-packages
-      - test-provider-packages-released-airflow
       - prod-images
       - docs
     if: >

--- a/PULL_REQUEST_WORKFLOW.rst
+++ b/PULL_REQUEST_WORKFLOW.rst
@@ -125,7 +125,8 @@ The logic implemented for the changes works as follows:
 
 1) In case of direct push (so when PR gets merged) or scheduled run, we always run all tests and checks.
    This is in order to make sure that the merge did not miss anything important. The remainder of the logic
-   is executed only in case of Pull Requests.
+   is executed only in case of Pull Requests. We do not add providers tests in case DEFAULT_BRANCH is
+   different than master, because providers are only important in master branch and PRs to master branch.
 
 2) We retrieve which files have changed in the incoming Merge Commit (github.sha is a merge commit
    automatically prepared by GitHub in case of Pull Request, so we can retrieve the list of changed
@@ -133,7 +134,9 @@ The logic implemented for the changes works as follows:
 
 3) If any of the important, environment files changed (Dockerfile, ci scripts, setup.py, GitHub workflow
    files), then we again run all tests and checks. Those are cases where the logic of the checks changed
-   or the environment for the checks changed so we want to make sure to check everything.
+   or the environment for the checks changed so we want to make sure to check everything. We do not add
+   providers tests in case DEFAULT_BRANCH is different than master, because providers are only
+   important in master branch and PRs to master branch.
 
 4) If any of py files changed: we need to have CI image and run full static checks so we enable image building
 
@@ -157,7 +160,7 @@ The logic implemented for the changes works as follows:
    b) if any of the Airflow API files changed we enable ``API`` test type
    c) if any of the Airflow CLI files changed we enable ``CLI`` test type and Kubernetes tests (the
       K8S tests depend on CLI changes as helm chart uses CLI to run Airflow).
-   d) if any of the Provider files changed we enable ``Providers`` test type
+   d) if this is a master branch and if any of the Provider files changed we enable ``Providers`` test type
    e) if any of the WWW files changed we enable ``WWW`` test type
    f) if any of the Kubernetes files changed we enable ``Kubernetes`` test type
    g) Then we subtract count of all the ``specific`` above per-type changed files from the count of


### PR DESCRIPTION
This PR skips building Provider packages for branches different
than master. Provider packages are always released from master
but never from any other branch so there is no point in running
the package building and tests there

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
