### PR TITLE
Speeds up Docker build process by combining RUN and ENV commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,6 @@ ARG AIRFLOW_HOME=/opt/airflow
 ARG AIRFLOW_UID="50000"
 ARG AIRFLOW_GID="50000"
 
-ARG CASS_DRIVER_BUILD_CONCURRENCY="8"
-
 ARG PYTHON_BASE_IMAGE="python:3.6-slim-buster"
 
 ARG AIRFLOW_PIP_VERSION=20.2.4
@@ -58,10 +56,8 @@ FROM ${PYTHON_BASE_IMAGE} as airflow-build-image
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 
 ARG PYTHON_BASE_IMAGE
-ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE}
-
-# Make sure noninteractive debian install is used and language variables set
-ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE} \
+    DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
     LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
 
 # Install curl and gnupg2 - needed for many other installation steps
@@ -106,21 +102,18 @@ ARG DEV_APT_DEPS="\
      unixodbc \
      unixodbc-dev \
      yarn"
-ENV DEV_APT_DEPS=${DEV_APT_DEPS}
-
 ARG ADDITIONAL_DEV_APT_DEPS=""
-ENV ADDITIONAL_DEV_APT_DEPS=${ADDITIONAL_DEV_APT_DEPS}
-
 ARG DEV_APT_COMMAND="\
     curl --fail --location https://deb.nodesource.com/setup_10.x | bash - \
     && curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - > /dev/null \
     && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list"
-ENV DEV_APT_COMMAND=${DEV_APT_COMMAND}
-
 ARG ADDITIONAL_DEV_APT_COMMAND="echo"
-ENV ADDITIONAL_DEV_APT_COMMAND=${ADDITIONAL_DEV_APT_COMMAND}
 
-ARG ADDITIONAL_DEV_APT_ENV=""
+ENV DEV_APT_DEPS=${DEV_APT_DEPS} \
+    ADDITIONAL_DEV_APT_DEPS=${ADDITIONAL_DEV_APT_DEPS} \
+    DEV_APT_COMMAND=${DEV_APT_COMMAND} \
+    ADDITIONAL_DEV_APT_COMMAND=${ADDITIONAL_DEV_APT_COMMAND} \
+    ADDITIONAL_DEV_APT_ENV=""
 
 # Note missing man directories on debian-buster
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
@@ -139,97 +132,91 @@ RUN mkdir -pv /usr/share/man/man1 \
     && rm -rf /var/lib/apt/lists/*
 
 ARG INSTALL_MYSQL_CLIENT="true"
-ENV INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT}
-
-# Only copy install_mysql.sh to not invalidate cache on other script changes
-COPY scripts/docker/install_mysql.sh /scripts/docker/install_mysql.sh
-COPY docker-context-files /docker-context-files
-# fix permission issue in Azure DevOps when running the script
-RUN bash ./scripts/docker/install_mysql.sh dev
-
 ARG AIRFLOW_REPO=apache/airflow
-ENV AIRFLOW_REPO=${AIRFLOW_REPO}
-
 ARG AIRFLOW_BRANCH=master
-ENV AIRFLOW_BRANCH=${AIRFLOW_BRANCH}
-
 ARG AIRFLOW_EXTRAS
 ARG ADDITIONAL_AIRFLOW_EXTRAS=""
-ENV AIRFLOW_EXTRAS=${AIRFLOW_EXTRAS}${ADDITIONAL_AIRFLOW_EXTRAS:+,}${ADDITIONAL_AIRFLOW_EXTRAS}
-
 # Allows to override constraints source
 ARG CONSTRAINTS_GITHUB_REPOSITORY="apache/airflow"
-ENV CONSTRAINTS_GITHUB_REPOSITORY=${CONSTRAINTS_GITHUB_REPOSITORY}
-
 ARG AIRFLOW_CONSTRAINTS="constraints"
-ENV AIRFLOW_CONSTRAINTS=${AIRFLOW_CONSTRAINTS}
 ARG AIRFLOW_CONSTRAINTS_REFERENCE=""
-ENV AIRFLOW_CONSTRAINTS_REFERENCE=${AIRFLOW_CONSTRAINTS_REFERENCE}
 ARG AIRFLOW_CONSTRAINTS_LOCATION=""
-ENV AIRFLOW_CONSTRAINTS_LOCATION=${AIRFLOW_CONSTRAINTS_LOCATION}
-
 ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-master"
-ENV DEFAULT_CONSTRAINTS_BRANCH=${DEFAULT_CONSTRAINTS_BRANCH}
-
-ENV PATH=${PATH}:/root/.local/bin
-RUN mkdir -p /root/.local/bin
-
-RUN if [[ -f /docker-context-files/.pypirc ]]; then \
-        cp /docker-context-files/.pypirc /root/.pypirc; \
-    fi
-
 ARG AIRFLOW_PIP_VERSION
-ENV AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION}
-
 # By default PIP has progress bar but you can disable it.
 ARG PIP_PROGRESS_BAR
-ENV PIP_PROGRESS_BAR=${PIP_PROGRESS_BAR}
-
-# Install Airflow with "--user" flag, so that we can copy the whole .local folder to the final image
-# from the build image and always in non-editable mode
-ENV AIRFLOW_INSTALL_USER_FLAG="--user"
-ENV AIRFLOW_INSTALL_EDITABLE_FLAG=""
-
-# Upgrade to specific PIP version
-RUN pip install --no-cache-dir --upgrade "pip==${AIRFLOW_PIP_VERSION}"
-
 # By default we do not use pre-cached packages, but in CI/Breeze environment we override this to speed up
 # builds in case setup.py/setup.cfg changed. This is pure optimisation of CI/Breeze builds.
 ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="false"
-ENV AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES}
-
+# This is airflow version that is put in the label of the image build
+ARG AIRFLOW_VERSION
 # By default we install providers from PyPI but in case of Breeze build we want to install providers
 # from local sources without the need of preparing provider packages upfront. This value is
 # automatically overridden by Breeze scripts.
 ARG INSTALL_PROVIDERS_FROM_SOURCES="false"
-ENV INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES}
-
-# This is airflow version that is put in the label of the image build
-ARG AIRFLOW_VERSION
-ENV AIRFLOW_VERSION=${AIRFLOW_VERSION}
-
 # Determines the way airflow is installed. By default we install airflow from PyPI `apache-airflow` package
 # But it also can be `.` from local installation or GitHub URL pointing to specific branch or tag
 # Of Airflow. Note That for local source installation you need to have local sources of
 # Airflow checked out together with the Dockerfile and AIRFLOW_SOURCES_FROM and AIRFLOW_SOURCES_TO
 # set to "." and "/opt/airflow" respectively.
 ARG AIRFLOW_INSTALLATION_METHOD="apache-airflow"
-ENV AIRFLOW_INSTALLATION_METHOD=${AIRFLOW_INSTALLATION_METHOD}
-
 # By default latest released version of airflow is installed (when empty) but this value can be overridden
 # and we can install version according to specification (For example ==2.0.2 or <3.0.0).
 ARG AIRFLOW_VERSION_SPECIFICATION=""
-ENV AIRFLOW_VERSION_SPECIFICATION=${AIRFLOW_VERSION_SPECIFICATION}
+# By default we do not upgrade to latest dependencies
+ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
+# By default we install latest airflow from PyPI so we do not need to copy sources of Airflow
+# but in case of breeze/CI builds we use latest sources and we override those
+# those SOURCES_FROM/TO with "." and "/opt/airflow" respectively
+ARG AIRFLOW_SOURCES_FROM="empty"
+ARG AIRFLOW_SOURCES_TO="/empty"
+
+ENV INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT} \
+    AIRFLOW_REPO=${AIRFLOW_REPO} \
+    AIRFLOW_BRANCH=${AIRFLOW_BRANCH} \
+    AIRFLOW_EXTRAS=${AIRFLOW_EXTRAS}${ADDITIONAL_AIRFLOW_EXTRAS:+,}${ADDITIONAL_AIRFLOW_EXTRAS} \
+    CONSTRAINTS_GITHUB_REPOSITORY=${CONSTRAINTS_GITHUB_REPOSITORY} \
+    AIRFLOW_CONSTRAINTS=${AIRFLOW_CONSTRAINTS} \
+    AIRFLOW_CONSTRAINTS_REFERENCE=${AIRFLOW_CONSTRAINTS_REFERENCE} \
+    AIRFLOW_CONSTRAINTS_LOCATION=${AIRFLOW_CONSTRAINTS_LOCATION} \
+    DEFAULT_CONSTRAINTS_BRANCH=${DEFAULT_CONSTRAINTS_BRANCH} \
+    PATH=${PATH}:/root/.local/bin \
+    AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION} \
+    PIP_PROGRESS_BAR=${PIP_PROGRESS_BAR} \
+    # Install Airflow with "--user" flag, so that we can copy the whole .local folder to the final image
+    # from the build image and always in non-editable mode
+    AIRFLOW_INSTALL_USER_FLAG="--user" \
+    AIRFLOW_INSTALL_EDITABLE_FLAG="" \
+    UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}
+
+# Only copy install_mysql.sh to not invalidate cache on other script changes
+COPY scripts/docker/install_mysql.sh /scripts/docker/install_mysql.sh
+RUN bash ./scripts/docker/install_mysql.sh dev
+
+RUN mkdir -p /root/.local/bin
+
+COPY docker-context-files /docker-context-files
+
+RUN if [[ -f /docker-context-files/.pypirc ]]; then \
+        cp /docker-context-files/.pypirc /root/.pypirc; \
+    fi
+
+# Upgrade to specific PIP version
+RUN pip install --no-cache-dir --upgrade "pip==${AIRFLOW_PIP_VERSION}"
+
+ENV AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES} \
+    INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES} \
+    AIRFLOW_VERSION=${AIRFLOW_VERSION} \
+    AIRFLOW_INSTALLATION_METHOD=${AIRFLOW_INSTALLATION_METHOD} \
+    AIRFLOW_VERSION_SPECIFICATION=${AIRFLOW_VERSION_SPECIFICATION} \
+    AIRFLOW_SOURCES_FROM=${AIRFLOW_SOURCES_FROM} \
+    AIRFLOW_SOURCES_TO=${AIRFLOW_SOURCES_TO}
 
 # Only copy common.sh to not invalidate cache on other script changes
 COPY scripts/docker/common.sh /scripts/docker/common.sh
 
 # Only copy install_airflow_from_branch_tip.sh to not invalidate cache on other script changes
 COPY scripts/docker/install_airflow_from_branch_tip.sh /scripts/docker/install_airflow_from_branch_tip.sh
-
-# By default we do not upgrade to latest dependencies
-ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
-ENV UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}
 
 # In case of Production build image segment we want to pre-install master version of airflow
 # dependencies from GitHub so that we do not have to always reinstall it from the scratch.
@@ -242,35 +229,17 @@ RUN if [[ ${AIRFLOW_PRE_CACHED_PIP_PACKAGES} == "true" && \
         bash /scripts/docker/install_airflow_from_branch_tip.sh; \
     fi
 
-# By default we install latest airflow from PyPI so we do not need to copy sources of Airflow
-# but in case of breeze/CI builds we use latest sources and we override those
-# those SOURCES_FROM/TO with "." and "/opt/airflow" respectively
-ARG AIRFLOW_SOURCES_FROM="empty"
-ENV AIRFLOW_SOURCES_FROM=${AIRFLOW_SOURCES_FROM}
-
-ARG AIRFLOW_SOURCES_TO="/empty"
-ENV AIRFLOW_SOURCES_TO=${AIRFLOW_SOURCES_TO}
-
 COPY ${AIRFLOW_SOURCES_FROM} ${AIRFLOW_SOURCES_TO}
-
-ARG CASS_DRIVER_BUILD_CONCURRENCY
-ENV CASS_DRIVER_BUILD_CONCURRENCY=${CASS_DRIVER_BUILD_CONCURRENCY}
 
 # Add extra python dependencies
 ARG ADDITIONAL_PYTHON_DEPS=""
-ENV ADDITIONAL_PYTHON_DEPS=${ADDITIONAL_PYTHON_DEPS}
-
 # We can set this value to true in case we want to install .whl .tar.gz packages placed in the
 # docker-context-files folder. This can be done for both - additional packages you want to install
 # and for airflow as well (you have to set INSTALL_FROM_PYPI to false in this case)
 ARG INSTALL_FROM_DOCKER_CONTEXT_FILES=""
-ENV INSTALL_FROM_DOCKER_CONTEXT_FILES=${INSTALL_FROM_DOCKER_CONTEXT_FILES}
-
 # By default we install latest airflow from PyPI. You can set it to false if you want to install
 # Airflow from the .whl or .tar.gz packages placed in `docker-context-files` folder.
 ARG INSTALL_FROM_PYPI="true"
-ENV INSTALL_FROM_PYPI=${INSTALL_FROM_PYPI}
-
 # Those are additional constraints that are needed for some extras but we do not want to
 # Force them on the main Airflow package.
 # * chardet<4 - required to keep snowflake happy
@@ -278,10 +247,16 @@ ENV INSTALL_FROM_PYPI=${INSTALL_FROM_PYPI}
 # * pyjwt<2.0.0: flask-jwt-extended requires it
 # * dill<0.3.3 required by apache-beam
 ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="chardet<4 urllib3<1.26 pyjwt<2.0.0 dill<0.3.3"
+ARG CONTINUE_ON_PIP_CHECK_FAILURE="false"
+
+
+ENV ADDITIONAL_PYTHON_DEPS=${ADDITIONAL_PYTHON_DEPS} \
+    INSTALL_FROM_DOCKER_CONTEXT_FILES=${INSTALL_FROM_DOCKER_CONTEXT_FILES} \
+    INSTALL_FROM_PYPI=${INSTALL_FROM_PYPI} \
+    EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS} \
+    CONTINUE_ON_PIP_CHECK_FAILURE=${CONTINUE_ON_PIP_CHECK_FAILURE}
 
 WORKDIR /opt/airflow
-
-ARG CONTINUE_ON_PIP_CHECK_FAILURE="false"
 
 # Copy all install scripts here
 COPY scripts/docker/install*.sh /scripts/docker/
@@ -301,20 +276,17 @@ RUN if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
 # Copy compile_www_assets.sh install scripts here
 COPY scripts/docker/compile_www_assets.sh /scripts/docker/compile_www_assets.sh
 
-RUN bash /scripts/docker/compile_www_assets.sh
-
+RUN bash /scripts/docker/compile_www_assets.sh && \
 # make sure that all directories and files in .local are also group accessible
-RUN find /root/.local -executable -print0 | xargs --null chmod g+x && \
+    find /root/.local -executable -print0 | xargs --null chmod g+x && \
     find /root/.local -print0 | xargs --null chmod g+rw
 
-
 ARG BUILD_ID
-ENV BUILD_ID=${BUILD_ID}
 ARG COMMIT_SHA
-ENV COMMIT_SHA=${COMMIT_SHA}
-
 ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
 ARG AIRFLOW_IMAGE_DATE_CREATED
+
+ENV BUILD_ID=${BUILD_ID} COMMIT_SHA=${COMMIT_SHA}
 
 LABEL org.apache.airflow.distro="debian" \
   org.apache.airflow.distro.version="buster" \
@@ -357,17 +329,15 @@ LABEL org.apache.airflow.distro="debian" \
   org.apache.airflow.gid="${AIRFLOW_GID}"
 
 ARG PYTHON_BASE_IMAGE
-ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE}
-
-ARG AIRFLOW_VERSION
-ENV AIRFLOW_VERSION=${AIRFLOW_VERSION}
-
-# Make sure noninteractive debian install is used and language variables set
-ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
-    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
-
 ARG AIRFLOW_PIP_VERSION
-ENV AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION}
+ARG AIRFLOW_VERSION
+
+ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE} \
+    AIRFLOW_VERSION=${AIRFLOW_VERSION} \
+    # Make sure noninteractive debian install is used and language variables set
+    DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 \
+    AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION}
 
 # Install curl and gnupg2 - needed for many other installation steps
 RUN apt-get update \
@@ -404,18 +374,38 @@ ARG RUNTIME_APT_DEPS="\
        sqlite3 \
        sudo \
        unixodbc"
-ENV RUNTIME_APT_DEPS=${RUNTIME_APT_DEPS}
-
 ARG ADDITIONAL_RUNTIME_APT_DEPS=""
-ENV ADDITIONAL_RUNTIME_APT_DEPS=${ADDITIONAL_RUNTIME_APT_DEPS}
-
 ARG RUNTIME_APT_COMMAND="echo"
-ENV RUNTIME_APT_COMMAND=${RUNTIME_APT_COMMAND}
-
 ARG ADDITIONAL_RUNTIME_APT_COMMAND=""
-ENV ADDITIONAL_RUNTIME_APT_COMMAND=${ADDITIONAL_RUNTIME_APT_COMMAND}
-
 ARG ADDITIONAL_RUNTIME_APT_ENV=""
+ARG INSTALL_MYSQL_CLIENT="true"
+ARG AIRFLOW_USER_HOME_DIR=/home/airflow
+ARG AIRFLOW_HOME
+# Having the variable in final image allows to disable providers manager warnings when
+# production image is prepared from sources rather than from package
+ARG AIRFLOW_INSTALLATION_METHOD="apache-airflow"
+ARG BUILD_ID
+ARG COMMIT_SHA
+ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
+ARG AIRFLOW_IMAGE_DATE_CREATED
+# By default PIP will install everything in ~/.local
+ARG PIP_USER="true"
+
+ENV RUNTIME_APT_DEPS=${RUNTIME_APT_DEPS} \
+    ADDITIONAL_RUNTIME_APT_DEPS=${ADDITIONAL_RUNTIME_APT_DEPS} \
+    RUNTIME_APT_COMMAND=${RUNTIME_APT_COMMAND} \
+    ADDITIONAL_RUNTIME_APT_COMMAND=${ADDITIONAL_RUNTIME_APT_COMMAND} \
+    INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT} \
+    AIRFLOW_UID=${AIRFLOW_UID} AIRFLOW_GID=${AIRFLOW_GID} \
+    AIRFLOW__CORE__LOAD_EXAMPLES="false" \
+    AIRFLOW_USER_HOME_DIR=${AIRFLOW_USER_HOME_DIR} \
+    AIRFLOW_HOME=${AIRFLOW_HOME} \
+    PATH="${AIRFLOW_USER_HOME_DIR}/.local/bin:${PATH}" \
+    GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm" \
+    AIRFLOW_INSTALLATION_METHOD=${AIRFLOW_INSTALLATION_METHOD} \
+    BUILD_ID=${BUILD_ID} \
+    COMMIT_SHA=${COMMIT_SHA} \
+    PIP_USER=${PIP_USER}
 
 # Note missing man directories on debian-buster
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
@@ -433,35 +423,18 @@ RUN mkdir -pv /usr/share/man/man1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-ARG INSTALL_MYSQL_CLIENT="true"
-ENV INSTALL_MYSQL_CLIENT=${INSTALL_MYSQL_CLIENT}
-
 # Only copy install_mysql script. We do not need any other
 COPY scripts/docker/install_mysql.sh /scripts/docker/install_mysql.sh
 # fix permission issue in Azure DevOps when running the scripts
-RUN chmod a+x /scripts/docker/install_mysql.sh
-
-RUN /scripts/docker/install_mysql.sh prod
-
-ENV AIRFLOW_UID=${AIRFLOW_UID}
-ENV AIRFLOW_GID=${AIRFLOW_GID}
-
-ENV AIRFLOW__CORE__LOAD_EXAMPLES="false"
-
-ARG AIRFLOW_USER_HOME_DIR=/home/airflow
-ENV AIRFLOW_USER_HOME_DIR=${AIRFLOW_USER_HOME_DIR}
-
-RUN addgroup --gid "${AIRFLOW_GID}" "airflow" && \
+RUN chmod a+x /scripts/docker/install_mysql.sh && \
+    /scripts/docker/install_mysql.sh prod && \
+    addgroup --gid "${AIRFLOW_GID}" "airflow" && \
     adduser --quiet "airflow" --uid "${AIRFLOW_UID}" \
         --gid "${AIRFLOW_GID}" \
-        --home "${AIRFLOW_USER_HOME_DIR}"
-
-ARG AIRFLOW_HOME
-ENV AIRFLOW_HOME=${AIRFLOW_HOME}
-
+        --home "${AIRFLOW_USER_HOME_DIR}" && \
 # Make Airflow files belong to the root group and are accessible. This is to accommodate the guidelines from
 # OpenShift https://docs.openshift.com/enterprise/3.0/creating_images/guidelines.html
-RUN mkdir -pv "${AIRFLOW_HOME}"; \
+    mkdir -pv "${AIRFLOW_HOME}"; \
     mkdir -pv "${AIRFLOW_HOME}/dags"; \
     mkdir -pv "${AIRFLOW_HOME}/logs"; \
     chown -R "airflow:root" "${AIRFLOW_USER_HOME_DIR}" "${AIRFLOW_HOME}"; \
@@ -469,7 +442,6 @@ RUN mkdir -pv "${AIRFLOW_HOME}"; \
         find "${AIRFLOW_HOME}" -print0 | xargs --null chmod g+rw
 
 COPY --chown=airflow:root --from=airflow-build-image /root/.local "${AIRFLOW_USER_HOME_DIR}/.local"
-
 COPY --chown=airflow:root scripts/in_container/prod/entrypoint_prod.sh /entrypoint
 COPY --chown=airflow:root scripts/in_container/prod/clean-logs.sh /clean-logs
 RUN chmod a+x /entrypoint /clean-logs
@@ -480,9 +452,6 @@ RUN pip install --no-cache-dir --upgrade "pip==${AIRFLOW_PIP_VERSION}"
 # See https://github.com/apache/airflow/issues/9248
 RUN chmod g=u /etc/passwd
 
-ENV PATH="${AIRFLOW_USER_HOME_DIR}/.local/bin:${PATH}"
-ENV GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm"
-
 WORKDIR ${AIRFLOW_HOME}
 
 EXPOSE 8080
@@ -490,19 +459,6 @@ EXPOSE 8080
 RUN usermod -g 0 airflow -G ${AIRFLOW_GID}
 
 USER ${AIRFLOW_UID}
-
-# Having the variable in final image allows to disable providers manager warnings when
-# production image is prepared from sources rather than from package
-ARG AIRFLOW_INSTALLATION_METHOD="apache-airflow"
-ENV AIRFLOW_INSTALLATION_METHOD=${AIRFLOW_INSTALLATION_METHOD}
-
-ARG BUILD_ID
-ENV BUILD_ID=${BUILD_ID}
-ARG COMMIT_SHA
-ENV COMMIT_SHA=${COMMIT_SHA}
-
-ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
-ARG AIRFLOW_IMAGE_DATE_CREATED
 
 LABEL org.apache.airflow.distro="debian" \
   org.apache.airflow.distro.version="buster" \
@@ -528,9 +484,6 @@ LABEL org.apache.airflow.distro="debian" \
   org.opencontainers.image.title="Production Airflow Image" \
   org.opencontainers.image.description="Installed Apache Airflow"
 
-# By default PIP will install everything in ~/.local
-ARG PIP_USER="true"
-ENV PIP_USER=${PIP_USER}
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
 CMD ["--help"]

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -21,23 +21,18 @@ FROM ${PYTHON_BASE_IMAGE} as main
 SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
 
 ARG PYTHON_BASE_IMAGE="python:3.6-slim-buster"
-ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE}
-
 ARG AIRFLOW_VERSION="2.0.0.dev0"
-ENV AIRFLOW_VERSION=$AIRFLOW_VERSION
-
-# Print versions
-RUN echo "Base image: ${PYTHON_BASE_IMAGE}"
-RUN echo "Airflow version: ${AIRFLOW_VERSION}"
-
-# Make sure noninteractive debian install is used and language variables set
-ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
-    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
-
 # By increasing this number we can do force build of all dependencies
 ARG DEPENDENCIES_EPOCH_NUMBER="6"
-# Increase the value below to force reinstalling of all dependencies
-ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
+
+# Make sure noninteractive debian install is used and language variables set
+ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE} AIRFLOW_VERSION=${AIRFLOW_VERSION} \
+    DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8 \
+    DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
+
+# Print versions
+RUN echo "Base image: ${PYTHON_BASE_IMAGE}, Airflow version: ${AIRFLOW_VERSION}"
 
 # Install curl and gnupg2 - needed to download nodejs in the next step
 RUN apt-get update \
@@ -49,18 +44,16 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 ARG ADDITIONAL_DEV_APT_DEPS=""
-ENV ADDITIONAL_DEV_APT_DEPS=${ADDITIONAL_DEV_APT_DEPS}
-
 ARG DEV_APT_COMMAND="\
     curl --fail --location https://deb.nodesource.com/setup_10.x | bash - \
     && curl https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - > /dev/null \
     && echo 'deb https://dl.yarnpkg.com/debian/ stable main' > /etc/apt/sources.list.d/yarn.list"
-ENV DEV_APT_COMMAND=${DEV_APT_COMMAND}
-
 ARG ADDITIONAL_DEV_APT_COMMAND=""
-ENV ADDITIONAL_DEV_APT_COMMAND=${ADDITIONAL_DEV_APT_COMMAND}
-
 ARG ADDITIONAL_DEV_ENV_VARS=""
+
+ENV DEV_APT_COMMAND=${DEV_APT_COMMAND} \
+    ADDITIONAL_DEV_APT_DEPS=${ADDITIONAL_DEV_APT_DEPS} \
+    ADDITIONAL_DEV_APT_COMMAND=${ADDITIONAL_DEV_APT_COMMAND}
 
 # Install basic and additional apt dependencies
 RUN mkdir -pv /usr/share/man/man1 \
@@ -134,19 +127,26 @@ ARG RUNTIME_APT_DEPS="\
       unzip \
       vim \
       xxd"
-ENV RUNTIME_APT_DEP=${RUNTIME_APT_DEPS}
-
 ARG ADDITIONAL_RUNTIME_APT_DEPS=""
-ENV ADDITIONAL_RUNTIME_APT_DEPS=${ADDITIONAL_RUNTIME_APT_DEPS}
-
 ARG RUNTIME_APT_COMMAND=""
-ENV RUNTIME_APT_COMMAND=${RUNTIME_APT_COMMAND}
-
 ARG ADDITIONAL_RUNTIME_APT_COMMAND=""
-ENV ADDITIONAL_RUNTIME_APT_COMMAND=${ADDITIONAL_RUNTIME_APT_COMMAND}
-
 ARG ADDITIONAL_DEV_APT_ENV=""
 ARG ADDITIONAL_RUNTIME_APT_ENV=""
+
+ARG DOCKER_CLI_VERSION=19.03.9
+ARG HOME=/root
+ARG AIRFLOW_HOME=/root/airflow
+ARG AIRFLOW_SOURCES=/opt/airflow
+
+
+ENV RUNTIME_APT_DEP=${RUNTIME_APT_DEPS} \
+    ADDITIONAL_RUNTIME_APT_DEPS=${ADDITIONAL_RUNTIME_APT_DEPS} \
+    RUNTIME_APT_COMMAND=${RUNTIME_APT_COMMAND}  \
+    ADDITIONAL_RUNTIME_APT_COMMAND=${ADDITIONAL_RUNTIME_APT_COMMAND}\
+    DOCKER_CLI_VERSION=${DOCKER_CLI_VERSION} \
+    HOME=${HOME} \
+    AIRFLOW_HOME=${AIRFLOW_HOME} \
+    AIRFLOW_SOURCES=${AIRFLOW_SOURCES}
 
 # Note missing man directories on debian-buster
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
@@ -162,22 +162,9 @@ RUN mkdir -pv /usr/share/man/man1 \
       ${ADDITIONAL_RUNTIME_APT_DEPS} \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-ARG DOCKER_CLI_VERSION=19.03.9
-ENV DOCKER_CLI_VERSION=${DOCKER_CLI_VERSION}
-
-RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz \
     |  tar -C /usr/bin --strip-components=1 -xvzf - docker/docker
-
-ARG HOME=/root
-ENV HOME=${HOME}
-
-ARG AIRFLOW_HOME=/root/airflow
-ENV AIRFLOW_HOME=${AIRFLOW_HOME}
-
-ARG AIRFLOW_SOURCES=/opt/airflow
-ENV AIRFLOW_SOURCES=${AIRFLOW_SOURCES}
 
 WORKDIR ${AIRFLOW_SOURCES}
 
@@ -193,101 +180,79 @@ ARG BATS_FILE_VERSION="0.2.0"
 
 RUN curl -sSL https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.tar.gz -o /tmp/bats.tgz \
     && tar -zxf /tmp/bats.tgz -C /tmp \
-    && /bin/bash /tmp/bats-core-${BATS_VERSION}/install.sh /opt/bats && rm -rf
-
-RUN mkdir -p /opt/bats/lib/bats-support \
+    && /bin/bash /tmp/bats-core-${BATS_VERSION}/install.sh /opt/bats && rm -rf \
+    && mkdir -p /opt/bats/lib/bats-support \
     && curl -sSL https://github.com/bats-core/bats-support/archive/v${BATS_SUPPORT_VERSION}.tar.gz -o /tmp/bats-support.tgz \
-    && tar -zxf /tmp/bats-support.tgz -C /opt/bats/lib/bats-support --strip 1 && rm -rf /tmp/*
-
-RUN mkdir -p /opt/bats/lib/bats-assert \
+    && tar -zxf /tmp/bats-support.tgz -C /opt/bats/lib/bats-support --strip 1 && rm -rf /tmp/* \
+    && mkdir -p /opt/bats/lib/bats-assert \
     && curl -sSL https://github.com/bats-core/bats-assert/archive/v${BATS_ASSERT_VERSION}.tar.gz -o /tmp/bats-assert.tgz \
-    && tar -zxf /tmp/bats-assert.tgz -C /opt/bats/lib/bats-assert --strip 1 && rm -rf /tmp/*
-
-RUN mkdir -p /opt/bats/lib/bats-file \
+    && tar -zxf /tmp/bats-assert.tgz -C /opt/bats/lib/bats-assert --strip 1 && rm -rf /tmp/* \
+    && mkdir -p /opt/bats/lib/bats-file \
     && curl -sSL https://github.com/bats-core/bats-file/archive/v${BATS_FILE_VERSION}.tar.gz -o /tmp/bats-file.tgz \
     && tar -zxf /tmp/bats-file.tgz -C /opt/bats/lib/bats-file --strip 1 && rm -rf /tmp/*
-
-ENV PATH "/opt/bats/bin/:${PATH}"
 
 # Additional scripts for managing BATS addons
 COPY scripts/docker/load.bash /opt/bats/lib/
 
-# Optimizing installation of Cassandra driver
+ARG AIRFLOW_REPO=apache/airflow
+ARG AIRFLOW_BRANCH=master
+# Airflow Extras installed
+ARG AIRFLOW_EXTRAS="all"
+ARG ADDITIONAL_AIRFLOW_EXTRAS=""
+# Allows to override constraints source
+ARG CONSTRAINTS_GITHUB_REPOSITORY="apache/airflow"
+ARG AIRFLOW_CONSTRAINTS="constraints"
+ARG AIRFLOW_CONSTRAINTS_REFERENCE=""
+ARG AIRFLOW_CONSTRAINTS_LOCATION=""
+ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-master"
+# By changing the CI build epoch we can force reinstalling Airflow and pip all dependencies
+# It can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
+ARG AIRFLOW_CI_BUILD_EPOCH="3"
+ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
+# By default in the image, we are installing all providers when installing from sources
+ARG INSTALL_PROVIDERS_FROM_SOURCES="true"
+ARG INSTALL_FROM_PYPI="true"
+ARG AIRFLOW_PIP_VERSION=20.2.4
+# Setup PIP
+# By default PIP install run without cache to make image smaller
+ARG PIP_NO_CACHE_DIR="true"
+# By default PIP has progress bar but you can disable it.
+ARG PIP_PROGRESS_BAR="on"
+# Optimizing installation of Cassandra driver (in case there are no prebuilt wheels which is the
+# case as of 20.04.2021 with Python 3.9
 # Speeds up building the image - cassandra driver without CYTHON saves around 10 minutes
 ARG CASS_DRIVER_NO_CYTHON="1"
 # Build cassandra driver on multiple CPUs
 ARG CASS_DRIVER_BUILD_CONCURRENCY="8"
 
-ENV CASS_DRIVER_BUILD_CONCURRENCY=${CASS_DRIVER_BUILD_CONCURRENCY}
-ENV CASS_DRIVER_NO_CYTHON=${CASS_DRIVER_NO_CYTHON}
-
-ARG AIRFLOW_REPO=apache/airflow
-ENV AIRFLOW_REPO=${AIRFLOW_REPO}
-
-ARG AIRFLOW_BRANCH=master
-ENV AIRFLOW_BRANCH=${AIRFLOW_BRANCH}
-
-# Airflow Extras installed
-ARG AIRFLOW_EXTRAS="all"
-ARG ADDITIONAL_AIRFLOW_EXTRAS=""
-ENV AIRFLOW_EXTRAS=${AIRFLOW_EXTRAS}${ADDITIONAL_AIRFLOW_EXTRAS:+,}${ADDITIONAL_AIRFLOW_EXTRAS}
-
-RUN echo "Installing with extras: ${AIRFLOW_EXTRAS}."
-
-# Allows to override constraints source
-ARG CONSTRAINTS_GITHUB_REPOSITORY="apache/airflow"
-ENV CONSTRAINTS_GITHUB_REPOSITORY=${CONSTRAINTS_GITHUB_REPOSITORY}
-
-ARG AIRFLOW_CONSTRAINTS="constraints"
-ENV AIRFLOW_CONSTRAINTS=${AIRFLOW_CONSTRAINTS}
-ARG AIRFLOW_CONSTRAINTS_REFERENCE=""
-ENV AIRFLOW_CONSTRAINTS_REFERENCE=${AIRFLOW_CONSTRAINTS_REFERENCE}
-ARG AIRFLOW_CONSTRAINTS_LOCATION=""
-ENV AIRFLOW_CONSTRAINTS_LOCATION=${AIRFLOW_CONSTRAINTS_LOCATION}
-
-ARG DEFAULT_CONSTRAINTS_BRANCH="constraints-master"
-ENV DEFAULT_CONSTRAINTS_BRANCH=${DEFAULT_CONSTRAINTS_BRANCH}
-
-# By changing the CI build epoch we can force reinstalling Airflow and pip all dependencies
-# It can also be overwritten manually by setting the AIRFLOW_CI_BUILD_EPOCH environment variable.
-ARG AIRFLOW_CI_BUILD_EPOCH="3"
-ENV AIRFLOW_CI_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH}
-
-ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
-ENV AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES}
-
-# By default in the image, we are installing all providers when installing from sources
-ARG INSTALL_PROVIDERS_FROM_SOURCES="true"
-ENV INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES}
-
-ARG INSTALL_FROM_PYPI="true"
-ENV INSTALL_FROM_PYPI=${INSTALL_FROM_PYPI}
-
-ARG AIRFLOW_PIP_VERSION=20.2.4
-ENV AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION}
-
+ENV AIRFLOW_REPO=${AIRFLOW_REPO}\
+    AIRFLOW_BRANCH=${AIRFLOW_BRANCH} \
+    AIRFLOW_EXTRAS=${AIRFLOW_EXTRAS}${ADDITIONAL_AIRFLOW_EXTRAS:+,}${ADDITIONAL_AIRFLOW_EXTRAS} \
+    CONSTRAINTS_GITHUB_REPOSITORY=${CONSTRAINTS_GITHUB_REPOSITORY} \
+    AIRFLOW_CONSTRAINTS=${AIRFLOW_CONSTRAINTS} \
+    AIRFLOW_CONSTRAINTS_REFERENCE=${AIRFLOW_CONSTRAINTS_REFERENCE} \
+    AIRFLOW_CONSTRAINTS_LOCATION=${AIRFLOW_CONSTRAINTS_LOCATION} \
+    DEFAULT_CONSTRAINTS_BRANCH=${DEFAULT_CONSTRAINTS_BRANCH} \
+    AIRFLOW_CI_BUILD_EPOCH=${AIRFLOW_CI_BUILD_EPOCH} \
+    AIRFLOW_PRE_CACHED_PIP_PACKAGES=${AIRFLOW_PRE_CACHED_PIP_PACKAGES} \
+    INSTALL_PROVIDERS_FROM_SOURCES=${INSTALL_PROVIDERS_FROM_SOURCES} \
+    INSTALL_FROM_PYPI=${INSTALL_FROM_PYPI} \
+    AIRFLOW_PIP_VERSION=${AIRFLOW_PIP_VERSION} \
 # In the CI image we always:
 # * install MySQL
 # * install airflow from current sources, not from PyPI package
 # * install airflow without `--user` flag
 # * install airflow in editable mode
 # * install always current version of airflow
-
-ENV INSTALL_MYSQL_CLIENT="true"
-ENV AIRFLOW_INSTALLATION_METHOD="."
-ENV AIRFLOW_INSTALL_USER_FLAG=""
-ENV AIRFLOW_INSTALL_EDITABLE_FLAG="--editable"
-ENV AIRFLOW_VERSION_SPECIFICATION=""
-
-# Setup PIP
-# By default PIP install run without cache to make image smaller
-ARG PIP_NO_CACHE_DIR="true"
-ENV PIP_NO_CACHE_DIR=${PIP_NO_CACHE_DIR}
-RUN echo "Pip no cache dir: ${PIP_NO_CACHE_DIR}"
-
-# By default PIP has progress bar but you can disable it.
-ARG PIP_PROGRESS_BAR="on"
-ENV PIP_PROGRESS_BAR=${PIP_PROGRESS_BAR}
+    INSTALL_MYSQL_CLIENT="true" \
+    AIRFLOW_INSTALLATION_METHOD="." \
+    AIRFLOW_INSTALL_USER_FLAG="" \
+    AIRFLOW_INSTALL_EDITABLE_FLAG="--editable" \
+    AIRFLOW_VERSION_SPECIFICATION="" \
+    PIP_NO_CACHE_DIR=${PIP_NO_CACHE_DIR} \
+    PIP_PROGRESS_BAR=${PIP_PROGRESS_BAR} \
+    CASS_DRIVER_BUILD_CONCURRENCY=${CASS_DRIVER_BUILD_CONCURRENCY} \
+    CASS_DRIVER_NO_CYTHON=${CASS_DRIVER_NO_CYTHON}
 
 RUN pip install --no-cache-dir --upgrade "pip==${AIRFLOW_PIP_VERSION}"
 
@@ -297,8 +262,18 @@ COPY scripts/docker/common.sh /scripts/docker/common.sh
 # Only copy install_airflow_from_branch_tip.sh to not invalidate cache on other script changes
 COPY scripts/docker/install_airflow_from_branch_tip.sh /scripts/docker/install_airflow_from_branch_tip.sh
 
+# Those are additional constraints that are needed for some extras but we do not want to
+# force them on the main Airflow package. Those limitations are:
+# * chardet<4: required by snowflake provider
+# * lazy-object-proxy<1.5.0: required by astroid
+# * pyOpenSSL: required by snowflake provider https://github.com/snowflakedb/snowflake-connector-python/blob/v2.3.6/setup.py#L201
+# * urllib3<1.26: Required to keep boto3 happy
+# * pyjwt<2.0.0: flask-jwt-extended requires it
+# * dill<0.3.3 required by apache-beam
+ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="chardet<4 lazy-object-proxy<1.5.0 pyOpenSSL<20.0.0 urllib3<1.26 pyjwt<2.0.0 dill<0.3.3"
 ARG UPGRADE_TO_NEWER_DEPENDENCIES="false"
-ENV UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}
+ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS} \
+    UPGRADE_TO_NEWER_DEPENDENCIES=${UPGRADE_TO_NEWER_DEPENDENCIES}
 
 # In case of CI builds we want to pre-install master version of airflow dependencies so that
 # We do not have to always reinstall it from the scratch.
@@ -337,17 +312,6 @@ COPY setup.py ${AIRFLOW_SOURCES}/setup.py
 COPY setup.cfg ${AIRFLOW_SOURCES}/setup.cfg
 
 COPY airflow/__init__.py ${AIRFLOW_SOURCES}/airflow/__init__.py
-
-# Those are additional constraints that are needed for some extras but we do not want to
-# force them on the main Airflow package. Those limitations are:
-# * chardet<4: required by snowflake provider
-# * lazy-object-proxy<1.5.0: required by astroid
-# * pyOpenSSL: required by snowflake provider https://github.com/snowflakedb/snowflake-connector-python/blob/v2.3.6/setup.py#L201
-# * urllib3<1.26: Required to keep boto3 happy
-# * pyjwt<2.0.0: flask-jwt-extended requires it
-# * dill<0.3.3 required by apache-beam
-ARG EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS="chardet<4 lazy-object-proxy<1.5.0 pyOpenSSL<20.0.0 urllib3<1.26 pyjwt<2.0.0 dill<0.3.3"
-ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS}
 
 ARG CONTINUE_ON_PIP_CHECK_FAILURE="false"
 
@@ -407,18 +371,15 @@ RUN if [[ -n "${ADDITIONAL_PYTHON_DEPS}" ]]; then \
         pip install --no-cache-dir ${ADDITIONAL_PYTHON_DEPS}; \
     fi
 
-ENV PATH "/files/bin/:/opt/airflow/scripts/in_container/bin/:${HOME}:${PATH}"
-
-# Needed to stop Gunicorn from crashing when /tmp is now mounted from host
-ENV GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm/"
-
 ARG BUILD_ID
-ENV BUILD_ID=${BUILD_ID}
 ARG COMMIT_SHA
-ENV COMMIT_SHA=${COMMIT_SHA}
-
 ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"
 ARG AIRFLOW_IMAGE_DATE_CREATED
+
+ENV PATH="/files/bin/:/opt/airflow/scripts/in_container/bin/:${HOME}:${PATH}" \
+    GUNICORN_CMD_ARGS="--worker-tmp-dir /dev/shm/" \
+    BUILD_ID=${BUILD_ID} \
+    COMMIT_SHA=${COMMIT_SHA}
 
 LABEL org.apache.airflow.distro="debian" \
   org.apache.airflow.distro.version="buster" \

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -540,9 +540,6 @@ The following build arguments (``--build-arg`` in docker build command) can be u
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_SOURCES``                      | ``/opt/airflow``                         | Mounted sources of Airflow               |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``CASS_DRIVER_NO_CYTHON``                | ``1``                                    | if set to 1 no CYTHON compilation is     |
-|                                          |                                          | done for cassandra driver (much faster)  |
-+------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_REPO``                         | ``apache/airflow``                       | the repository from which PIP            |
 |                                          |                                          | dependencies are pre-installed           |
 +------------------------------------------+------------------------------------------+------------------------------------------+

--- a/breeze
+++ b/breeze
@@ -258,8 +258,7 @@ function breeze::initialize_virtualenv() {
         echo
         pushd "${AIRFLOW_SOURCES}" >/dev/null 2>&1 || exit 1
         set +e
-        # We need to export this one to speed up Cassandra driver installation in virtualenv
-        CASS_DRIVER_NO_CYTHON="1" pip install -e ".[devel]" \
+        pip install -e ".[devel]" \
             --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${PYTHON_MAJOR_MINOR_VERSION}.txt"
         res=$?
         set -e

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -127,11 +127,6 @@ for examples of using those arguments.
 | ``ADDITIONAL_RUNTIME_APT_ENV``           |                                          | Additional env variables defined         |
 |                                          |                                          | when installing runtime deps.            |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``CASS_DRIVER_BUILD_CONCURRENCY``        | ``8``                                    | Number of processors to use for          |
-|                                          |                                          | cassandra PIP install (speeds up         |
-|                                          |                                          | installing in case cassandra extra is    |
-|                                          |                                          | used).                                   |
-+------------------------------------------+------------------------------------------+------------------------------------------+
 | ``INSTALL_MYSQL_CLIENT``                 | ``true``                                 | Whether MySQL client should be installed |
 |                                          |                                          | The mysql extra is removed from extras   |
 |                                          |                                          | if the client is not installed.          |


### PR DESCRIPTION
The Dockerfile is more "packed" and certain ARG/ENVs are in separate
parts of it but we save minutes in certain scenarios when the images
are built (especially when they are built in parallell, the
difference might be significant)

This change also removes some of the old, already unused CASS_DRIVER
ARGS and ENVS. They are not needed any more as cassandra drivers do
not require CPYTHON compilation any more.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
