### PR TITLE
Remove extra/needless deprecation warnings from airflow.contrib module

### DIFF
--- a/airflow/contrib/__init__.py
+++ b/airflow/contrib/__init__.py
@@ -16,7 +16,3 @@
 # specific language governing permissions and limitations
 # under the License.
 """This package is deprecated."""
-
-import warnings
-
-warnings.warn("This module is deprecated.", DeprecationWarning, stacklevel=2)

--- a/airflow/contrib/operators/__init__.py
+++ b/airflow/contrib/operators/__init__.py
@@ -17,11 +17,3 @@
 # under the License.
 #
 """This package is deprecated. Please use `airflow.operators` or `airflow.providers.*.operators`."""
-
-import warnings
-
-warnings.warn(
-    "This package is deprecated. Please use `airflow.operators` or `airflow.providers.*.operators`.",
-    DeprecationWarning,
-    stacklevel=2,
-)


### PR DESCRIPTION
If you have `from airflow.contrib.operators.emr_add_steps_operator
import EmrAddStepsOperator` line in your DAG file, you get three
warnings for this one line

```
/home/ash/airflow/dags/foo.py:3 DeprecationWarning: This module is deprecated.
/home/ash/airflow/dags/foo.py:3 DeprecationWarning: This package is deprecated. Please use `airflow.operators` or `airflow.providers.*.operators`.
/home/ash/airflow/dags/foo.py:3 DeprecationWarning: This module is deprecated. Please use `airflow.providers.amazon.aws.operators.emr_add_steps`.
```

All but the last is not helpful.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).