### PR TITLE
Fixing pool set and pool delete via cli

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -299,11 +299,11 @@ def pool_get(args):
 
 
 def pool_set(args):
-    _pool_wrapper(args, set=(args.name, args.slots, args.description))
+    _pool_wrapper(args, set=(args.pool, args.slots, args.description))
 
 
 def pool_delete(args):
-    _pool_wrapper(args, delete=pool.name)
+    _pool_wrapper(args, delete=args.pool)
 
 
 def pool_import(args):


### PR DESCRIPTION
There was a typo in 1.10.15 which was causing pool set and pool delete to fail when done via the new CLI command.
Fixed the typos.

closes: #14940
related: #14940
