### PR TITLE
Fixed #14270: Add error message in OOM situations

### DIFF
--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -121,3 +121,11 @@ class StandardTaskRunner(BaseTaskRunner):
         if self._rc is None:
             # Something else reaped it before we had a chance, so let's just "guess" at an error code.
             self._rc = -9
+
+        if self._rc == -9:
+            # If either we or psutil gives out a -9 return code, it likely means
+            # an OOM happened
+            self.log.error(
+                'Job %s was killed before it finished (likely due to running out of memory)',
+                self._task_instance.job_id,
+            )


### PR DESCRIPTION
In the case where a child process is reaped early (before we get to it) the presumption in the code is that it is due to an OOM error and either we or psutil set the return code to `-9`. This adds an error message alongside that return code to make it more obvious.

It also adds a test that checks this overall functionality, and in the process of doing that switches the StandardTaskRunner tests to use `pytest`-style tests rather than a TestCase, as otherwise we can't use the `caplog` fixture. It also removes the apparently unnecessary logging propagation removal in this file.

closes: #14270