### PR TITLE
Fix rendering of ``object_name`` in ``GCSToLocalFilesystemOperator``

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -119,7 +119,7 @@ class GCSToLocalFilesystemOperator(BaseOperator):
 
         super().__init__(**kwargs)
         self.bucket = bucket
-        self.object = object_name
+        self.object_name = object_name
         self.filename = filename  # noqa
         self.store_to_xcom_key = store_to_xcom_key  # noqa
         self.gcp_conn_id = gcp_conn_id
@@ -127,7 +127,7 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         self.impersonation_chain = impersonation_chain
 
     def execute(self, context):
-        self.log.info('Executing download: %s, %s, %s', self.bucket, self.object, self.filename)
+        self.log.info('Executing download: %s, %s, %s', self.bucket, self.object_name, self.filename)
         hook = GCSHook(
             gcp_conn_id=self.gcp_conn_id,
             delegate_to=self.delegate_to,
@@ -135,10 +135,10 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         )
 
         if self.store_to_xcom_key:
-            file_bytes = hook.download(bucket_name=self.bucket, object_name=self.object)
+            file_bytes = hook.download(bucket_name=self.bucket, object_name=self.object_name)
             if sys.getsizeof(file_bytes) < MAX_XCOM_SIZE:
                 context['ti'].xcom_push(key=self.store_to_xcom_key, value=str(file_bytes))
             else:
                 raise AirflowException('The size of the downloaded file is too large to push to XCom!')
         else:
-            hook.download(bucket_name=self.bucket, object_name=self.object, filename=self.filename)
+            hook.download(bucket_name=self.bucket, object_name=self.object_name, filename=self.filename)


### PR DESCRIPTION

https://github.com/apache/airflow/pull/14918 made coms consistency changes
where the template_fields was changed for ``GCSToLocalFilesystemOperator``.

While the change was correct since``object`` param was deprecated, the
instance attribute wasn't updated hence you see this error:

```
AttributeError: 'GCSToLocalFilesystemOperator' object has no attribute 'object_name'
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
