### PR TITLE
Breeze should load local tmux configuration in 'breeze start-airflow' 

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -258,10 +258,15 @@ You should set up the autocomplete option automatically by running:
 
 You get the auto-completion working when you re-enter the shell.
 
+Customize your environment
+--------------------------
 When you enter the Breeze environment, automatically an environment file is sourced from
 ``files/airflow-breeze-config/variables.env``. The ``files`` folder from your local sources is
 automatically mounted to the container under ``/files`` path and you can put there any files you want
 to make available for the Breeze container.
+
+You can also add your local tmux configuration in ``files/airflow-breeze-config/.tmux.conf`` and
+these configurations will be available for your tmux environment.
 
 .. raw:: html
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -268,6 +268,16 @@ to make available for the Breeze container.
 You can also add your local tmux configuration in ``files/airflow-breeze-config/.tmux.conf`` and
 these configurations will be available for your tmux environment.
 
+there is a symlink between ``files/airflow-breeze-config/.tmux.conf`` and ``~/.tmux.conf`` in the container,
+so you can change it at any place, and run
+
+.. code-block:: bash
+
+  tmux source ~/.tmux.conf
+
+inside container, to enable modified tmux configurations.
+
+
 .. raw:: html
 
     <div align="center">

--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -63,6 +63,6 @@ if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
 else
     echo
     echo "You can add ${AIRFLOW_BREEZE_CONFIG_DIR} directory and place ${TMUX_CONF_FILE}"
-    echo "In it to make breeze will use your ${TMUX_CONF_FILE} for tmux"
+    echo "In it to make breeze use your local ${TMUX_CONF_FILE} for tmux"
     echo
 fi

--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -58,7 +58,7 @@ if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
     echo "Using ${TMUX_CONF_FILE} from ${AIRFLOW_BREEZE_CONFIG_DIR}"
     echo
      # shellcheck disable=1090
-    cp "${AIRFLOW_BREEZE_CONFIG_DIR}/${TMUX_CONF_FILE}" ~
+    ln -sf "${AIRFLOW_BREEZE_CONFIG_DIR}/${TMUX_CONF_FILE}" ~
     popd >/dev/null 2>&1 || exit 1
 else
     echo

--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -59,10 +59,6 @@ if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
     echo
      # shellcheck disable=1090
     cp "${AIRFLOW_BREEZE_CONFIG_DIR}/${TMUX_CONF_FILE}" ~
-
-    if [[ $? -ne 0 ]]; then
-        return 1;
-    fi
     popd >/dev/null 2>&1 || exit 1
 else
     echo

--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -63,6 +63,6 @@ if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
 else
     echo
     echo "You can add ${AIRFLOW_BREEZE_CONFIG_DIR} directory and place ${TMUX_CONF_FILE}"
-    echo "In it to make breeze use your local ${TMUX_CONF_FILE} for tmux"
+    echo "in it to make breeze use your local ${TMUX_CONF_FILE} for tmux"
     echo
 fi

--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -19,6 +19,7 @@
 export FILES_DIR="/files"
 export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
 VARIABLES_ENV_FILE="variables.env"
+TMUX_CONF_FILE=".tmux.conf"
 
 if [[ -d "${FILES_DIR}" ]]; then
     export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"
@@ -46,5 +47,26 @@ else
     echo
     echo "You can add ${AIRFLOW_BREEZE_CONFIG_DIR} directory and place ${VARIABLES_ENV_FILE}"
     echo "In it to make breeze source the variables automatically for you"
+    echo
+fi
+
+
+if [[ -d "${AIRFLOW_BREEZE_CONFIG_DIR}" && \
+    -f "${AIRFLOW_BREEZE_CONFIG_DIR}/${TMUX_CONF_FILE}" ]]; then
+    pushd "${AIRFLOW_BREEZE_CONFIG_DIR}" >/dev/null 2>&1 || exit 1
+    echo
+    echo "Using ${TMUX_CONF_FILE} from ${AIRFLOW_BREEZE_CONFIG_DIR}"
+    echo
+     # shellcheck disable=1090
+    cp "${AIRFLOW_BREEZE_CONFIG_DIR}/${TMUX_CONF_FILE}" ~
+
+    if [[ $? -ne 0 ]]; then
+        return 1;
+    fi
+    popd >/dev/null 2>&1 || exit 1
+else
+    echo
+    echo "You can add ${AIRFLOW_BREEZE_CONFIG_DIR} directory and place ${TMUX_CONF_FILE}"
+    echo "In it to make breeze will use your ${TMUX_CONF_FILE} for tmux"
     echo
 fi


### PR DESCRIPTION
closes #15416 

---
**Description**

Currently, when we run 

`
breeze start-airflow
`

**breeze** doesn't load local tmux configuration file **.tmux.conf** and we get default tmux configuration inside the containers.

**PR effect**
After this change developers will be able to put their **.tmux.conf** file as **/files/airflow-breeze-config/.tmux.conf**
and Breeze will load local **tmux configuration** in to the containers and developers should be able to use their local configurations.
