### PR TITLE
Prevent clickable bad links on disabled pagination

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -126,9 +126,11 @@ def generate_pages(current_page, num_of_pages, search=None, status=None, window=
     output = [Markup('<ul class="pagination" style="margin-top:0;">')]
 
     is_disabled = 'disabled' if current_page <= 0 else ''
+
+    first_node_link = void_link if is_disabled else f'?{get_params(page=0, search=search, status=status)}'
     output.append(
         first_node.format(
-            href_link=f"?{get_params(page=0, search=search, status=status)}",  # noqa
+            href_link=first_node_link,
             disabled=is_disabled,
         )
     )
@@ -171,9 +173,13 @@ def generate_pages(current_page, num_of_pages, search=None, status=None, window=
     )
 
     output.append(next_node.format(href_link=page_link, disabled=is_disabled))  # noqa
+
+    last_node_link = (
+        void_link if is_disabled else f'?{get_params(page=last_page, search=search, status=status)}'
+    )
     output.append(
         last_node.format(
-            href_link=f"?{get_params(page=last_page, search=search, status=status)}",  # noqa
+            href_link=last_node_link,
             disabled=is_disabled,
         )
     )


### PR DESCRIPTION
Resolves #10200

The " first page" and " last page" links in the DAGs pagination has a "disabled" class added to them when they are disabled. This yields a "not allowed" cursor on hover, but the anchors yield a **still clickable** malformed url in the `href` (e.g. `page=-1`) as described in #10200.

This update simply returns `javascript:void(0)` if the links are disabled the same way that the "previous page" and "next page" buttons already handle it.
