### PR TITLE
Fix-wasb-read-to-return-decoded-string-instead-of-bytes

### DIFF
--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -51,6 +51,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         self.remote_base = wasb_log_folder
         self.log_relative_path = ''
         self._hook = None
+        self.encoding = "UTF-8"
         self.closed = False
         self.upload_on_close = True
         self.delete_local_copy = delete_local_copy
@@ -159,7 +160,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         :type return_error: bool
         """
         try:
-            return self.hook.read_file(self.wasb_container, remote_log_location)
+            return self.hook.read_file(self.wasb_container, remote_log_location).decode(self.encoding)
         except AzureHttpError as e:
             msg = f'Could not read logs from {remote_log_location}'
             self.log.exception("Message: '%s', exception '%s'", msg, e)

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -98,7 +98,7 @@ class TestWasbTaskHandler(unittest.TestCase):
 
     @mock.patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook")
     def test_wasb_read(self, mock_hook):
-        mock_hook.return_value.read_file.return_value = 'Log line'
+        mock_hook.return_value.read_file.return_value = b'Log line'
         assert self.wasb_task_handler.wasb_read(self.remote_log_location) == "Log line"
         assert self.wasb_task_handler.read(self.ti) == (
             [


### PR DESCRIPTION
The azure block client returns a utf-encoded string instead of a string which is the expected return for the wasb logger. This causes a parsing error when trying to merge files. 

https://docs.microsoft.com/en-us/python/api/azure-storage-blob/azure.storage.blob.blobclient?view=azure-python#download-blob-offset-none--length-none----kwargs-


