### PR TITLE
Merge Quarantined tests with other tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -794,84 +794,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           path: ./files/coverage.xml
           retention-days: 7
 
-  tests-quarantined:
-    timeout-minutes: 60
-    name: "Quarantined tests"
-    runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
-    continue-on-error: true
-    needs: [build-info, ci-images]
-    strategy:
-      matrix:
-        include:
-          - backend: mysql
-          - backend: postgres
-          - backend: sqlite
-    env:
-      RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn) }}
-      BACKEND: ${{ matrix.backend }}
-      PYTHON_MAJOR_MINOR_VERSION: ${{ needs.build-info.outputs.defaultPythonVersion }}
-      MYSQL_VERSION: ${{needs.build-info.outputs.defaultMySQLVersion}}
-      POSTGRES_VERSION: ${{needs.build-info.outputs.defaultPostgresVersion}}
-      TEST_TYPES: "Quarantined"
-      NUM_RUNS: 10
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_REGISTRY: ${{ needs.ci-images.outputs.githubRegistry }}
-    if: needs.build-info.outputs.run-tests == 'true'
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-      - name: "Setup python"
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.PYTHON_MAJOR_MINOR_VERSION }}
-      - name: "Set issue id for master"
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "ISSUE_ID=10118" >> $GITHUB_ENV
-      - name: "Set issue id for v1-10-stable"
-        if: github.ref == 'refs/heads/v1-10-stable'
-        run: |
-          echo "ISSUE_ID=10127" >> $GITHUB_ENV
-      - name: "Set issue id for v1-10-test"
-        if: github.ref == 'refs/heads/v1-10-test'
-        run: |
-          echo "ISSUE_ID=10128" >> $GITHUB_ENV
-      - name: "Free space"
-        run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-      - name: "Prepare CI image ${{env.PYTHON_MAJOR_MINOR_VERSION}}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}"
-        run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
-      - name: "Tests: Quarantined"
-        run: ./scripts/ci/testing/ci_run_airflow_testing.sh
-      - name: "Upload Quarantine test results"
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: quarantined_tests
-          path: "files/test_result-*.xml"
-          retention-days: 7
-      - name: "Upload airflow logs"
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: airflow-logs-quarantined-${{ matrix.backend }}
-          path: "./files/airflow_logs*"
-          retention-days: 7
-      - name: "Upload container logs"
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: container-logs-quarantined-${{ matrix.backend }}
-          path: "./files/container_logs*"
-          retention-days: 7
-      - name: "Upload artifact for coverage"
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage-quarantined-${{ matrix.backend }}
-          path: "./files/coverage.xml"
-          retention-days: 7
-
   upload-coverage:
     timeout-minutes: 15
     name: "Upload coverage"
@@ -883,7 +805,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       - tests-postgres
       - tests-sqlite
       - tests-mysql
-      - tests-quarantined
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     steps:

--- a/scripts/ci/images/ci_test_examples_of_prod_image_building.sh
+++ b/scripts/ci/images/ci_test_examples_of_prod_image_building.sh
@@ -88,4 +88,4 @@ test_images
 parallel --semaphore --semaphorename "${SEMAPHORE_NAME}" --wait
 start_end::group_end
 
-parallel::print_job_summary_and_return_status_code
+parallel::print_job_summary_and_return_status_code ""

--- a/scripts/ci/libraries/_parallel.sh
+++ b/scripts/ci/libraries/_parallel.sh
@@ -139,7 +139,8 @@ function parallel::output_log_for_failed_job(){
 }
 
 # Prints summary of jobs and returns status:
-# 0 - all jobs succeeded (SKIPPED_FAILED_JOBS is not counted)
+# $1 - (optional) skip failure if the job name is equal to this parameter
+# 0 - all jobs succeeded (Quarantined tests not counted)
 # >0 - number of failed jobs (except Quarantine)
 function parallel::print_job_summary_and_return_status_code() {
     local return_code="0"
@@ -152,8 +153,7 @@ function parallel::print_job_summary_and_return_status_code() {
             parallel::output_log_for_successful_job "${job}"
         else
             parallel::output_log_for_failed_job "${job}"
-            # SKIPPED_FAILED_JOB failure does not trigger whole test failure
-            if [[ ${SKIPPED_FAILED_JOB=} != "${job}" ]]; then
+            if [[ $# == "0" || ${job} != "$1" ]]; then
                 return_code=$((return_code + 1))
             fi
         fi

--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -204,10 +204,10 @@ function set_upgrade_to_newer_dependencies() {
 }
 
 if [[ ${DEFAULT_BRANCH} == "master" ]]; then
-    ALL_TESTS="Always API Core Other CLI Providers WWW Integration"
+    ALL_TESTS="Always API Core Other CLI Providers WWW Integration Quarantined"
 else
     # Skips Provider tests in case current default branch is not master
-    ALL_TESTS="Always API Core Other CLI WWW Integration"
+    ALL_TESTS="Always API Core Other CLI WWW Integration Quarantined"
 fi
 readonly ALL_TESTS
 


### PR DESCRIPTION
With the build parallelisation it is fine now to merge the
quarantined tests back into other tests.

This has low risk (Quarantined tests will not block other tests,
at most they will cause EXIT 137 if they use too much memory, but
this should be a rare event.

Merging the Quarantined tests back will decrease the pressure
on the number of jobs run on CI and will use more of
the parallelism we have for both self-hosted runners and
public runners.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
