### PR TITLE
[airflow-5146]: parse MongoDB replica set URI, #14659

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -45,7 +45,7 @@ def parse_netloc_to_hostname(*args, **kwargs):
 # See: https://issues.apache.org/jira/browse/AIRFLOW-3615
 def _parse_netloc_to_hostname(uri_parts):
     """Parse a URI string to get correct Hostname."""
-    hostname = unquote(uri_parts.hostname or '')
+    hostname = unquote(uri_parts.hostname or '') if "," not in uri_parts.netloc else unquote(uri_parts.netloc)
     if '/' in hostname:
         hostname = uri_parts.netloc
         if "@" in hostname:
@@ -159,7 +159,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
         self.schema = unquote(quoted_schema) if quoted_schema else quoted_schema
         self.login = unquote(uri_parts.username) if uri_parts.username else uri_parts.username
         self.password = unquote(uri_parts.password) if uri_parts.password else uri_parts.password
-        self.port = uri_parts.port
+        self.port = uri_parts.port if "," not in self.host else None
         if uri_parts.query:
             self.extra = json.dumps(dict(parse_qsl(uri_parts.query, keep_blank_values=True)))
 

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -32,7 +32,9 @@ from airflow.models import Connection, crypto
 from airflow.providers.sqlite.hooks.sqlite import SqliteHook
 from tests.test_utils.config import conf_vars
 
-ConnectionParts = namedtuple("ConnectionParts", ["conn_type", "login", "password", "host", "port", "schema"])
+ConnectionParts = namedtuple(
+    "ConnectionParts", ["conn_type", "login", "password", "host", "port", "schema", "extra"]
+)
 
 
 class UriTestCaseConfig:
@@ -362,31 +364,61 @@ class TestConnection(unittest.TestCase):
             (
                 "http://:password@host:80/database",
                 ConnectionParts(
-                    conn_type="http", login='', password="password", host="host", port=80, schema="database"
+                    conn_type="http",
+                    login='',
+                    password="password",
+                    host="host",
+                    port=80,
+                    schema="database",
+                    extra="",
                 ),
             ),
             (
                 "http://user:@host:80/database",
                 ConnectionParts(
-                    conn_type="http", login="user", password=None, host="host", port=80, schema="database"
+                    conn_type="http",
+                    login="user",
+                    password=None,
+                    host="host",
+                    port=80,
+                    schema="database",
+                    extra="",
                 ),
             ),
             (
                 "http://user:password@/database",
                 ConnectionParts(
-                    conn_type="http", login="user", password="password", host="", port=None, schema="database"
+                    conn_type="http",
+                    login="user",
+                    password="password",
+                    host="",
+                    port=None,
+                    schema="database",
+                    extra="",
                 ),
             ),
             (
                 "http://user:password@host:80/",
                 ConnectionParts(
-                    conn_type="http", login="user", password="password", host="host", port=80, schema=""
+                    conn_type="http",
+                    login="user",
+                    password="password",
+                    host="host",
+                    port=80,
+                    schema="",
+                    extra="",
                 ),
             ),
             (
                 "http://user:password@/",
                 ConnectionParts(
-                    conn_type="http", login="user", password="password", host="", port=None, schema=""
+                    conn_type="http",
+                    login="user",
+                    password="password",
+                    host="",
+                    port=None,
+                    schema="",
+                    extra="",
                 ),
             ),
             (
@@ -398,6 +430,7 @@ class TestConnection(unittest.TestCase):
                     host="/tmp/z6rqdzqh/example:west1:testdb",
                     port=None,
                     schema="testdb",
+                    extra="",
                 ),
             ),
             (
@@ -409,6 +442,7 @@ class TestConnection(unittest.TestCase):
                     host="/tmp/z6rqdzqh/example:europe-west1:testdb",
                     port=None,
                     schema="testdb",
+                    extra="",
                 ),
             ),
             (
@@ -420,6 +454,19 @@ class TestConnection(unittest.TestCase):
                     host="/tmp/z6rqdzqh/example:europe-west1:testdb",
                     port=None,
                     schema="",
+                    extra="",
+                ),
+            ),
+            (
+                "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017,mongodb2.example.com:27017/?replicaSet=myRepl",
+                ConnectionParts(
+                    conn_type="mongodb",
+                    login=None,
+                    password=None,
+                    host="mongodb0.example.com:27017,mongodb1.example.com:27017,mongodb2.example.com:27017",
+                    port=None,
+                    schema="",
+                    extra="replicaSet=myRepl",
                 ),
             ),
         ]

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -458,7 +458,9 @@ class TestConnection(unittest.TestCase):
                 ),
             ),
             (
-                "mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017,mongodb2.example.com:27017/?replicaSet=myRepl",
+                "mongodb://mongodb0.example.com:27017,"
+                "mongodb1.example.com:27017,mongodb2.example.com:27017"
+                "/?replicaSet=myRepl",
                 ConnectionParts(
                     conn_type="mongodb",
                     login=None,


### PR DESCRIPTION
closes: #14659 
related: airflow-5146

This PR closes #14659. 
- `hostname` returned from urllib.parse.urlparse is set to `.netloc` in case the uri contains a coma "," in `airflow.models.connection`;
- The tests were adapted to take the `extra` connection attribute in account;
- Test performed with [MongoDB connection string for replica set](https://docs.mongodb.com/manual/reference/connection-string/): `mongodb://mongodb0.example.com:27017,mongodb1.example.com:27017,mongodb2.example.com:27017/?replicaSet=myRepl`
- 