### PR TITLE
Add dynamic connection fields to Azure Connection

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -18,7 +18,7 @@
 #
 
 """This module contains Azure Data Explorer hook"""
-from typing import Dict, Optional
+from typing import Dict, Optional, Any
 
 from azure.kusto.data.exceptions import KustoServiceError
 from azure.kusto.data.request import ClientRequestProperties, KustoClient, KustoConnectionStringBuilder
@@ -83,6 +83,49 @@ class AzureDataExplorerHook(BaseHook):
     conn_type = 'azure_data_explorer'
     hook_name = 'Azure Data Explorer'
 
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure_data_explorer__auth_method": StringField(
+                lazy_gettext('Tenant ID'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_data_explorer__tenant": StringField(
+                lazy_gettext('Authentication Method'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_data_explorer__certificate": StringField(
+                lazy_gettext('Application PEM Certificate'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_data_explorer__thumbprint": StringField(
+                lazy_gettext('Application Certificate Thumbprint'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'extra'],
+            "relabeling": {
+                'login': 'Auth Username',
+                'password': 'Auth Password',
+                'host': 'Data Explorer Cluster Url'
+            },
+            "placeholders": {
+                'login': 'varies with authentication method',
+                'password': 'varies with authentication method',
+                'host': 'cluster url',
+                'extra__azure_data_explorer__auth_method': 'AAD_APP/AAD_APP_CERT/AAD_CREDS/AAD_DEVICE',
+                'extra__azure_data_explorer__tenant': 'used with AAD_APP/AAD_APP_CERT/AAD_CREDS',
+                'extra__azure_data_explorer__certificate': 'used with AAD_APP_CERT',
+                'extra__azure_data_explorer__thumbprint': 'used with AAD_APP_CERT',
+            },
+        }
+
     def __init__(self, azure_data_explorer_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = azure_data_explorer_conn_id
@@ -102,23 +145,32 @@ class AzureDataExplorerHook(BaseHook):
                 raise AirflowException(f'Extra connection option is missing required parameter: `{name}`')
             return value
 
-        auth_method = get_required_param('auth_method')
+        auth_method = get_required_param('auth_method') or get_required_param('extra__azure_data_explorer__auth_method')
 
         if auth_method == 'AAD_APP':
+            tenant = get_required_param('tenant') or get_required_param('extra__azure_data_explorer__tenant')
             kcsb = KustoConnectionStringBuilder.with_aad_application_key_authentication(
-                cluster, conn.login, conn.password, get_required_param('tenant')
+                cluster, conn.login, conn.password, tenant
             )
         elif auth_method == 'AAD_APP_CERT':
+            certificate = get_required_param('certificate') or get_required_param(
+                'extra__azure_data_explorer__certificate'
+            )
+            thumbprint = get_required_param('thumbprint') or get_required_param(
+                'extra__azure_data_explorer__thumbprint'
+            )
+            tenant = get_required_param('tenant') or get_required_param('extra__azure_data_explorer__tenant')
             kcsb = KustoConnectionStringBuilder.with_aad_application_certificate_authentication(
                 cluster,
                 conn.login,
-                get_required_param('certificate'),
-                get_required_param('thumbprint'),
-                get_required_param('tenant'),
+                certificate,
+                thumbprint,
+                tenant,
             )
         elif auth_method == 'AAD_CREDS':
+            tenant = get_required_param('tenant') or get_required_param('extra__azure_data_explorer__tenant')
             kcsb = KustoConnectionStringBuilder.with_aad_user_password_authentication(
-                cluster, conn.login, conn.password, get_required_param('tenant')
+                cluster, conn.login, conn.password, tenant
             )
         elif auth_method == 'AAD_DEVICE':
             kcsb = KustoConnectionStringBuilder.with_aad_device_authentication(cluster)

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -18,7 +18,7 @@
 #
 
 """This module contains Azure Data Explorer hook"""
-from typing import Dict, Optional, Any
+from typing import Any, Dict, Optional
 
 from azure.kusto.data.exceptions import KustoServiceError
 from azure.kusto.data.request import ClientRequestProperties, KustoClient, KustoConnectionStringBuilder
@@ -113,7 +113,7 @@ class AzureDataExplorerHook(BaseHook):
             "relabeling": {
                 'login': 'Auth Username',
                 'password': 'Auth Password',
-                'host': 'Data Explorer Cluster Url'
+                'host': 'Data Explorer Cluster Url',
             },
             "placeholders": {
                 'login': 'varies with authentication method',

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -86,9 +86,9 @@ class AzureDataExplorerHook(BaseHook):
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""
-        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
         from flask_babel import lazy_gettext
-        from wtforms import StringField
+        from wtforms import PasswordField, StringField
 
         return {
             "extra__azure_data_explorer__auth_method": StringField(
@@ -97,11 +97,11 @@ class AzureDataExplorerHook(BaseHook):
             "extra__azure_data_explorer__tenant": StringField(
                 lazy_gettext('Authentication Method'), widget=BS3TextFieldWidget()
             ),
-            "extra__azure_data_explorer__certificate": StringField(
-                lazy_gettext('Application PEM Certificate'), widget=BS3TextFieldWidget()
+            "extra__azure_data_explorer__certificate": PasswordField(
+                lazy_gettext('Application PEM Certificate'), widget=BS3PasswordFieldWidget()
             ),
-            "extra__azure_data_explorer__thumbprint": StringField(
-                lazy_gettext('Application Certificate Thumbprint'), widget=BS3TextFieldWidget()
+            "extra__azure_data_explorer__thumbprint": PasswordField(
+                lazy_gettext('Application Certificate Thumbprint'), widget=BS3PasswordFieldWidget()
             ),
         }
 

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -145,7 +145,9 @@ class AzureDataExplorerHook(BaseHook):
                 raise AirflowException(f'Extra connection option is missing required parameter: `{name}`')
             return value
 
-        auth_method = get_required_param('auth_method') or get_required_param('extra__azure_data_explorer__auth_method')
+        auth_method = get_required_param('auth_method') or get_required_param(
+            'extra__azure_data_explorer__auth_method'
+        )
 
         if auth_method == 'AAD_APP':
             tenant = get_required_param('tenant') or get_required_param('extra__azure_data_explorer__tenant')

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -97,7 +97,9 @@ class AzureBatchHook(BaseHook):
                 raise AirflowException(f'Extra connection option is missing required parameter: `{name}`')
             return value
 
-        batch_account_url = _get_required_param('account_url') or _get_required_param('extra__azure_batch__account_url')
+        batch_account_url = _get_required_param('account_url') or _get_required_param(
+            'extra__azure_batch__account_url'
+        )
         credentials = batch_auth.SharedKeyCredentials(conn.login, conn.password)
         batch_client = BatchServiceClient(credentials, batch_url=batch_account_url)
         return batch_client

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -18,7 +18,7 @@
 #
 import time
 from datetime import timedelta
-from typing import Optional, Set, Dict, Any
+from typing import Any, Dict, Optional, Set
 
 from azure.batch import BatchServiceClient, batch_auth, models as batch_models
 from azure.batch.models import JobAddParameter, PoolAddParameter, TaskAddParameter

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -18,7 +18,7 @@
 #
 import time
 from datetime import timedelta
-from typing import Optional, Set
+from typing import Optional, Set, Dict, Any
 
 from azure.batch import BatchServiceClient, batch_auth, models as batch_models
 from azure.batch.models import JobAddParameter, PoolAddParameter, TaskAddParameter
@@ -41,6 +41,35 @@ class AzureBatchHook(BaseHook):
     default_conn_name = 'azure_batch_default'
     conn_type = 'azure_batch'
     hook_name = 'Azure Batch Service'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure_batch__account_url": StringField(
+                lazy_gettext('Azure Batch Account URl'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'host', 'extra'],
+            "relabeling": {
+                'login': 'Azure Batch Account Name',
+                'password': 'Azure Batch Key',
+            },
+            "placeholders": {
+                'login': 'batch account',
+                'password': 'key',
+                'extra__azure_batch__account_url': 'account url',
+            },
+        }
 
     def __init__(self, azure_batch_conn_id: str = default_conn_name) -> None:
         super().__init__()
@@ -68,7 +97,7 @@ class AzureBatchHook(BaseHook):
                 raise AirflowException(f'Extra connection option is missing required parameter: `{name}`')
             return value
 
-        batch_account_url = _get_required_param('account_url')
+        batch_account_url = _get_required_param('account_url') or _get_required_param('extra__azure_batch__account_url')
         credentials = batch_auth.SharedKeyCredentials(conn.login, conn.password)
         batch_client = BatchServiceClient(credentials, batch_url=batch_account_url)
         return batch_client

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -18,7 +18,7 @@
 #
 
 import warnings
-from typing import Any
+from typing import Any, Dict
 
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.containerinstance.models import ContainerGroup
@@ -41,10 +41,52 @@ class AzureContainerInstanceHook(AzureBaseHook):
     :type conn_id: str
     """
 
-    conn_name_attr = 'conn_id'
+    conn_name_attr = 'azure_conn_id'
     default_conn_name = 'azure_default'
     conn_type = 'azure_container_instances'
     hook_name = 'Azure Container Instance'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure__tenantId": StringField(
+                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure__subscriptionId": StringField(
+                lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        import json
+
+        return {
+            "hidden_fields": ['schema', 'port', 'host'],
+            "relabeling": {
+                'login': 'Azure Client ID',
+                'password': 'Azure Secret',
+            },
+            "placeholders": {
+                'extra': json.dumps(
+                    {
+                        "key_path": "path to json file for auth",
+                        "key_json": "specifies json dict for auth",
+                    },
+                    indent=1,
+                ),
+                'login': 'client_id (token credentials auth)',
+                'password': 'secret (token credentials auth)',
+                'extra__azure__tenantId': 'tenentId (token credentials auth)',
+                'extra__azure__subscriptionId': 'subscriptionId (token credentials auth)',
+            },
+        }
 
     def __init__(self, conn_id: str = default_conn_name) -> None:
         super().__init__(sdk_client=ContainerInstanceManagementClient, conn_id=conn_id)

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -81,10 +81,10 @@ class AzureContainerInstanceHook(AzureBaseHook):
                     },
                     indent=1,
                 ),
-                'login': 'client_id (token credentials auth)',
+                'login': 'client id (token credentials auth)',
                 'password': 'secret (token credentials auth)',
-                'extra__azure__tenantId': 'tenentId (token credentials auth)',
-                'extra__azure__subscriptionId': 'subscriptionId (token credentials auth)',
+                'extra__azure__tenantId': 'tenant id (token credentials auth)',
+                'extra__azure__subscriptionId': 'subscription id (token credentials auth)',
             },
         }
 

--- a/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
@@ -17,6 +17,8 @@
 # under the License.
 """Hook for Azure Container Registry"""
 
+from typing import Dict
+
 from azure.mgmt.containerinstance.models import ImageRegistryCredential
 
 from airflow.hooks.base import BaseHook
@@ -30,6 +32,28 @@ class AzureContainerRegistryHook(BaseHook):
         to start the container instance
     :type conn_id: str
     """
+
+    conn_name_attr = 'azure_container_registry_conn_id'
+    default_conn_name = 'azure_container_registry_default'
+    conn_type = 'azure_container_registry'
+    hook_name = 'Azure Container Registry'
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'extra'],
+            "relabeling": {
+                'login': 'Registry Username',
+                'password': 'Registry Password',
+                'host': 'Registry Server',
+            },
+            "placeholders": {
+                'login': 'private registry username',
+                'password': 'private registry password',
+                'host': 'docker image registry server'
+            },
+        }
 
     def __init__(self, conn_id: str = 'azure_registry') -> None:
         super().__init__()

--- a/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
@@ -51,7 +51,7 @@ class AzureContainerRegistryHook(BaseHook):
             "placeholders": {
                 'login': 'private registry username',
                 'password': 'private registry password',
-                'host': 'docker image registry server'
+                'host': 'docker image registry server',
             },
         }
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -24,7 +24,7 @@ login (=Endpoint uri), password (=secret key) and extra fields database_name and
 the default database and collection to use (see connection `azure_cosmos_default` for an example).
 """
 import uuid
-from typing import Optional, Any, Dict
+from typing import Any, Dict, Optional
 
 from azure.cosmos.cosmos_client import CosmosClient
 from azure.cosmos.errors import HTTPFailure

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -59,10 +59,10 @@ class AzureCosmosDBHook(BaseHook):
 
         return {
             "extra__azure_cosmos__database_name": StringField(
-                lazy_gettext('Cosmos Database Name'), widget=BS3TextFieldWidget()
+                lazy_gettext('Cosmos Database Name (optional)'), widget=BS3TextFieldWidget()
             ),
             "extra__azure_cosmos__collection_name": StringField(
-                lazy_gettext('Cosmos Collection Name'), widget=BS3TextFieldWidget()
+                lazy_gettext('Cosmos Collection Name (optional)'), widget=BS3TextFieldWidget()
             ),
         }
 
@@ -78,8 +78,8 @@ class AzureCosmosDBHook(BaseHook):
             "placeholders": {
                 'login': 'endpoint uri',
                 'password': 'master key',
-                'extra__azure_cosmos__database_name': 'database name (optional)',
-                'extra__azure_cosmos__collection_name': 'collection name (optional)',
+                'extra__azure_cosmos__database_name': 'database name',
+                'extra__azure_cosmos__collection_name': 'collection name',
             },
         }
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -24,7 +24,7 @@ login (=Endpoint uri), password (=secret key) and extra fields database_name and
 the default database and collection to use (see connection `azure_cosmos_default` for an example).
 """
 import uuid
-from typing import Optional
+from typing import Optional, Any, Dict
 
 from azure.cosmos.cosmos_client import CosmosClient
 from azure.cosmos.errors import HTTPFailure
@@ -50,6 +50,39 @@ class AzureCosmosDBHook(BaseHook):
     conn_type = 'azure_cosmos'
     hook_name = 'Azure CosmosDB'
 
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure_cosmos__database_name": StringField(
+                lazy_gettext('Cosmos Database Name'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_cosmos__collection_name": StringField(
+                lazy_gettext('Cosmos Collection Name'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'host', 'extra'],
+            "relabeling": {
+                'login': 'Cosmos Endpoint URI',
+                'password': 'Cosmos Master Key Token',
+            },
+            "placeholders": {
+                'login': 'endpoint uri',
+                'password': 'master key',
+                'extra__azure_cosmos__database_name': 'database name (optional)',
+                'extra__azure_cosmos__collection_name': 'collection name (optional)',
+            },
+        }
+
     def __init__(self, azure_cosmos_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = azure_cosmos_conn_id
@@ -66,8 +99,10 @@ class AzureCosmosDBHook(BaseHook):
             endpoint_uri = conn.login
             master_key = conn.password
 
-            self.default_database_name = extras.get('database_name')
-            self.default_collection_name = extras.get('collection_name')
+            self.default_database_name = extras.get('database_name') or extras.get('extra__azure_cosmos__database_name')
+            self.default_collection_name = extras.get('collection_name') or extras.get(
+                'extra__azure_cosmos__collection_name'
+            )
 
             # Initialize the Python Azure Cosmos DB client
             self._conn = CosmosClient(endpoint_uri, {'masterKey': master_key})

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -99,7 +99,9 @@ class AzureCosmosDBHook(BaseHook):
             endpoint_uri = conn.login
             master_key = conn.password
 
-            self.default_database_name = extras.get('database_name') or extras.get('extra__azure_cosmos__database_name')
+            self.default_database_name = extras.get('database_name') or extras.get(
+                'extra__azure_cosmos__database_name'
+            )
             self.default_collection_name = extras.get('collection_name') or extras.get(
                 'extra__azure_cosmos__collection_name'
             )

--- a/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
@@ -136,10 +136,12 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
             return self._conn
 
         conn = self.get_connection(self.conn_id)
-        tenant = conn.extra_dejson.get('extra__azure_data_factory__tenantId') or conn.extra_dejson.get('tenantId')
-        subscription_id = conn.extra_dejson.get('extra__azure_data_factory__subscriptionId') or conn.extra_dejson.get(
-            'subscriptionId'
-        )
+        tenant = conn.extra_dejson.get(
+            'extra__azure_data_factory__tenantId'
+        ) or conn.extra_dejson.get('tenantId')
+        subscription_id = conn.extra_dejson.get(
+            'extra__azure_data_factory__subscriptionId'
+        ) or conn.extra_dejson.get('subscriptionId')
 
         self._conn = DataFactoryManagementClient(
             credential=ClientSecretCredential(

--- a/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
@@ -119,7 +119,7 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
                     },
                     indent=1,
                 ),
-                'login': 'client_id',
+                'login': 'client id',
                 'password': 'secret',
                 'extra__azure_data_factory__tenantId': 'tenant id',
                 'extra__azure_data_factory__subscriptionId': 'subscription id',

--- a/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
@@ -16,7 +16,7 @@
 # under the License.
 import inspect
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Dict
 
 from azure.core.polling import LROPoller
 from azure.identity import ClientSecretCredential
@@ -75,12 +75,56 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
     A hook to interact with Azure Data Factory.
 
     :param conn_id: The Azure Data Factory connection id.
+    :type conn_id: str
     """
 
     conn_type: str = 'azure_data_factory'
     conn_name_attr: str = 'azure_data_factory_conn_id'
     default_conn_name: str = 'azure_data_factory_default'
     hook_name: str = 'Azure Data Factory'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure_data_factory__tenantId": StringField(
+                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_data_factory__subscriptionId": StringField(
+                lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        import json
+
+        return {
+            "hidden_fields": ['schema', 'port', 'host'],
+            "relabeling": {
+                'login': 'Azure Client ID',
+                'password': 'Azure Secret',
+                'extra': 'Extra (optional)',
+            },
+            "placeholders": {
+                'extra': json.dumps(
+                    {
+                        "resourceGroup": "azure resource group name",
+                        "factory": "azure data factory name",
+                    },
+                    indent=1,
+                ),
+                'login': 'client_id',
+                'password': 'secret',
+                'extra__azure_data_factory__tenantId': 'tenant id',
+                'extra__azure_data_factory__subscriptionId': 'subscription id',
+            },
+        }
 
     def __init__(self, conn_id: Optional[str] = default_conn_name):
         self._conn: DataFactoryManagementClient = None
@@ -92,12 +136,16 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
             return self._conn
 
         conn = self.get_connection(self.conn_id)
+        tenant = conn.extra_dejson.get('extra__azure_data_factory__tenantId') or conn.extra_dejson.get('tenantId')
+        subscription_id = conn.extra_dejson.get('extra__azure_data_factory__subscriptionId') or conn.extra_dejson.get(
+            'subscriptionId'
+        )
 
         self._conn = DataFactoryManagementClient(
             credential=ClientSecretCredential(
-                client_id=conn.login, client_secret=conn.password, tenant_id=conn.extra_dejson.get("tenantId")
+                client_id=conn.login, client_secret=conn.password, tenant_id=tenant
             ),
-            subscription_id=conn.extra_dejson.get("subscriptionId"),
+            subscription_id=subscription_id,
         )
 
         return self._conn

--- a/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
@@ -16,7 +16,7 @@
 # under the License.
 import inspect
 from functools import wraps
-from typing import Any, Callable, Optional, Dict
+from typing import Any, Callable, Dict, Optional
 
 from azure.core.polling import LROPoller
 from azure.identity import ClientSecretCredential
@@ -136,9 +136,9 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
             return self._conn
 
         conn = self.get_connection(self.conn_id)
-        tenant = conn.extra_dejson.get(
-            'extra__azure_data_factory__tenantId'
-        ) or conn.extra_dejson.get('tenantId')
+        tenant = conn.extra_dejson.get('extra__azure_data_factory__tenantId') or conn.extra_dejson.get(
+            'tenantId'
+        )
         subscription_id = conn.extra_dejson.get(
             'extra__azure_data_factory__subscriptionId'
         ) or conn.extra_dejson.get('subscriptionId')

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -75,9 +75,9 @@ class AzureDataLakeHook(BaseHook):
                 'password': 'Azure Client Secret',
             },
             "placeholders": {
-                'login': 'client_id',
+                'login': 'client id',
                 'password': 'secret',
-                'extra__azure_data_lake__tenant': 'tenent id',
+                'extra__azure_data_lake__tenant': 'tenant id',
                 'extra__azure_data_lake__account_name': 'datalake store',
             },
         }

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -24,7 +24,7 @@ Airflow connection of type `azure_data_lake` exists. Authorization can be done b
 login (=Client ID), password (=Client Secret) and extra fields tenant (Tenant) and account_name (Account Name)
 (see connection `azure_data_lake_default` for an example).
 """
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 from azure.datalake.store import core, lib, multithread
 
@@ -98,9 +98,7 @@ class AzureDataLakeHook(BaseHook):
             )
             tenant = service_options.get('tenant') or service_options.get('extra__azure_data_lake__tenant')
 
-            adl_creds = lib.auth(
-                tenant_id=tenant, client_secret=conn.password, client_id=conn.login
-            )
+            adl_creds = lib.auth(tenant_id=tenant, client_secret=conn.password, client_id=conn.login)
             self._conn = core.AzureDLFileSystem(adl_creds, store_name=self.account_name)
             self._conn.connect()
         return self._conn

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -24,7 +24,7 @@ Airflow connection of type `azure_data_lake` exists. Authorization can be done b
 login (=Client ID), password (=Client Secret) and extra fields tenant (Tenant) and account_name (Account Name)
 (see connection `azure_data_lake_default` for an example).
 """
-from typing import Optional
+from typing import Optional, Dict, Any
 
 from azure.datalake.store import core, lib, multithread
 
@@ -49,6 +49,39 @@ class AzureDataLakeHook(BaseHook):
     conn_type = 'azure_data_lake'
     hook_name = 'Azure Data Lake'
 
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure_data_lake__tenant": StringField(
+                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_data_lake__account_name": StringField(
+                lazy_gettext('Azure DataLake Store Name'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'host', 'extra'],
+            "relabeling": {
+                'login': 'Azure Client ID',
+                'password': 'Azure Client Secret',
+            },
+            "placeholders": {
+                'login': 'client_id',
+                'password': 'secret',
+                'extra__azure_data_lake__tenant': 'tenent id',
+                'extra__azure_data_lake__account_name': 'datalake store',
+            },
+        }
+
     def __init__(self, azure_data_lake_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = azure_data_lake_conn_id
@@ -60,10 +93,13 @@ class AzureDataLakeHook(BaseHook):
         if not self._conn:
             conn = self.get_connection(self.conn_id)
             service_options = conn.extra_dejson
-            self.account_name = service_options.get('account_name')
+            self.account_name = service_options.get('account_name') or service_options.get(
+                'extra__azure_data_lake__account_name'
+            )
+            tenant = service_options.get('tenant') or service_options.get('extra__azure_data_lake__tenant')
 
             adl_creds = lib.auth(
-                tenant_id=service_options.get('tenant'), client_secret=conn.password, client_id=conn.login
+                tenant_id=tenant, client_secret=conn.password, client_id=conn.login
             )
             self._conn = core.AzureDLFileSystem(adl_creds, store_name=self.account_name)
             self._conn.connect()

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -48,19 +48,9 @@ class AzureBaseHook(BaseHook):
         from wtforms import StringField
 
         return {
-<<<<<<< HEAD
-<<<<<<< HEAD
             "extra__azure__tenantId": StringField(
                 lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
             ),
-=======
-            "extra__azure__tenantId": StringField(lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()),
->>>>>>> add dynamic connection fields
-=======
-            "extra__azure__tenantId": StringField(
-                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
-            ),
->>>>>>> add dynamic fields to AzureContainerInstanceHook
             "extra__azure__subscriptionId": StringField(
                 lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
             ),

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any
+from typing import Any, Dict
 
 from azure.common.client_factory import get_client_from_auth_file, get_client_from_json_dict
 from azure.common.credentials import ServicePrincipalCredentials
@@ -30,13 +30,55 @@ class AzureBaseHook(BaseHook):
     authenticate the client library used for upstream azure hooks.
 
     :param sdk_client: The SDKClient to use.
+    :type sdk_client: Optional[str]
     :param conn_id: The azure connection id which refers to the information to connect to the service.
+    :type conn_id: str
     """
 
-    conn_name_attr = 'conn_id'
+    conn_name_attr = 'azure_conn_id'
     default_conn_name = 'azure_default'
     conn_type = 'azure'
     hook_name = 'Azure'
+
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__azure__tenantId": StringField(lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()),
+            "extra__azure__subscriptionId": StringField(
+                lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        import json
+
+        return {
+            "hidden_fields": ['schema', 'port', 'host'],
+            "relabeling": {
+                'login': 'Azure Client ID',
+                'password': 'Azure Secret',
+            },
+            "placeholders": {
+                'extra': json.dumps(
+                    {
+                        "key_path": "path to json file for auth",
+                        "key_json": "specifies json dict for auth",
+                    },
+                    indent=1,
+                ),
+                'login': 'client_id (token credentials auth)',
+                'password': 'secret (token credentials auth)',
+                'extra__azure__tenantId': 'tenentId (token credentials auth)',
+                'extra__azure__subscriptionId': 'subscriptionId (token credentials auth)',
+            },
+        }
 
     def __init__(self, sdk_client: Any, conn_id: str = 'azure_default'):
         self.sdk_client = sdk_client
@@ -50,6 +92,10 @@ class AzureBaseHook(BaseHook):
         :return: the authenticated client.
         """
         conn = self.get_connection(self.conn_id)
+        tenant = conn.extra_dejson.get('extra__azure__tenantId') or conn.extra_dejson.get('tenantId')
+        subscription_id = conn.extra_dejson.get('extra__azure__subscriptionId') or conn.extra_dejson.get(
+            'subscriptionId'
+        )
 
         key_path = conn.extra_dejson.get('key_path')
         if key_path:
@@ -66,7 +112,7 @@ class AzureBaseHook(BaseHook):
         self.log.info('Getting connection using specific credentials and subscription_id.')
         return self.sdk_client(
             credentials=ServicePrincipalCredentials(
-                client_id=conn.login, secret=conn.password, tenant=conn.extra_dejson.get('tenantId')
+                client_id=conn.login, secret=conn.password, tenant=tenant
             ),
-            subscription_id=conn.extra_dejson.get('subscriptionId'),
+            subscription_id=subscription_id,
         )

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -49,12 +49,18 @@ class AzureBaseHook(BaseHook):
 
         return {
 <<<<<<< HEAD
+<<<<<<< HEAD
             "extra__azure__tenantId": StringField(
                 lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
             ),
 =======
             "extra__azure__tenantId": StringField(lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()),
 >>>>>>> add dynamic connection fields
+=======
+            "extra__azure__tenantId": StringField(
+                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
+            ),
+>>>>>>> add dynamic fields to AzureContainerInstanceHook
             "extra__azure__subscriptionId": StringField(
                 lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
             ),

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -48,7 +48,9 @@ class AzureBaseHook(BaseHook):
         from wtforms import StringField
 
         return {
-            "extra__azure__tenantId": StringField(lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()),
+            "extra__azure__tenantId": StringField(
+                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
+            ),
             "extra__azure__subscriptionId": StringField(
                 lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
             ),

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -48,9 +48,13 @@ class AzureBaseHook(BaseHook):
         from wtforms import StringField
 
         return {
+<<<<<<< HEAD
             "extra__azure__tenantId": StringField(
                 lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
             ),
+=======
+            "extra__azure__tenantId": StringField(lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()),
+>>>>>>> add dynamic connection fields
             "extra__azure__subscriptionId": StringField(
                 lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
             ),

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -57,6 +57,50 @@ class WasbHook(BaseHook):
     conn_type = 'wasb'
     hook_name = 'Azure Blob Storage'
 
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import StringField
+
+        return {
+            "extra__wasb__connection_string": StringField(
+                lazy_gettext('Blob Storage Connection String (optional)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__wasb__shared_access_key": StringField(
+                lazy_gettext('Blob Storage Shared Access Key (optional)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__wasb__tenant_id": StringField(
+                lazy_gettext('Tenant Id (Active Directory Auth)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__wasb__sas_token": StringField(
+                lazy_gettext('SAS Token (optional)'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'host'],
+            "relabeling": {
+                'login': 'Blob Storage Login (optional)',
+                'password': 'Blob Storage Token (optional)',
+                'host': 'Account Name (Active Directory Auth)'
+            },
+            "placeholders": {
+                'extra': 'additional options for use with FileService and AzureFileVolume',
+                'login': 'account name',
+                'password': 'secret',
+                'host': 'account url',
+                'extra__wasb__connection_string': 'connection string auth',
+                'extra__wasb__tenant_id': 'tenant',
+                'extra__wasb__shared_access_key': 'shared access key',
+                'extra__wasb__sas_token': 'account url or token'
+            },
+        }
+
     def __init__(self, wasb_conn_id: str = default_conn_name, public_read: bool = False) -> None:
         super().__init__()
         self.conn_id = wasb_conn_id
@@ -74,19 +118,22 @@ class WasbHook(BaseHook):
             # https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-access-to-resources
             return BlobServiceClient(account_url=conn.host)
 
-        if extra.get('connection_string'):
+        if extra.get('connection_string') or extra.get('extra__wasb__connection_string'):
             # connection_string auth takes priority
-            return BlobServiceClient.from_connection_string(extra.get('connection_string'))
-        if extra.get('shared_access_key'):
+            connection_string = extra.get('connection_string') or extra.get('extra__wasb__connection_string')
+            return BlobServiceClient.from_connection_string(connection_string)
+        if extra.get('shared_access_key') or extra.get('extra__wasb__shared_access_key'):
+            shared_access_key = extra.get('shared_access_key') or extra.get('extra__wasb__shared_access_key')
             # using shared access key
-            return BlobServiceClient(account_url=conn.host, credential=extra.get('shared_access_key'))
-        if extra.get('tenant_id'):
+            return BlobServiceClient(account_url=conn.host, credential=shared_access_key)
+        if extra.get('tenant_id') or extra.get('extra__wasb__tenant_id'):
             # use Active Directory auth
             app_id = conn.login
             app_secret = conn.password
-            token_credential = ClientSecretCredential(extra.get('tenant_id'), app_id, app_secret)
+            tenant = extra.get('tenant_id') or extra.get('extra__wasb__tenant_id')
+            token_credential = ClientSecretCredential(tenant, app_id, app_secret)
             return BlobServiceClient(account_url=conn.host, credential=token_credential)
-        sas_token = extra.get('sas_token')
+        sas_token = extra.get('sas_token') or extra.get('extra__wasb__sas_token')
         if sas_token and sas_token.startswith('https'):
             return BlobServiceClient(account_url=extra.get('sas_token'))
         if sas_token and not sas_token.startswith('https'):

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -87,7 +87,7 @@ class WasbHook(BaseHook):
             "relabeling": {
                 'login': 'Blob Storage Login (optional)',
                 'password': 'Blob Storage Token (optional)',
-                'host': 'Account Name (Active Directory Auth)'
+                'host': 'Account Name (Active Directory Auth)',
             },
             "placeholders": {
                 'extra': 'additional options for use with FileService and AzureFileVolume',
@@ -97,7 +97,7 @@ class WasbHook(BaseHook):
                 'extra__wasb__connection_string': 'connection string auth',
                 'extra__wasb__tenant_id': 'tenant',
                 'extra__wasb__shared_access_key': 'shared access key',
-                'extra__wasb__sas_token': 'account url or token'
+                'extra__wasb__sas_token': 'account url or token',
             },
         }
 

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -60,22 +60,22 @@ class WasbHook(BaseHook):
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""
-        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
+        from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
         from flask_babel import lazy_gettext
-        from wtforms import StringField
+        from wtforms import PasswordField, StringField
 
         return {
-            "extra__wasb__connection_string": StringField(
-                lazy_gettext('Blob Storage Connection String (optional)'), widget=BS3TextFieldWidget()
+            "extra__wasb__connection_string": PasswordField(
+                lazy_gettext('Blob Storage Connection String (optional)'), widget=BS3PasswordFieldWidget()
             ),
-            "extra__wasb__shared_access_key": StringField(
-                lazy_gettext('Blob Storage Shared Access Key (optional)'), widget=BS3TextFieldWidget()
+            "extra__wasb__shared_access_key": PasswordField(
+                lazy_gettext('Blob Storage Shared Access Key (optional)'), widget=BS3PasswordFieldWidget()
             ),
             "extra__wasb__tenant_id": StringField(
                 lazy_gettext('Tenant Id (Active Directory Auth)'), widget=BS3TextFieldWidget()
             ),
-            "extra__wasb__sas_token": StringField(
-                lazy_gettext('SAS Token (optional)'), widget=BS3TextFieldWidget()
+            "extra__wasb__sas_token": PasswordField(
+                lazy_gettext('SAS Token (optional)'), widget=BS3PasswordFieldWidget()
             ),
         }
 
@@ -86,7 +86,7 @@ class WasbHook(BaseHook):
             "hidden_fields": ['schema', 'port', 'host'],
             "relabeling": {
                 'login': 'Blob Storage Login (optional)',
-                'password': 'Blob Storage Token (optional)',
+                'password': 'Blob Storage Key (optional)',
                 'host': 'Account Name (Active Directory Auth)',
             },
             "placeholders": {

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -156,3 +156,4 @@ hook-class-names:
   - airflow.providers.microsoft.azure.hooks.azure_container_instance.AzureContainerInstanceHook
   - airflow.providers.microsoft.azure.hooks.wasb.WasbHook
   - airflow.providers.microsoft.azure.hooks.azure_data_factory.AzureDataFactoryHook
+  - airflow.providers.microsoft.azure.hooks.azure_container_registry.AzureContainerRegistryHook

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -157,7 +157,7 @@ function discover_all_connection_form_widgets() {
 
     COLUMNS=180 airflow providers widgets
 
-    local expected_number_of_widgets=38
+    local expected_number_of_widgets=42
     local actual_number_of_widgets
     actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
     if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
@@ -176,11 +176,7 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-<<<<<<< HEAD
-    local expected_number_of_connections_with_behaviours=20
-=======
-    local expected_number_of_connections_with_behaviours=14
->>>>>>> add dynamic fields to AzureContainerInstanceHook
+    local expected_number_of_connections_with_behaviours=21
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -176,11 +176,7 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-<<<<<<< HEAD
     local expected_number_of_connections_with_behaviours=14
-=======
-    local expected_number_of_connections_with_behaviours=13
->>>>>>> add dynamic connection fields
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -157,7 +157,7 @@ function discover_all_connection_form_widgets() {
 
     COLUMNS=180 airflow providers widgets
 
-    local expected_number_of_widgets=27
+    local expected_number_of_widgets=38
     local actual_number_of_widgets
     actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
     if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
@@ -176,7 +176,7 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-    local expected_number_of_connections_with_behaviours=14
+    local expected_number_of_connections_with_behaviours=20
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -176,7 +176,11 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
+<<<<<<< HEAD
     local expected_number_of_connections_with_behaviours=20
+=======
+    local expected_number_of_connections_with_behaviours=14
+>>>>>>> add dynamic fields to AzureContainerInstanceHook
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -176,7 +176,11 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
+<<<<<<< HEAD
     local expected_number_of_connections_with_behaviours=14
+=======
+    local expected_number_of_connections_with_behaviours=13
+>>>>>>> add dynamic connection fields
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -176,7 +176,7 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-    local expected_number_of_connections_with_behaviours=13
+    local expected_number_of_connections_with_behaviours=14
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -157,7 +157,7 @@ function discover_all_connection_form_widgets() {
 
     COLUMNS=180 airflow providers widgets
 
-    local expected_number_of_widgets=25
+    local expected_number_of_widgets=27
     local actual_number_of_widgets
     actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
     if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
@@ -176,7 +176,7 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-    local expected_number_of_connections_with_behaviours=12
+    local expected_number_of_connections_with_behaviours=13
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -118,7 +118,7 @@ function discover_all_hooks() {
     group_start "Listing available hooks via 'airflow providers hooks'"
     COLUMNS=180 airflow providers hooks
 
-    local expected_number_of_hooks=63
+    local expected_number_of_hooks=64
     local actual_number_of_hooks
     actual_number_of_hooks=$(airflow providers hooks --output table | grep -c "| apache" | xargs)
     if [[ ${actual_number_of_hooks} != "${expected_number_of_hooks}" ]]; then

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -94,6 +94,7 @@ CONNECTIONS_LIST = [
     'azure',
     'azure_batch',
     'azure_container_instances',
+    'azure_container_registry',
     'azure_cosmos',
     'azure_data_explorer',
     'azure_data_factory',
@@ -156,6 +157,17 @@ CONNECTIONS_LIST = [
 ]
 
 CONNECTION_FORM_WIDGETS = [
+    'extra__azure_batch__account_url',
+    'extra__azure_cosmos__collection_name',
+    'extra__azure_cosmos__database_name',
+    'extra__azure_data_explorer__auth_method',
+    'extra__azure_data_explorer__certificate',
+    'extra__azure_data_explorer__tenant',
+    'extra__azure_data_explorer__thumbprint',
+    'extra__azure_data_factory__subscriptionId',
+    'extra__azure_data_factory__tenantId',
+    'extra__azure_data_lake__account_name',
+    'extra__azure_data_lake__tenant',
     'extra__azure__subscriptionId',
     'extra__azure__tenantId',
     'extra__google_cloud_platform__key_path',
@@ -187,7 +199,13 @@ CONNECTION_FORM_WIDGETS = [
 
 CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
     'azure',
+    'azure_batch',
     'azure_container_instances',
+    'azure_container_registry',
+    'azure_cosmos',
+    'azure_data_explorer',
+    'azure_data_factory',
+    'azure_data_lake',
     'cloudant',
     'docker',
     'gcpssh',

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -187,6 +187,7 @@ CONNECTION_FORM_WIDGETS = [
 
 CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
     'azure',
+    'azure_container_instances',
     'cloudant',
     'docker',
     'gcpssh',

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -190,6 +190,10 @@ CONNECTION_FORM_WIDGETS = [
     'extra__snowflake__database',
     'extra__snowflake__region',
     'extra__snowflake__warehouse',
+    'extra__wasb__connection_string',
+    'extra__wasb__sas_token',
+    'extra__wasb__shared_access_key',
+    'extra__wasb__tenant_id',
     'extra__yandexcloud__folder_id',
     'extra__yandexcloud__oauth',
     'extra__yandexcloud__public_ssh_key',
@@ -217,6 +221,7 @@ CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
     'snowflake',
     'spark',
     'ssh',
+    'wasb',
     'yandexcloud',
 ]
 

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -157,6 +157,8 @@ CONNECTIONS_LIST = [
 ]
 
 CONNECTION_FORM_WIDGETS = [
+    'extra__azure__subscriptionId',
+    'extra__azure__tenantId',
     'extra__azure_batch__account_url',
     'extra__azure_cosmos__collection_name',
     'extra__azure_cosmos__database_name',
@@ -168,8 +170,6 @@ CONNECTION_FORM_WIDGETS = [
     'extra__azure_data_factory__tenantId',
     'extra__azure_data_lake__account_name',
     'extra__azure_data_lake__tenant',
-    'extra__azure__subscriptionId',
-    'extra__azure__tenantId',
     'extra__google_cloud_platform__key_path',
     'extra__google_cloud_platform__keyfile_dict',
     'extra__google_cloud_platform__num_retries',

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -156,6 +156,8 @@ CONNECTIONS_LIST = [
 ]
 
 CONNECTION_FORM_WIDGETS = [
+    'extra__azure__subscriptionId',
+    'extra__azure__tenantId',
     'extra__google_cloud_platform__key_path',
     'extra__google_cloud_platform__keyfile_dict',
     'extra__google_cloud_platform__num_retries',
@@ -184,6 +186,7 @@ CONNECTION_FORM_WIDGETS = [
 ]
 
 CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
+    'azure',
     'cloudant',
     'docker',
     'gcpssh',


### PR DESCRIPTION
This PR adds custom connection form widgets and behaviors to the Azure Connections defined in the following hooks:  
- AzureBaseHook
- AzureContainerInstanceHook
-  AzureDataExplorerHook
- AzureCosmosDBHook
- AzureBatchHook
- AzureDataFactoryHook
- AzureDataLakeHook
- AzureContainerRegistryHook
- WasbHook

This PR also adds a new connection 'azure_container_registry' for the AzureContainerRegistryHook. The form for both the Azure connection, and the Azure Container Instance connection are identical.

screenshots:

AzureContainerInstanceHook
![Screenshot_2021-04-01 Add Connection - Airflow(1)](https://user-images.githubusercontent.com/63181127/113424206-ba51be80-939d-11eb-94f0-493fffcd9728.png)

AzureDataExplorerHook
![azure-data-explorer](https://user-images.githubusercontent.com/63181127/113774431-485adb80-96f5-11eb-9288-97c75b77f502.png)

AzureCosmosDBHook
![image](https://user-images.githubusercontent.com/63181127/113774462-53157080-96f5-11eb-9e21-71e63659de83.png)

AzureBatchHook
![azure-batch](https://user-images.githubusercontent.com/63181127/113774499-60caf600-96f5-11eb-82d6-b05fa57b25da.png)

AzureDataFactoryHook
![azure-data-factory](https://user-images.githubusercontent.com/63181127/113774580-76d8b680-96f5-11eb-802d-abd2c4784f84.png)

AzureDataLakeHook
![azure-data-lake](https://user-images.githubusercontent.com/63181127/113774715-a12a7400-96f5-11eb-890a-2e5fe5621492.png)


AzureContainerRegistryHook
![image](https://user-images.githubusercontent.com/63181127/113774632-8657ff80-96f5-11eb-878d-5293045b967b.png)

WasbHook
![Azure-blob](https://user-images.githubusercontent.com/63181127/113774745-aedff980-96f5-11eb-8cd2-4c64dbb3eaf7.png)




