### PR TITLE
Better handling of docker command

### DIFF
--- a/breeze
+++ b/breeze
@@ -609,7 +609,7 @@ if [[ \${VERBOSE} == "true" ]]; then
   echo
   echo "Executing script:"
   echo
-  echo "${file} \${@}"
+  echo "${COLOR_CYAN}${file} \${@}${COLOR_RESET}"
   echo
   set -x
 fi

--- a/dev/provider_packages/enter_breeze_provider_package_tests.sh
+++ b/dev/provider_packages/enter_breeze_provider_package_tests.sh
@@ -21,7 +21,7 @@ export MOUNT_SELECTED_LOCAL_SOURCES="false"
 . "$(dirname "${BASH_SOURCE[0]}")/../../scripts/ci/libraries/_script_init.sh"
 
 function enter_breeze_with_mapped_sources() {
-    docker run -it "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run -it "${EXTRA_DOCKER_FLAGS[@]}" \
         -v "${AIRFLOW_SOURCES}/setup.py:/airflow_sources/setup.py:cached" \
         -v "${AIRFLOW_SOURCES}/setup.cfg:/airflow_sources/setup.cfg:cached" \
         -v "${AIRFLOW_SOURCES}/airflow/__init__.py:/airflow_sources/airflow/__init__.py:cached" \

--- a/scripts/ci/libraries/_docker_engine_resources.sh
+++ b/scripts/ci/libraries/_docker_engine_resources.sh
@@ -22,27 +22,25 @@ function docker_engine_resources::print_overall_stats() {
     echo "Overall resource statistics"
     echo
     docker stats --all --no-stream --no-trunc
-    docker run --rm --entrypoint /bin/bash "${AIRFLOW_CI_IMAGE}" -c "free -h"
-    df --human || true
+    docker run --rm --entrypoint /bin/bash "debian:buster-slim" -c "cat /proc/meminfo"
+    df -h || true
 }
 
 
 function docker_engine_resources::get_available_memory_in_docker() {
-    MEMORY_AVAILABLE_FOR_DOCKER=$(docker run --rm --entrypoint /bin/bash debian:buster-slim -c \
-        'echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024)))')
+    MEMORY_AVAILABLE_FOR_DOCKER=$(docker run --rm  --entrypoint /bin/bash "debian:buster-slim" -c 'echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1024 * 1024)))')
     echo "${COLOR_BLUE}Memory available for Docker${COLOR_RESET}: $(numfmt --to iec $((MEMORY_AVAILABLE_FOR_DOCKER * 1024 * 1024)))"
     export MEMORY_AVAILABLE_FOR_DOCKER
 }
 
 function docker_engine_resources::get_available_cpus_in_docker() {
-    CPUS_AVAILABLE_FOR_DOCKER=$(docker run --rm --entrypoint /bin/bash debian:buster-slim -c \
-        'grep -cE "cpu[0-9]+" </proc/stat')
+    CPUS_AVAILABLE_FOR_DOCKER=$(docker run --rm "debian:buster-slim" grep -cE 'cpu[0-9]+' /proc/stat)
     echo "${COLOR_BLUE}CPUS available for Docker${COLOR_RESET}: ${CPUS_AVAILABLE_FOR_DOCKER}"
     export CPUS_AVAILABLE_FOR_DOCKER
 }
 
 function docker_engine_resources::get_available_disk_space_in_docker() {
-    DISK_SPACE_AVAILABLE_FOR_DOCKER=$(docker run --rm --entrypoint /bin/bash debian:buster-slim -c \
+    DISK_SPACE_AVAILABLE_FOR_DOCKER=$(docker run --rm --entrypoint /bin/bash "debian:buster-slim" -c \
         'df  / | tail -1 | awk '\''{print $4}'\')
     echo "${COLOR_BLUE}Disk space available for Docker${COLOR_RESET}: $(numfmt --to iec $((DISK_SPACE_AVAILABLE_FOR_DOCKER * 1024)))"
     export DISK_SPACE_AVAILABLE_FOR_DOCKER

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -568,11 +568,13 @@ function initialization::set_output_color_variables() {
     COLOR_RED=$'\e[31m'
     COLOR_RESET=$'\e[0m'
     COLOR_YELLOW=$'\e[33m'
+    COLOR_CYAN=$'\e[36m'
     export COLOR_BLUE
     export COLOR_GREEN
     export COLOR_RED
     export COLOR_RESET
     export COLOR_YELLOW
+    export COLOR_CYAN
 }
 
 # Common environment that is initialized by both Breeze and CI scripts

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -252,7 +252,7 @@ function kind::check_cluster_ready_for_airflow() {
 function kind::build_image_for_kubernetes_tests() {
     start_end::group_start "Build image for kubernetes tests ${AIRFLOW_PROD_IMAGE_KUBERNETES}"
     cd "${AIRFLOW_SOURCES}" || exit 1
-    docker build --tag "${AIRFLOW_PROD_IMAGE_KUBERNETES}" . -f - <<EOF
+    docker_v build --tag "${AIRFLOW_PROD_IMAGE_KUBERNETES}" . -f - <<EOF
 FROM ${AIRFLOW_PROD_IMAGE}
 
 COPY airflow/example_dags/ \${AIRFLOW_HOME}/dags/

--- a/scripts/ci/libraries/_runs.sh
+++ b/scripts/ci/libraries/_runs.sh
@@ -19,7 +19,7 @@
 # Docker command to build documentation
 function runs::run_docs() {
     start_end::group_start "Run build docs"
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" -t \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" -t \
         -e "GITHUB_ACTIONS=${GITHUB_ACTIONS="false"}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         "${AIRFLOW_CI_IMAGE}" \
@@ -30,7 +30,7 @@ function runs::run_docs() {
 # Docker command to generate constraint files.
 function runs::run_generate_constraints() {
     start_end::group_start "Run generate constraints"
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         "${AIRFLOW_CI_IMAGE}" \
         "--" "/opt/airflow/scripts/in_container/run_generate_constraints.sh"
@@ -40,7 +40,7 @@ function runs::run_generate_constraints() {
 # Docker command to prepare airflow packages
 function runs::run_prepare_airflow_packages() {
     start_end::group_start "Run prepare airflow packages"
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
         -v "${AIRFLOW_SOURCES}:/opt/airflow" \
@@ -53,7 +53,7 @@ function runs::run_prepare_airflow_packages() {
 # Docker command to prepare provider packages
 function runs::run_prepare_provider_packages() {
     # No group here - groups are added internally
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
         -v "${AIRFLOW_SOURCES}:/opt/airflow" \
@@ -64,7 +64,7 @@ function runs::run_prepare_provider_packages() {
 # Docker command to generate release notes for provider packages
 function runs::run_prepare_provider_documentation() {
     # No group here - groups are added internally
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
         -v "${AIRFLOW_SOURCES}:/opt/airflow" \

--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -79,7 +79,7 @@ function start_end::dump_container_logs() {
     echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
     echo "                   Dumping logs from ${container} container"
     echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
-    docker logs "${container}" > "${dump_file}"
+    docker_v logs "${container}" > "${dump_file}"
     echo "                   Container ${container} logs dumped to ${dump_file}"
     echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
     start_end::group_end

--- a/scripts/ci/libraries/_verbosity.sh
+++ b/scripts/ci/libraries/_verbosity.sh
@@ -39,10 +39,10 @@ function verbosity::restore_exit_on_error_status() {
 # In case "VERBOSE" is set to "true" (--verbose flag in Breeze) all docker commands run will be
 # printed before execution. In case of DRY_RUN_DOCKER flag set to "true"
 # show the command to execute instead of executing them
-function docker {
+function docker_v {
     if [[ ${DRY_RUN_DOCKER} != "false" ]]; then
         echo
-        echo "${COLOR_YELLOW}docker" "${@}" "${COLOR_RESET}"
+        echo "${COLOR_CYAN}docker" "${@}" "${COLOR_RESET}"
         echo
         return
     fi
@@ -52,7 +52,7 @@ function docker {
         ${VERBOSE_COMMANDS:=} != "true" && \
         # And when generally printing info is disabled
         ${PRINT_INFO_FROM_SCRIPTS} == "true" ]]; then
-        >&2 echo "docker" "${@}"
+        >&2 echo "${COLOR_CYAN}docker ${*} ${COLOR_RESET}"
     fi
     if [[ ${PRINT_INFO_FROM_SCRIPTS} == "false" ]]; then
         ${DOCKER_BINARY_PATH} "${@}" >>"${OUTPUT_LOG}" 2>&1

--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 function verify_image::run_command_in_image() {
-    docker run --rm \
+    docker_v run --rm \
             -e COLUMNS=180 \
             --entrypoint /bin/bash "${DOCKER_IMAGE}" \
             -c "${@}"
@@ -83,7 +83,7 @@ function verify_image::verify_prod_image_has_airflow_and_providers() {
 function verify_image::verify_ci_image_dependencies() {
     start_end::group_start "Checking if Airflow dependencies are non-conflicting in ${DOCKER_IMAGE} image."
     set +e
-    docker run --rm --entrypoint /bin/bash "${DOCKER_IMAGE}" -c 'pip check'
+    docker_v run --rm --entrypoint /bin/bash "${DOCKER_IMAGE}" -c 'pip check'
     local res=$?
     if [[ ${res} != "0" ]]; then
         echo  "${COLOR_RED}ERROR: ^^^ Some dependencies are conflicting. See instructions below on how to deal with it.  ${COLOR_RESET}"
@@ -212,7 +212,7 @@ function verify_image::verify_prod_image_as_root() {
     echo "Checking airflow as root"
     local output
     local res
-    output=$(docker run --rm --user 0 "${DOCKER_IMAGE}" "airflow" "info" 2>&1)
+    output=$(docker_v run --rm --user 0 "${DOCKER_IMAGE}" "airflow" "info" 2>&1)
     res=$?
     if [[ ${res} == "0" ]]; then
         echo "${COLOR_GREEN}OK${COLOR_RESET}"
@@ -229,7 +229,7 @@ function verify_image::verify_prod_image_as_root() {
     tmp_dir="$(mktemp -d)"
     touch "${tmp_dir}/__init__.py"
     echo 'print("Awesome")' >> "${tmp_dir}/awesome.py"
-    output=$(docker run \
+    output=$(docker_v run \
         --rm \
         -e "PYTHONPATH=${tmp_dir}" \
         -v "${tmp_dir}:${tmp_dir}" \

--- a/scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
+++ b/scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
@@ -29,7 +29,7 @@ fi
 
 function run_test_package_import_all_classes() {
     # Groups are added internally
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
         -v "${AIRFLOW_SOURCES}/setup.py:/airflow_sources/setup.py:cached" \

--- a/scripts/ci/static_checks/bats_tests.sh
+++ b/scripts/ci/static_checks/bats_tests.sh
@@ -53,7 +53,7 @@ function run_bats_tests() {
     # deduplicate
     FS=" " read -r -a bats_arguments <<< "$(tr ' ' '\n' <<< "${bats_arguments[@]}" | sort -u | tr '\n' ' ' )"
     if [[ ${#@} == "0" ]]; then
-        # Run all tests
+        # Run al tests
         docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
             apache/airflow:bats-2020.09.05-1.2.1 --tap /airflow/tests/bats/
     elif [[ ${#bats_arguments} == "0" ]]; then

--- a/scripts/ci/static_checks/check_license.sh
+++ b/scripts/ci/static_checks/check_license.sh
@@ -31,7 +31,7 @@ function run_check_license() {
 
     echo "Running license checks. This can take a while."
     # We mount ALL airflow files for the licence check. We want to check them all!
-    if ! docker run -v "${AIRFLOW_SOURCES}:/opt/airflow" -t \
+    if ! docker_v run -v "${AIRFLOW_SOURCES}:/opt/airflow" -t \
             --user "$(id -ur):$(id -gr)" \
             --rm --env-file "${AIRFLOW_SOURCES}/scripts/ci/docker-compose/_docker.env" \
             apache/airflow:apache-rat-2020.07.10-0.13 \

--- a/scripts/ci/static_checks/flake8.sh
+++ b/scripts/ci/static_checks/flake8.sh
@@ -20,12 +20,12 @@
 
 function run_flake8() {
     if [[ "${#@}" == "0" ]]; then
-        docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+        docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
             --entrypoint "/usr/local/bin/dumb-init"  \
             "${AIRFLOW_CI_IMAGE}" \
             "--" "/opt/airflow/scripts/in_container/run_flake8.sh"
     else
-        docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+        docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
             --entrypoint "/usr/local/bin/dumb-init"  \
             "${AIRFLOW_CI_IMAGE}" \
             "--" "/opt/airflow/scripts/in_container/run_flake8.sh" "${@}"

--- a/scripts/ci/static_checks/in_container_bats_tests.sh
+++ b/scripts/ci/static_checks/in_container_bats_tests.sh
@@ -20,13 +20,13 @@
 
 function run_in_container_bats_tests() {
     if [[ "${#@}" == "0" ]]; then
-        docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+        docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/opt/bats/bin/bats"  \
         "-v" "$(pwd):/airflow" \
         "${AIRFLOW_CI_IMAGE}" \
         --tap  "tests/bats/in_container/"
     else
-        docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+        docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/opt/bats/bin/bats"  \
         "-v" "$(pwd):/airflow" \
         "${AIRFLOW_CI_IMAGE}" \

--- a/scripts/ci/static_checks/lint_dockerfile.sh
+++ b/scripts/ci/static_checks/lint_dockerfile.sh
@@ -25,7 +25,7 @@ function run_docker_lint() {
         echo "Running docker lint for all Dockerfiles"
         echo
         # shellcheck disable=SC2046
-        docker run \
+        docker_v run \
             -v "$(pwd):/root" \
             -w "/root" \
             --rm \
@@ -37,7 +37,7 @@ function run_docker_lint() {
         echo
         echo "Running docker lint for $*"
         echo
-        docker run \
+        docker_v run \
             -v "$(pwd):/root" \
             -w "/root" \
             --rm \

--- a/scripts/ci/static_checks/mypy.sh
+++ b/scripts/ci/static_checks/mypy.sh
@@ -26,7 +26,7 @@ function run_mypy() {
       files=("$@")
     fi
 
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
         "-v" "${AIRFLOW_SOURCES}/.mypy_cache:/opt/airflow/.mypy_cache" \
         "${AIRFLOW_CI_IMAGE}" \

--- a/scripts/ci/static_checks/pylint.sh
+++ b/scripts/ci/static_checks/pylint.sh
@@ -20,12 +20,12 @@
 
 function run_pylint() {
     if [[ "${#@}" == "0" ]]; then
-       docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+       docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
             --entrypoint "/usr/local/bin/dumb-init"  \
             "${AIRFLOW_CI_IMAGE}" \
             "--" "/opt/airflow/scripts/in_container/run_pylint.sh"
     else
-        docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+        docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
             --entrypoint "/usr/local/bin/dumb-init" \
             "${AIRFLOW_CI_IMAGE}" \
             "--" "/opt/airflow/scripts/in_container/run_pylint.sh" "${@}"

--- a/scripts/ci/static_checks/refresh_pylint_todo.sh
+++ b/scripts/ci/static_checks/refresh_pylint_todo.sh
@@ -21,7 +21,7 @@ export FORCE_ANSWER_TO_QUESTIONS="quit"
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
 function refresh_pylint_todo() {
-    docker run "${EXTRA_DOCKER_FLAGS[@]}" \
+    docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         "${AIRFLOW_CI_IMAGE}" \
         "/opt/airflow/scripts/in_container/refresh_pylint_todo.sh"
 }

--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -110,7 +110,7 @@ function system_prune_docker() {
     echo
     echo "${COLOR_BLUE}System-prune docker${COLOR_RESET}"
     echo
-    docker system prune --force --volumes
+    docker_v system prune --force --volumes
     echo
 }
 

--- a/scripts/ci/tools/ci_clear_tmp.sh
+++ b/scripts/ci/tools/ci_clear_tmp.sh
@@ -27,7 +27,7 @@ sanity_checks::sanitize_mounted_files
 
 read -r -a EXTRA_DOCKER_FLAGS <<<"$(local_mounts::convert_local_mounts_to_docker_params)"
 
-docker run --entrypoint /bin/bash "${EXTRA_DOCKER_FLAGS[@]}" \
+docker_v run --entrypoint /bin/bash "${EXTRA_DOCKER_FLAGS[@]}" \
     --rm \
     --env-file "${AIRFLOW_SOURCES}/scripts/ci/docker-compose/_docker.env" \
     "${AIRFLOW_CI_IMAGE}" \

--- a/scripts/ci/tools/ci_fix_ownership.sh
+++ b/scripts/ci/tools/ci_fix_ownership.sh
@@ -33,7 +33,7 @@ sanity_checks::sanitize_mounted_files
 
 read -r -a EXTRA_DOCKER_FLAGS <<<"$(local_mounts::convert_local_mounts_to_docker_params)"
 
-docker run --entrypoint /bin/bash "${EXTRA_DOCKER_FLAGS[@]}" \
+docker_v run --entrypoint /bin/bash "${EXTRA_DOCKER_FLAGS[@]}" \
     --rm \
     --env-file "${AIRFLOW_SOURCES}/scripts/ci/docker-compose/_docker.env" \
     "${AIRFLOW_CI_IMAGE}" \

--- a/scripts/ci/tools/ci_free_space_on_ci.sh
+++ b/scripts/ci/tools/ci_free_space_on_ci.sh
@@ -26,7 +26,7 @@ echo "${COLOR_BLUE}Cleaning apt${COLOR_RESET}"
 sudo apt clean
 
 echo "${COLOR_BLUE}Pruning docker${COLOR_RESET}"
-docker system prune --all --force --volumes
+docker_v system prune --all --force --volumes
 
 echo "${COLOR_BLUE}Free disk space  ${COLOR_RESET}"
 df -h


### PR DESCRIPTION
Not all docker commands are replaced with functions now.

Earlier wer replaced all docker commands with a function to be able
to capture docker commands used and display it with -v for breeze.
This has proven to be harmful as
this is an unexpected behaviour for a docker command.

This change introduces docker_v command which outputs the command
when needed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
