### PR TITLE
Update botocore dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ def get_sphinx_theme_version() -> str:
 # Start dependencies group
 amazon = [
     'boto3>=1.15.0,<1.18.0',
-    'botocore>=1.18.0,<1.19.0',
+    'botocore>=1.18.0,<1.21.0',
     'watchtower~=0.7.3',
 ]
 apache_beam = [


### PR DESCRIPTION
On installing a new package, the boto3 and botocore deps conflicted:

```
boto3 1.17.38 has requirement botocore<1.21.0,>=1.20.38, but you have botocore 1.18.18.
```

Noticed here https://github.com/apache/airflow/runs/2204050994?check_suite_focus=true#step:10:8316 when updating an unrelated dep.

This loosens the dep requirement to fix allow the right versions here.

It maybe time to try with pip 21.0.1 and see if it fixes this, and how
long it would take to resolve our huge dep tree.

