### PR TITLE
Mark tasks as failed when using ONE_SUCCESS and Upstream has no successes

### DIFF
--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -134,8 +134,12 @@ class TriggerRuleDep(BaseTIDep):
                 if successes or skipped:
                     ti.set_state(State.SKIPPED, session)
             elif trigger_rule == TR.ONE_SUCCESS:
-                if upstream_done and not successes:
+                if upstream_done and done == skipped:
+                    # if upstream is done and all are skipped mark as skipped
                     ti.set_state(State.SKIPPED, session)
+                elif upstream_done and successes <= 0:
+                    # if upstream is done and there are no successes mark as upstream failed
+                    ti.set_state(State.UPSTREAM_FAILED, session)
             elif trigger_rule == TR.ONE_FAILED:
                 if upstream_done and not (failed or upstream_failed):
                     ti.set_state(State.SKIPPED, session)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -905,6 +905,13 @@ class TestTaskInstance(unittest.TestCase):
             ['one_success', 2, 0, 0, 0, 2, True, None, True],
             ['one_success', 2, 0, 1, 0, 3, True, None, True],
             ['one_success', 2, 1, 0, 0, 3, True, None, True],
+            ['one_success', 0, 5, 0, 0, 5, True, State.SKIPPED, False],
+            ['one_success', 0, 4, 1, 0, 5, True, State.UPSTREAM_FAILED, False],
+            ['one_success', 0, 3, 1, 1, 5, True, State.UPSTREAM_FAILED, False],
+            ['one_success', 0, 4, 0, 1, 5, True, State.UPSTREAM_FAILED, False],
+            ['one_success', 0, 0, 5, 0, 5, True, State.UPSTREAM_FAILED, False],
+            ['one_success', 0, 0, 4, 1, 5, True, State.UPSTREAM_FAILED, False],
+            ['one_success', 0, 0, 0, 5, 5, True, State.UPSTREAM_FAILED, False],
             #
             # Tests for all_failed
             #
@@ -932,15 +939,15 @@ class TestTaskInstance(unittest.TestCase):
     )
     def test_check_task_dependencies(
         self,
-        trigger_rule,
-        successes,
-        skipped,
-        failed,
-        upstream_failed,
-        done,
-        flag_upstream_failed,
-        expect_state,
-        expect_completed,
+        trigger_rule: str,
+        successes: int,
+        skipped: int,
+        failed: int,
+        upstream_failed: int,
+        done: int,
+        flag_upstream_failed: bool,
+        expect_state: State,
+        expect_completed: bool,
     ):
         start_date = timezone.datetime(2016, 2, 1, 0, 0, 0)
         dag = models.DAG('test-dag', start_date=start_date)


### PR DESCRIPTION
# What this does
1. When tasks use trigger_rule = `ONE_SUCCESS` Mark them as upstream_failed when no upstreams succeed
    * Leaves skipped behavior when all upstream are skipped
1. Adds several new tests to ensure the new behavior is as expected
# Why do this
1. I had several dags that weren't failing out as expected when no successes were found
1. Other users appear to have run into this same issue https://stackoverflow.com/questions/64603004/aiflow-skipping-task-on-one-success-trigger-rule 
