### PR TITLE
UI scaffold views, routes, and layout containers for Runs and Tasks

### DIFF
--- a/airflow/ui/package.json
+++ b/airflow/ui/package.json
@@ -23,7 +23,8 @@
     "react-hot-loader": "^4",
     "react-icons": "^4.2.0",
     "react-query": "^3.12.3",
-    "react-router-dom": "^5.2.0"
+    "react-router-dom": "^5.2.0",
+    "use-react-router": "^1.0.7"
   },
   "devDependencies": {
     "@neutrinojs/eslint": "^9.5.0",

--- a/airflow/ui/src/App.tsx
+++ b/airflow/ui/src/App.tsx
@@ -24,7 +24,21 @@ import { Route, Redirect, Switch } from 'react-router-dom';
 import PrivateRoute from 'auth/PrivateRoute';
 
 import Pipelines from 'views/Pipelines';
-import Pipeline from 'views/Pipeline';
+
+import Details from 'views/Pipeline/runs/Details';
+import Code from 'views/Pipeline/runs/Code';
+import TaskTries from 'views/Pipeline/runs/TaskTries';
+import TaskDuration from 'views/Pipeline/runs/TaskDuration';
+import LandingTimes from 'views/Pipeline/runs/LandingTimes';
+
+import Graph from 'views/Pipeline/run/Graph';
+import Gantt from 'views/Pipeline/run/Gantt';
+
+import TIDetails from 'views/Pipeline/ti/Details';
+import RenderedTemplate from 'views/Pipeline/ti/RenderedTemplate';
+import RenderedK8s from 'views/Pipeline/ti/RenderedK8s';
+import Log from 'views/Pipeline/ti/Log';
+import XCom from 'views/Pipeline/ti/XCom';
 
 import EventLogs from 'views/Activity/EventLogs';
 import Runs from 'views/Activity/Runs';
@@ -51,7 +65,24 @@ const App = () => (
   <Switch>
     <Redirect exact path="/" to="/pipelines" />
     <PrivateRoute exact path="/pipelines" component={Pipelines} />
-    <PrivateRoute exact path="/pipelines/:dagId" component={Pipeline} />
+
+    <Redirect exact path="/pipelines/:dagId" to="/pipelines/:dagId/details" />
+    <PrivateRoute exact path="/pipelines/:dagId/details" component={Details} />
+    <PrivateRoute exact path="/pipelines/:dagId/code" component={Code} />
+    <PrivateRoute exact path="/pipelines/:dagId/task-tries" component={TaskTries} />
+    <PrivateRoute exact path="/pipelines/:dagId/task-duration" component={TaskDuration} />
+    <PrivateRoute exact path="/pipelines/:dagId/landing-times" component={LandingTimes} />
+
+    <Redirect exact path="/pipelines/:dagId/:dagRunId" to="/pipelines/:dagId/:dagRunId/graph" />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/graph" component={Graph} />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/gantt" component={Gantt} />
+
+    <Redirect exact path="/pipelines/:dagId/:dagRunId/:taskId" to="/pipelines/:dagId/:dagRunId/:taskId/details" />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/:taskId/details" component={TIDetails} />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/:taskId/rendered-template" component={RenderedTemplate} />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/:taskId/rendered-k8s" component={RenderedK8s} />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/:taskId/log" component={Log} />
+    <PrivateRoute exact path="/pipelines/:dagId/:dagRunId/:taskId/xcom" component={XCom} />
 
     <PrivateRoute exact path="/activity/event-logs" component={EventLogs} />
     <PrivateRoute exact path="/activity/runs" component={Runs} />

--- a/airflow/ui/src/api/defaults.ts
+++ b/airflow/ui/src/api/defaults.ts
@@ -20,3 +20,7 @@
 export const defaultVersion = { version: '', gitVersion: '' };
 
 export const defaultDags = { dags: [], totalEntries: 0 };
+
+export const defaultDagRuns = { dagRuns: [], totalEntries: 0 };
+
+export const defaultTaskInstances = { taskInstances: [], totalEntries: 0 };

--- a/airflow/ui/src/api/index.ts
+++ b/airflow/ui/src/api/index.ts
@@ -21,8 +21,8 @@ import axios, { AxiosResponse } from 'axios';
 import { useQuery } from 'react-query';
 import humps from 'humps';
 
-import type { Version } from 'interfaces';
-import type { DagsResponse } from 'interfaces/api';
+import type { Dag, DagRun, Version } from 'interfaces';
+import type { DagsResponse, DagRunsResponse, TaskInstancesResponse } from 'interfaces/api';
 
 axios.defaults.baseURL = `${process.env.WEBSERVER_URL}/api/v1`;
 axios.interceptors.response.use(
@@ -36,6 +36,23 @@ export function useDags() {
     'dags',
     (): Promise<DagsResponse> => axios.get('/dags'),
     { refetchInterval },
+  );
+}
+
+export function useDagRuns(dagId: Dag['dagId'], dateMin?: string) {
+  return useQuery<DagRunsResponse, Error>(
+    ['dagRun', dagId],
+    (): Promise<DagRunsResponse> => axios.get(`dags/${dagId}/dagRuns${dateMin ? `?start_date_gte=${dateMin}` : ''}`),
+    { refetchInterval },
+  );
+}
+
+export function useTaskInstances(dagId: Dag['dagId'], dagRunId: DagRun['dagRunId'], dateMin?: string) {
+  return useQuery<TaskInstancesResponse, Error>(
+    ['taskInstance', dagRunId],
+    (): Promise<TaskInstancesResponse> => (
+      axios.get(`dags/${dagId}/dagRuns/${dagRunId}/taskInstances${dateMin ? `?start_date_gte=${dateMin}` : ''}`)
+    ),
   );
 }
 

--- a/airflow/ui/src/components/PipelineBreadcrumb.tsx
+++ b/airflow/ui/src/components/PipelineBreadcrumb.tsx
@@ -1,0 +1,93 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Box, Flex, Heading, useColorModeValue,
+} from '@chakra-ui/react';
+
+import type {
+  Dag as DagType,
+  DagRun as DagRunType,
+  Task as TaskType,
+} from 'interfaces';
+
+interface Props {
+  dagId: DagType['dagId'];
+  dagRunId?: DagRunType['dagRunId'];
+  taskId?: TaskType['taskId'];
+}
+
+const PipelineBreadcrumb: React.FC<Props> = ({ dagId, dagRunId, taskId }) => {
+  const dividerColor = useColorModeValue('gray.100', 'gray.700');
+
+  return (
+    <Flex py={2}>
+      <Box>
+        <Heading as="h5" size="xs" color="gray.500">PIPELINE</Heading>
+        <Heading as="h4" size="sm">
+          {!dagRunId && dagId}
+          {dagRunId && (
+            <Box
+              as={Link}
+              to={`/pipelines/${dagId}`}
+              color="currentColor"
+              _hover={{ color: 'teal.500' }}
+            >
+              {dagId}
+            </Box>
+          )}
+        </Heading>
+      </Box>
+      {dagRunId && (
+        <>
+          <Box color={dividerColor} px={2} fontSize="2em" lineHeight="1em">/</Box>
+          <Box>
+            <Heading as="h5" size="xs" color="gray.500">RUN</Heading>
+            <Heading as="h4" size="sm">
+              {!taskId && dagRunId}
+              {taskId && (
+                <Box
+                  as={Link}
+                  to={`/pipelines/${dagId}/${dagRunId}`}
+                  color="currentColor"
+                  _hover={{ color: 'teal.500' }}
+                >
+                  {dagRunId}
+                </Box>
+              )}
+            </Heading>
+          </Box>
+        </>
+      )}
+      {taskId && (
+        <>
+          <Box color={dividerColor} px={2} fontSize="2em" lineHeight="1em">/</Box>
+          <Box>
+            <Heading as="h5" size="xs" color="gray.500">TASK INSTANCE</Heading>
+            <Heading as="h4" size="sm">{taskId}</Heading>
+          </Box>
+        </>
+      )}
+    </Flex>
+  );
+};
+
+export default PipelineBreadcrumb;

--- a/airflow/ui/src/components/SectionNav.tsx
+++ b/airflow/ui/src/components/SectionNav.tsx
@@ -18,31 +18,44 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import {
+  Box,
+  useColorModeValue,
+} from '@chakra-ui/react';
+
+import SectionNavBtn from 'components/SectionNavBtn';
 
 interface Props {
-  item: {
+  currentView: string;
+  navItems: {
     label: string;
     path: string;
-  };
-  currentView: string;
+  }[]
 }
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
+const SectionNav: React.FC<Props> = ({ currentView, navItems }) => {
+  const bg = useColorModeValue('gray.100', 'gray.700');
   return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
+    <Box
+      pt={2}
+      mx={-4}
+      px={4}
+      pb={2}
+      bg={bg}
     >
-      {label}
-    </Button>
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+      >
+        <Box as="nav">
+          {navItems.map((item) => (
+            <SectionNavBtn key={item.label} item={item} currentView={currentView} />
+          ))}
+        </Box>
+      </Box>
+    </Box>
   );
 };
 
-export default SectionNavBtn;
+export default SectionNav;

--- a/airflow/ui/src/components/SectionWrapper.tsx
+++ b/airflow/ui/src/components/SectionWrapper.tsx
@@ -24,9 +24,8 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react';
 
-import SectionNavBtn from 'components/SectionNavBtn';
-
 import AppContainer from 'components/AppContainer';
+import SectionNav from 'components/SectionNav';
 
 interface Props {
   currentSection: string;
@@ -42,7 +41,6 @@ const SectionWrapper: React.FC<Props> = ({
   children, currentSection, currentView, navItems, toolBar,
 }) => {
   const heading = useColorModeValue('gray.400', 'gray.500');
-  const bg = useColorModeValue('gray.100', 'gray.700');
   const border = useColorModeValue('gray.100', 'gray.700');
   const toolbarBg = useColorModeValue('white', 'gray.800');
   return (
@@ -60,25 +58,7 @@ const SectionWrapper: React.FC<Props> = ({
         </Heading>
     )}
     >
-      <Box
-        pt={2}
-        mx={-4}
-        px={4}
-        pb="2"
-        bg={bg}
-      >
-        <Box
-          display="flex"
-          alignItems="center"
-          justifyContent="space-between"
-        >
-          <Box as="nav">
-            {navItems.map((item) => (
-              <SectionNavBtn key={item.label} item={item} currentLabel={currentView} />
-            ))}
-          </Box>
-        </Box>
-      </Box>
+      <SectionNav navItems={navItems} currentView={currentView} />
       {toolBar && (
       <Box
         position="sticky"

--- a/airflow/ui/src/interfaces/api.ts
+++ b/airflow/ui/src/interfaces/api.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import type { Dag } from './index';
+import type { Dag, DagRun, TaskInstance } from './index';
 
 interface Entries {
   totalEntries: number;
@@ -25,4 +25,12 @@ interface Entries {
 
 export interface DagsResponse extends Entries {
   dags: Dag[];
+}
+
+export interface DagRunsResponse extends Entries {
+  dagRuns: DagRun[];
+}
+
+export interface TaskInstancesResponse extends Entries {
+  taskInstances: TaskInstance[];
 }

--- a/airflow/ui/src/interfaces/index.ts
+++ b/airflow/ui/src/interfaces/index.ts
@@ -46,6 +46,55 @@ export interface Dag {
   tags: DagTag[],
 }
 
+export interface DagRun {
+  dagRunId: string,
+  dagId: Dag['dagId'],
+  executionDate: Date,
+  startDate: Date,
+  endDate: Date,
+  state: 'success' | 'running' | 'failed',
+  externalTrigger: boolean,
+  conf: JSON,
+}
+
+export interface Task {
+  taskId: string,
+  owner: string,
+  startDate: Date,
+  endDate: Date,
+}
+
+export interface TaskInstance {
+  taskId: Task['taskId'],
+  dagId: Dag['dagId'],
+  executionDate: Date,
+  startDate: Date,
+  endDate: Date,
+  duration: number,
+  state: string, // TODO: create enum
+  tryNumber: number,
+  maxTries: number,
+  hostname: string,
+  unixname: string,
+  pool: string,
+  poolSlots: number,
+  queue: string,
+  priorityWeight: number,
+  operator: string,
+  queuedWhen: string,
+  pid: number
+  executorConfig: string,
+  slaMiss: {
+    taskId: Task['taskId'],
+    dagId: Dag['dagId'],
+    executionDate: Date,
+    emailSent: boolean,
+    timestamp: Date,
+    description: string,
+    notification_sent: boolean,
+  },
+}
+
 export interface Version {
   version: string,
   gitVersion: string,

--- a/airflow/ui/src/views/Pipeline/PipelineContainer.tsx
+++ b/airflow/ui/src/views/Pipeline/PipelineContainer.tsx
@@ -69,7 +69,7 @@ const PipelineContainer: React.FC = ({ children }) => {
         <Box flex="1" borderRightWidth="2px" borderColor={dividerColor}>
           <Heading mb={2}>Runs</Heading>
           {!!dagRuns.length && dagRuns.map((dagRun: DagRunType) => (
-            <Box>
+            <Box key={dagRun.dagRunId}>
               <Link to={`/pipelines/${dagId}/${dagRun.dagRunId}`}>{dagRun.dagRunId}</Link>
             </Box>
           ))}
@@ -77,7 +77,7 @@ const PipelineContainer: React.FC = ({ children }) => {
             <>
               <Heading mb={2} size="md" mt={8}>Task Instances:</Heading>
               {!!taskInstances.length && taskInstances.map((ti: TaskInstanceType) => (
-                <Box>
+                <Box key={ti.taskId}>
                   <Link to={`/pipelines/${dagId}/${dagRunId}/${ti.taskId}`}>{ti.taskId}</Link>
                 </Box>
               ))}

--- a/airflow/ui/src/views/Pipeline/PipelineContainer.tsx
+++ b/airflow/ui/src/views/Pipeline/PipelineContainer.tsx
@@ -68,7 +68,7 @@ const PipelineContainer: React.FC = ({ children }) => {
       <Flex height="100%">
         <Box flex="1" borderRightWidth="2px" borderColor={dividerColor}>
           <Heading mb={2}>Runs</Heading>
-          {!!dagRuns.length && dagRuns.map((dagRun: DagRunType) => (
+          {dagRuns.map((dagRun: DagRunType) => (
             <Box key={dagRun.dagRunId}>
               <Link to={`/pipelines/${dagId}/${dagRun.dagRunId}`}>{dagRun.dagRunId}</Link>
             </Box>
@@ -76,7 +76,7 @@ const PipelineContainer: React.FC = ({ children }) => {
           {dagRunId && (
             <>
               <Heading mb={2} size="md" mt={8}>Task Instances:</Heading>
-              {!!taskInstances.length && taskInstances.map((ti: TaskInstanceType) => (
+              {taskInstances.map((ti: TaskInstanceType) => (
                 <Box key={ti.taskId}>
                   <Link to={`/pipelines/${dagId}/${dagRunId}/${ti.taskId}`}>{ti.taskId}</Link>
                 </Box>

--- a/airflow/ui/src/views/Pipeline/PipelineContainer.tsx
+++ b/airflow/ui/src/views/Pipeline/PipelineContainer.tsx
@@ -1,0 +1,95 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import useReactRouter from 'use-react-router';
+import {
+  Box,
+  Flex,
+  Heading,
+  useColorModeValue,
+} from '@chakra-ui/react';
+
+import AppContainer from 'components/AppContainer';
+
+import { useDagRuns, useTaskInstances } from 'api';
+import { defaultDagRuns, defaultTaskInstances } from 'api/defaults';
+
+import type {
+  Dag as DagType, DagRun as DagRunType, TaskInstance as TaskInstanceType,
+} from 'interfaces';
+
+interface RouterProps {
+  match: { params: { dagId: DagType['dagId'], dagRunId: DagRunType['dagRunId'] } }
+}
+
+const PipelineContainer: React.FC = ({ children }) => {
+  const { match: { params: { dagId, dagRunId } } }: RouterProps = useReactRouter();
+
+  const { data: { dagRuns } = defaultDagRuns } = useDagRuns(dagId);
+  const { data: { taskInstances } = defaultTaskInstances } = useTaskInstances(dagId, dagRunId);
+
+  const linkColor = useColorModeValue('gray.400', 'gray.500');
+  const dividerColor = useColorModeValue('gray.100', 'gray.700');
+
+  return (
+    <AppContainer
+      breadcrumb={(
+        <Heading as="h1" size="md">
+          <Box
+            as="span"
+            color={linkColor}
+            _hover={{ color: 'teal.500' }}
+          >
+            <Link to="/pipelines" color="currentColor">Pipelines</Link>
+            /
+          </Box>
+          {dagId}
+        </Heading>
+      )}
+    >
+      <Flex height="100%">
+        <Box flex="1" borderRightWidth="2px" borderColor={dividerColor}>
+          <Heading mb={2}>Runs</Heading>
+          {!!dagRuns.length && dagRuns.map((dagRun: DagRunType) => (
+            <Box>
+              <Link to={`/pipelines/${dagId}/${dagRun.dagRunId}`}>{dagRun.dagRunId}</Link>
+            </Box>
+          ))}
+          {dagRunId && (
+            <>
+              <Heading mb={2} size="md" mt={8}>Task Instances:</Heading>
+              {!!taskInstances.length && taskInstances.map((ti: TaskInstanceType) => (
+                <Box>
+                  <Link to={`/pipelines/${dagId}/${dagRunId}/${ti.taskId}`}>{ti.taskId}</Link>
+                </Box>
+              ))}
+            </>
+          )}
+        </Box>
+        <Box width="50%" pl={4} ml="2px">
+          {children}
+        </Box>
+      </Flex>
+    </AppContainer>
+  );
+};
+
+export default PipelineContainer;

--- a/airflow/ui/src/views/Pipeline/run/Gantt.tsx
+++ b/airflow/ui/src/views/Pipeline/run/Gantt.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import RunContainer from './RunContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const Gantt: React.FC = () => (
+  <RunContainer currentView="Gantt">
+    <Heading>Gantt</Heading>
+  </RunContainer>
+);
 
-export default SectionNavBtn;
+export default Gantt;

--- a/airflow/ui/src/views/Pipeline/run/Graph.tsx
+++ b/airflow/ui/src/views/Pipeline/run/Graph.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import RunContainer from './RunContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const Graph: React.FC = () => (
+  <RunContainer currentView="Graph">
+    <Heading>Graph</Heading>
+  </RunContainer>
+);
 
-export default SectionNavBtn;
+export default Graph;

--- a/airflow/ui/src/views/Pipeline/run/RunContainer.tsx
+++ b/airflow/ui/src/views/Pipeline/run/RunContainer.tsx
@@ -1,0 +1,65 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import useReactRouter from 'use-react-router';
+
+import PipelineBreadcrumb from 'components/PipelineBreadcrumb';
+import SectionNav from 'components/SectionNav';
+
+import type {
+  Dag as DagType,
+  DagRun as DagRunType,
+} from 'interfaces';
+
+import PipelineContainer from '../PipelineContainer';
+
+interface RouterProps {
+  match: { params: { dagId: DagType['dagId'], dagRunId: DagRunType['dagRunId'] } }
+}
+
+interface Props {
+  currentView: string;
+}
+
+const RunContainer: React.FC<Props> = ({ children, currentView }) => {
+  const { match: { params: { dagId, dagRunId } } }: RouterProps = useReactRouter();
+
+  const basePath = `/pipelines/${dagId}/${dagRunId}`;
+  const navItems = [
+    {
+      label: 'Graph',
+      path: `${basePath}/graph`,
+    },
+    {
+      label: 'Gantt',
+      path: `${basePath}/gantt`,
+    },
+  ];
+
+  return (
+    <PipelineContainer>
+      <PipelineBreadcrumb dagId={dagId} dagRunId={dagRunId} />
+      <SectionNav navItems={navItems} currentView={currentView} />
+      {children}
+    </PipelineContainer>
+  );
+};
+
+export default RunContainer;

--- a/airflow/ui/src/views/Pipeline/runs/Code.tsx
+++ b/airflow/ui/src/views/Pipeline/runs/Code.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import RunsContainer from './RunsContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const Code: React.FC = () => (
+  <RunsContainer currentView="DAG Code">
+    <Heading>DAG Code</Heading>
+  </RunsContainer>
+);
 
-export default SectionNavBtn;
+export default Code;

--- a/airflow/ui/src/views/Pipeline/runs/Details.tsx
+++ b/airflow/ui/src/views/Pipeline/runs/Details.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import RunsContainer from './RunsContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const Details: React.FC = () => (
+  <RunsContainer currentView="Details">
+    <Heading>Details</Heading>
+  </RunsContainer>
+);
 
-export default SectionNavBtn;
+export default Details;

--- a/airflow/ui/src/views/Pipeline/runs/LandingTimes.tsx
+++ b/airflow/ui/src/views/Pipeline/runs/LandingTimes.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import RunsContainer from './RunsContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const LandingTimes: React.FC = () => (
+  <RunsContainer currentView="Landing Times">
+    <Heading>Landing Times</Heading>
+  </RunsContainer>
+);
 
-export default SectionNavBtn;
+export default LandingTimes;

--- a/airflow/ui/src/views/Pipeline/runs/RunsContainer.tsx
+++ b/airflow/ui/src/views/Pipeline/runs/RunsContainer.tsx
@@ -1,0 +1,76 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import useReactRouter from 'use-react-router';
+
+import PipelineBreadcrumb from 'components/PipelineBreadcrumb';
+import SectionNav from 'components/SectionNav';
+
+import type {
+  Dag as DagType,
+} from 'interfaces';
+
+import PipelineContainer from '../PipelineContainer';
+
+interface RouterProps {
+  match: { params: { dagId: DagType['dagId'] } }
+}
+
+interface Props {
+  currentView: string;
+}
+
+const RunContainer: React.FC<Props> = ({ children, currentView }) => {
+  const { match: { params: { dagId } } }: RouterProps = useReactRouter();
+
+  const basePath = `/pipelines/${dagId}`;
+  const navItems = [
+    {
+      label: 'Details',
+      path: `${basePath}/details`,
+    },
+    {
+      label: 'DAG Code',
+      path: `${basePath}/code`,
+    },
+    {
+      label: 'Task Tries',
+      path: `${basePath}/task-tries`,
+    },
+    {
+      label: 'Task Duration',
+      path: `${basePath}/task-duration`,
+    },
+    {
+      label: 'Landing Times',
+      path: `${basePath}/landing-times`,
+    },
+  ];
+
+  return (
+    <PipelineContainer>
+      <PipelineBreadcrumb dagId={dagId} />
+      <SectionNav navItems={navItems} currentView={currentView} />
+      {children}
+    </PipelineContainer>
+  );
+};
+
+export default RunContainer;

--- a/airflow/ui/src/views/Pipeline/runs/TaskDuration.tsx
+++ b/airflow/ui/src/views/Pipeline/runs/TaskDuration.tsx
@@ -18,12 +18,14 @@
  */
 
 import React from 'react';
-import { Center, Heading } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-const Pipeline: React.FC = () => (
-  <Center height="100vh">
-    <Heading>Pipeline</Heading>
-  </Center>
+import RunsContainer from './RunsContainer';
+
+const TaskDuration: React.FC = () => (
+  <RunsContainer currentView="Task Duration">
+    <Heading>Task Duration</Heading>
+  </RunsContainer>
 );
 
-export default Pipeline;
+export default TaskDuration;

--- a/airflow/ui/src/views/Pipeline/runs/TaskTries.tsx
+++ b/airflow/ui/src/views/Pipeline/runs/TaskTries.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import RunsContainer from './RunsContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const TaskTries: React.FC = () => (
+  <RunsContainer currentView="Task Tries">
+    <Heading>Task Tries</Heading>
+  </RunsContainer>
+);
 
-export default SectionNavBtn;
+export default TaskTries;

--- a/airflow/ui/src/views/Pipeline/ti/Details.tsx
+++ b/airflow/ui/src/views/Pipeline/ti/Details.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import TIContainer from './TIContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const Details: React.FC = () => (
+  <TIContainer currentView="Details">
+    <Heading>Details</Heading>
+  </TIContainer>
+);
 
-export default SectionNavBtn;
+export default Details;

--- a/airflow/ui/src/views/Pipeline/ti/Log.tsx
+++ b/airflow/ui/src/views/Pipeline/ti/Log.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import TIContainer from './TIContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const Log: React.FC = () => (
+  <TIContainer currentView="Log">
+    <Heading>Log</Heading>
+  </TIContainer>
+);
 
-export default SectionNavBtn;
+export default Log;

--- a/airflow/ui/src/views/Pipeline/ti/RenderedK8s.tsx
+++ b/airflow/ui/src/views/Pipeline/ti/RenderedK8s.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import TIContainer from './TIContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const RenderedK8s: React.FC = () => (
+  <TIContainer currentView="Rendered K8s">
+    <Heading>Rendered K8s</Heading>
+  </TIContainer>
+);
 
-export default SectionNavBtn;
+export default RenderedK8s;

--- a/airflow/ui/src/views/Pipeline/ti/RenderedTemplate.tsx
+++ b/airflow/ui/src/views/Pipeline/ti/RenderedTemplate.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import TIContainer from './TIContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const RenderedTemplate: React.FC = () => (
+  <TIContainer currentView="Rendered Template">
+    <Heading>Rendered Template</Heading>
+  </TIContainer>
+);
 
-export default SectionNavBtn;
+export default RenderedTemplate;

--- a/airflow/ui/src/views/Pipeline/ti/TIContainer.tsx
+++ b/airflow/ui/src/views/Pipeline/ti/TIContainer.tsx
@@ -1,0 +1,78 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import useReactRouter from 'use-react-router';
+
+import PipelineBreadcrumb from 'components/PipelineBreadcrumb';
+import SectionNav from 'components/SectionNav';
+
+import type {
+  Dag as DagType,
+  DagRun as DagRunType,
+  TaskInstance as TaskInstanceType,
+} from 'interfaces';
+
+import PipelineContainer from '../PipelineContainer';
+
+interface RouterProps {
+  match: { params: { dagId: DagType['dagId'], dagRunId: DagRunType['dagRunId'], taskId: TaskInstanceType['taskId'] } }
+}
+
+interface Props {
+  currentView: string;
+}
+
+const RunContainer: React.FC<Props> = ({ children, currentView }) => {
+  const { match: { params: { dagId, dagRunId, taskId } } }: RouterProps = useReactRouter();
+
+  const basePath = `/pipelines/${dagId}/${dagRunId}/${taskId}`;
+  const navItems = [
+    {
+      label: 'Details',
+      path: `${basePath}/details`,
+    },
+    {
+      label: 'Rendered Template',
+      path: `${basePath}/rendered-template`,
+    },
+    {
+      label: 'Rendered K8s',
+      path: `${basePath}/rendered-k8s`,
+    },
+    {
+      label: 'Log',
+      path: `${basePath}/log`,
+    },
+    {
+      label: 'XCom',
+      path: `${basePath}/xcom`,
+    },
+  ];
+
+  return (
+    <PipelineContainer>
+      <PipelineBreadcrumb dagId={dagId} dagRunId={dagRunId} taskId={taskId} />
+      <SectionNav navItems={navItems} currentView={currentView} />
+      {children}
+    </PipelineContainer>
+  );
+};
+
+export default RunContainer;

--- a/airflow/ui/src/views/Pipeline/ti/XCom.tsx
+++ b/airflow/ui/src/views/Pipeline/ti/XCom.tsx
@@ -18,31 +18,14 @@
  */
 
 import React from 'react';
-import { Link } from 'react-router-dom';
-import { Button } from '@chakra-ui/react';
+import { Heading } from '@chakra-ui/react';
 
-interface Props {
-  item: {
-    label: string;
-    path: string;
-  };
-  currentView: string;
-}
+import TIContainer from './TIContainer';
 
-const SectionNavBtn: React.FC<Props> = ({ item, currentView }) => {
-  const { label, path } = item;
-  return (
-    <Button
-      as={Link}
-      to={path}
-      variant={currentView === label ? 'solid' : 'ghost'}
-      colorScheme="blue"
-      size="sm"
-      mr="2"
-    >
-      {label}
-    </Button>
-  );
-};
+const XCom: React.FC = () => (
+  <TIContainer currentView="XCom">
+    <Heading>XCom</Heading>
+  </TIContainer>
+);
 
-export default SectionNavBtn;
+export default XCom;

--- a/airflow/ui/src/views/Pipelines/index.tsx
+++ b/airflow/ui/src/views/Pipelines/index.tsx
@@ -85,7 +85,7 @@ const Pipelines: React.FC = () => {
                 <Flex alignItems="center">
                   <Link
                     as={RouterLink}
-                    to={`/pipeline/${dag.dagId}`}
+                    to={`/pipelines/${dag.dagId}`}
                     fontWeight="bold"
                   >
                     {dag.dagId}

--- a/airflow/ui/yarn.lock
+++ b/airflow/ui/yarn.lock
@@ -9939,6 +9939,18 @@ use-callback-ref@^1.2.1, use-callback-ref@^1.2.3:
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.5.tgz#6115ed242cfbaed5915499c0a9842ca2912f38a5"
   integrity sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==
 
+use-force-update@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/use-force-update/-/use-force-update-1.0.7.tgz#f5e672633f5a398b25c33b2287150918bcb3526b"
+  integrity sha512-k5dppYhO+I5X/cd7ildbrzeMZJkWwdAh5adaIk0qKN2euh7J0h2GBGBcB4QZ385eyHHnp7LIygvebdRx3XKdwA==
+
+use-react-router@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/use-react-router/-/use-react-router-1.0.7.tgz#04216066d87e45040309f24d2fd5e9f28308b3e2"
+  integrity sha512-gdqIHEO28E+qDJQ+tOMGQPthPib7mhLI/4MY7wtxJuaVUkosbP+FAYcHmmE7/FjYoMsuzL/bvY/25st7QHodpw==
+  dependencies:
+    use-force-update "^1.0.5"
+
 use-sidecar@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.5.tgz#ffff2a17c1df42e348624b699ba6e5c220527f2b"


### PR DESCRIPTION
Follow-up to #15007 that also provides scaffold routes and their correlating view files.

- Adds nesting layout containers `RunsContainer`, `RunContainer`, and `TIContainer` that all inherit from a shared `PipelineContainer`.
- Refactors the navigation in `SectionWrapper` into a shareable `SectionNav` component that is now used for all sub-navigations.
- The usage of `useDagRuns` and `useTaskInstances` query hooks is only a temporary implementation to allow rendering of links (left half of screen in GIF below) to traverse all of the new routes introduced in this PR.

![Screen Recording 2021-03-26 at 04 39 57 PM](https://user-images.githubusercontent.com/3267/112690626-7c5f1280-8e52-11eb-95c2-6be88ff7bccb.gif)

**DISCLAIMER:** All aesthetics (colors, fonts, icons) will be subject to future change—this simply uses a default theme. View routes and naming are "working titles"—also subject to change.