### PR TITLE
Add support for labelling DAG edges

### DIFF
--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -15,12 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator  # pylint: disable=R0401
 from airflow.models.taskmixin import TaskMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
+from airflow.utils.edgemodifier import EdgeModifier
 
 
 class XComArg(TaskMixin):
@@ -111,13 +112,21 @@ class XComArg(TaskMixin):
         """Returns keys of this XComArg"""
         return self._key
 
-    def set_upstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]]):
+    def set_upstream(
+        self,
+        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        edge_modifier: Optional[EdgeModifier] = None,
+    ):
         """Proxy to underlying operator set_upstream method. Required by TaskMixin."""
-        self.operator.set_upstream(task_or_task_list)
+        self.operator.set_upstream(task_or_task_list, edge_modifier)
 
-    def set_downstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]]):
+    def set_downstream(
+        self,
+        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        edge_modifier: Optional[EdgeModifier] = None,
+    ):
         """Proxy to underlying operator set_downstream method. Required by TaskMixin."""
-        self.operator.set_downstream(task_or_task_list)
+        self.operator.set_downstream(task_or_task_list, edge_modifier)
 
     def resolve(self, context: Dict) -> Any:
         """

--- a/airflow/serialization/enums.py
+++ b/airflow/serialization/enums.py
@@ -46,3 +46,4 @@ class DagAttributeTypes(str, Enum):
     TUPLE = 'tuple'
     POD = 'k8s.V1Pod'
     TASK_GROUP = 'taskgroup'
+    EDGE_INFO = 'edgeinfo'

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -102,7 +102,8 @@
         "_task_group": {"anyOf": [
           { "type": "null" },
           { "$ref": "#/definitions/task_group" }
-        ]}
+        ]},
+        "edge_info": { "$ref": "#/definitions/edge_info" }
       },
       "required": [
         "_dag_id",
@@ -217,6 +218,21 @@
         }
       },
       "additionalProperties": false
+    },
+    "edge_info": {
+      "$comment": "Metadata about DAG edges",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "label": { "type": "string" }
+          },
+          "required": ["label"],
+          "additionalProperties": false
+        }
+      }
     }
   },
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -647,6 +647,9 @@ class SerializedDAG(DAG, BaseSerialization):
             serialize_dag["tasks"] = [cls._serialize(task) for _, task in dag.task_dict.items()]
             serialize_dag['_task_group'] = SerializedTaskGroup.serialize_task_group(dag.task_group)
 
+            # Edge info in the JSON exactly matches our internal structure
+            serialize_dag["edge_info"] = dag.edge_info
+
             # has_on_*_callback are only stored if the value is True, as the default is False
             if dag.has_on_success_callback:
                 serialize_dag['has_on_success_callback'] = True
@@ -678,6 +681,9 @@ class SerializedDAG(DAG, BaseSerialization):
                 v = cls._deserialize_timedelta(v)
             elif k.endswith("_date"):
                 v = cls._deserialize_datetime(v)
+            elif k == "edge_info":
+                # Value structure matches exactly
+                pass
             elif k in cls._decorated_fields:
                 v = cls._deserialize(v)
             # else use v as it is

--- a/airflow/utils/dot_renderer.py
+++ b/airflow/utils/dot_renderer.py
@@ -156,6 +156,10 @@ def render_dag(dag: DAG, tis: Optional[List[TaskInstance]] = None) -> graphviz.D
     _draw_nodes(dag.task_group, dot, states_by_task_id)
 
     for edge in dag_edges(dag):
-        dot.edge(edge["source_id"], edge["target_id"])
+        # Gets an optional label for the edge; this will be None if none is specified.
+        label = dag.get_edge_info(edge["source_id"], edge["target_id"]).get("label")
+        # Add the edge to the graph with optional label
+        # (we can just use the maybe-None label variable directly)
+        dot.edge(edge["source_id"], edge["target_id"], label)
 
     return dot

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -1,0 +1,126 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Sequence, Union
+
+from airflow.models.taskmixin import TaskMixin
+
+
+class EdgeModifier(TaskMixin):
+    """
+    Class that represents edge information to be added between two
+    tasks/operators. Has shorthand factory functions, like Label("hooray").
+
+    Current implementation supports
+        t1 >> Label("Success route") >> t2
+        t2 << Label("Success route") << t2
+
+    Note that due to the potential for use in either direction, this waits
+    to make the actual connection between both sides until both are declared,
+    and will do so progressively if multiple ups/downs are added.
+
+    This and EdgeInfo are related - an EdgeModifier is the Python object you
+    use to add information to (potentially multiple) edges, and EdgeInfo
+    is the representation of the information for one specific edge.
+    """
+
+    def __init__(self, label: str = None):
+        self.label = label
+        self._upstream = []
+        self._downstream = []
+
+    @property
+    def roots(self):
+        """Should return list of root operator List["BaseOperator"]"""
+        return self._downstream
+
+    @property
+    def leaves(self):
+        """Should return list of leaf operator List["BaseOperator"]"""
+        return self._upstream
+
+    def set_upstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]], chain: bool = True):
+        """
+        Sets the given task/list onto the upstream attribute, and then checks if
+        we have both sides so we can resolve the relationship.
+
+        Providing this also provides << via TaskMixin.
+        """
+        # Ensure we have a list, even if it's just one item
+        if not isinstance(task_or_task_list, list):
+            task_or_task_list = [task_or_task_list]
+        # Unfurl it into actual operators
+        operators = []
+        for task in task_or_task_list:
+            operators.extend(task.roots)
+        # For each already-declared downstream, pair off with each new upstream
+        # item and store the edge info.
+        for operator in operators:
+            for downstream in self._downstream:
+                self.add_edge_info(operator.dag, operator.task_id, downstream.task_id)
+                if chain:
+                    operator.set_downstream(downstream)
+        # Add the new tasks to our list of ones we've seen
+        self._upstream.extend(operators)
+
+    def set_downstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]], chain: bool = True):
+        """
+        Sets the given task/list onto the downstream attribute, and then checks if
+        we have both sides so we can resolve the relationship.
+
+        Providing this also provides >> via TaskMixin.
+        """
+        # Ensure we have a list, even if it's just one item
+        if not isinstance(task_or_task_list, list):
+            task_or_task_list = [task_or_task_list]
+        # Unfurl it into actual operators
+        operators = []
+        for task in task_or_task_list:
+            operators.extend(task.leaves)
+        # Pair them off with existing
+        for operator in operators:
+            for upstream in self._upstream:
+                self.add_edge_info(upstream.dag, upstream.task_id, operator.task_id)
+                if chain:
+                    upstream.set_downstream(operator)
+        # Add the new tasks to our list of ones we've seen
+        self._downstream.extend(operators)
+
+    def update_relative(self, other: "TaskMixin", upstream: bool = True) -> None:
+        """
+        Called if we're not the "main" side of a relationship; we still run the
+        same logic, though.
+        """
+        if upstream:
+            self.set_upstream(other, chain=False)
+        else:
+            self.set_downstream(other, chain=False)
+
+    def add_edge_info(self, dag, upstream_id: str, downstream_id: str):
+        """
+        Adds or updates task info on the DAG for this specific pair of tasks.
+
+        Called either from our relationship trigger methods above, or directly
+        by set_upstream/set_downstream in operators.
+        """
+        dag.set_edge_info(upstream_id, downstream_id, {"label": self.label})
+
+
+# Factory functions
+def Label(label: str):  # pylint: disable=C0103
+    """Creates an EdgeModifier that sets a human-readable label on the edge."""
+    return EdgeModifier(label=label)

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import enum
+from typing import Optional
+
+from airflow.typing_compat import TypedDict
 
 
 class DagRunType(str, enum.Enum):
@@ -34,3 +37,12 @@ class DagRunType(str, enum.Enum):
             if run_id and run_id.startswith(f"{run_type.value}__"):
                 return run_type
         return DagRunType.MANUAL
+
+
+class EdgeInfoType(TypedDict):
+    """
+    Represents extra metadata that the DAG can store about an edge,
+    usually generated from an EdgeModifier.
+    """
+
+    label: Optional[str]

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -686,6 +686,7 @@
             g.setEdge(source_id, target_id, {
               curve: d3.curveBasis,
               arrowheadClass: 'arrowhead',
+              label: edge.label
             });
         })
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -348,10 +348,16 @@ def dag_edges(dag):
     for root in dag.roots:
         get_downstream(root)
 
-    return [
-        {'source_id': source_id, 'target_id': target_id}
-        for source_id, target_id in sorted(edges.union(edges_to_add) - edges_to_skip)
-    ]
+    result = []
+    # Build result dicts with the two ends of the edge, plus any extra metadata
+    # if we have it.
+    for source_id, target_id in sorted(edges.union(edges_to_add) - edges_to_skip):
+        record = {"source_id": source_id, "target_id": target_id}
+        label = dag.get_edge_info(source_id, target_id).get("label")
+        if label:
+            record["label"] = label
+        result.append(record)
+    return result
 
 
 ######################################################################################

--- a/docs/apache-airflow/concepts.rst
+++ b/docs/apache-airflow/concepts.rst
@@ -1128,13 +1128,36 @@ This animated gif shows the UI interactions. TaskGroups are expanded or collapse
 
 .. image:: img/task_group.gif
 
-
 TaskGroup can be created using ``@task_group`` decorator, it takes one argument ``group_id`` which is same as constructor of TaskGroup class, if not given it copies function name as ``group_id``. It works exactly same as creating TaskGroup using context manager ``with TaskGroup('groupid') as section:``.
 
 .. exampleinclude:: /../../airflow/example_dags/example_task_group_decorator.py
     :language: python
     :start-after: [START howto_task_group_decorator]
     :end-before: [END howto_task_group_decorator]
+
+
+Edge Labels
+===========
+
+As well as grouping tasks into groups, you can also label the edges between
+different tasks in the Graph View - this can be especially useful for branching
+areas of your DAG, so you can label the conditions under which certain branches
+might run.
+
+To add labels, you can either pass a Label object to
+``set_upstream``/``set_downstream``:
+
+.. code-block:: python
+
+    from airflow.utils.edgemodifier import Label
+    my_task.set_downstream(other_task, Label("When empty"))
+
+Or, you can use them directly inline with the ``>>`` and ``<<`` operators:
+
+.. code-block:: python
+
+    from airflow.utils.edgemodifier import Label
+    my_task >> Label("When empty") >> other_task
 
 
 SLAs

--- a/tests/utils/test_edgemodifier.py
+++ b/tests/utils/test_edgemodifier.py
@@ -1,0 +1,164 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from airflow import DAG
+from airflow.models.xcom_arg import XComArg
+from airflow.operators.python import PythonOperator
+from airflow.utils.edgemodifier import Label
+from airflow.utils.task_group import TaskGroup
+
+DEFAULT_ARGS = {
+    "owner": "test",
+    "depends_on_past": True,
+    "start_date": datetime.today(),
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+@pytest.fixture
+def test_dag():
+    """Creates a test DAG with a few operators to test on."""
+
+    def f(task_id):
+        return f"OP:{task_id}"
+
+    with DAG(dag_id="test_xcom_dag", default_args=DEFAULT_ARGS) as dag:
+        operators = [PythonOperator(python_callable=f, task_id="test_op_%i" % i) for i in range(4)]
+        return dag, operators
+
+
+@pytest.fixture
+def test_taskgroup_dag():
+    """Creates a test DAG with a few operators to test on, with some in a task group."""
+
+    def f(task_id):
+        return f"OP:{task_id}"
+
+    with DAG(dag_id="test_xcom_dag", default_args=DEFAULT_ARGS) as dag:
+        op1 = PythonOperator(python_callable=f, task_id="test_op_1")
+        op4 = PythonOperator(python_callable=f, task_id="test_op_4")
+        with TaskGroup("group_1") as group:
+            op2 = PythonOperator(python_callable=f, task_id="test_op_2")
+            op3 = PythonOperator(python_callable=f, task_id="test_op_3")
+            return dag, group, (op1, op2, op3, op4)
+
+
+class TestEdgeModifierBuilding:
+    """
+    Tests that EdgeModifiers work when composed with Tasks (either via >>
+    or set_upstream styles)
+    """
+
+    def test_operator_set(self, test_dag):
+        """Tests the set_upstream/downstream style with a plain operator"""
+        # Unpack the fixture
+        dag, (op1, op2, op3, op4) = test_dag
+        # Arrange the operators with a Label in the middle
+        op1.set_downstream(op2, Label("Label 1"))
+        op3.set_upstream(op2, Label("Label 2"))
+        op4.set_upstream(op2)
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op2.task_id, op3.task_id) == {"label": "Label 2"}
+        assert dag.get_edge_info(op2.task_id, op4.task_id) == {}
+
+    def test_tasklist_set(self, test_dag):
+        """Tests the set_upstream/downstream style with a list of operators"""
+        # Unpack the fixture
+        dag, (op1, op2, op3, op4) = test_dag
+        # Arrange the operators with a Label in the middle
+        op1.set_downstream([op2, op3], Label("Label 1"))
+        op4.set_upstream(op2)
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op1.task_id, op3.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op2.task_id, op4.task_id) == {}
+
+    def test_xcomarg_set(self, test_dag):
+        """Tests the set_upstream/downstream style with an XComArg"""
+        # Unpack the fixture
+        dag, (op1, op2, op3, op4) = test_dag
+        # Arrange the operators with a Label in the middle
+        op1_arg = XComArg(op1, "test_key")
+        op1_arg.set_downstream(op2, Label("Label 1"))
+        op1.set_downstream([op3, op4])
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op1.task_id, op4.task_id) == {}
+
+    def test_taskgroup_set(self, test_taskgroup_dag):
+        """Tests the set_upstream/downstream style with a TaskGroup"""
+        # Unpack the fixture
+        dag, group, (op1, op2, op3, op4) = test_taskgroup_dag
+        # Arrange them with a Label in the middle
+        op1.set_downstream(group, Label("Group label"))
+        group.set_downstream(op4)
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Group label"}
+        assert dag.get_edge_info(op1.task_id, op3.task_id) == {"label": "Group label"}
+        assert dag.get_edge_info(op3.task_id, op4.task_id) == {}
+
+    def test_operator_shift(self, test_dag):
+        """Tests the >> / << style with a plain operator"""
+        # Unpack the fixture
+        dag, (op1, op2, op3, op4) = test_dag
+        # Arrange the operators with a Label in the middle
+        op1 >> Label("Label 1") >> op2  # pylint: disable=W0106
+        op3 << Label("Label 2") << op2 >> op4  # pylint: disable=W0106
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op2.task_id, op3.task_id) == {"label": "Label 2"}
+        assert dag.get_edge_info(op2.task_id, op4.task_id) == {}
+
+    def test_tasklist_shift(self, test_dag):
+        """Tests the >> / << style with a list of operators"""
+        # Unpack the fixture
+        dag, (op1, op2, op3, op4) = test_dag
+        # Arrange the operators with a Label in the middle
+        op1 >> Label("Label 1") >> [op2, op3] << Label("Label 2") << op4  # pylint: disable=W0106
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op1.task_id, op3.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op4.task_id, op2.task_id) == {"label": "Label 2"}
+
+    def test_xcomarg_shift(self, test_dag):
+        """Tests the >> / << style with an XComArg"""
+        # Unpack the fixture
+        dag, (op1, op2, op3, op4) = test_dag
+        # Arrange the operators with a Label in the middle
+        op1_arg = XComArg(op1, "test_key")
+        op1_arg >> Label("Label 1") >> [op2, op3]  # pylint: disable=W0106
+        op1_arg >> op4
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Label 1"}
+        assert dag.get_edge_info(op1.task_id, op4.task_id) == {}
+
+    def test_taskgroup_shift(self, test_taskgroup_dag):
+        """Tests the set_upstream/downstream style with a TaskGroup"""
+        # Unpack the fixture
+        dag, group, (op1, op2, op3, op4) = test_taskgroup_dag
+        # Arrange them with a Label in the middle
+        op1 >> Label("Group label") >> group >> op4  # pylint: disable=W0106
+        # Check that the DAG has the right edge info
+        assert dag.get_edge_info(op1.task_id, op2.task_id) == {"label": "Group label"}
+        assert dag.get_edge_info(op1.task_id, op3.task_id) == {"label": "Group label"}
+        assert dag.get_edge_info(op3.task_id, op4.task_id) == {}


### PR DESCRIPTION
This adds support for putting human-readable labels on edges in the DAG between Tasks, as well as making the underlying framework for that generic enough that future metadata could be added if desired.

What's left to do:

- [x] Add support for XComArgs
- [x] Add either support or a nice error for TaskGroups
- [x] Add tests
- [x] Add documentation
- [x] Add custom serialisation

It modifies both the GraphViz and the D3 renderers - example:

![image](https://user-images.githubusercontent.com/36182/113334929-8a44e580-92e1-11eb-82d2-1737f1f85c39.png)

```
from airflow.models import Label
...
data = fetch_data()
mean_height = calculate_mean_height(data)
mean_height >> Label("Mean") >> print_result
max_height = calculate_max_height(data)
max_height.set_downstream(print_result_again, Label("Max"))
```

closes: #15140 