### PR TITLE
Remove condition field from depends_on for Docker Compose version 3 file.

### DIFF
--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -56,10 +56,8 @@ x-airflow-common:
     - ./plugins:/opt/airflow/plugins
   user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
   depends_on:
-    redis:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
+    - redis
+    - postgres
 
 services:
   postgres:


### PR DESCRIPTION
Docker Compose version 3 does not support the `condition` field for `depends_on` objects (see https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on). The current use of `condition` can be confusing (I was confused by it at first).

This change removes the `condition` fields and makes the `depends_on` a list. 

This should present no problems with the current state of the application as it simply fixes a yaml file structure.