### PR TITLE
Bugfix: Invalid name when trimmed `pod_id` ends with hyphen in ``Kube…

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -469,7 +469,10 @@ class PodGenerator:
 
         safe_uuid = uuid.uuid4().hex  # safe uuid will always be less than 63 chars
         trimmed_pod_id = pod_id[:MAX_LABEL_LEN]
-        safe_pod_id = f"{trimmed_pod_id}.{safe_uuid}"
+
+        # Since we use '.' as separator we need to remove all the occurences of '-' if any
+        # in the trimmed_pod_id as the regex does not allow '-' followed by '.'.
+        safe_pod_id = f"{trimmed_pod_id.rstrip('-')}.{safe_uuid}"
 
         return safe_pod_id
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+import re
 import sys
 import unittest
 import uuid
@@ -655,6 +656,24 @@ class TestPodGenerator(unittest.TestCase):
         else:
             assert len(parts[0]) <= 63
         assert len(parts[1]) <= 63
+
+    @parameterized.expand(
+        (
+            ("pod-name-with-hyphen-", "pod-name-with-hyphen"),
+            ("pod-name-with-double-hyphen--", "pod-name-with-double-hyphen"),
+            ("pod0-name", "pod0-name"),
+            ("simple", "simple"),
+        )
+    )
+    def test_pod_name_is_valid(self, pod_id, expected_starts_with):
+        name = PodGenerator.make_unique_pod_id(pod_id)
+
+        regex = r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        assert (
+            len(name) <= 253 and all(ch.lower() == ch for ch in name) and re.match(regex, name)
+        ), "pod_id is invalid - fails allowed regex check"
+
+        assert name.rsplit(".")[0] == expected_starts_with
 
     def test_deserialize_model_string(self):
         fixture = """


### PR DESCRIPTION
…rnetesPodOperator``

When a pod name is more than `MAX_LABEL_LEN` (63 characters), it is trimmed to 63 chars

https://github.com/apache/airflow/blob/8711f90ab820ed420ef317b931e933a2062c891f/airflow/kubernetes/pod_generator.py#L470-L472

and we add a safe UUID to the `pod_id` joined by a dot `.`. However the regex
for Kubernetes name does not allow `-` followed by a `.`.

Valid Regex:

```python
^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
```

This commit strips any hypens at the end of the trimmed `pod_id`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
