### PR TITLE
Fix access_control syncing; faster cli sync-perm

### DIFF
--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Sync permission command"""
-from airflow.models import DagBag
 from airflow.utils import cli as cli_utils
 from airflow.www.app import cached_app
 
@@ -29,9 +28,3 @@ def sync_perm(args):
     # Add missing permissions for all the Base Views _before_ syncing/creating roles
     appbuilder.add_permissions(update_perms=True)
     appbuilder.sm.sync_roles()
-    print('Updating permission on all DAG views')
-    dagbag = DagBag(read_dags_from_db=True)
-    dagbag.collect_dags_from_db()
-    dags = dagbag.dags.values()
-    for dag in dags:
-        appbuilder.sm.sync_perm_for_dag(dag.dag_id, dag.access_control)

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -27,9 +27,8 @@ from flask_appbuilder.security.sqla.models import PermissionView, Role, User
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
 
-from airflow import models
 from airflow.exceptions import AirflowException
-from airflow.models import DagModel
+from airflow.models import DagBag, DagModel
 from airflow.security import permissions
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
@@ -516,23 +515,24 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
 
     def create_dag_specific_permissions(self) -> None:
         """
-        Creates 'can_read' and 'can_edit' permissions for all active and paused DAGs.
+        Creates 'can_read' and 'can_edit' permissions for all active and paused DAGs,
+        along with any `access_control` permissions provided in the DAG.
 
         :return: None.
         """
         perms = self.get_all_permissions()
-        rows = (
-            self.get_session.query(models.DagModel.dag_id)
-            .filter(or_(models.DagModel.is_active, models.DagModel.is_paused))
-            .all()
-        )
+        dagbag = DagBag(read_dags_from_db=True)
+        dagbag.collect_dags_from_db()
+        dags = dagbag.dags.values()
 
-        for row in rows:
-            dag_id = row[0]
+        for dag in dags:
+            dag_resource_name = self.prefixed_dag_id(dag.dag_id)
             for perm_name in self.DAG_PERMS:
-                dag_resource_name = self.prefixed_dag_id(dag_id)
                 if (perm_name, dag_resource_name) not in perms:
                     self._merge_perm(perm_name, dag_resource_name)
+
+            if dag.access_control:
+                self._sync_dag_view_permissions(dag_resource_name, dag.access_control)
 
     def update_admin_perm_view(self):
         """
@@ -593,7 +593,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
     def sync_perm_for_dag(self, dag_id, access_control=None):
         """
         Sync permissions for given dag id. The dag id surely exists in our dag bag
-        as only / refresh button or cli.sync_perm will call this function
+        as only / refresh button will call this function
 
         :param dag_id: the ID of the DAG whose permissions should be updated
         :type dag_id: str

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -21,48 +21,20 @@ from unittest import mock
 
 from airflow.cli import cli_parser
 from airflow.cli.commands import sync_perm_command
-from airflow.models.dag import DAG
-from airflow.models.dagbag import DagBag
-from airflow.security import permissions
 
 
 class TestCliSyncPerm(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dagbag = DagBag(include_examples=True)
         cls.parser = cli_parser.get_parser()
 
     @mock.patch("airflow.cli.commands.sync_perm_command.cached_app")
-    @mock.patch("airflow.cli.commands.sync_perm_command.DagBag")
-    def test_cli_sync_perm(self, dagbag_mock, mock_cached_app):
-        dags = [
-            DAG('has_access_control', access_control={'Public': {permissions.ACTION_CAN_READ}}),
-            DAG('no_access_control'),
-        ]
-
-        collect_dags_from_db_mock = mock.Mock()
-        dagbag = mock.Mock()
-
-        dagbag.dags = {dag.dag_id: dag for dag in dags}
-        dagbag.collect_dags_from_db = collect_dags_from_db_mock
-        dagbag_mock.return_value = dagbag
-
+    def test_cli_sync_perm(self, mock_cached_app):
         appbuilder = mock_cached_app.return_value.appbuilder
         appbuilder.sm = mock.Mock()
 
         args = self.parser.parse_args(['sync-perm'])
         sync_perm_command.sync_perm(args)
 
-        assert appbuilder.sm.sync_roles.call_count == 1
-
-        dagbag_mock.assert_called_once_with(read_dags_from_db=True)
-        collect_dags_from_db_mock.assert_called_once_with()
-        assert 2 == len(appbuilder.sm.sync_perm_for_dag.mock_calls)
-        appbuilder.sm.sync_perm_for_dag.assert_any_call(
-            'has_access_control', {'Public': {permissions.ACTION_CAN_READ}}
-        )
-        appbuilder.sm.sync_perm_for_dag.assert_any_call(
-            'no_access_control',
-            None,
-        )
         appbuilder.add_permissions.assert_called_once_with(update_perms=True)
+        assert appbuilder.sm.sync_roles.call_count == 1

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -29,6 +29,7 @@ from sqlalchemy import Column, Date, Float, Integer, String
 from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.models import DagModel
+from airflow.models.dag import DAG
 from airflow.security import permissions
 from airflow.www import app as application
 from airflow.www.utils import CustomSQLAInterface
@@ -436,7 +437,7 @@ class TestSecurity(unittest.TestCase):
 
     def test_access_control_with_non_existent_role(self):
         with pytest.raises(AirflowException) as ctx:
-            self.security_manager.sync_perm_for_dag(
+            self.security_manager._sync_dag_view_permissions(
                 dag_id='access-control-test',
                 access_control={
                     'this-role-does-not-exist': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]
@@ -478,7 +479,7 @@ class TestSecurity(unittest.TestCase):
         for permission in invalid_permissions:
             self.expect_user_is_in_role(user, rolename='team-a')
             with pytest.raises(AirflowException) as ctx:
-                self.security_manager.sync_perm_for_dag(
+                self.security_manager._sync_dag_view_permissions(
                     'access_control_test', access_control={'team-a': {permission}}
                 )
             assert "invalid permissions" in str(ctx.value)
@@ -494,7 +495,7 @@ class TestSecurity(unittest.TestCase):
                 permissions=[],
             )
             self.expect_user_is_in_role(user, rolename='team-a')
-            self.security_manager.sync_perm_for_dag(
+            self.security_manager._sync_dag_view_permissions(
                 'access_control_test',
                 access_control={'team-a': [permissions.ACTION_CAN_EDIT, permissions.ACTION_CAN_READ]},
             )
@@ -522,12 +523,12 @@ class TestSecurity(unittest.TestCase):
                 permissions=[],
             )
             self.expect_user_is_in_role(user, rolename='team-a')
-            self.security_manager.sync_perm_for_dag(
+            self.security_manager._sync_dag_view_permissions(
                 'access_control_test', access_control={'team-a': READ_WRITE}
             )
             self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id='access_control_test', user=user)
 
-            self.security_manager.sync_perm_for_dag(
+            self.security_manager._sync_dag_view_permissions(
                 'access_control_test', access_control={'team-a': READ_ONLY}
             )
             self.assert_user_has_dag_perms(
@@ -567,25 +568,43 @@ class TestSecurity(unittest.TestCase):
                     f"on {permissions.RESOURCE_CONFIG}"
                 )
 
-    def test_create_dag_specific_permissions(self):
-        dag_id = 'some_dag_id'
-        dag_permission_name = self.security_manager.prefixed_dag_id(dag_id)
-        assert ('can_read', dag_permission_name) not in self.security_manager.get_all_permissions()
+    @mock.patch("airflow.www.security.DagBag")
+    def test_create_dag_specific_permissions(self, dagbag_mock):
+        access_control = {'Public': {permissions.ACTION_CAN_READ}}
+        dags = [
+            DAG('has_access_control', access_control=access_control),
+            DAG('no_access_control'),
+        ]
 
-        dag_model = DagModel(
-            dag_id=dag_id, fileloc='/tmp/dag_.py', schedule_interval='2 2 * * *', is_paused=True
-        )
-        self.session.add(dag_model)
-        self.session.commit()
+        collect_dags_from_db_mock = mock.Mock()
+        dagbag = mock.Mock()
+
+        dagbag.dags = {dag.dag_id: dag for dag in dags}
+        dagbag.collect_dags_from_db = collect_dags_from_db_mock
+        dagbag_mock.return_value = dagbag
+
+        self.security_manager._sync_dag_view_permissions = mock.Mock()
+
+        for dag in dags:
+            prefixed_dag_id = self.security_manager.prefixed_dag_id(dag.dag_id)
+            all_perms = self.security_manager.get_all_permissions()
+            assert ('can_read', prefixed_dag_id) not in all_perms
+            assert ('can_edit', prefixed_dag_id) not in all_perms
 
         self.security_manager.create_dag_specific_permissions()
-        self.session.commit()
 
-        assert ('can_read', dag_permission_name) in self.security_manager.get_all_permissions()
+        dagbag_mock.assert_called_once_with(read_dags_from_db=True)
+        collect_dags_from_db_mock.assert_called_once_with()
 
-        # Make sure we short circuit when the perms already exist
-        with assert_queries_count(2):  # One query to get DagModels, one query to get all perms
-            self.security_manager.create_dag_specific_permissions()
+        for dag in dags:
+            prefixed_dag_id = self.security_manager.prefixed_dag_id(dag.dag_id)
+            all_perms = self.security_manager.get_all_permissions()
+            assert ('can_read', prefixed_dag_id) in all_perms
+            assert ('can_edit', prefixed_dag_id) in all_perms
+
+        self.security_manager._sync_dag_view_permissions.assert_called_once_with(
+            self.security_manager.prefixed_dag_id('has_access_control'), access_control
+        )
 
     def test_get_all_permissions(self):
         with assert_queries_count(1):


### PR DESCRIPTION
This consolidates the cli sync-perm command and the syncing that happens by default during webserver startup. Prior to this change, `access_control` wasn't supported in the default sync and the cli sync-perm command was slow when you have many DAGs.

With ~5k simple DAGs, this makes sync-perms faster (~24s -> ~10s). It does make the webserver startup slower (due to loading DagBag from the db vs just querying `DagModel`, but it also syncs `access_control` where it wasn't before.