### PR TITLE
Handle kubernetes watcher stream disconnection

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -113,7 +113,6 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         resource_version: str,
         scheduler_job_id: Optional[str],
         kube_config: Configuration,
-        allow_watch_bookmarks: bool = True,
     ):
         super().__init__()
         self.namespace = namespace
@@ -122,7 +121,6 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         self.watcher_queue = watcher_queue
         self.resource_version = resource_version
         self.kube_config = kube_config
-        self.allow_watch_bookmarks = allow_watch_bookmarks
 
     def run(self) -> None:
         """Performs watching"""
@@ -177,8 +175,6 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         kwargs = {
             'label_selector': f'airflow-worker={scheduler_job_id}',
             'resource_version': resource_version,
-            'allow_watch_bookmarks': self.allow_watch_bookmarks,
-            # see https://kubernetes.io/docs/reference/using-api/api-concepts/#watch-bookmarks
         }
         if kube_config.kube_client_request_args:
             for key, value in kube_config.kube_client_request_args.items():

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -677,7 +677,6 @@ class TestKubernetesJobWatcher(unittest.TestCase):
             resource_version="0",
             scheduler_job_id="123",
             kube_config=mock.MagicMock(),
-            allow_watch_bookmarks=True,
         )
         self.kube_client = mock.MagicMock()
         self.core_annotations = {

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -677,6 +677,7 @@ class TestKubernetesJobWatcher(unittest.TestCase):
             resource_version="0",
             scheduler_job_id="123",
             kube_config=mock.MagicMock(),
+            allow_watch_bookmarks=True,
         )
         self.kube_client = mock.MagicMock()
         self.core_annotations = {


### PR DESCRIPTION
Currently, when Kubernetes watch stream times out and we get error 410,
we just return resource version '0' which is not the latest version.

From the documentation, timing out is expected and we should handle it
by performing a list>watch>relist operation so we can continue watching
from the latest resource version. See https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes

This PR follows the list>watch>relist pattern

Closes: #15418
This would likely fix some issues #14175, #13916, and #12644 (comment)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
