### PR TITLE
Remove GH Action sections that are always empty

### DIFF
--- a/scripts/ci/libraries/_script_init.sh
+++ b/scripts/ci/libraries/_script_init.sh
@@ -24,33 +24,19 @@ readonly AIRFLOW_SOURCES
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 . "${AIRFLOW_SOURCES}/scripts/ci/libraries/_all_libs.sh"
 
-start_end::group_start "Initialization"
 initialization::initialize_common_environment
-start_end::group_end
 
-start_end::group_start "Basic sanity checks"
 sanity_checks::basic_sanity_checks
-start_end::group_end
 
-start_end::group_start "Starting script $(basename "$0")"
 start_end::script_start
-start_end::group_end
 
-start_end::group_start "Determine docker caching strategy"
 build_images::determine_docker_cache_strategy
-start_end::group_end
 
-start_end::group_start "Get environment for builds on CI"
 initialization::get_environment_for_builds_on_ci
-start_end::group_end
 
-start_end::group_start "Get docker image names"
 build_images::get_docker_image_names
-start_end::group_end
 
-start_end::group_start "Make constants read-only"
 initialization::make_constants_read_only
-start_end::group_end
 
 # Work around occasional unexplained failure on CI. Clear file flags on
 # STDOUT (which is connected to a tmp file by GitHub Runner).

--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -46,8 +46,12 @@ function start_end::group_end {
 # Also prints some useful diagnostics information at start of the script if VERBOSE is set to true
 #
 function start_end::script_start {
-    verbosity::print_info
+    START_SCRIPT_TIME=$(date +%s)
     verbosity::print_info "Running '${COLOR_GREEN}$(basename "$0")${COLOR_RESET}'"
+    if [[ "${GITHUB_ACTIONS=}" == "true" &&  ${VERBOSE_COMMANDS:="false"} == "false" ]]; then
+      return
+    fi
+
     verbosity::print_info
     verbosity::print_info "${COLOR_BLUE}Log is redirected to '${OUTPUT_LOG}'${COLOR_RESET}"
     verbosity::print_info
@@ -65,7 +69,6 @@ function start_end::script_start {
         verbosity::print_info
         set +x
     fi
-    START_SCRIPT_TIME=$(date +%s)
 }
 
 function start_end::dump_container_logs() {


### PR DESCRIPTION
These sections only produce output when verbose output is enabled,
otherwise. In all other times they just have extra sections to look at.

This also removes the log lines about redirected output or settings that
can be tweaked when run under GitHub Actions -- it's not relevant there!

Before:

![image](https://user-images.githubusercontent.com/34150/112481945-72181800-8d6f-11eb-8885-87a9280b4637.png)

(Not these sections are already expanded.)

After:

(Will populate once it has run once)
![image](https://user-images.githubusercontent.com/34150/112483304-ce2f6c00-8d70-11eb-8836-95b95f4e7578.png)


