### PR TITLE
Fix incorrect order of messages in logs when using Elasticsearch

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -129,10 +129,11 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             key = getattr(log, 'host', 'default_host')
             grouped_logs[key].append(log)
 
-        # return items sorted by timestamp.
-        result = sorted(grouped_logs.items(), key=lambda kv: getattr(kv[1][0], 'message', '_'))
+        # return items sorted by asctime.
+        for host in grouped_logs:
+            grouped_logs[host].sort(key=lambda log: getattr(log, 'asctime', '_'))
 
-        return result
+        return grouped_logs.items()
 
     def _read_grouped_logs(self):
         return True

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -130,8 +130,11 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
             grouped_logs[key].append(log)
 
         # return items sorted by asctime.
-        for host in grouped_logs:
-            grouped_logs[host].sort(key=lambda log: getattr(log, 'asctime', '_'))
+        def sorter(log):
+            return getattr(log, 'asctime', '_')
+
+        for logs in grouped_logs.values():
+            logs.sort(key=sorter)
 
         return grouped_logs.items()
 

--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -133,8 +133,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, LoggingMixin):
         def sorter(log):
             return getattr(log, 'asctime', '_')
 
-        for logs in grouped_logs.values():
-            logs.sort(key=sorter)
+        for host_logs in grouped_logs.values():
+            host_logs.sort(key=sorter)
 
         return grouped_logs.items()
 

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -162,7 +162,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             'asctime': '2020-12-24 19:25:00,862',
             'message': another_test_message,
             'log_id': self.LOG_ID,
-            'offset': 1
+            'offset': 1,
         }
         self.es.index(index=self.index_name, doc_type=self.doc_type, body=outdated_body, id=1)
         logs, metadatas = self.es_task_handler.read(self.ti, 1)

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -74,7 +74,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):
             'asctime': '2020-12-24 19:25:00,962',
             'message': self.test_message,
             'log_id': self.LOG_ID,
-            'offset': 1
+            'offset': 1,
         }
 
         self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body, id=1)


### PR DESCRIPTION
Сurrent implementation of sorting is not correct, because it unreasonable sorts `grouped_logs` by first message text:
```python
result = sorted(grouped_logs.items(), key=lambda kv: getattr(kv[1][0], 'message', '_'))
```
