### PR TITLE
Fix semantic mistake in ISSUE_TRIAGE_PROCESS.rst

### DIFF
--- a/ISSUE_TRIAGE_PROCESS.rst
+++ b/ISSUE_TRIAGE_PROCESS.rst
@@ -26,7 +26,7 @@ Airflow including labels, milestones, and priorities as well as the process
 of resolving issues.
 
 An unusual element of the Apache Airflow project is that you can open a PR
-to fix an issue or make an enhancement, without needing to open a PR first.
+to fix an issue or make an enhancement, without needing to open an issue first.
 This is intended to make it as easy as possible to contribute to
 the project.
 


### PR DESCRIPTION
Fixed a small semantic mistake in the documentation:
>An unusual element of the Apache Airflow project is that you can **open a PR** to fix an issue or make an enhancement, **without needing to open a PR** first.