### PR TITLE
Add core-operators label to boring cyborg automation

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -177,6 +177,16 @@ labelPRBasedOnFilePath:
     - tests/models/test_serialized_dag.py
     - docs/apache-airflow/dag-serialization.rst
 
+  area:core-operators:
+    - airflow/operators/**/*
+    - airflow/hooks/**/*
+    - airflow/sensors/**/*
+    - tests/operators/**/*
+    - tests/hooks/**/*
+    - tests/sensors/**/*
+    - docs/apache-airflow/operators-and-hooks-ref.rst
+    - docs/apache-airflow/howto/operator/*
+
 # Various Flags to control behaviour of the "Labeler"
 labelerFlags:
   # If this flag is changed to 'false', labels would only be added when the PR is first created


### PR DESCRIPTION
recently we added `area:core-operators` label to mark issues related to core hooks/sensors/operators. This PR adds the label to the cyborg automation.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
