### PR TITLE
Change KPO node_selectors warning to proper deprecationwarning

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -250,12 +250,14 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         self.image_pull_policy = image_pull_policy
         if node_selectors:
             # Node selectors is incorrect based on k8s API
-            warnings.warn("node_selectors is deprecated. Please use node_selector instead.")
-            self.node_selector = node_selectors or {}
+            warnings.warn(
+                "node_selectors is deprecated. Please use node_selector instead.", DeprecationWarning
+            )
+            self.node_selector = node_selectors
         elif node_selector:
-            self.node_selector = node_selector or {}
+            self.node_selector = node_selector
         else:
-            self.node_selector = None
+            self.node_selector = {}
         self.annotations = annotations or {}
         self.affinity = convert_affinity(affinity) if affinity else k8s.V1Affinity()
         self.k8s_resources = convert_resources(resources) if resources else {}

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -876,6 +876,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 'hostNetwork': False,
                 'imagePullSecrets': [],
                 'initContainers': [],
+                'nodeSelector': {},
                 'restartPolicy': 'Never',
                 'securityContext': {},
                 'serviceAccountName': 'default',

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -105,6 +105,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 'hostNetwork': False,
                 'imagePullSecrets': [],
                 'initContainers': [],
+                'nodeSelector': {},
                 'restartPolicy': 'Never',
                 'securityContext': {},
                 'serviceAccountName': 'default',

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -103,6 +103,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 'hostNetwork': False,
                 'imagePullSecrets': [],
                 'initContainers': [],
+                'nodeSelector': {},
                 'restartPolicy': 'Never',
                 'securityContext': {},
                 'serviceAccountName': 'default',

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -495,19 +495,22 @@ class TestKubernetesPodOperator(unittest.TestCase):
         assert sanitized_pod["spec"]["nodeSelector"] == node_selector
 
         # repeat tests using deprecated parameter
-        k = KubernetesPodOperator(
-            namespace="default",
-            image="ubuntu:16.04",
-            cmds=["bash", "-cx"],
-            arguments=["echo 10"],
-            labels={"foo": "bar"},
-            name="name",
-            task_id="task",
-            in_cluster=False,
-            do_xcom_push=False,
-            cluster_context="default",
-            node_selectors=node_selector,
-        )
+        with pytest.warns(
+            DeprecationWarning, match="node_selectors is deprecated. Please use node_selector instead."
+        ):
+            k = KubernetesPodOperator(
+                namespace="default",
+                image="ubuntu:16.04",
+                cmds=["bash", "-cx"],
+                arguments=["echo 10"],
+                labels={"foo": "bar"},
+                name="name",
+                task_id="task",
+                in_cluster=False,
+                do_xcom_push=False,
+                cluster_context="default",
+                node_selectors=node_selector,
+            )
 
         pod = k.create_pod_request_obj()
         sanitized_pod = self.sanitize_for_serialization(pod)


### PR DESCRIPTION
Changes the warning KPO raises when `node_selectors` is used into a `DeprecationWarning` and also simplifies that code path.