### PR TITLE
Prevent datepicker submit on page load

### DIFF
--- a/airflow/www/static/js/task_instance.js
+++ b/airflow/www/static/js/task_instance.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-document.addEventListener('DOMContentLoaded', () => {
+$(document).ready(() => {
   function dateChange() {
     // We don't want to navigate away if the datetimepicker is still visible
     if ($('.datetimepicker bootstrap-datetimepicker-widget :visible').length > 0) {


### PR DESCRIPTION
Fixes #15103

Switching the 'has the document loaded' function removes a phantom `onChange` event from firing and submitting the form when the page loads and changing the url.

What is really happening is that the datetimepicker doesn't have millisecond precision (nor should it from a UX perspective), but getting logs do require millisecond precision. Even being 1 millisecond off will not load logs. Therefore any manipulation of the datetimepicker will still break logs. Long term, we should go down to at least second precision, if not even moreso.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
