### PR TITLE
Fix exception caused by missing keys in the ES Record

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -207,7 +207,7 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         if self.json_format:
             try:
                 # pylint: disable=protected-access
-                return self.formatter._style.format(_ESJsonLogFmt(**log_line.to_dict()))
+                return self.formatter._style.format(_ESJsonLogFmt(self.json_fields, **log_line.to_dict()))
             except Exception:  # noqa pylint: disable=broad-except
                 pass
 
@@ -349,5 +349,7 @@ class _ESJsonLogFmt:
     """Helper class to read ES Logs and re-format it to match settings.LOG_FORMAT"""
 
     # A separate class is needed because 'self.formatter._style.format' uses '.__dict__'
-    def __init__(self, **kwargs):
+    def __init__(self, json_fields: List, **kwargs):
+        for field in json_fields:
+            self.__setattr__(field, '')
         self.__dict__.update(kwargs)

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -53,7 +53,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         self.end_of_log_mark = 'end_of_log\n'
         self.write_stdout = False
         self.json_format = False
-        self.json_fields = 'asctime,filename,lineno,levelname,message'
+        self.json_fields = 'asctime,filename,lineno,levelname,message,exc_text'
         self.es_task_handler = ElasticsearchTaskHandler(
             self.local_log_location,
             self.filename_template,
@@ -103,7 +103,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             self.write_stdout,
             self.json_format,
             self.json_fields,
-            es_conf,
+            es_kwargs=es_conf,
         )
 
     def test_read(self):
@@ -253,7 +253,9 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
 
     def test_read_with_json_format(self):
         ts = pendulum.now()
-        formatter = logging.Formatter('[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s')
+        formatter = logging.Formatter(
+            '[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s - %(exc_text)s'
+        )
         self.es_task_handler.formatter = formatter
         self.es_task_handler.json_format = True
 
@@ -272,7 +274,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
         logs, _ = self.es_task_handler.read(
             self.ti, 1, {'offset': 0, 'last_log_timestamp': str(ts), 'end_of_log': False}
         )
-        assert "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff" == logs[0][0][1]
+        assert "[2020-12-24 19:25:00,962] {taskinstance.py:851} INFO - some random stuff - " == logs[0][0][1]
 
     def test_close(self):
         formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
Optional LogRecord attributes cannot be added to log_format due to format exception.
This happened because ElasticSearch removes keys with null values from the record.

Configuration to reproduce. Optional attribute `exc_text` added to `log_format` and `json_fields`:
```
[logging]
remote_logging = True
log_format = [%%(asctime)s] {%%(filename)s:%%(lineno)d} %%(levelname)s - %%(message)s - %%(exc_text)s

[elasticsearch]
json_format = True
json_fields = asctime, filename, lineno, levelname, message, exc_text
```