### PR TITLE
Revert "Fix Helm GitSync dag volume mount"

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -70,6 +70,7 @@ spec:
         - mountPath: {{ include "airflow_dags" . }}
           name: dags
           readOnly: true
+          subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 8 }}


### PR DESCRIPTION
Reverts apache/airflow#15331

Reverting this, it is a fix for the helm chart for branch `v2-0-stable`, but it appears that helm chart is not in sync with master.