### PR TITLE
Chart: Allow disabling `git-sync` for Webserver

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -358,9 +358,10 @@
         Whether to persist DAG files code in DB.
         If set to True, Webserver reads file contents from DB instead of
         trying to access files in a DAG folder.
+        (Default is ``True``)
       version_added: 1.10.10
       type: string
-      example: "False"
+      example: "True"
       default: ~
     - name: max_num_rendered_ti_fields_per_task
       description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -205,7 +205,8 @@ min_serialized_dag_fetch_interval = 10
 # Whether to persist DAG files code in DB.
 # If set to True, Webserver reads file contents from DB instead of
 # trying to access files in a DAG folder.
-# Example: store_dag_code = False
+# (Default is ``True``)
+# Example: store_dag_code = True
 # store_dag_code =
 
 # Maximum number of Rendered Task Instance Fields (Template Fields) per task to store

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -92,7 +92,7 @@ spec:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
       containers:
-{{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
+{{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) (not .Values.dags.gitSync.excludeWebserver) }}
 {{- include "git_sync_container" . | indent 8 }}
 {{- end }}
         - name: webserver
@@ -118,7 +118,7 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
 {{- end }}
-{{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
+{{- if or (and .Values.dags.gitSync.enabled (not .Values.dags.gitSync.excludeWebserver)) .Values.dags.persistence.enabled }}
             - name: dags
               mountPath: {{ template "airflow_dags_mount_path" . }}
 {{- end }}
@@ -175,7 +175,7 @@ spec:
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
-        {{- else if .Values.dags.gitSync.enabled }}
+        {{- else if and (.Values.dags.gitSync.enabled) (not .Values.dags.gitSync.excludeWebserver) }}
         - name: dags
           emptyDir: {}
         {{- if  .Values.dags.gitSync.sshKeySecret }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1426,6 +1426,10 @@
                             "description": "Enable Git sync.",
                             "type": "boolean"
                         },
+                        "excludeWebserver": {
+                            "description": "Disable Git sync on webserver as it is not needed when DAG Serialization is enabled.",
+                            "type": "boolean"
+                        },
                         "repo": {
                             "description": "Git repository.",
                             "type": "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -816,6 +816,13 @@ dags:
     existingClaim:
   gitSync:
     enabled: false
+
+    # Change it to true when DAG Serialization is turned on. This will exclude git sync containers
+    # from Webserver as DAGs are fetched from the DB. DAG Serialization was introduced in
+    # 1.10.7 and is optional for <2.0.0.
+    # https://airflow.apache.org/docs/apache-airflow/1.10.15/dag-serialization.html
+    excludeWebserver: false
+
     # git repo clone url
     # ssh examples ssh://git@github.com/apache/airflow.git
     # git@github.com:apache/airflow.git

--- a/docs/apache-airflow/dag-serialization.rst
+++ b/docs/apache-airflow/dag-serialization.rst
@@ -16,7 +16,7 @@
     under the License.
 
 
-
+.. _dag-serialization:
 
 DAG Serialization
 =================

--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -114,8 +114,8 @@ This is also recommended when enabling DAG Serialization for ``apache-airflow>=1
 Mounting DAGs using Git-Sync sidecar without Persistence
 --------------------------------------------------------
 
-This option will use an always running Git-Sync side car on every scheduler, webserver and worker pods.
-The Git-Sync side car containers will sync DAGs from a git repository every configured number of
+This option will use an always running Git-Sync sidecar on every scheduler, webserver and worker pods.
+The Git-Sync sidecar containers will sync DAGs from a git repository every configured number of
 seconds. If you are using the ``KubernetesExecutor``, Git-sync will run as an init container on your worker pods.
 
 .. code-block:: bash

--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -80,7 +80,12 @@ If you are deploying an image with a constant tag, you need to make sure that th
 Mounting DAGs using Git-Sync sidecar with Persistence enabled
 -------------------------------------------------------------
 
-This option will use a Persistent Volume Claim with an access mode of ``ReadWriteMany``. The scheduler pod will sync DAGs from a git repository onto the PVC every configured number of seconds. The other pods will read the synced DAGs. Not all volume  plugins have support for ``ReadWriteMany`` access mode. Refer `Persistent Volume Access Modes <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`__ for details
+This option will use a Persistent Volume Claim with an access mode of ``ReadWriteMany``.
+The scheduler pod will sync DAGs from a git repository onto the PVC every configured number of
+seconds. The other pods will read the synced DAGs. Not all volume  plugins have support for
+``ReadWriteMany`` access mode.
+Refer `Persistent Volume Access Modes <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`__
+for details.
 
 .. code-block:: bash
 
@@ -91,10 +96,27 @@ This option will use a Persistent Volume Claim with an access mode of ``ReadWrit
       # by setting the  dags.persistence.* and dags.gitSync.* values
       # Please refer to values.yaml for details
 
+When using ``apache-airflow>=2.0.0``, :ref:`DAG Serialization <apache-airflow:dag-serialization>` is enabled by default,
+hence Webserver does not need access to DAG files, so you can turn off ``git-sync`` for Webserver by setting
+``dags.gitSync.excludeWebserver`` to ``true``.
+This is also recommended when enabling DAG Serialization for ``apache-airflow>=1.10.11,<2``.
+
+.. code-block:: bash
+
+    helm upgrade airflow . \
+      --set dags.persistence.enabled=true \
+      --set dags.gitSync.enabled=true \
+      --set dags.gitSync.excludeWebserver=true
+      # you can also override the other persistence or gitSync values
+      # by setting the  dags.persistence.* and dags.gitSync.* values
+      # Please refer to values.yaml for details
+
 Mounting DAGs using Git-Sync sidecar without Persistence
 --------------------------------------------------------
 
-This option will use an always running Git-Sync side car on every scheduler, webserver and worker pods. The Git-Sync side car containers will sync DAGs from a git repository every configured number of seconds. If you are using the KubernetesExecutor, Git-sync will run as an init container on your worker pods.
+This option will use an always running Git-Sync side car on every scheduler, webserver and worker pods.
+The Git-Sync side car containers will sync DAGs from a git repository every configured number of
+seconds. If you are using the ``KubernetesExecutor``, Git-sync will run as an init container on your worker pods.
 
 .. code-block:: bash
 


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/11704

When DAG Serialization is enabled for `Airflow >= 1.10.10, <2.0`, we don't need to run `git-sync` container for Webserver as DAGs are fetched from Database. DAG Serialization is enabled for `Airflow > 2` so users should be able to stop running §git-sync` containers for Webserver when by running:

```bash
helm upgrade airflow . \
  --set dags.gitSync.enabled=true \
  --set dags.gitSync.excludeWebserver=true
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
