### PR TITLE
Add support for arbitrary json in conn uri format

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -18,7 +18,6 @@
 
 import json
 import warnings
-from base64 import urlsafe_b64decode, urlsafe_b64encode
 from json import JSONDecodeError
 from typing import Dict, Optional
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse
@@ -90,7 +89,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
     :type uri: str
     """
 
-    EXTRA_BASE64_KEY = '__extra__'
+    EXTRA_KEY = '__extra__'
 
     __tablename__ = "connection"
 
@@ -165,8 +164,8 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
         self.port = uri_parts.port
         if uri_parts.query:
             query = dict(parse_qsl(uri_parts.query, keep_blank_values=True))
-            if self.EXTRA_BASE64_KEY in query:
-                self.extra = urlsafe_b64decode(query[self.EXTRA_BASE64_KEY]).decode('utf-8')
+            if self.EXTRA_KEY in query:
+                self.extra = query[self.EXTRA_KEY]
             else:
                 self.extra = json.dumps(query)
 
@@ -209,7 +208,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
             if query and self.extra_dejson == dict(parse_qsl(query, keep_blank_values=True)):
                 uri += '?' + query
             else:
-                uri += '?' + urlencode({self.EXTRA_BASE64_KEY: urlsafe_b64encode(self.extra.encode('utf-8'))})
+                uri += '?' + urlencode({self.EXTRA_KEY: self.extra})
 
         return uri
 

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -201,7 +201,7 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
 
         uri += host_block
 
-        if self.extra_dejson:
+        if self.extra:
             try:
                 query = urlencode(self.extra_dejson)
             except TypeError:

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -277,7 +277,7 @@ Additionally, if you have created a connection, you can use ``airflow connection
 Encoding arbitrary json
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Some json structures cannot be urlencoded without loss.  For such jsons, ``get_uri``
+Some json structures cannot be urlencoded without loss.  For such json, ``get_uri``
 will store the entire string under the url query param ``__extra__``.
 
 For example:

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -278,7 +278,7 @@ Encoding arbitrary json
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Some json structures cannot be urlencoded without loss.  For such jsons, ``get_uri``
-will encode the json as base64 and store under the url query param ``__extra__``.
+will store the entire string under the url query param ``__extra__``.
 
 For example:
 
@@ -296,7 +296,7 @@ For example:
     >>> )
     >>> uri = c.get_uri()
     >>> uri
-    'scheme://user:password@host%2Flocation:1234/schema?__extra__=eyJteV92YWwiOiBbImxpc3QiLCAib2YiLCAidmFsdWVzIl0sICJleHRyYSI6IHsibmVzdGVkIjogeyJqc29uIjogInZhbCJ9fX0%3D'
+    'scheme://user:password@host%2Flocation:1234/schema?__extra__=%7B%22my_val%22%3A+%5B%22list%22%2C+%22of%22%2C+%22values%22%5D%2C+%22extra%22%3A+%7B%22nested%22%3A+%7B%22json%22%3A+%22val%22%7D%7D%7D'
 
 
 And we can verify that it returns the same dictionary:

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -277,7 +277,7 @@ Additionally, if you have created a connection, you can use ``airflow connection
 Encoding arbitrary JSON
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Some json structures cannot be urlencoded without loss.  For such json, ``get_uri``
+Some JSON structures cannot be urlencoded without loss.  For such JSON, ``get_uri``
 will store the entire string under the url query param ``__extra__``.
 
 For example:

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -212,10 +212,6 @@ In general, Airflow's URI format is like so:
 
     my-conn-type://my-login:my-password@my-host:5432/my-schema?param1=val1&param2=val2
 
-.. note::
-
-    The params ``param1`` and ``param2`` are just examples; you may supply arbitrary urlencoded json-serializable data there.
-
 The above URI would produce a ``Connection`` object equivalent to the following:
 
 .. code-block:: python
@@ -232,17 +228,6 @@ The above URI would produce a ``Connection`` object equivalent to the following:
         extra=json.dumps(dict(param1='val1', param2='val2'))
     )
 
-You can verify a URI is parsed correctly like so:
-
-.. code-block:: pycon
-
-    >>> from airflow.models.connection import Connection
-
-    >>> c = Connection(uri='my-conn-type://my-login:my-password@my-host:5432/my-schema?param1=val1&param2=val2')
-    >>> print(c.login)
-    my-login
-    >>> print(c.password)
-    my-password
 
 .. _generating_connection_uri:
 
@@ -289,12 +274,63 @@ Additionally, if you have created a connection, you can use ``airflow connection
 
 .. _manage-connections-connection-types:
 
+Encoding arbitrary json
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Some json structures cannot be urlencoded without loss.  For such jsons, ``get_uri``
+will encode the json as base64 and store under the url query param ``__extra__``.
+
+For example:
+
+.. code-block:: pycon
+
+    >>> extra_dict = {'my_val': ['list', 'of', 'values'], 'extra': {'nested': {'json': 'val'}}}
+    >>> c = Connection(
+    >>>     conn_type='scheme',
+    >>>     host='host/location',
+    >>>     schema='schema',
+    >>>     login='user',
+    >>>     password='password',
+    >>>     port=1234,
+    >>>     extra=json.dumps(extra_dict),
+    >>> )
+    >>> uri = c.get_uri()
+    >>> uri
+    'scheme://user:password@host%2Flocation:1234/schema?__extra__=eyJteV92YWwiOiBbImxpc3QiLCAib2YiLCAidmFsdWVzIl0sICJleHRyYSI6IHsibmVzdGVkIjogeyJqc29uIjogInZhbCJ9fX0%3D'
+
+
+And we can verify that it returns the same dictionary:
+
+.. code-block:: pycon
+
+    >>> new_c = Connection(uri=uri)
+    >>> new_c.extra_dejson == extra_dict
+    True
+
+
+But for the most common case of storing only key-value pairs, plain urlencoding is used.
+
+You can verify a URI is parsed correctly like so:
+
+.. code-block:: pycon
+
+    >>> from airflow.models.connection import Connection
+
+    >>> c = Connection(uri='my-conn-type://my-login:my-password@my-host:5432/my-schema?param1=val1&param2=val2')
+    >>> print(c.login)
+    my-login
+    >>> print(c.password)
+    my-password
+
+
 Handling of special characters in connection params
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
 
-    This process is automated as described in section :ref:`Generating a Connection URI <generating_connection_uri>`.
+    Use the convenience method ``Connection.get_uri`` when generating a connection
+    as described in section :ref:`Generating a Connection URI <generating_connection_uri>`.
+    This section for informational purposes only.
 
 Special handling is required for certain characters when building a URI manually.
 

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -308,7 +308,7 @@ And we can verify that it returns the same dictionary:
     True
 
 
-But for the most common case of storing only key-value pairs, plain urlencoding is used.
+But for the most common case of storing only key-value pairs, plain url encoding is used.
 
 You can verify a URI is parsed correctly like so:
 

--- a/docs/apache-airflow/howto/connection.rst
+++ b/docs/apache-airflow/howto/connection.rst
@@ -274,7 +274,7 @@ Additionally, if you have created a connection, you can use ``airflow connection
 
 .. _manage-connections-connection-types:
 
-Encoding arbitrary json
+Encoding arbitrary JSON
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Some json structures cannot be urlencoded without loss.  For such json, ``get_uri``

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -153,6 +153,20 @@ class TestConnection(unittest.TestCase):
         ),
         UriTestCaseConfig(
             test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
+            '__extra__=YXJiaXRyYXJ5IHN0cmluZyAqKSok',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra='arbitrary string *)*$',
+            ),
+            description='with extra non-json',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
             '__extra__=WyJsaXN0IiwgIm9mIiwgInZhbHVlcyJd',
             test_conn_attributes=dict(
                 conn_type='scheme',

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -138,8 +138,7 @@ class TestConnection(unittest.TestCase):
             description='with extras',
         ),
         UriTestCaseConfig(
-            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
-            '__extra__=InNpbmdsZSB2YWx1ZSI%3D',
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?' '__extra__=single+value',
             test_conn_attributes=dict(
                 conn_type='scheme',
                 host='host/location',
@@ -147,13 +146,13 @@ class TestConnection(unittest.TestCase):
                 login='user',
                 password='password',
                 port=1234,
-                extra_dejson='single value',
+                extra='single value',
             ),
             description='with extras single value',
         ),
         UriTestCaseConfig(
             test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
-            '__extra__=YXJiaXRyYXJ5IHN0cmluZyAqKSok',
+            '__extra__=arbitrary+string+%2A%29%2A%24',
             test_conn_attributes=dict(
                 conn_type='scheme',
                 host='host/location',
@@ -167,7 +166,7 @@ class TestConnection(unittest.TestCase):
         ),
         UriTestCaseConfig(
             test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
-            '__extra__=WyJsaXN0IiwgIm9mIiwgInZhbHVlcyJd',
+            '__extra__=%5B%22list%22%2C+%22of%22%2C+%22values%22%5D',
             test_conn_attributes=dict(
                 conn_type='scheme',
                 host='host/location',
@@ -181,7 +180,7 @@ class TestConnection(unittest.TestCase):
         ),
         UriTestCaseConfig(
             test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
-            '__extra__=eyJteV92YWwiOiBbImxpc3QiLCAib2YiLCAidmFsdWVzIl0sICJleHRyYSI6IHsibmVzdGVkIjogeyJqc29uIjogInZhbCJ9fX0%3D',  # noqa: E501 # pylint: disable=C0301
+            '__extra__=%7B%22my_val%22%3A+%5B%22list%22%2C+%22of%22%2C+%22values%22%5D%2C+%22extra%22%3A+%7B%22nested%22%3A+%7B%22json%22%3A+%22val%22%7D%7D%7D',  # noqa: E501 # pylint: disable=C0301
             test_conn_attributes=dict(
                 conn_type='scheme',
                 host='host/location',

--- a/tests/models/test_connection.py
+++ b/tests/models/test_connection.py
@@ -138,6 +138,48 @@ class TestConnection(unittest.TestCase):
             description='with extras',
         ),
         UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
+            '__extra__=InNpbmdsZSB2YWx1ZSI%3D',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra_dejson='single value',
+            ),
+            description='with extras single value',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
+            '__extra__=WyJsaXN0IiwgIm9mIiwgInZhbHVlcyJd',
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra_dejson=['list', 'of', 'values'],
+            ),
+            description='with extras list',
+        ),
+        UriTestCaseConfig(
+            test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?'
+            '__extra__=eyJteV92YWwiOiBbImxpc3QiLCAib2YiLCAidmFsdWVzIl0sICJleHRyYSI6IHsibmVzdGVkIjogeyJqc29uIjogInZhbCJ9fX0%3D',  # noqa: E501 # pylint: disable=C0301
+            test_conn_attributes=dict(
+                conn_type='scheme',
+                host='host/location',
+                schema='schema',
+                login='user',
+                password='password',
+                port=1234,
+                extra_dejson={'my_val': ['list', 'of', 'values'], 'extra': {'nested': {'json': 'val'}}},
+            ),
+            description='with nested json',
+        ),
+        UriTestCaseConfig(
             test_conn_uri='scheme://user:password@host%2Flocation:1234/schema?extra1=a%20value&extra2=',
             test_conn_attributes=dict(
                 conn_type='scheme',
@@ -351,11 +393,9 @@ class TestConnection(unittest.TestCase):
         for conn_attr, expected_val in test_config.test_conn_attributes.items():
             actual_val = getattr(new_conn, conn_attr)
             if expected_val is None:
-                assert expected_val is None
-            if isinstance(expected_val, dict):
-                assert expected_val == actual_val
+                assert actual_val is None
             else:
-                assert expected_val == actual_val
+                assert actual_val == expected_val
 
     @parameterized.expand(
         [

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -219,8 +219,9 @@ class TestLoadConnection(unittest.TestCase):
                password: None
                port: 1234
                extra_dejson:
-                 extra__google_cloud_platform__keyfile_dict:
-                   a: b
+                 arbitrary_dict:
+                    a: b
+                 extra__google_cloud_platform__keyfile_dict: '{"a": "b"}'
                  extra__google_cloud_platform__keyfile_path: asaa""",
                 {
                     "conn_a": {'conn_type': 'mysql', 'host': 'hosta'},
@@ -232,7 +233,8 @@ class TestLoadConnection(unittest.TestCase):
                         'password': 'None',
                         'port': 1234,
                         'extra_dejson': {
-                            'extra__google_cloud_platform__keyfile_dict': {'a': 'b'},
+                            'arbitrary_dict': {"a": "b"},
+                            'extra__google_cloud_platform__keyfile_dict': '{"a": "b"}',
                             'extra__google_cloud_platform__keyfile_path': 'asaa',
                         },
                     },

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -222,9 +222,9 @@ class TestLoadConnection(unittest.TestCase):
                 {
                     "conn_a": "mysql://hosta",
                     "conn_b": ''.join(
-                        """scheme://Login:None@host:1234/lschema?
-                        extra__google_cloud_platform__keyfile_dict=%7B%27a%27%3A+%27b%27%7D
-                        &extra__google_cloud_platform__keyfile_path=asaa""".split()
+                        """scheme://Login:None@host:1234/lschema?__extra__=%7B
+                        %22extra__google_cloud_platform__keyfile_dict%22%3A+%7B%22a%22%3A+%22b%22%7D%2C
+                        +%22extra__google_cloud_platform__keyfile_path%22%3A+%22asaa%22%7D""".split()
                     ),
                 },
             ),

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -204,7 +204,10 @@ class TestLoadConnection(unittest.TestCase):
 
     @parameterized.expand(
         (
-            ("""CONN_A: 'mysql://host_a'""", {"CONN_A": "mysql://host_a"}),
+            (
+                """CONN_A: 'mysql://host_a'""",
+                {"CONN_A": {'conn_type': 'mysql', 'host': 'host_a'}},
+            ),
             (
                 """
             conn_a: mysql://hosta
@@ -220,24 +223,30 @@ class TestLoadConnection(unittest.TestCase):
                    a: b
                  extra__google_cloud_platform__keyfile_path: asaa""",
                 {
-                    "conn_a": "mysql://hosta",
-                    "conn_b": ''.join(
-                        """scheme://Login:None@host:1234/lschema?__extra__=%7B
-                        %22extra__google_cloud_platform__keyfile_dict%22%3A+%7B%22a%22%3A+%22b%22%7D%2C
-                        +%22extra__google_cloud_platform__keyfile_path%22%3A+%22asaa%22%7D""".split()
-                    ),
+                    "conn_a": {'conn_type': 'mysql', 'host': 'hosta'},
+                    "conn_b": {
+                        'conn_type': 'scheme',
+                        'host': 'host',
+                        'schema': 'lschema',
+                        'login': 'Login',
+                        'password': 'None',
+                        'port': 1234,
+                        'extra_dejson': {
+                            'extra__google_cloud_platform__keyfile_dict': {'a': 'b'},
+                            'extra__google_cloud_platform__keyfile_path': 'asaa',
+                        },
+                    },
                 },
             ),
         )
     )
-    def test_yaml_file_should_load_connection(self, file_content, expected_connection_uris):
+    def test_yaml_file_should_load_connection(self, file_content, expected_attrs_dict):
         with mock_local_file(file_content):
             connections_by_conn_id = local_filesystem.load_connections_dict("a.yaml")
-            connection_uris_by_conn_id = {
-                conn_id: connection.get_uri() for conn_id, connection in connections_by_conn_id.items()
-            }
-
-            assert expected_connection_uris == connection_uris_by_conn_id
+            for conn_id, connection in connections_by_conn_id.items():
+                expected_attrs = expected_attrs_dict[conn_id]
+                actual_attrs = {k: getattr(connection, k) for k in expected_attrs.keys()}
+                assert actual_attrs == expected_attrs
 
     @parameterized.expand(
         (


### PR DESCRIPTION
## Overview

PRs #15013 and #13934  raise the issue that airflow's conn uri format cannot handle arbitrary json values.

This leaves us with connections that we can define in the web UI that are impossible to serialize to URI format (see #13934).

And with some secrets backends using json serialization instead of URI, this leaves us with an inconsistency -- some backends can produce connections where `extra_dejson` is a nested dict; others cannot.

This PR adds support for nested json within the URI format without breaking backward compatibility.

## Details

### URI generation

When generating the URI, the method `get_uri` will check whether the `extra` can be simply urlencoded without loss or error.  

If so, it will use traditional urlencoding.

When loss or error would occur, `get_uri` will serialize the full dict to json and store under query param `__extra__`.

### URI parsing

First airflow will check for the existence of special query param `__extra__`.  If it exists, airflow will parse it.

If this param is not present, the traditional approach is used.

## More background

Here's example given in #15013:

```
>>> Connection(conn_id='id', conn_type='http', extra='foobar').get_uri()
[2021-03-25 13:31:07,535] {connection.py:337} ERROR - Expecting value: line 1 column 1 (char 0)
Traceback (most recent call last):
  File "/Users/da.lum/code/python/airflow/airflow/models/connection.py", line 335, in extra_dejson
    obj = json.loads(self.extra)
  File "/nix/store/8kzdflq0v06fq0mh9m2fd73gnyqp57xr-python3-3.7.3/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/nix/store/8kzdflq0v06fq0mh9m2fd73gnyqp57xr-python3-3.7.3/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/nix/store/8kzdflq0v06fq0mh9m2fd73gnyqp57xr-python3-3.7.3/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
[2021-03-25 13:31:07,535] {connection.py:338} ERROR - Failed parsing the json for conn_id id
'http://'
```

As of now, this PR adds support for this case.  Though there is debate whether such values should be allowed in the `extra` field, or whether extra should always be key-value.
