### PR TITLE
Don't import mysql exceptions from "private" module

### DIFF
--- a/tests/providers/google/cloud/transfers/test_mysql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_mysql_to_gcs.py
@@ -22,7 +22,7 @@ import unittest
 from unittest import mock
 
 import pytest
-from _mysql_exceptions import ProgrammingError
+from MySQLdb import ProgrammingError  # pylint: disable=no-name-in-module
 from parameterized import parameterized
 
 from airflow.providers.google.cloud.transfers.mysql_to_gcs import MySQLToGCSOperator

--- a/tests/providers/mysql/operators/test_mysql.py
+++ b/tests/providers/mysql/operators/test_mysql.py
@@ -100,7 +100,7 @@ class TestMySql(unittest.TestCase):
                 database="foobar",
             )
 
-            from _mysql_exceptions import OperationalError
+            from MySQLdb import OperationalError  # pylint: disable=no-name-in-module
 
             try:
                 op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)


### PR DESCRIPTION
This module was removed/renamed in mysqlclient 2.0 -- this new name
works for both.

Broken by https://github.com/apache/airflow/pull/14978, but due to https://github.com/apache/airflow/pull/15033 that didn't actually run tests against the new deps. Ooops


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).