### PR TITLE
Add link to not deprecated modules docs

### DIFF
--- a/airflow/contrib/hooks/fs_hook.py
+++ b/airflow/contrib/hooks/fs_hook.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.hooks.filesystem`."""
+"""This module is deprecated. Please use :class:`airflow.hooks.filesystem`."""
 
 import warnings
 

--- a/airflow/contrib/sensors/bash_sensor.py
+++ b/airflow/contrib/sensors/bash_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.bash`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.bash`."""
 
 import warnings
 

--- a/airflow/contrib/sensors/file_sensor.py
+++ b/airflow/contrib/sensors/file_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.filesystem`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.filesystem`."""
 
 import warnings
 

--- a/airflow/contrib/sensors/python_sensor.py
+++ b/airflow/contrib/sensors/python_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.python`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.python`."""
 
 import warnings
 

--- a/airflow/contrib/sensors/weekday_sensor.py
+++ b/airflow/contrib/sensors/weekday_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.weekday`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.weekday`."""
 
 import warnings
 

--- a/airflow/contrib/task_runner/cgroup_task_runner.py
+++ b/airflow/contrib/task_runner/cgroup_task_runner.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.task.task_runner.cgroup_task_runner`."""
+"""This module is deprecated. Please use :class:`airflow.task.task_runner.cgroup_task_runner`."""
 
 import warnings
 

--- a/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
+++ b/airflow/contrib/utils/log/task_handler_with_custom_formatter.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.utils.log.task_handler_with_custom_formatter`."""
+"""This module is deprecated. Please use :class:`airflow.utils.log.task_handler_with_custom_formatter`."""
 
 import warnings
 

--- a/airflow/contrib/utils/weekday.py
+++ b/airflow/contrib/utils/weekday.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.utils.weekday`."""
+"""This module is deprecated. Please use :class:`airflow.utils.weekday`."""
 import warnings
 
 # pylint: disable=unused-import

--- a/airflow/hooks/base_hook.py
+++ b/airflow/hooks/base_hook.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.hooks.base`."""
+"""This module is deprecated. Please use :class:`airflow.hooks.base`."""
 
 import warnings
 

--- a/airflow/hooks/dbapi_hook.py
+++ b/airflow/hooks/dbapi_hook.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.hooks.dbapi`."""
+"""This module is deprecated. Please use :class:`airflow.hooks.dbapi`."""
 
 import warnings
 

--- a/airflow/kubernetes/pod.py
+++ b/airflow/kubernetes/pod.py
@@ -15,7 +15,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port."""
+"""
+This module is deprecated.
+Please use `kubernetes.client.models` for V1ResourceRequirements and Port.
+"""
 # flake8: noqa
 # pylint: disable=unused-import
 import warnings
@@ -27,7 +30,7 @@ with warnings.catch_warnings():
     )
 
 warnings.warn(
-    "This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port.",
+    "This module is deprecated. Please use `kubernetes.client.models` for V1ResourceRequirements and Port.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -15,7 +15,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models for V1ResourceRequirements and Port."""
+"""
+This module is deprecated.
+Please use `kubernetes.client.models` for V1ResourceRequirements and Port.
+"""
 # flake8: noqa
 # pylint: disable=unused-import
 from airflow.kubernetes.pod_launcher_deprecated import PodLauncher, PodStatus  # pylint: disable=unused-import

--- a/airflow/kubernetes/pod_runtime_info_env.py
+++ b/airflow/kubernetes/pod_runtime_info_env.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models.V1EnvVar`."""
+"""This module is deprecated. Please use :class:`kubernetes.client.models.V1EnvVar`."""
 # flake8: noqa
 # pylint: disable=unused-import
 import warnings

--- a/airflow/kubernetes/volume.py
+++ b/airflow/kubernetes/volume.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models.V1Volume`."""
+"""This module is deprecated. Please use :class:`kubernetes.client.models.V1Volume`."""
 # flake8: noqa
 # pylint: disable=unused-import
 

--- a/airflow/kubernetes/volume_mount.py
+++ b/airflow/kubernetes/volume_mount.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models.V1VolumeMount`."""
+"""This module is deprecated. Please use :class:`kubernetes.client.models.V1VolumeMount`."""
 # flake8: noqa
 # pylint: disable=unused-import
 

--- a/airflow/operators/bash_operator.py
+++ b/airflow/operators/bash_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.bash`."""
+"""This module is deprecated. Please use :class:`airflow.operators.bash`."""
 
 import warnings
 

--- a/airflow/operators/branch_operator.py
+++ b/airflow/operators/branch_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.branch`."""
+"""This module is deprecated. Please use :class:`airflow.operators.branch`."""
 
 import warnings
 

--- a/airflow/operators/check_operator.py
+++ b/airflow/operators/check_operator.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module is deprecated. Please use `airflow.operators.sql`."""
+"""This module is deprecated. Please use :class:`airflow.operators.sql`."""
 
 import warnings
 

--- a/airflow/operators/dagrun_operator.py
+++ b/airflow/operators/dagrun_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.trigger_dagrun`."""
+"""This module is deprecated. Please use :class:`airflow.operators.trigger_dagrun`."""
 
 import warnings
 

--- a/airflow/operators/dummy_operator.py
+++ b/airflow/operators/dummy_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.dummy`."""
+"""This module is deprecated. Please use :class:`airflow.operators.dummy`."""
 
 import warnings
 

--- a/airflow/operators/email_operator.py
+++ b/airflow/operators/email_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.email`."""
+"""This module is deprecated. Please use :class:`airflow.operators.email`."""
 
 import warnings
 

--- a/airflow/operators/latest_only_operator.py
+++ b/airflow/operators/latest_only_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.latest_only`"""
+"""This module is deprecated. Please use :class:`airflow.operators.latest_only`"""
 import warnings
 
 # pylint: disable=unused-import

--- a/airflow/operators/presto_check_operator.py
+++ b/airflow/operators/presto_check_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.sql`."""
+"""This module is deprecated. Please use :class:`airflow.operators.sql`."""
 
 import warnings
 

--- a/airflow/operators/python_operator.py
+++ b/airflow/operators/python_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.python`."""
+"""This module is deprecated. Please use :class:`airflow.operators.python`."""
 
 import warnings
 

--- a/airflow/operators/sql_branch_operator.py
+++ b/airflow/operators/sql_branch_operator.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.sql`."""
+"""This module is deprecated. Please use :class:`airflow.operators.sql`."""
 import warnings
 
 from airflow.operators.sql import BranchSQLOperator

--- a/airflow/operators/subdag_operator.py
+++ b/airflow/operators/subdag_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.operators.subdag`."""
+"""This module is deprecated. Please use :class:`airflow.operators.subdag`."""
 
 import warnings
 

--- a/airflow/providers/cncf/kubernetes/backcompat/volume.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/volume.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `kubernetes.client.models.V1Volume`."""
+"""This module is deprecated. Please use :class:`kubernetes.client.models.V1Volume`."""
 
 import warnings
 

--- a/airflow/sensors/base_sensor_operator.py
+++ b/airflow/sensors/base_sensor_operator.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.base`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.base`."""
 
 import warnings
 

--- a/airflow/sensors/date_time_sensor.py
+++ b/airflow/sensors/date_time_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.date_time`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.date_time`."""
 
 import warnings
 

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.external_task`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.external_task`."""
 
 import warnings
 

--- a/airflow/sensors/sql_sensor.py
+++ b/airflow/sensors/sql_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.sql`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.sql`."""
 
 import warnings
 

--- a/airflow/sensors/time_delta_sensor.py
+++ b/airflow/sensors/time_delta_sensor.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""This module is deprecated. Please use `airflow.sensors.time_delta`."""
+"""This module is deprecated. Please use :class:`airflow.sensors.time_delta`."""
 
 import warnings
 


### PR DESCRIPTION
closes: #14394

I was only able to link python classes that are defined in `apache-airflow`.

Not sure how to link them with classes that are defined in providers.