### PR TITLE
Documentation: Fix name of setting to use internal IP in docs (use_private -> use_internal_ip)

### DIFF
--- a/docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
@@ -110,7 +110,7 @@ output of ``gcloud container clusters describe`` in the endpoint field.
 Private clusters have two unique endpoint values: ``privateEndpoint``, which is an internal IP address, and
 ``publicEndpoint``, which is an external one. Running ``GKEStartPodOperator`` against a private cluster
 sets the external IP address as the endpoint by default. If you prefer to use the internal IP as the
-endpoint, you need to set ``use_private`` parameter to ``True``.
+endpoint, you need to set ``use_internal_ip`` parameter to ``True``.
 
 Use of XCom
 '''''''''''


### PR DESCRIPTION
The setting described in the docs is incorrect.
Introduced in b1c8c5ed5b

