### PR TITLE
Add support for Hyperparameter Tuning on Google Cloud AI Platform

### DIFF
--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1189,7 +1189,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         mode: str = 'PRODUCTION',
         labels: Optional[Dict[str, str]] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
-        hyperparameters: Optional[Dict] = None
+        hyperparameters: Optional[Dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1135,9 +1135,8 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         will be printed out. In 'CLOUD' mode, a real MLEngine training job
         creation request will be issued.
     :type mode: str
-    :param hyperparameters: Optional HyperparameterSpec dictionary to be used during model training for hyperparameter tuning
-        For further reference, check these:
-        https://cloud.google.com/ai-platform/training/docs/using-hyperparameter-tuning
+    :param hyperparameters: Optional HyperparameterSpec dictionary for hyperparameter tuning.
+        For further reference, check:
         https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#HyperparameterSpec
     :type hyperparameters: Dict
     :param labels: a dictionary containing labels for the job; passed to BigQuery

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1278,7 +1278,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
 
         if self._hyperparameters:
             training_request['trainingInput']['hyperparameters'] = self._hyperparameters
-        
+
         if self._labels:
             training_request['labels'] = self._labels
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1189,6 +1189,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         mode: str = 'PRODUCTION',
         labels: Optional[Dict[str, str]] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        hyperparameters: Optional[Dict] = None
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -1210,6 +1211,7 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         self._mode = mode
         self._labels = labels
         self._impersonation_chain = impersonation_chain
+        self._hyperparameters = hyperparameters
 
         custom = self._scale_tier is not None and self._scale_tier.upper() == 'CUSTOM'
         custom_image = (
@@ -1274,6 +1276,9 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         if self._service_account:
             training_request['trainingInput']['serviceAccount'] = self._service_account
 
+        if self._hyperparameters:
+            training_request['trainingInput']['hyperparameters'] = self._hyperparameters
+        
         if self._labels:
             training_request['labels'] = self._labels
 

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -1135,6 +1135,11 @@ class MLEngineStartTrainingJobOperator(BaseOperator):
         will be printed out. In 'CLOUD' mode, a real MLEngine training job
         creation request will be issued.
     :type mode: str
+    :param hyperparameters: Optional HyperparameterSpec dictionary to be used during model training for hyperparameter tuning
+        For further reference, check these:
+        https://cloud.google.com/ai-platform/training/docs/using-hyperparameter-tuning
+        https://cloud.google.com/ai-platform/training/docs/reference/rest/v1/projects.jobs#HyperparameterSpec
+    :type hyperparameters: Dict
     :param labels: a dictionary containing labels for the job; passed to BigQuery
     :type labels: Dict[str, str]
     :param impersonation_chain: Optional service account to impersonate using short-term


### PR DESCRIPTION
The <b>MLEngineStartTrainingJobOperator</b> is modified in <i>airflow/providers/google/cloud/operators/mlengine.py</i> file.

The lines 1138-1142, 1192, 1214, 1279, and 1280 are added to the file. 

These lines add support for Model training involving hyperparameter tuning on AI Platform.