### PR TITLE
Fix incorrect slots stats (#15399)

### DIFF
--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -109,7 +109,7 @@ class Pool(Base):
             pools[pool_name] = PoolStats(total=total_slots, running=0, queued=0, open=0)
 
         state_count_by_pool = (
-            session.query(TaskInstance.pool, TaskInstance.state, func.count())
+            session.query(TaskInstance.pool, TaskInstance.state, func.sum(TaskInstance.pool_slots))
             .filter(TaskInstance.state.in_(list(EXECUTION_STATES)))
             .group_by(TaskInstance.pool, TaskInstance.state)
         ).all()

--- a/tests/models/test_pool.py
+++ b/tests/models/test_pool.py
@@ -102,6 +102,20 @@ class TestPool(unittest.TestCase):
         assert 1 == pool.running_slots()  # pylint: disable=no-value-for-parameter
         assert 1 == pool.queued_slots()  # pylint: disable=no-value-for-parameter
         assert 2 == pool.occupied_slots()  # pylint: disable=no-value-for-parameter
+        assert {
+            "default_pool": {
+                "open": 128,
+                "queued": 0,
+                "total": 128,
+                "running": 0,
+            },
+            "test_pool": {
+                "open": -1,
+                "queued": 1,
+                "running": 1,
+                "total": -1,
+            },
+        } == pool.slots_stats()
 
     def test_default_pool_open_slots(self):
         set_default_pool_slots(5)
@@ -125,3 +139,11 @@ class TestPool(unittest.TestCase):
         session.close()
 
         assert 2 == Pool.get_default_pool().open_slots()
+        assert {
+            "default_pool": {
+                "open": 2,
+                "queued": 2,
+                "total": 5,
+                "running": 1,
+            }
+        } == Pool.slots_stats()


### PR DESCRIPTION
Fixes the incorrect number of queued and running slots, and therefore, open slots, when there exist task instances that occupy > 1 pool_slots. This was causing the scheduler to over-commit to a given pool, and a subsequent state where no further tasks can be scheduled because slots cannot be freed.

closes: #15399 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
