### PR TITLE
Fix: allow hiding of all edges in Graph when highlighting states

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -43,7 +43,8 @@ svg {
   transition: stroke 0.2s ease-in-out, opacity 0.2s ease-in-out;
 }
 
-.edgePath[data-highlight="fade"] {
+.edgePath[data-highlight="fade"],
+.edgePaths[data-highlight="fade"] > .edgePath {
   opacity: 0.2 !important;
 }
 


### PR DESCRIPTION
Fixes a small regression introduced by #15257.

Fades out the edges (lines between tasks) when hovering or clicking a state in the legend.

| Before | After |
|---|---|
| ![Screen Recording 2021-04-08 at 11 47 23 AM](https://user-images.githubusercontent.com/3267/114057044-3d708a00-9860-11eb-83bb-ec1864a06cfe.gif)  |  ![Screen Recording 2021-04-08 at 11 46 03 AM](https://user-images.githubusercontent.com/3267/114056832-1023dc00-9860-11eb-9952-0b73ec3d2910.gif) |

