### PR TITLE
Undeprecate private_key option in SFTPHook

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -102,13 +102,6 @@ class SFTPHook(SSHHook):
                     self.ciphers = extra_options['ciphers']
 
                 if 'private_key' in extra_options:
-                    warnings.warn(
-                        'Extra option `private_key` is deprecated.'
-                        'Please use `key_file` instead.'
-                        'This option will be removed in Airflow 2.1',
-                        DeprecationWarning,
-                        stacklevel=2,
-                    )
                     self.key_file = extra_options.get('private_key')
 
     @tenacity.retry(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Remove the deprecation warning for the `private_key` option in `SFTPHook`. There are valid use cases for storing a private key as a string (i.e. storing them in connections backed by an external secrets backend).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
