### PR TITLE
Validate that the extra parameter is parseable as JSON

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -137,7 +137,28 @@ class Connection(Base, LoggingMixin):  # pylint: disable=too-many-instance-attri
             self.password = password
             self.schema = schema
             self.port = port
-            self.extra = extra
+            self.extra = self.validate_extra(extra)
+
+    @staticmethod
+    def validate_extra(extra: str) -> Optional[str]:
+        """
+        `extra` parameter is a JSON encoded object. This methods validates that the data
+        adheres to this specification.
+
+        :param extra: The extra section of the .
+        :type extra: str
+
+        :return str
+        """
+        if not extra:
+            return None
+
+        try:
+            json.loads(extra)
+        except JSONDecodeError as e:
+            raise AirflowException("The `extra` section of a Connection must be valid JSON") from e
+
+        return extra
 
     def parse_from_uri(self, **uri):
         """This method is deprecated. Please use uri parameter in constructor."""


### PR DESCRIPTION
Before this commit there was a documented but unenforced
limitation that the extra parameter be encoded JSON.
In #15013 this issue garnered attention and motivated
this PR.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
