### PR TITLE
Fix typo in task_runner for AirflowConfigException

### DIFF
--- a/airflow/task/task_runner/__init__.py
+++ b/airflow/task/task_runner/__init__.py
@@ -56,7 +56,7 @@ def get_task_runner(local_task_job):
             task_runner_class = import_string(_TASK_RUNNER_NAME)
         except ImportError:
             raise AirflowConfigException(
-                f'The task runner could not be loaded. Please check "executor" key in "core" section. '
+                f'The task runner could not be loaded. Please check "task_runner" key in "core" section. '
                 f'Current value: "{_TASK_RUNNER_NAME}".'
             )
 


### PR DESCRIPTION
Key name "executor" has changed to "task_runner" since this value does not belong to the executor, but the task_runner.

This PR fixes the typo in the exception message.

closes: #14933