### PR TITLE
Separate Kubernetes pod_launcher from core airflow

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -74,7 +74,7 @@ https://developers.google.com/style/inclusive-documentation
 
 Moved the pod launcher from `airflow.kubernetes.pod_launcher` to `airflow.providers.cncf.kubernetes.utils.pod_launcher`
 
-This will alow users to fix the KubernetesPodOperator without requiring an airflow upgrade
+This will alow users to update the pod_launcher for the KubernetesPodOperator without requiring an airflow upgrade
 
 ### Default `[webserver] worker_refresh_interval` is changed to `6000` seconds
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -70,6 +70,12 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Removed pod_launcher from core airflow
+
+Moved the pod launcher from `airflow.kubernetes.pod_launcher` to `airflow.providers.cncf.kubernetes.utils.pod_launcher`
+
+This will alow users to fix the KubernetesPodOperator without requiring an airflow upgrade
+
 ### Default `[webserver] worker_refresh_interval` is changed to `6000` seconds
 
 The default value for `[webserver] worker_refresh_interval` was `30` seconds for

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -20,8 +20,7 @@
 # pylint: disable=unused-import
 import warnings
 
-with warnings.catch_warnings():
-    from airflow.providers.cncf.kubernetes.utils import pod_launcher  # pylint: disable=unused-import
+from airflow.providers.cncf.kubernetes.utils import pod_launcher  # pylint: disable=unused-import
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -18,12 +18,4 @@
 """This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port."""
 # flake8: noqa
 # pylint: disable=unused-import
-import warnings
-
 from airflow.kubernetes.pod_launcher_deprecated import PodLauncher, PodStatus  # pylint: disable=unused-import
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -20,7 +20,7 @@
 # pylint: disable=unused-import
 import warnings
 
-from airflow.kubernetes import pod_launcher_deprecated  # pylint: disable=unused-import
+from airflow.kubernetes.pod_launcher_deprecated import PodLauncher, PodStatus  # pylint: disable=unused-import
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -20,7 +20,7 @@
 # pylint: disable=unused-import
 import warnings
 
-from airflow.providers.cncf.kubernetes.utils import pod_launcher  # pylint: disable=unused-import
+from airflow.kubernetes import pod_launcher_deprecated  # pylint: disable=unused-import
 
 warnings.warn(
     "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",

--- a/airflow/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/kubernetes/pod_launcher_deprecated.py
@@ -38,7 +38,14 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",
+    """
+    This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`
+
+    To use this module install the provider package by installing this pip package:
+
+    https://pypi.org/project/apache-airflow-providers-cncf-kubernetes/
+
+    """,
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/kubernetes/pod_launcher_deprecated.py
@@ -48,7 +48,8 @@ class PodStatus:
 
 class PodLauncher(LoggingMixin):
     """Deprecated class for launching pods. please use
-    airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher instead"""
+    airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher instead
+    """
 
     def __init__(
         self,

--- a/airflow/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/kubernetes/pod_launcher_deprecated.py
@@ -18,6 +18,7 @@
 import json
 import math
 import time
+import warnings
 from datetime import datetime as dt
 from typing import Optional, Tuple
 
@@ -35,6 +36,12 @@ from airflow.kubernetes.pod_generator import PodDefaults
 from airflow.settings import pod_mutation_hook
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.state import State
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class PodStatus:

--- a/airflow/kubernetes/pod_launcher_deprecated.py
+++ b/airflow/kubernetes/pod_launcher_deprecated.py
@@ -1,0 +1,299 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Launches PODs"""
+import json
+import math
+import time
+from datetime import datetime as dt
+from typing import Optional, Tuple
+
+import pendulum
+import tenacity
+from kubernetes import client, watch
+from kubernetes.client.models.v1_pod import V1Pod
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream as kubernetes_stream
+from requests.exceptions import BaseHTTPError
+
+from airflow.exceptions import AirflowException
+from airflow.kubernetes.kube_client import get_kube_client
+from airflow.kubernetes.pod_generator import PodDefaults
+from airflow.settings import pod_mutation_hook
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import State
+
+
+class PodStatus:
+    """Status of the PODs"""
+
+    PENDING = 'pending'
+    RUNNING = 'running'
+    FAILED = 'failed'
+    SUCCEEDED = 'succeeded'
+
+
+class PodLauncher(LoggingMixin):
+    """Deprecated class for launching pods. please use
+    airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher instead"""
+
+    def __init__(
+        self,
+        kube_client: client.CoreV1Api = None,
+        in_cluster: bool = True,
+        cluster_context: Optional[str] = None,
+        extract_xcom: bool = False,
+    ):
+        """
+        Deprecated class for launching pods. please use
+        airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher instead
+        Creates the launcher.
+
+        :param kube_client: kubernetes client
+        :param in_cluster: whether we are in cluster
+        :param cluster_context: context of the cluster
+        :param extract_xcom: whether we should extract xcom
+        """
+        super().__init__()
+        self._client = kube_client or get_kube_client(in_cluster=in_cluster, cluster_context=cluster_context)
+        self._watch = watch.Watch()
+        self.extract_xcom = extract_xcom
+
+    def run_pod_async(self, pod: V1Pod, **kwargs):
+        """Runs POD asynchronously"""
+        pod_mutation_hook(pod)
+
+        sanitized_pod = self._client.api_client.sanitize_for_serialization(pod)
+        json_pod = json.dumps(sanitized_pod, indent=2)
+
+        self.log.debug('Pod Creation Request: \n%s', json_pod)
+        try:
+            resp = self._client.create_namespaced_pod(
+                body=sanitized_pod, namespace=pod.metadata.namespace, **kwargs
+            )
+            self.log.debug('Pod Creation Response: %s', resp)
+        except Exception as e:
+            self.log.exception('Exception when attempting to create Namespaced Pod: %s', json_pod)
+            raise e
+        return resp
+
+    def delete_pod(self, pod: V1Pod):
+        """Deletes POD"""
+        try:
+            self._client.delete_namespaced_pod(
+                pod.metadata.name, pod.metadata.namespace, body=client.V1DeleteOptions()
+            )
+        except ApiException as e:
+            # If the pod is already deleted
+            if e.status != 404:
+                raise
+
+    def start_pod(self, pod: V1Pod, startup_timeout: int = 120):
+        """
+        Launches the pod synchronously and waits for completion.
+
+        :param pod:
+        :param startup_timeout: Timeout for startup of the pod (if pod is pending for too long, fails task)
+        :return:
+        """
+        resp = self.run_pod_async(pod)
+        curr_time = dt.now()
+        if resp.status.start_time is None:
+            while self.pod_not_started(pod):
+                self.log.warning("Pod not yet started: %s", pod.metadata.name)
+                delta = dt.now() - curr_time
+                if delta.total_seconds() >= startup_timeout:
+                    raise AirflowException("Pod took too long to start")
+                time.sleep(1)
+
+    def monitor_pod(self, pod: V1Pod, get_logs: bool) -> Tuple[State, Optional[str]]:
+        """
+        Monitors a pod and returns the final state
+
+        :param pod: pod spec that will be monitored
+        :type pod : V1Pod
+        :param get_logs: whether to read the logs locally
+        :return:  Tuple[State, Optional[str]]
+        """
+        if get_logs:
+            read_logs_since_sec = None
+            last_log_time = None
+            while True:
+                logs = self.read_pod_logs(pod, timestamps=True, since_seconds=read_logs_since_sec)
+                for line in logs:
+                    timestamp, message = self.parse_log_line(line.decode('utf-8'))
+                    last_log_time = pendulum.parse(timestamp)
+                    self.log.info(message)
+                time.sleep(1)
+
+                if not self.base_container_is_running(pod):
+                    break
+
+                self.log.warning('Pod %s log read interrupted', pod.metadata.name)
+                if last_log_time:
+                    delta = pendulum.now() - last_log_time
+                    # Prefer logs duplication rather than loss
+                    read_logs_since_sec = math.ceil(delta.total_seconds())
+        result = None
+        if self.extract_xcom:
+            while self.base_container_is_running(pod):
+                self.log.info('Container %s has state %s', pod.metadata.name, State.RUNNING)
+                time.sleep(2)
+            result = self._extract_xcom(pod)
+            self.log.info(result)
+            result = json.loads(result)
+        while self.pod_is_running(pod):
+            self.log.info('Pod %s has state %s', pod.metadata.name, State.RUNNING)
+            time.sleep(2)
+        return self._task_status(self.read_pod(pod)), result
+
+    def parse_log_line(self, line: str) -> Tuple[str, str]:
+        """
+        Parse K8s log line and returns the final state
+
+        :param line: k8s log line
+        :type line: str
+        :return: timestamp and log message
+        :rtype: Tuple[str, str]
+        """
+        split_at = line.find(' ')
+        if split_at == -1:
+            raise Exception(f'Log not in "{{timestamp}} {{log}}" format. Got: {line}')
+        timestamp = line[:split_at]
+        message = line[split_at + 1 :].rstrip()
+        return timestamp, message
+
+    def _task_status(self, event):
+        self.log.info('Event: %s had an event of type %s', event.metadata.name, event.status.phase)
+        status = self.process_status(event.metadata.name, event.status.phase)
+        return status
+
+    def pod_not_started(self, pod: V1Pod):
+        """Tests if pod has not started"""
+        state = self._task_status(self.read_pod(pod))
+        return state == State.QUEUED
+
+    def pod_is_running(self, pod: V1Pod):
+        """Tests if pod is running"""
+        state = self._task_status(self.read_pod(pod))
+        return state not in (State.SUCCESS, State.FAILED)
+
+    def base_container_is_running(self, pod: V1Pod):
+        """Tests if base container is running"""
+        event = self.read_pod(pod)
+        status = next(iter(filter(lambda s: s.name == 'base', event.status.container_statuses)), None)
+        if not status:
+            return False
+        return status.state.running is not None
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    def read_pod_logs(
+        self,
+        pod: V1Pod,
+        tail_lines: Optional[int] = None,
+        timestamps: bool = False,
+        since_seconds: Optional[int] = None,
+    ):
+        """Reads log from the POD"""
+        additional_kwargs = {}
+        if since_seconds:
+            additional_kwargs['since_seconds'] = since_seconds
+
+        if tail_lines:
+            additional_kwargs['tail_lines'] = tail_lines
+
+        try:
+            return self._client.read_namespaced_pod_log(
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                container='base',
+                follow=True,
+                timestamps=timestamps,
+                _preload_content=False,
+                **additional_kwargs,
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(f'There was an error reading the kubernetes API: {e}')
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    def read_pod_events(self, pod):
+        """Reads events from the POD"""
+        try:
+            return self._client.list_namespaced_event(
+                namespace=pod.metadata.namespace, field_selector=f"involvedObject.name={pod.metadata.name}"
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(f'There was an error reading the kubernetes API: {e}')
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    def read_pod(self, pod: V1Pod):
+        """Read POD information"""
+        try:
+            return self._client.read_namespaced_pod(pod.metadata.name, pod.metadata.namespace)
+        except BaseHTTPError as e:
+            raise AirflowException(f'There was an error reading the kubernetes API: {e}')
+
+    def _extract_xcom(self, pod: V1Pod):
+        resp = kubernetes_stream(
+            self._client.connect_get_namespaced_pod_exec,
+            pod.metadata.name,
+            pod.metadata.namespace,
+            container=PodDefaults.SIDECAR_CONTAINER_NAME,
+            command=['/bin/sh'],
+            stdin=True,
+            stdout=True,
+            stderr=True,
+            tty=False,
+            _preload_content=False,
+        )
+        try:
+            result = self._exec_pod_command(resp, f'cat {PodDefaults.XCOM_MOUNT_PATH}/return.json')
+            self._exec_pod_command(resp, 'kill -s SIGINT 1')
+        finally:
+            resp.close()
+        if result is None:
+            raise AirflowException(f'Failed to extract xcom from pod: {pod.metadata.name}')
+        return result
+
+    def _exec_pod_command(self, resp, command):
+        if resp.is_open():
+            self.log.info('Running command... %s\n', command)
+            resp.write_stdin(command + '\n')
+            while resp.is_open():
+                resp.update(timeout=1)
+                if resp.peek_stdout():
+                    return resp.read_stdout()
+                if resp.peek_stderr():
+                    self.log.info(resp.read_stderr())
+                    break
+        return None
+
+    def process_status(self, job_id, status):
+        """Process status information for the JOB"""
+        status = status.lower()
+        if status == PodStatus.PENDING:
+            return State.QUEUED
+        elif status == PodStatus.FAILED:
+            self.log.error('Event with job id %s Failed', job_id)
+            return State.FAILED
+        elif status == PodStatus.SUCCEEDED:
+            self.log.info('Event with job id %s Succeeded', job_id)
+            return State.SUCCESS
+        elif status == PodStatus.RUNNING:
+            return State.RUNNING
+        else:
+            self.log.error('Event: Invalid state %s on job %s', status, job_id)
+            return State.FAILED

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -27,7 +27,7 @@ except ImportError:
     import yaml
 
 from airflow.exceptions import AirflowException
-from airflow.kubernetes import kube_client, pod_generator, pod_launcher
+from airflow.kubernetes import kube_client, pod_generator
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.kubernetes.secret import Secret
 from airflow.models import BaseOperator
@@ -44,6 +44,7 @@ from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters im
     convert_volume_mount,
 )
 from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
+from airflow.providers.cncf.kubernetes.utils import pod_launcher
 from airflow.utils.decorators import apply_defaults
 from airflow.utils.helpers import validate_key
 from airflow.utils.state import State

--- a/airflow/providers/cncf/kubernetes/utils/__init__.py
+++ b/airflow/providers/cncf/kubernetes/utils/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,16 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port."""
-# flake8: noqa
-# pylint: disable=unused-import
-import warnings
-
-with warnings.catch_warnings():
-    from airflow.providers.cncf.kubernetes.utils import pod_launcher  # pylint: disable=unused-import
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -1,0 +1,295 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Launches PODs"""
+import json
+import math
+import time
+from datetime import datetime as dt
+from typing import Optional, Tuple
+
+import pendulum
+import tenacity
+from kubernetes import client, watch
+from kubernetes.client.models.v1_pod import V1Pod
+from kubernetes.client.rest import ApiException
+from kubernetes.stream import stream as kubernetes_stream
+from requests.exceptions import BaseHTTPError
+
+from airflow.exceptions import AirflowException
+from airflow.kubernetes.kube_client import get_kube_client
+from airflow.kubernetes.pod_generator import PodDefaults
+from airflow.settings import pod_mutation_hook
+from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.state import State
+
+
+class PodStatus:
+    """Status of the PODs"""
+
+    PENDING = 'pending'
+    RUNNING = 'running'
+    FAILED = 'failed'
+    SUCCEEDED = 'succeeded'
+
+
+class PodLauncher(LoggingMixin):
+    """Launches PODS"""
+
+    def __init__(
+        self,
+        kube_client: client.CoreV1Api = None,
+        in_cluster: bool = True,
+        cluster_context: Optional[str] = None,
+        extract_xcom: bool = False,
+    ):
+        """
+        Creates the launcher.
+
+        :param kube_client: kubernetes client
+        :param in_cluster: whether we are in cluster
+        :param cluster_context: context of the cluster
+        :param extract_xcom: whether we should extract xcom
+        """
+        super().__init__()
+        self._client = kube_client or get_kube_client(in_cluster=in_cluster, cluster_context=cluster_context)
+        self._watch = watch.Watch()
+        self.extract_xcom = extract_xcom
+
+    def run_pod_async(self, pod: V1Pod, **kwargs):
+        """Runs POD asynchronously"""
+        pod_mutation_hook(pod)
+
+        sanitized_pod = self._client.api_client.sanitize_for_serialization(pod)
+        json_pod = json.dumps(sanitized_pod, indent=2)
+
+        self.log.debug('Pod Creation Request: \n%s', json_pod)
+        try:
+            resp = self._client.create_namespaced_pod(
+                body=sanitized_pod, namespace=pod.metadata.namespace, **kwargs
+            )
+            self.log.debug('Pod Creation Response: %s', resp)
+        except Exception as e:
+            self.log.exception('Exception when attempting to create Namespaced Pod: %s', json_pod)
+            raise e
+        return resp
+
+    def delete_pod(self, pod: V1Pod):
+        """Deletes POD"""
+        try:
+            self._client.delete_namespaced_pod(
+                pod.metadata.name, pod.metadata.namespace, body=client.V1DeleteOptions()
+            )
+        except ApiException as e:
+            # If the pod is already deleted
+            if e.status != 404:
+                raise
+
+    def start_pod(self, pod: V1Pod, startup_timeout: int = 120):
+        """
+        Launches the pod synchronously and waits for completion.
+
+        :param pod:
+        :param startup_timeout: Timeout for startup of the pod (if pod is pending for too long, fails task)
+        :return:
+        """
+        resp = self.run_pod_async(pod)
+        curr_time = dt.now()
+        if resp.status.start_time is None:
+            while self.pod_not_started(pod):
+                self.log.warning("Pod not yet started: %s", pod.metadata.name)
+                delta = dt.now() - curr_time
+                if delta.total_seconds() >= startup_timeout:
+                    raise AirflowException("Pod took too long to start")
+                time.sleep(1)
+
+    def monitor_pod(self, pod: V1Pod, get_logs: bool) -> Tuple[State, Optional[str]]:
+        """
+        Monitors a pod and returns the final state
+
+        :param pod: pod spec that will be monitored
+        :param get_logs: whether to read the logs locally
+        :return:  Tuple[State, Optional[str]]
+        """
+        if get_logs:
+            read_logs_since_sec = None
+            last_log_time = None
+            while True:
+                logs = self.read_pod_logs(pod, timestamps=True, since_seconds=read_logs_since_sec)
+                for line in logs:
+                    timestamp, message = self.parse_log_line(line.decode('utf-8'))
+                    last_log_time = pendulum.parse(timestamp)
+                    self.log.info(message)
+                time.sleep(1)
+
+                if not self.base_container_is_running(pod):
+                    break
+
+                self.log.warning('Pod %s log read interrupted', pod.metadata.name)
+                if last_log_time:
+                    delta = pendulum.now() - last_log_time
+                    # Prefer logs duplication rather than loss
+                    read_logs_since_sec = math.ceil(delta.total_seconds())
+        result = None
+        if self.extract_xcom:
+            while self.base_container_is_running(pod):
+                self.log.info('Container %s has state %s', pod.metadata.name, State.RUNNING)
+                time.sleep(2)
+            result = self._extract_xcom(pod)
+            self.log.info(result)
+            result = json.loads(result)
+        while self.pod_is_running(pod):
+            self.log.info('Pod %s has state %s', pod.metadata.name, State.RUNNING)
+            time.sleep(2)
+        return self._task_status(self.read_pod(pod)), result
+
+    def parse_log_line(self, line: str) -> Tuple[str, str]:
+        """
+        Parse K8s log line and returns the final state
+
+        :param line: k8s log line
+        :type line: str
+        :return: timestamp and log message
+        :rtype: Tuple[str, str]
+        """
+        split_at = line.find(' ')
+        if split_at == -1:
+            raise Exception(f'Log not in "{{timestamp}} {{log}}" format. Got: {line}')
+        timestamp = line[:split_at]
+        message = line[split_at + 1 :].rstrip()
+        return timestamp, message
+
+    def _task_status(self, event):
+        self.log.info('Event: %s had an event of type %s', event.metadata.name, event.status.phase)
+        status = self.process_status(event.metadata.name, event.status.phase)
+        return status
+
+    def pod_not_started(self, pod: V1Pod):
+        """Tests if pod has not started"""
+        state = self._task_status(self.read_pod(pod))
+        return state == State.QUEUED
+
+    def pod_is_running(self, pod: V1Pod):
+        """Tests if pod is running"""
+        state = self._task_status(self.read_pod(pod))
+        return state not in (State.SUCCESS, State.FAILED)
+
+    def base_container_is_running(self, pod: V1Pod):
+        """Tests if base container is running"""
+        event = self.read_pod(pod)
+        status = next(iter(filter(lambda s: s.name == 'base', event.status.container_statuses)), None)
+        if not status:
+            return False
+        return status.state.running is not None
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    def read_pod_logs(
+        self,
+        pod: V1Pod,
+        tail_lines: Optional[int] = None,
+        timestamps: bool = False,
+        since_seconds: Optional[int] = None,
+    ):
+        """Reads log from the POD"""
+        additional_kwargs = {}
+        if since_seconds:
+            additional_kwargs['since_seconds'] = since_seconds
+
+        if tail_lines:
+            additional_kwargs['tail_lines'] = tail_lines
+
+        try:
+            return self._client.read_namespaced_pod_log(
+                name=pod.metadata.name,
+                namespace=pod.metadata.namespace,
+                container='base',
+                follow=True,
+                timestamps=timestamps,
+                _preload_content=False,
+                **additional_kwargs,
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(f'There was an error reading the kubernetes API: {e}')
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    def read_pod_events(self, pod):
+        """Reads events from the POD"""
+        try:
+            return self._client.list_namespaced_event(
+                namespace=pod.metadata.namespace, field_selector=f"involvedObject.name={pod.metadata.name}"
+            )
+        except BaseHTTPError as e:
+            raise AirflowException(f'There was an error reading the kubernetes API: {e}')
+
+    @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
+    def read_pod(self, pod: V1Pod):
+        """Read POD information"""
+        try:
+            return self._client.read_namespaced_pod(pod.metadata.name, pod.metadata.namespace)
+        except BaseHTTPError as e:
+            raise AirflowException(f'There was an error reading the kubernetes API: {e}')
+
+    def _extract_xcom(self, pod: V1Pod):
+        resp = kubernetes_stream(
+            self._client.connect_get_namespaced_pod_exec,
+            pod.metadata.name,
+            pod.metadata.namespace,
+            container=PodDefaults.SIDECAR_CONTAINER_NAME,
+            command=['/bin/sh'],
+            stdin=True,
+            stdout=True,
+            stderr=True,
+            tty=False,
+            _preload_content=False,
+        )
+        try:
+            result = self._exec_pod_command(resp, f'cat {PodDefaults.XCOM_MOUNT_PATH}/return.json')
+            self._exec_pod_command(resp, 'kill -s SIGINT 1')
+        finally:
+            resp.close()
+        if result is None:
+            raise AirflowException(f'Failed to extract xcom from pod: {pod.metadata.name}')
+        return result
+
+    def _exec_pod_command(self, resp, command):
+        if resp.is_open():
+            self.log.info('Running command... %s\n', command)
+            resp.write_stdin(command + '\n')
+            while resp.is_open():
+                resp.update(timeout=1)
+                if resp.peek_stdout():
+                    return resp.read_stdout()
+                if resp.peek_stderr():
+                    self.log.info(resp.read_stderr())
+                    break
+        return None
+
+    def process_status(self, job_id, status):
+        """Process status information for the JOB"""
+        status = status.lower()
+        if status == PodStatus.PENDING:
+            return State.QUEUED
+        elif status == PodStatus.FAILED:
+            self.log.error('Event with job id %s Failed', job_id)
+            return State.FAILED
+        elif status == PodStatus.SUCCEEDED:
+            self.log.info('Event with job id %s Succeeded', job_id)
+            return State.SUCCESS
+        elif status == PodStatus.RUNNING:
+            return State.RUNNING
+        else:
+            self.log.error('Event: Invalid state %s on job %s', status, job_id)
+            return State.FAILED

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -38,7 +38,7 @@ from airflow.kubernetes.pod_generator import PodDefaults
 from airflow.kubernetes.secret import Secret
 from airflow.models import DAG, TaskInstance
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
-from airflow.providers.cnf.kubernetes.utils.pod_launcher import PodLauncher
+from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher
 from airflow.utils import timezone
 from airflow.version import version as airflow_version
 

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -35,10 +35,10 @@ from kubernetes.client.rest import ApiException
 from airflow.exceptions import AirflowException
 from airflow.kubernetes import kube_client
 from airflow.kubernetes.pod_generator import PodDefaults
-from airflow.kubernetes.pod_launcher import PodLauncher
 from airflow.kubernetes.secret import Secret
 from airflow.models import DAG, TaskInstance
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cnf.kubernetes.utils.pod_launcher import PodLauncher
 from airflow.utils import timezone
 from airflow.version import version as airflow_version
 
@@ -570,8 +570,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_configmaps(self, mock_client, mock_monitor, mock_start):
         # GIVEN
@@ -598,8 +598,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         k.execute(context)
         assert mock_start.call_args[0][0].spec.containers[0].env_from == env_from
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_secrets(self, mock_client, monitor_mock, start_mock):
         # GIVEN
@@ -813,8 +813,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ]
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_template_file(
         self, mock_client, monitor_mock, start_mock  # pylint: disable=unused-argument
@@ -884,8 +884,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         }
         assert expected_dict == actual_pod
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_priority_class_name(
         self, mock_client, monitor_mock, start_mock  # pylint: disable=unused-argument
@@ -929,7 +929,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 do_xcom_push=False,
             )
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     def test_on_kill(self, monitor_mock):  # pylint: disable=unused-argument
         from airflow.utils.state import State
 
@@ -980,7 +980,9 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
         context = create_context(k)
 
-        with mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod") as monitor_mock:
+        with mock.patch(
+            "airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod"
+        ) as monitor_mock:
             monitor_mock.return_value = (State.SUCCESS, None)
             k.execute(context)
             name = k.pod.metadata.name

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -570,8 +570,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_configmaps(self, mock_client, mock_monitor, mock_start):
         # GIVEN
@@ -598,8 +598,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         k.execute(context)
         assert mock_start.call_args[0][0].spec.containers[0].env_from == env_from
 
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_secrets(self, mock_client, monitor_mock, start_mock):
         # GIVEN
@@ -813,8 +813,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ]
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_template_file(
         self, mock_client, monitor_mock, start_mock  # pylint: disable=unused-argument
@@ -884,8 +884,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         }
         assert expected_dict == actual_pod
 
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_priority_class_name(
         self, mock_client, monitor_mock, start_mock  # pylint: disable=unused-argument
@@ -929,7 +929,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 do_xcom_push=False,
             )
 
-    @mock.patch("airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     def test_on_kill(self, monitor_mock):  # pylint: disable=unused-argument
         from airflow.utils.state import State
 
@@ -981,7 +981,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         context = create_context(k)
 
         with mock.patch(
-            "airflow.providers.cnf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod"
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod"
         ) as monitor_mock:
             monitor_mock.return_value = (State.SUCCESS, None)
             k.execute(context)

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -32,13 +32,13 @@ from airflow.exceptions import AirflowException
 from airflow.kubernetes import kube_client
 from airflow.kubernetes.pod import Port
 from airflow.kubernetes.pod_generator import PodDefaults
-from airflow.kubernetes.pod_launcher import PodLauncher
 from airflow.kubernetes.pod_runtime_info_env import PodRuntimeInfoEnv
 from airflow.kubernetes.secret import Secret
 from airflow.kubernetes.volume import Volume
 from airflow.kubernetes.volume_mount import VolumeMount
 from airflow.models import DAG, TaskInstance
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher
 from airflow.utils import timezone
 from airflow.utils.state import State
 from airflow.version import version as airflow_version

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -127,8 +127,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             "ti": task_instance,
         }
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_image_pull_secrets_correctly_set(self, mock_client, monitor_mock, start_mock):
         fake_pull_secrets = "fakeSecret"
@@ -152,9 +152,9 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             k8s.V1LocalObjectReference(name=fake_pull_secrets)
         ]
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.delete_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.delete_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_delete_even_on_launcher_error(
         self, mock_client, delete_pod_mock, monitor_pod_mock, start_pod_mock
@@ -483,8 +483,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_configmaps(self, mock_client, mock_monitor, mock_start):
         # GIVEN
@@ -510,8 +510,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name=configmap))
         ]
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_secrets(self, mock_client, monitor_mock, start_mock):
         # GIVEN
@@ -641,8 +641,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ]
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_priority_class_name(
         self, mock_client, monitor_mock, start_mock

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -42,8 +42,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             "ti": task_instance,
         }
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_config_path(self, client_mock, monitor_mock, start_mock):  # pylint: disable=unused-argument
         from airflow.utils.state import State
@@ -94,8 +94,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
         assert k.env_vars[0].value == "footemplated"
         assert k.env_vars[0].name == "bartemplated"
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_image_pull_secrets_correctly_set(self, mock_client, monitor_mock, start_mock):
         from airflow.utils.state import State
@@ -121,8 +121,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             k8s.V1LocalObjectReference(name=fake_pull_secrets)
         ]
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_image_pull_policy_not_set(self, mock_client, monitor_mock, start_mock):
         from airflow.utils.state import State
@@ -144,8 +144,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
         k.execute(context=context)
         assert start_mock.call_args[0][0].spec.containers[0].image_pull_policy == 'IfNotPresent'
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_image_pull_policy_correctly_set(self, mock_client, monitor_mock, start_mock):
         from airflow.utils.state import State
@@ -168,9 +168,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
         k.execute(context=context)
         assert start_mock.call_args[0][0].spec.containers[0].image_pull_policy == 'Always'
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.delete_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.delete_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_pod_delete_even_on_launcher_error(
         self, mock_client, delete_pod_mock, monitor_pod_mock, start_pod_mock
@@ -207,8 +207,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
         task.render_template_fields(context={"image_jinja": "ubuntu"})
         assert task.image == "ubuntu:16.04"
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_randomize_pod_name(self, mock_client, monitor_mock, start_mock):
         from airflow.utils.state import State
@@ -234,8 +234,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
         assert start_mock.call_args[0][0].metadata.name.startswith(name_base)
         assert start_mock.call_args[0][0].metadata.name != name_base
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_describes_pod_on_failure(self, mock_client, monitor_mock, start_mock):
         from airflow.utils.state import State
@@ -270,8 +270,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
         assert mock_client.return_value.read_namespaced_pod.called
         assert read_namespaced_pod_mock.call_args[0][0] == k.pod.metadata.name
 
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.kubernetes.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_no_need_to_describe_pod_on_success(self, mock_client, monitor_mock, start_mock):
         from airflow.utils.state import State

--- a/tests/providers/cncf/kubernetes/utils/__init__.py
+++ b/tests/providers/cncf/kubernetes/utils/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,16 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port."""
-# flake8: noqa
-# pylint: disable=unused-import
-import warnings
-
-with warnings.catch_warnings():
-    from airflow.providers.cncf.kubernetes.utils import pod_launcher  # pylint: disable=unused-import
-
-warnings.warn(
-    "This module is deprecated. Please use `airflow.providers.cncf.kubernetes.utils.pod_launcher`",
-    DeprecationWarning,
-    stacklevel=2,
-)

--- a/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
@@ -21,7 +21,7 @@ import pytest
 from requests.exceptions import BaseHTTPError
 
 from airflow.exceptions import AirflowException
-from airflow.kubernetes.pod_launcher import PodLauncher, PodStatus
+from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher, PodStatus
 
 
 class TestPodLauncher(unittest.TestCase):


### PR DESCRIPTION
Currently, the KubernetesPodOperator uses the pod_launcher class in airflow core. This means that if we need to fix a bug in the KubernetesPodOperator such as #15137 then the new cncf.kubernetes package will require an Airflow upgrade. Since we hope to release providers in a much faster cadence than Airflow core releases, we should separate this dependency.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
