### PR TITLE
Merge contextlib.suppress() calls

### DIFF
--- a/airflow/executors/executor_loader.py
+++ b/airflow/executors/executor_loader.py
@@ -88,7 +88,7 @@ class ExecutorLoader:
                 "executor from a plugin",
                 executor_name,
             )
-            with suppress(ImportError), suppress(AttributeError):
+            with suppress(ImportError, AttributeError):
                 # Load plugins here for executors as at that time the plugins might not have been
                 # initialized yet
                 from airflow import plugins_manager


### PR DESCRIPTION
Noticed this while tracing some unrelated code. `contextlib.suppress()` can take multiple exception classes directly so there’s no need for two calls.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
