### PR TITLE
read timestamp from Cloudwatch events

### DIFF
--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -26,7 +26,6 @@ except ImportError:
     from cached_property import cached_property
 
 from airflow.configuration import conf
-from airflow.utils import timezone
 from airflow.utils.log.file_task_handler import FileTaskHandler
 from airflow.utils.log.logging_mixin import LoggingMixin
 
@@ -131,7 +130,7 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
             return msg
 
     def _event_to_str(self, event: dict) -> str:
-        event_dt = timezone.make_aware(datetime.utcfromtimestamp(event['timestamp'] / 1000.0))
-        formatted_event_dt = timezone.make_naive(event_dt).isoformat(timespec='seconds')
+        event_dt = datetime.utcfromtimestamp(event['timestamp'] / 1000.0)
+        formatted_event_dt = event_dt.strftime('%Y-%m-%d %H:%M:%S,%f')[:-3]
         message = event['message']
         return f'[{formatted_event_dt}] {message}'

--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -122,16 +122,16 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
                 )
             )
 
-            def event_to_str(event):
-                event_dt = timezone.make_aware(datetime.utcfromtimestamp(event['timestamp'] / 1000.0))
-                formatted_event_dt = timezone.make_naive(event_dt).isoformat(timespec='seconds')
-                message = event['message']
-                return f'[{formatted_event_dt}] {message}'
-
-            return '\n'.join([event_to_str(event) for event in events])
+            return '\n'.join([self._event_to_str(event) for event in events])
         except Exception:  # pylint: disable=broad-except
             msg = 'Could not read remote logs from log_group: {} log_stream: {}.'.format(
                 self.log_group, stream_name
             )
             self.log.exception(msg)
             return msg
+
+    def _event_to_str(self, event: dict) -> str:
+        event_dt = timezone.make_aware(datetime.utcfromtimestamp(event['timestamp'] / 1000.0))
+        formatted_event_dt = timezone.make_naive(event_dt).isoformat(timespec='seconds')
+        message = event['message']
+        return f'[{formatted_event_dt}] {message}'

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -122,17 +122,22 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
             self.remote_log_group,
             self.remote_log_stream,
             [
-                {'timestamp': 10000, 'message': 'First'},
-                {'timestamp': 20000, 'message': 'Second'},
-                {'timestamp': 30000, 'message': 'Third'},
+                {'timestamp': 1617400267000, 'message': 'First'},
+                {'timestamp': 1617400367000, 'message': 'Second'},
+                {'timestamp': 1617400467000, 'message': 'Third'},
             ],
         )
 
-        expected = (
-            '*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\nFirst\nSecond\nThird\n'
+        msg_template = '*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n'
+        events = '\n'.join(
+            [
+                '[2021-04-02T21:51:07] First',
+                '[2021-04-02T21:52:47] Second',
+                '[2021-04-02T21:54:27] Third',
+            ]
         )
         assert self.cloudwatch_task_handler.read(self.ti) == (
-            [[('', expected.format(self.remote_log_group, self.remote_log_stream))]],
+            [[('', msg_template.format(self.remote_log_group, self.remote_log_stream, events))]],
             [{'end_of_log': True}],
         )
 

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -112,6 +112,21 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
                 handler.handle(message)
             mock_emit.assert_has_calls([call(message) for message in messages])
 
+    def test_event_to_str(self):
+        handler = self.cloudwatch_task_handler
+        events = [
+            {'timestamp': 1617400267000, 'message': 'First'},
+            {'timestamp': 1617400367000, 'message': 'Second'},
+            {'timestamp': 1617400467000, 'message': 'Third'},
+        ]
+        assert [handler._event_to_str(event) for event in events] == (
+            [
+                '[2021-04-02T21:51:07] First',
+                '[2021-04-02T21:52:47] Second',
+                '[2021-04-02T21:54:27] Third',
+            ]
+        )
+
     def test_read(self):
         # Confirmed via AWS Support call:
         # CloudWatch events must be ordered chronologically otherwise

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -115,15 +115,15 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
     def test_event_to_str(self):
         handler = self.cloudwatch_task_handler
         events = [
-            {'timestamp': 1617400267000, 'message': 'First'},
-            {'timestamp': 1617400367000, 'message': 'Second'},
-            {'timestamp': 1617400467000, 'message': 'Third'},
+            {'timestamp': 1617400267123, 'message': 'First'},
+            {'timestamp': 1617400367456, 'message': 'Second'},
+            {'timestamp': 1617400467789, 'message': 'Third'},
         ]
         assert [handler._event_to_str(event) for event in events] == (
             [
-                '[2021-04-02T21:51:07] First',
-                '[2021-04-02T21:52:47] Second',
-                '[2021-04-02T21:54:27] Third',
+                '[2021-04-02 21:51:07,123] First',
+                '[2021-04-02 21:52:47,456] Second',
+                '[2021-04-02 21:54:27,789] Third',
             ]
         )
 
@@ -137,18 +137,18 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
             self.remote_log_group,
             self.remote_log_stream,
             [
-                {'timestamp': 1617400267000, 'message': 'First'},
-                {'timestamp': 1617400367000, 'message': 'Second'},
-                {'timestamp': 1617400467000, 'message': 'Third'},
+                {'timestamp': 1617400267123, 'message': 'First'},
+                {'timestamp': 1617400367456, 'message': 'Second'},
+                {'timestamp': 1617400467789, 'message': 'Third'},
             ],
         )
 
         msg_template = '*** Reading remote log from Cloudwatch log_group: {} log_stream: {}.\n{}\n'
         events = '\n'.join(
             [
-                '[2021-04-02T21:51:07] First',
-                '[2021-04-02T21:52:47] Second',
-                '[2021-04-02T21:54:27] Third',
+                '[2021-04-02 21:51:07,123] First',
+                '[2021-04-02 21:52:47,456] Second',
+                '[2021-04-02 21:54:27,789] Third',
             ]
         )
         assert self.cloudwatch_task_handler.read(self.ti) == (


### PR DESCRIPTION
Related: #15144. That's my first pr. Here is the main idea of the feature. The handler reads the timestamp of Cloudwatch events. So timestamp can be seen on the `Log` page of the task. Also I wanted to add a support of `DEFAULT_UI_TIMEZONE` here. Basically to format UTC timestamp with respect to specified UI timezone. However i found only the code that resolves `DEFAULT_TIMEZONE`. So i used it for now. Also i'm making `event_dt` as naive right before formatting in order to remove timezone information in logs. 

So my main question is is it fine to use `DEFAULT_TIMEZONE` for formatting of the timestamps? Or there should be similar resolver for `DEFAULT_UI_TIMEZONE` and timestamps are formatted with respect to specified ui timezone?