### PR TITLE
UI TypeScript linting fix

### DIFF
--- a/airflow/ui/test/Pipelines.test.tsx
+++ b/airflow/ui/test/Pipelines.test.tsx
@@ -129,10 +129,11 @@ describe('Test Pipelines Table', () => {
 
     await waitFor(() => expect(getByText(sampleDag.dagId)).toBeInTheDocument());
     const toggle = getByRole('switch');
-    expect(toggle.firstChild?.checked).toBeTruthy();
+    const input = toggle.querySelector('input') as HTMLInputElement;
+    expect(input.checked).toBeTruthy();
     fireEvent.click(toggle);
     // 'Dag Updated' is the toast confirming the change happened
     await waitFor(() => expect(getByText('Pipeline Updated')).toBeInTheDocument());
-    await waitFor(() => expect(toggle.firstChild?.checked).toBeFalsy());
+    await waitFor(() => expect(input.checked).toBeFalsy());
   });
 });


### PR DESCRIPTION
Resolves the following linting errors:

```bash
test/Pipelines.test.tsx(132,31): error TS2339: Property 'checked' does not exist on type 'ChildNode'.
test/Pipelines.test.tsx(136,51): error TS2339: Property 'checked' does not exist on type 'ChildNode'.
```

Linting enforcement coming in #15009.