### PR TITLE
Fix `sendgrid` -> `google`.

### DIFF
--- a/docs/apache-airflow-providers-google/secrets-backends/google-cloud-secret-manager-backend.rst
+++ b/docs/apache-airflow-providers-google/secrets-backends/google-cloud-secret-manager-backend.rst
@@ -28,7 +28,7 @@ Before you begin
 
 Before you start, make sure you have performed the following tasks:
 
-1.  Include sendgrid subpackage as part of your Airflow installation
+1.  Include `google` subpackage as an extra of your Airflow installation
 
     .. code-block:: bash
 

--- a/docs/apache-airflow-providers-google/secrets-backends/google-cloud-secret-manager-backend.rst
+++ b/docs/apache-airflow-providers-google/secrets-backends/google-cloud-secret-manager-backend.rst
@@ -28,7 +28,7 @@ Before you begin
 
 Before you start, make sure you have performed the following tasks:
 
-1.  Include `google` subpackage as an extra of your Airflow installation
+1.  Include ``google`` subpackage as an extra of your Airflow installation
 
     .. code-block:: bash
 


### PR DESCRIPTION
Fixes minor typo in Airflow documentation. The documentation talks about `sendgrid`, when the section is about Google Cloud Platform's Secrets Manager.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
