### PR TITLE
Fixes failing tests for helm chart after changing default version

### DIFF
--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -34,8 +34,8 @@ class CleanupPodsTest(unittest.TestCase):
         assert "airflow-cleanup-pods" == jmespath.search(
             "spec.jobTemplate.spec.template.spec.containers[0].name", docs[0]
         )
-        assert "apache/airflow:2.0.0" == jmespath.search(
-            "spec.jobTemplate.spec.template.spec.containers[0].image", docs[0]
+        assert jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].image", docs[0]).startswith(
+            'apache/airflow'
         )
         assert {"name": "config", "configMap": {"name": "RELEASE-NAME-airflow-config"}} in jmespath.search(
             "spec.jobTemplate.spec.template.spec.volumes", docs[0]


### PR DESCRIPTION
After changing default Airflow version in #15497 the test started
failing. This change fixes it and makes the test works no matter
the version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
