### PR TITLE
Fix password masking in CLI action_logging

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -113,17 +113,19 @@ def _build_metrics(func_name, namespace):
     """
     from airflow.models import Log
 
+    sub_commands_to_check = {'users', 'connections'}
     sensitive_fields = {'-p', '--password', '--conn-password'}
     full_command = list(sys.argv)
-    for idx, command in enumerate(full_command):  # pylint: disable=too-many-nested-blocks
-        if command in sensitive_fields:
-            # For cases when password is passed as "--password xyz" (with space between key and value)
-            full_command[idx + 1] = "*" * 8
-        else:
-            # For cases when password is passed as "--password=xyz" (with '=' between key and value)
-            for sensitive_field in sensitive_fields:
-                if command.startswith(f'{sensitive_field}='):
-                    full_command[idx] = f'{sensitive_field}={"*" * 8}'
+    if full_command[1] in sub_commands_to_check:  # pylint: disable=too-many-nested-blocks
+        for idx, command in enumerate(full_command):
+            if command in sensitive_fields:
+                # For cases when password is passed as "--password xyz" (with space between key and value)
+                full_command[idx + 1] = "*" * 8
+            else:
+                # For cases when password is passed as "--password=xyz" (with '=' between key and value)
+                for sensitive_field in sensitive_fields:
+                    if command.startswith(f'{sensitive_field}='):
+                        full_command[idx] = f'{sensitive_field}={"*" * 8}'
 
     metrics = {
         'sub_command': func_name,

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -123,6 +123,8 @@ class TestCliUtil(unittest.TestCase):
         ]
     )
     def test_cli_create_user_supplied_password_is_masked(self, given_command, expected_masked_command):
+        # '-p' value which is not password, like 'airflow scheduler -p'
+        # or 'airflow celery flower -p 8888', should not be masked
         args = given_command.split()
 
         expected_command = expected_masked_command.split()

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -112,6 +112,14 @@ class TestCliUtil(unittest.TestCase):
                 "airflow connections add dsfs --conn-login asd --conn-password test --conn-type google",
                 "airflow connections add dsfs --conn-login asd --conn-password ******** --conn-type google",
             ),
+            (
+                "airflow scheduler -p",
+                "airflow scheduler -p",
+            ),
+            (
+                "airflow celery flower -p 8888",
+                "airflow celery flower -p 8888",
+            ),
         ]
     )
     def test_cli_create_user_supplied_password_is_masked(self, given_command, expected_masked_command):


### PR DESCRIPTION
closes: #15131 

Currently as long as argument '-p' if present, code tries to mask it.
However, '-p' may mean something else (not password), like a boolean flag. Such cases may result in exception.

More detailed analysis can be found in issue https://github.com/apache/airflow/issues/15131#issuecomment-812109409

The solution here is to only try masking the next arg when we are sure `-p` means "password".

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
