### PR TITLE
Allow SQSSensor to filter messages by their attribute names

### DIFF
--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -38,6 +38,8 @@ class SQSSensor(BaseSensorOperator):
     :type max_messages: int
     :param wait_time_seconds: The time in seconds to wait for receiving messages (default: 1 second)
     :type wait_time_seconds: int
+    :param message_attribute_names: The message attribute names to filter receiving messages (default: All Messages)
+    :type wait_time_seconds: list
     """
 
     template_fields = ('sqs_queue', 'max_messages')
@@ -50,6 +52,7 @@ class SQSSensor(BaseSensorOperator):
         aws_conn_id: str = 'aws_default',
         max_messages: int = 5,
         wait_time_seconds: int = 1,
+        message_attribute_names: list = ['.*']
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -57,6 +60,7 @@ class SQSSensor(BaseSensorOperator):
         self.aws_conn_id = aws_conn_id
         self.max_messages = max_messages
         self.wait_time_seconds = wait_time_seconds
+        elf.message_attribute_names = message_attribute_names
         self.hook: Optional[SQSHook] = None
 
     def poke(self, context):
@@ -75,6 +79,7 @@ class SQSSensor(BaseSensorOperator):
             QueueUrl=self.sqs_queue,
             MaxNumberOfMessages=self.max_messages,
             WaitTimeSeconds=self.wait_time_seconds,
+            MessageAttributeNames=self.message_attribute_names,
         )
 
         self.log.info("received message %s", str(messages))


### PR DESCRIPTION
Ability to filter messages by their attribute names using MessageAttributeNames filter.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
