### PR TITLE
Support regex pattern in SFTPHOOK

### DIFF
--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -43,6 +43,7 @@ TMP_PATH = '/tmp'
 TMP_DIR_FOR_TESTS = 'tests_sftp_hook_dir'
 SUB_DIR = "sub_dir"
 TMP_FILE_FOR_TESTS = 'test_file.txt'
+CSV_TMP_FILE_FOR_TESTS = 'test_file.csv'
 
 SFTP_CONNECTION_USER = "root"
 
@@ -68,6 +69,8 @@ class TestSFTPHook(unittest.TestCase):
             file.write('Test file')
         with open(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, SUB_DIR, TMP_FILE_FOR_TESTS), 'a') as file:
             file.write('Test file')
+        with open(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, CSV_TMP_FILE_FOR_TESTS), 'a') as file:
+            file.write('Test file')
 
     def test_get_conn(self):
         output = self.hook.get_conn()
@@ -85,7 +88,13 @@ class TestSFTPHook(unittest.TestCase):
 
     def test_list_directory(self):
         output = self.hook.list_directory(path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
-        assert output == [SUB_DIR]
+        assert output == [SUB_DIR, CSV_TMP_FILE_FOR_TESTS]
+
+    def test_list_directory_with_pattern(self):
+        output = self.hook.list_directory(
+            path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS), regex_pattern=".*.csv"
+        )
+        assert output == [CSV_TMP_FILE_FOR_TESTS]
 
     def test_create_and_delete_directory(self):
         new_dir_name = 'new_dir'
@@ -117,7 +126,7 @@ class TestSFTPHook(unittest.TestCase):
             local_full_path=os.path.join(TMP_PATH, TMP_FILE_FOR_TESTS),
         )
         output = self.hook.list_directory(path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
-        assert output == [SUB_DIR, TMP_FILE_FOR_TESTS]
+        assert output == [SUB_DIR, CSV_TMP_FILE_FOR_TESTS, TMP_FILE_FOR_TESTS]
         retrieved_file_name = 'retrieved.txt'
         self.hook.retrieve_file(
             remote_full_path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, TMP_FILE_FOR_TESTS),
@@ -127,7 +136,15 @@ class TestSFTPHook(unittest.TestCase):
         os.remove(os.path.join(TMP_PATH, retrieved_file_name))
         self.hook.delete_file(path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, TMP_FILE_FOR_TESTS))
         output = self.hook.list_directory(path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
-        assert output == [SUB_DIR]
+        assert output == [SUB_DIR, CSV_TMP_FILE_FOR_TESTS]
+
+    def test_retrieve_with_pattern(self):
+        self.hook.retrieve_file(
+            remote_full_path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS),
+            local_full_path=os.path.join(TMP_PATH),
+            regex_pattern=".*.csv",
+        )
+        assert CSV_TMP_FILE_FOR_TESTS in os.listdir(TMP_PATH)
 
     def test_get_mod_time(self):
         self.hook.store_file(
@@ -252,9 +269,16 @@ class TestSFTPHook(unittest.TestCase):
         tree_map = self.hook.get_tree_map(path=os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         files, dirs, unknowns = tree_map
 
-        assert files == [os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, SUB_DIR, TMP_FILE_FOR_TESTS)]
+        assert files == [
+            os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, SUB_DIR, TMP_FILE_FOR_TESTS),
+            os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, CSV_TMP_FILE_FOR_TESTS),
+        ]
         assert dirs == [os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, SUB_DIR)]
         assert unknowns == []
+
+    def test_get_tree_map_with_pattern(self):
+        files, _, _ = self.hook.get_tree_map(path=os.path.join(TMP_PATH), regex_pattern=".*.csv")
+        assert os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, CSV_TMP_FILE_FOR_TESTS) in files
 
     def tearDown(self):
         shutil.rmtree(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))

--- a/tests/providers/sftp/sensors/test_sftp.py
+++ b/tests/providers/sftp/sensors/test_sftp.py
@@ -32,7 +32,16 @@ class TestSFTPSensor(unittest.TestCase):
         sftp_sensor = SFTPSensor(task_id='unit_test', path='/path/to/file/1970-01-01.txt')
         context = {'ds': '1970-01-01'}
         output = sftp_sensor.poke(context)
-        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with('/path/to/file/1970-01-01.txt')
+        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with('/path/to/file/1970-01-01.txt', None)
+        assert output
+
+    @patch('airflow.providers.sftp.sensors.sftp.SFTPHook')
+    def test_file_present_with_pattern(self, sftp_hook_mock):
+        sftp_hook_mock.return_value.get_mod_time.return_value = '19700101000000'
+        sftp_sensor = SFTPSensor(task_id='unit_test', path='/path/to/file/', regex_pattern=".*.txt")
+        context = {'ds': '1970-01-01'}
+        output = sftp_sensor.poke(context)
+        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with('/path/to/file/', ".*.txt")
         assert output
 
     @patch('airflow.providers.sftp.sensors.sftp.SFTPHook')
@@ -41,7 +50,7 @@ class TestSFTPSensor(unittest.TestCase):
         sftp_sensor = SFTPSensor(task_id='unit_test', path='/path/to/file/1970-01-01.txt')
         context = {'ds': '1970-01-01'}
         output = sftp_sensor.poke(context)
-        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with('/path/to/file/1970-01-01.txt')
+        sftp_hook_mock.return_value.get_mod_time.assert_called_once_with('/path/to/file/1970-01-01.txt', None)
         assert not output
 
     @patch('airflow.providers.sftp.sensors.sftp.SFTPHook')
@@ -51,7 +60,9 @@ class TestSFTPSensor(unittest.TestCase):
         context = {'ds': '1970-01-01'}
         with pytest.raises(OSError):
             sftp_sensor.poke(context)
-            sftp_hook_mock.return_value.get_mod_time.assert_called_once_with('/path/to/file/1970-01-01.txt')
+            sftp_hook_mock.return_value.get_mod_time.assert_called_once_with(
+                '/path/to/file/1970-01-01.txt', None
+            )
 
     def test_hook_not_created_during_init(self):
         sftp_sensor = SFTPSensor(task_id='unit_test', path='/path/to/file/1970-01-01.txt')


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In many cases, users are interested in some cases of files or types, not the whole thing. for example, users want to retrieve only CSV files in the `/tmp` directory and etc. Unfortunately, `Paramiko` does not support wi


related: #15332
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
