### PR TITLE
Chart: Allow setting an existing secret for PgBouncer config

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -249,7 +249,7 @@
 {{- end }}
 
 {{ define "pgbouncer_config_secret" -}}
-{{ default (printf "%s-pgbouncer-config" .Release.Name) .Values.pgbouncer.pgbouncerConfigSecretName }}
+{{ default (printf "%s-pgbouncer-config" .Release.Name) .Values.pgbouncer.configSecretName }}
 {{- end }}
 
 {{ define "pgbouncer_certificates_secret" -}}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -249,7 +249,7 @@
 {{- end }}
 
 {{ define "pgbouncer_config_secret" -}}
-{{ .Release.Name }}-pgbouncer-config
+{{ default (printf "%s-pgbouncer-config" .Release.Name) .Values.pgbouncer.pgbouncerConfigSecretName }}
 {{- end }}
 
 {{ define "pgbouncer_certificates_secret" -}}

--- a/chart/templates/secrets/pgbouncer-config-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-config-secret.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Pgbouncer Config Secret
 #################################
-{{- if .Values.pgbouncer.enabled }}
+{{- if (and .Values.pgbouncer.enabled (not .Values.pgbouncer.pgbouncerConfigSecretName)) }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/chart/templates/secrets/pgbouncer-config-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-config-secret.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Pgbouncer Config Secret
 #################################
-{{- if (and .Values.pgbouncer.enabled (not .Values.pgbouncer.pgbouncerConfigSecretName)) }}
+{{- if (and .Values.pgbouncer.enabled (not .Values.pgbouncer.configSecretName)) }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -82,35 +82,26 @@ class PgbouncerTest(unittest.TestCase):
         docs = render_chart(
             "TEST-PGBOUNCER-CONFIG",
             values={
-                "pgbouncer": {
-                    "enabled": True
-                },
+                "pgbouncer": {"enabled": True},
             },
             show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
         )
 
         assert {
             "name": "pgbouncer-config",
-            "secret": {
-                "secretName": "TEST-PGBOUNCER-CONFIG-pgbouncer-config"
-            }
+            "secret": {"secretName": "TEST-PGBOUNCER-CONFIG-pgbouncer-config"},
         } == jmespath.search("spec.template.spec.volumes[0]", docs[0])
 
     def test_existing_secret(self):
         docs = render_chart(
             "TEST-PGBOUNCER-CONFIG",
             values={
-                "pgbouncer": {
-                    "enabled": True,
-                    "configSecretName": "pgbouncer-config-secret"
-                },
+                "pgbouncer": {"enabled": True, "configSecretName": "pgbouncer-config-secret"},
             },
             show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
         )
 
         assert {
             "name": "pgbouncer-config",
-            "secret": {
-                "secretName": "pgbouncer-config-secret"
-            }
+            "secret": {"secretName": "pgbouncer-config-secret"},
         } == jmespath.search("spec.template.spec.volumes[0]", docs[0])

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -77,3 +77,40 @@ class PgbouncerTest(unittest.TestCase):
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    def test_no_existing_secret(self):
+        docs = render_chart(
+            "TEST-PGBOUNCER-CONFIG",
+            values={
+                "pgbouncer": {
+                    "enabled": True
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+
+        assert {
+            "name": "pgbouncer-config",
+            "secret": {
+                "secretName": "TEST-PGBOUNCER-CONFIG-pgbouncer-config"
+            }
+        } == jmespath.search("spec.template.spec.volumes[0]", docs[0])
+
+    def test_existing_secret(self):
+        docs = render_chart(
+            "TEST-PGBOUNCER-CONFIG",
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "configSecretName": "pgbouncer-config-secret"
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+
+        assert {
+            "name": "pgbouncer-config",
+            "secret": {
+                "secretName": "pgbouncer-config-secret"
+            }
+        } == jmespath.search("spec.template.spec.volumes[0]", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1049,7 +1049,7 @@
                     "description": "Maximum clients that can connect to pgbouncer (higher = more file descriptors).",
                     "type": "integer"
                 },
-                "pgbouncerConfigSecretName": {
+                "configSecretName": {
                     "description": "The pgbouncer config secret name.",
                     "type": [
                         "string",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1050,7 +1050,7 @@
                     "type": "integer"
                 },
                 "configSecretName": {
-                    "description": "The pgbouncer config secret name.",
+                    "description": "The PgBouncer config secret name.",
                     "type": [
                         "string",
                         "null"

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1049,6 +1049,13 @@
                     "description": "Maximum clients that can connect to pgbouncer (higher = more file descriptors).",
                     "type": "integer"
                 },
+                "pgbouncerConfigSecretName": {
+                    "description": "The pgbouncer config secret name.",
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
                 "podDisruptionBudget": {
                     "description": "Pgbouner pod disruption budget.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -567,6 +567,9 @@ pgbouncer:
   # Maximum clients that can connect to pgbouncer (higher = more file descriptors)
   maxClientConn: 100
 
+  # supply name of existing secret with pgbouncer.ini and users.txt defined
+  pgbouncerConfigSecretName: ~
+
   # Pgbouner pod disruption budget
   podDisruptionBudget:
     enabled: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -567,8 +567,20 @@ pgbouncer:
   # Maximum clients that can connect to pgbouncer (higher = more file descriptors)
   maxClientConn: 100
 
-  # supply name of existing secret with pgbouncer.ini and users.txt defined
-  pgbouncerConfigSecretName: ~
+  # supply the name of existing secret with pgbouncer.ini and users.txt defined
+  # you can load them to a k8s secret like the one below
+  #  apiVersion: v1
+  #  kind: Secret
+  #  metadata:
+  #    name: pgbouncer-config-secret
+  #  data:
+  #     pgbouncer.ini: <base64_encoded pgbouncer.ini file content>
+  #     users.txt: <base64_encoded users.txt file content>
+  #  type: Opaque
+  #
+  #  configSecretName: pgbouncer-config-secret
+  #
+  configSecretName: ~
 
   # Pgbouner pod disruption budget
   podDisruptionBudget:

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -415,7 +415,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
      - Toleration labels for pod assignment
      - ``1``
    * - ``pgbouncer.configSecretName``
-     - Name of existing pgbouncer config secret
+     - Name of existing PgBouncer config secret
      - ``~``
    * - ``redis.enabled``
      - Enable the redis provisioned by the chart

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -414,7 +414,7 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``pgbouncer.tolerations``
      - Toleration labels for pod assignment
      - ``1``
-   * - ``pgbouncer.pgbouncerConfigSecretName``
+   * - ``pgbouncer.configSecretName``
      - Name of existing pgbouncer config secret
      - ``~``
    * - ``redis.enabled``

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -414,6 +414,9 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``pgbouncer.tolerations``
      - Toleration labels for pod assignment
      - ``1``
+   * - ``pgbouncer.pgbouncerConfigSecretName``
+     - Name of existing pgbouncer config secret
+     - ``~``
    * - ``redis.enabled``
      - Enable the redis provisioned by the chart
      - ``1``


### PR DESCRIPTION
Previously, if a user wanted to supply the username and password to the `users.txt` secret for use by pgbouncer, they had to be set directly in the `values.yaml` file. This change allows users to create this secret out of band (with the `pgbouncer.ini`) and avoid supplying secrets directly.