### PR TITLE
PostgresHook: deepcopy connection to avoid mutating connection obj

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -18,6 +18,7 @@
 
 import os
 from contextlib import closing
+from copy import deepcopy
 from typing import Iterable, Optional, Tuple, Union
 
 import psycopg2
@@ -80,7 +81,7 @@ class PostgresHook(DbApiHook):
     def get_conn(self) -> connection:
         """Establishes a connection to a postgres database."""
         conn_id = getattr(self, self.conn_name_attr)
-        conn = self.connection or self.get_connection(conn_id)
+        conn = deepcopy(self.connection or self.get_connection(conn_id))
 
         # check for authentication via AWS IAM
         if conn.extra_dejson.get('iam', False):

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -123,8 +123,20 @@ class TestPostgresHookConn(unittest.TestCase):
             'DbUser': login,
         }
         self.db_hook.get_conn()
+        get_cluster_credentials_call = mock.call(
+            DbUser=self.connection.login,
+            DbName=self.connection.schema,
+            ClusterIdentifier="different-identifier",
+            AutoCreate=False,
+        )
+        mock_client.return_value.get_cluster_credentials.assert_has_calls([get_cluster_credentials_call])
         mock_connect.assert_called_once_with(
             user=login, password='aws_token', host=self.connection.host, dbname='schema', port=5439
+        )
+        # Verify that the connection object has not been mutated.
+        self.db_hook.get_conn()
+        mock_client.return_value.get_cluster_credentials.assert_has_calls(
+            [get_cluster_credentials_call, get_cluster_credentials_call]
         )
 
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
PostgresHook: deepcopy connection object to avoid unexpected mutation
---

For AWS IAM based connections, the connection object is mutated by setting the `login`, `password` and `port` properties after the call to `self.get_iam_token(...)`. The connection object's `login` field is set to `"IAM:original-login"` because the `login` value returned has `IAM:` prefixed.

As a result, any subsequent calls to `get_conn()` will fail with the AWS `client.get_cluster_credentials(...)` call complaining that `:` cannot be part of the `DbUser` argument.

In general, the values within any connection objects used by this hook should not be subject to mutation by `get_conn()` calls, and the addition of `deepcopy` is meant to enforce this.