### PR TITLE
Loosen cassandra-driver requirement to allow latest version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -321,7 +321,9 @@ repos:
           ^airflow/providers/apache/hive/.*README.md$|
           ^tests/providers/apache/cassandra/hooks/test_cassandra.py$|
           ^docs/apache-airflow-providers-apache-cassandra/connections/cassandra.rst$|
-          ^docs/apache-airflow-providers-apache-hive/commits.rst$|git|
+          ^docs/apache-airflow-providers-apache-hive/commits.rst$|
+          git|
+          ^pylintrc |
           ^CHANGELOG.txt$
       - id: consistent-pylint
         language: pygrep

--- a/pylintrc
+++ b/pylintrc
@@ -54,6 +54,8 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+# Pylint 2.8 changes this to `extension-pkg-allow-list`
+extension-pkg-whitelist=cassandra
 
 [MESSAGES CONTROL]
 

--- a/pylintrc-tests
+++ b/pylintrc-tests
@@ -54,6 +54,8 @@ suggestion-mode=yes
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no
 
+# Pylint 2.8 changes this to `extension-pkg-allow-list`
+extension-pkg-whitelist=cassandra
 
 [MESSAGES CONTROL]
 

--- a/setup.py
+++ b/setup.py
@@ -224,7 +224,7 @@ azure = [
     'azure-storage-file>=2.1.0',
 ]
 cassandra = [
-    'cassandra-driver>=3.13.0,<3.21.0',
+    'cassandra-driver>=3.13.0,<4',
 ]
 celery = [
     'celery~=4.4.2',


### PR DESCRIPTION
I have left the CASS_ settings in the dockerfile -- they do nothing when a .whl is available, but will do something for Py3.9 for example.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
