### PR TITLE
Add Connection Documentation to more Providers

### DIFF
--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -32,6 +32,10 @@ class FTPHook(BaseHook):
     Errors that may occur throughout but should be handled downstream.
     You can specify mode for data transfers in the extra field of your
     connection as ``{"passive": "true"}``.
+
+    :param ftp_conn_id: The :ref:`ftp connection id <howto/connection:ftp>`
+        reference.
+    :type ftp_conn_id: str
     """
 
     conn_name_attr = 'ftp_conn_id'

--- a/airflow/providers/ftp/sensors/ftp.py
+++ b/airflow/providers/ftp/sensors/ftp.py
@@ -32,7 +32,8 @@ class FTPSensor(BaseSensorOperator):
     :param fail_on_transient_errors: Fail on all errors,
         including 4xx transient errors. Default True.
     :type fail_on_transient_errors: bool
-    :param ftp_conn_id: The connection to run the sensor against
+    :param ftp_conn_id: The :ref:`ftp connection id <howto/connection:ftp>`
+        reference to run the sensor against.
     :type ftp_conn_id: str
     """
 

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -45,9 +45,12 @@ class SFTPHook(SSHHook):
           permissions.
 
     Errors that may occur throughout but should be handled downstream.
+
+    :param sftp_conn_id: The :ref:`sftp connection id<howto/connection:sftp>`
+    :type sftp_conn_id: str
     """
 
-    conn_name_attr = 'ftp_conn_id'
+    conn_name_attr = 'sftp_conn_id'
     default_conn_name = 'sftp_default'
     conn_type = 'sftp'
     hook_name = 'SFTP'

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -50,7 +50,7 @@ class SFTPHook(SSHHook):
     :type sftp_conn_id: str
     """
 
-    conn_name_attr = 'sftp_conn_id'
+    conn_name_attr = 'ftp_conn_id'
     default_conn_name = 'sftp_default'
     conn_type = 'sftp'
     hook_name = 'SFTP'

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -42,8 +42,9 @@ class SFTPOperator(BaseOperator):
     :param ssh_hook: predefined ssh_hook to use for remote execution.
         Either `ssh_hook` or `ssh_conn_id` needs to be provided.
     :type ssh_hook: airflow.providers.ssh.hooks.ssh.SSHHook
-    :param ssh_conn_id: connection id from airflow Connections.
-        `ssh_conn_id` will be ignored if `ssh_hook` is provided.
+    :param ssh_conn_id: :ref:`ssh connection id<howto/connection:ssh>`
+        from airflow Connections. `ssh_conn_id` will be ignored if `ssh_hook`
+        is provided.
     :type ssh_conn_id: str
     :param remote_host: remote host to connect (templated)
         Nullable. If provided, it will replace the `remote_host` which was

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -36,6 +36,9 @@ class SnowflakeHook(DbApiHook):
     in the connection or hook instantiation. If used with the S3ToSnowflakeOperator
     add 'aws_access_key_id' and 'aws_secret_access_key' to extra field in the connection.
 
+    :param snowflake_conn_id: Reference to
+        :ref:`Snowflake connection id<howto/connection:snowflake>`
+    :type snowflake_conn_id: str
     :param account: snowflake account name
     :type account: Optional[str]
     :param authenticator: authenticator for Snowflake.

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -30,7 +30,8 @@ class SnowflakeOperator(BaseOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:SnowflakeOperator`
 
-    :param snowflake_conn_id: reference to specific snowflake connection id
+    :param snowflake_conn_id: Reference to
+        :ref:`Snowflake connection id<howto/connection:snowflake>`
     :type snowflake_conn_id: str
     :param sql: the sql code to be executed. (templated)
     :type sql: Can receive a str representing a sql statement,

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -53,7 +53,8 @@ class S3ToSnowflakeOperator(BaseOperator):
     :type database: str
     :param columns_array: reference to a specific columns array in snowflake database
     :type columns_array: list
-    :param snowflake_conn_id: reference to a specific snowflake connection
+    :param snowflake_conn_id: Reference to
+        :ref:`Snowflake connection id<howto/connection:snowflake>`
     :type snowflake_conn_id: str
     :param role: name of role (will overwrite any role defined in
         connection's extra JSON)

--- a/airflow/providers/snowflake/transfers/snowflake_to_slack.py
+++ b/airflow/providers/snowflake/transfers/snowflake_to_slack.py
@@ -46,7 +46,8 @@ class SnowflakeToSlackOperator(BaseOperator):
         You can use the default JINJA variable {{ results_df }} to access the pandas dataframe containing the
         SQL results
     :type slack_message: str
-    :param snowflake_conn_id: The Snowflake connection id
+    :param snowflake_conn_id: Reference to
+        :ref:`Snowflake connection id<howto/connection:snowflake>`
     :type snowflake_conn_id: str
     :param slack_conn_id: The connection id for Slack
     :type slack_conn_id: str

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -44,7 +44,7 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
     :param ssh_conn_id: :ref:`ssh connection id<howto/connection:ssh>` from airflow
         Connections from where all the required parameters can be fetched like
         username, password or key_file. Thought the priority is given to the
-         param passed during init
+        param passed during init
     :type ssh_conn_id: str
     :param remote_host: remote host to connect
     :type remote_host: str

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -41,9 +41,10 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
     ref: https://github.com/paramiko/paramiko
     This hook also lets you create ssh tunnel and serve as basis for SFTP file transfer
 
-    :param ssh_conn_id: connection id from airflow Connections from where all the required
-        parameters can be fetched like username, password or key_file.
-        Thought the priority is given to the param passed during init
+    :param ssh_conn_id: :ref:`ssh connection id<howto/connection:ssh>` from airflow
+        Connections from where all the required parameters can be fetched like
+        username, password or key_file. Thought the priority is given to the
+         param passed during init
     :type ssh_conn_id: str
     :param remote_host: remote host to connect
     :type remote_host: str

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -34,8 +34,9 @@ class SSHOperator(BaseOperator):
     :param ssh_hook: predefined ssh_hook to use for remote execution.
         Either `ssh_hook` or `ssh_conn_id` needs to be provided.
     :type ssh_hook: airflow.providers.ssh.hooks.ssh.SSHHook
-    :param ssh_conn_id: connection id from airflow Connections.
-        `ssh_conn_id` will be ignored if `ssh_hook` is provided.
+    :param ssh_conn_id: :ref:`ssh connection id<howto/connection:ssh>`
+        from airflow Connections. `ssh_conn_id` will be ignored if
+        `ssh_hook` is provided.
     :type ssh_conn_id: str
     :param remote_host: remote host to connect (templated)
         Nullable. If provided, it will replace the `remote_host` which was

--- a/docs/apache-airflow-providers-ftp/connections/ftp.rst
+++ b/docs/apache-airflow-providers-ftp/connections/ftp.rst
@@ -27,8 +27,8 @@ The FTP connection type enables the FTP Integrations.
 Authenticating to FTP
 -----------------------
 
-Authenticate too FTP using  `ftplib
-  <https://docs.python.org/3/library/ftplib.html>`_.
+Authenticate to FTP using `ftplib
+<https://docs.python.org/3/library/ftplib.html>`_.
 i.e. indicate ``user``, ``password``, ``host``
 
 Default Connection IDs

--- a/docs/apache-airflow-providers-ftp/connections/ftp.rst
+++ b/docs/apache-airflow-providers-ftp/connections/ftp.rst
@@ -1,0 +1,67 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:ftp:
+
+FTP Connection
+===============
+
+The FTP connection type enables the FTP Integrations.
+
+Authenticating to FTP
+-----------------------
+
+Authenticate too FTP using  `ftplib
+  <https://docs.python.org/3/library/ftplib.html>`_.
+i.e. indicate ``user``, ``password``, ``host``
+
+Default Connection IDs
+----------------------
+
+Hooks, operators, and sensors related to FTP use ``ftp_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the ftp ``user`` value.
+
+Password
+    Specify the ftp ``passwd`` value.
+
+Host (optional)
+    Specify the Hostname or IP of the remote machine.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in ftp connection.
+    The following parameters are all optional:
+
+    * ``passive``: Enable “passive” mode if val is true, otherwise disable passive mode.
+      Passive mode is on by default.
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+Example connection string:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_FTP_DEFAULT='ftp://user:pass@localhost?passive=false'

--- a/docs/apache-airflow-providers-ftp/index.rst
+++ b/docs/apache-airflow-providers-ftp/index.rst
@@ -26,6 +26,7 @@ Content
     :maxdepth: 1
     :caption: References
 
+    Connection Types <connections/ftp>
     Python API <_api/airflow/providers/ftp/index>
 
 .. toctree::

--- a/docs/apache-airflow-providers-sftp/connections/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/connections/sftp.rst
@@ -1,0 +1,102 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:sftp:
+
+SFTP Connection
+===============
+
+The SFTP connection type enables SFTP Integrations.
+
+Authenticating to SFTP
+-----------------------
+
+There are two ways to connect to SFTP using Airflow.
+
+1. Use `host key
+   <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.CnOpts>`_
+i.e. host key entered in extras value ``host_key``
+2. Use a `private key, private key pass, or password
+   <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.Connection>`_
+   i.e. use the ``private_key``, ``private_key_pass``, or ``private_key`` extra values.
+
+Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
+configure multiple connections.
+
+Default Connection IDs
+----------------------
+
+Hooks, operators, and sensors related to SFTP use ``sftp_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login (optional)
+    Specify the sftp username for the remote machine.
+
+Password (optional)
+    Specify the sftp password for the remote machine.
+
+Port (optional)
+    Specify the SSH port of the remote machine
+
+Host (optional)
+    Specify the Hostname or IP of the remote machine
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in sftp connection.
+    The following parameters are all optional:
+
+    * ``private_key_pass``: Specify the password to use, if private_key is encrypted.
+    * ``no_host_key_check``: Set to false to restrict connecting to hosts with either no entries in ~/.ssh/known_hosts
+      (Hosts file) or not present in the host_key extra. This provides maximum protection against trojan horse attacks,
+      but can be troublesome when the /etc/ssh/ssh_known_hosts file is poorly maintained or connections to new hosts are
+      frequently made. This option forces the user to manually add all new hosts. Default is true, ssh will automatically
+      add new host keys to the user known hosts files.
+    * ``host_key``: The base64 encoded ssh-rsa public key of the host, as you would find in the known_hosts file.
+      Specifying this, along with no_host_key_check=False allows you to only make the connection if the public key of
+      the endpoint matches this value.
+    * ``private_key`` Specify the path to private key file(str) or paramiko.AgentKey
+
+Example “extras” field:
+
+.. code-block:: bash
+
+    {
+       "private_key": "path/to/private_key",
+       "no_host_key_check": "false",
+       "allow_host_key_change": "false",
+       "host_key": "AAAHD...YDWwq=="
+    }
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+Example connection string with ``private_key``:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_SFTP_DEFAULT='sftp://user:pass@localhost:22?private_key=64bit-encoded-private-key'
+
+Example connection string with ``host_key``:
+
+.. code-block:: bash
+    AIRFLOW_CONN_SFTP_DEFAULT='sftp://user:pass@localhost:22?host_key=AAAHD...YDWwq%3D%3D&no_host_key_check=false'

--- a/docs/apache-airflow-providers-sftp/connections/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/connections/sftp.rst
@@ -31,7 +31,7 @@ There are two ways to connect to SFTP using Airflow.
 
 1. Use `host key
    <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.CnOpts>`_
-i.e. host key entered in extras value ``host_key``
+   i.e. host key entered in extras value ``host_key``.
 2. Use a `private key, private key pass, or password
    <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.Connection>`_
    i.e. use the ``private_key``, ``private_key_pass``, or ``private_key`` extra values.
@@ -99,4 +99,5 @@ Example connection string with ``private_key``:
 Example connection string with ``host_key``:
 
 .. code-block:: bash
+
     AIRFLOW_CONN_SFTP_DEFAULT='sftp://user:pass@localhost:22?host_key=AAAHD...YDWwq%3D%3D&no_host_key_check=false'

--- a/docs/apache-airflow-providers-sftp/index.rst
+++ b/docs/apache-airflow-providers-sftp/index.rst
@@ -26,6 +26,7 @@ Content
     :maxdepth: 1
     :caption: References
 
+    Connection types <connections/sftp>
     Python API <_api/airflow/providers/sftp/index>
 
 .. toctree::

--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -63,6 +63,8 @@ Extra (optional)
     * ``private_key_file``: Specify the path to the private key file.
     * ``session_parameters``: Specify `session level parameters
       <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_
+    * ``aws_access_key_id``: Specify your aws S3 access key for use with the S3ToSnowflakeOperator.
+    * ``aws_secret_access_key``: Specify your aws S3 secret access key for use with the S3ToSnowflakeOperator.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -1,0 +1,76 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:snowflake:
+
+Snowflake Connection
+====================
+
+The Snowflake connection type enables integrations with Snowflake.
+
+Authenticating to Snowflake
+---------------------------
+
+Authenticate too Snowflake using the `Snowflake python connector default authentication
+    <https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-using-the-default-authenticator>`_.
+
+Default Connection IDs
+----------------------
+
+Hooks, operators, and sensors related to Snowflake use ``snowflake_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login
+    Specify the snowflake username.
+
+Password
+    Specify the snowflake password.
+
+Host (optional)
+    Specify the snowflake hostname.
+
+Schema (optional)
+    Specify the snowflake schema to be used.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in the snowflake connection.
+    The following parameters are all optional:
+
+    * ``account``: Snowflake account name.
+    * ``database``: Snowflake database name.
+    * ``region``: Warehouse region.
+    * ``warehouse``: Snowflake warehouse name.
+    * ``role``: Snowflake role.
+    * ``authenticator``: To connect using OAuth set this parameter ``oath``
+    * ``private_key_file``: Specify the path to the private key file.
+    * ``session_parameters``: Specify `session level parameters
+      <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+Example connection string:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_SNOWFLAKE_DEFAULT='snowflake://user:password@snowflake.example/db-schema?account=account&database=snow-db&region=us-east&warehouse=snow-warehouse'

--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -27,8 +27,8 @@ The Snowflake connection type enables integrations with Snowflake.
 Authenticating to Snowflake
 ---------------------------
 
-Authenticate too Snowflake using the `Snowflake python connector default authentication
-    <https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-using-the-default-authenticator>`_.
+Authenticate to Snowflake using the `Snowflake python connector default authentication
+<https://docs.snowflake.com/en/user-guide/python-connector-example.html#connecting-using-the-default-authenticator>`_.
 
 Default Connection IDs
 ----------------------

--- a/docs/apache-airflow-providers-snowflake/index.rst
+++ b/docs/apache-airflow-providers-snowflake/index.rst
@@ -26,6 +26,7 @@ Content
     :maxdepth: 1
     :caption: Guides
 
+    Connection Types <connections/snowflake>
     Operators <operators/index>
 
 .. toctree::

--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -17,6 +17,8 @@
 
 
 
+.. _howto/connection:ssh:
+
 SSH Connection
 ==============
 The SSH connection type provides connection to use :class:`~airflow.providers.ssh.hooks.ssh.SSHHook` to run

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,5 +1,6 @@
 Ack
 Acyclic
+AgentKey
 Airbnb
 Airbyte
 AirflowException


### PR DESCRIPTION
This PR adds and updates documentation for connecting to some popular providers. It also adds links to this documentation in the doc strings of modules that use each connection. Documentation for the following connections is improved or updated:

- ftp
- sftp
- ssh
- snowflake
