### PR TITLE
Do not log info when ssm secret not found

### DIFF
--- a/airflow/providers/amazon/aws/secrets/secrets_manager.py
+++ b/airflow/providers/amazon/aws/secrets/secrets_manager.py
@@ -154,10 +154,5 @@ class SecretsManagerBackend(BaseSecretsBackend, LoggingMixin):
             )
             return response.get('SecretString')
         except self.client.exceptions.ResourceNotFoundException:
-            self.log.debug(
-                "An error occurred (ResourceNotFoundException) when calling the "
-                "get_secret_value operation: "
-                "Secret %s not found.",
-                secrets_path,
-            )
+            self.log.debug("Secret %s not found.", secrets_path)
             return None

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -140,9 +140,5 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
             value = response["Parameter"]["Value"]
             return value
         except self.client.exceptions.ParameterNotFound:
-            self.log.info(
-                "An error occurred (ParameterNotFound) when calling the GetParameter operation: "
-                "Parameter %s not found.",
-                ssm_path,
-            )
+            self.log.debug("Parameter %s not found.", ssm_path)
             return None


### PR DESCRIPTION
Not finding a connection in a particular backend is not and event that merits logging.  That's why we have 3 connections in the search path.  

It's only when the connection is not found in all 3 backends is something exceptional happening.

Log level should be DEBUG.

Also, use of the word 'error' is misleading, because not finding a parameter is normal.