### PR TITLE
Synchronize the commiter list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
     # change this and get access to our self-hosted runners
     #
     # When changing this list, ensure that it is kept in sync with the
-    # configOverride parameter in AWS SSM (which is what the runner uses)
+    # /runners/apache/airflow/configOverlay
+    # parameter in AWS SSM ParameterStore (which is what the runner uses)
     runs-on: >-
       ${{ (
         (
@@ -119,7 +120,8 @@ jobs:
             "jhtimmins",
             "dstandish",
             "xinbinhuang",
-            "yuqian"
+            "yuqian",
+            "eladkal"
           ]'), github.actor)
         ) && github.repository == 'apache/airflow'
       ) && 'self-hosted' || 'ubuntu-20.04' }}


### PR DESCRIPTION
The list of committers was not fully synchronized with the
`/runners/apache/airflow/configOverlay`

The name of the parameter was not updated either in the ci.yml.

The list of committers is now synchronized, as well as the name
of parameter fixed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
