### PR TITLE
Fail task when containers inside a pod fails

### DIFF
--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -507,7 +507,7 @@ class TestKubernetesJobWatcher(unittest.TestCase):
         self._run()
         self.watcher.watcher_queue.put.assert_not_called()
 
-    def test_container_status_of_terminating_with_exit_code_1_fails_pod(self):
+    def test_container_status_of_waiting_with_errimagepull_fails_pod(self):
         self.pod.status.phase = "Pending"
         self.pod.status.container_statuses = [
             k8s.V1ContainerStatus(
@@ -517,73 +517,14 @@ class TestKubernetesJobWatcher(unittest.TestCase):
                 name="base",
                 ready="false",
                 restart_count=0,
-                state=k8s.V1ContainerState(
-                    terminated=k8s.V1ContainerStateTerminated(
-                        reason="Terminating", exit_code=1
-                    )  # Terminating
-                ),
+                state=k8s.V1ContainerState(waiting=k8s.V1ContainerStateWaiting(reason='ErrImagePull')),
             )
         ]
         self.events.append({"type": 'MODIFIED', "object": self.pod})
         self._run()
         self.watcher.watcher_queue.put.assert_called()
 
-    def test_container_status_of_terminating_with_exit_code_0_fails_pod(self):
-        self.pod.status.phase = "Pending"
-        self.pod.status.container_statuses = [
-            k8s.V1ContainerStatus(
-                container_id=None,
-                image="apache/airflow:2.0.1-python3.8",
-                image_id="",
-                name="base",
-                ready="false",
-                restart_count=0,
-                state=k8s.V1ContainerState(
-                    terminated=k8s.V1ContainerStateTerminated(
-                        reason="Terminating", exit_code=0
-                    )  # Terminating
-                ),
-            )
-        ]
-        self.events.append({"type": 'MODIFIED', "object": self.pod})
-        self._run()
-        self.watcher.watcher_queue.put.assert_not_called()
-
-    def test_container_status_of_waiting_do_not_fail_pod(self):
-        self.pod.status.phase = "Pending"
-        self.pod.status.container_statuses = [
-            k8s.V1ContainerStatus(
-                container_id=None,
-                image="apache/airflow:2.0.1-python3.8",
-                image_id="",
-                name="base",
-                ready="false",
-                restart_count=0,
-                state=k8s.V1ContainerState(waiting=k8s.V1ContainerStateWaiting()),
-            )
-        ]
-        self.events.append({"type": 'MODIFIED', "object": self.pod})
-        self._run()
-        self.watcher.watcher_queue.put.assert_not_called()
-
-    def test_container_status_of_running_do_not_fail_pod(self):
-        self.pod.status.phase = "Pending"
-        self.pod.status.container_statuses = [
-            k8s.V1ContainerStatus(
-                container_id=None,
-                image="apache/airflow:2.0.1-python3.8",
-                image_id="",
-                name="base",
-                ready="false",
-                restart_count=0,
-                state=k8s.V1ContainerState(running=k8s.V1ContainerStateRunning(started_at=datetime.now())),
-            )
-        ]
-        self.events.append({"type": 'MODIFIED', "object": self.pod})
-        self._run()
-        self.watcher.watcher_queue.put.assert_not_called()
-
-    def test_init_container_status_of_terminating_with_exit_code_1_fails_pod(self):
+    def test_init_container_status_of_waiting_with_errimagepull_fails_pod(self):
         self.pod.status.phase = "Pending"
         self.pod.status.init_container_statuses = [
             k8s.V1ContainerStatus(
@@ -593,68 +534,9 @@ class TestKubernetesJobWatcher(unittest.TestCase):
                 name="base",
                 ready="false",
                 restart_count=0,
-                state=k8s.V1ContainerState(
-                    terminated=k8s.V1ContainerStateTerminated(
-                        reason="Terminating", exit_code=1
-                    )  # Terminating
-                ),
+                state=k8s.V1ContainerState(waiting=k8s.V1ContainerStateWaiting(reason='ErrImagePull')),
             )
         ]
         self.events.append({"type": 'MODIFIED', "object": self.pod})
         self._run()
         self.watcher.watcher_queue.put.assert_called()
-
-    def test_init_container_status_of_terminating_with_exit_code_0_fails_pod(self):
-        self.pod.status.phase = "Pending"
-        self.pod.status.init_container_statuses = [
-            k8s.V1ContainerStatus(
-                container_id=None,
-                image="apache/airflow:2.0.1-python3.8",
-                image_id="",
-                name="base",
-                ready="false",
-                restart_count=0,
-                state=k8s.V1ContainerState(
-                    terminated=k8s.V1ContainerStateTerminated(
-                        reason="Terminating", exit_code=0
-                    )  # Terminating
-                ),
-            )
-        ]
-        self.events.append({"type": 'MODIFIED', "object": self.pod})
-        self._run()
-        self.watcher.watcher_queue.put.assert_not_called()
-
-    def test_init_container_status_of_waiting_do_not_fail_pod(self):
-        self.pod.status.phase = "Pending"
-        self.pod.status.init_container_statuses = [
-            k8s.V1ContainerStatus(
-                container_id=None,
-                image="apache/airflow:2.0.1-python3.8",
-                image_id="",
-                name="base",
-                ready="false",
-                restart_count=0,
-                state=k8s.V1ContainerState(waiting=k8s.V1ContainerStateWaiting()),
-            )
-        ]
-        self.events.append({"type": 'MODIFIED', "object": self.pod})
-        self._run()
-        self.watcher.watcher_queue.put.assert_not_called()
-
-    def test_init_container_status_of_running_do_not_fail_pod(self):
-        self.pod.status.phase = "Pending"
-        self.pod.status.init_container_statuses = [
-            k8s.V1ContainerStatus(
-                container_id=None,
-                image="apache/airflow:2.0.1-python3.8",
-                image_id="",
-                name="base",
-                ready="false",
-                restart_count=0,
-                state=k8s.V1ContainerState(running=k8s.V1ContainerStateRunning(started_at=datetime.now())),
-            )
-        ]
-        self.events.append({"type": 'MODIFIED', "object": self.pod})
-        self._run()
-        self.watcher.watcher_queue.put.assert_not_called()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -46,40 +46,6 @@ try:
 except ImportError:
     AirflowKubernetesScheduler = None  # type: ignore
 
-WATCHER_STREAM_CONTAINER_STATUSES = [
-    {
-        "container_id": "None",
-        "image": "apache/airflow:2.0.1-python3.8",
-        "image_id": "",
-        "last_state": {"running": "None", "terminated": "None", "waiting": "None"},
-        "name": "base",
-        "ready": "false",
-        "restart_count": 0,
-        "state": {
-            "running": "None",
-            "terminated": {"message": "Terminating", "reason": "Terminating"},
-            "waiting": "None",
-        },
-    }
-]
-
-WATCHER_STREAM_INIT_CONTAINER_STATUSES = [
-    {
-        "container_id": "None",
-        "image": "apache/airflow:2.0.1-python3.8",
-        "image_id": "",
-        "last_state": {"running": "None", "terminated": "None", "waiting": "None"},
-        "name": "base",
-        "ready": "false",
-        "restart_count": 0,
-        "state": {
-            "running": "None",
-            "terminated": {"message": "Terminating", "reason": "Terminating"},
-            "waiting": "None",
-        },
-    }
-]
-
 
 # pylint: disable=unused-argument
 class TestAirflowKubernetesScheduler(unittest.TestCase):

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -507,7 +507,7 @@ class TestKubernetesJobWatcher(unittest.TestCase):
         self._run()
         self.watcher.watcher_queue.put.assert_not_called()
 
-    def test_container_status_of_terminating_fails_pod(self):
+    def test_container_status_of_terminating_with_exit_code_1_fails_pod(self):
         self.pod.status.phase = "Pending"
         self.pod.status.container_statuses = [
             k8s.V1ContainerStatus(
@@ -527,6 +527,27 @@ class TestKubernetesJobWatcher(unittest.TestCase):
         self.events.append({"type": 'MODIFIED', "object": self.pod})
         self._run()
         self.watcher.watcher_queue.put.assert_called()
+
+    def test_container_status_of_terminating_with_exit_code_0_fails_pod(self):
+        self.pod.status.phase = "Pending"
+        self.pod.status.container_statuses = [
+            k8s.V1ContainerStatus(
+                container_id=None,
+                image="apache/airflow:2.0.1-python3.8",
+                image_id="",
+                name="base",
+                ready="false",
+                restart_count=0,
+                state=k8s.V1ContainerState(
+                    terminated=k8s.V1ContainerStateTerminated(
+                        reason="Terminating", exit_code=0
+                    )  # Terminating
+                ),
+            )
+        ]
+        self.events.append({"type": 'MODIFIED', "object": self.pod})
+        self._run()
+        self.watcher.watcher_queue.put.assert_not_called()
 
     def test_container_status_of_waiting_do_not_fail_pod(self):
         self.pod.status.phase = "Pending"
@@ -562,7 +583,7 @@ class TestKubernetesJobWatcher(unittest.TestCase):
         self._run()
         self.watcher.watcher_queue.put.assert_not_called()
 
-    def test_init_container_status_of_terminating_fails_pod(self):
+    def test_init_container_status_of_terminating_with_exit_code_1_fails_pod(self):
         self.pod.status.phase = "Pending"
         self.pod.status.init_container_statuses = [
             k8s.V1ContainerStatus(
@@ -582,6 +603,27 @@ class TestKubernetesJobWatcher(unittest.TestCase):
         self.events.append({"type": 'MODIFIED', "object": self.pod})
         self._run()
         self.watcher.watcher_queue.put.assert_called()
+
+    def test_init_container_status_of_terminating_with_exit_code_0_fails_pod(self):
+        self.pod.status.phase = "Pending"
+        self.pod.status.init_container_statuses = [
+            k8s.V1ContainerStatus(
+                container_id=None,
+                image="apache/airflow:2.0.1-python3.8",
+                image_id="",
+                name="base",
+                ready="false",
+                restart_count=0,
+                state=k8s.V1ContainerState(
+                    terminated=k8s.V1ContainerStateTerminated(
+                        reason="Terminating", exit_code=0
+                    )  # Terminating
+                ),
+            )
+        ]
+        self.events.append({"type": 'MODIFIED', "object": self.pod})
+        self._run()
+        self.watcher.watcher_queue.put.assert_not_called()
 
     def test_init_container_status_of_waiting_do_not_fail_pod(self):
         self.pod.status.phase = "Pending"


### PR DESCRIPTION
Currently, when a container inside a encounter Image pull error, airflow doesn't know about it and
 tasks remain queued. The kubernetes Job Watcher does not watch the status of containers
inside pods. It only watches the pod and report the pod's status to airflow.

From kubernetes doc, the pending phase of a pod is defined to include the
time a Pod spends waiting to be scheduled as well as
the time spent downloading container images over the network.

Network failure can crash the container while the pod remains Pending until a certain
time before it's deleted.

This PR fixes this by including watching of containers in kubernetes job watcher's job

This should close https://github.com/apache/airflow/issues/13542 and https://github.com/apache/airflow/issues/15218 hopefully.
And I prefer it to timing out.

cc: @jedcunningham 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
