### PR TITLE
turn off autocomplete for connection forms

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -59,6 +59,8 @@ function getControlsContainer() {
 $(document).ready(function () {
   const fieldBehavioursElem = document.getElementById('field_behaviours');
   const config = JSON.parse(decode(fieldBehavioursElem.textContent));
+  const passwordInput = document.getElementById('password');
+  if (passwordInput) passwordInput.setAttribute('autocomplete', 'off');
 
   // Save all DOM elements into a map on load.
   const controlsContainer = getControlsContainer();

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -59,6 +59,8 @@ function getControlsContainer() {
 $(document).ready(function () {
   const fieldBehavioursElem = document.getElementById('field_behaviours');
   const config = JSON.parse(decode(fieldBehavioursElem.textContent));
+
+  // Prevent login/password fields from triggering browser auth extensions
   const form = document.getElementById('model_form');
   if (form) form.setAttribute('autocomplete', 'off');
 

--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -59,8 +59,8 @@ function getControlsContainer() {
 $(document).ready(function () {
   const fieldBehavioursElem = document.getElementById('field_behaviours');
   const config = JSON.parse(decode(fieldBehavioursElem.textContent));
-  const passwordInput = document.getElementById('password');
-  if (passwordInput) passwordInput.setAttribute('autocomplete', 'off');
+  const form = document.getElementById('model_form');
+  if (form) form.setAttribute('autocomplete', 'off');
 
   // Save all DOM elements into a map on load.
   const controlsContainer = getControlsContainer();


### PR DESCRIPTION
Adding `autocomplete="off"` to the add/edit connection form. In addition to passwords, I could see an unintentional change to "Login" too, so turned off autocomplete to the whole form.

Fixes #13656

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
