### PR TITLE
Chart: Fix passing upgrading strategies to Celery Worker

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -46,8 +46,13 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
-  {{ if .Values.workers.updateStrategy }}
-{{ toYaml .Values.workers.updateStrategy | indent 2 }}
+  {{- if and $persistence .Values.workers.updateStrategy }}
+  updateStrategy:
+    {{- toYaml .Values.workers.updateStrategy | nindent 4 }}
+  {{- end }}
+  {{- if and (not $persistence) (.Values.workers.strategy) }}
+  strategy:
+    {{- toYaml .Values.workers.strategy | nindent 4 }}
   {{- end }}
   template:
     metadata:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -561,8 +561,12 @@
                     "type": "integer"
                 },
                 "updateStrategy": {
-                    "description": "Specifies the strategy used to replace old Pods by new ones.",
-                    "type": "object"
+                    "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a StatefulSet.",
+                    "type": ["null", "object"]
+                },
+                "strategy": {
+                    "description": "Specifies the strategy used to replace old Pods by new ones when deployed as a Deployment.",
+                    "type": ["null", "object"]
                 },
                 "keda": {
                     "description": "KEDA configuration.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -299,11 +299,13 @@ kerberos:
 workers:
   # Number of airflow celery workers in StatefulSet
   replicas: 1
-  updateStrategy:
-    strategy:
-      rollingUpdate:
-        maxSurge: "100%"
-        maxUnavailable: "50%"
+  # Update Strategy when worker is deployed as a StatefulSet
+  updateStrategy: ~
+  # Update Strategy when worker is deployed as a Deployment
+  strategy:
+    rollingUpdate:
+      maxSurge: "100%"
+      maxUnavailable: "50%"
 
   # Allow KEDA autoscaling.
   # Persistence.enabled must be set to false to use KEDA.

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -280,7 +280,10 @@ The following tables lists the configurable parameters of the Airflow chart and 
      - HostAliases to use in Celery workers
      - ``[]``
    * - ``workers.updateStrategy``
-     - The strategy used to replace old Pods by new ones.
+     - The strategy used to replace old Pods by new ones persistence is enabled.
+     - ``~``
+   * - ``workers.strategy``
+     - The strategy used to replace old Pods by new ones when persistence is not enabled.
      - ``{"rollingUpdate": {"maxSurge": "100%", "maxUnavailable": "50%"}``
    * - ``scheduler.podDisruptionBudget.enabled``
      - Enable PDB on Airflow scheduler


### PR DESCRIPTION
We create a Statefulset if persistence is enabled and Deployment
otherwise. Upgrading strategies are different for both those types
of resources.

Statefulst needs `updateStrategy`, deployment needs `strategy`.

Without this fix, using Helm Chart with CeleryExecutor failed with

```
helm install airflow -n airflow --set executor=CeleryExecutor --set images.airflow.repository=k8s-dags --set images.airflow.tag=1.0.2 .
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec): unknown field "strategy" in io.k8s.api.apps.v1.StatefulSetSpec
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
