### PR TITLE
Add worker_pod_pending_timeout support 

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2149,6 +2149,28 @@
       type: boolean
       example: ~
       default: "True"
+    - name: worker_pods_pending_timeout
+      description: |
+        How long in seconds a worker can be in Pending before it is considered a failure
+      version_added: 2.1.0
+      type: integer
+      example: ~
+      default: "300"
+    - name: worker_pods_pending_timeout_check_interval
+      description: |
+        How often in seconds to check if Pending workers have exceeded their timeouts
+      version_added: 2.1.0
+      type: integer
+      example: ~
+      default: "120"
+    - name: worker_pods_pending_timeout_batch_size
+      description: |
+        How many pending pods to check for timeout violations in each check interval.
+        You may want this higher if you have a very large cluster and/or use ``multi_namespace_mode``.
+      version_added: 2.1.0
+      type: integer
+      example: ~
+      default: "100"
 - name: smart_sensor
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1063,6 +1063,16 @@ tcp_keep_cnt = 6
 # Set this to false to skip verifying SSL certificate of Kubernetes python client.
 verify_ssl = True
 
+# How long in seconds a worker can be in Pending before it is considered a failure
+worker_pods_pending_timeout = 300
+
+# How often in seconds to check if Pending workers have exceeded their timeouts
+worker_pods_pending_timeout_check_interval = 120
+
+# How many pending pods to check for timeout violations in each check interval.
+# You may want this higher if you have a very large cluster and/or use ``multi_namespace_mode``.
+worker_pods_pending_timeout_batch_size = 100
+
 [smart_sensor]
 # When `use_smart_sensor` is True, Airflow redirects multiple qualified sensor tasks to
 # smart sensor task.

--- a/airflow/kubernetes/kube_config.py
+++ b/airflow/kubernetes/kube_config.py
@@ -59,10 +59,18 @@ class KubeConfig:  # pylint: disable=too-many-instance-attributes
         # interact with cluster components.
         self.executor_namespace = conf.get(self.kubernetes_section, 'namespace')
 
+        self.worker_pods_pending_timeout = conf.getint(self.kubernetes_section, 'worker_pods_pending_timeout')
+        self.worker_pods_pending_timeout_check_interval = conf.getint(
+            self.kubernetes_section, 'worker_pods_pending_timeout_check_interval'
+        )
+        self.worker_pods_pending_timeout_batch_size = conf.getint(
+            self.kubernetes_section, 'worker_pods_pending_timeout_batch_size'
+        )
+
         kube_client_request_args = conf.get(self.kubernetes_section, 'kube_client_request_args')
         if kube_client_request_args:
             self.kube_client_request_args = json.loads(kube_client_request_args)
-            if self.kube_client_request_args['_request_timeout'] and isinstance(
+            if '_request_timeout' in self.kube_client_request_args and isinstance(
                 self.kube_client_request_args['_request_timeout'], list
             ):
                 self.kube_client_request_args['_request_timeout'] = tuple(

--- a/airflow/utils/event_scheduler.py
+++ b/airflow/utils/event_scheduler.py
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sched import scheduler
+from typing import Callable
+
+
+class EventScheduler(scheduler):
+    """General purpose event scheduler"""
+
+    def call_regular_interval(
+        self,
+        delay: float,
+        action: Callable,
+        arguments=(),
+        kwargs={},
+    ):  # pylint: disable=dangerous-default-value
+        """Helper to call a function at (roughly) a given interval"""
+
+        def repeat(*args, **kwargs):
+            action(*args, **kwargs)
+            # This is not perfect. If we want a timer every 60s, but action
+            # takes 10s to run, this will run it every 70s.
+            # Good enough for now
+            self.enter(delay, 1, repeat, args, kwargs)
+
+        self.enter(delay, 1, repeat, arguments, kwargs)

--- a/tests/utils/test_event_scheduler.py
+++ b/tests/utils/test_event_scheduler.py
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest import mock
+
+from airflow.utils.event_scheduler import EventScheduler
+
+
+class TestEventScheduler(unittest.TestCase):
+    def test_call_regular_interval(self):
+        somefunction = mock.MagicMock()
+
+        timers = EventScheduler()
+        timers.call_regular_interval(30, somefunction)
+        assert len(timers.queue) == 1
+        somefunction.assert_not_called()
+
+        # Fake a run (it won't actually pop from the queue):
+        timers.queue[0].action()
+
+        # Make sure it added another event to the queue
+        assert len(timers.queue) == 2
+        somefunction.assert_called_once()
+        assert timers.queue[0].time < timers.queue[1].time


### PR DESCRIPTION
Instead of allowing pending worker pods to be stuck in pending forever,
we define a timeout after which point they will be deleted and marked as
failed. This allows the retry mechanism to be applied to these tasks as
well.

closes: #15218