### PR TITLE
Further fix trimmed `pod_id` for `KubernetesPodOperator`

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -468,12 +468,10 @@ class PodGenerator:
             return None
 
         safe_uuid = uuid.uuid4().hex  # safe uuid will always be less than 63 chars
-        trimmed_pod_id = pod_id[:MAX_LABEL_LEN]
+        # Strip trailing '-' and '.' as they cant be followed by '.'
+        trimmed_pod_id = pod_id[:MAX_LABEL_LEN].rstrip('-.')
 
-        # Since we use '.' as separator we need to remove all the occurences of '-' if any
-        # in the trimmed_pod_id as the regex does not allow '-' followed by '.'.
-        safe_pod_id = f"{trimmed_pod_id.rstrip('-')}.{safe_uuid}"
-
+        safe_pod_id = f"{trimmed_pod_id}.{safe_uuid}"
         return safe_pod_id
 
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -663,6 +663,9 @@ class TestPodGenerator(unittest.TestCase):
             ("pod-name-with-double-hyphen--", "pod-name-with-double-hyphen"),
             ("pod0-name", "pod0-name"),
             ("simple", "simple"),
+            ("pod-name-with-dot.", "pod-name-with-dot"),
+            ("pod-name-with-double-dot..", "pod-name-with-double-dot"),
+            ("pod-name-with-hyphen-dot-.", "pod-name-with-hyphen-dot"),
         )
     )
     def test_pod_name_is_valid(self, pod_id, expected_starts_with):


### PR DESCRIPTION
Missed a case in (#15443) where `.` can be followed by another `.`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
