### PR TITLE
Pass environment variables to process with yarn kill command

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -392,7 +392,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 )
 
         else:
-            # Requesting submission statuses is only supported in standalone or Mesos mode!
+
             connection_cmd = self._get_spark_binary_path()
 
             # The url to the spark master
@@ -497,14 +497,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 match = re.search('(application[0-9_]+)', line)
                 if match:
                     self._yarn_application_id = match.groups()[0]
-                    #self._driver_id = self._yarn_application_id
-                    self.log.info("Identified spark driver id: %s", self._driver_id)
-
-                # if self._yarn_application_id:
-                #     match_current_state = re.search(f'{self._yarn_application_id}\W+state: (\w+)', line)
-                #     if match_current_state:
-                #         self._driver_status = match_current_state.groups()[0]
-                #         self.log.info("Set spark driver status: %s", self._driver_status)
+                    self.log.info("Identified spark driver id: %s", self._yarn_application_id)
 
             # If we run Kubernetes cluster mode, we want to extract the driver pod id
             # from the logs so we can kill the application when we stop it unexpectedly
@@ -663,7 +656,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
             if self._yarn_application_id:
                 kill_cmd = f"yarn application -kill {self._yarn_application_id}".split()
-                env = {**os.environ.copy(), **(self._env if self._env else {})}
+                env = {**os.environ, **(self._env or {})}
                 if self._keytab is not None and self._principal is not None:
                     # we are ignoring renewal failures from renew_from_kt
                     # here as the failure could just be due to a non-renewable ticket,

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -392,7 +392,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 )
 
         else:
-            # Requesting submission statuses is only supported in standalone or Mesos mode!
+
             connection_cmd = self._get_spark_binary_path()
 
             # The url to the spark master
@@ -497,14 +497,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 match = re.search('(application[0-9_]+)', line)
                 if match:
                     self._yarn_application_id = match.groups()[0]
-                    #self._driver_id = self._yarn_application_id
-                    self.log.info("Identified spark driver id: %s", self._driver_id)
-
-                # if self._yarn_application_id:
-                #     match_current_state = re.search(f'{self._yarn_application_id}\W+state: (\w+)', line)
-                #     if match_current_state:
-                #         self._driver_status = match_current_state.groups()[0]
-                #         self.log.info("Set spark driver status: %s", self._driver_status)
+                    self.log.info("Identified spark driver id: %s", self._yarn_application_id)
 
             # If we run Kubernetes cluster mode, we want to extract the driver pod id
             # from the logs so we can kill the application when we stop it unexpectedly

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -392,7 +392,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 )
 
         else:
-
+            # Requesting submission statuses is only supported in standalone or Mesos mode!
             connection_cmd = self._get_spark_binary_path()
 
             # The url to the spark master
@@ -497,7 +497,14 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
                 match = re.search('(application[0-9_]+)', line)
                 if match:
                     self._yarn_application_id = match.groups()[0]
-                    self.log.info("Identified spark driver id: %s", self._yarn_application_id)
+                    #self._driver_id = self._yarn_application_id
+                    self.log.info("Identified spark driver id: %s", self._driver_id)
+
+                # if self._yarn_application_id:
+                #     match_current_state = re.search(f'{self._yarn_application_id}\W+state: (\w+)', line)
+                #     if match_current_state:
+                #         self._driver_status = match_current_state.groups()[0]
+                #         self.log.info("Set spark driver status: %s", self._driver_status)
 
             # If we run Kubernetes cluster mode, we want to extract the driver pod id
             # from the logs so we can kill the application when we stop it unexpectedly
@@ -656,7 +663,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
             if self._yarn_application_id:
                 kill_cmd = f"yarn application -kill {self._yarn_application_id}".split()
-                env = None
+                env = {**os.environ.copy(), **(self._env if self._env else {})}
                 if self._keytab is not None and self._principal is not None:
                     # we are ignoring renewal failures from renew_from_kt
                     # here as the failure could just be due to a non-renewable ticket,

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -745,7 +745,8 @@ class TestSparkSubmitHook(unittest.TestCase):
             + 'NodeManagerapplication_1486558679801_1820s',
             'INFO Client: Submitting application application_1486558679801_1820 ' + 'to ResourceManager',
         ]
-        hook = SparkSubmitHook(conn_id='spark_yarn_cluster')
+        env = {"PATH": "hadoop/bin"}
+        hook = SparkSubmitHook(conn_id='spark_yarn_cluster', env_vars=env)
         hook._process_spark_submit_log(log_lines)
         hook.submit()
 
@@ -756,7 +757,7 @@ class TestSparkSubmitHook(unittest.TestCase):
         assert (
             call(
                 ['yarn', 'application', '-kill', 'application_1486558679801_1820'],
-                env=None,
+                env={**os.environ, **env},
                 stderr=-1,
                 stdout=-1,
             )


### PR DESCRIPTION
**Pass environment variables to process with yarn kill command**
When I manual stop DAG's job, for example, mark it as "failed", in Yarn cluster the same job is still running.
This error occurs because empty environment is passed to subprocess.Popen and hadoop bin directory doesn't exist in PATH (ERROR - [Errno 2] No such file or directory: 'yarn': 'yarn').

Closes https://github.com/apache/airflow/issues/15280