### PR TITLE
Execute `on_failure_callback` when SIGTERM is received

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -76,6 +76,12 @@ class LocalTaskJob(BaseJob):
             """Setting kill signal handler"""
             self.log.error("Received SIGTERM. Terminating subprocesses")
             self.on_kill()
+            self.task_instance.refresh_from_db()
+            if self.task_instance.state not in State.finished:
+                self.task_instance.set_state(State.FAILED)
+            self.task_instance._run_finished_callback(  # pylint: disable=protected-access
+                error="task received sigterm"
+            )
             raise AirflowException("LocalTaskJob received SIGTERM signal")
 
         # pylint: enable=unused-argument

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1544,6 +1544,17 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             session.merge(self)
         session.commit()
 
+    @provide_session
+    def handle_failure_with_callback(
+        self,
+        error: Union[str, Exception],
+        test_mode: Optional[bool] = None,
+        force_fail: bool = False,
+        session=None,
+    ) -> None:
+        self.handle_failure(error=error, test_mode=test_mode, force_fail=force_fail, session=session)
+        self._run_finished_callback(error=error)
+
     def is_eligible_to_retry(self):
         """Is task instance is eligible for retry"""
         return self.task.retries and self.try_number <= self.max_tries

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1263,6 +1263,9 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         def signal_handler(signum, frame):  # pylint: disable=unused-argument
             self.log.error("Received SIGTERM. Terminating subprocesses.")
             task_copy.on_kill()
+            if task_copy.on_failure_callback is not None:
+                context = self.get_template_context()
+                task_copy.on_failure_callback(context)
             raise AirflowException("Task received SIGTERM signal")
 
         signal.signal(signal.SIGTERM, signal_handler)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1168,7 +1168,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             self.refresh_from_db()
             # for case when task is marked as success/failed externally
             # current behavior doesn't hit the success callback
-            if self.state == State.SUCCESS:
+            if self.state in {State.SUCCESS, State.FAILED}:
+                return
+            elif self.state == State.RUNNING:
+                self.handle_failure_with_callback(e, test_mode)
                 return
             else:
                 self.handle_failure(e, test_mode, error_file=error_file)
@@ -1359,7 +1362,13 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         NOTE: Only invoke this function from caller of self._run_raw_task or
         self.run
         """
-        if self.state == State.SUCCESS:
+        if self.state == State.FAILED:
+            task = self.task
+            if task.on_failure_callback is not None:
+                context = self.get_template_context()
+                context["exception"] = error
+                task.on_failure_callback(context)
+        elif self.state == State.SUCCESS:
             task = self.task
             if task.on_success_callback is not None:
                 context = self.get_template_context()
@@ -1370,15 +1379,6 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                 context = self.get_template_context()
                 context["exception"] = error
                 task.on_retry_callback(context)
-
-    def _run_failure_callback(self, error: Optional[Union[str, Exception]] = None) -> None:
-        """Call failure callback when there's exception or task failure"""
-        if self.state == State.FAILED:
-            task = self.task
-            if task.on_failure_callback is not None:
-                context = self.get_template_context()
-                context["exception"] = error
-                task.on_failure_callback(context)
 
     @provide_session
     def run(  # pylint: disable=too-many-arguments
@@ -1539,7 +1539,6 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             except Exception as exec2:  # pylint: disable=broad-except
                 self.log.error('Failed to send email to: %s', task.email)
                 self.log.exception(exec2)
-        self._run_failure_callback(error=error)
         if not test_mode:
             session.merge(self)
         session.commit()

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1168,7 +1168,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             self.refresh_from_db()
             # for case when task is marked as success/failed externally
             # current behavior doesn't hit the success callback
-            if self.state in {State.SUCCESS, State.FAILED}:
+            if self.state == State.SUCCESS:
                 return
             else:
                 self.handle_failure(e, test_mode, error_file=error_file)
@@ -1263,9 +1263,6 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         def signal_handler(signum, frame):  # pylint: disable=unused-argument
             self.log.error("Received SIGTERM. Terminating subprocesses.")
             task_copy.on_kill()
-            if task_copy.on_failure_callback is not None:
-                context = self.get_template_context()
-                task_copy.on_failure_callback(context)
             raise AirflowException("Task received SIGTERM signal")
 
         signal.signal(signal.SIGTERM, signal_handler)
@@ -1362,13 +1359,7 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         NOTE: Only invoke this function from caller of self._run_raw_task or
         self.run
         """
-        if self.state == State.FAILED:
-            task = self.task
-            if task.on_failure_callback is not None:
-                context = self.get_template_context()
-                context["exception"] = error
-                task.on_failure_callback(context)
-        elif self.state == State.SUCCESS:
+        if self.state == State.SUCCESS:
             task = self.task
             if task.on_success_callback is not None:
                 context = self.get_template_context()
@@ -1379,6 +1370,15 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                 context = self.get_template_context()
                 context["exception"] = error
                 task.on_retry_callback(context)
+
+    def _run_failure_callback(self, error: Optional[Union[str, Exception]] = None) -> None:
+        """Call failure callback when there's exception or task failure"""
+        if self.state == State.FAILED:
+            task = self.task
+            if task.on_failure_callback is not None:
+                context = self.get_template_context()
+                context["exception"] = error
+                task.on_failure_callback(context)
 
     @provide_session
     def run(  # pylint: disable=too-many-arguments
@@ -1539,21 +1539,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             except Exception as exec2:  # pylint: disable=broad-except
                 self.log.error('Failed to send email to: %s', task.email)
                 self.log.exception(exec2)
-
+        self._run_failure_callback(error=error)
         if not test_mode:
             session.merge(self)
         session.commit()
-
-    @provide_session
-    def handle_failure_with_callback(
-        self,
-        error: Union[str, Exception],
-        test_mode: Optional[bool] = None,
-        force_fail: bool = False,
-        session=None,
-    ) -> None:
-        self.handle_failure(error=error, test_mode=test_mode, force_fail=force_fail, session=session)
-        self._run_finished_callback(error=error)
 
     def is_eligible_to_retry(self):
         """Is task instance is eligible for retry"""

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -497,7 +497,7 @@ class TestLocalTaskJob(unittest.TestCase):
 
     def test_process_kill_call_on_failure_callback(self):
         """
-        Test that ensures that where a task is killed with sigterm
+        Test that ensures that when a task is killed with sigterm
         on_failure_callback gets executed
         """
         # use shared memory value so we can properly track value change even if

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -18,6 +18,7 @@
 #
 import multiprocessing
 import os
+import signal
 import time
 import unittest
 import uuid
@@ -552,7 +553,7 @@ class TestLocalTaskJob(unittest.TestCase):
                 break
             time.sleep(0.2)
         assert ti.state == State.RUNNING
-        os.kill(ti.pid, 15)
+        os.kill(ti.pid, signal.SIGTERM)
         process.join(timeout=10)
         assert failure_callback_called.value == 1
         assert task_terminated_externally.value == 1

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -520,7 +520,6 @@ class TestLocalTaskJob(unittest.TestCase):
             # This should not happen -- the state change should be noticed and the task should get killed
             with shared_mem_lock:
                 task_terminated_externally.value = 0
-            raise Exception
 
         task = PythonOperator(
             task_id='test_on_failure',

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -29,7 +29,6 @@ import pytest
 
 from airflow import settings
 from airflow.exceptions import AirflowException, AirflowFailException
-from airflow.executors.kubernetes_executor import KubernetesExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models.dag import DAG
@@ -540,7 +539,7 @@ class TestLocalTaskJob(unittest.TestCase):
         )
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
-        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=KubernetesExecutor())
+        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())
         job1.task_runner = StandardTaskRunner(job1)
 
         settings.engine.dispose()

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -520,6 +520,7 @@ class TestLocalTaskJob(unittest.TestCase):
             # This should not happen -- the state change should be noticed and the task should get killed
             with shared_mem_lock:
                 task_terminated_externally.value = 0
+            raise Exception
 
         task = PythonOperator(
             task_id='test_on_failure',
@@ -547,7 +548,7 @@ class TestLocalTaskJob(unittest.TestCase):
         process = multiprocessing.Process(target=job1.run)
         process.start()
 
-        for _ in range(0, 25):
+        for _ in range(0, 10):
             ti.refresh_from_db()
             if ti.state == State.RUNNING:
                 break

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -29,6 +29,7 @@ import pytest
 
 from airflow import settings
 from airflow.exceptions import AirflowException, AirflowFailException
+from airflow.executors.kubernetes_executor import KubernetesExecutor
 from airflow.executors.sequential_executor import SequentialExecutor
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models.dag import DAG
@@ -492,6 +493,69 @@ class TestLocalTaskJob(unittest.TestCase):
 
         process.join(timeout=10)
         assert success_callback_called.value == 1
+        assert task_terminated_externally.value == 1
+        assert not process.is_alive()
+
+    def test_process_kill_call_on_failure_callback(self):
+        """
+        Test that ensures that where a task is killed with sigterm
+        on_failure_callback gets executed
+        """
+        # use shared memory value so we can properly track value change even if
+        # it's been updated across processes.
+        failure_callback_called = Value('i', 0)
+        task_terminated_externally = Value('i', 1)
+        shared_mem_lock = Lock()
+
+        def failure_callback(context):
+            with shared_mem_lock:
+                failure_callback_called.value += 1
+            assert context['dag_run'].dag_id == 'test_mark_failure'
+
+        dag = DAG(dag_id='test_mark_failure', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
+
+        def task_function(ti):
+            # pylint: disable=unused-argument
+            time.sleep(60)
+            # This should not happen -- the state change should be noticed and the task should get killed
+            with shared_mem_lock:
+                task_terminated_externally.value = 0
+
+        task = PythonOperator(
+            task_id='test_on_failure',
+            python_callable=task_function,
+            on_failure_callback=failure_callback,
+            dag=dag,
+        )
+
+        session = settings.Session()
+
+        dag.clear()
+        dag.create_dagrun(
+            run_id="test",
+            state=State.RUNNING,
+            execution_date=DEFAULT_DATE,
+            start_date=DEFAULT_DATE,
+            session=session,
+        )
+        ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
+        ti.refresh_from_db()
+        job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=KubernetesExecutor())
+        job1.task_runner = StandardTaskRunner(job1)
+
+        settings.engine.dispose()
+        process = multiprocessing.Process(target=job1.run)
+        process.start()
+
+        for _ in range(0, 25):
+            ti.refresh_from_db()
+            if ti.state == State.RUNNING:
+                break
+            time.sleep(0.2)
+        assert ti.state == State.RUNNING
+        os.kill(ti.pid, 15)
+        process.join(timeout=10)
+        assert failure_callback_called.value == 1
         assert task_terminated_externally.value == 1
         assert not process.is_alive()
 


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/14422

Currently, on_failure_callback is only called when a task finishes
executing not while executing. When a pod is deleted, a SIGTERM is
sent to the task and the task is stopped immediately. The task is
still running when it was killed and therefore on_failure_callback
is not called.

This PR makes sure that when a pod is marked for deletion and the
task is killed, if the task has on_failure_callback, the callback
is called

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
