### PR TITLE
Configuration for rendered value visibility

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1247,6 +1247,14 @@
       type: string
       example: ~
       default:
+    - name: show_templated_fields
+      description: |
+        Whether templated fields in tasks are shown in UI. Possible fields:
+        none, all, public
+      version_added: 2.1.0
+      type: string
+      example: ~
+      default: all
 
 - name: email
   description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -620,6 +620,10 @@ session_lifetime_minutes = 43200
 # Sets a custom page title for the DAGs overview page and site title for all pages
 # instance_name =
 
+# Whether templated fields in tasks are shown in UI. Possible fields:
+# none, all, public
+show_templated_fields = all
+
 [email]
 
 # Configuration email backend and whether to


### PR DESCRIPTION
This adds a new configuration

    [webserver]
    show_templated_fields

This configuration controls whether template values are displayed in the *Rendered Template* tab of a task instance. When set to `all` (default), all values rendered from templates are displayed (the current behaviour), and `none` hides everything. A smart `public` config would only hide values under keys starting with an underscore.

Eventually close #8421.

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
