### PR TITLE
Fix tasks in an infinite slots pool were never scheduled

### DIFF
--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -106,6 +106,8 @@ class Pool(Base):
 
         pool_rows: Iterable[Tuple[str, int]] = query.all()
         for (pool_name, total_slots) in pool_rows:
+            if total_slots == -1:
+                total_slots = float('inf')  # type: ignore
             pools[pool_name] = PoolStats(total=total_slots, running=0, queued=0, open=0)
 
         state_count_by_pool = (

--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -117,8 +117,10 @@ class Pool(Base):
         ).all()
 
         # calculate queued and running metrics
-        count: int
         for (pool_name, state, count) in state_count_by_pool:
+            # Some databases return decimal.Decimal here.
+            count = int(count)
+
             stats_dict: Optional[PoolStats] = pools.get(pool_name)
             if not stats_dict:
                 continue

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -110,10 +110,10 @@ class TestPool(unittest.TestCase):
                 "running": 0,
             },
             "test_pool": {
-                "open": -1,
+                "open": float('inf'),
                 "queued": 1,
                 "running": 1,
-                "total": -1,
+                "total": float('inf'),
             },
         } == pool.slots_stats()
 


### PR DESCRIPTION
Should fix #14515.

I saw 3 ways of fixing it:
1. do a DB migration to represent an infinite pool with `maxint` slots instead of `-1`.
2. do the same thing but at runtime in `slots_stats`.
3. get `_executable_task_instances_to_queued` to understand `-1` pools, changing all code operating on `pool_slots_free` and `open_slots ` [#](https://github.com/apache/airflow/blob/master/airflow/jobs/scheduler_job.py#L908) [#](https://github.com/apache/airflow/blob/master/airflow/jobs/scheduler_job.py#L975) [#](https://github.com/apache/airflow/blob/master/airflow/jobs/scheduler_job.py#L992) [#](https://github.com/apache/airflow/blob/master/airflow/jobs/scheduler_job.py#L1045) [#](https://github.com/apache/airflow/blob/master/airflow/jobs/scheduler_job.py#L1060)

As to why I chose 2:
1. could be a decent alternative but it's a DB migration with all the complexities inherent to it.
2. is relatively non-intrusive: it's almost free to do it at runtime and it keeps the change completely in the core Python part of Airflow ( in case someone out there directly creates pools by inserting them in his DB 😨 )
3. has the benefit of truly handling infinite pools but I doubt anyone has reached a scale where it matters ( we're talking about a pool with `9223372036854775807` slots here on my system ), plus it increases the overall complexity of that function which is close to the core of the scheduler, we might as well try to keep it as lean as possible.
