### PR TITLE
Check if we need to upgrade deps before rebuilding everything

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -321,7 +321,7 @@ function check_if_python_security_scans_should_be_run() {
 }
 
 function check_if_setup_files_changed() {
-    start_end::group_start "Check Python security scans"
+    start_end::group_start "Check setup.py/cfg changed"
     local pattern_array=(
         "^setup.cfg"
         "^setup.py"
@@ -655,8 +655,8 @@ tests_needed="false"
 kubernetes_tests_needed="false"
 
 get_changed_files
-run_all_tests_if_environment_files_changed
 check_if_setup_files_changed
+run_all_tests_if_environment_files_changed
 check_if_any_py_files_changed
 check_if_docs_should_be_generated
 check_if_helm_tests_should_be_run


### PR DESCRIPTION
Due to the order of checkes in selective_ci_checks.sh, we were never
eagerly upgrading deps on a Pull Reuqest, because we exited before
getting to `check_if_setup_files_changed`.

Previoulsy the output was this

```
Get changed files
Check if everything should be run

  Changed files matching the ^.github/workflows/|^Dockerfile|^scripts|^setup.py|^setup.cfg pattern:

  Dockerfile
  Dockerfile.ci
  setup.py

  Important environment files changed. Running everything
  ...
  image-build=true
  upgrade-to-newer-dependencies=false
```

And then it exited. By simply changing the order we set the right flag
_first_ and then exit.
