### PR TITLE
Add support for modifying celery worker deployment strategy

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -46,6 +46,9 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+  {{ if .Values.workers.updateStrategy }}
+{{ toYaml .Values.workers.updateStrategy | indent 2 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -72,3 +72,19 @@ class WorkerTest(unittest.TestCase):
 
         assert "127.0.0.2" == jmespath.search("spec.template.spec.hostAliases[0].ip", docs[0])
         assert "test.hostname" == jmespath.search("spec.template.spec.hostAliases[0].hostnames[0]", docs[0])
+
+    def test_workers_update_strategy(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {
+                    "updateStrategy": {
+                        "strategy": {"rollingUpdate": {"maxSurge": "100%", "maxUnavailable": "50%"}}
+                    },
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert "100%" == jmespath.search("spec.strategy.rollingUpdate.maxSurge", docs[0])
+        assert "50%" == jmespath.search("spec.strategy.rollingUpdate.maxUnavailable", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -560,6 +560,10 @@
                     "description": "Number of airflow celery workers in StatefulSet.",
                     "type": "integer"
                 },
+                "updateStrategy": {
+                    "description": "Specifies the strategy used to replace old Pods by new ones.",
+                    "type": "object"
+                },
                 "keda": {
                     "description": "KEDA configuration.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -299,6 +299,11 @@ kerberos:
 workers:
   # Number of airflow celery workers in StatefulSet
   replicas: 1
+  updateStrategy:
+    strategy:
+      rollingUpdate:
+        maxSurge: "100%"
+        maxUnavailable: "50%"
 
   # Allow KEDA autoscaling.
   # Persistence.enabled must be set to false to use KEDA.

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -279,6 +279,9 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``workers.hostAliases``
      - HostAliases to use in Celery workers
      - ``[]``
+   * - ``workers.updateStrategy``
+     - The strategy used to replace old Pods by new ones.
+     - ``{"rollingUpdate": {"maxSurge": "100%", "maxUnavailable": "50%"}``
    * - ``scheduler.podDisruptionBudget.enabled``
      - Enable PDB on Airflow scheduler
      - ``1``


### PR DESCRIPTION
This commit modifies the worker template to allow passing a non-default deployment update strategy to worker deployments, in particular celery workers. The values have been set to allow 100% `maxSurge` and 50% `maxUnavailable` allowing new deployments of celery workers to launch a full set of replicas before the old set goes away. Allowing the new workers to pick up work as quickly as possible, rather than the current default which is 1 at a time.

`maxSurge` is the number of pods that will be scheduled beyond the replica count during a rolling deploy. You can specify specific values or percentages. For example if you set the `Marburger to 100% and had 4 replicas, when a rolling deployment started it would launch 4 new pods and then scale down the old ones as the new ones came online.

This is explained here: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
