### PR TITLE
Updates provider release process

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -1815,8 +1815,11 @@ def get_current_tag(provider_package_id: str, suffix: str, git_update: bool, ver
 
 def cleanup_remnants(verbose: bool):
     if verbose:
-        print("Cleaning remnants (*.egginfo)")
+        print("Cleaning remnants")
     files = glob.glob("*.egg-info")
+    for file in files:
+        shutil.rmtree(file, ignore_errors=True)
+    files = glob.glob("build")
     for file in files:
         shutil.rmtree(file, ignore_errors=True)
 


### PR DESCRIPTION
Updates the provider release process with approach where
Final PyPI upload are the same as SVN uploads.

This way we avoid re-building packages again when we release PyPI
version and the files which get uploaded to PyPI are the same that
are stored in SVN.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
