### PR TITLE
Graph "edge label" interaction styling

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -32,6 +32,19 @@ svg {
   stroke: #017cee !important;
 }
 
+.edgeLabel {
+  transition: opacity 0.2s ease-in-out;
+}
+
+.edgeLabel > .label {
+  font-weight: normal;
+  font-size: 10px;
+}
+
+.edgeLabel text {
+  transform: translate(16px, 0);
+}
+
 .edgeLabel rect {
   fill: #fff;
 }
@@ -44,7 +57,8 @@ svg {
 }
 
 .edgePath[data-highlight="fade"],
-.edgePaths[data-highlight="fade"] > .edgePath {
+.edgePaths[data-highlight="fade"] > .edgePath,
+.edgeLabel[data-highlight="fade"] {
   opacity: 0.2 !important;
 }
 

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -223,15 +223,18 @@
             var val = g.nodeEdges(d).includes(x.__data__) ? 'highlight' : 'fade';
             d3.select(x).attr('data-highlight', val);
           });
+          d3.selectAll('g.edgeLabel')[0].forEach(function (x) {
+            if (!g.nodeEdges(d).includes(x.__data__)) {
+              d3.select(x).attr('data-highlight', 'fade');
+            }
+          });
         });
 
         d3.selectAll('g.node').on('mouseout', function (d) {
           d3.select(this).selectAll('rect, circle').attr('data-highlight', null);
           unHighlightNodes(g.predecessors(d))
           unHighlightNodes(g.successors(d))
-          d3.selectAll('g.node')
-            .attr('data-highlight', null);
-          d3.selectAll('g.edgePath')
+          d3.selectAll('g.node, g.edgePath, g.edgeLabel')
             .attr('data-highlight', null);
           localStorage.removeItem(focused_group_key(dag_id));
         });
@@ -310,6 +313,8 @@
           setFocusMap(state);
         } else {
           setFocusMap();
+          d3.selectAll('.js-state-legend-item')
+            .style('background-color', null);
         }
       });
 
@@ -343,10 +348,10 @@
 
           d3.selectAll('g.nodes g.node').filter(function(d, i){
             if (s == '') {
-              d3.select('g.edgePaths').attr('data-highlight', null);
+              d3.selectAll('g.edgePaths, g.edgeLabel').attr('data-highlight', null);
               d3.select(this).attr('data-highlight', null);
             } else {
-              d3.select('g.edgePaths').attr('data-highlight', 'fade');
+              d3.selectAll('g.edgePaths, g.edgeLabel').attr('data-highlight', 'fade');
               if (node_matches(d, s)) {
                 if (!match) match = this;
                 d3.select(this).attr('data-highlight', null);
@@ -376,24 +381,18 @@
       });
 
       function clearFocus() {
-        d3.selectAll('g.node')
+        d3.selectAll('g.node, g.edgePaths, g.edgeLabel')
           .attr('data-highlight', null);
-        d3.select('g.edgePaths')
-          .attr('data-highlight', null);
-        d3.selectAll('.js-state-legend-item')
-          .style('background-color', null);
         localStorage.removeItem(focused_group_key(dag_id));
       }
 
       function focusState(state, node, color) {
-        d3.selectAll('g.node')
+        d3.selectAll('g.node, g.edgePaths, g.edgeLabel')
           .attr('data-highlight', 'fade');
         d3.selectAll(`g.node.${state}`)
           .attr('data-highlight', null);
         d3.selectAll(`g.node.${state} rect`)
           .attr('data-highlight', null);
-        d3.select('g.edgePaths')
-          .attr('data-highlight', 'fade');
         d3.select(node)
           .style('background-color', color);
       }


### PR DESCRIPTION
Part of the resolution of #15140 (paired with #15142)

"Edge labels" are an existing concept in the library that powers the Graph view. This feature will be employed in Airflow the Airflow Graph view with #15142. This PR ensures that the labels are displayed properly when interacting with the Task/path/status highlighting features of the Graph. Primarily, it fades out the labels when not relevant.

| Before | After |
|---|---|
|  ![Screen Recording 2021-04-08 at 10 11 19 PM](https://user-images.githubusercontent.com/3267/114119202-337a7580-98b8-11eb-8556-66341974d544.gif) |  ![Screen Recording 2021-04-08 at 10 09 22 PM](https://user-images.githubusercontent.com/3267/114119214-37a69300-98b8-11eb-8559-1fcc3f257b45.gif) |
