### PR TITLE
Add `latest_only` parameter to BaseOperator

### DIFF
--- a/airflow/example_dags/example_latest_only.py
+++ b/airflow/example_dags/example_latest_only.py
@@ -30,8 +30,19 @@ with DAG(
     start_date=dt.datetime(2021, 1, 1),
     catchup=False,
     tags=['example2', 'example3'],
-) as dag:
+) as dag1:
     latest_only = LatestOnlyOperator(task_id='latest_only')
     task1 = DummyOperator(task_id='task1')
 
     latest_only >> task1
+
+
+# [START latest_only_param]
+with DAG(
+    dag_id='latest_only_param',
+    schedule_interval='0 0 * * *',
+    start_date=dt.datetime(2021, 1, 1),
+) as dag2:
+    will_skip = DummyOperator(task_id='will_skip', latest_only=True)
+    wont_skip = DummyOperator(task_id='wont_skip', latest_only=False)
+# [END latest_only_param]

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -398,8 +398,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             )
 
     :type executor_config: dict
-    :param do_xcom_push: if True, an XCom is pushed containing the Operator's
-        result
+    :param do_xcom_push: if True, an XCom is pushed containing the Operator's result
     :type do_xcom_push: bool
     :param task_group: The TaskGroup to which the task should belong. This is typically provided when not
         using a TaskGroup as a context manager.
@@ -419,6 +418,8 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     :param doc_yaml: Add documentation (in YAML format) or notes to your Task objects
         that is visible in Task Instance details View in the Webserver
     :type doc_yaml: str
+    :param latest_only: if True, operator will skip when its dag run is not the "latest"
+    :type latest_only: bool
     """
 
     # For derived classes to define which fields will get jinjaified
@@ -529,6 +530,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         doc_json: Optional[str] = None,
         doc_yaml: Optional[str] = None,
         doc_rst: Optional[str] = None,
+        latest_only: bool = False,
         **kwargs,
     ):
         from airflow.models.dag import DagContext
@@ -709,6 +711,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
                     outlets,
                 ]
             )
+        self.latest_only = latest_only
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -975,11 +978,54 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             raise AirflowException("Can't load operators")
         return {link.name: link for link in plugins_manager.global_operator_extra_links}
 
+    def _skip_if_not_latest(self, context: Optional[Any] = None) -> None:
+        """
+        Will raise :class:`~.AirflowSkipException` if dag run is not the latest dag run,
+        with the following exceptions:
+            - the operator's ``latest_only`` parameter is not set to ``True``
+            - the context dictionary has no dag run
+            - the context dictionary has no dag
+            - the ``context`` dictionary is ``None`` or empty
+            - the dag run is externally triggered
+        """
+        if not (self.latest_only is True and context):
+            return
+
+        import pendulum
+
+        from airflow.exceptions import AirflowSkipException
+
+        dag_run = context.get('dag_run')
+        if not dag_run:
+            return
+
+        if dag_run and dag_run.external_trigger:
+            self.log.info("Externally triggered DAG_Run: allowing execution to proceed.")
+            return
+
+        dag = context.get('dag')
+        if not dag:
+            return
+
+        now = pendulum.now('UTC')
+        left_window = dag.following_schedule(context['execution_date'])
+        right_window = dag.following_schedule(left_window)
+        self.log.info(  # pylint: disable=logging-fstring-interpolation
+            f"Checking latest only:\n"
+            f"\tleft_window: {left_window}\n"
+            f"\tright_window: {right_window}\n"
+            f"\tnow: {now}\n",
+        )
+
+        if not left_window < now <= right_window:
+            raise AirflowSkipException('Not latest execution; skipping...')
+
     @prepare_lineage
     def pre_execute(self, context: Any):
         """This hook is triggered right before self.execute() is called."""
         if self._pre_execute_hook is not None:
             self._pre_execute_hook(context)
+        self._skip_if_not_latest(context)
 
     def execute(self, context: Any):
         """


### PR DESCRIPTION
With this change we don't need to add a `LatestOnlyOperator` ensure that a task will skip in a backfill.

Now, we can just set the parameter `latest_only=True`.

We don't deprecate LatestOnlyOperator here -- its behavior is somewhat different because it skips downstream tasks irrespective of trigger rule (I _think_) while this lets any task skip _itself_, and downstream tasks may or may not also therefore skip depending on trigger rules.

In most cases, though, this will save users from adding an extra task to dags.  IMHO, setting latest only behavior directly on the task itself is also more direct and more intuitive than setting it via a separate task.