### PR TITLE
Action job for third-party inventory mirroring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1250,3 +1250,28 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           tags: true
           force: true
           branch: master
+
+  intersphinx-inventory-mirror:
+    timeout-minutes: 10
+    name: "Update Intersphinx inventory mirror"
+    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
+    if: github.event_name == 'schedule' && github.repository == 'apache/airflow'
+    needs: [ci-images]
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
+        run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+      - name: "Fetch third-party module inventories"
+        run: ./scripts/ci/docs/ci_inventories.sh
+      - name: Configure AWS credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          aws-access-key-id: ${{ secrets.DOCS_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-central-1
+      - name: "Upload inventories to AWS S3"
+        run: aws s3 sync --delete ./files/inventory s3://apache-airflow-docs/_inventory

--- a/scripts/ci/docs/ci_inventories.sh
+++ b/scripts/ci/docs/ci_inventories.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# shellcheck source=scripts/ci/libraries/_script_init.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
+
+build_images::prepare_ci_build
+
+build_images::rebuild_ci_image_if_needed_with_group
+
+start_end::group_start "Run fetch inventories"
+docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    --entrypoint "/usr/local/bin/dumb-init"  \
+    "${AIRFLOW_CI_IMAGE}" \
+    "--" "/opt/airflow/scripts/in_container/run_inventory_fetch.sh" "${@}"
+start_end::group_end

--- a/scripts/in_container/run_inventory_fetch.sh
+++ b/scripts/in_container/run_inventory_fetch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# shellcheck source=scripts/in_container/_in_container_script_init.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/_in_container_script_init.sh"
+
+sudo -E python -c "
+import sys
+from docs.exts.docs_build.fetch_inventories import fetch_inventories
+failures = fetch_inventories(skips_airflow=True)
+sys.exit(1 if failures else 0)
+" || RET_CODE=$?
+
+if [[ ${CI:="false"} == "true" && -d "${AIRFLOW_SOURCES}/docs/_inventory_cache/" ]]; then
+    rm -rf "/files/inventory"
+    cp -r "${AIRFLOW_SOURCES}/docs/_inventory_cache" "/files/inventory"
+fi
+
+exit ${RET_CODE:-0}


### PR DESCRIPTION
First part of #14989. This implements a job invoked in scheduled CI runs to fetch third-party Intersphinx inventories, and sync them to S3.

I’m currently putting the files in `s3://apache-airflow-docs/_inventory`.

The scripts seem to work fine for my local tests, but I’m not so sure about the CI configuration.

---
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
