### PR TITLE
Don't run UI tests when python files have changed

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -232,13 +232,12 @@ function set_outputs_run_everything_and_exit() {
     exit
 }
 
-function set_outputs_run_all_tests() {
+function set_outputs_run_all_python_tests() {
     run_tests "true"
     run_kubernetes_tests "true"
     set_test_types "${ALL_TESTS}"
     set_basic_checks_only "false"
     set_image_build "true"
-    needs_ui_tests "true"
     kubernetes_tests_needed="true"
 }
 
@@ -613,9 +612,9 @@ function calculate_test_types_to_run() {
         # Running all tests because some core or other files changed
         echo
         echo "Looks like ${COUNT_CORE_OTHER_CHANGED_FILES} files changed in the core/other area and"
-        echo "We have to run all tests. This will take longer than usual"
+        echo "We have to run all python tests. This will take longer than usual"
         echo
-        set_outputs_run_all_tests
+        set_outputs_run_all_python_tests
     else
         if [[ ${COUNT_KUBERNETES_CHANGED_FILES} != "0" ]]; then
             kubernetes_tests_needed="true"


### PR DESCRIPTION
The intent of the `set_outputs_run_all_tests` function wasn't
immediately clear to me, so I mistakenly set `needs_ui_tests true` in
there, which resulted in running the React UI test jobs in cases where
we only changed python files -- a waste of a job!


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).