### PR TITLE
Fixes doc for SQSSensor

### DIFF
--- a/airflow/providers/amazon/aws/sensors/sqs.py
+++ b/airflow/providers/amazon/aws/sensors/sqs.py
@@ -28,7 +28,7 @@ class SQSSensor(BaseSensorOperator):
     """
     Get messages from an SQS queue and then deletes  the message from the SQS queue.
     If deletion of messages fails an AirflowException is thrown otherwise, the message
-    is pushed through XCom with the key ``message``.
+    is pushed through XCom with the key ``messages``.
 
     :param aws_conn_id: AWS connection id
     :type aws_conn_id: str


### PR DESCRIPTION
As far as I understand, Docstrings for `SQSSensor` seemes to include a mistake.
The key for XCom should be 'messages', not 'message'.

https://github.com/apache/airflow/blob/0f327788b5b0887c463cb83dd8f732245da96577/airflow/providers/amazon/aws/sensors/sqs.py#L91