### PR TITLE
Adding a call for exit code and a terminate call on finished processors to prevent defunct processes in airflow scheduler

### DIFF
--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -1203,7 +1203,8 @@ class DagFileProcessorManager(LoggingMixin):
             else:
                 for simple_dag in processor.result[0]:
                     simple_dags.append(simple_dag)
-
+                self.log.info("Processor for %s exited with return code %s.", processor.file_path, processor.exit_code)
+                processor.terminate(sigkill=True)
         return simple_dags
 
     def heartbeat(self):


### PR DESCRIPTION
closes: #14166

Calls upon the exit code of the processes launched by scheduler to gather dags. This prevents from completed processors from becoming defunct.