### PR TITLE
Bugfix: resources in `executor_config` breaks Graph View in UI

### DIFF
--- a/airflow/utils/json.py
+++ b/airflow/utils/json.py
@@ -66,7 +66,7 @@ class AirflowJsonEncoder(JSONEncoder):
             obj, (np.float_, np.float16, np.float32, np.float64, np.complex_, np.complex64, np.complex128)
         ):
             return float(obj)
-        elif k8s is not None and isinstance(obj, k8s.V1Pod):
+        elif k8s is not None and isinstance(obj, (k8s.V1Pod, k8s.V1ResourceRequirements)):
             from airflow.kubernetes.pod_generator import PodGenerator
 
             return PodGenerator.serialize_pod(obj)


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/14327

When using `KubernetesExecutor` and the task as follows:

```python
PythonOperator(
    task_id=f"sync_{table_name}",
    python_callable=sync_table,
    provide_context=True,
    op_kwargs={"table_name": table_name},
    executor_config={"KubernetesExecutor": {"request_cpu": "1"}},
    retries=5,
    dag=dag,
)
```

it breaks the UI as settings resources in such a way is only there
for backwards compatibility.

This commits fixes it.

The new way of doing this is:

```
PythonOperator(
    task_id=f"sync_{table_name}",
    python_callable=sync_table,
    provide_context=True,
    op_kwargs={"table_name": table_name},
    executor_config={
        "pod_override": k8s.V1Pod(
            spec=k8s.V1PodSpec(
                containers=[
                    k8s.V1Container(
                        name="base",
                        resources=k8s.V1ResourceRequirements(requests={"cpu": "1"}),
                    )
                ]
            )
        )
    },
    retries=5,
    dag=dag,
)
```

But nevertheless this PR makes it work with old dags

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
