### PR TITLE
BugFix: CLI 'kubernetes cleanup-pods' should only clean up Airflow-created Pods

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1400,7 +1400,11 @@ CONFIG_COMMANDS = (
 KUBERNETES_COMMANDS = (
     ActionCommand(
         name='cleanup-pods',
-        help="Clean up Kubernetes pods in evicted/failed/succeeded states",
+        help=(
+            "Clean up Kubernetes pods "
+            "(created by KubernetesExecutor/KubernetesPodOperator) "
+            "in evicted/failed/succeeded states"
+        ),
         func=lazy_load_command('airflow.cli.commands.kubernetes_command.cleanup_pods'),
         args=(ARG_NAMESPACE,),
     ),

--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -90,7 +90,25 @@ def cleanup_pods(args):
     print('Loading Kubernetes configuration')
     kube_client = get_kube_client()
     print(f'Listing pods in namespace {namespace}')
-    list_kwargs = {"namespace": namespace, "limit": 500}
+    airflow_pod_labels = [
+        'airflow-worker',
+        'dag_id',
+        'task_id',
+        'execution_date',
+        'try_number',
+        'airflow_version',
+        'kubernetes_executor',
+    ]
+    list_kwargs = {
+        "namespace": namespace,
+        "limit": 500,
+        "label_selector": client.V1LabelSelector(
+            match_expressions=[
+                client.V1LabelSelectorRequirement(key=label, operator="Exists")
+                for label in airflow_pod_labels
+            ]
+        ),
+    }
     while True:  # pylint: disable=too-many-nested-blocks
         pod_list = kube_client.list_namespaced_pod(**list_kwargs)
         for pod in pod_list.items:

--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -91,13 +91,11 @@ def cleanup_pods(args):
     kube_client = get_kube_client()
     print(f'Listing pods in namespace {namespace}')
     airflow_pod_labels = [
-        'airflow-worker',
         'dag_id',
         'task_id',
         'execution_date',
         'try_number',
         'airflow_version',
-        'kubernetes_executor',
     ]
     list_kwargs = {
         "namespace": namespace,

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -56,10 +56,10 @@ class TestGenerateDagYamlCommand(unittest.TestCase):
 
 class TestCleanUpPodsCommand(unittest.TestCase):
     label_selector = kubernetes.client.V1LabelSelector(
-            match_expressions=[
-                kubernetes.client.V1LabelSelectorRequirement(key=label, operator="Exists")
-                for label in ['dag_id', 'task_id', 'execution_date', 'try_number', 'airflow_version']
-            ]
+        match_expressions=[
+            kubernetes.client.V1LabelSelectorRequirement(key=label, operator="Exists")
+            for label in ['dag_id', 'task_id', 'execution_date', 'try_number', 'airflow_version']
+        ]
     )
 
     @classmethod
@@ -86,8 +86,9 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
-                                                    label_selector=self.label_selector)
+        list_namespaced_pod.assert_called_once_with(
+            namespace='awesome-namespace', limit=500, label_selector=self.label_selector
+        )
         delete_pod.assert_not_called()
         load_incluster_config.assert_called_once()
 
@@ -106,8 +107,9 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
-                                                    label_selector=self.label_selector)
+        list_namespaced_pod.assert_called_once_with(
+            namespace='awesome-namespace', limit=500, label_selector=self.label_selector
+        )
         delete_pod.assert_called_with('dummy', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -129,8 +131,9 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
-                                                    label_selector=self.label_selector)
+        list_namespaced_pod.assert_called_once_with(
+            namespace='awesome-namespace', limit=500, label_selector=self.label_selector
+        )
         delete_pod.assert_not_called()
         load_incluster_config.assert_called_once()
 
@@ -152,8 +155,9 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
-                                                    label_selector=self.label_selector)
+        list_namespaced_pod.assert_called_once_with(
+            namespace='awesome-namespace', limit=500, label_selector=self.label_selector
+        )
         delete_pod.assert_called_with('dummy3', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -173,8 +177,9 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
-                                                    label_selector=self.label_selector)
+        list_namespaced_pod.assert_called_once_with(
+            namespace='awesome-namespace', limit=500, label_selector=self.label_selector
+        )
         delete_pod.assert_called_with('dummy4', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -194,8 +199,9 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
-                                                    label_selector=self.label_selector)
+        list_namespaced_pod.assert_called_once_with(
+            namespace='awesome-namespace', limit=500, label_selector=self.label_selector
+        )
         load_incluster_config.assert_called_once()
 
     @mock.patch('airflow.cli.commands.kubernetes_command._delete_pod')
@@ -217,11 +223,13 @@ class TestCleanUpPodsCommand(unittest.TestCase):
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
         calls = [
-            call.first(namespace='awesome-namespace', limit=500,
-                       label_selector=self.label_selector),
-            call.second(namespace='awesome-namespace', limit=500,
-                        label_selector=self.label_selector,
-                        _continue='dummy-token'),
+            call.first(namespace='awesome-namespace', limit=500, label_selector=self.label_selector),
+            call.second(
+                namespace='awesome-namespace',
+                limit=500,
+                label_selector=self.label_selector,
+                _continue='dummy-token',
+            ),
         ]
         list_namespaced_pod.assert_has_calls(calls)
         delete_pod.assert_called_with('dummy', 'awesome-namespace')

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -55,6 +55,14 @@ class TestGenerateDagYamlCommand(unittest.TestCase):
 
 
 class TestCleanUpPodsCommand(unittest.TestCase):
+    label_selector = kubernetes.client.V1LabelSelector(
+            match_expressions=[
+                kubernetes.client.V1LabelSelectorRequirement(key=label, operator="Exists")
+                for label in ['airflow-worker', 'dag_id', 'task_id', 'execution_date',
+                              'try_number', 'airflow_version', 'kubernetes_executor']
+            ]
+    )
+
     @classmethod
     def setUpClass(cls):
         cls.parser = cli_parser.get_parser()
@@ -79,7 +87,8 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
+                                                    label_selector=self.label_selector)
         delete_pod.assert_not_called()
         load_incluster_config.assert_called_once()
 
@@ -98,7 +107,8 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
+                                                    label_selector=self.label_selector)
         delete_pod.assert_called_with('dummy', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -120,7 +130,8 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
+                                                    label_selector=self.label_selector)
         delete_pod.assert_not_called()
         load_incluster_config.assert_called_once()
 
@@ -142,7 +153,8 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
+                                                    label_selector=self.label_selector)
         delete_pod.assert_called_with('dummy3', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -162,7 +174,8 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
+                                                    label_selector=self.label_selector)
         delete_pod.assert_called_with('dummy4', 'awesome-namespace')
         load_incluster_config.assert_called_once()
 
@@ -182,7 +195,8 @@ class TestCleanUpPodsCommand(unittest.TestCase):
         kubernetes_command.cleanup_pods(
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
-        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500)
+        list_namespaced_pod.assert_called_once_with(namespace='awesome-namespace', limit=500,
+                                                    label_selector=self.label_selector)
         load_incluster_config.assert_called_once()
 
     @mock.patch('airflow.cli.commands.kubernetes_command._delete_pod')
@@ -204,8 +218,11 @@ class TestCleanUpPodsCommand(unittest.TestCase):
             self.parser.parse_args(['kubernetes', 'cleanup-pods', '--namespace', 'awesome-namespace'])
         )
         calls = [
-            call.first(namespace='awesome-namespace', limit=500),
-            call.second(namespace='awesome-namespace', limit=500, _continue='dummy-token'),
+            call.first(namespace='awesome-namespace', limit=500,
+                       label_selector=self.label_selector),
+            call.second(namespace='awesome-namespace', limit=500,
+                        label_selector=self.label_selector,
+                        _continue='dummy-token'),
         ]
         list_namespaced_pod.assert_has_calls(calls)
         delete_pod.assert_called_with('dummy', 'awesome-namespace')

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -58,8 +58,7 @@ class TestCleanUpPodsCommand(unittest.TestCase):
     label_selector = kubernetes.client.V1LabelSelector(
             match_expressions=[
                 kubernetes.client.V1LabelSelectorRequirement(key=label, operator="Exists")
-                for label in ['airflow-worker', 'dag_id', 'task_id', 'execution_date',
-                              'try_number', 'airflow_version', 'kubernetes_executor']
+                for label in ['dag_id', 'task_id', 'execution_date', 'try_number', 'airflow_version']
             ]
     )
 


### PR DESCRIPTION
closes: #15193

Currently condition `if the pod is created by Airflow` is not considered. This commit fixes this.

We decide if the Pod is created by Airflow via checking if it has all the labels added in [`PodGenerator.construct_pod()`](https://github.com/apache/airflow/blob/2.0.1/airflow/kubernetes/pod_generator.py#L385) or `KubernetesPodOperator.create_labels_for_pod()`.

Test added.
