### PR TITLE
Add support to create airflow pools from chart values

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -364,6 +364,10 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{ (printf "%s-airflow-config" .Release.Name) }}
 {{- end }}
 
+{{ define "airflow_pools_path" -}}
+{{ (printf "%s/pools.json" .Values.airflowHome) | quote }}
+{{- end }}
+
 {{ define "wait-for-migrations-command" }}
   {{/* From Airflow 2.0.0 this can become [airflow, db, check-migrations] */}}
   - python

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -42,6 +42,8 @@ data:
     {{- end }}
     {{ end }}
 
+  pools.json: {{ .Values.airflowPools | toJson | quote }}
+
   airflow_local_settings.py: |
 {{- if .Values.scheduler.airflowLocalSettings }}
     {{ .Values.scheduler.airflowLocalSettings | nindent 4 }}

--- a/chart/templates/create-pools-job.yaml
+++ b/chart/templates/create-pools-job.yaml
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+################################
+## Airflow Create Pool Job
+#################################
+{{- if .Values.airflowPools }}
+{{- $nodeSelector := .Values.nodeSelector }}
+{{- $affinity := .Values.affinity }}
+{{- $tolerations := .Values.tolerations }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-create-pools
+  labels:
+    tier: airflow
+    component: create-pool-job
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        tier: airflow
+        component: create-pool-job
+        release: {{ .Release.Name }}
+    spec:
+      securityContext:
+          runAsUser: {{ .Values.uid }}
+      restartPolicy: OnFailure
+      nodeSelector:
+{{ toYaml $nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml $affinity | indent 8 }}
+      tolerations:
+{{ toYaml $tolerations | indent 8 }}
+      {{- if or .Values.registry.secretName .Values.registry.connection }}
+      imagePullSecrets:
+        - name: {{ template "registry_secret" . }}
+      {{- end }}
+      containers:
+        - name: create-pools
+          image: {{ template "airflow_image" . }}
+          imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
+          args:
+            - "bash"
+            - "-c"
+            - 'airflow pools import {{ template "airflow_pools_path" . }}'
+          envFrom:
+          {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
+          env:
+          {{- include "custom_airflow_environment" . | indent 10 }}
+          {{- include "standard_airflow_environment" . | indent 10 }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ template "airflow_config_path" . }}
+              subPath: airflow.cfg
+              readOnly: true
+            - name: config
+              mountPath: {{ template "airflow_pools_path" . }}
+              subPath: pools.json
+              readOnly: true
+
+      volumes:
+        - name: config
+          configMap:
+            name: {{ template "airflow_config" . }}
+{{- end }}

--- a/chart/tests/test_create_pools.py
+++ b/chart/tests/test_create_pools.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import textwrap
+import unittest
+
+import jmespath
+import yaml
+
+from tests.helm_template_generator import prepare_k8s_lookup_dict, render_chart
+
+RELEASE_NAME = "TEST-POOLS-CONFIGMAPS"
+
+
+class DoNotCreatePoolsTest(unittest.TestCase):
+    def setUp(self):
+        values_str = textwrap.dedent(
+            """
+            airflowPools: {}
+            """
+        )
+        values = yaml.safe_load(values_str)
+        k8s_objects = render_chart(
+            RELEASE_NAME,
+            values=values,
+            show_only=["templates/configmaps/configmap.yaml", "templates/create-pools-job.yaml"],
+        )
+
+        self.k8s_objects_by_key = prepare_k8s_lookup_dict(k8s_objects)
+
+        all_expected_keys = [
+            ("ConfigMap", f"{RELEASE_NAME}-airflow-config"),
+        ]
+
+        assert set(self.k8s_objects_by_key.keys()) == set(all_expected_keys)
+
+    def test_configmap_properly_configured(self):
+        configmap_obj = self.k8s_objects_by_key[("ConfigMap", f"{RELEASE_NAME}-airflow-config")]
+        assert json.loads(configmap_obj["data"]["pools.json"]) == {}
+
+
+class CreatePoolsTest(unittest.TestCase):
+    def setUp(self):
+        values_str = textwrap.dedent(
+            """
+            airflowPools:
+              my-pool-name:
+                description: My description
+                slots: 1
+            """
+        )
+        values = yaml.safe_load(values_str)
+        k8s_objects = render_chart(
+            RELEASE_NAME,
+            values=values,
+            show_only=["templates/configmaps/configmap.yaml", "templates/create-pools-job.yaml"],
+        )
+
+        self.k8s_objects_by_key = prepare_k8s_lookup_dict(k8s_objects)
+
+        all_expected_keys = [
+            ("ConfigMap", f"{RELEASE_NAME}-airflow-config"),
+            ("Job", f"{RELEASE_NAME}-create-pool"),
+        ]
+
+        assert set(self.k8s_objects_by_key.keys()) == set(all_expected_keys)
+
+    def test_configmap_properly_configured(self):
+        configmap_obj = self.k8s_objects_by_key[("ConfigMap", f"{RELEASE_NAME}-airflow-config")]
+        assert json.loads(configmap_obj["data"]["pools.json"]) == {
+            "my-pool-name": {"description": "My description", "slots": 1}
+        }
+
+    def test_create_pool_job_setup(self):
+        job_obj = self.k8s_objects_by_key[("Job", f"{RELEASE_NAME}-create-pool")]
+        args = jmespath.search("spec.template.spec.containers[0].args", job_obj)
+        assert args == ['bash', '-c', 'airflow pools import "/opt/airflow/pools.json"']

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -15,6 +15,25 @@
             "description": "Airflow home directory. Used for mount paths.",
             "type": "string"
         },
+        "airflowPools": {
+            "description": "Pools that will be added to Airflow (Keys are pools names and values are pools settings)",
+            "type": ["object"],
+            "additionalProperties": {
+              "type" : "object",
+              "properties": {
+                "description" : {
+                  "type" : "string",
+                  "description": "Pool's description"
+                },
+                "slots" : {
+                  "type" : "integer",
+                  "description": "Number of slots for the pool"
+                }
+              },
+              "required" : ["description","slots"],
+              "additionalProperties": false
+            }
+          },
         "defaultAirflowRepository": {
             "description": "Default airflow repository. Overrides all the specific images below.",
             "type": "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -27,6 +27,14 @@ gid: 50000
 # Used for mount paths
 airflowHome: "/opt/airflow"
 
+# Pools that will be added to Airflow (Keys are pools names and values are pools settings)
+airflowPools: {}
+# eg:
+# airflowPools:
+#   my-pool-name:
+#     description: My description
+#     slots: 1
+
 # Default airflow repository -- overrides all the specific images below
 defaultAirflowRepository: apache/airflow
 

--- a/docs/apache-airflow/cli-and-env-variables-ref.rst
+++ b/docs/apache-airflow/cli-and-env-variables-ref.rst
@@ -39,6 +39,8 @@ development and testing.
    :func: get_parser
    :prog: airflow
 
+.. _env_variables:
+
 Environment Variables
 '''''''''''''''''''''
 

--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -773,6 +773,8 @@ like iPython or Jupyter Notebook.
 .. seealso::
     :ref:`List Airflow hooks <pythonapi:hooks>`
 
+.. _concepts:pools:
+
 Pools
 =====
 

--- a/docs/helm-chart/airflow-configuration.rst
+++ b/docs/helm-chart/airflow-configuration.rst
@@ -16,7 +16,10 @@
     under the License.
 
 Configuring Airflow
--------------------
+===================
+
+General Airflow configuration
+-----------------------------
 
 All Airflow configuration parameters (equivalent of ``airflow.cfg``) are
 stored in
@@ -68,3 +71,23 @@ configuration prior to installing and deploying the service.
   The recommended way to load example DAGs using the official Docker image and chart is to configure the ``AIRFLOW__CORE__LOAD_EXAMPLES`` environment variable
   in ``extraEnv`` (see :doc:`Parameters reference <parameters-ref>`). Because the official Docker image has ``AIRFLOW__CORE__LOAD_EXAMPLES=False``
   set within the image, so you need to override it when deploying the chart.
+
+..
+   Uncomment before merge
+
+   Airflow Variables, Connections and Pools
+   ----------------------------------------
+
+   Airflow variables and connections may be set directly with environment variables (see :ref:`apache-airflow:cli-and-env-variables-ref:_env_variables`). You can set them by using the chart values ``extraEnv``, or a combination of ``extraConfigMaps``/``extraSecrets`` and ``extraEnvFrom`` (see :doc:`Parameters reference <parameters-ref>`). You may also use a secret backend (**TODO, before merge. Need clarification: I am not familiar with this.**)
+
+   Regarding Airflow :ref:`pools <apache-airflow:concepts:_concepts:pools>`, you can also have them handled with "infrastructure as code" directly through this chart values:
+
+   .. code-block:: yaml
+
+     airflowPools:
+       my-pool-name:
+         description: My description
+         slots: 1
+       another-pool-name:
+         description: A second description
+         slots: 10

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -66,6 +66,9 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``airflowHome``
      - Location of airflow home directory
      - ``1``
+   * - ``airflowPools``
+     - Pools that will be added to Airflow
+     - ``{}``
    * - ``rbacEnabled``
      - Deploy pods with Kubernetes RBAC enabled
      - ``1``


### PR DESCRIPTION
Hello @mik-laj, 

I finally had time to look into #11707 ; _for this issue I have introduced 4 of my soon-to-be ex-collaborators to this chart so maybe you will have new contributors (you should expect a bit less contributions from myself in the coming months)._

## Changes

* Pools can now be added through the airflowPools value
* Docs also updated in that regard

Done in collaboration with @abrasseu @Jattakuy @JonathanCiglia @manzkel .

Closes #11707

## Todos

I have left a couple of TODOs mostly in docs as I was having issues cross-referencing docs locally.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
