### PR TITLE
Create the S3MultipleKeySensor for the s3 service for aws provider

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3_multiple_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_multiple_key.py
@@ -1,0 +1,114 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import List, Optional, Union
+from urllib.parse import urlparse
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class S3MultipleKeySensor(BaseSensorOperator):
+    """
+    Waits for the keys (a file-like instance on S3) to be present in a S3 bucket.
+    S3 being a key/value it does not support folders. The path is just a key
+    a resource.
+
+    :param bucket_key: The key being waited on. Supports full s3:// style url
+        or relative path from root level. When it's specified as a full s3://
+        url different buckets for each key can be used, and lease leave
+         the bucket_name as `None`.
+    :type bucket_key: str
+    :param bucket_name: Name of the S3 bucket. Only needed when ``bucket_key``
+        is not provided as a full s3:// url.
+    :type bucket_name: str
+    :param wildcard_match: whether the bucket_key should be interpreted as a
+        Unix wildcard pattern
+    :type wildcard_match: bool
+    :param aws_conn_id: a reference to the s3 connection
+    :type aws_conn_id: str
+    :param verify: Whether or not to verify SSL certificates for S3 connection.
+        By default SSL certificates are verified.
+        You can provide the following values:
+
+        - ``False``: do not validate SSL certificates. SSL will still be used
+                 (unless use_ssl is False), but SSL certificates will not be
+                 verified.
+        - ``path/to/cert/bundle.pem``: A filename of the CA cert bundle to uses.
+                 You can specify this argument if you want to use a different
+                 CA cert bundle than the one used by botocore.
+    :type verify: bool or str
+    """
+
+    template_fields = ('bucket_keys', 'bucket_name')
+
+    @apply_defaults
+    def __init__(
+        self,
+        *,
+        bucket_keys: List[str],
+        bucket_name: Optional[str] = None,
+        wildcard_match: bool = False,
+        aws_conn_id: str = 'aws_default',
+        verify: Optional[Union[str, bool]] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.bucket_name = bucket_name
+        self.bucket_keys = bucket_keys
+        self.wildcard_match = wildcard_match
+        self.aws_conn_id = aws_conn_id
+        self.verify = verify
+        self.hook: Optional[S3Hook] = None
+
+    def poke(self, context):
+        for bucket_key in self.bucket_keys:
+            if self.bucket_name is None:
+                parsed_url = urlparse(bucket_key)
+                if parsed_url.netloc == '':
+                    raise AirflowException(
+                        'If key is a relative path from root, please provide a bucket_name'
+                    )
+                self.bucket_name = parsed_url.netloc
+                bucket_key = parsed_url.path.lstrip('/')
+            else:
+                parsed_url = urlparse(bucket_key)
+                if parsed_url.scheme != '' or parsed_url.netloc != '':
+                    raise AirflowException(
+                        'If bucket_name is provided, bucket_key'
+                        + ' should be relative path from root'
+                        + ' level, rather than a full s3:// url'
+                    )
+
+            self.log.info('Poking for key : s3://%s/%s', self.bucket_name, bucket_key)
+            if self.wildcard_match:
+                if not self.get_hook().check_for_wildcard_key(bucket_key, self.bucket_name):
+                    return False
+            if not self.get_hook().check_for_key(bucket_key, self.bucket_name):
+                return False
+        return True
+
+    def get_hook(self) -> S3Hook:
+        """Create and return an S3Hook"""
+        if self.hook:
+            return self.hook
+
+        self.hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
+        return self.hook

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -225,6 +225,7 @@ sensors:
     python-modules:
       - airflow.providers.amazon.aws.sensors.s3_key
       - airflow.providers.amazon.aws.sensors.s3_keys_unchanged
+      - airflow.providers.amazon.aws.sensors.s3_multiple_key
       - airflow.providers.amazon.aws.sensors.s3_prefix
   - integration-name: Amazon SageMaker
     python-modules:

--- a/docs/apache-airflow-providers-amazon/operators/s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/s3.rst
@@ -35,6 +35,7 @@ Airflow to Amazon Simple Storage Service (S3) integration provides several opera
 
  - :class:`~airflow.providers.amazon.aws.sensors.s3_key.S3KeySensor`
  - :class:`~airflow.providers.amazon.aws.sensors.s3_key.S3KeySizeSensor`
+ - :class:`~airflow.providers.amazon.aws.sensors.s3_multiple_key.S3MultipleKeySensor`
  - :class:`~airflow.providers.amazon.aws.sensors.s3_keys_unchanged.S3KeysUnchangedSensor`
  - :class:`~airflow.providers.amazon.aws.sensors.s3_prefix.S3PrefixSensor`
  - :class:`~airflow.providers.amazon.aws.operators.s3_bucket.S3CreateBucketOperator`

--- a/tests/providers/amazon/aws/sensors/test_s3_multiple_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_multiple_key.py
@@ -1,0 +1,154 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from datetime import datetime
+from unittest import mock
+
+import pytest
+from parameterized import parameterized
+
+from airflow.exceptions import AirflowException
+from airflow.models import TaskInstance
+from airflow.models.dag import DAG
+from airflow.models.variable import Variable
+from airflow.providers.amazon.aws.sensors.s3_multiple_key import S3MultipleKeySensor
+
+
+class TestS3MultipleKeySensor(unittest.TestCase):
+    def test_bucket_name_none_and_bucket_key_as_relative_path(self):
+        """
+        Test if exception is raised when bucket_name is None
+        and bucket_key is provided as relative path rather than s3:// url.
+        :return:
+        """
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor', bucket_keys=["file_1_in_bucket", "file_2_in_bucket"]
+        )
+        with pytest.raises(AirflowException):
+            op.poke(None)
+
+    def test_bucket_name_provided_and_bucket_key_is_s3_url(self):
+        """
+        Test if exception is raised when bucket_name is provided
+        while bucket_key is provided as a full s3:// url.
+        :return:
+        """
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor',
+            bucket_keys=["s3://test_bucket/file", "s3://test_bucket/file_2"],
+            bucket_name='test_bucket',
+        )
+        with pytest.raises(AirflowException):
+            op.poke(None)
+
+    @parameterized.expand(
+        [
+            [['s3://bucket/key'], None, ['s3://bucket/key'], 'bucket'],
+            [
+                ['s3://bucket/key_1', 's3://bucket/key_2'],
+                None,
+                ['s3://bucket/key_1', 's3://bucket/key_2'],
+                'bucket',
+            ],
+            [['key_1'], 'bucket', ['key_1'], 'bucket'],
+            [['key_1, key_2'], 'bucket', ['key_1, key_2'], 'bucket'],
+        ]
+    )
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_multiple_key.S3Hook')
+    def test_parse_bucket_key(self, key, bucket, parsed_key, parsed_bucket, mock_hook):
+        mock_hook.return_value.check_for_key.return_value = False
+
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor',
+            bucket_keys=key,
+            bucket_name=bucket,
+        )
+
+        op.poke(None)
+
+        assert op.bucket_keys == parsed_key
+        assert op.bucket_name == parsed_bucket
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_multiple_key.S3Hook')
+    def test_parse_bucket_key_from_jinja(self, mock_hook):
+        mock_hook.return_value.check_for_key.return_value = False
+
+        Variable.set("test_bucket_key_1", "s3://bucket/key_1")
+        Variable.set("test_bucket_key_2", "s3://bucket/key_2")
+
+        execution_date = datetime(2020, 1, 1)
+
+        dag = DAG("test_s3_key", start_date=execution_date)
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor',
+            bucket_keys=['{{ var.value.test_bucket_key_1 }}', '{{ var.value.test_bucket_key_2 }}'],
+            bucket_name=None,
+            dag=dag,
+        )
+
+        ti = TaskInstance(task=op, execution_date=execution_date)
+        context = ti.get_template_context()
+        ti.render_templates(context)
+
+        op.poke(None)
+
+        assert op.bucket_keys == ["s3://bucket/key_1", "s3://bucket/key_2"]
+        assert op.bucket_name == "bucket"
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_multiple_key.S3Hook')
+    def test_poke_for_nonexistent_keys(self, mock_hook):
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor', bucket_keys=['s3://test_bucket/file_1', 's3://test_bucket/file_2']
+        )
+
+        mock_check_for_key = mock_hook.return_value.check_for_key
+        mock_check_for_key.return_value = False
+        assert not op.poke(None)
+        mock_check_for_key.assert_called_once_with('file_1', op.bucket_name)
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_multiple_key.S3Hook')
+    def test_poke_for_found_keys(self, mock_hook):
+        op = S3MultipleKeySensor(task_id='s3_key_sensor', bucket_keys=['s3://test_bucket/file'])
+
+        mock_check_for_key = mock_hook.return_value.check_for_key
+        mock_check_for_key.return_value = True
+        assert op.poke(None)
+        mock_check_for_key.assert_called_once_with('file', op.bucket_name)
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_multiple_key.S3Hook')
+    def test_poke_wildcard_for_nonexistent_key(self, mock_hook):
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor', bucket_keys=['s3://test_bucket/file'], wildcard_match=True
+        )
+
+        mock_check_for_wildcard_key = mock_hook.return_value.check_for_wildcard_key
+        mock_check_for_wildcard_key.return_value = False
+        assert not op.poke(None)
+        mock_check_for_wildcard_key.assert_called_once_with('file', op.bucket_name)
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_multiple_key.S3Hook')
+    def test_poke_wildcard_for_found_key(self, mock_hook):
+        op = S3MultipleKeySensor(
+            task_id='s3_key_sensor', bucket_keys=['s3://test_bucket/file'], wildcard_match=True
+        )
+
+        mock_check_for_wildcard_key = mock_hook.return_value.check_for_wildcard_key
+        mock_check_for_wildcard_key.return_value = True
+        assert op.poke(None)
+        mock_check_for_wildcard_key.assert_called_once_with('file', op.bucket_name)


### PR DESCRIPTION
For cases where is needed to wait for multiples keys to exist on s3, this operator could help

closes: #15001

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
