### PR TITLE
Automatically replace current Airflow version in docs

### DIFF
--- a/docs/apache-airflow/extra-packages-ref.rst
+++ b/docs/apache-airflow/extra-packages-ref.rst
@@ -84,14 +84,15 @@ For example the below command will install:
   * apache-airflow-providers-google
   * apache-airflow-providers-apache-spark
 
-with a consistent set of dependencies based on constraint files provided by Airflow Community at the time 2.0.2 version was released.
+with a consistent set of dependencies based on constraint files provided by Airflow Community at the time |version| version was released.
 
 .. code-block:: bash
+    :substitutions:
 
-    pip install apache-airflow[google,amazon,apache.spark]==2.0.2 \
-      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.6.txt"
+    pip install apache-airflow[google,amazon,apache.spark]==|version| \
+      --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.6.txt"
 
-Note, that this will install providers in the versions that were released at the time of Airflow 2.0.2 release. You can later
+Note, that this will install providers in the versions that were released at the time of Airflow |version| release. You can later
 upgrade those providers manually if you want to use latest versions of the providers.
 
 

--- a/docs/apache-airflow/installation.rst
+++ b/docs/apache-airflow/installation.rst
@@ -130,6 +130,7 @@ You need certain system level requirements in order to install Airflow. Those ar
 to be needed for Linux system (Tested on Ubuntu Buster LTS) :
 
 .. code-block:: bash
+   :substitutions:
 
    sudo apt-get install -y --no-install-recommends \
            freetds-bin \
@@ -162,7 +163,7 @@ not work or will produce unusable Airflow installation.
 In order to have repeatable installation, starting from **Airflow 1.10.10** and updated in
 **Airflow 1.10.13** we also keep a set of "known-to-be-working" constraint files in the
 ``constraints-master``, ``constraints-2-0`` and ``constraints-1-10`` orphan branches and then we create tag
-for each released version e.g. ``constraints-2.0.2``. This way, when we keep a tested and working set of dependencies.
+for each released version e.g. :subst-code:`constraints-|version|`. This way, when we keep a tested and working set of dependencies.
 
 Those "known-to-be-working" constraints are per major/minor Python version. You can use them as constraint
 files when installing Airflow from PyPI. Note that you have to specify correct Airflow version
@@ -176,7 +177,7 @@ You can create the URL to the file substituting the variables in the template be
 
 where:
 
-- ``AIRFLOW_VERSION`` - Airflow version (e.g. ``2.0.2``) or ``master``, ``2-0``, ``1-10`` for latest development version
+- ``AIRFLOW_VERSION`` - Airflow version (e.g. :subst-code:`|version|`) or ``master``, ``2-0``, ``1-10`` for latest development version
 - ``PYTHON_VERSION`` Python version e.g. ``3.8``, ``3.7``
 
 There is also a no-providers constraint file, which contains just constraints required to install Airflow core. This allows
@@ -201,8 +202,9 @@ you can use the script below to make an installation a one-liner (the example be
 postgres and google provider, as well as ``async`` extra.
 
 .. code-block:: bash
+    :substitutions:
 
-    AIRFLOW_VERSION=2.0.2
+    AIRFLOW_VERSION=|version|
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
     pip install "apache-airflow[async,postgres,google]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
@@ -219,8 +221,9 @@ being installed.
 
 
 .. code-block:: bash
+    :substitutions:
 
-    AIRFLOW_VERSION=2.0.2
+    AIRFLOW_VERSION=|version|
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
     pip install --upgrade "apache-airflow[postgres,google]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
@@ -255,12 +258,13 @@ You can also upgrade the providers to latest versions (you need to use master ve
 If you don't want to install any extra providers, initially you can use the command set below.
 
 .. code-block:: bash
+    :substitutions:
 
-    AIRFLOW_VERSION=2.0.2
+    AIRFLOW_VERSION=|version|
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     # For example: 3.6
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-no-providers-${PYTHON_VERSION}.txt"
-    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-no-providers-2.0.2/constraints-3.6.txt
+    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-no-providers-|version|/constraints-3.6.txt
     pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
 

--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -39,7 +39,7 @@
 version: '3'
 x-airflow-common:
   &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:master-python3.8}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:|version|}
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -82,11 +82,11 @@ On **all operating systems**, you need to run database migrations and create the
 
 After initialization is complete, you should see a message like below.
 
-.. code-block:: text
+.. parsed-literal::
 
     airflow-init_1       | Upgrades done
     airflow-init_1       | Admin user airflow created
-    airflow-init_1       | 2.1.0.dev0
+    airflow-init_1       | |version|
     start_airflow-init_1 exited with code 0
 
 The account created has the login ``airflow`` and the password ``airflow``.
@@ -102,16 +102,17 @@ Now you can start all services:
 
 In the second terminal you can check the condition of the containers and make sure that no containers are in unhealthy condition:
 
-.. code-block:: bash
+.. code-block:: text
+    :substitutions:
 
     $ docker ps
-    CONTAINER ID   IMAGE                             COMMAND                  CREATED          STATUS                    PORTS                              NAMES
-    247ebe6cf87a   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    8080/tcp                           compose_airflow-worker_1
-    ed9b09fc84b1   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    8080/tcp                           compose_airflow-scheduler_1
-    65ac1da2c219   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    0.0.0.0:5555->5555/tcp, 8080/tcp   compose_flower_1
-    7cb1fb603a98   apache/airflow:master-python3.8   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    0.0.0.0:8080->8080/tcp             compose_airflow-webserver_1
-    74f3bbe506eb   postgres:13                       "docker-entrypoint.s…"   18 minutes ago   Up 17 minutes (healthy)   5432/tcp                           compose_postgres_1
-    0bd6576d23cb   redis:latest                      "docker-entrypoint.s…"   10 hours ago     Up 17 minutes (healthy)   0.0.0.0:6379->6379/tcp             compose_redis_1
+    CONTAINER ID   IMAGE            |version-spacepad| COMMAND                  CREATED          STATUS                    PORTS                              NAMES
+    247ebe6cf87a   apache/airflow:|version|   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    8080/tcp                           compose_airflow-worker_1
+    ed9b09fc84b1   apache/airflow:|version|   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    8080/tcp                           compose_airflow-scheduler_1
+    65ac1da2c219   apache/airflow:|version|   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    0.0.0.0:5555->5555/tcp, 8080/tcp   compose_flower_1
+    7cb1fb603a98   apache/airflow:|version|   "/usr/bin/dumb-init …"   3 minutes ago    Up 3 minutes (healthy)    0.0.0.0:8080->8080/tcp             compose_airflow-webserver_1
+    74f3bbe506eb   postgres:13      |version-spacepad| "docker-entrypoint.s…"   18 minutes ago   Up 17 minutes (healthy)   5432/tcp                           compose_postgres_1
+    0bd6576d23cb   redis:latest     |version-spacepad| "docker-entrypoint.s…"   10 hours ago     Up 17 minutes (healthy)   0.0.0.0:6379->6379/tcp             compose_redis_1
 
 Accessing the environment
 =========================

--- a/docs/apache-airflow/start/local.rst
+++ b/docs/apache-airflow/start/local.rst
@@ -46,17 +46,18 @@ The installation of Airflow is painless if you are following the instructions be
 constraint files to enable reproducible installation, so using ``pip`` and constraint files is recommended.
 
 .. code-block:: bash
+    :substitutions:
 
     # airflow needs a home, ~/airflow is the default,
     # but you can lay foundation somewhere else if you prefer
     # (optional)
     export AIRFLOW_HOME=~/airflow
 
-    AIRFLOW_VERSION=2.0.2
+    AIRFLOW_VERSION=|version|
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     # For example: 3.6
     CONSTRAINT_URL="https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
-    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.6.txt
+    # For example: https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.6.txt
     pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
     # initialize the database

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -104,6 +104,10 @@ version = PACKAGE_VERSION
 # The full version, including alpha/beta/rc tags.
 release = PACKAGE_VERSION
 
+rst_epilog = f"""
+.. |version| replace:: {version}
+"""
+
 # -- General configuration -----------------------------------------------------
 # See: https://www.sphinx-doc.org/en/master/usage/configuration.html
 
@@ -124,6 +128,7 @@ extensions = [
     "sphinxcontrib.spelling",
     'sphinx_airflow_theme',
     'redirects',
+    'substitution_extensions',
 ]
 if PACKAGE_NAME == 'apache-airflow':
     extensions.extend(
@@ -132,6 +137,7 @@ if PACKAGE_NAME == 'apache-airflow':
             'sphinx.ext.graphviz',
             'sphinxcontrib.httpdomain',
             'sphinxcontrib.httpdomain',
+            'extra_files_with_substitutions',
             # First, generate redoc
             'sphinxcontrib.redoc',
             # Second, update redoc script
@@ -240,8 +246,10 @@ else:
     html_js_files = []
 if PACKAGE_NAME == 'apache-airflow':
     html_extra_path = [
-        f"{ROOT_DIR}/docs/apache-airflow/start/docker-compose.yaml",
         f"{ROOT_DIR}/docs/apache-airflow/start/airflow.sh",
+    ]
+    html_extra_with_substituions = [
+        f"{ROOT_DIR}/docs/apache-airflow/start/docker-compose.yaml",
     ]
 
 # -- Theme configuration -------------------------------------------------------

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -32,7 +32,7 @@ Those are the most common arguments that you use when you want to build a custom
 +==========================================+==========================================+==========================================+
 | ``PYTHON_BASE_IMAGE``                    | ``python:3.6-slim-buster``               | Base python image.                       |
 +------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_VERSION``                      | ``2.0.2``                                | version of Airflow.                      |
+| ``AIRFLOW_VERSION``                      | :subst-code:`|version|`                  | version of Airflow.                      |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 | ``AIRFLOW_EXTRAS``                       | (see Dockerfile)                         | Default extras with which airflow is     |
 |                                          |                                          | installed.                               |
@@ -64,7 +64,7 @@ Those are the most common arguments that you use when you want to build a custom
 |                                          |                                          | 2.0.* installation. In case of building  |
 |                                          |                                          | specific version you want to point it    |
 |                                          |                                          | to specific tag, for example             |
-|                                          |                                          | ``constraints-2.0.2``.                   |
+|                                          |                                          | :subst-code:`constraints-|version|`.     |
 |                                          |                                          | Auto-detected if empty.                  |
 +------------------------------------------+------------------------------------------+------------------------------------------+
 

--- a/docs/exts/extra_files_with_substitutions.py
+++ b/docs/exts/extra_files_with_substitutions.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+
+
+def copy_docker_compose(app, exception):
+    """Sphinx "build-finished" event handler."""
+    from sphinx.builders import html as builders
+
+    if exception or not isinstance(app.builder, builders.StandaloneHTMLBuilder):
+        return
+
+    # Replace `|version|` in the docker-compose.yaml that we produce in the built docs
+    for path in app.config.html_extra_with_substituions:
+        with open(path) as file:
+            with open(os.path.join(app.outdir, os.path.basename(path)), "w") as output:
+                for line in file:
+                    output.write(line.replace('|version|', app.config.version))
+
+
+def setup(app):
+    """Setup plugin"""
+    app.connect("build-finished", copy_docker_compose)
+
+    app.add_config_value("html_extra_with_substituions", [], '[str]')
+
+    return {
+        'parallel_write_safe': True,
+    }

--- a/docs/exts/substitution_extensions.py
+++ b/docs/exts/substitution_extensions.py
@@ -1,0 +1,127 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# from __future__ import annotations
+
+import logging
+from typing import Any, List, Tuple, Union
+
+from docutils import nodes
+from docutils.nodes import Node, system_message
+from docutils.parsers.rst import Directive, directives
+from docutils.parsers.rst.roles import code_role
+from sphinx.application import Sphinx
+from sphinx.transforms import SphinxTransform
+from sphinx.transforms.post_transforms.code import HighlightLanguageTransform
+
+LOGGER = logging.getLogger(__name__)
+
+OriginalCodeBlock: Directive = directives._directives['code-block']  # pylint: disable=protected-access
+
+_SUBSTITUTION_OPTION_NAME = 'substitutions'
+
+
+class SubstitutionCodeBlock(OriginalCodeBlock):  # type: ignore
+    """Similar to CodeBlock but replaces placeholders with variables."""
+
+    option_spec = OriginalCodeBlock.option_spec.copy()
+    option_spec[_SUBSTITUTION_OPTION_NAME] = directives.flag
+
+    def run(self) -> list:
+        """Decorate code block so that SubstitutionCodeBlockTransform will notice it"""
+        [node] = super().run()
+
+        if _SUBSTITUTION_OPTION_NAME in self.options:
+            node.attributes['substitutions'] = True
+        return [node]
+
+
+class SubstitutionCodeBlockTransform(SphinxTransform):
+    """Substitue ``|variables|`` in code and code-block nodes"""
+
+    # Run before we highlight the code!
+    default_priority = HighlightLanguageTransform.default_priority - 1
+
+    def apply(self, **kwargs: Any) -> None:
+        def condition(node):
+            return isinstance(node, (nodes.literal_block, nodes.literal))
+
+        for node in self.document.traverse(condition):  # type: Union[nodes.literal_block, nodes.literal]
+            if _SUBSTITUTION_OPTION_NAME not in node:
+                continue
+
+            # Some nodes don't have a direct document property, so walk up until we find it
+            document = node.document
+            parent = node.parent
+            while document is None:
+                parent = parent.parent
+                document = parent.document
+
+            substitution_defs = document.substitution_defs
+            for child in node.children:
+                old_child = child
+                for name, value in substitution_defs.items():
+                    replacement = value.astext()
+                    child = nodes.Text(child.replace(f'|{name}|', replacement))
+                node.replace(old_child, child)
+
+            # The highlighter checks this -- without this, it will refuse to apply highlighting
+            node.rawsource = node.astext()
+
+
+def substitution_code_role(*args, **kwargs) -> Tuple[List[Node], List[system_message]]:
+    """Decorate an inline code so that SubstitutionCodeBlockTransform will notice it"""
+    [node], system_messages = code_role(*args, **kwargs)
+    node[_SUBSTITUTION_OPTION_NAME] = True
+
+    return [node], system_messages
+
+
+substitution_code_role.options = {  # type: ignore
+    'class': directives.class_option,
+    'language': directives.unchanged,
+}
+
+
+class AddSpacepadSubstReference(SphinxTransform):
+    """
+    Add a custom ``|version-spacepad|`` replacement definition
+
+    Since this desired replacement text is all just whitespace, we can't use
+    the normal RST to define this, we instead of to create this definition
+    manually after docutils has parsed the source files.
+    """
+
+    # Run as early as possible
+    default_priority = 1
+
+    def apply(self, **kwargs: Any) -> None:
+        substitution_defs = self.document.substitution_defs
+        version = substitution_defs['version'].astext()
+        pad = " " * len(version)
+        substitution_defs['version-spacepad'] = nodes.substitution_definition(version, pad)
+        ...
+
+
+def setup(app: Sphinx) -> dict:
+    """Setup plugin"""
+    app.add_config_value('substitutions', [], 'html')
+    directives.register_directive('code-block', SubstitutionCodeBlock)
+    app.add_role('subst-code', substitution_code_role)
+    app.add_post_transform(SubstitutionCodeBlockTransform)
+    app.add_post_transform(AddSpacepadSubstReference)
+    return {'parallel_write_safe': True}


### PR DESCRIPTION
There are a number of places where we want the current Airflow version
to appear in the docs, and sphinx has this build in, `|version|`.

But sadly that only works for "inline text", it doesn't work in code
blocks or inline code. This PR also adds two custom plugins that make
this work inspired by
https://github.com/adamtheturtle/sphinx-substitution-extensions (but
entirely re-written as that module Just Didn't Work), and another one that does
similar in the "html_extra_files"

This means PRs like #15459 won't be needed in the future as it is all handled automatically
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).