### PR TITLE
Operator to run a Python callable against an arbitrary Python interpreter

### DIFF
--- a/airflow/decorators/python_virtualenv.py
+++ b/airflow/decorators/python_virtualenv.py
@@ -25,6 +25,7 @@ from airflow.utils.decorators import apply_defaults
 from airflow.utils.python_virtualenv import remove_task_decorator
 
 
+# pylint: disable=too-many-ancestors
 class _PythonVirtualenvDecoratedOperator(DecoratedOperator, PythonVirtualenvOperator):
     """
     Wraps a Python callable and captures args/kwargs when called for execution.

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -215,7 +215,146 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
         self.log.info("Done.")
 
 
-class PythonVirtualenvOperator(PythonOperator):
+class _BaseExternalPythonOperator(PythonOperator):
+    BASE_SERIALIZABLE_CONTEXT_KEYS = {
+        'ds_nodash',
+        'inlets',
+        'next_ds',
+        'next_ds_nodash',
+        'outlets',
+        'params',
+        'prev_ds',
+        'prev_ds_nodash',
+        'run_id',
+        'task_instance_key_str',
+        'test_mode',
+        'tomorrow_ds',
+        'tomorrow_ds_nodash',
+        'ts',
+        'ts_nodash',
+        'ts_nodash_with_tz',
+        'yesterday_ds',
+        'yesterday_ds_nodash',
+    }
+    PENDULUM_SERIALIZABLE_CONTEXT_KEYS = {
+        'execution_date',
+        'next_execution_date',
+        'prev_execution_date',
+        'prev_execution_date_success',
+        'prev_start_date_success',
+    }
+    AIRFLOW_SERIALIZABLE_CONTEXT_KEYS = {'macros', 'conf', 'dag', 'dag_run', 'task'}
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        *,
+        python_callable: Callable,
+        use_airflow: bool,
+        use_dill: bool = False,
+        use_pendulum: bool,
+        op_args: Optional[List] = None,
+        op_kwargs: Optional[Dict] = None,
+        string_args: Optional[Iterable[str]] = None,
+        templates_dict: Optional[Dict] = None,
+        templates_exts: Optional[List[str]] = None,
+        **kwargs,
+    ):
+        if (
+            not isinstance(python_callable, types.FunctionType)
+            or isinstance(python_callable, types.LambdaType)
+            and python_callable.__name__ == "<lambda>"
+        ):
+            raise AirflowException('PythonVirtualenvOperator only supports functions for python_callable arg')
+        super().__init__(
+            python_callable=python_callable,
+            op_args=op_args,
+            op_kwargs=op_kwargs,
+            templates_dict=templates_dict,
+            templates_exts=templates_exts,
+            **kwargs,
+        )
+        self.string_args = string_args or []
+        self.use_airflow = use_airflow
+        self.use_dill = use_dill
+        self.use_pendulum = use_pendulum
+        self.pickling_library = dill if self.use_dill else pickle
+
+    def _get_serializable_context_keys(self):
+        serializable_context_keys = self.BASE_SERIALIZABLE_CONTEXT_KEYS.copy()
+        if self.use_airflow:
+            serializable_context_keys.update(self.AIRFLOW_SERIALIZABLE_CONTEXT_KEYS)
+        if self.use_airflow or self.use_pendulum:
+            serializable_context_keys.update(self.PENDULUM_SERIALIZABLE_CONTEXT_KEYS)
+        return serializable_context_keys
+
+    def execute(self, context: Dict):
+        serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
+        return super().execute(context=serializable_context)
+
+    def get_python_source(self):
+        """
+        Returns the source of self.python_callable
+        @return:
+        """
+        return dedent(inspect.getsource(self.python_callable))
+
+    def _write_args(self, filename):
+        if self.op_args or self.op_kwargs:
+            with open(filename, 'wb') as file:
+                self.pickling_library.dump({'args': self.op_args, 'kwargs': self.op_kwargs}, file)
+
+    def _write_string_args(self, filename):
+        with open(filename, 'w') as file:
+            file.write('\n'.join(map(str, self.string_args)))
+
+    def _read_result(self, filename):
+        if os.stat(filename).st_size == 0:
+            return None
+        with open(filename, 'rb') as file:
+            try:
+                return self.pickling_library.load(file)
+            except ValueError:
+                self.log.error(
+                    "Error deserializing result. Note that result deserialization "
+                    "is not supported across major Python versions."
+                )
+                raise
+
+    def _execute_callable_with(self, executable: str, env_root: str) -> Any:
+        if self.templates_dict:
+            self.op_kwargs['templates_dict'] = self.templates_dict
+
+        input_filename = os.path.join(env_root, 'script.in')
+        output_filename = os.path.join(env_root, 'script.out')
+        string_args_filename = os.path.join(env_root, 'script.out')
+        script_filename = os.path.join(env_root, 'script.py')
+
+        self._write_args(input_filename)
+        self._write_string_args(string_args_filename)
+        write_python_script(
+            jinja_context=dict(
+                op_args=self.op_args,
+                op_kwargs=self.op_kwargs,
+                pickling_library=self.pickling_library.__name__,
+                python_callable=self.python_callable.__name__,
+                python_callable_source=self.get_python_source(),
+            ),
+            filename=script_filename,
+        )
+
+        execute_in_subprocess(
+            cmd=[
+                executable,
+                script_filename,
+                input_filename,
+                output_filename,
+                string_args_filename,
+            ]
+        )
+        return self._read_result(output_filename)
+
+
+class PythonVirtualenvOperator(_BaseExternalPythonOperator):
     """
     Allows one to run a function in a virtualenv that is created and destroyed
     automatically (with certain caveats).
@@ -268,35 +407,6 @@ class PythonVirtualenvOperator(PythonOperator):
     :type templates_exts: list[str]
     """
 
-    BASE_SERIALIZABLE_CONTEXT_KEYS = {
-        'ds_nodash',
-        'inlets',
-        'next_ds',
-        'next_ds_nodash',
-        'outlets',
-        'params',
-        'prev_ds',
-        'prev_ds_nodash',
-        'run_id',
-        'task_instance_key_str',
-        'test_mode',
-        'tomorrow_ds',
-        'tomorrow_ds_nodash',
-        'ts',
-        'ts_nodash',
-        'ts_nodash_with_tz',
-        'yesterday_ds',
-        'yesterday_ds_nodash',
-    }
-    PENDULUM_SERIALIZABLE_CONTEXT_KEYS = {
-        'execution_date',
-        'next_execution_date',
-        'prev_execution_date',
-        'prev_execution_date_success',
-        'prev_start_date_success',
-    }
-    AIRFLOW_SERIALIZABLE_CONTEXT_KEYS = {'macros', 'conf', 'dag', 'dag_run', 'task'}
-
     @apply_defaults
     def __init__(  # pylint: disable=too-many-arguments
         self,
@@ -314,12 +424,6 @@ class PythonVirtualenvOperator(PythonOperator):
         **kwargs,
     ):
         if (
-            not isinstance(python_callable, types.FunctionType)
-            or isinstance(python_callable, types.LambdaType)
-            and python_callable.__name__ == "<lambda>"
-        ):
-            raise AirflowException('PythonVirtualenvOperator only supports functions for python_callable arg')
-        if (
             python_version
             and str(python_version)[0] != str(sys.version_info.major)
             and (op_args or op_kwargs)
@@ -328,111 +432,39 @@ class PythonVirtualenvOperator(PythonOperator):
                 "Passing op_args or op_kwargs is not supported across different Python "
                 "major versions for PythonVirtualenvOperator. Please use string_args."
             )
+
+        requirements = list(requirements or [])
+        if not system_site_packages and use_dill and 'dill' not in requirements:
+            requirements.append('dill')
+
+        use_airflow = system_site_packages or 'apache-airflow' in requirements
+        use_pendulum = 'pendulum' in requirements and 'lazy_object_proxy' in requirements
+
         super().__init__(
             python_callable=python_callable,
+            use_airflow=use_airflow,
+            use_dill=use_dill,
+            use_pendulum=use_pendulum,
             op_args=op_args,
             op_kwargs=op_kwargs,
+            string_args=string_args,
             templates_dict=templates_dict,
             templates_exts=templates_exts,
             **kwargs,
         )
-        self.requirements = list(requirements or [])
-        self.string_args = string_args or []
+        self.requirements = requirements
         self.python_version = python_version
-        self.use_dill = use_dill
         self.system_site_packages = system_site_packages
-        if not self.system_site_packages and self.use_dill and 'dill' not in self.requirements:
-            self.requirements.append('dill')
-        self.pickling_library = dill if self.use_dill else pickle
-
-    def execute(self, context: Dict):
-        serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
-        return super().execute(context=serializable_context)
 
     def execute_callable(self):
         with TemporaryDirectory(prefix='venv') as tmp_dir:
-            if self.templates_dict:
-                self.op_kwargs['templates_dict'] = self.templates_dict
-
-            input_filename = os.path.join(tmp_dir, 'script.in')
-            output_filename = os.path.join(tmp_dir, 'script.out')
-            string_args_filename = os.path.join(tmp_dir, 'string_args.txt')
-            script_filename = os.path.join(tmp_dir, 'script.py')
-
             prepare_virtualenv(
                 venv_directory=tmp_dir,
                 python_bin=f'python{self.python_version}' if self.python_version else None,
                 system_site_packages=self.system_site_packages,
                 requirements=self.requirements,
             )
-
-            self._write_args(input_filename)
-            self._write_string_args(string_args_filename)
-            write_python_script(
-                jinja_context=dict(
-                    op_args=self.op_args,
-                    op_kwargs=self.op_kwargs,
-                    pickling_library=self.pickling_library.__name__,
-                    python_callable=self.python_callable.__name__,
-                    python_callable_source=self.get_python_source(),
-                ),
-                filename=script_filename,
-            )
-
-            execute_in_subprocess(
-                cmd=[
-                    f'{tmp_dir}/bin/python',
-                    script_filename,
-                    input_filename,
-                    output_filename,
-                    string_args_filename,
-                ]
-            )
-
-            return self._read_result(output_filename)
-
-    def get_python_source(self):
-        """
-        Returns the source of self.python_callable
-        @return:
-        """
-        return dedent(inspect.getsource(self.python_callable))
-
-    def _write_args(self, filename):
-        if self.op_args or self.op_kwargs:
-            with open(filename, 'wb') as file:
-                self.pickling_library.dump({'args': self.op_args, 'kwargs': self.op_kwargs}, file)
-
-    def _get_serializable_context_keys(self):
-        def _is_airflow_env():
-            return self.system_site_packages or 'apache-airflow' in self.requirements
-
-        def _is_pendulum_env():
-            return 'pendulum' in self.requirements and 'lazy_object_proxy' in self.requirements
-
-        serializable_context_keys = self.BASE_SERIALIZABLE_CONTEXT_KEYS.copy()
-        if _is_airflow_env():
-            serializable_context_keys.update(self.AIRFLOW_SERIALIZABLE_CONTEXT_KEYS)
-        if _is_pendulum_env() or _is_airflow_env():
-            serializable_context_keys.update(self.PENDULUM_SERIALIZABLE_CONTEXT_KEYS)
-        return serializable_context_keys
-
-    def _write_string_args(self, filename):
-        with open(filename, 'w') as file:
-            file.write('\n'.join(map(str, self.string_args)))
-
-    def _read_result(self, filename):
-        if os.stat(filename).st_size == 0:
-            return None
-        with open(filename, 'rb') as file:
-            try:
-                return self.pickling_library.load(file)
-            except ValueError:
-                self.log.error(
-                    "Error deserializing result. Note that result deserialization "
-                    "is not supported across major Python versions."
-                )
-                raise
+            return self._execute_callable_with(f'{tmp_dir}/bin/python', tmp_dir)
 
 
 def get_current_context() -> Dict[str, Any]:


### PR DESCRIPTION
Context available in https://github.com/apache/airflow/issues/15286#issuecomment-818866373

Most of the diff is to refactor the serialisation stuff out of `PythonVirtualenvOperator`; the only real addition in the `ExternalPythonOperator` class at the bottom.

Tests and documentation to come.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
