### PR TITLE
AIP-39: Handle DAG scheduling with timetables

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -257,7 +257,7 @@ def get_execution_dates(dag, execution_date, future, past):
         dag_runs = dag.get_dagruns_between(start_date=start_date, end_date=end_date)
         dates = sorted({d.execution_date for d in dag_runs})
     else:
-        dates = dag.date_range(start_date=start_date, end_date=end_date)
+        dates = dag.get_run_dates(start_date, end_date, align=False)
     return dates
 
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -265,11 +265,11 @@ def dag_next_execution(args):
             )
             print(None)
         else:
-            print(next_execution_dttm)
+            print(next_execution_dttm.isoformat())
 
             for _ in range(1, args.num_executions):
                 next_execution_dttm = dag.following_schedule(next_execution_dttm)
-                print(next_execution_dttm)
+                print(next_execution_dttm.isoformat())
     else:
         print("[WARN] Only applicable when there is execution record found for the DAG.", file=sys.stderr)
         print(None)

--- a/airflow/compat/functools.pyi
+++ b/airflow/compat/functools.pyi
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This stub exists to work around false linter errors due to python/mypy#10408.
+# TODO: Remove this file after the upstream fix is available in our toolchain.
+
+from typing import Callable, TypeVar
+
+T = TypeVar("T")
+
+def cached_property(f: Callable[..., T]) -> T: ...
+def cache(f: T) -> T: ...

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -115,6 +115,10 @@ class AirflowClusterPolicyViolation(AirflowException):
     """Raise when there is a violation of a Cluster Policy in Dag definition"""
 
 
+class AirflowTimetableInvalid(AirflowException):
+    """Raise when a DAG has an invalid timetable."""
+
+
 class DagNotFound(AirflowNotFoundException):
     """Raise when a DAG is not available in the system"""
 

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -756,7 +756,7 @@ class BackfillJob(BaseJob):
         start_date = self.bf_start_date
 
         # Get intervals between the start/end dates, which will turn into dag runs
-        run_dates = self.dag.get_run_dates(start_date=start_date, end_date=self.bf_end_date)
+        run_dates = self.dag.get_run_dates(start_date=start_date, end_date=self.bf_end_date, align=True)
         if self.run_backwards:
             tasks_that_depend_on_past = [t.task_id for t in self.dag.task_dict.values() if t.depends_on_past]
             if tasks_that_depend_on_past:

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1244,7 +1244,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         start_date = start_date or self.start_date
         end_date = end_date or self.end_date or timezone.utcnow()
 
-        for execution_date in self.dag.date_range(start_date, end_date=end_date):
+        for execution_date in self.dag.get_run_dates(start_date, end_date, align=False):
             TaskInstance(self, execution_date).run(
                 mark_success=mark_success,
                 ignore_depends_on_past=(execution_date == start_date and ignore_first_depends_on_past),

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -369,14 +369,14 @@ class DagRun(Base, LoggingMixin):
     @provide_session
     def get_previous_scheduled_dagrun(self, session: Session = None) -> Optional['DagRun']:
         """The previous, SCHEDULED DagRun, if there is one"""
-        dag = self.get_dag()
-
         return (
             session.query(DagRun)
             .filter(
                 DagRun.dag_id == self.dag_id,
-                DagRun.execution_date == dag.previous_schedule(self.execution_date),
+                DagRun.execution_date < self.execution_date,
+                DagRun.run_type != DagRunType.MANUAL,
             )
+            .order_by(DagRun.execution_date.desc())
             .first()
         )
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -762,11 +762,18 @@ class TaskInstance(Base, LoggingMixin):
             # LEGACY: most likely running from unit tests
             if not dr:
                 # Means that this TaskInstance is NOT being run from a DR, but from a catchup
-                previous_scheduled_date = dag.previous_schedule(self.execution_date)
-                if not previous_scheduled_date:
+                try:
+                    # XXX: This uses DAG internals, but as the outer comment
+                    # said, the block is only reached for legacy reasons for
+                    # development code, so that's OK-ish.
+                    schedule = dag.timetable._schedule
+                except AttributeError:
                     return None
-
-                return TaskInstance(task=self.task, execution_date=previous_scheduled_date)
+                dt = pendulum.instance(self.execution_date)
+                return TaskInstance(
+                    task=self.task,
+                    execution_date=schedule.get_prev(dt),
+                )
 
             dr.dag = dag
 

--- a/airflow/timetables/__init__.py
+++ b/airflow/timetables/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Iterator, NamedTuple, Optional
+
+from pendulum import DateTime
+
+from airflow.typing_compat import Protocol
+
+
+class DataInterval(NamedTuple):
+    """A data interval for a DagRun to operate over.
+
+    The represented interval is ``[start, end)``.
+    """
+
+    start: DateTime
+    end: DateTime
+
+
+class TimeRestriction(NamedTuple):
+    """Restriction on when a DAG can be scheduled for a run.
+
+    Specifically, the run must not be earlier than ``earliest``, nor later than
+    ``latest``. If ``catchup`` is *False*, the run must also not be earlier than
+    the current time, i.e. "missed" schedules are not backfilled.
+
+    These values are generally set on the DAG or task's ``start_date``,
+    ``end_date``, and ``catchup`` arguments.
+
+    Both ``earliest`` and ``latest`` are inclusive; a DAG run can happen exactly
+    at either point of time.
+    """
+
+    earliest: Optional[DateTime]
+    latest: Optional[DateTime]
+    catchup: bool
+
+
+class DagRunInfo(NamedTuple):
+    """Information to schedule a DagRun.
+
+    Instances of this will be returned by timetables when they are asked to
+    schedule a DagRun creation.
+    """
+
+    run_after: DateTime
+    """The earliest time this DagRun is created and its tasks scheduled."""
+
+    data_interval: DataInterval
+    """The data interval this DagRun to operate over, if applicable."""
+
+    @classmethod
+    def exact(cls, at: DateTime) -> "DagRunInfo":
+        """Represent a run on an exact time."""
+        return cls(run_after=at, data_interval=DataInterval(at, at))
+
+    @classmethod
+    def interval(cls, start: DateTime, end: DateTime) -> "DagRunInfo":
+        """Represent a run on a continuous schedule.
+
+        In such a schedule, each data interval starts right after the previous
+        one ends, and each run is scheduled right after the interval ends. This
+        applies to all schedules prior to AIP-39 except ``@once`` and ``None``.
+        """
+        return cls(run_after=end, data_interval=DataInterval(start, end))
+
+
+class Timetable(Protocol):
+    """Protocol that all Timetable classes are expected to implement."""
+
+    def validate(self) -> None:
+        """Validate the timetable is correctly specified.
+
+        This should raise AirflowTimetableInvalid on validation failure.
+        """
+        raise NotImplementedError()
+
+    def next_dagrun_info(
+        self,
+        last_automated_dagrun: Optional[DateTime],
+        restriction: TimeRestriction,
+    ) -> Optional[DagRunInfo]:
+        """Provide information to schedule the next DagRun.
+
+        :param last_automated_dagrun: The ``execution_date`` of the associated
+            DAG's last scheduled or backfilled run (manual runs not considered).
+        :param restriction: Restriction to apply when scheduling the DAG run.
+            See documentation of :class:`TimeRestriction` for details.
+
+        :return: Information on when the next DagRun can be scheduled. None
+            means a DagRun will not happen. This does not mean no more runs
+            will be scheduled even again for this DAG; the timetable can return
+            a DagRunInfo object when asked at another time.
+        """
+        raise NotImplementedError()
+
+    def iter_between(
+        self,
+        start: DateTime,
+        end: DateTime,
+        *,
+        align: bool,
+    ) -> Iterator[DateTime]:
+        """Get schedules between the *start* and *end*."""
+        if start > end:
+            raise ValueError(f"start ({start}) > end ({end})")
+        between = TimeRestriction(start, end, catchup=True)
+
+        if align:
+            next_info = self.next_dagrun_info(None, between)
+        else:
+            yield start
+            next_info = self.next_dagrun_info(start, between)
+
+        while next_info is not None:
+            dagrun_start = next_info.data_interval.start
+            yield dagrun_start
+            next_info = self.next_dagrun_info(dagrun_start, between)

--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+from typing import Any, Optional
+
+from pendulum import DateTime
+
+from airflow.timetables.base import DagRunInfo, TimeRestriction, Timetable
+from airflow.timetables.schedules import CronSchedule, Delta, DeltaSchedule, Schedule
+
+
+class _DataIntervalTimetable(Timetable):
+    """Basis for timetable implementations that schedule data intervals.
+
+    This kind of timetable classes create periodic data intervals from an
+    underlying schedule representation (e.g. a cron expression, or a timedelta
+    instance), and schedule a DagRun at the end of each interval.
+    """
+
+    _schedule: Schedule
+
+    def __eq__(self, other: Any) -> bool:
+        """Delegate to the schedule."""
+        if not isinstance(other, _DataIntervalTimetable):
+            return NotImplemented
+        return self._schedule == other._schedule
+
+    def validate(self) -> None:
+        self._schedule.validate()
+
+    def next_dagrun_info(
+        self,
+        last_automated_dagrun: Optional[DateTime],
+        restriction: TimeRestriction,
+    ) -> Optional[DagRunInfo]:
+        earliest = restriction.earliest
+        if not restriction.catchup:
+            earliest = self._schedule.skip_to_latest(earliest)
+        if last_automated_dagrun is None:
+            # First run; schedule the run at the first available time matching
+            # the schedule, and retrospectively create a data interval for it.
+            if earliest is None:
+                return None
+            start = self._schedule.align(earliest)
+        else:
+            # There's a previous run. Create a data interval starting from when
+            # the end of the previous interval.
+            start = self._schedule.get_next(last_automated_dagrun)
+        if restriction.latest is not None and start > restriction.latest:
+            return None
+        end = self._schedule.get_next(start)
+        return DagRunInfo.interval(start=start, end=end)
+
+
+class CronDataIntervalTimetable(_DataIntervalTimetable):
+    """Timetable that schedules data intervals with a cron expression.
+
+    This corresponds to ``schedule_interval=<cron>``, where ``<cron>`` is either
+    a five/six-segment representation, or one of ``cron_presets``.
+
+    Don't pass ``@once`` in here; use ``OnceTimetable`` instead.
+    """
+
+    def __init__(self, cron: str, timezone: datetime.tzinfo) -> None:
+        self._schedule = CronSchedule(cron, timezone)
+
+
+class DeltaDataIntervalTimetable(_DataIntervalTimetable):
+    """Timetable that schedules data intervals with a time delta.
+
+    This corresponds to ``schedule_interval=<delta>``, where ``<delta>`` is
+    either a ``datetime.timedelta`` or ``dateutil.relativedelta.relativedelta``
+    instance.
+    """
+
+    def __init__(self, delta: Delta) -> None:
+        self._schedule = DeltaSchedule(delta)

--- a/airflow/timetables/schedules.py
+++ b/airflow/timetables/schedules.py
@@ -1,0 +1,207 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime
+import typing
+
+from cached_property import cached_property
+from croniter import CroniterBadCronError, CroniterBadDateError, croniter
+from dateutil.relativedelta import relativedelta
+from pendulum import DateTime
+
+from airflow.exceptions import AirflowTimetableInvalid
+from airflow.typing_compat import Protocol
+from airflow.utils.dates import cron_presets
+from airflow.utils.timezone import convert_to_utc, make_aware, make_naive
+
+Delta = typing.Union[datetime.timedelta, relativedelta]
+
+
+class Schedule(Protocol):
+    """Base protocol for schedules."""
+
+    def skip_to_latest(self, earliest: typing.Optional[DateTime]) -> DateTime:
+        """Bound the earliest time a run can be scheduled.
+
+        This is called when ``catchup=False``. See docstring of subclasses for
+        exact skipping behaviour of a schedule.
+        """
+        raise NotImplementedError()
+
+    def validate(self) -> None:
+        """Validate the timetable is correctly specified.
+
+        This should raise AirflowTimetableInvalid on validation failure.
+        """
+        raise NotImplementedError()
+
+    def get_next(self, current: DateTime) -> DateTime:
+        """Get the first schedule after the current time."""
+        raise NotImplementedError()
+
+    def get_prev(self, current: DateTime) -> DateTime:
+        """Get the last schedule before the current time."""
+        raise NotImplementedError()
+
+    def align(self, current: DateTime) -> DateTime:
+        """Align given time to the scheduled.
+
+        For fixed schedules (e.g. every midnight); this finds the next time that
+        aligns to the declared time, if the given time does not align. If the
+        schedule is not fixed (e.g. every hour), the given time is returned.
+        """
+        raise NotImplementedError()
+
+
+def _is_schedule_fixed(expression: str) -> bool:
+    """Figures out if the schedule has a fixed time (e.g. 3 AM every day).
+
+    :return: True if the schedule has a fixed time, False if not.
+
+    Detection is done by "peeking" the next two cron trigger time; if the
+    two times have the same minute and hour value, the schedule is fixed,
+    and we *don't* need to perform the DST fix.
+
+    This assumes DST happens on whole minute changes (e.g. 12:59 -> 12:00).
+    """
+    cron = croniter(expression)
+    next_a = cron.get_next(datetime.datetime)
+    next_b = cron.get_next(datetime.datetime)
+    return next_b.minute == next_a.minute and next_b.hour == next_a.hour
+
+
+class CronSchedule(Schedule):
+    """Schedule things from a cron expression.
+
+    The implementation extends on croniter to add timezone awareness. This is
+    because crontier works only with naive timestamps, and cannot consider DST
+    when determining the next/previous time.
+    """
+
+    def __init__(self, expression: str, timezone: datetime.tzinfo) -> None:
+        self._expression = expression = cron_presets.get(expression, expression)
+        self._timezone = timezone
+
+    def __eq__(self, other: typing.Any) -> bool:
+        """Both expression and timezone should match."""
+        if not isinstance(other, CronSchedule):
+            return NotImplemented
+        return self._expression == other._expression and self._timezone == other._timezone
+
+    def validate(self) -> None:
+        try:
+            croniter(self._expression)
+        except (CroniterBadCronError, CroniterBadDateError) as e:
+            raise AirflowTimetableInvalid(str(e))
+
+    @cached_property
+    def _should_fix_dst(self) -> bool:
+        # This is lazy so instantiating a schedule does not immediately raise
+        # an exception. Validity is checked with validate() during DAG-bagging.
+        return not _is_schedule_fixed(self._expression)
+
+    def get_next(self, current: DateTime) -> DateTime:
+        """Get the first schedule after specified time, with DST fixed."""
+        naive = make_naive(current, self._timezone)
+        cron = croniter(self._expression, start_time=naive)
+        scheduled = cron.get_next(datetime.datetime)
+        if not self._should_fix_dst:
+            return convert_to_utc(make_aware(scheduled, self._timezone))
+        delta = scheduled - naive
+        return convert_to_utc(current.in_timezone(self._timezone) + delta)
+
+    def get_prev(self, current: DateTime) -> DateTime:
+        """Get the first schedule before specified time, with DST fixed."""
+        naive = make_naive(current, self._timezone)
+        cron = croniter(self._expression, start_time=naive)
+        scheduled = cron.get_prev(datetime.datetime)
+        if not self._should_fix_dst:
+            return convert_to_utc(make_aware(scheduled, self._timezone))
+        delta = naive - scheduled
+        return convert_to_utc(current.in_timezone(self._timezone) - delta)
+
+    def align(self, current: DateTime) -> DateTime:
+        """Get the next scheduled time.
+
+        This is ``current + interval``, unless ``current`` is first interval,
+        then ``current`` is returned.
+        """
+        next_time = self.get_next(current)
+        if self.get_prev(next_time) != current:
+            return next_time
+        return current
+
+    def skip_to_latest(self, earliest: typing.Optional[DateTime]) -> DateTime:
+        """Bound the earliest time a run can be scheduled.
+
+        The logic is that we move start_date up until one period before, so the
+        current time is AFTER the period end, and the job can be created...
+
+        This is slightly different from the delta version at terminal values.
+        If the next schedule should start *right now*, we want the data interval
+        that start right now now, not the one that ends now.
+        """
+        current_time = DateTime.utcnow()
+        next_start = self.get_next(current_time)
+        last_start = self.get_prev(current_time)
+        if next_start == current_time:
+            new_start = last_start
+        elif next_start > current_time:
+            new_start = self.get_prev(last_start)
+        else:
+            raise AssertionError("next schedule shouldn't be earlier")
+        if earliest is None:
+            return new_start
+        return max(new_start, earliest)
+
+
+class DeltaSchedule(Schedule):
+    """Schedule things on a fixed time delta."""
+
+    def __init__(self, delta: Delta) -> None:
+        self._delta = delta
+
+    def __eq__(self, other: typing.Any) -> bool:
+        """The offset should match."""
+        if not isinstance(other, DeltaSchedule):
+            return NotImplemented
+        return self._delta == other._delta
+
+    def validate(self) -> None:
+        pass  # TODO: Check the delta is positive?
+
+    def get_next(self, current: DateTime) -> DateTime:
+        return convert_to_utc(current + self._delta)
+
+    def get_prev(self, current: DateTime) -> DateTime:
+        return convert_to_utc(current - self._delta)
+
+    def align(self, current: DateTime) -> DateTime:
+        return current
+
+    def skip_to_latest(self, earliest: typing.Optional[DateTime]) -> DateTime:
+        """Bound the earliest time a run can be scheduled.
+
+        The logic is that we move start_date up until one period before, so the
+        current time is AFTER the period end, and the job can be created...
+
+        This is slightly different from the cron version at terminal values.
+        """
+        new_start = self.get_prev(DateTime.utcnow())
+        if earliest is None:
+            return new_start
+        return max(new_start, earliest)

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Any, Optional
+
+from pendulum import DateTime
+
+from airflow.timetables.base import DagRunInfo, TimeRestriction, Timetable
+
+
+class NullTimetable(Timetable):
+    """Timetable that never schedules anything.
+
+    This corresponds to ``schedule_interval=None``.
+    """
+
+    def __eq__(self, other: Any) -> bool:
+        """As long as *other* is of the same type."""
+        if not isinstance(other, NullTimetable):
+            return NotImplemented
+        return True
+
+    def validate(self) -> None:
+        pass
+
+    def next_dagrun_info(
+        self,
+        last_automated_dagrun: Optional[DateTime],
+        restriction: TimeRestriction,
+    ) -> Optional[DagRunInfo]:
+        return None
+
+
+class OnceTimetable(Timetable):
+    """Timetable that schedules the execution once as soon as possible.
+
+    This corresponds to ``schedule_interval="@once"``.
+    """
+
+    def __eq__(self, other: Any) -> bool:
+        """As long as *other* is of the same type."""
+        if not isinstance(other, OnceTimetable):
+            return NotImplemented
+        return True
+
+    def validate(self) -> None:
+        pass
+
+    def next_dagrun_info(
+        self,
+        last_automated_dagrun: Optional[DateTime],
+        restriction: TimeRestriction,
+    ) -> Optional[DagRunInfo]:
+        if last_automated_dagrun is not None:
+            return None  # Already run, no more scheduling.
+        if restriction.earliest is None:  # No start date, won't run.
+            return None
+        # "@once" always schedule to the start_date determined by the DAG and
+        # tasks, regardless of catchup or not. This has been the case since 1.10
+        # and we're inheriting it. See AIRFLOW-1928.
+        run_after = restriction.earliest
+        if restriction.latest is not None and run_after > restriction.latest:
+            return None
+        return DagRunInfo.exact(run_after)

--- a/airflow/utils/dates.py
+++ b/airflow/utils/dates.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import warnings
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union
 
@@ -72,6 +73,12 @@ def date_range(
     :param delta: step length. It can be datetime.timedelta or cron expression as string
     :type delta: datetime.timedelta or str or dateutil.relativedelta
     """
+    warnings.warn(
+        "`airflow.utils.dates.date_range()` is deprecated. Please use `airflow.timetables`.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+
     if not delta:
         return []
     if end_date:

--- a/airflow/utils/timezone.py
+++ b/airflow/utils/timezone.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import datetime as dt
+from typing import Optional, Union
 
 import pendulum
 from pendulum.datetime import DateTime
@@ -172,3 +173,14 @@ def parse(string: str, timezone=None) -> DateTime:
     :param timezone: the timezone
     """
     return pendulum.parse(string, tz=timezone or TIMEZONE, strict=False)  # type: ignore
+
+
+def coerce_datetime(v: Union[None, dt.datetime, DateTime]) -> Optional[DateTime]:
+    """Convert whatever is passed in to ``pendulum.DateTime``."""
+    if v is None:
+        return None
+    if isinstance(v, DateTime):
+        return v
+    if v.tzinfo is None:
+        v = make_aware(v)
+    return pendulum.instance(v)

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -298,10 +298,15 @@ class TestCliDags(unittest.TestCase):
 
         # The details below is determined by the schedule_interval of example DAGs
         now = DEFAULT_DATE
-        expected_output = [str(now + timedelta(days=1)), str(now + timedelta(hours=4)), "None", "None"]
+        expected_output = [
+            (now + timedelta(days=1)).isoformat(),
+            (now + timedelta(hours=4)).isoformat(),
+            "None",
+            "None",
+        ]
         expected_output_2 = [
-            str(now + timedelta(days=1)) + os.linesep + str(now + timedelta(days=2)),
-            str(now + timedelta(hours=4)) + os.linesep + str(now + timedelta(hours=8)),
+            (now + timedelta(days=1)).isoformat() + os.linesep + (now + timedelta(days=2)).isoformat(),
+            (now + timedelta(hours=4)).isoformat() + os.linesep + (now + timedelta(hours=8)).isoformat(),
             "None",
             "None",
         ]

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -1362,8 +1362,8 @@ class TestBackfillJob(unittest.TestCase):
         session.close()
 
     def test_dag_get_run_dates(self):
-        def get_test_dag_for_backfill(schedule_interval=None):
-            dag = DAG(dag_id='test_get_dates', start_date=DEFAULT_DATE, schedule_interval=schedule_interval)
+        def get_test_dag_for_backfill():
+            dag = DAG(dag_id='test_get_dates', start_date=DEFAULT_DATE, schedule_interval="@hourly")
             DummyOperator(
                 task_id='dummy',
                 dag=dag,
@@ -1372,9 +1372,13 @@ class TestBackfillJob(unittest.TestCase):
             return dag
 
         test_dag = get_test_dag_for_backfill()
-        assert [DEFAULT_DATE] == test_dag.get_run_dates(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        assert [DEFAULT_DATE] == test_dag.get_run_dates(
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE,
+            align=True,
+        )
 
-        test_dag = get_test_dag_for_backfill(schedule_interval="@hourly")
+        test_dag = get_test_dag_for_backfill()
         assert [
             DEFAULT_DATE - datetime.timedelta(hours=3),
             DEFAULT_DATE - datetime.timedelta(hours=2),
@@ -1383,6 +1387,7 @@ class TestBackfillJob(unittest.TestCase):
         ] == test_dag.get_run_dates(
             start_date=DEFAULT_DATE - datetime.timedelta(hours=3),
             end_date=DEFAULT_DATE,
+            align=True,
         )
 
     def test_backfill_run_backwards(self):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1780,7 +1780,7 @@ class TestSchedulerJob(unittest.TestCase):
         dag = self.dagbag.get_dag(dag_id)
         dr = dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
-            execution_date=dag.next_dagrun_after_date(None),
+            execution_date=dag.next_dagrun_info(None)[0],
             state=State.RUNNING,
         )
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -48,6 +48,7 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.subdag import SubDagOperator
 from airflow.security import permissions
+from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.utils import timezone
 from airflow.utils.file import list_py_file_paths
 from airflow.utils.session import create_session, provide_session
@@ -58,6 +59,7 @@ from airflow.utils.weight_rule import WeightRule
 from tests.models import DEFAULT_DATE
 from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.db import clear_db_dags, clear_db_runs
+from tests.test_utils.timetables import cron_timetable, delta_timetable
 
 TEST_DATE = datetime_tz(2015, 1, 2, 0, 0)
 
@@ -1135,7 +1137,7 @@ class TestDag(unittest.TestCase):
         dag_id = "test_schedule_dag_once"
         dag = DAG(dag_id=dag_id)
         dag.schedule_interval = '@once'
-        assert dag.normalized_schedule_interval is None
+        assert isinstance(dag.timetable, OnceTimetable)
         dag.add_task(BaseOperator(task_id="faketastic", owner='Also fake', start_date=TEST_DATE))
 
         # Sync once to create the DagModel
@@ -1247,20 +1249,20 @@ class TestDag(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (None, None),
-            ("@daily", "0 0 * * *"),
-            ("@weekly", "0 0 * * 0"),
-            ("@monthly", "0 0 1 * *"),
-            ("@quarterly", "0 0 1 */3 *"),
-            ("@yearly", "0 0 1 1 *"),
-            ("@once", None),
-            (datetime.timedelta(days=1), datetime.timedelta(days=1)),
+            (None, NullTimetable()),
+            ("@daily", cron_timetable("0 0 * * *")),
+            ("@weekly", cron_timetable("0 0 * * 0")),
+            ("@monthly", cron_timetable("0 0 1 * *")),
+            ("@quarterly", cron_timetable("0 0 1 */3 *")),
+            ("@yearly", cron_timetable("0 0 1 1 *")),
+            ("@once", OnceTimetable()),
+            (datetime.timedelta(days=1), delta_timetable(datetime.timedelta(days=1))),
         ]
     )
-    def test_normalized_schedule_interval(self, schedule_interval, expected_n_schedule_interval):
+    def test_timetable(self, schedule_interval, expected_timetable):
         dag = DAG("test_schedule_interval", schedule_interval=schedule_interval)
 
-        assert dag.normalized_schedule_interval == expected_n_schedule_interval
+        assert dag.timetable == expected_timetable
         assert dag.schedule_interval == schedule_interval
 
     def test_create_dagrun_run_id_is_generated(self):
@@ -1474,19 +1476,19 @@ class TestDag(unittest.TestCase):
         assert task_instance.state == ti_state_end
         self._clean_up(dag_id)
 
-    def test_next_dagrun_after_date_once(self):
+    def test_next_dagrun_info_once(self):
         dag = DAG(
             'test_scheduler_dagrun_once', start_date=timezone.datetime(2015, 1, 1), schedule_interval="@once"
         )
 
-        next_date = dag.next_dagrun_after_date(None)
+        next_date, _ = dag.next_dagrun_info(None)
 
         assert next_date == timezone.datetime(2015, 1, 1)
 
-        next_date = dag.next_dagrun_after_date(next_date)
+        next_date, _ = dag.next_dagrun_info(next_date)
         assert next_date is None
 
-    def test_next_dagrun_after_date_start_end_dates(self):
+    def test_next_dagrun_info_start_end_dates(self):
         """
         Tests that an attempt to schedule a task after the Dag's end_date
         does not succeed.
@@ -1503,7 +1505,7 @@ class TestDag(unittest.TestCase):
         dates = []
         date = None
         for _ in range(runs):
-            date = dag.next_dagrun_after_date(date)
+            date, _ = dag.next_dagrun_info(date)
             dates.append(date)
 
         for date in dates:
@@ -1511,9 +1513,9 @@ class TestDag(unittest.TestCase):
 
         assert dates[-1] == end_date
 
-        assert dag.next_dagrun_after_date(date) is None
+        assert dag.next_dagrun_info(date)[0] is None
 
-    def test_next_dagrun_after_date_catcup(self):
+    def test_next_dagrun_info_catchup(self):
         """
         Test to check that a DAG with catchup = False only schedules beginning now, not back to the start date
         """
@@ -1551,7 +1553,7 @@ class TestDag(unittest.TestCase):
             start_date=six_hours_ago_to_the_hour,
             catchup=False,
         )
-        next_date = dag1.next_dagrun_after_date(None)
+        next_date, _ = dag1.next_dagrun_info(None)
         # The DR should be scheduled in the last half an hour, not 6 hours ago
         assert next_date > half_an_hour_ago
         assert next_date < timezone.utcnow()
@@ -1563,7 +1565,7 @@ class TestDag(unittest.TestCase):
             catchup=False,
         )
 
-        next_date = dag2.next_dagrun_after_date(None)
+        next_date, _ = dag2.next_dagrun_info(None)
         # The DR should be scheduled in the last 2 hours, not 6 hours ago
         assert next_date > two_hours_ago
         # The DR should be scheduled BEFORE now
@@ -1576,12 +1578,12 @@ class TestDag(unittest.TestCase):
             catchup=False,
         )
 
-        next_date = dag3.next_dagrun_after_date(None)
+        next_date, _ = dag3.next_dagrun_info(None)
         # The DR should be scheduled in the last 2 hours, not 6 hours ago
         assert next_date == six_hours_ago_to_the_hour
 
     @freeze_time(timezone.datetime(2020, 1, 5))
-    def test_next_dagrun_after_date_timedelta_schedule_and_catchup_false(self):
+    def test_next_dagrun_info_timedelta_schedule_and_catchup_false(self):
         """
         Test that the dag file processor does not create multiple dagruns
         if a dag is scheduled with 'timedelta' and catchup=False
@@ -1593,15 +1595,15 @@ class TestDag(unittest.TestCase):
             catchup=False,
         )
 
-        next_date = dag.next_dagrun_after_date(None)
+        next_date, _ = dag.next_dagrun_info(None)
         assert next_date == timezone.datetime(2020, 1, 4)
 
         # The date to create is in the future, this is handled by "DagModel.dags_needing_dagruns"
-        next_date = dag.next_dagrun_after_date(next_date)
+        next_date, _ = dag.next_dagrun_info(next_date)
         assert next_date == timezone.datetime(2020, 1, 5)
 
     @freeze_time(timezone.datetime(2020, 5, 4))
-    def test_next_dagrun_after_date_timedelta_schedule_and_catchup_true(self):
+    def test_next_dagrun_info_timedelta_schedule_and_catchup_true(self):
         """
         Test that the dag file processor creates multiple dagruns
         if a dag is scheduled with 'timedelta' and catchup=True
@@ -1613,17 +1615,17 @@ class TestDag(unittest.TestCase):
             catchup=True,
         )
 
-        next_date = dag.next_dagrun_after_date(None)
+        next_date, _ = dag.next_dagrun_info(None)
         assert next_date == timezone.datetime(2020, 5, 1)
 
-        next_date = dag.next_dagrun_after_date(next_date)
+        next_date, _ = dag.next_dagrun_info(next_date)
         assert next_date == timezone.datetime(2020, 5, 2)
 
-        next_date = dag.next_dagrun_after_date(next_date)
+        next_date, _ = dag.next_dagrun_info(next_date)
         assert next_date == timezone.datetime(2020, 5, 3)
 
         # The date to create is in the future, this is handled by "DagModel.dags_needing_dagruns"
-        next_date = dag.next_dagrun_after_date(next_date)
+        next_date, _ = dag.next_dagrun_info(next_date)
         assert next_date == timezone.datetime(2020, 5, 4)
 
     def test_next_dagrun_after_auto_align(self):
@@ -1640,7 +1642,7 @@ class TestDag(unittest.TestCase):
         )
         DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
-        next_date = dag.next_dagrun_after_date(None)
+        next_date, _ = dag.next_dagrun_info(None)
         assert next_date == timezone.datetime(2016, 1, 2, 5, 4)
 
         dag = DAG(
@@ -1650,7 +1652,7 @@ class TestDag(unittest.TestCase):
         )
         DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
-        next_date = dag.next_dagrun_after_date(None)
+        next_date, _ = dag.next_dagrun_info(None)
         assert next_date == timezone.datetime(2016, 1, 1, 10, 10)
 
     def test_next_dagrun_after_not_for_subdags(self):
@@ -1690,10 +1692,10 @@ class TestDag(unittest.TestCase):
         subdag.parent_dag = dag
         subdag.is_subdag = True
 
-        next_date = dag.next_dagrun_after_date(None)
+        next_date, _ = dag.next_dagrun_info(None)
         assert next_date == timezone.datetime(2019, 1, 1, 0, 0)
 
-        next_subdag_date = subdag.next_dagrun_after_date(None)
+        next_subdag_date, _ = subdag.next_dagrun_info(None)
         assert next_subdag_date is None, "SubDags should never have DagRuns created by the scheduler"
 
     def test_replace_outdated_access_control_actions(self):

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -651,8 +651,8 @@ class TestDagRun(unittest.TestCase):
         dag = self.dagbag.get_dag(dag_id)
         task = dag.tasks[0]
 
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0))
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0))
+        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0), is_backfill=True)
+        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0), is_backfill=True)
 
         prev_ti = TI(task, timezone.datetime(2016, 1, 1, 0, 0, 0))
         ti = TI(task, timezone.datetime(2016, 1, 2, 0, 0, 0))
@@ -678,8 +678,8 @@ class TestDagRun(unittest.TestCase):
 
         # For ti.set_state() to work, the DagRun has to exist,
         # Otherwise ti.previous_ti returns an unpersisted TI
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0))
-        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0))
+        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0), is_backfill=True)
+        self.create_dag_run(dag, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0), is_backfill=True)
 
         prev_ti_downstream = TI(task=downstream, execution_date=timezone.datetime(2016, 1, 1, 0, 0, 0))
         ti = TI(task=upstream, execution_date=timezone.datetime(2016, 1, 2, 0, 0, 0))

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -868,6 +868,12 @@ class TestTaskInstance(unittest.TestCase):
         )
         dag.clear()
 
+        dag.create_dagrun(
+            execution_date=DEFAULT_DATE,
+            state=State.FAILED,
+            run_type=DagRunType.SCHEDULED,
+        )
+
         run_date = task.start_date + datetime.timedelta(days=5)
 
         dag.create_dagrun(

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -421,7 +421,8 @@ class TestBaseSensor(unittest.TestCase):
         # poke returns False and AirflowRescheduleException is raised
         date1 = timezone.utcnow()
         with freeze_time(date1):
-            for date in self.dag.date_range(DEFAULT_DATE, end_date=DEFAULT_DATE):
+            dates = self.dag.get_run_dates(DEFAULT_DATE, end_date=DEFAULT_DATE, align=True)
+            for date in dates:
                 TaskInstance(sensor, date).run(ignore_ti_state=True, test_mode=True)
         tis = dr.get_task_instances()
         assert len(tis) == 2

--- a/tests/test_utils/perf/scheduler_dag_execution_timing.py
+++ b/tests/test_utils/perf/scheduler_dag_execution_timing.py
@@ -163,18 +163,18 @@ def create_dag_runs(dag, num_runs, session):
 
         id_prefix = DagRun.ID_PREFIX
 
-    next_run_date = dag.normalize_schedule(dag.start_date or min(t.start_date for t in dag.tasks))
-
+    last_dagrun_at = None
     for _ in range(num_runs):
+        next_info = dag.next_dagrun_info(last_dagrun_at)
+        last_dagrun_at = next_info.data_interval.start
         dag.create_dagrun(
-            run_id=id_prefix + next_run_date.isoformat(),
-            execution_date=next_run_date,
+            run_id=f"{id_prefix}{last_dagrun_at.isoformat()}",
+            execution_date=last_dagrun_at,
             start_date=timezone.utcnow(),
             state=State.RUNNING,
             external_trigger=False,
             session=session,
         )
-        next_run_date = dag.following_schedule(next_run_date)
 
 
 @click.command()

--- a/tests/test_utils/timetables.py
+++ b/tests/test_utils/timetables.py
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow import settings
+from airflow.timetables.interval import CronDataIntervalTimetable, DeltaDataIntervalTimetable
+
+
+def cron_timetable(expr: str) -> CronDataIntervalTimetable:
+    return CronDataIntervalTimetable(expr, settings.TIMEZONE)
+
+
+def delta_timetable(delta) -> DeltaDataIntervalTimetable:
+    return DeltaDataIntervalTimetable(delta)

--- a/tests/ti_deps/deps/test_prev_dagrun_dep.py
+++ b/tests/ti_deps/deps/test_prev_dagrun_dep.py
@@ -17,105 +17,117 @@
 # under the License.
 
 
-import unittest
-from datetime import datetime
 from unittest.mock import Mock
+
+import pytest
 
 from airflow.models import DAG
 from airflow.models.baseoperator import BaseOperator
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.deps.prev_dagrun_dep import PrevDagrunDep
 from airflow.utils.state import State
+from airflow.utils.timezone import datetime
 
 
-class TestPrevDagrunDep(unittest.TestCase):
-    def _get_task(self, **kwargs):
-        return BaseOperator(task_id='test_task', dag=DAG('test_dag'), **kwargs)
-
-    def test_not_depends_on_past(self):
-        """
-        If depends on past isn't set in the task then the previous dagrun should be
-        ignored, even though there is no previous_ti which would normally fail the dep
-        """
-        task = self._get_task(
-            depends_on_past=False, start_date=datetime(2016, 1, 1), wait_for_downstream=False
-        )
-        prev_ti = Mock(
-            task=task,
-            state=State.SUCCESS,
-            are_dependents_done=Mock(return_value=True),
+@pytest.mark.parametrize(
+    "depends_on_past, wait_for_downstream, prev_ti, context_ignore_depends_on_past, dep_met",
+    [
+        # If the task does not set depends_on_past, the previous dagrun should
+        # be ignored, even though previous_ti would otherwise fail the dep.
+        pytest.param(
+            False,
+            False,  # wait_for_downstream=True overrides depends_on_past=False.
+            Mock(
+                state=State.NONE,
+                **{"are_dependents_done.return_value": False},
+            ),
+            False,
+            True,
+            id="not_depends_on_past",
+        ),
+        # If the context overrides depends_on_past, the dep should be met even
+        # though there is no previous_ti which would normally fail the dep.
+        pytest.param(
+            True,
+            False,
+            Mock(
+                state=State.SUCCESS,
+                **{"are_dependents_done.return_value": True},
+            ),
+            True,
+            True,
+            id="context_ignore_depends_on_past",
+        ),
+        # The first task run should pass since it has no previous dagrun.
+        pytest.param(True, False, None, False, True, id="first_task_run"),
+        # Previous TI did not complete execution. This dep should fail.
+        pytest.param(
+            True,
+            False,
+            Mock(
+                state=State.NONE,
+                **{"are_dependents_done.return_value": True},
+            ),
+            False,
+            False,
+            id="prev_ti_bad_state",
+        ),
+        # Previous TI specified to wait for the downstream tasks of the previous
+        # dagrun. It should fail this dep if the previous TI's downstream TIs
+        # are not done.
+        pytest.param(
+            True,
+            True,
+            Mock(
+                state=State.SUCCESS,
+                **{"are_dependents_done.return_value": False},
+            ),
+            False,
+            False,
+            id="failed_wait_for_downstream",
+        ),
+        # All the conditions for the dep are met.
+        pytest.param(
+            True,
+            True,
+            Mock(
+                state=State.SUCCESS,
+                **{"are_dependents_done.return_value": True},
+            ),
+            False,
+            True,
+            id="all_met",
+        ),
+    ],
+)
+def test_dagrun_dep(
+    depends_on_past,
+    wait_for_downstream,
+    prev_ti,
+    context_ignore_depends_on_past,
+    dep_met,
+):
+    task = BaseOperator(
+        task_id="test_task",
+        dag=DAG("test_dag"),
+        depends_on_past=depends_on_past,
+        start_date=datetime(2016, 1, 1),
+        wait_for_downstream=wait_for_downstream,
+    )
+    if prev_ti:
+        prev_dagrun = Mock(
             execution_date=datetime(2016, 1, 2),
+            **{"get_task_instance.return_value": prev_ti},
         )
-        ti = Mock(task=task, previous_ti=prev_ti, execution_date=datetime(2016, 1, 3))
-        dep_context = DepContext(ignore_depends_on_past=False)
+    else:
+        prev_dagrun = None
+    dagrun = Mock(
+        **{
+            "get_previous_scheduled_dagrun.return_value": prev_dagrun,
+            "get_previous_dagrun.return_value": prev_dagrun,
+        },
+    )
+    ti = Mock(task=task, **{"get_dagrun.return_value": dagrun})
+    dep_context = DepContext(ignore_depends_on_past=context_ignore_depends_on_past)
 
-        assert PrevDagrunDep().is_met(ti=ti, dep_context=dep_context)
-
-    def test_context_ignore_depends_on_past(self):
-        """
-        If the context overrides depends_on_past then the dep should be met,
-        even though there is no previous_ti which would normally fail the dep
-        """
-        task = self._get_task(
-            depends_on_past=True, start_date=datetime(2016, 1, 1), wait_for_downstream=False
-        )
-        prev_ti = Mock(
-            task=task,
-            state=State.SUCCESS,
-            are_dependents_done=Mock(return_value=True),
-            execution_date=datetime(2016, 1, 2),
-        )
-        ti = Mock(task=task, previous_ti=prev_ti, execution_date=datetime(2016, 1, 3))
-        dep_context = DepContext(ignore_depends_on_past=True)
-
-        assert PrevDagrunDep().is_met(ti=ti, dep_context=dep_context)
-
-    def test_first_task_run(self):
-        """
-        The first task run for a TI should pass since it has no previous dagrun.
-        """
-        task = self._get_task(
-            depends_on_past=True, start_date=datetime(2016, 1, 1), wait_for_downstream=False
-        )
-        prev_ti = None
-        ti = Mock(task=task, previous_ti=prev_ti, execution_date=datetime(2016, 1, 1))
-        dep_context = DepContext(ignore_depends_on_past=False)
-
-        assert PrevDagrunDep().is_met(ti=ti, dep_context=dep_context)
-
-    def test_prev_ti_bad_state(self):
-        """
-        If the previous TI did not complete execution this dep should fail.
-        """
-        task = self._get_task(
-            depends_on_past=True, start_date=datetime(2016, 1, 1), wait_for_downstream=False
-        )
-        prev_ti = Mock(state=State.NONE, are_dependents_done=Mock(return_value=True))
-        ti = Mock(task=task, previous_ti=prev_ti, execution_date=datetime(2016, 1, 2))
-        dep_context = DepContext(ignore_depends_on_past=False)
-
-        assert not PrevDagrunDep().is_met(ti=ti, dep_context=dep_context)
-
-    def test_failed_wait_for_downstream(self):
-        """
-        If the previous TI specified to wait for the downstream tasks of the
-        previous dagrun then it should fail this dep if the downstream TIs of
-        the previous TI are not done.
-        """
-        task = self._get_task(depends_on_past=True, start_date=datetime(2016, 1, 1), wait_for_downstream=True)
-        prev_ti = Mock(state=State.SUCCESS, are_dependents_done=Mock(return_value=False))
-        ti = Mock(task=task, previous_ti=prev_ti, execution_date=datetime(2016, 1, 2))
-        dep_context = DepContext(ignore_depends_on_past=False)
-
-        assert not PrevDagrunDep().is_met(ti=ti, dep_context=dep_context)
-
-    def test_all_met(self):
-        """
-        Test to make sure all the conditions for the dep are met
-        """
-        task = self._get_task(depends_on_past=True, start_date=datetime(2016, 1, 1), wait_for_downstream=True)
-        prev_ti = Mock(state=State.SUCCESS, are_dependents_done=Mock(return_value=True))
-        ti = Mock(task=task, execution_date=datetime(2016, 1, 2), **{'get_previous_ti.return_value': prev_ti})
-        dep_context = DepContext(ignore_depends_on_past=False)
-
-        assert PrevDagrunDep().is_met(ti=ti, dep_context=dep_context)
+    assert PrevDagrunDep().is_met(ti=ti, dep_context=dep_context) == dep_met

--- a/tests/timetables/test_time_table_iter_ranges.py
+++ b/tests/timetables/test_time_table_iter_ranges.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for Timetable.iter_between()."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from airflow.settings import TIMEZONE
+from airflow.timetables.interval import DeltaDataIntervalTimetable
+
+
+@pytest.fixture()
+def timetable_1s():
+    return DeltaDataIntervalTimetable(timedelta(seconds=1))
+
+
+def test_end_date_before_start_date(timetable_1s):
+    start = datetime(2016, 2, 1, tzinfo=TIMEZONE)
+    end = datetime(2016, 1, 1, tzinfo=TIMEZONE)
+    message = r"start \([- :+\d]{25}\) > end \([- :+\d]{25}\)"
+    with pytest.raises(ValueError, match=message):
+        list(timetable_1s.iter_between(start, end, align=True))


### PR DESCRIPTION
This creates a skeleton for the AIP-39 implementation to build on, and refactor the logic handling `@once` schedules out of the DAG class.

~~The current implementation contains a lot of duplicated code, and the PR probably shouldn’t be merged until I can pick most of `next_dagrun_after_date` apart (and ultimately eliminate it entirely and rewrite all the tests against `DAG.next_dagrun_info()` or the various TimeTable classes instead).~~

Update: I’ve since did that, so this PR is clean now.

I want to post this WIP since the trivial `@once` implementation already exposes things missing from the interface outlined in AIP-39, and I had to invent an argument (`between`) to cover it. I want to know how ya’ll think of it 🙂 

(Note: The current `TimeTable.next_dagrun_info()` interface is missing the session argument from AIP-39 because I don’t need it yet. It will be added when it needs to be.)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
