### PR TITLE
UI: DAG Calendar View

### DIFF
--- a/airflow/www/static/css/calendar.css
+++ b/airflow/www/static/css/calendar.css
@@ -1,0 +1,51 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+text.year-label {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+text.day-label {
+  font-size: 12px;
+}
+
+path.month {
+  stroke: black;
+  stroke-width: 2px;
+}
+
+rect.day {
+  fill: #eeeeee;
+  stroke: #cccccc;
+  stroke-width: 1px;
+  cursor: pointer;
+}
+
+rect.success {
+  fill: green;
+}
+
+rect.running {
+  fill: lime;
+}
+
+rect.failed {
+  fill: red;
+}

--- a/airflow/www/static/css/calendar.css
+++ b/airflow/www/static/css/calendar.css
@@ -17,6 +17,11 @@
  * under the License.
  */
 
+text.title {
+  font-size: 16px;
+  font-weight: bold;
+}
+
 text.year-label {
   font-size: 16px;
   font-weight: bold;
@@ -24,6 +29,10 @@ text.year-label {
 
 text.day-label {
   font-size: 12px;
+}
+
+text.status-label {
+  font-size: 11px;
 }
 
 path.month {
@@ -37,24 +46,7 @@ rect.day {
   cursor: pointer;
 }
 
-rect.success {
-  fill: green;
-}
-
-rect.running {
-  fill: lime;
-}
-
-rect.failed {
-  fill: red;
-}
-
-rect.no_status {
-  fill: #fff;
-}
-
 .legend-item__swatch {
-  /* Keep in sync with the formatting of rect.no_status */
   background-color: #fff;
   border: 1px solid #ccc;
 }

--- a/airflow/www/static/css/calendar.css
+++ b/airflow/www/static/css/calendar.css
@@ -32,7 +32,7 @@ path.month {
 }
 
 rect.day {
-  stroke: #cccccc;
+  stroke: #ccc;
   stroke-width: 1px;
   cursor: pointer;
 }
@@ -50,11 +50,11 @@ rect.failed {
 }
 
 rect.no_status {
-  fill: #eeeeee;
+  fill: #eee;
 }
 
 .legend-item__swatch {
   /* Keep in sync with the formatting of rect.no_status */
-  background-color: #eeeeee;
-  border: 1px solid #cccccc;
+  background-color: #eee;
+  border: 1px solid #ccc;
 }

--- a/airflow/www/static/css/calendar.css
+++ b/airflow/www/static/css/calendar.css
@@ -50,11 +50,11 @@ rect.failed {
 }
 
 rect.no_status {
-  fill: #eee;
+  fill: #fff;
 }
 
 .legend-item__swatch {
   /* Keep in sync with the formatting of rect.no_status */
-  background-color: #eee;
+  background-color: #fff;
   border: 1px solid #ccc;
 }

--- a/airflow/www/static/css/calendar.css
+++ b/airflow/www/static/css/calendar.css
@@ -32,7 +32,6 @@ path.month {
 }
 
 rect.day {
-  fill: #eeeeee;
   stroke: #cccccc;
   stroke-width: 1px;
   cursor: pointer;
@@ -48,4 +47,14 @@ rect.running {
 
 rect.failed {
   fill: red;
+}
+
+rect.no_status {
+  fill: #eeeeee;
+}
+
+.legend-item__swatch {
+  /* Keep in sync with the formatting of rect.no_status */
+  background-color: #eeeeee;
+  border: 1px solid #cccccc;
 }

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -1,5 +1,3 @@
-/* eslint-disable func-names */
-/* eslint-disable no-underscore-dangle */
 /*!
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -26,226 +24,219 @@ const dagId = getMetaValue('dag_id');
 const treeUrl = getMetaValue('tree_url');
 
 function getTreeViewURL(d) {
-  return treeUrl +
-    "?dag_id=" + encodeURIComponent(dagId) +
-    "&base_date=" + encodeURIComponent(d.toISOString())
+  return `${treeUrl
+  }?dag_id=${encodeURIComponent(dagId)
+  }&base_date=${encodeURIComponent(d.toISOString())}`;
 }
 
 // date helpers
 function formatDay(d) {
-  return ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][d]
+  return ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][d];
 }
 
 function toMoment(y, m, d) {
-  return moment.utc([y, m, d])
+  return moment.utc([y, m, d]);
 }
 
 function weekOfMonth(y, m, d) {
-  const monthOffset = toMoment(y, m, 1).day()
-  const dayOfMonth = toMoment(y, m, d).date()
-  return Math.floor((dayOfMonth + monthOffset - 1) / 7)
+  const monthOffset = toMoment(y, m, 1).day();
+  const dayOfMonth = toMoment(y, m, d).date();
+  return Math.floor((dayOfMonth + monthOffset - 1) / 7);
 }
 
 function weekOfYear(y, m) {
-  const yearOffset = toMoment(y, 0, 1).day()
-  const dayOfYear = toMoment(y, m, 1).dayOfYear()
-  return Math.floor((dayOfYear + yearOffset - 1) / 7)
+  const yearOffset = toMoment(y, 0, 1).day();
+  const dayOfYear = toMoment(y, m, 1).dayOfYear();
+  return Math.floor((dayOfYear + yearOffset - 1) / 7);
 }
 
 function daysInMonth(y, m) {
-  const lastDay = toMoment(y, m, 1).add(1, 'month').subtract(1, 'day')
-  return lastDay.date()
+  const lastDay = toMoment(y, m, 1).add(1, 'month').subtract(1, 'day');
+  return lastDay.date();
 }
 
 function weeksInMonth(y, m) {
-  const firstDay = toMoment(y, m, 1)
-  const monthOffset = firstDay.day()
-  return Math.floor((daysInMonth(y, m) + monthOffset) / 7) + 1
+  const firstDay = toMoment(y, m, 1);
+  const monthOffset = firstDay.day();
+  return Math.floor((daysInMonth(y, m) + monthOffset) / 7) + 1;
 }
 
-const dateFormat = 'YYYY-MM-DD'
+const dateFormat = 'YYYY-MM-DD';
 
 // The state of the days will picked according to the states of the dag runs for that day
 // using the following states priority:
-const priority = ["failed", "running", "success"]
+const priority = ['failed', 'running', 'success'];
 
 function stateClass(dagStates) {
-  for (const state of priority) {
-    if (dagStates[state] !== undefined) return state
+  for (let i = 0; i < priority.length; i += 1) {
+    const state = priority[i];
+    if (dagStates[state] !== undefined) return state;
   }
-  return 'no_status'
+  return 'no_status';
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   $('span.status_square').tooltip({ html: true });
 
   // JSON.parse is faster for large payloads than an object literal
-  const data = JSON.parse(calendarData);
+  const rootData = JSON.parse(calendarData);
 
   const dayTip = d3.tip()
     .attr('class', 'tooltip d3-tip')
-    .html(function(toolTipHtml) {
-      return toolTipHtml;
-  });
+    .html((toolTipHtml) => toolTipHtml);
 
   // draw the calendar
   function draw() {
-
     // display constants
-    const leftPadding = 32
-    const yearLabelWidth = 34
-    const dayLabelWidth = 14
-    const dayLabelPadding = 4
-    const yearPadding = 20
-    const cellSize = 16
-    const yearHeight = cellSize * 7 + 2
-    const maxWeeksInYear = 53
-    const fullWidth = leftPadding * 2 + yearLabelWidth + dayLabelWidth + maxWeeksInYear * cellSize
+    const leftPadding = 32;
+    const yearLabelWidth = 34;
+    const dayLabelWidth = 14;
+    const dayLabelPadding = 4;
+    const yearPadding = 20;
+    const cellSize = 16;
+    const yearHeight = cellSize * 7 + 2;
+    const maxWeeksInYear = 53;
+    const fullWidth = leftPadding * 2 + yearLabelWidth + dayLabelWidth + maxWeeksInYear * cellSize;
 
     // group dag run stats by year -> month -> day -> state
     let dagStates = d3
       .nest()
-      .key(dr => moment.utc(dr.date, dateFormat).year())
-      .key(dr => moment.utc(dr.date, dateFormat).month())
-      .key(dr => moment.utc(dr.date, dateFormat).date())
-      .key(dr => dr.state)
-      .map(data.dag_states);
+      .key((dr) => moment.utc(dr.date, dateFormat).year())
+      .key((dr) => moment.utc(dr.date, dateFormat).month())
+      .key((dr) => moment.utc(dr.date, dateFormat).date())
+      .key((dr) => dr.state)
+      .map(rootData.dag_states);
 
     // Make sure we have one year displayed for each year between the start and end dates.
     // This also ensures we do not have show an empty calendar view when no dag runs exist.
-    const startYear = moment.utc(data.start_date, dateFormat).year()
-    const endYear = moment.utc(data.end_date, dateFormat).year()
-    for (let y = startYear; y <= endYear; y++) {
-      dagStates[y] = dagStates[y] || {}
+    const startYear = moment.utc(rootData.start_date, dateFormat).year();
+    const endYear = moment.utc(rootData.end_date, dateFormat).year();
+    for (let y = startYear; y <= endYear; y += 1) {
+      dagStates[y] = dagStates[y] || {};
     }
 
     dagStates = d3
       .entries(dagStates)
-      .map(keyVal => ({
-        'year': keyVal.key,
-        'dagStates': keyVal.value,
+      .map((keyVal) => ({
+        year: keyVal.key,
+        dagStates: keyVal.value,
       }))
-      .sort(data => data.year);
+      .sort((data) => data.year);
 
     // root SVG element
     const svg = d3
-      .select("#calendar-svg")
-      .attr("width", fullWidth)
-      .attr("height", (yearHeight + yearPadding) * dagStates.length + yearPadding)
-      .call(dayTip)
+      .select('#calendar-svg')
+      .attr('width', fullWidth)
+      .attr('height', (yearHeight + yearPadding) * dagStates.length + yearPadding)
+      .call(dayTip);
 
-    const group = svg.append("g");
+    const group = svg.append('g');
 
     // create the years groups, each holding a year of data
     const year = group
-      .selectAll("g")
+      .selectAll('g')
       .data(dagStates)
       .enter()
       .append('g')
-      .attr("transform", (d, i) => `translate(${leftPadding}, ${yearPadding + (yearHeight + yearPadding) * i})`);
+      .attr('transform', (d, i) => `translate(${leftPadding}, ${yearPadding + (yearHeight + yearPadding) * i})`);
 
     year
-      .append("text")
-      .attr("x", - yearHeight * 0.5)
-      .attr("transform", "rotate(270)")
-      .attr("text-anchor", "middle")
-      .attr("class", "year-label")
-      .text(d => d.year);
+      .append('text')
+      .attr('x', -yearHeight * 0.5)
+      .attr('transform', 'rotate(270)')
+      .attr('text-anchor', 'middle')
+      .attr('class', 'year-label')
+      .text((d) => d.year);
 
     // write day names
     year
-      .append("g")
-      .attr("transform", `translate(${yearLabelWidth}, ${dayLabelPadding})`)
-      .attr("text-anchor", "end")
-      .selectAll("g")
+      .append('g')
+      .attr('transform', `translate(${yearLabelWidth}, ${dayLabelPadding})`)
+      .attr('text-anchor', 'end')
+      .selectAll('g')
       .data(d3.range(7))
       .enter()
       .append('text')
-      .attr("y", i => (i + 0.5) * cellSize)
-      .attr("class", "day-label")
+      .attr('y', (i) => (i + 0.5) * cellSize)
+      .attr('class', 'day-label')
       .text(formatDay);
 
     // create months groups to old the individual day cells
     const months = year
-      .append("g")
-      .attr("transform", data => `translate(${yearLabelWidth + dayLabelWidth}, 0)`);
+      .append('g')
+      .attr('transform', `translate(${yearLabelWidth + dayLabelWidth}, 0)`);
 
     const month = months
-      .append("g")
-      .selectAll("g")
-      .data(data => d3
+      .append('g')
+      .selectAll('g')
+      .data((data) => d3
         .range(12)
-        .map(i => {
-          const year = data.year
-          const month = i
-          const dagStatesByDay = data.dagStates[month] || {}
-          return {
-            'year': year,
-            'month': month,
-            'dagStates': dagStatesByDay,
-          }
-        })
-      )
+        .map((i) => ({
+          year: data.year,
+          month: i,
+          dagStates: data.dagStates[i] || {},
+        })))
       .enter()
       .append('g')
-      .attr("transform", data => `translate(${weekOfYear(data.year, data.month) * cellSize}, 0)`);
+      .attr('transform', (data) => `translate(${weekOfYear(data.year, data.month) * cellSize}, 0)`);
 
     // create days inside the month groups
-    const tipHtml = data => {
-      const stateCounts = d3.entries(data.dagStates).map(kv => `${kv.value[0].count} ${kv.key}`)
-      const date = toMoment(data.year, data.month, data.day)
-      const daySr = formatDay(date.day())
-      const dateStr = date.format(dateFormat)
-      return `<strong>${daySr} ${dateStr}</strong><br>${stateCounts.join('<br>')}`
-    }
+    const tipHtml = (data) => {
+      const stateCounts = d3.entries(data.dagStates).map((kv) => `${kv.value[0].count} ${kv.key}`);
+      const date = toMoment(data.year, data.month, data.day);
+      const daySr = formatDay(date.day());
+      const dateStr = date.format(dateFormat);
+      return `<strong>${daySr} ${dateStr}</strong><br>${stateCounts.join('<br>')}`;
+    };
 
     month
-      .selectAll("g")
-      .data(data => d3
+      .selectAll('g')
+      .data((data) => d3
         .range(daysInMonth(data.year, data.month))
-        .map(i => {
-          const day = i + 1
-          const dagStatesByState = data.dagStates[day] || {}
+        .map((i) => {
+          const day = i + 1;
+          const dagStatesByState = data.dagStates[day] || {};
           return {
-            'year': data.year,
-            'month': data.month,
-            'day': day,
-            'dagStates': dagStatesByState,
-          }
-        })
-      )
+            year: data.year,
+            month: data.month,
+            day,
+            dagStates: dagStatesByState,
+          };
+        }))
       .enter()
       .append('rect')
-      .attr("x", data => weekOfMonth(data.year, data.month, data.day)  * cellSize)
-      .attr("y", data => toMoment(data.year, data.month, data.day).day()  * cellSize)
-      .attr("width", cellSize)
-      .attr("height", cellSize)
-      .attr("class", data => 'day ' + stateClass(data.dagStates))
-      .on("click", data => {
+      .attr('x', (data) => weekOfMonth(data.year, data.month, data.day) * cellSize)
+      .attr('y', (data) => toMoment(data.year, data.month, data.day).day() * cellSize)
+      .attr('width', cellSize)
+      .attr('height', cellSize)
+      .attr('class', (data) => `day ${stateClass(data.dagStates)}`)
+      .on('click', (data) => {
         window.location.href = getTreeViewURL(
           // add 1 day and substract 1 ms to not show any run from the next day.
-          toMoment(data.year, data.month, data.day).add(1, 'day').subtract(1, 'ms')
-        )
+          toMoment(data.year, data.month, data.day).add(1, 'day').subtract(1, 'ms'),
+        );
       })
-      .on("mouseover", function(data) {
+      .on('mouseover', function showTip(data) {
         const tt = tipHtml(data);
         dayTip.direction('n');
         dayTip.show(tt, this);
       })
-      .on('mouseout', function(d,i){dayTip.hide(d, this)});
+      .on('mouseout', function hideTip(data) {
+        dayTip.hide(data, this);
+      });
 
     // add paths around months
     month
-      .selectAll("g")
-      .data(data => [data])
+      .selectAll('g')
+      .data((data) => [data])
       .enter()
       .append('path')
       .attr('class', 'month')
-      .style("fill", "none")
-      .attr("d", data => {
-        const firstDayOffset = toMoment(data.year, data.month, 1).day()
-        const lastDayOffset = toMoment(data.year, data.month, 1).add(1, 'month').day()
-        const weeks = weeksInMonth(data.year, data.month)
+      .style('fill', 'none')
+      .attr('d', (data) => {
+        const firstDayOffset = toMoment(data.year, data.month, 1).day();
+        const lastDayOffset = toMoment(data.year, data.month, 1).add(1, 'month').day();
+        const weeks = weeksInMonth(data.year, data.month);
         return d3.svg.line()([
           [0, firstDayOffset * cellSize],
           [cellSize, firstDayOffset * cellSize],
@@ -255,9 +246,9 @@ document.addEventListener('DOMContentLoaded', () => {
           [(weeks - 1) * cellSize, lastDayOffset * cellSize],
           [(weeks - 1) * cellSize, 7 * cellSize],
           [0, 7 * cellSize],
-          [0, firstDayOffset * cellSize]
-        ])
-      })
+          [0, firstDayOffset * cellSize],
+        ]);
+      });
   }
 
   function update() {

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -110,9 +110,10 @@ document.addEventListener('DOMContentLoaded', () => {
       .key(dr => dr.state)
       .map(data.dag_states);
 
-    if (Object.keys(dagStates).length == 0) {
-      // never display an empty calendar, instead show the current year
-      dagStates[moment.utc().year()] = {}
+    const startYear = moment.utc(data.start_date, dateFormat).year()
+    const endYear = moment.utc(data.end_date, dateFormat).year()
+    for (let y = startYear; y <= endYear; y++) {
+      dagStates[y] = dagStates[y] || {}
     }
 
     dagStates = d3

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -57,10 +57,8 @@ function daysInMonth(y, m) {
 }
 
 // The state of the days will picked according to the states of the dag runs for that day
-// using the following states priority
-const priority = ["failed", "upstream_failed", "up_for_retry","up_for_reschedule",
-                  "queued", "scheduled", "sensing", "running", "shutdown", "removed",
-                  "no_status", "success", "skipped"]
+// using the following states priority:
+const priority = ["failed", "running", "success"]
 
 function stateClass(dagStates) {
   for (const state of priority) {

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -63,6 +63,8 @@ function weeksInMonth(y, m) {
   return Math.floor((daysInMonth(y, m) + monthOffset) / 7) + 1
 }
 
+const dateFormat = 'YYYY-MM-DD'
+
 // The state of the days will picked according to the states of the dag runs for that day
 // using the following states priority:
 const priority = ["failed", "running", "success"]
@@ -73,8 +75,6 @@ function stateClass(dagStates) {
   }
   return 'no_status'
 }
-
-const dateFormat = 'YYYY-MM-DD'
 
 document.addEventListener('DOMContentLoaded', () => {
   $('span.status_square').tooltip({ html: true });
@@ -99,7 +99,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const yearPadding = 20
     const cellSize = 16
     const yearHeight = cellSize * 7 + 2
-    const fullWidth = leftPadding * 2 + yearLabelWidth + dayLabelWidth + 53 * cellSize
+    const maxWeeksInYear = 53
+    const fullWidth = leftPadding * 2 + yearLabelWidth + dayLabelWidth + maxWeeksInYear * cellSize
 
     // group dag run stats by year -> month -> day -> state
     let dagStates = d3
@@ -110,6 +111,8 @@ document.addEventListener('DOMContentLoaded', () => {
       .key(dr => dr.state)
       .map(data.dag_states);
 
+    // Make sure we have one year displayed for each year between the start and end dates.
+    // This also ensures we do not have show an empty calendar view when no dag runs exist.
     const startYear = moment.utc(data.start_date, dateFormat).year()
     const endYear = moment.utc(data.end_date, dateFormat).year()
     for (let y = startYear; y <= endYear; y++) {

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-/* global calendarData, document, window, $, d3, moment, call_modal_dag, call_modal, */
+/* global calendarData, document, window, $, d3, moment */
 import getMetaValue from './meta_value';
 import { defaultFormat } from './datetime_utils';
 

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -1,0 +1,256 @@
+/* eslint-disable func-names */
+/* eslint-disable no-underscore-dangle */
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/* global calendarData, document, window, $, d3, moment, call_modal_dag, call_modal, */
+import getMetaValue from './meta_value';
+
+const dagId = getMetaValue('dag_id');
+const treeUrl = getMetaValue('tree_url');
+
+function getTreeViewURL(d) {
+  return treeUrl +
+    "?dag_id=" + encodeURIComponent(dagId) +
+    "&base_date=" + encodeURIComponent(d.toISOString())
+}
+
+// date helpers
+function formatDay(d) {
+  return ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"][d]
+}
+
+function formatMonth(m) {
+  return ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sept", "Oct", "Nov", "Dec"][m]
+}
+
+function toMoment(y, m, d) {
+  return moment.utc(`${y}-${m + 1}-${d}`, 'YYYY-MM-DD')
+}
+
+function weekOfMonth(y, m, d) {
+  const offset = toMoment(y, m, 1).isoWeekday()
+  return Math.floor((toMoment(y, m, d).date() - 1 + offset) / 7)
+}
+
+function daysInMonth(y, m) {
+  const startDay = toMoment(y, m, 1)
+  // we substract 1 otherwise moment will return a duration of 1 month and 0 days
+  const endDay = toMoment(y, m, 1).add(1, 'month').subtract(1, 'day')
+  return moment.duration(endDay.diff(startDay)).asDays() + 1
+}
+
+// The state of the days will picked according to the states of the dag runs for that day
+// using the following states priority
+const priority = ["failed", "upstream_failed", "up_for_retry","up_for_reschedule",
+                  "queued", "scheduled", "sensing", "running", "shutdown", "removed",
+                  "no_status", "success", "skipped"]
+
+function stateClass(dagStates) {
+  for (const state of priority) {
+    if (dagStates[state] !== undefined) return state
+  }
+  return 'no_dag_states'
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  $('span.status_square').tooltip({ html: true });
+
+  // JSON.parse is faster for large payloads than an object literal
+  const data = JSON.parse(calendarData);
+
+  const dayTip = d3.tip()
+    .attr('class', 'tooltip d3-tip')
+    .html(function(toolTipHtml) {
+      return toolTipHtml;
+  });
+
+  // draw the calendar
+  function draw() {
+
+    // display constants
+    const fullWidth = 1100
+    const leftPadding = 40
+    const yearPadding = 20
+    const yearHeaderHeight = 20
+    const monthHeaderHeight = 16
+    const cellSize = 16;
+    const yearHeight = yearPadding + yearHeaderHeight + monthHeaderHeight + cellSize * 7
+
+    // group dag run stats by year -> month -> day -> state
+    let dagStates = d3
+      .nest()
+      .key(dr => new Date(dr.execution_date).getUTCFullYear())
+      .key(dr => new Date(dr.execution_date).getMonth())
+      .key(dr => new Date(dr.execution_date).getDate())
+      .key(dr => dr.state)
+      .map(data.dag_states);
+
+    dagStates = d3
+      .entries(dagStates)
+      .map(keyVal => ({
+        'year': keyVal.key,
+        'dagStates': keyVal.value,
+      }))
+      .sort(data => data.year);
+
+    // root SVG element
+    const svg = d3
+      .select("#calendar-svg")
+      .attr("width", fullWidth)
+      .attr("height", yearHeight * dagStates.length)
+      .call(dayTip)
+
+    const group = svg.append("g");
+
+    // create the years groups, eahc holding a year of data
+    const year = group
+      .selectAll("g")
+      .data(dagStates)
+      .enter()
+      .append('g')
+      .attr("transform", (d, i) => `translate(0, ${yearHeight * i + yearPadding})`);
+
+    year
+      .append("text")
+      .attr("x", fullWidth / 2)
+      .attr("y", yearHeaderHeight / 2)
+      .attr("text-anchor", "middle")
+      .attr("font-size", 16)
+      .attr("font-weight", 550)
+      .text(d => d.year)
+
+    const yearBody = year
+      .append('g')
+      .attr("transform", `translate(${leftPadding}, ${yearHeaderHeight})`);
+
+    // write day names
+    yearBody
+      .append("g")
+      .attr("text-anchor", "end")
+      .attr("transform", `translate(0, ${monthHeaderHeight})`)
+      .selectAll("g")
+      .data(d3.range(7))
+      .enter()
+      .append('text')
+      .attr("y", i => (i + 0.5) * cellSize)
+      .attr("dy", "0.31em")
+      .attr("font-size", 12)
+      .text(formatDay);
+
+    // create months groups to old the individual day cells
+    const months = yearBody
+      .append("g")
+      .attr("transform", data => `translate(10, 0)`);
+
+    const startWeekOffset = (y, m) => m == 0 ? 0 : toMoment(y, m, 1).isoWeek()
+    const endWeekOffset = (y, m) => toMoment(y, m, 1).add(1, 'month').subtract(7, 'day').isoWeek() + 1
+    const monthXPos = (y, m) => startWeekOffset(y, m) * cellSize + m * cellSize
+    const monthWitdth = (y, m) => (endWeekOffset(y, m) - startWeekOffset(y, m) + 1) * cellSize
+
+    const month = months
+      .append("g")
+      .selectAll("g")
+      .data(data => d3
+        .range(12)
+        .map(i => {
+          const year = data.year
+          const month = i
+          const dagStatesByDay = data.dagStates[month] || {}
+          return {
+            'year': year,
+            'month': month,
+            'dagStates': dagStatesByDay,
+          }
+        })
+      )
+      .enter()
+      .append('g')
+      .attr("transform", data => `translate(${monthXPos(data.year, data.month)}, 0)`);
+
+    // write month names
+    month
+      .append('text')
+      .attr("x", data => monthWitdth(data.year, data.month) / 2)
+      .attr("y", monthHeaderHeight / 2)
+      .attr("text-anchor", "middle")
+      .text(data => formatMonth(data.month))
+
+    const monthBody =  month
+      .append("g")
+      .attr("transform", data => `translate(0, ${monthHeaderHeight})`)
+
+    // create days inside the month groups
+    const tipHtml = data => {
+      const stateCounts = d3.entries(data.dagStates).map(kv => `${kv.value[0].count} ${kv.key}`)
+      const d = toMoment(data.year, data.month, data.day)
+      return `<strong>${d}</strong><br>${stateCounts.join('<br>')}`
+    }
+
+    monthBody
+      .selectAll("text")
+      .data(data => d3
+        .range(daysInMonth(data.year, data.month))
+        .map(i => {
+          const day = i + 1
+          const dagStatesByState = data.dagStates[day] || {}
+          return {
+            'year': data.year,
+            'month': data.month,
+            'day': day,
+            'dagStates': dagStatesByState,
+            'weekDay': toMoment(data.year, data.month, day).day(),
+            'monthWeek': weekOfMonth(data.year, data.month, day),
+          }
+        })
+      )
+      .enter()
+      .append('rect')
+      .attr("x", data => data.monthWeek  * cellSize)
+      .attr("y", data => data.weekDay  * cellSize)
+      .attr("width", cellSize)
+      .attr("height", cellSize)
+      .attr("class", data => stateClass(data.dagStates))
+      .style({
+        "fill": "#eeeeee",
+        "stroke": "#ffffff",
+        "stroke-width": 1,
+        "cursor": "pointer"
+      })
+      .on("click", data => {
+        window.location.href=getTreeViewURL(
+          // add 1 day and substract 1 ms to not show any run from the next day.
+          toMoment(data.year, data.month, data.day).add(1, 'day').subtract(1, 'ms')
+        )
+      })
+      .on("mouseover", function(data) {
+        const tt = tipHtml(data);
+        dayTip.direction('n');
+        dayTip.show(tt, this);
+      })
+      .on('mouseout', function(d,i){dayTip.hide(d, this)});
+  }
+
+  function update() {
+    $('#loading').remove();
+    draw();
+  }
+
+  update();
+});

--- a/airflow/www/static/js/calendar.js
+++ b/airflow/www/static/js/calendar.js
@@ -96,9 +96,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // group dag run stats by year -> month -> day -> state
     let dagStates = d3
       .nest()
-      .key(dr => new Date(dr.execution_date).getUTCFullYear())
-      .key(dr => new Date(dr.execution_date).getMonth())
-      .key(dr => new Date(dr.execution_date).getDate())
+      .key(dr => new Date(dr.date).getUTCFullYear())
+      .key(dr => new Date(dr.date).getMonth())
+      .key(dr => new Date(dr.date).getDate())
       .key(dr => dr.state)
       .map(data.dag_states);
 

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -25,34 +25,11 @@
   <meta name="dag_id" content="{{ dag.dag_id }}">
   <meta name="tree_url" content="{{ url_for('Airflow.tree') }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('calendar.css') }}">
-  <style type="text/css">
-    {% for state in ['failed', 'success', 'running'] %}
-      rect.{{state}} {
-        fill: {{ state_color_mapping[state] }} !important;
-      }
-    {% endfor %}
   </style>
 {% endblock %}
 
 {% block content %}
   {{ super() }}
-  <hr>
-  <div class="legend-row">
-    <div></div>
-    <div>
-      {% for state in ['failed', 'success', 'running'] %}
-        <span class="legend-item legend-item--no-border">
-        <span class="legend-item__swatch legend-item__swatch--no-border"
-          style="background: {{ state_color_mapping[state] }};">
-        </span>
-        {{state}}
-        </span>
-      {% endfor %}
-      <span class="legend-item legend-item--no-border">
-      <span class="legend-item__swatch legend-item__swatch--no-border">
-      </span>no_status</span>
-    </div>
-  </div>
   <hr>
   <div id="svg_container">
     <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
@@ -67,6 +44,12 @@
   <script src="{{ url_for_asset('d3-tip.js') }}"></script>
   <script src="{{ url_for_asset('calendar.js') }}"></script>
   <script>
+    const statesColors = {};
+    statesColors["no_status"] = "white";
+    {% for state in ['failed', 'success', 'running'] %}
+    statesColors["{{state}}"] = "{{state_color_mapping[state]}}";
+    {% endfor %}
+
     const calendarData = {{ data|tojson }};
   </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -24,10 +24,11 @@
   {{ super() }}
   <meta name="dag_id" content="{{ dag.dag_id }}">
   <meta name="tree_url" content="{{ url_for('Airflow.tree') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('calendar.css') }}">
   <style type="text/css">
-    {% for state, state_color in state_color_mapping.items() %}
+    {% for state in ['failed', 'success', 'running'] %}
       rect.{{state}} {
-        fill: {{state_color}} !important;
+        fill: {{ state_color_mapping[state] }} !important;
       }
     {% endfor %}
   </style>
@@ -37,11 +38,16 @@
   {{ super() }}
   <hr>
   <div class="legend-row">
+    <div></div>
     <div>
-      {% for state, state_color in state_color_mapping.items() %}<span class="legend-item legend-item--no-border">
-        <span class="legend-item__swatch legend-item__swatch--no-border" style="background: {{ state_color }};"></span>
-        {{state}}</span>{% endfor %}<span class="legend-item legend-item--no-border">
-        <span class="legend-item__swatch"></span>no_status</span>
+      {% for state in ['failed', 'success', 'running'] %}
+        <span class="legend-item legend-item--no-border">
+        <span class="legend-item__swatch legend-item__swatch--no-border"
+          style="background: {{ state_color_mapping[state] }};">
+        </span>
+        {{state}}
+        </span>
+      {% endfor %}
     </div>
   </div>
   <hr>

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -25,7 +25,6 @@
   <meta name="dag_id" content="{{ dag.dag_id }}">
   <meta name="tree_url" content="{{ url_for('Airflow.tree') }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('calendar.css') }}">
-  </style>
 {% endblock %}
 
 {% block content %}
@@ -33,8 +32,7 @@
   <hr>
   <div id="svg_container">
     <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
-    <svg id="calendar-svg">
-    </svg>
+    <svg id="calendar-svg"></svg>
   </div>
 {% endblock %}
 
@@ -47,7 +45,7 @@
     const statesColors = {};
     statesColors["no_status"] = "white";
     {% for state in ['failed', 'success', 'running'] %}
-    statesColors["{{state}}"] = "{{state_color_mapping[state]}}";
+      statesColors["{{state}}"] = "{{state_color_mapping[state]}}";
     {% endfor %}
 
     const calendarData = {{ data|tojson }};

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -1,0 +1,63 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+{% extends "airflow/dag.html" %}
+{% block page_title %}{{ dag.dag_id }} - Tree - {{ appbuilder.app_name }}{% endblock %}
+
+{% block head_css %}
+  {{ super() }}
+  <meta name="dag_id" content="{{ dag.dag_id }}">
+  <meta name="tree_url" content="{{ url_for('Airflow.tree') }}">
+  <style type="text/css">
+    {% for state, state_color in state_color_mapping.items() %}
+      rect.{{state}} {
+        fill: {{state_color}} !important;
+      }
+    {% endfor %}
+  </style>
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <hr>
+  <div class="legend-row">
+    <div>
+      {% for state, state_color in state_color_mapping.items() %}<span class="legend-item legend-item--no-border">
+        <span class="legend-item__swatch legend-item__swatch--no-border" style="background: {{ state_color }};"></span>
+        {{state}}</span>{% endfor %}<span class="legend-item legend-item--no-border">
+        <span class="legend-item__swatch"></span>no_status</span>
+    </div>
+  </div>
+  <hr>
+  <div id="svg_container">
+    <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
+    <svg id="calendar-svg">
+    </svg>
+  </div>
+{% endblock %}
+
+{% block tail_js %}
+  {{ super() }}
+  <script src="{{ url_for_asset('d3.min.js') }}"></script>
+  <script src="{{ url_for_asset('d3-tip.js') }}"></script>
+  <script src="{{ url_for_asset('calendar.js') }}"></script>
+  <script>
+    const calendarData = {{ data|tojson }};
+  </script>
+{% endblock %}

--- a/airflow/www/templates/airflow/calendar.html
+++ b/airflow/www/templates/airflow/calendar.html
@@ -48,6 +48,9 @@
         {{state}}
         </span>
       {% endfor %}
+      <span class="legend-item legend-item--no-border">
+      <span class="legend-item__swatch legend-item__swatch--no-border">
+      </span>no_status</span>
     </div>
   </div>
   <hr>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -85,6 +85,10 @@
     <div class="row">
       <div class="col-md-10">
         <ul class="nav nav-pills">
+          <li><a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}">
+            <span class="material-icons" aria-hidden="true">event</span>
+            Calendar View
+          </a></li>
           <li><a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">nature</span>
             Tree View

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -85,10 +85,6 @@
     <div class="row">
       <div class="col-md-10">
         <ul class="nav nav-pills">
-          <li><a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}">
-            <span class="material-icons" aria-hidden="true">event</span>
-            Calendar View
-          </a></li>
           <li><a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs_arg, root=root, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">nature</span>
             Tree View
@@ -96,6 +92,10 @@
           <li><a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
             <span class="material-icons" aria-hidden="true">account_tree</span>
             Graph View</a></li>
+          <li><a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}">
+            <span class="material-icons" aria-hidden="true">event</span>
+            Calendar View
+          </a></li>
           <li><a href="{{ url_for('Airflow.duration', dag_id=dag.dag_id, days=30, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
             <span class="material-icons" aria-hidden="true">hourglass_bottom</span>
             Task Duration</a></li>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -241,6 +241,10 @@
                           <span class="material-icons" aria-hidden="true">nature</span>
                           Tree
                         </a>
+                        <a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}" class="dags-table-more__link">
+                          <span class="material-icons" aria-hidden="true">event</span>
+                          Calendar
+                        </a>
                       </div>
                       <span class="dags-table-more__toggle"><span class="material-icons">more_horiz</span></span>
                     </div>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -233,6 +233,10 @@
                           <span class="material-icons" aria-hidden="true">hourglass_bottom</span>
                           Duration
                         </a>
+                        <a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}" class="dags-table-more__link">
+                          <span class="material-icons" aria-hidden="true">event</span>
+                          Calendar
+                        </a>
                         <a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id) }}" class="dags-table-more__link">
                           <span class="material-icons" aria-hidden="true">account_tree</span>
                           Graph
@@ -240,10 +244,6 @@
                         <a href="{{ url_for('Airflow.tree', dag_id=dag.dag_id, num_runs=num_runs) }}" class="dags-table-more__link">
                           <span class="material-icons" aria-hidden="true">nature</span>
                           Tree
-                        </a>
-                        <a href="{{ url_for('Airflow.calendar', dag_id=dag.dag_id) }}" class="dags-table-more__link">
-                          <span class="material-icons" aria-hidden="true">event</span>
-                          Calendar
                         </a>
                       </div>
                       <span class="dags-table-more__toggle"><span class="material-icons">more_horiz</span></span>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2109,13 +2109,15 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
                 )
                 .filter(DagRun.dag_id == dag.dag_id)
                 .group_by(func.date(DagRun.execution_date), DagRun.state)
-                .order_by(DagRun.execution_date.asc())
+                .order_by(func.date(DagRun.execution_date).asc())
                 .all()
             )
 
         dag_states = [
             {
-                'date': dr.date,
+                # DATE() in SQLite and MySQL behave differently:
+                # SQLite returns a string, MySQL returns a date.
+                'date': dr.date if isinstance(dr.date, str) else dr.date.isoformat(),
                 'state': dr.state,
                 'count': dr.count,
             }

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2123,6 +2123,8 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         data = {
             'dag_states': dag_states,
+            'start_date': (dag.start_date or datetime.utcnow()).date().isoformat(),
+            'end_date': (dag.end_date or datetime.utcnow()).date().isoformat(),
         }
 
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2095,10 +2095,13 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             flash(f'DAG "{dag_id}" seems to be missing from DagBag.', "error")
             return redirect(url_for('Airflow.index'))
 
+        root = request.args.get('root')
+        if root:
+            dag = dag.sub_dag(task_ids_or_regex=root, include_downstream=False, include_upstream=True)
+
         with create_session() as session:
             dag_states = (
-                session
-                .query(
+                session.query(
                     func.date(DagRun.execution_date).label('date'),
                     DagRun.state,
                     func.count('*').label('count'),
@@ -2132,6 +2135,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag=dag,
             doc_md=doc_md,
             data=data,
+            root=root,
         )
 
     @expose('/graph')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2099,7 +2099,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             dag_states = (
                 session
                 .query(
-                    DagRun.execution_date,
+                    func.date(DagRun.execution_date).label('date'),
                     DagRun.state,
                     func.count('*').label('count'),
                 )
@@ -2111,7 +2111,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         dag_states = [
             {
-                'execution_date': dr.execution_date.date().isoformat(),
+                'date': dr.date,
                 'state': dr.state,
                 'count': dr.count,
             }
@@ -2119,10 +2119,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         ]
 
         data = {
-            'name': '[DAG]',
-            'dag_id': dag_id,
-            'start_date': dag.start_date.isoformat() if dag.start_date else None,
-            'end_date': dag.end_date.isoformat() if dag.end_date else None,
             'dag_states': dag_states,
         }
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2126,8 +2126,8 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         data = {
             'dag_states': dag_states,
-            'start_date': (dag.start_date or datetime.utcnow()).date().isoformat(),
-            'end_date': (dag.end_date or datetime.utcnow()).date().isoformat(),
+            'start_date': (dag.start_date or DateTime.utcnow()).date().isoformat(),
+            'end_date': (dag.end_date or DateTime.utcnow()).date().isoformat(),
         }
 
         doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None))

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -76,7 +76,7 @@ from jinja2.utils import htmlsafe_json_dumps, pformat  # type: ignore
 from pendulum.datetime import DateTime
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter  # noqa pylint: disable=no-name-in-module
-from sqlalchemy import and_, desc, func, or_, union_all
+from sqlalchemy import and_, desc, func, or_, union_all, extract
 from sqlalchemy.orm import joinedload
 from wtforms import SelectField, validators
 from wtforms.validators import InputRequired
@@ -2076,6 +2076,66 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             num_runs=num_runs,
             show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name,
+        )
+
+    @expose('/calendar')
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
+        ]
+    )
+    @gzipped  # pylint: disable=too-many-locals
+    @action_logging  # pylint: disable=too-many-locals
+    def calendar(self):
+        dag_id = request.args.get('dag_id')
+        dag = current_app.dag_bag.get_dag(dag_id)
+        if not dag:
+            flash(f'DAG "{dag_id}" seems to be missing from DagBag.', "error")
+            return redirect(url_for('Airflow.index'))
+
+        with create_session() as session:
+            dag_states = (
+                session
+                .query(
+                    DagRun.execution_date,
+                    DagRun.state,
+                    func.count('*').label('count'),
+                )
+                .filter(DagRun.dag_id == dag.dag_id)
+                .group_by(func.date(DagRun.execution_date), DagRun.state)
+                .order_by(DagRun.execution_date.asc())
+                .all()
+            )
+
+        dag_states = [
+            {
+                'execution_date': dr.execution_date.date().isoformat(),
+                'state': dr.state,
+                'count': dr.count,
+            }
+            for dr in dag_states
+        ]
+
+        data = {
+            'name': '[DAG]',
+            'dag_id': dag_id,
+            'start_date': dag.start_date.isoformat() if dag.start_date else None,
+            'end_date': dag.end_date.isoformat() if dag.end_date else None,
+            'dag_states': dag_states,
+        }
+
+        doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None))
+
+        # avoid spaces to reduce payload size
+        data = htmlsafe_json_dumps(data, separators=(',', ':'))
+
+        return self.render_template(
+            'airflow/calendar.html',
+            dag=dag,
+            doc_md=doc_md,
+            data=data,
         )
 
     @expose('/graph')

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2083,7 +2083,6 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         [
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_LOG),
         ]
     )
     @gzipped  # pylint: disable=too-many-locals

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -76,7 +76,7 @@ from jinja2.utils import htmlsafe_json_dumps, pformat  # type: ignore
 from pendulum.datetime import DateTime
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter  # noqa pylint: disable=no-name-in-module
-from sqlalchemy import and_, desc, func, or_, union_all, extract
+from sqlalchemy import and_, desc, func, or_, union_all
 from sqlalchemy.orm import joinedload
 from wtforms import SelectField, validators
 from wtforms.validators import InputRequired
@@ -2089,6 +2089,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
     @gzipped  # pylint: disable=too-many-locals
     @action_logging  # pylint: disable=too-many-locals
     def calendar(self):
+        """Get DAG runs as calendar"""
         dag_id = request.args.get('dag_id')
         dag = current_app.dag_bag.get_dag(dag_id)
         if not dag:

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -54,6 +54,7 @@ const config = {
     taskInstance: `${JS_DIR}/task_instance.js`,
     tiLog: `${JS_DIR}/ti_log.js`,
     tree: [`${CSS_DIR}/tree.css`, `${JS_DIR}/tree.js`],
+    calendar: [`${JS_DIR}/calendar.js`],
     circles: `${JS_DIR}/circles.js`,
     durationChart: `${JS_DIR}/duration_chart.js`,
     trigger: `${JS_DIR}/trigger.js`,

--- a/airflow/www/webpack.config.js
+++ b/airflow/www/webpack.config.js
@@ -54,7 +54,7 @@ const config = {
     taskInstance: `${JS_DIR}/task_instance.js`,
     tiLog: `${JS_DIR}/ti_log.js`,
     tree: [`${CSS_DIR}/tree.css`, `${JS_DIR}/tree.js`],
-    calendar: [`${JS_DIR}/calendar.js`],
+    calendar: [`${CSS_DIR}/calendar.css`, `${JS_DIR}/calendar.js`],
     circles: `${JS_DIR}/circles.js`,
     durationChart: `${JS_DIR}/duration_chart.js`,
     trigger: `${JS_DIR}/trigger.js`,

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -37,7 +37,6 @@ from urllib.parse import quote_plus
 import jinja2
 import pytest
 from flask import Markup, session as flask_session, template_rendered, url_for
-from jinja2.utils import htmlsafe_json_dumps
 from parameterized import parameterized
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -37,6 +37,7 @@ from urllib.parse import quote_plus
 import jinja2
 import pytest
 from flask import Markup, session as flask_session, template_rendered, url_for
+from jinja2.utils import htmlsafe_json_dumps
 from parameterized import parameterized
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
@@ -994,10 +995,10 @@ class TestAirflowBaseViews(TestBase):
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('DAG Details', resp)
 
-    @parameterized.expand(["graph", "tree", "dag_details"])
+    @parameterized.expand(["graph", "tree", "calendar", "dag_details"])
     def test_view_uses_existing_dagbag(self, endpoint):
         """
-        Test that Graph, Tree & Dag Details View uses the DagBag already created in views.py
+        Test that Graph, Tree, Calendar & Dag Details View uses the DagBag already created in views.py
         instead of creating a new one.
         """
         url = f'{endpoint}?dag_id=example_bash_operator'
@@ -1099,6 +1100,14 @@ class TestAirflowBaseViews(TestBase):
         url = 'tree?dag_id=example_subdag_operator.section-1'
         resp = self.client.get(url, follow_redirects=True)
         self.check_content_in_response('section-1-task-1', resp)
+
+    def test_calendar(self):
+        url = 'calendar?dag_id=example_bash_operator'
+        resp = self.client.get(url, follow_redirects=True)
+        dag_run_date = self.bash_dagrun.execution_date.date().isoformat()
+        expected_data = {'dag_states': [{'date': dag_run_date, 'state': State.RUNNING, 'count': 1}]}
+        expected_data_json_escaped = json.dumps(expected_data).replace('"', '\\"').replace(' ', '')
+        self.check_content_in_response(expected_data_json_escaped, resp)
 
     def test_duration(self):
         url = 'duration?days=30&dag_id=example_bash_operator'

--- a/tests/www/test_views.py
+++ b/tests/www/test_views.py
@@ -1105,7 +1105,7 @@ class TestAirflowBaseViews(TestBase):
         url = 'calendar?dag_id=example_bash_operator'
         resp = self.client.get(url, follow_redirects=True)
         dag_run_date = self.bash_dagrun.execution_date.date().isoformat()
-        expected_data = {'dag_states': [{'date': dag_run_date, 'state': State.RUNNING, 'count': 1}]}
+        expected_data = [{'date': dag_run_date, 'state': State.RUNNING, 'count': 1}]
         expected_data_json_escaped = json.dumps(expected_data).replace('"', '\\"').replace(' ', '')
         self.check_content_in_response(expected_data_json_escaped, resp)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

# Motivation

Introduce a DAG Calendar View to provide visibility over the full state of the dag by displaying the aggregated dag runs' states in a calendar.
This makes it possible to monitor the state of thousands of dag runs in a single view that is concise and easy to understand. It is particularly useful to monitor the state of large backfills:

![image](https://user-images.githubusercontent.com/6229788/115161178-0b4afd80-a094-11eb-9d9f-38709d76700b.png)

Each day is displayed with a color according to the dag runs' states for that day:
- If at least one dag run has failed for a day, the day will be displayed as "failed".
- If all dag runs have succeeded, the day will be shown as "succeeded". 
- If there are still running dag runs (and no failed dag run) for that day, the day will be shown as "running".

A tooltip, for each day, gives the exact number of dag runs in each state for the day.
![image](https://user-images.githubusercontent.com/6229788/115161622-acd34e80-a096-11eb-989c-d40c0aa82676.png)

Clicking on a day redirects to the tree view for that day to show the task instances for that day.

# Implementation
- New `/calendar` endpoint in `views.py`. 
This view returns, for each day, the number of dag run in each state. Thus, only the `dag_run` table is queried, and the query returns at most 3 * days records. Thus, this view puts little strain on the database, even for dags with a large number of task instances.
- New `calendar.html` template, `calendar.js` and `calendar.css` static files.
The calendar view is implemented usng d3, thus no additional dependency has been introduced.

The proposal has been discussed on the dev mailing list:
https://lists.apache.org/thread.html/r6f2ea3f83d268a665ac63219553718ed089a01e9530627cca0572ab1%40%3Cdev.airflow.apache.org%3E