### PR TITLE
#15023 Add validation for dag_run conf to be a dict

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -88,6 +88,12 @@ def trigger_dag(dag_id):
     conf = None
     if 'conf' in data:
         conf = data['conf']
+        if type(conf) is not dict:
+            error_message = 'Dag Run conf must be a dictionary object, other types are not supported'
+            log.error(error_message)
+            response = jsonify({'error': error_message})
+            response.status_code = 400
+            return response
 
     execution_date = None
     if 'execution_date' in data and data['execution_date'] is not None:

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -35,7 +35,7 @@
     <input type="hidden" name="dag_id" value="{{ dag_id }}">
     <input type="hidden" name="origin" value="{{ origin }}">
     <div class="form-group">
-      <label for="conf">Configuration JSON (Optional)</label>
+      <label for="conf">Configuration JSON (Optional, must be a dict object)</label>
       <textarea class="form-control" name="conf" id="json">{{ conf }}</textarea>
     </div>
     <p>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1467,8 +1467,13 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         if request_conf:
             try:
                 run_conf = json.loads(request_conf)
+                if type(run_conf) is not dict:
+                    flash("Invalid JSON configuration, must be a dict", "error")
+                    return self.render_template(
+                        'airflow/trigger.html', dag_id=dag_id, origin=origin, conf=request_conf
+                    )
             except json.decoder.JSONDecodeError:
-                flash("Invalid JSON configuration", "error")
+                flash("Invalid JSON configuration, not parseable", "error")
                 return self.render_template(
                     'airflow/trigger.html', dag_id=dag_id, origin=origin, conf=request_conf
                 )

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -851,6 +851,27 @@ class TestPostDagRun(TestDagRunEndpoint):
         assert response.status_code == 400
         assert response.json['detail'] == expected
 
+    @parameterized.expand(
+        [
+            (
+                "Conf is an array, not a dict",
+                {
+                    "dag_run_id": "TEST_DAG_RUN",
+                    "execution_date": "2020-06-11T18:00:00+00:00",
+                    "conf": "some string"
+                },
+                "'some string' is not of type 'object' - 'conf'"
+            )
+        ]
+    )
+    def test_should_response_400_for_non_dict_dagrun_conf(self, name, data, expected):
+        self._create_dag("TEST_DAG_ID")
+        response = self.client.post(
+            "api/v1/dags/TEST_DAG_ID/dagRuns", json=data, environ_overrides={'REMOTE_USER': "test"}
+        )
+        assert response.status_code == 400
+        assert response.json['detail'] == expected
+
     def test_response_404(self):
         response = self.client.post(
             "api/v1/dags/TEST_DAG_ID/dagRuns",

--- a/tests/www/api/experimental/test_endpoints.py
+++ b/tests/www/api/experimental/test_endpoints.py
@@ -152,9 +152,27 @@ class TestApiExperimental(TestBase):
     def test_trigger_dag(self):
         url_template = '/api/experimental/dags/{}/dag_runs'
         run_id = 'my_run' + utcnow().isoformat()
+
+        # Test error for nonexistent dag
+        response = self.client.post(
+            url_template.format('does_not_exist_dag'), data=json.dumps({}), content_type="application/json"
+        )
+        assert 404 == response.status_code
+
+        # Test error for bad conf data
+        response = self.client.post(
+            url_template.format('example_bash_operator'), data=json.dumps({'conf': 'This is a string not a dict'}), content_type="application/json"
+        )
+        assert 400 == response.status_code
+
+        # Test OK case
         response = self.client.post(
             url_template.format('example_bash_operator'),
-            data=json.dumps({'run_id': run_id}),
+            data=json.dumps({
+                'run_id': run_id,
+                'conf': {
+                    'param': 'value'
+                }}),
             content_type="application/json",
         )
         self.assert_deprecated(response)
@@ -171,12 +189,6 @@ class TestApiExperimental(TestBase):
         dag_run_id = dag_run.run_id
         assert run_id == dag_run_id
         assert dag_run_id == response['run_id']
-
-        # Test error for nonexistent dag
-        response = self.client.post(
-            url_template.format('does_not_exist_dag'), data=json.dumps({}), content_type="application/json"
-        )
-        assert 404 == response.status_code
 
     def test_trigger_dag_for_date(self):
         url_template = '/api/experimental/dags/{}/dag_runs'

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -2803,6 +2803,19 @@ class TestTriggerDag(TestBase):
         run = self.session.query(DR).filter(DR.dag_id == test_dag_id).first()
         assert run is None
 
+    def test_trigger_dag_conf_not_dict(self):
+        test_dag_id = "example_bash_operator"
+
+        DR = models.DagRun  # pylint: disable=invalid-name
+        self.session.query(DR).delete()
+        self.session.commit()
+
+        response = self.client.post(f'trigger?dag_id={test_dag_id}', data={'conf': 'string and not a dict'})
+        self.check_content_in_response('must be a dict', response)
+
+        run = self.session.query(DR).filter(DR.dag_id == test_dag_id).first()
+        assert run is None
+
     def test_trigger_dag_form(self):
         test_dag_id = "example_bash_operator"
         resp = self.client.get(f'trigger?dag_id={test_dag_id}')


### PR DESCRIPTION
With this PR new DAG triggers are validated that the submitted conf (=dag_run_conf) is a dictionary. Previously submissions were possible and the logic just validated if the parameter is a valid JSON. Nevertheless currently some business logic fails in Airflow if the con value is not a dictionary object.

Explicitly I added the validation NOT to the data model as instances with migrated legacy data (in Airflow 1.x non dictionary cases were supported) are not failing in loading data via ORM.

The PR mainly adds validation for Legacy Experimental API and WWW UI.
It adds pytest for Legacy Experimental API, "new" API and WWW UI.

closes: #15023
related: #15023