### PR TITLE
Remove user_id from API schema

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1499,10 +1499,6 @@ components:
         A user object
       type: object
       properties:
-        user_id:
-          type: integer
-          description: The user id
-          readOnly: true
         first_name:
           type: string
           description: The user firstname

--- a/airflow/api_connexion/schemas/user_schema.py
+++ b/airflow/api_connexion/schemas/user_schema.py
@@ -33,7 +33,6 @@ class UserCollectionItemSchema(SQLAlchemySchema):
         model = User
         dateformat = "iso"
 
-    user_id = auto_field('id', dump_only=True)
     first_name = auto_field()
     last_name = auto_field()
     username = auto_field()

--- a/tests/api_connexion/endpoints/test_user_endpoint.py
+++ b/tests/api_connexion/endpoints/test_user_endpoint.py
@@ -98,7 +98,6 @@ class TestGetUser(TestUserEndpoint):
             'last_name': 'test1',
             'login_count': None,
             'roles': [],
-            'user_id': users[0].id,
             'username': 'TEST_USER1',
         }
 

--- a/tests/api_connexion/schemas/test_user_schema.py
+++ b/tests/api_connexion/schemas/test_user_schema.py
@@ -71,12 +71,11 @@ class TestUserCollectionItemSchema(TestUserBase):
         self.session.commit()
         user = self.session.query(User).filter(User.email == TEST_EMAIL).first()
         deserialized_user = user_collection_item_schema.dump(user)
-        # No password in dump
+        # No user_id and password in dump
         assert deserialized_user == {
             'created_on': DEFAULT_TIME,
             'email': 'test@example.org',
             'changed_on': DEFAULT_TIME,
-            'user_id': user.id,
             'active': None,
             'last_login': None,
             'last_name': 'Bar',
@@ -103,13 +102,12 @@ class TestUserSchema(TestUserBase):
         self.session.commit()
         user = self.session.query(User).filter(User.email == TEST_EMAIL).first()
         deserialized_user = user_schema.dump(user)
-        # No password in dump
+        # No user_id and password in dump
         assert deserialized_user == {
             'roles': [],
             'created_on': DEFAULT_TIME,
             'email': 'test@example.org',
             'changed_on': DEFAULT_TIME,
-            'user_id': user.id,
             'active': None,
             'last_login': None,
             'last_name': 'Bar',


### PR DESCRIPTION
Fix #15059. The role schema doesn't seem to contain an ID at all (only the role name), so I just removed the user ID.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
