### PR TITLE
Revert "Fixes failing docs upload on master (#15148)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: >
           github.ref == 'refs/heads/master' && github.repository == 'apache/airflow' &&
           github.event_name == 'push'
-        run: aws s3 sync --delete ./docs/_build s3://apache-airflow-docs
+        run: aws s3 sync --delete ./files/documentation s3://apache-airflow-docs
 
   prepare-test-provider-packages-wheel:
     timeout-minutes: 40


### PR DESCRIPTION
This reverts commit 83d702c345f8f4ce16d32268f4f83ee508fea676.

We use less Docker in the documentation build process, so the files are in a different directory.
Related: https://github.com/apache/airflow/pull/15176

This also affects other workflows on PRs as the cache is not updated, so it's worth merging ASAP.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
