### PR TITLE
Fixes problem with two different files mdsumed with the same name

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -187,18 +187,18 @@ FILES_FOR_REBUILD_CHECK=()
 
 # Determine which files trigger rebuild check
 #
-# !!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!1
+# !!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!
 #  When you add files here, please make sure to not add files
 #  with the same name. And if you do - make sure that files with the
 #  same name are stored in directories with different name. For
-#  example we hava two package.json files here, but they are in
-#  directories with different names (`wwww` and `ui`).
+#  example we have two package.json files here, but they are in
+#  directories with different names (`www` and `ui`).
 #  The problem is that md5 hashes of those files are stored in
-#  ./build/directory in the same directory as <PARENT_DIR>-<FILE>.md5sum .
+#  `./build/directory` in the same directory as <PARENT_DIR>-<FILE>.md5sum.
 #  For example md5sum of the `airflow/www/package.json` file is stored
 #  as `www-package.json` and `airflow/ui/package.json` as `ui-package.json`,
 #  The file list here changes extremely rarely.
-# !!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!1
+# !!!!!!!!!! IMPORTANT NOTE !!!!!!!!!!
 function initialization::initialize_files_for_rebuild_check() {
     FILES_FOR_REBUILD_CHECK+=(
         "setup.py"

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -186,6 +186,19 @@ function initialization::initialize_available_integrations() {
 FILES_FOR_REBUILD_CHECK=()
 
 # Determine which files trigger rebuild check
+#
+# !!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!1
+#  When you add files here, please make sure to not add files
+#  with the same name. And if you do - make sure that files with the
+#  same name are stored in directories with different name. For
+#  example we hava two package.json files here, but they are in
+#  directories with different names (`wwww` and `ui`).
+#  The problem is that md5 hashes of those files are stored in
+#  ./build/directory in the same directory as <PARENT_DIR>-<FILE>.md5sum .
+#  For example md5sum of the `airflow/www/package.json` file is stored
+#  as `www-package.json` and `airflow/ui/package.json` as `ui-package.json`,
+#  The file list here changes extremely rarely.
+# !!!! IMPORTANT NOTE !!!!!!!!!!!!!!!!!!!!!!!!1
 function initialization::initialize_files_for_rebuild_check() {
     FILES_FOR_REBUILD_CHECK+=(
         "setup.py"

--- a/scripts/ci/libraries/_md5sum.sh
+++ b/scripts/ci/libraries/_md5sum.sh
@@ -28,9 +28,9 @@ function md5sum::calculate_file_md5sum {
     mkdir -pv "${MD5SUM_CACHE_DIR}"
     MD5SUM=$(md5sum "${FILE}")
     local MD5SUM_FILE
-    MD5SUM_FILE="${MD5SUM_CACHE_DIR}"/$(basename "${FILE}").md5sum
+    MD5SUM_FILE="${MD5SUM_CACHE_DIR}"/$(basename "$(dirname "${FILE}")")-$(basename "${FILE}").md5sum
     local MD5SUM_FILE_NEW
-    MD5SUM_FILE_NEW=${CACHE_TMP_FILE_DIR}/$(basename "${FILE}").md5sum.new
+    MD5SUM_FILE_NEW=${CACHE_TMP_FILE_DIR}/$(basename "$(dirname "${FILE}")")-$(basename "${FILE}").md5sum.new
     echo "${MD5SUM}" > "${MD5SUM_FILE_NEW}"
     local RET_CODE=0
     if [[ ! -f "${MD5SUM_FILE}" ]]; then
@@ -56,9 +56,9 @@ function md5sum::move_file_md5sum {
     local MD5SUM_FILE
     local MD5SUM_CACHE_DIR="${BUILD_CACHE_DIR}/${BRANCH_NAME}/${PYTHON_MAJOR_MINOR_VERSION}/${THE_IMAGE_TYPE}"
     mkdir -pv "${MD5SUM_CACHE_DIR}"
-    MD5SUM_FILE="${MD5SUM_CACHE_DIR}"/$(basename "${FILE}").md5sum
+    MD5SUM_FILE="${MD5SUM_CACHE_DIR}"/$(basename "$(dirname "${FILE}")")-$(basename "${FILE}").md5sum
     local MD5SUM_FILE_NEW
-    MD5SUM_FILE_NEW=${CACHE_TMP_FILE_DIR}/$(basename "${FILE}").md5sum.new
+    MD5SUM_FILE_NEW=${CACHE_TMP_FILE_DIR}/$(basename "$(dirname "${FILE}")")-$(basename "${FILE}").md5sum.new
     if [[ -f "${MD5SUM_FILE_NEW}" ]]; then
         mv "${MD5SUM_FILE_NEW}" "${MD5SUM_FILE}"
         verbosity::print_info "Updated md5sum file ${MD5SUM_FILE} for ${FILE}."


### PR DESCRIPTION
When we check whether we should rebuild image, we check if the
md5sum of some important files changed - which would trigger
question whether to rebuild the image or not (because of
changed dependencies which need to be installed). This
happens for example when package.json or yarn.lock changes.

Previously, all the important files had distinct names, so
we stored the md5 hashes of those files with just filenames +.md5sum
but they were flattened to a single directory. Unfortunately,
as of #14927 (merged with failing build) we had two package.json
and two yarn.locks and it caused overwriting of md5hash of one
by the other. This triggered unnecessary rebuilding of the image
in CI part which resulted in failure (because of Apache Beam
dependency problem).

This PR fixes it by adding parent directory to the name of
the md5sum file (so we have www-package.json and ui-package.json)
now. Those important files change very rarely so this incident
should not happen again but we added some comments preventing
it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
