### PR TITLE
improve react-query testing

### DIFF
--- a/airflow/ui/jest.config.js
+++ b/airflow/ui/jest.config.js
@@ -23,5 +23,6 @@
 const neutrino = require('neutrino');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'test';
+process.env.WEBSERVER_URL = process.env.WEBSERVER_URL || 'http://localhost:9999';
 
 module.exports = neutrino().jest();

--- a/airflow/ui/src/api/index.ts
+++ b/airflow/ui/src/api/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,7 +19,7 @@
  */
 
 import axios, { AxiosResponse } from 'axios';
-import { useQuery } from 'react-query';
+import { useQuery, setLogger } from 'react-query';
 import humps from 'humps';
 
 import type { Version } from 'interfaces';
@@ -29,13 +30,25 @@ axios.interceptors.response.use(
   (res) => (res.data ? humps.camelizeKeys(res.data) as unknown as AxiosResponse : res),
 );
 
-const refetchInterval = 1000;
+// turn off logging, retry and refetch on tests
+const isTest = process.env.NODE_ENV === 'test';
+
+setLogger({
+  log: isTest ? () => {} : console.log,
+  warn: isTest ? () => {} : console.warn,
+  error: isTest ? () => {} : console.warn,
+});
+
+const refetchInterval = isTest ? false : 1000;
 
 export function useDags() {
   return useQuery<DagsResponse, Error>(
     'dags',
     (): Promise<DagsResponse> => axios.get('/dags'),
-    { refetchInterval },
+    {
+      refetchInterval,
+      retry: !isTest,
+    },
   );
 }
 

--- a/airflow/ui/test/Login.test.tsx
+++ b/airflow/ui/test/Login.test.tsx
@@ -32,24 +32,30 @@ import { url, defaultHeaders, QueryWrapper } from './utils';
 
 axios.defaults.adapter = require('axios/lib/adapters/http');
 
-nock(url)
-  .defaultReplyHeaders(defaultHeaders)
-  .persist()
-  .get('/version')
-  .reply(200, { version: '', gitVersion: '' });
-
-test('App shows Login screen by default', () => {
-  const { getByText } = render(
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>,
-    { wrapper: QueryWrapper },
-  );
-
-  expect(getByText('Password')).toBeInTheDocument();
-});
-
 describe('test login component', () => {
+  beforeAll(() => {
+    nock(url)
+      .defaultReplyHeaders(defaultHeaders)
+      .persist()
+      .get('/version')
+      .reply(200, { version: '', gitVersion: '' });
+  });
+
+  afterAll(() => {
+    nock.cleanAll();
+  });
+
+  test('App shows Login screen by default', () => {
+    const { getByText } = render(
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>,
+      { wrapper: QueryWrapper },
+    );
+
+    expect(getByText('Password')).toBeInTheDocument();
+  });
+
   test('Button is disabled when there is no username or password', () => {
     const { getByTestId } = render(
       <BrowserRouter>


### PR DESCRIPTION
Improving how we test components that include API requests

- simplify react-query actions on test environments
- before set ups and `afterAll` clean ups
- add missing async/await
- add a dummy url to mock requests


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
