### PR TITLE
Fix mountpath in pod template

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -61,13 +61,8 @@ spec:
           name: git-sync-ssh-key
           subPath: ssh
 {{- end }}
-{{- if .Values.dags.persistence.enabled }}
+{{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
         - mountPath: {{ include "airflow_dags_mount_path" . }}
-          name: dags
-          readOnly: true
-{{- end }}
-{{- if .Values.dags.gitSync.enabled }}
-        - mountPath: {{ include "airflow_dags" . }}
           name: dags
           readOnly: true
 {{- end }}


### PR DESCRIPTION
When `dags.gitSync.enabled` is set to `true`, the dags should live in `$AIRFLOW_HOME/dags/repo/dags/`, but they live in `$AIRFLOW_HOME/dags/repo/dags/repo/dags/` instead.

Also, if both `dags.gitSync.enabled` and `dags.persistence.enabled` are true, the mounts would conflict as the paths overlap.

I've changed it such that the volume mount setting is consistent with that of the [scheduler pod spec](https://github.com/apache/airflow/blob/6e31465a30dfd17e2e1409a81600b2e83c910036/chart/templates/scheduler/scheduler-deployment.yaml#L163-L166) that has no issue.