### PR TITLE
Chart: Add tests to check labels, kind and annotations

### DIFF
--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -17,6 +17,7 @@
 import unittest
 from subprocess import CalledProcessError
 from typing import Any, Dict, List, Union
+from unittest import mock
 
 import jmespath
 from parameterized import parameterized
@@ -106,6 +107,86 @@ class TestBaseChartTest(unittest.TestCase):
         ]
         for kind_name in expected_kind_names:
             assert kind_name in kind_names_tuples
+
+    def test_labels_are_valid(self):
+        """Test labels are correctly applied on all objects created by this chart"""
+        release_name = "TEST-BASIC"
+        k8s_objects = render_chart(
+            name=release_name,
+            values={
+                "labels": {"label1": "value1", "label2": "value2"},
+                "executor": "CeleryExecutor",
+                "pgbouncer": {"enabled": True},
+                "redis": {"enabled": True},
+                "networkPolicies": {"enabled": True},
+            },
+        )
+        kind_k8s_obj_labels_tuples = {
+            (k8s_object['metadata']['name'], k8s_object['kind']): k8s_object['metadata']['labels']
+            for k8s_object in k8s_objects
+        }
+
+        kind_names_tuples = [
+            (f"{release_name}-airflow-config", "ConfigMap", "config"),
+            (f"{release_name}-create-user", "Job", "create-user-job"),
+            (f"{release_name}-flower", "Deployment", "flower"),
+            (f"{release_name}-flower", "Service", "flower"),
+            (f"{release_name}-flower-policy", "NetworkPolicy", "airflow-flower-policy"),
+            (f"{release_name}-pgbouncer", "Deployment", "pgbouncer"),
+            (f"{release_name}-pgbouncer", "Service", "pgbouncer"),
+            (f"{release_name}-pgbouncer-policy", "NetworkPolicy", "airflow-pgbouncer-policy"),
+            (f"{release_name}-redis", "Service", "redis"),
+            (f"{release_name}-redis", "StatefulSet", "redis"),
+            (f"{release_name}-redis-policy", "NetworkPolicy", "redis-policy"),
+            (f"{release_name}-run-airflow-migrations", "Job", "run-airflow-migrations"),
+            (f"{release_name}-scheduler", "Deployment", "scheduler"),
+            (f"{release_name}-scheduler-policy", "NetworkPolicy", "airflow-scheduler-policy"),
+            (f"{release_name}-statsd", "Deployment", "statsd"),
+            (f"{release_name}-statsd", "Service", "statsd"),
+            (f"{release_name}-statsd-policy", "NetworkPolicy", "statsd-policy"),
+            (f"{release_name}-webserver", "Deployment", "webserver"),
+            (f"{release_name}-webserver", "Service", "webserver"),
+            (f"{release_name}-webserver-policy", "NetworkPolicy", "airflow-webserver-policy"),
+            (f"{release_name}-worker", "Service", "worker"),
+            (f"{release_name}-worker", "StatefulSet", "worker"),
+            (f"{release_name}-worker-policy", "NetworkPolicy", "airflow-worker-policy"),
+        ]
+        for k8s_object_name, kind, component in kind_names_tuples:
+            assert kind_k8s_obj_labels_tuples[(k8s_object_name, kind)] == {
+                "label1": "value1",
+                "label2": "value2",
+                "tier": "airflow",
+                "release": release_name,
+                "component": component,
+                "heritage": "Helm",
+                "chart": mock.ANY,
+            }
+
+    def test_annotations_on_airflow_pods_in_deployment(self):
+        """
+        Test Annotations are correctly applied on all pods created Scheduler, Webserver & Worker
+        deployments.
+        """
+        release_name = "TEST-BASIC"
+        k8s_objects = render_chart(
+            name=release_name,
+            values={
+                "airflowPodAnnotations": {"test-annotation/safe-to-evict": "true"},
+                "executor": "CeleryExecutor",
+            },
+            show_only=[
+                "templates/scheduler/scheduler-deployment.yaml",
+                "templates/workers/worker-deployment.yaml",
+                "templates/webserver/webserver-deployment.yaml",
+            ],
+        )
+
+        assert len(k8s_objects) == 3
+
+        for k8s_object in k8s_objects:
+            annotations = k8s_object["spec"]["template"]["metadata"]["annotations"]
+            assert "test-annotation/safe-to-evict" in annotations
+            assert "true" in annotations.get("test-annotation/safe-to-evict")
 
     def test_chart_is_consistent_with_official_airflow_image(self):
         def get_k8s_objs_with_image(obj: Union[List[Any], Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -18,11 +18,34 @@
 import unittest
 
 import jmespath
+from parameterized import parameterized
 
 from tests.helm_template_generator import render_chart
 
 
 class WorkerTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("CeleryExecutor", False, "Deployment"),
+            ("CeleryExecutor", True, "StatefulSet"),
+            ("CeleryKubernetesExecutor", False, "Deployment"),
+            ("CeleryKubernetesExecutor", True, "StatefulSet"),
+        ]
+    )
+    def test_worker_kind(self, executor, persistence, kind):
+        """
+        Test worker kind is StatefulSet when worker persistence is enabled.
+        """
+        docs = render_chart(
+            values={
+                "executor": executor,
+                "workers": {"persistence": {"enabled": persistence}},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert kind == jmespath.search("kind", docs[0])
+
     def test_should_add_extra_containers(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
This commits adds more unit tests to test:

- labels are added to all pods
- annotations are added to pods of Scheduler, Worker & Webserver deployment
- kind of scheduler and worker deployment as it can be `StatefulSet` or `Deployment`
  based on if persistence is enabled or not

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
