### PR TITLE
Auto refresh on Tree View

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -165,20 +165,3 @@ g.node.removed rect {
   background-color: #f0f0f0;
   cursor: move;
 }
-
-.refresh-actions {
-  float: right;
-  display: inline-flex;
-  align-items: center;
-  top: 10px;
-  right: 10px;
-  position: relative;
-}
-
-.refresh-actions > .switch-label {
-  margin: 0 10px 0 20px;
-}
-
-.loading-dots.refresh-loading {
-  display: none;
-}

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -445,3 +445,20 @@ label[for="timezone-other"],
   margin-top: 8px;
   overflow-x: auto;
 }
+
+.refresh-actions {
+  float: right;
+  display: inline-flex;
+  align-items: center;
+  right: 10px;
+  margin-bottom: 15px;
+  position: relative;
+}
+
+.refresh-actions > .switch-label {
+  margin: 0 10px 0 20px;
+}
+
+.loading-dots.refresh-loading {
+  display: none;
+}

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -447,6 +447,8 @@ label[for="timezone-other"],
 }
 
 .refresh-actions {
+  justify-content: flex-end;
+  min-width: 225px;
   float: right;
   display: inline-flex;
   align-items: center;

--- a/airflow/www/static/css/tree.css
+++ b/airflow/www/static/css/tree.css
@@ -118,20 +118,3 @@ g.axis path {
 g.tick line {
   shape-rendering: crispEdges;
 }
-
-.refresh-actions {
-  float: right;
-  display: inline-flex;
-  align-items: center;
-  right: 10px;
-  margin-bottom: 15px;
-  position: relative;
-}
-
-.refresh-actions > .switch-label {
-  margin: 0 10px 0 20px;
-}
-
-.loading-dots.refresh-loading {
-  display: none;
-}

--- a/airflow/www/static/css/tree.css
+++ b/airflow/www/static/css/tree.css
@@ -118,3 +118,20 @@ g.axis path {
 g.tick line {
   shape-rendering: crispEdges;
 }
+
+.refresh-actions {
+  float: right;
+  display: inline-flex;
+  align-items: center;
+  right: 10px;
+  margin-bottom: 15px;
+  position: relative;
+}
+
+.refresh-actions > .switch-label {
+  margin: 0 10px 0 20px;
+}
+
+.loading-dots.refresh-loading {
+  display: none;
+}

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -27,6 +27,7 @@ import getMetaValue from './meta_value';
 import { escapeHtml } from './main';
 import tiTooltip, { taskNoInstanceTooltip } from './task_instances';
 
+// dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
 const executionDate = getMetaValue('execution_date');
 const arrange = getMetaValue('arrange');

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -87,34 +87,37 @@ document.addEventListener('DOMContentLoaded', () => {
       const dataInstance = data.instances[j];
       const row = node.instances[j];
 
-      if (row) {
-        const taskInstance = {
-          state: row[0],
-          try_number: row[1],
-          start_ts: row[2],
-          duration: row[3],
-        };
-        node.instances[j] = taskInstance;
+      // check that the dataInstance and the row are valid
+      if (dataInstance && dataInstance.execution_date) {
+        if (row && row.length) {
+          const taskInstance = {
+            state: row[0],
+            try_number: row[1],
+            start_ts: row[2],
+            duration: row[3],
+          };
+          node.instances[j] = taskInstance;
 
-        taskInstance.task_id = node.name;
-        taskInstance.operator = node.operator;
-        taskInstance.execution_date = dataInstance.execution_date;
-        taskInstance.external_trigger = dataInstance.external_trigger;
+          taskInstance.task_id = node.name;
+          taskInstance.operator = node.operator;
+          taskInstance.execution_date = dataInstance.execution_date;
+          taskInstance.external_trigger = dataInstance.external_trigger;
 
-        // compute start_date and end_date if applicable
-        if (taskInstance.start_ts !== null) {
-          taskInstance.start_date = toDateString(taskInstance.start_ts);
-          if (taskInstance.state === 'running') {
-            taskInstance.duration = now - taskInstance.start_ts;
-          } else if (taskInstance.duration !== null) {
-            taskInstance.end_date = toDateString(taskInstance.start_ts + taskInstance.duration);
+          // compute start_date and end_date if applicable
+          if (taskInstance.start_ts !== null) {
+            taskInstance.start_date = toDateString(taskInstance.start_ts);
+            if (taskInstance.state === 'running') {
+              taskInstance.duration = now - taskInstance.start_ts;
+            } else if (taskInstance.duration !== null) {
+              taskInstance.end_date = toDateString(taskInstance.start_ts + taskInstance.duration);
+            }
           }
+        } else {
+          node.instances[j] = {
+            task_id: node.name,
+            execution_date: dataInstance.execution_date,
+          };
         }
-      } else {
-        node.instances[j] = {
-          task_id: node.name,
-          execution_date: dataInstance.execution_date,
-        };
       }
     }
   }

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -87,35 +87,34 @@ document.addEventListener('DOMContentLoaded', () => {
       const dataInstance = data.instances[j];
       const row = node.instances[j];
 
-      if (row === null) {
+      if (row) {
+        const taskInstance = {
+          state: row[0],
+          try_number: row[1],
+          start_ts: row[2],
+          duration: row[3],
+        };
+        node.instances[j] = taskInstance;
+
+        taskInstance.task_id = node.name;
+        taskInstance.operator = node.operator;
+        taskInstance.execution_date = dataInstance.execution_date;
+        taskInstance.external_trigger = dataInstance.external_trigger;
+
+        // compute start_date and end_date if applicable
+        if (taskInstance.start_ts !== null) {
+          taskInstance.start_date = toDateString(taskInstance.start_ts);
+          if (taskInstance.state === 'running') {
+            taskInstance.duration = now - taskInstance.start_ts;
+          } else if (taskInstance.duration !== null) {
+            taskInstance.end_date = toDateString(taskInstance.start_ts + taskInstance.duration);
+          }
+        }
+      } else {
         node.instances[j] = {
           task_id: node.name,
           execution_date: dataInstance.execution_date,
         };
-        continue;
-      }
-
-      const taskInstance = {
-        state: row[0],
-        try_number: row[1],
-        start_ts: row[2],
-        duration: row[3],
-      };
-      node.instances[j] = taskInstance;
-
-      taskInstance.task_id = node.name;
-      taskInstance.operator = node.operator;
-      taskInstance.execution_date = dataInstance.execution_date;
-      taskInstance.external_trigger = dataInstance.external_trigger;
-
-      // compute start_date and end_date if applicable
-      if (taskInstance.start_ts !== null) {
-        taskInstance.start_date = toDateString(taskInstance.start_ts);
-        if (taskInstance.state === 'running') {
-          taskInstance.duration = now - taskInstance.start_ts;
-        } else if (taskInstance.duration !== null) {
-          taskInstance.end_date = toDateString(taskInstance.start_ts + taskInstance.duration);
-        }
       }
     }
   }

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -24,6 +24,7 @@ import { escapeHtml } from './main';
 import tiTooltip from './task_instances';
 import getMetaValue from './meta_value';
 
+// dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
 
 function toDateString(ts) {

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -242,12 +242,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         taskTip.direction('e');
         taskTip.show(tt, this);
-        d3.select(this)
+        d3.select(this).transition().duration(duration)
           .style('stroke-width', 3);
       })
       .on('mouseout', function (d) {
         taskTip.hide(d);
-        d3.select(this)
+        d3.select(this).transition().duration(duration)
           .style('stroke-width', (dd) => (isDagRun(dd) ? '2' : '1'));
       })
       .attr('height', barHeight)
@@ -357,6 +357,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Transition links to their new position.
     link
+      .transition()
+      .duration(duration)
       .attr('d', diagonal);
 
     // Transition exiting nodes to the parent's new position.

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -22,6 +22,11 @@
 
 {% block page_title %}{{ dag.dag_id }} - {{ appbuilder.app_name }}{% endblock %}
 
+{% block head_meta %}
+  {{ super() }}
+  <meta name="dag_id" content="{{ dag.dag_id }}">
+{% endblock %}
+
 {% block head_css %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('switch.css') }}">

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -24,7 +24,6 @@
 
 {% block head_meta %}
   {{ super() }}
-  <meta name="dag_id" content="{{ dag.dag_id }}">
   <meta name="execution_date" content="{{ execution_date }}">
   <meta name="arrange" content="{{ arrange }}">
   <meta name="task_instances_url" content="{{ url_for('Airflow.task_instances') }}">

--- a/airflow/www/templates/airflow/ti_log.html
+++ b/airflow/www/templates/airflow/ti_log.html
@@ -22,7 +22,6 @@
 
 {% block head_meta %}
   {{ super() }}
-  <meta name="dag_id" content="{{ dag_id }}">
   <meta name="task_id" content="{{ task_id }}">
   <meta name="execution_date" content="{{ execution_date }}">
   <meta name="logs_with_metadata_url" content="{{ url_for('Airflow.get_logs_with_metadata') }}">

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -19,6 +19,12 @@
 
 {% extends "airflow/dag.html" %}
 {% block page_title %}{{ dag.dag_id }} - Tree - {{ appbuilder.app_name }}{% endblock %}
+{% from 'appbuilder/loading_dots.html' import loading_dots %}
+
+{% block head_meta %}
+  {{ super() }}
+  <meta name="dag_id" content="{{ dag.dag_id }}">
+{% endblock %}
 
 {% block head_css %}
   {{ super() }}
@@ -75,6 +81,21 @@
   <hr>
   <div id="svg_container">
     <img id='loading' width="50" src="{{ url_for('static', filename='loading.gif') }}">
+    <div id="error" style="display: none; margin-top: 10px;" class="alert alert-danger" role="alert">
+      <span class="material-icons" aria-hidden="true">error</span>
+      <span id="error_msg">Oops.</span>
+    </div>
+    <div class="refresh-actions">
+      {{ loading_dots(id='loading-dots', classes='refresh-loading') }}
+      <label class="switch-label">
+        <input class="switch-input" id="auto_refresh" type="checkbox">
+        <span class="switch" aria-hidden="true"></span>
+        Auto-refresh
+      </label>
+      <button class="btn btn-default btn-sm" id="refresh_button">
+        <span class="material-icons" aria-hidden="true">refresh</span>
+      </button>
+    </div>
     <svg id="tree-svg" class='tree' width="100%"></svg>
   </div>
 {% endblock %}

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -21,11 +21,6 @@
 {% block page_title %}{{ dag.dag_id }} - Tree - {{ appbuilder.app_name }}{% endblock %}
 {% from 'appbuilder/loading_dots.html' import loading_dots %}
 
-{% block head_meta %}
-  {{ super() }}
-  <meta name="dag_id" content="{{ dag.dag_id }}">
-{% endblock %}
-
 {% block head_css %}
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('tree.css') }}">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2708,7 +2708,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
 
         root = request.args.get('root')
         if root:
-            dag = dag.sub_dag(task_ids_or_regex=root, include_downstream=False, include_upstream=True)
+            dag = dag.partial_subset(task_ids_or_regex=root, include_downstream=False, include_upstream=True)
 
         base_date = request.args.get('base_date')
         num_runs = request.args.get('num_runs', type=int)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2043,7 +2043,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
             )
         dag_runs = {dr.execution_date: alchemy_to_dict(dr) for dr in dag_runs}
 
-        max_date = max(dag_runs, default=None)
+        max_date = max(dag_runs.keys(), default=None)
 
         form = DateTimeWithNumRunsForm(
             data={

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2703,8 +2703,14 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         dag = current_app.dag_bag.get_dag(dag_id)
 
         if not dag:
-            flash(f'DAG "{dag_id}" seems to be missing from DagBag.', "error")
-            return redirect(url_for('Airflow.index'))
+            response = jsonify(
+                {
+                    'error': f"can't find dag {dag_id}"
+                }
+            )
+            response.status_code = 404
+            return response
+
 
         root = request.args.get('root')
         if root:


### PR DESCRIPTION
Auto-refresh on Graph View was a very popular feature when 2.0.0 was released. This PR adds auto-refresh for Tree View.

- add a new `tree_data` endpoint to ping for updates every 3 seconds
- only rerender if the task instances have changed
- turn off autorefresh after there are no more `running` dag runs

![pr-gif](https://user-images.githubusercontent.com/4600967/115597018-63ede680-a29e-11eb-9678-52f9477a4a41.gif)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
