### PR TITLE
Add serve_logs endpoint for scheduler when using LocalExecutor

### DIFF
--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -37,6 +37,7 @@ def scheduler(args):
     print(settings.HEADER)
     skip_serve_logs = args.skip_serve_logs
     is_local_executor = conf.get("core", "executor") in ["LocalExecutor", "SequentialExecutor"]
+    sub_proc = None
     job = SchedulerJob(
         subdir=process_subdir(args.subdir),
         num_runs=args.num_runs,
@@ -68,7 +69,8 @@ def scheduler(args):
         signal.signal(signal.SIGINT, sigint_handler)
         signal.signal(signal.SIGTERM, sigint_handler)
         signal.signal(signal.SIGQUIT, sigquit_handler)
-        sub_proc = _serve_logs(skip_serve_logs)
+        if is_local_executor:
+            sub_proc = _serve_logs(skip_serve_logs)
         job.run()
     if sub_proc:
         sub_proc.terminate()


### PR DESCRIPTION
Currently, the serve_logs endpoint only exists on Celery workers. This
means if someone launches Airflow with the LocalExecutor and wants to
grab the logs from the scheduler, there is no way to move that to the
webserver if it is on a different pod/machine

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
