### PR TITLE
Fix typo in a docstring

### DIFF
--- a/airflow/providers/google/cloud/operators/gcs.py
+++ b/airflow/providers/google/cloud/operators/gcs.py
@@ -174,7 +174,7 @@ class GCSCreateBucketOperator(BaseOperator):
 
 class GCSListObjectsOperator(BaseOperator):
     """
-    List all objects from the bucket with the give string prefix and delimiter in name.
+    List all objects from the bucket with the given string prefix and delimiter in name.
 
     This operator returns a python list with the name of objects which can be used by
      `xcom` in the downstream task.


### PR DESCRIPTION
This PR fixes a typo in a docstring to GCSListObjectsOperator class.
