### PR TITLE
S3Hook.load_file should accept Path object in addition to str

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -26,7 +26,7 @@ import shutil
 from functools import wraps
 from inspect import signature
 from io import BytesIO
-from pathlib import Path
+from pathlib import PurePosixPath
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 from urllib.parse import urlparse
@@ -465,7 +465,7 @@ class S3Hook(AwsBaseHook):
     @unify_bucket_name_and_key
     def load_file(
         self,
-        filename: Union[Path, str],
+        filename: Union[PurePosixPath, str],
         key: str,
         bucket_name: Optional[str] = None,
         replace: bool = False,
@@ -477,7 +477,7 @@ class S3Hook(AwsBaseHook):
         Loads a local file to S3
 
         :param filename: path to the file to load.
-        :type filename: Union[Path, str]
+        :type filename: Union[PurePosixPath, str]
         :param key: S3 key that will point to the file
         :type key: str
         :param bucket_name: Name of the bucket in which to store the file
@@ -495,7 +495,7 @@ class S3Hook(AwsBaseHook):
             uploaded to the S3 bucket.
         :type acl_policy: str
         """
-        filename = filename.as_posix() if isinstance(filename, Path) else filename
+        filename = str(filename)
         if not replace and self.check_for_key(key, bucket_name):
             raise ValueError(f"The key {key} already exists.")
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -465,7 +465,7 @@ class S3Hook(AwsBaseHook):
     @unify_bucket_name_and_key
     def load_file(
         self,
-        filename: Union[str, Path],
+        filename: Union[Path, str],
         key: str,
         bucket_name: Optional[str] = None,
         replace: bool = False,
@@ -476,8 +476,8 @@ class S3Hook(AwsBaseHook):
         """
         Loads a local file to S3
 
-        :param filename: name of the file to load.
-        :type filename: str
+        :param filename: path to the file to load.
+        :type filename: Union[Path, str]
         :param key: S3 key that will point to the file
         :type key: str
         :param bucket_name: Name of the bucket in which to store the file

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -26,6 +26,7 @@ import shutil
 from functools import wraps
 from inspect import signature
 from io import BytesIO
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 from urllib.parse import urlparse
@@ -464,7 +465,7 @@ class S3Hook(AwsBaseHook):
     @unify_bucket_name_and_key
     def load_file(
         self,
-        filename: str,
+        filename: Union[str, Path],
         key: str,
         bucket_name: Optional[str] = None,
         replace: bool = False,
@@ -494,6 +495,7 @@ class S3Hook(AwsBaseHook):
             uploaded to the S3 bucket.
         :type acl_policy: str
         """
+        filename = filename.as_posix() if isinstance(filename, Path) else filename
         if not replace and self.check_for_key(key, bucket_name):
             raise ValueError(f"The key {key} already exists.")
 

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -26,7 +26,7 @@ import shutil
 from functools import wraps
 from inspect import signature
 from io import BytesIO
-from pathlib import PurePosixPath
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Callable, Dict, List, Optional, Tuple, TypeVar, Union, cast
 from urllib.parse import urlparse
@@ -465,7 +465,7 @@ class S3Hook(AwsBaseHook):
     @unify_bucket_name_and_key
     def load_file(
         self,
-        filename: Union[PurePosixPath, str],
+        filename: Union[Path, str],
         key: str,
         bucket_name: Optional[str] = None,
         replace: bool = False,
@@ -477,7 +477,7 @@ class S3Hook(AwsBaseHook):
         Loads a local file to S3
 
         :param filename: path to the file to load.
-        :type filename: Union[PurePosixPath, str]
+        :type filename: Union[Path, str]
         :param key: S3 key that will point to the file
         :type key: str
         :param bucket_name: Name of the bucket in which to store the file


### PR DESCRIPTION
When uploading files to s3 it's convenient to be able to use Path objects

Since I'm not changing behavior I think it may be OK to not write additional test but let me know if you think it's warranted.