### PR TITLE
Option to use or skip fsGroup in security context

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -80,7 +80,9 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: {{ .Values.uid }}
+    {{- if .Values.useFsGroup }}
     fsGroup: {{ .Values.gid }}
+    {{- end }}
   nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
   affinity: {{ toYaml .Values.affinity | nindent 4 }}
   tolerations: {{ toYaml .Values.tolerations | nindent 4 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -89,7 +89,9 @@ spec:
       serviceAccountName: {{ .Release.Name }}-scheduler
       securityContext:
         runAsUser: {{ .Values.uid }}
+      {{- if .Values.useFsGroup  }}
         fsGroup: {{ .Values.gid }}
+      {{- end }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -75,7 +75,9 @@ spec:
       restartPolicy: Always
       securityContext:
         runAsUser: {{ .Values.uid }}
+        {{- if .Values.useFsGroup }}
         fsGroup: {{ .Values.gid }}
+        {{- end }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -84,7 +84,9 @@ spec:
       serviceAccountName: {{ .Release.Name }}-worker
       securityContext:
         runAsUser: {{ .Values.uid }}
+        {{- if .Values.useFsGroup }}
         fsGroup: {{ .Values.gid }}
+        {{- end }}
       {{- if or .Values.registry.secretName .Values.registry.connection }}
       imagePullSecrets:
         - name: {{ template "registry_secret" . }}

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -42,6 +42,29 @@ class SchedulerTest(unittest.TestCase):
 
         assert "test-container" == jmespath.search("spec.template.spec.containers[-1].name", docs[0])
 
+    def test_should_skip_fsgroup(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "useFsGroup": False,
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert {'runAsUser': 50000} == jmespath.search("spec.template.spec.securityContext", docs[0])
+
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "useFsGroup": True,
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert {'fsGroup': 50000, 'runAsUser': 50000} == jmespath.search(
+            "spec.template.spec.securityContext", docs[0]
+        )
+
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(
             values={

--- a/chart/tests/test_webserver_deployment.py
+++ b/chart/tests/test_webserver_deployment.py
@@ -40,6 +40,29 @@ class WebserverDeploymentTest(unittest.TestCase):
             "spec.template.spec.containers[0].readinessProbe.httpGet.httpHeaders", docs[0]
         )
 
+    def test_should_skip_fsgroup(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "useFsGroup": False,
+            },
+            show_only=["templates/scheduler/webserver-deployment.yaml"],
+        )
+
+        assert {'runAsUser': 50000} == jmespath.search("spec.template.spec.securityContext", docs[0])
+
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "useFsGroup": True,
+            },
+            show_only=["templates/scheduler/webserver-deployment.yaml"],
+        )
+
+        assert {'fsGroup': 50000, 'runAsUser': 50000} == jmespath.search(
+            "spec.template.spec.securityContext", docs[0]
+        )
+
     def test_should_add_path_to_liveness_and_readiness_probes(self):
         docs = render_chart(
             values={

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -42,6 +42,29 @@ class WorkerTest(unittest.TestCase):
 
         assert "test-container" == jmespath.search("spec.template.spec.containers[-1].name", docs[0])
 
+    def test_should_skip_fsgroup(self):
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "useFsGroup": False,
+            },
+            show_only=["templates/scheduler/worker-deployment.yaml"],
+        )
+
+        assert {'runAsUser': 50000} == jmespath.search("spec.template.spec.securityContext", docs[0])
+
+        docs = render_chart(
+            values={
+                "executor": "LocalExecutor",
+                "useFsGroup": True,
+            },
+            show_only=["templates/scheduler/worker-deployment.yaml"],
+        )
+
+        assert {'fsGroup': 50000, 'runAsUser': 50000} == jmespath.search(
+            "spec.template.spec.securityContext", docs[0]
+        )
+
     def test_should_add_extra_volume_and_extra_volume_mount(self):
         docs = render_chart(
             values={

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,6 +22,7 @@
 # User and group of airflow user
 uid: 50000
 gid: 50000
+useFsGroup: true
 
 # Airflow home directory
 # Used for mount paths


### PR DESCRIPTION
addresses https://github.com/apache/airflow/issues/13972

There is a bug in kubernetes where if you mount a large volume and there
is an fsgroup set it can delay startup by multiple minutes https://github.com/kubernetes/kubernetes/issues/67014

This PR addresses this issue by allowing users to skip the FSGroup

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
