### PR TITLE
Remove 'conf' from search_columns in DagRun View

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3302,7 +3302,6 @@ class DagRunModelView(AirflowModelView):
         'start_date',
         'end_date',
         'external_trigger',
-        'conf',
     ]
     edit_columns = ['state', 'dag_id', 'execution_date', 'start_date', 'end_date', 'run_id', 'conf']
 


### PR DESCRIPTION
closes: #14374

i.e. to not support filter by `Conf` column.

Detailed analysis behind this change is in https://github.com/apache/airflow/issues/14374#issuecomment-803893158 and https://github.com/apache/airflow/issues/14374#issuecomment-810215075 .


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
