### PR TITLE
Fix used_group_ids in partial_subset (#13700)

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1504,6 +1504,8 @@ class DAG(LoggingMixin):
                 if isinstance(child, BaseOperator):
                     if child.task_id in dag.task_dict:
                         copied.children[child.task_id] = dag.task_dict[child.task_id]
+                    else:
+                        copied.used_group_ids.discard(child.task_id)
                 else:
                     filtered_child = filter_task_group(child, copied)
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1006,6 +1006,9 @@ class TestDag(unittest.TestCase):
         sub_dag = dag.sub_dag('t2', include_upstream=True, include_downstream=False)
         assert id(sub_dag.task_dict['t1'].downstream_list[0].dag) == id(sub_dag)
 
+        # Copied DAG should not include unused task IDs in used_group_ids
+        assert 't3' not in sub_dag._task_group.used_group_ids
+
     def test_schedule_dag_no_previous_runs(self):
         """
         Tests scheduling a dag with no previous runs


### PR DESCRIPTION
closes: #13700 

This should address the root cause by removing any task_ids that are not in the subset DAG from the `used_group_ids`
