### PR TITLE
Fix Helm GitSync dag volume mount

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -70,7 +70,6 @@ spec:
         - mountPath: {{ include "airflow_dags" . }}
           name: dags
           readOnly: true
-          subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 8 }}


### PR DESCRIPTION
This fixes an issue where the workers cannot find the dag that is meant to run.

With git-sync enabled, the airflow_dag location is being set to where the dags are being cloned to, ex `$AIRFLOWHOME/dags/repo/dags`, but the subpath is remapping it to `$AIRFLOWHOME/dags`, thus the workers are not able to find the actually dag. 

Also related: https://github.com/apache/airflow/blob/master/chart/templates/_helpers.yaml#L333

Removing the subpath resolves this issue. I locally ran the helm unit tests, and it succeeded.