### PR TITLE
Update azure connection documentation

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -74,12 +74,7 @@ class AzureDataExplorerHook(BaseHook):
                      that is initialized. It is highly recommended to create one instance
                      and use it for all queries.
 
-    :param azure_data_explorer_conn_id: Reference to the Azure Data Explorer connection.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:adx`
-
+    :param azure_data_explorer_conn_id: Reference to the :ref:`Azure Data Explorer connection<howto/connection:adx>`.
     :type azure_data_explorer_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -74,7 +74,8 @@ class AzureDataExplorerHook(BaseHook):
                      that is initialized. It is highly recommended to create one instance
                      and use it for all queries.
 
-    :param azure_data_explorer_conn_id: Reference to the :ref:`Azure Data Explorer connection<howto/connection:adx>`.
+    :param azure_data_explorer_conn_id: Reference to the
+        :ref:`Azure Data Explorer connection<howto/connection:adx>`.
     :type azure_data_explorer_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -75,6 +75,11 @@ class AzureDataExplorerHook(BaseHook):
                      and use it for all queries.
 
     :param azure_data_explorer_conn_id: Reference to the Azure Data Explorer connection.
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:adx`
+
     :type azure_data_explorer_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -35,6 +35,15 @@ class AzureBatchHook(BaseHook):
 
     Account name and account key should be in login and password parameters.
     The account url should be in extra parameter as account_url
+
+    :param azure_batch_conn_id: connection id of a service principal which will be used
+        to start the container instance
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:azure_batch`
+
+    :type azure_batch_conn_id: str
     """
 
     conn_name_attr = 'azure_batch_conn_id'

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -36,8 +36,8 @@ class AzureBatchHook(BaseHook):
     Account name and account key should be in login and password parameters.
     The account url should be in extra parameter as account_url
 
-    :param azure_batch_conn_id: :ref:`Azure Batch connection id<howto/connection:azure_batch>` of a service principal which
-        will be used to start the container instance.
+    :param azure_batch_conn_id: :ref:`Azure Batch connection id<howto/connection:azure_batch>`
+        of a service principal which will be used to start the container instance.
     :type azure_batch_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_batch.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_batch.py
@@ -36,13 +36,8 @@ class AzureBatchHook(BaseHook):
     Account name and account key should be in login and password parameters.
     The account url should be in extra parameter as account_url
 
-    :param azure_batch_conn_id: connection id of a service principal which will be used
-        to start the container instance
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:azure_batch`
-
+    :param azure_batch_conn_id: :ref:`Azure Batch connection id<howto/connection:azure_batch>` of a service principal which
+        will be used to start the container instance.
     :type azure_batch_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -36,8 +36,8 @@ class AzureContainerInstanceHook(AzureBaseHook):
     client_id (Application ID) as login, the generated password as password,
     and tenantId and subscriptionId in the extra's field as a json.
 
-    :param azure_conn_id: :ref:`Azure connection id<howto/connection:azure>` of a service principal which will be used
-        to start the container instance.
+    :param azure_conn_id: :ref:`Azure connection id<howto/connection:azure>` of
+        a service principal which will be used to start the container instance.
     :type azure_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -38,6 +38,11 @@ class AzureContainerInstanceHook(AzureBaseHook):
 
     :param conn_id: connection id of a service principal which will be used
         to start the container instance
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:azure`
+
     :type conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -36,14 +36,9 @@ class AzureContainerInstanceHook(AzureBaseHook):
     client_id (Application ID) as login, the generated password as password,
     and tenantId and subscriptionId in the extra's field as a json.
 
-    :param conn_id: connection id of a service principal which will be used
-        to start the container instance
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:azure`
-
-    :type conn_id: str
+    :param azure_conn_id: :ref:`Azure connection id<howto/connection:azure>` of a service principal which will be used
+        to start the container instance.
+    :type azure_conn_id: str
     """
 
     conn_name_attr = 'azure_conn_id'

--- a/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
@@ -28,12 +28,8 @@ class AzureContainerRegistryHook(BaseHook):
     """
     A hook to communicate with a Azure Container Registry.
 
-    :param conn_id: connection id of a service principal which will be used
-        to start the container instance
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:acr`
+    :param conn_id: :ref:`Azure Container Registry connection id<howto/connection:acr>` of a service principal which
+        will be used to start the container instance
 
     :type conn_id: str
     """

--- a/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
@@ -30,6 +30,11 @@ class AzureContainerRegistryHook(BaseHook):
 
     :param conn_id: connection id of a service principal which will be used
         to start the container instance
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:acr`
+
     :type conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_registry.py
@@ -28,8 +28,8 @@ class AzureContainerRegistryHook(BaseHook):
     """
     A hook to communicate with a Azure Container Registry.
 
-    :param conn_id: :ref:`Azure Container Registry connection id<howto/connection:acr>` of a service principal which
-        will be used to start the container instance
+    :param conn_id: :ref:`Azure Container Registry connection id<howto/connection:acr>`
+        of a service principal which will be used to start the container instance
 
     :type conn_id: str
     """

--- a/airflow/providers/microsoft/azure/hooks/azure_container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_volume.py
@@ -27,6 +27,11 @@ class AzureContainerVolumeHook(BaseHook):
 
     :param wasb_conn_id: connection id of a Azure storage account of
         which file shares should be mounted
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:wasp`
+
     :type wasb_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_volume.py
@@ -25,13 +25,8 @@ class AzureContainerVolumeHook(BaseHook):
     """
     A hook which wraps an Azure Volume.
 
-    :param wasb_conn_id: connection id of a Azure storage account of
-        which file shares should be mounted
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:wasp`
-
+    :param  wasb_conn_id: :ref:`Wasb connection id<howto/connection:wasb>` of an Azure storage
+        account of which file shares should be mounted.
     :type wasb_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -41,12 +41,7 @@ class AzureCosmosDBHook(BaseHook):
     optionally, you can use the following extras to default these values
     {"database_name": "<DATABASE_NAME>", "collection_name": "COLLECTION_NAME"}.
 
-    :param azure_cosmos_conn_id: Reference to the Azure CosmosDB connection.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:azure_cosmos`
-
+    :param azure_cosmos_conn_id: Reference to the :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
     :type azure_cosmos_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -42,6 +42,11 @@ class AzureCosmosDBHook(BaseHook):
     {"database_name": "<DATABASE_NAME>", "collection_name": "COLLECTION_NAME"}.
 
     :param azure_cosmos_conn_id: Reference to the Azure CosmosDB connection.
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:azure_cosmos`
+
     :type azure_cosmos_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -41,7 +41,8 @@ class AzureCosmosDBHook(BaseHook):
     optionally, you can use the following extras to default these values
     {"database_name": "<DATABASE_NAME>", "collection_name": "COLLECTION_NAME"}.
 
-    :param azure_cosmos_conn_id: Reference to the :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
+    :param azure_cosmos_conn_id: Reference to the
+        :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
     :type azure_cosmos_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
@@ -75,7 +75,12 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
     A hook to interact with Azure Data Factory.
 
     :param conn_id: The Azure Data Factory connection id.
-    :type conn_id: str
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:adf`
+
+    :type: str
     """
 
     conn_type: str = 'azure_data_factory'

--- a/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_factory.py
@@ -74,12 +74,7 @@ class AzureDataFactoryHook(BaseHook):  # pylint: disable=too-many-public-methods
     """
     A hook to interact with Azure Data Factory.
 
-    :param conn_id: The Azure Data Factory connection id.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:adf`
-
+    :param conn_id: The :ref:`Azure Data Factory connection id<howto/connection:adf>`.
     :type: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -41,6 +41,11 @@ class AzureDataLakeHook(BaseHook):
     {"tenant": "<TENANT>", "account_name": "ACCOUNT_NAME"}.
 
     :param azure_data_lake_conn_id: Reference to the Azure Data Lake connection.
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:adf`
+
     :type azure_data_lake_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_data_lake.py
@@ -40,12 +40,7 @@ class AzureDataLakeHook(BaseHook):
     Tenant and account name should be extra field as
     {"tenant": "<TENANT>", "account_name": "ACCOUNT_NAME"}.
 
-    :param azure_data_lake_conn_id: Reference to the Azure Data Lake connection.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:adf`
-
+    :param azure_data_lake_conn_id: Reference to the :ref:`Azure Data Lake connection<howto/connection:adl>`.
     :type azure_data_lake_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
@@ -30,12 +30,7 @@ class AzureFileShareHook(BaseHook):
     Additional options passed in the 'extra' field of the connection will be
     passed to the `FileService()` constructor.
 
-    :param wasb_conn_id: Reference to the wasb connection.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:wasp`
-
+    :param wasb_conn_id: Reference to the :ref:`wasb connection <howto/connection:wasb>`.
     :type wasb_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
@@ -31,6 +31,11 @@ class AzureFileShareHook(BaseHook):
     passed to the `FileService()` constructor.
 
     :param wasb_conn_id: Reference to the wasb connection.
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:wasp`
+
     :type wasb_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -31,12 +31,8 @@ class AzureBaseHook(BaseHook):
 
     :param sdk_client: The SDKClient to use.
     :type sdk_client: Optional[str]
-    :param azure_conn_id: The azure connection id which refers to the information to connect to the service.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:azure`
-
+    :param azure_conn_id: The :ref:`Azure connection id<howto/connection:azure>` which refers to the information
+        to connect to the service.
     :type: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -31,8 +31,13 @@ class AzureBaseHook(BaseHook):
 
     :param sdk_client: The SDKClient to use.
     :type sdk_client: Optional[str]
-    :param conn_id: The azure connection id which refers to the information to connect to the service.
-    :type conn_id: str
+    :param azure_conn_id: The azure connection id which refers to the information to connect to the service.
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:azure`
+
+    :type: str
     """
 
     conn_name_attr = 'azure_conn_id'

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -31,8 +31,8 @@ class AzureBaseHook(BaseHook):
 
     :param sdk_client: The SDKClient to use.
     :type sdk_client: Optional[str]
-    :param azure_conn_id: The :ref:`Azure connection id<howto/connection:azure>` which refers to the information
-        to connect to the service.
+    :param azure_conn_id: The :ref:`Azure connection id<howto/connection:azure>`
+        which refers to the information to connect to the service.
     :type: str
     """
 

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -46,12 +46,7 @@ class WasbHook(BaseHook):
     passed to the `BlockBlockService()` constructor. For example, authenticate
     using a SAS token by adding {"sas_token": "YOUR_TOKEN"}.
 
-    :param wasb_conn_id: Reference to the wasb connection.
-
-        .. seealso::
-            See the docs for information on how to setup this connection:
-            :ref:`howto/connection:wasp`
-
+    :param wasb_conn_id: Reference to the :ref:`wasb connection <howto/connection:wasb>`.
     :type wasb_conn_id: str
     :param public_read: Whether an anonymous public read access should be used. default is False
     :type public_read: bool

--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -47,6 +47,11 @@ class WasbHook(BaseHook):
     using a SAS token by adding {"sas_token": "YOUR_TOKEN"}.
 
     :param wasb_conn_id: Reference to the wasb connection.
+
+        .. seealso::
+            See the docs for information on how to setup this connection:
+            :ref:`howto/connection:wasp`
+
     :type wasb_conn_id: str
     :param public_read: Whether an anonymous public read access should be used. default is False
     :type public_read: bool

--- a/airflow/providers/microsoft/azure/operators/adls_delete.py
+++ b/airflow/providers/microsoft/azure/operators/adls_delete.py
@@ -36,6 +36,8 @@ class AzureDataLakeStorageDeleteOperator(BaseOperator):
     :type recursive: bool
     :param ignore_not_found: Whether to raise error if file to delete is not found
     :type ignore_not_found: bool
+    :param azure_data_lake_conn_id: Reference to the :ref:`Azure Data Lake connection<howto/connection:adl>`.
+    :type azure_data_lake_conn_id: str
     """
 
     template_fields: Sequence[str] = ('path',)

--- a/airflow/providers/microsoft/azure/operators/adls_list.py
+++ b/airflow/providers/microsoft/azure/operators/adls_list.py
@@ -32,8 +32,7 @@ class AzureDataLakeStorageListOperator(BaseOperator):
     :param path: The Azure Data Lake path to find the objects. Supports glob
         strings (templated)
     :type path: str
-    :param azure_data_lake_conn_id: The connection ID to use when
-        connecting to Azure Data Lake Storage.
+    :param azure_data_lake_conn_id: Reference to the :ref:`Azure Data Lake connection<howto/connection:adl>`.
     :type azure_data_lake_conn_id: str
 
     **Example**:

--- a/airflow/providers/microsoft/azure/operators/adx.py
+++ b/airflow/providers/microsoft/azure/operators/adx.py
@@ -39,7 +39,7 @@ class AzureDataExplorerQueryOperator(BaseOperator):
     :param options: Optional query options. See:
       https://docs.microsoft.com/en-us/azure/kusto/api/netfx/request-properties#list-of-clientrequestproperties
     :type options: dict
-    :param azure_data_explorer_conn_id: Azure Data Explorer connection to use.
+    :param azure_data_explorer_conn_id: Reference to the :ref:`Azure Data Explorer connection<howto/connection:adx>`.
     :type azure_data_explorer_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/operators/adx.py
+++ b/airflow/providers/microsoft/azure/operators/adx.py
@@ -39,7 +39,8 @@ class AzureDataExplorerQueryOperator(BaseOperator):
     :param options: Optional query options. See:
       https://docs.microsoft.com/en-us/azure/kusto/api/netfx/request-properties#list-of-clientrequestproperties
     :type options: dict
-    :param azure_data_explorer_conn_id: Reference to the :ref:`Azure Data Explorer connection<howto/connection:adx>`.
+    :param azure_data_explorer_conn_id: Reference to the
+        :ref:`Azure Data Explorer connection<howto/connection:adx>`.
     :type azure_data_explorer_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/operators/azure_batch.py
+++ b/airflow/providers/microsoft/azure/operators/azure_batch.py
@@ -89,7 +89,7 @@ class AzureBatchOperator(BaseOperator):
         This property must not be specified if enableAutoScale is set to false.
         It is required if enableAutoScale is set to true.
     :type auto_scale_formula: Optional[str]
-    :param azure_batch_conn_id: The connection id of Azure batch service
+    :param azure_batch_conn_id: The :ref:`Azure Batch connection id<howto/connection:azure_batch>`
     :type azure_batch_conn_id: str
     :param use_latest_verified_vm_image_and_sku: Whether to use the latest verified virtual
         machine image and sku in the batch account. Default is false.

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -62,7 +62,8 @@ class AzureContainerInstancesOperator(BaseOperator):
         to start the container instance
     :type ci_conn_id: str
     :param registry_conn_id: connection id of a user which can login to a
-        private docker registry. If None, we assume a public registry
+        private docker registry. For Azure use :ref:`Azure connection id<howto/connection:azure>`
+    :type azure_conn_id: str If None, we assume a public registry
     :type registry_conn_id: Optional[str]
     :param resource_group: name of the resource group wherein this container
         instance should be started

--- a/airflow/providers/microsoft/azure/operators/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/operators/azure_cosmos.py
@@ -32,7 +32,7 @@ class AzureCosmosInsertDocumentOperator(BaseOperator):
     :type collection_name: str
     :param document: The document to insert
     :type document: dict
-    :param azure_cosmos_conn_id: reference to a CosmosDB connection.
+    :param azure_cosmos_conn_id: Reference to the :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
     :type azure_cosmos_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/operators/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/operators/azure_cosmos.py
@@ -32,7 +32,8 @@ class AzureCosmosInsertDocumentOperator(BaseOperator):
     :type collection_name: str
     :param document: The document to insert
     :type document: dict
-    :param azure_cosmos_conn_id: Reference to the :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
+    :param azure_cosmos_conn_id: Reference to the
+        :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
     :type azure_cosmos_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/operators/wasb_delete_blob.py
+++ b/airflow/providers/microsoft/azure/operators/wasb_delete_blob.py
@@ -31,7 +31,7 @@ class WasbDeleteBlobOperator(BaseOperator):
     :type container_name: str
     :param blob_name: Name of the blob. (templated)
     :type blob_name: str
-    :param wasb_conn_id: Reference to the wasb connection.
+    :param wasb_conn_id: Reference to the :ref:`wasb connection <howto/connection:wasb>`.
     :type wasb_conn_id: str
     :param check_options: Optional keyword arguments that
         `WasbHook.check_for_blob()` takes.

--- a/airflow/providers/microsoft/azure/sensors/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/sensors/azure_cosmos.py
@@ -41,7 +41,8 @@ class AzureCosmosDocumentSensor(BaseSensorOperator):
     :type collection_name: str
     :param document_id: The ID of the target document.
     :type document_id: str
-    :param azure_cosmos_conn_id: Reference to the Azure CosmosDB connection.
+    :param azure_cosmos_conn_id: Reference to the
+        :ref:`Azure CosmosDB connection<howto/connection:azure_cosmos>`.
     :type azure_cosmos_conn_id: str
     """
 

--- a/airflow/providers/microsoft/azure/sensors/wasb.py
+++ b/airflow/providers/microsoft/azure/sensors/wasb.py
@@ -31,7 +31,7 @@ class WasbBlobSensor(BaseSensorOperator):
     :type container_name: str
     :param blob_name: Name of the blob.
     :type blob_name: str
-    :param wasb_conn_id: Reference to the wasb connection.
+    :param wasb_conn_id: Reference to the :ref:`wasb connection <howto/connection:wasb>`.
     :type wasb_conn_id: str
     :param check_options: Optional keyword arguments that
         `WasbHook.check_for_blob()` takes.

--- a/docs/apache-airflow-providers-microsoft-azure/connections/acr.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/acr.rst
@@ -59,5 +59,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_AZURE_CONTAINER_REGISTRY_DEFAULT='azure-container-registry://password:registryserver.com@username?tenant=tenant+id&account_name=store+name'
-
+    export AIRFLOW_CONN_AZURE_CONTAINER_REGISTRY_DEFAULT='azure-container-registry://password:registryserver.com@username?tenant=tenant+id&account_name=store+name'

--- a/docs/apache-airflow-providers-microsoft-azure/connections/acr.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/acr.rst
@@ -59,4 +59,4 @@ For example:
 
 .. code-block:: bash
 
-    export AIRFLOW_CONN_AZURE_CONTAINER_REGISTRY_DEFAULT='azure-container-registry://password:registryserver.com@username?tenant=tenant+id&account_name=store+name'
+    export AIRFLOW_CONN_AZURE_CONTAINER_REGISTRY_DEFAULT='azure-container-registry://username:password@myregistry.com?tenant=tenant+id&account_name=store+name'

--- a/docs/apache-airflow-providers-microsoft-azure/connections/acr.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/acr.rst
@@ -1,0 +1,63 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:acr:
+
+Microsoft Azure Container Registry Connection
+==============================================
+
+The Microsoft Azure Container Registry connection type enables the Azure Container Registry Integrations.
+
+Authenticating to Azure Container Registry
+------------------------------------------
+
+There is one way to connect to Azure Container Registry using Airflow.
+
+1. Use `Individual login with Azure AD
+   <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication#individual-login-with-azure-ad>`_
+   i.e. add specific credentials to the Airflow connection.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Container Registry use ``azure_container_registry_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the Image Registry Username used for the initial connection.
+
+Password
+    Specify the Image Registry Password used for the initial connection.
+
+Host
+    Specify the Image Registry Server used for the initial connection.
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_AZURE_CONTAINER_REGISTRY_DEFAULT='azure-container-registry://password:registryserver.com@username?tenant=tenant+id&account_name=store+name'
+

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
@@ -70,4 +70,3 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_AZURE_DATA_FACTORY_DEFAULT='azure-data-factory://client%20id:secret@?tenantId=tenant+id&subscriptionId=subscription+id&resourceGroup=group+name&factory=factory+name'
-

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
@@ -1,0 +1,73 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:adf:
+
+Microsoft Azure Data Factory Connection
+=======================================
+
+The Microsoft Azure Data Factory connection type enables the Azure Data Factory Integrations.
+
+Authenticating to Azure Data Factory
+------------------------------------
+
+There is one way to connect to Azure Data Factory using Airflow.
+
+1. Use `token credentials
+   <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
+   i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Data Factory use ``azure_data_factory_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the ``client_id`` used for the initial connection.
+    This is needed for *token credentials* authentication mechanism.
+
+Password
+    Specify the ``secret`` used for the initial connection.
+    This is needed for *token credentials* authentication mechanism.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Azure Data Lake connection.
+    The following parameters are all optional:
+
+    * ``tenantId``: Specify the tenant to use.
+      This is  needed for *token credentials* authentication mechanism.
+    * ``subscriptionId``: Specify the subscription id to use.
+      This is  needed for *token credentials* authentication mechanism.
+    * ``resourceGroup``: Specify the azure resource group name.
+    * ``factory``: Specify the azure data factory to use
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_AZURE_DATA_FACTORY_DEFAULT='azure-data-factory://client%20id:secret@?tenantId=tenant+id&subscriptionId=subscription+id&resourceGroup=group+name&factory=factory+name'
+

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adl.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adl.rst
@@ -68,4 +68,3 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_AZURE_DATA_LAKE_DEFAULT='azure-data-lake://client%20id:secret@?tenant=tenant+id&account_name=store+name'
-

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adl.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adl.rst
@@ -1,0 +1,71 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:adl:
+
+Microsoft Azure Data Lake Connection
+====================================
+
+The Microsoft Azure Data Lake connection type enables the Azure Data Lake Integrations.
+
+Authenticating to Azure Data Lake
+---------------------------------
+
+There is one way to connect to Azure Data Lake using Airflow.
+
+1. Use `token credentials
+   <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
+   i.e. add specific credentials (client_id, secret, tenant) and account name to the Airflow connection.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Data Lake use ``azure_data_lake_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the ``client_id`` used for the initial connection.
+    This is needed for *token credentials* authentication mechanism.
+
+Password
+    Specify the ``secret`` used for the initial connection.
+    This is only needed for *token credentials* authentication mechanism.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Azure Data Lake connection.
+    The following parameters are all optional:
+
+    * ``tenant``: Specify the tenant to use.
+      This is needed for *token credentials* authentication mechanism.
+    * ``account_name``: Specify the azure data lake account name.
+      This is sometimes called the ``store_name``
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_AZURE_DATA_LAKE_DEFAULT='azure-data-lake://client%20id:secret@?tenant=tenant+id&account_name=store+name'
+

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adx.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adx.rst
@@ -1,0 +1,96 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:adx:
+
+Microsoft Azure Data Explorer Connection
+=========================================
+
+The Microsoft Azure Blob Storage connection type enables the Azure Blob Storage Integrations.
+
+Authenticating to Azure Data Explorer
+---------------------------------------
+
+There are three ways to connect to Azure Data Explorer using Airflow.
+
+1. Use `AAD application certificate
+   <https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-certificate-credentials>`_
+   i.e. use AAD_APP or AAD_APP_CERT as ``auth_method`` in the Airflow connection.
+2. Use `AAD username and password
+   <https://docs.microsoft.com/en-us/azure/active-directory/authentication/concept-authentication-methods>`_
+   i.e. use AAD_CREDS as ``auth_method`` in the Airflow connection.
+3. Use a `AAD device code
+   <https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-device-code>`_
+   i.e. use AAD_DEVICE as ``auth_method`` in the Airflow connection.
+
+Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
+configure multiple connections.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Data Explorer use ``azure_data_explorer_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login (optional)
+    Specify the username used for data explorer. Needed for with AAD_APP, AAD_APP_CERT, and AAD_CREDS authentication methods.
+
+Password (optional)
+    Specify the password used for data explorer. Needed for with AAD_APP, and AAD_CREDS authentication methods.
+
+Host
+    Specify the data explorer cluster url. Needed for all authentication methods.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Azure connection.
+    The following parameters are all optional:
+
+    * ``auth_method``: Specify authentication method. Available authentication methods are:
+
+      AAD_APP : Authentication with AAD application certificate. Extra parameters:
+      "tenant" is required when using this method. Provide application ID
+      and application key through username and password parameters.
+
+      AAD_APP_CERT: Authentication with AAD application certificate. Extra parameters:
+      "tenant", "certificate" and "thumbprint" are required when using this method.
+
+      AAD_CREDS : Authentication with AAD username and password. Extra parameters:
+      "tenant" is required when using this method. Username and password
+      parameters are used for authentication with AAD.
+
+      AAD_DEVICE : Authenticate with AAD device code. Please note that if you choose
+      this option, you'll need to authenticate for every new instance that is initialized.
+      It is highly recommended to create one instance and use it for all queries.
+
+    * ``tenant``: Specify AAD tenant. Needed for AAD_APP, AAD_APP_CERT, and AAD_CREDS.
+    * ``certificate``: Specify the certificate. Needed for AAD_APP_CERT authentication method.
+    * ``thumbprint``: Specify the thumbprint needed for use with AAD_APP_CERT authentication method.
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_AZURE_DATA_EXPLORER_DEFAULT='azure-data-explorer://add%20username:add%20password@mycluster.com?auth_method=AAD_APP&tenant=tenant+id'

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure.rst
@@ -45,7 +45,7 @@ configure multiple connections.
 Default Connection IDs
 ----------------------
 
-Some hooks and operators related to Microsoft Azure use ``azure_default`` by default.
+All hooks and operators related to Microsoft Azure Container Instances use ``azure_default`` by default.
 
 Configuring the Connection
 --------------------------
@@ -69,7 +69,7 @@ Extra (optional)
     * ``key_path``: If set, it uses the *JSON file* authentication mechanism.
       It specifies the path to the json file that contains the authentication information.
     * ``key_json``: If set, it uses the *JSON dictionary* authentication mechanism.
-      It specifies the json that contains the authentication information. See
+      It specifies the json that contains the authentication information.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -81,3 +81,4 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_AZURE_DEFAULT='azure://?key_path=%2Fkeys%2Fkey.json'
+

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure.rst
@@ -81,4 +81,3 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_AZURE_DEFAULT='azure://?key_path=%2Fkeys%2Fkey.json'
-

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_batch.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_batch.rst
@@ -1,0 +1,66 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:azure_batch:
+
+Microsoft Azure Batch Connection
+====================================
+
+The Microsoft Azure Batch connection type enables the Azure Batch Integrations.
+
+Authenticating to Azure Batch
+------------------------------------------
+
+There is one way to connect to Azure Batch using Airflow.
+
+1. Use `Azure Shared Key Credential
+   <https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key>`_
+   i.e. add shared key credentials to the Airflow connection.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Batch use ``azure_batch_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the Azure Batch Account Name used for the initial connection.
+
+Password
+    Specify the Azure Batch Key used for the initial connection.
+
+Extra
+    Specify the extra parameters (as json dictionary) that can be used in Azure Batch connection.
+    The following parameters are all optional:
+
+    * ``account_url``: Specify the batch account url you would like to use.
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_AZURE_BATCH_DEFAULT='azure-batch://batch%20acount:batch%20key@?account_url=mybatchaccount.com'
+

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_batch.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_batch.rst
@@ -63,4 +63,3 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_AZURE_BATCH_DEFAULT='azure-batch://batch%20acount:batch%20key@?account_url=mybatchaccount.com'
-

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_cosmos.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_cosmos.rst
@@ -64,4 +64,3 @@ For example:
 .. code-block:: bash
 
    export AIRFLOW_CONN_AZURE_COSMOS_DEFAULT='azure-cosmos://https%3A%2F%2Fairflow.azure.com:master%20key@?database_name=mydatabase&collection_name=mycollection'
-

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_cosmos.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_cosmos.rst
@@ -1,0 +1,67 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:azure_cosmos:
+
+Microsoft Azure Cosmos
+====================================
+
+The Microsoft Azure Cosmos connection type enables the Azure Cosmos Integrations.
+
+Authenticating to Azure
+-----------------------
+
+There is one way to connect to Azure Cosmos using Airflow.
+
+1. Use `Primary Keys
+   <https://docs.microsoft.com/en-us/azure/cosmos-db/secure-access-to-data#primary-keys>`_
+   i.e. add specific credentials (client_id, secret, tenant) and account name to the Airflow connection.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Cosmos use ``azure_cosmos_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the Cosmos Endpoint URI used for the initial connection.
+
+Password
+    Specify the Cosmos Master Key Token used for the initial connection.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Azure Cosmos connection.
+    The following parameters are all optional:
+
+    * ``database_name``: Specify the azure cosmos database to use.
+    * ``collection_name``: Specify the azure cosmos collection to use.
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_AZURE_COSMOS_DEFAULT='azure-cosmos://https%3A%2F%2Fairflow.azure.com:master%20key@?database_name=mydatabase&collection_name=mycollection'
+

--- a/docs/apache-airflow-providers-microsoft-azure/connections/index.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/index.rst
@@ -1,0 +1,25 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Connection Types
+----------------
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    *

--- a/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/wasb.rst
@@ -17,7 +17,7 @@
 
 
 
-.. _howto/connection:wasp:
+.. _howto/connection:wasb:
 
 Microsoft Azure Blob Storage Connection
 =======================================
@@ -81,4 +81,4 @@ For example connect with token credentials:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_WASP_DEFAULT='wasp://blob%20username:blob%20password@myblob.com?tenant_id=tenant+id'
+   export AIRFLOW_CONN_WASP_DEFAULT='wasb://blob%20username:blob%20password@myblob.com?tenant_id=tenant+id'

--- a/docs/apache-airflow-providers-microsoft-azure/connections/wasp.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/wasp.rst
@@ -1,0 +1,84 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:wasp:
+
+Microsoft Azure Blob Storage Connection
+=======================================
+
+The Microsoft Azure Blob Storage connection type enables the Azure Blob Storage Integrations.
+
+Authenticating to Azure Blob Storage
+------------------------------------
+
+There are four ways to connect to Azure Blob Storage using Airflow.
+
+1. Use `token credentials
+   <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
+   i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
+2. Use `Azure Shared Key Credential
+   <https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key>`_
+   i.e. add shared key credentials to the Airflow connection.
+3. Use a `SAS Token
+   <https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas>`_
+   i.e. add a key config directly into the Airflow connection.
+4. Use a `Connection String
+   <https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/connection-strings/storage>`_
+   i.e. add connection string to ``connection_string`` in the Airflow connection.
+
+Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
+configure multiple connections.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Microsoft Azure Blob Storage, Azure FileShare Storage, and Azure Volume use ``wasp_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login (optional)
+    Specify the login used for azure blob storage. For use with Shared Key Credential and SAS Token authentication.
+
+Password (optional)
+    Specify the password used for azure blob storage. For use with
+    Active Directory (token credential) and shared key authentication.
+
+Host (optional)
+    Specify the account url for anonymous public read, Active Directory, shared access key authentication.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Azure connection.
+    The following parameters are all optional:
+
+    * ``tenant_id``: Specify the tenant to use. Needed for Active Directory (token) authentication.
+    * ``shared_access_key``: Specify the shared access key. Needed for shared access key authentication.
+    * ``connection_string``: Connection string for use with connection string authentication.
+    * ``sas_token``: SAS Token for use with SAS Token authentication.
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example connect with token credentials:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_WASP_DEFAULT='wasp://blob%20username:blob%20password@myblob.com?tenant_id=tenant+id'

--- a/docs/apache-airflow-providers-microsoft-azure/index.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/index.rst
@@ -26,7 +26,7 @@ Content
     :maxdepth: 1
     :caption: Guides
 
-    Connection types <connections/azure>
+    Connection types <connections/index>
     Operators <operators/index>
     Secrets backends <secrets-backends/azure-key-vault>
     Logging for Tasks <logging>


### PR DESCRIPTION
Update the documentation on connecting to azure services. This PR creates a page in docs for each azure connection that explains how to setup the connection. This PR also connects the `conn_id` params in hooks and operators docstrings to connection documentation as shown below.

![image](https://user-images.githubusercontent.com/63181127/114768640-284f9b80-9d37-11eb-982c-cd3bfca43f83.png)

