### PR TITLE
Implement BigQuery Table Schema Update Operator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigquery_operations.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_operations.py
@@ -36,6 +36,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryPatchDatasetOperator,
     BigQueryUpdateDatasetOperator,
     BigQueryUpdateTableOperator,
+    BigQueryUpdateTableSchemaOperator,
     BigQueryUpsertTableOperator,
 )
 from airflow.utils.dates import days_ago
@@ -72,6 +73,18 @@ with models.DAG(
         ],
     )
     # [END howto_operator_bigquery_create_table]
+
+    # [START howto_operator_bigquery_update_table_schema]
+    update_table_schema = BigQueryUpdateTableSchemaOperator(
+        task_id="update_table_schema",
+        dataset_id=DATASET_NAME,
+        table_id="test_table",
+        schema_fields_updates=[
+            {"name": "emp_name", "description": "Name of employee"},
+            {"name": "salary", "description": "Monthly salary in USD"},
+        ],
+    )
+    # [END howto_operator_bigquery_update_table_schema]
 
     # [START howto_operator_bigquery_delete_table]
     delete_table = BigQueryDeleteTableOperator(
@@ -216,6 +229,7 @@ with models.DAG(
             delete_view,
         ]
         >> upsert_table
+        >> update_table_schema
         >> delete_materialized_view
         >> delete_table
         >> delete_dataset

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -245,6 +245,23 @@ in the given dataset.
     :start-after: [START howto_operator_bigquery_upsert_table]
     :end-before: [END howto_operator_bigquery_upsert_table]
 
+.. _howto/operator:BigQueryUpdateTableSchemaOperator:
+
+Update table schema
+"""""""""""""""""""
+
+To update the schema of a table you can use
+:class:`~airflow.providers.google.cloud.operators.bigquery.BigQueryUpdateTableSchemaOperator`.
+
+This operator updates the schema field values supplied, while leaving the rest unchanged. This is useful
+for instance to set new field descriptions on an existing table schema.
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_bigquery_operations.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_update_table_schema]
+    :end-before: [END howto_operator_bigquery_update_table_schema]
+
 .. _howto/operator:BigQueryDeleteTableOperator:
 
 Delete table

--- a/tests/providers/google/cloud/hooks/test_bigquery.py
+++ b/tests/providers/google/cloud/hooks/test_bigquery.py
@@ -676,6 +676,178 @@ class TestBigQueryHookMethods(_BigQueryBaseTestClass):
         assert "fields" in result
         assert len(result["fields"]) == 2
 
+    @mock.patch('airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema')
+    @mock.patch('airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_table')
+    def test_update_table_schema_with_policy_tags(self, mock_update, mock_get_schema):
+        mock_get_schema.return_value = {
+            "fields": [
+                {'name': 'emp_name', 'type': 'STRING', 'mode': 'REQUIRED'},
+                {
+                    'name': 'salary',
+                    'type': 'INTEGER',
+                    'mode': 'REQUIRED',
+                    'policyTags': {'names': ['sensitive']},
+                },
+                {'name': 'not_changed', 'type': 'INTEGER', 'mode': 'REQUIRED'},
+                {
+                    'name': 'subrecord',
+                    'type': 'RECORD',
+                    'mode': 'REQUIRED',
+                    'fields': [
+                        {
+                            'name': 'field_1',
+                            'type': 'STRING',
+                            'mode': 'REQUIRED',
+                            'policyTags': {'names': ['sensitive']},
+                        },
+                    ],
+                },
+            ]
+        }
+
+        schema_fields_updates = [
+            {'name': 'emp_name', 'description': 'Name of employee', 'policyTags': {'names': ['sensitive']}},
+            {
+                'name': 'salary',
+                'description': 'Monthly salary in USD',
+                'policyTags': {},
+            },
+            {
+                'name': 'subrecord',
+                'description': 'Some Desc',
+                'fields': [
+                    {'name': 'field_1', 'description': 'Some nested desc'},
+                ],
+            },
+        ]
+
+        expected_result_schema = {
+            'fields': [
+                {
+                    'name': 'emp_name',
+                    'type': 'STRING',
+                    'mode': 'REQUIRED',
+                    'description': 'Name of employee',
+                    'policyTags': {'names': ['sensitive']},
+                },
+                {
+                    'name': 'salary',
+                    'type': 'INTEGER',
+                    'mode': 'REQUIRED',
+                    'description': 'Monthly salary in USD',
+                    'policyTags': {},
+                },
+                {'name': 'not_changed', 'type': 'INTEGER', 'mode': 'REQUIRED'},
+                {
+                    'name': 'subrecord',
+                    'type': 'RECORD',
+                    'mode': 'REQUIRED',
+                    'description': 'Some Desc',
+                    'fields': [
+                        {
+                            'name': 'field_1',
+                            'type': 'STRING',
+                            'mode': 'REQUIRED',
+                            'description': 'Some nested desc',
+                            'policyTags': {'names': ['sensitive']},
+                        }
+                    ],
+                },
+            ]
+        }
+
+        self.hook.update_table_schema(
+            schema_fields_updates=schema_fields_updates,
+            include_policy_tags=True,
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+        )
+
+        mock_update.assert_called_once_with(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            project_id=PROJECT_ID,
+            table_resource={'schema': expected_result_schema},
+            fields=['schema'],
+        )
+
+    @mock.patch('airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema')
+    @mock.patch('airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_table')
+    def test_update_table_schema_without_policy_tags(self, mock_update, mock_get_schema):
+        mock_get_schema.return_value = {
+            "fields": [
+                {'name': 'emp_name', 'type': 'STRING', 'mode': 'REQUIRED'},
+                {'name': 'salary', 'type': 'INTEGER', 'mode': 'REQUIRED'},
+                {'name': 'not_changed', 'type': 'INTEGER', 'mode': 'REQUIRED'},
+                {
+                    'name': 'subrecord',
+                    'type': 'RECORD',
+                    'mode': 'REQUIRED',
+                    'fields': [
+                        {'name': 'field_1', 'type': 'STRING', 'mode': 'REQUIRED'},
+                    ],
+                },
+            ]
+        }
+
+        schema_fields_updates = [
+            {'name': 'emp_name', 'description': 'Name of employee'},
+            {
+                'name': 'salary',
+                'description': 'Monthly salary in USD',
+                'policyTags': {'names': ['sensitive']},
+            },
+            {
+                'name': 'subrecord',
+                'description': 'Some Desc',
+                'fields': [
+                    {'name': 'field_1', 'description': 'Some nested desc'},
+                ],
+            },
+        ]
+
+        expected_result_schema = {
+            'fields': [
+                {'name': 'emp_name', 'type': 'STRING', 'mode': 'REQUIRED', 'description': 'Name of employee'},
+                {
+                    'name': 'salary',
+                    'type': 'INTEGER',
+                    'mode': 'REQUIRED',
+                    'description': 'Monthly salary in USD',
+                },
+                {'name': 'not_changed', 'type': 'INTEGER', 'mode': 'REQUIRED'},
+                {
+                    'name': 'subrecord',
+                    'type': 'RECORD',
+                    'mode': 'REQUIRED',
+                    'description': 'Some Desc',
+                    'fields': [
+                        {
+                            'name': 'field_1',
+                            'type': 'STRING',
+                            'mode': 'REQUIRED',
+                            'description': 'Some nested desc',
+                        }
+                    ],
+                },
+            ]
+        }
+
+        self.hook.update_table_schema(
+            schema_fields_updates=schema_fields_updates,
+            include_policy_tags=False,
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+        )
+
+        mock_update.assert_called_once_with(
+            dataset_id=DATASET_ID,
+            table_id=TABLE_ID,
+            project_id=PROJECT_ID,
+            table_resource={'schema': expected_result_schema},
+            fields=['schema'],
+        )
+
     @mock.patch("airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_service")
     def test_invalid_source_format(self, mock_get_service):
         with pytest.raises(

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -46,6 +46,7 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryPatchDatasetOperator,
     BigQueryUpdateDatasetOperator,
     BigQueryUpdateTableOperator,
+    BigQueryUpdateTableSchemaOperator,
     BigQueryUpsertTableOperator,
     BigQueryValueCheckOperator,
 )
@@ -284,6 +285,36 @@ class TestBigQueryUpdateTableOperator(unittest.TestCase):
         mock_hook.return_value.update_table.assert_called_once_with(
             table_resource=table_resource,
             fields=None,
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE_ID,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+
+
+class TestBigQueryUpdateTableSchemaOperator(unittest.TestCase):
+    @mock.patch('airflow.providers.google.cloud.operators.bigquery.BigQueryHook')
+    def test_execute(self, mock_hook):
+
+        schema_field_updates = [
+            {
+                'name': 'emp_name',
+                'description': 'Name of employee',
+            }
+        ]
+
+        operator = BigQueryUpdateTableSchemaOperator(
+            schema_fields_updates=schema_field_updates,
+            include_policy_tags=False,
+            task_id=TASK_ID,
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE_ID,
+            project_id=TEST_GCP_PROJECT_ID,
+        )
+        operator.execute(None)
+
+        mock_hook.return_value.update_table_schema.assert_called_once_with(
+            schema_fields_updates=schema_field_updates,
+            include_policy_tags=False,
             dataset_id=TEST_DATASET,
             table_id=TEST_TABLE_ID,
             project_id=TEST_GCP_PROJECT_ID,


### PR DESCRIPTION
With this change we implement a new operator that handles patching of table schemas in bigquery.

This is needed as typing out an entire schema data structure (schema), in order to set e.g. a field description on a single field requires a lot of overhead. Also, many times the schema is not known or very complex as it may be the result of a Query or parsed automatically when importing files as tables.

This operator is useful for a workflow like:
Upstream: Create a BigQuery table as the output of a Query or import operator. Writer of job/operator knows the names of the fields, perhaps the types, but not necessarily how other schema fields are defined.

Downstream (this operator): Supply a partial schema definition that only contains field names and description values that will be patched on to the "generated by bigquery" schema from upstream.


