### PR TITLE
Parse Error 410 in kubernetes Watcher and return latest resource version

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -176,12 +176,14 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         if raw_object['code'] == 410:
             message = raw_object['message']
             latest_resource_version = self._parse_too_old_failure(message)
+            if latest_resource_version is None:
+                # Return resource version 0
+                return '0'
             self.log.warning(
                 "Updated to new resource version: %s due to 'too old' error: %s",
                 latest_resource_version,
                 raw_object,
             )
-
             return latest_resource_version
         raise AirflowException(
             'Kubernetes failure for %s with code %s and message: %s'


### PR DESCRIPTION
Currently, when kubernetes watcher stream encounter Error 410('too old resource version'),
it returns resource version '0' which is not the latest version.

This 410 error contains the latest resource version in its message.

This PR parses the message and return the latest resource version so that
watcher can continue watching instead of dieing

Some relevant links on this:
https://github.com/kubernetes-client/python/issues/609
https://github.com/kubernetes-client/python/issues/728#issuecomment-561134890

This would likely fix some issues #14175, #13916, and https://github.com/apache/airflow/issues/12644#issuecomment-741663708

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
