### PR TITLE
Do not forward cluster-identifier to psycopg2

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -102,6 +102,7 @@ class PostgresHook(DbApiHook):
                 'iam',
                 'redshift',
                 'cursor',
+                'cluster-identifier',
             ]:
                 conn_args[arg_name] = arg_val
 

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -115,7 +115,7 @@ class TestPostgresHookConn(unittest.TestCase):
     @mock.patch('airflow.providers.postgres.hooks.postgres.psycopg2.connect')
     @mock.patch('airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.get_client_type')
     def test_get_conn_rds_iam_redshift(self, mock_client, mock_connect):
-        self.connection.extra = '{"iam":true, "redshift":true}'
+        self.connection.extra = '{"iam":true, "redshift":true, "cluster-identifier": "different-identifier"}'
         self.connection.host = 'cluster-identifier.ccdfre4hpd39h.us-east-1.redshift.amazonaws.com'
         login = f'IAM:{self.connection.login}'
         mock_client.return_value.get_cluster_credentials.return_value = {


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Do not forward cluster-identifier parameter to psycopgy2
---
Cluster ID is used by botocore to fetch Redshift credentials only, and will result in
```
psycopg2.ProgrammingError: invalid dsn: invalid connection option "cluster-identifier"
```
if subsequently passed to the postgres connection constructor.
