### PR TITLE
Fixed deprecated code example in Concepts doc

### DIFF
--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -371,7 +371,8 @@ using ``@task`` decorator.
 
 .. code-block:: python
 
-    from airflow.operators.python import task, get_current_context
+    from airflow.decorators import task
+    from airflow.operators.python import get_current_context
 
     @task
     def my_task():


### PR DESCRIPTION
This document used the now-deprecated import for "task"; this updates it to come from `airflow.decorators` so it won't raise a DeprecationWarning if copied and used.