### PR TITLE
adds airflowConfigAnnotations field to allow for the setting of the main configmaps annotations

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -31,6 +31,10 @@ metadata:
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end -}}
+{{- if .Values.airflowConfigAnnotations }}
+  annotations:
+{{- toYaml .Values.airflowConfigAnnotations | nindent 4 }}
+{{- end }}
 {{- $Global := . }}
 data:
   # These are system-specified config overrides.

--- a/chart/tests/test_configmap.py
+++ b/chart/tests/test_configmap.py
@@ -26,9 +26,7 @@ class ConfigmapTest(unittest.TestCase):
     def test_single_annotation(self):
         docs = render_chart(
             values={
-                "airflowConfigAnnotations": {
-                    "key": "value"
-                },
+                "airflowConfigAnnotations": {"key": "value"},
             },
             show_only=["templates/configmaps/configmap.yaml"],
         )
@@ -39,10 +37,7 @@ class ConfigmapTest(unittest.TestCase):
     def test_multiple_annotations(self):
         docs = render_chart(
             values={
-                "airflowConfigAnnotations": {
-                    "key": "value",
-                    "key-two": "value-two"
-                },
+                "airflowConfigAnnotations": {"key": "value", "key-two": "value-two"},
             },
             show_only=["templates/configmaps/configmap.yaml"],
         )

--- a/chart/tests/test_configmap.py
+++ b/chart/tests/test_configmap.py
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import jmespath
+
+from tests.helm_template_generator import render_chart
+
+
+class ConfigmapTest(unittest.TestCase):
+    def test_single_annotation(self):
+        docs = render_chart(
+            values={
+                "airflowConfigAnnotations": {
+                    "key": "value"
+                },
+            },
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert "value" == annotations.get("key")
+
+    def test_multiple_annotations(self):
+        docs = render_chart(
+            values={
+                "airflowConfigAnnotations": {
+                    "key": "value",
+                    "key-two": "value-two"
+                },
+            },
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert "value" == annotations.get("key")
+        assert "value-two" == annotations.get("key-two")

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -163,7 +163,7 @@
             "type": "object"
         },
         "airflowConfigAnnotations": {
-            "description": "Extra annotations to apply to the main Airflow configs.",
+            "description": "Extra annotations to apply to the main Airflow configmap.",
             "type": "object"
         },
         "rbac": {

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -162,6 +162,10 @@
             "description": "Extra annotations to apply to all Airflow pods.",
             "type": "object"
         },
+        "airflowConfigAnnotations": {
+            "description": "Extra annotations to apply to the main Airflow configs.",
+            "type": "object"
+        },
         "rbac": {
             "description": "Enable RBAC (default on most clusters these days).",
             "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -111,6 +111,10 @@ networkPolicies:
 # Airflow pods
 airflowPodAnnotations: {}
 
+# Extra annotations to apply to
+# Airflow's main config
+airflowConfigAnnotations: {}
+
 # Enable RBAC (default on most clusters these days)
 rbac:
   # Specifies whether RBAC resources should be created

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -112,7 +112,7 @@ networkPolicies:
 airflowPodAnnotations: {}
 
 # Extra annotations to apply to
-# Airflow's main config
+# main Airflow configmap
 airflowConfigAnnotations: {}
 
 # Enable RBAC (default on most clusters these days)

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -75,6 +75,12 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``rbac.create``
      - Deploy pods with Kubernetes RBAC enabled
      - ``true``
+   * - ``airflowPodAnnotations``
+     - Extra annotations to apply to all Airflow pods.
+     - ``{}``
+   * - ``airflowConfigAnnotations``
+     - Extra annotations to apply to the main Airflow configs.
+     - ``{}``
    * - ``executor``
      - Airflow executor (eg SequentialExecutor, LocalExecutor, CeleryExecutor, KubernetesExecutor)
      - ``1``

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -79,7 +79,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
      - Extra annotations to apply to all Airflow pods.
      - ``{}``
    * - ``airflowConfigAnnotations``
-     - Extra annotations to apply to the main Airflow configs.
+     - Extra annotations to apply to the main Airflow configmap.
      - ``{}``
    * - ``executor``
      - Airflow executor (eg SequentialExecutor, LocalExecutor, CeleryExecutor, KubernetesExecutor)


### PR DESCRIPTION
# Overview
This PR adds a new field (`airflowConfigAnnotations`) that allows users to add `annotations` to the main `configmap.yaml` file. 

I ended up setting up a new testing file as I didn't find a file where this specifically fit, but if it should be moved elsewhere let me know.


related: https://github.com/apache/airflow/issues/13643


