### PR TITLE
Skip `DatabaseVersionCheckRule` check if invalid version is detected

### DIFF
--- a/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
+++ b/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from airflow.configuration import conf
 from airflow.upgrade.rules.base_rule import BaseRule
@@ -34,6 +34,17 @@ SQLite - 3.15+
 
     @provide_session
     def check(self, session=None):
+        return self._check(session=session)
+
+    def should_skip(self):
+        try:
+            self._check()
+        except InvalidVersion:
+            return "Unable to parse DB version, skipped!"
+
+    @staticmethod
+    @provide_session
+    def _check(session=None):
 
         more_info = "See link below for more details: https://github.com/apache/airflow#requirements"
 


### PR DESCRIPTION
When the version is something like `12.2 (Debian 12.2-2.pgdg100+1)`, the upgrade check errors with the following:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/airflow/upgrade/checker.py", line 130, in __main__
    run(args)
  File "/usr/local/lib/python3.7/site-packages/airflow/upgrade/checker.py", line 118, in run
    all_problems = check_upgrade(formatter, rules)
  File "/usr/local/lib/python3.7/site-packages/airflow/upgrade/checker.py", line 38, in check_upgrade
    rule_status = RuleStatus.from_rule(rule)
  File "/usr/local/lib/python3.7/site-packages/airflow/upgrade/problem.py", line 44, in from_rule
    result = rule.check()
  File "/usr/local/lib/python3.7/site-packages/airflow/utils/db.py", line 74, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/airflow/upgrade/rules/postgres_mysql_sqlite_version_upgrade_check.py", line 52, in check
    installed_postgres_version = Version(session.execute('SHOW server_version;').scalar())
  File "/usr/local/lib/python3.7/site-packages/packaging/version.py", line 298, in __init__
    raise InvalidVersion("Invalid version: '{0}'".format(version))
packaging.version.InvalidVersion: Invalid version: '12.2 (Debian 12.2-2.pgdg100+1)'
```

This commit will SKIP the check during such occasions.

cc @Dr-Denzy 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
