### PR TITLE
Ensure `mysql_to_gcs` fully compatible with MySQL and BigQuery for `datetime`-related values 

### DIFF
--- a/airflow/providers/google/cloud/transfers/mysql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/mysql_to_gcs.py
@@ -18,8 +18,7 @@
 """MySQL to GCS operator."""
 
 import base64
-import calendar
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from typing import Dict
 
@@ -102,10 +101,12 @@ class MySQLToGCSOperator(BaseSQLToGCSOperator):
         Takes a value from MySQLdb, and converts it to a value that's safe for
         JSON/Google Cloud Storage/BigQuery.
 
-        * Datetimes are converted to UTC seconds.
+        * Datetimes are converted to `str(value)` (`datetime.isoformat(' ')`)
+          strings.
+        * Times are converted to `str((datetime.min + value).time())` strings.
         * Decimals are converted to floats.
-        * Dates are converted to ISO formatted string if given schema_type is
-          DATE, or UTC seconds otherwise.
+        * Dates are converted to ISO formatted strings if given schema_type is
+          DATE, or `datetime.isoformat(' ')` strings otherwise.
         * Binary type fields are converted to integer if given schema_type is
           INTEGER, or encoded with base64 otherwise. Imported BYTES data must
           be base64-encoded according to BigQuery documentation:
@@ -119,16 +120,16 @@ class MySQLToGCSOperator(BaseSQLToGCSOperator):
         if value is None:
             return value
         if isinstance(value, datetime):
-            value = calendar.timegm(value.timetuple())
+            value = str(value)
         elif isinstance(value, timedelta):
-            value = value.total_seconds()
+            value = str((datetime.min + value).time())
         elif isinstance(value, Decimal):
             value = float(value)
         elif isinstance(value, date):
             if schema_type == "DATE":
                 value = value.isoformat()
             else:
-                value = calendar.timegm(value.timetuple())
+                value = str(datetime.combine(value, time.min))
         elif isinstance(value, bytes):
             if schema_type == "INTEGER":
                 value = int.from_bytes(value, "big")

--- a/tests/providers/google/cloud/transfers/test_mysql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mysql_to_gcs.py
@@ -88,9 +88,14 @@ class TestMySqlToGoogleCloudStorageOperator(unittest.TestCase):
     @parameterized.expand(
         [
             ("string", None, "string"),
-            (datetime.date(1970, 1, 2), None, 86400),
+            (datetime.date(1970, 1, 2), None, "1970-01-02 00:00:00"),
+            (datetime.date(1000, 1, 2), None, "1000-01-02 00:00:00"),
             (datetime.date(1970, 1, 2), "DATE", "1970-01-02"),
-            (datetime.datetime(1970, 1, 1, 1, 0), None, 3600),
+            (datetime.date(1000, 1, 2), "DATE", "1000-01-02"),
+            (datetime.datetime(1970, 1, 1, 1, 0), None, "1970-01-01 01:00:00"),
+            (datetime.datetime(1000, 1, 1, 1, 0), None, "1000-01-01 01:00:00"),
+            (datetime.timedelta(), None, "00:00:00"),
+            (datetime.timedelta(hours=23, minutes=59, seconds=59), None, "23:59:59"),
             (decimal.Decimal(5), None, 5),
             (b"bytes", "BYTES", "Ynl0ZXM="),
             (b"\x00\x01", "INTEGER", 1),


### PR DESCRIPTION
Compatibility issues for `datetime`-related values:
- Valid data:
  - BigQuery's range starts from year 0001.
    - TIME range: 00:00:00 to 23:59:59.99999 (but the canonical format says "[.DDDDDD]: Up to six fractional digits")
  - MySQL's range starts from year 1000 (except for an error value starts from year 0000 which is already addressed);
    - TIME range: -838:59:59.000000 to 838:59:59.000000
      - [ ] **Shall I raise an exception when `timedelta.total_seconds() > 86399.99999(9)`?
        This PR implicitly raises an `OverflowError: date value out of range` when `timedelta.total_seconds() < 0`.**

- Supported output format:
  - https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#limitations
    > When you load JSON or CSV data, values in TIMESTAMP columns must use a dash (-) separator for the date portion of the timestamp, and the date must be in the following format: YYYY-MM-DD (year-month-day). The hh:mm:ss (hour-minute-second) portion of the timestamp must use a colon (:) separator.
  - https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-json#details_of_loading_json_data
    > If you provide a schema, BigQuery also accepts Unix Epoch time for timestamp values. However, schema autodetection will not detect this case, and will treat the value as a numeric or string type instead.

When no `schema` provided, the current version of the operator assumes that MySQL's DATETIME and DATE values becoming BigQuery's TIMESTAMP, which doesn't accept Unix Epoch integer unless the downstream `gcs_to_bigquery` actually takes the output of `_write_local_schema_file()`.

Should there be a `schema`, the current version of the operator sends integers and floats to BigQuery's DATETIME/TIMESTAMP and TIME, respectively. Issues are:
- For DATETIME, BigQuery will throw errors;
- For TIMESTAMP, although BigQuery accepts Unix Epoch integer in this case, `calendar.timegm()` will still cause troubles (unless the downstream `gcs_to_bigquery` uses a connection that switches to legacy SQL of BigQuery);
  ```python
  >>> calendar.timegm((1000,1,1,0,0,0))
  -30610224000
  ```
- For TIME, BigQuery may silently convert to incorrect values.

As for DATE, if the `schema` is indeed sent to the downstream `gcs_to_bigquery`, then the current version will work. Otherwise, it will still encounter issues of BigQuery's integer-to-TIMESTAMP rejection and negative integers from `timege()` for edge cases.

A side note:
I suppose some usages might have been designed for BigQuery's legacy SQL dialect. However, since `gcs_to_bigquery` doesn't explicitly support it (only one line detects it for `escaped_table_name`), and standard SQL dialect is the default for Python library, it might be safe to follow standard SQL dialect's requirements.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
