### PR TITLE
Fix deprecated warning hvac auth

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -319,11 +319,11 @@ class _VaultClient(LoggingMixin):  # pylint: disable=too-many-instance-attribute
 
     def _auth_approle(self, _client: hvac.Client) -> None:
         if self.auth_mount_point:
-            _client.auth_approle(
+            _client.auth.approle.login(
                 role_id=self.role_id, secret_id=self.secret_id, mount_point=self.auth_mount_point
             )
         else:
-            _client.auth_approle(role_id=self.role_id, secret_id=self.secret_id)
+            _client.auth.approle.login(role_id=self.role_id, secret_id=self.secret_id)
 
     def _set_token(self, _client: hvac.Client) -> None:
         if self.token_path:

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -58,7 +58,7 @@ class TestVaultClient(TestCase):
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url='http://localhost:8180')
-        client.auth_approle.assert_called_with(role_id="role", secret_id="pass")
+        client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
 
@@ -75,7 +75,7 @@ class TestVaultClient(TestCase):
         )
         client = vault_client.client
         mock_hvac.Client.assert_called_with(url='http://localhost:8180')
-        client.auth_approle.assert_called_with(role_id="role", secret_id="pass", mount_point="other")
+        client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass", mount_point="other")
         client.is_authenticated.assert_called_with()
         assert 2 == vault_client.kv_engine_version
 

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -185,7 +185,7 @@ class TestVaultHook(TestCase):
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url=expected_url)
-        test_client.auth_approle.assert_called_with(role_id="role", secret_id="pass")
+        test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 
@@ -211,7 +211,7 @@ class TestVaultHook(TestCase):
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url='http://localhost:8180')
-        test_client.auth_approle.assert_called_with(role_id="role", secret_id="pass")
+        test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 
@@ -237,7 +237,7 @@ class TestVaultHook(TestCase):
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url='http://localhost:8180')
-        test_client.auth_approle.assert_called_with(role_id="role", secret_id="pass")
+        test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 


### PR DESCRIPTION
Fixes the following Hashicorp Vault (hvac) approle auth deprecation warning:
```
DeprecationWarning: Call to deprecated function 'auth_approle'. This method will be removed in version '0.12.0' Please use the 'login' method on the 'hvac.api.auth_methods.approle' class moving forward.
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
