### PR TITLE
Get connection URI with AWS Secrets Manager

### DIFF
--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -135,12 +135,14 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
 
         # These lines will check if we have with some denomination stored an username, password and host
         if secret:
-            possible_words_for_conn_fields = {'user': ['user', 'username', 'login', 'user_name'],
-                                              'password': ['password', 'pass', 'key'],
-                                              'host': ['host', 'remote_host', 'server'],
-                                              'port': ['port'],
-                                              'schema': ['database', 'schema'],
-                                              'conn_type': ['conn_type', 'conn_id', 'connection_type', 'engine']}
+            possible_words_for_conn_fields = {
+                'user': ['user', 'username', 'login', 'user_name'],
+                'password': ['password', 'pass', 'key'],
+                'host': ['host', 'remote_host', 'server'],
+                'port': ['port'],
+                'schema': ['database', 'schema'],
+                'conn_type': ['conn_type', 'conn_id', 'connection_type', 'engine']
+            }
 
             conn_d = {}
             for conn_field, possible_words in possible_words_for_conn_fields.items():

--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -79,15 +79,15 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
     ):
         super().__init__()
         if connections_prefix is not None:
-            self.connections_prefix = connections_prefix.rstrip("/")
+            self.connections_prefix = connections_prefix.rstrip(sep)
         else:
             self.connections_prefix = connections_prefix
         if variables_prefix is not None:
-            self.variables_prefix = variables_prefix.rstrip('/')
+            self.variables_prefix = variables_prefix.rstrip(sep)
         else:
             self.variables_prefix = variables_prefix
         if config_prefix is not None:
-            self.config_prefix = config_prefix.rstrip('/')
+            self.config_prefix = config_prefix.rstrip(sep)
         else:
             self.config_prefix = config_prefix
         self.profile_name = profile_name


### PR DESCRIPTION
One of the main advantages of using AWS Secrets Manager is its ability to automatically create secrets of RDS databases and Redshift databases. Those secrets consist of several keys with their values, i.e user, pass, etc. Also, it is normal to store API Keys, sftp, or whatever using different values, as shown in the picture below:
![Captura de pantalla 2020-05-22 a las 10 41 07](https://user-images.githubusercontent.com/11339132/82648933-c23ac100-9c18-11ea-9f7c-6a36d0333bbe.png)

With the current code, all the keys and values obtained from a secret are stored in the schema attribute of the conn object, unless you have just one key with the conn_uri in the value. Thus, the current situation is forcing to use Secrets Manager in a way it is not intended to.

With this proposed modification, you can use AWS Secrets Manager using keys and values and have some kind of freedom to choose different words for each key to make the get_conn work.

I need help and guidance with tests, please. Thanks
