### PR TITLE
Fixed all remaining usage of the old task import

### DIFF
--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -38,6 +38,7 @@ from parameterized import parameterized
 
 from airflow import models, settings
 from airflow.configuration import conf
+from airflow.decorators import task as task_decorator
 from airflow.exceptions import AirflowException, DuplicateTaskIdFound
 from airflow.models import DAG, DagModel, DagRun, DagTag, TaskFail, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
@@ -45,7 +46,6 @@ from airflow.models.dag import dag as dag_decorator
 from airflow.models.dagparam import DagParam
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
-from airflow.operators.python import task as task_decorator
 from airflow.operators.subdag import SubDagOperator
 from airflow.security import permissions
 from airflow.utils import timezone

--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -19,8 +19,8 @@
 import unittest
 from datetime import timedelta
 
+from airflow.decorators import task
 from airflow.models.dag import DAG
-from airflow.operators.python import task
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType

--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -269,7 +269,7 @@ def test_build_task_group_with_task_decorator():
     """
     Test that TaskGroup can be used with the @task decorator.
     """
-    from airflow.operators.python import task
+    from airflow.decorators import task
 
     @task
     def task_1():


### PR DESCRIPTION
This finishes the job of removing all imports of `task` from the deprecated location of `operators.python` and replaces them with the new import from `decorators`.