### PR TITLE
Fix DAG last run link

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -160,7 +160,7 @@ function blockedHandler(error, json) {
 
 function lastDagRunsHandler(error, json) {
   Object.keys(json).forEach((safeDagId) => {
-    const { dagId } = json[safeDagId];
+    const dagId = json[safeDagId].dag_id;
     const executionDate = json[safeDagId].execution_date;
     const startDate = json[safeDagId].start_date;
     const g = d3.select(`#last-run-${safeDagId}`);


### PR DESCRIPTION
Camelcase was mistakenly used instead of snake case for `dag_id`, resulting in `?dag_id=undefined` link in the column "Last run" on the DAG list (airflow `/home` page)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
