### PR TITLE
OdbcHook returns None. Related to #15016 issue.

### DIFF
--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -162,7 +162,6 @@ class OdbcHook(DbApiHook):
 
         If ``attrs_before`` provided, keys and values are converted to int, as required by pyodbc.
         """
-
         conn_connect_kwargs = self.connection_extra_lower.get('connect_kwargs', {})
         hook_connect_kwargs = self._connect_kwargs or {}
         merged_connect_kwargs = merge_dicts(conn_connect_kwargs, hook_connect_kwargs)

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -171,6 +171,8 @@ class OdbcHook(DbApiHook):
                     return True
                 elif val.lower() == 'false':
                     return False
+                else:
+                    return val
             else:
                 return val
 

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -171,7 +171,7 @@ class OdbcHook(DbApiHook):
                 int(k): int(v) for k, v in merged_connect_kwargs['attrs_before'].items()
             }
 
-        return {k: v for k, v in merged_connect_kwargs.items()}
+        return merged_connect_kwargs
 
     def get_conn(self) -> pyodbc.Connection:
         """Returns a pyodbc connection object."""

--- a/airflow/providers/odbc/hooks/odbc.py
+++ b/airflow/providers/odbc/hooks/odbc.py
@@ -160,21 +160,8 @@ class OdbcHook(DbApiHook):
 
         Hook ``connect_kwargs`` precedes ``connect_kwargs`` from conn extra.
 
-        String values for 'true' and 'false' are converted to bool type.
-
         If ``attrs_before`` provided, keys and values are converted to int, as required by pyodbc.
         """
-
-        def clean_bool(val):  # pylint: disable=inconsistent-return-statements
-            if hasattr(val, 'lower'):
-                if val.lower() == 'true':
-                    return True
-                elif val.lower() == 'false':
-                    return False
-                else:
-                    return val
-            else:
-                return val
 
         conn_connect_kwargs = self.connection_extra_lower.get('connect_kwargs', {})
         hook_connect_kwargs = self._connect_kwargs or {}
@@ -185,7 +172,7 @@ class OdbcHook(DbApiHook):
                 int(k): int(v) for k, v in merged_connect_kwargs['attrs_before'].items()
             }
 
-        return {k: clean_bool(v) for k, v in merged_connect_kwargs.items()}
+        return {k: v for k, v in merged_connect_kwargs.items()}
 
     def get_conn(self) -> pyodbc.Connection:
         """Returns a pyodbc connection object."""

--- a/docs/apache-airflow-providers-odbc/connections/odbc.rst
+++ b/docs/apache-airflow-providers-odbc/connections/odbc.rst
@@ -111,8 +111,8 @@ Extra (optional)
           "ApplicationIntent": "ReadOnly",
           "TrustedConnection": "Yes",
           "connect_kwargs": {
-            "autocommit": "false",
-            "ansi": "true"
+            "autocommit": false,
+            "ansi": true
           }
         }
 

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -161,7 +161,7 @@ class TestOdbcHook:
         """
         Bools will be parsed from uri as strings
         """
-        conn_extra = json.dumps(dict(connect_kwargs={'ansi': true}))
+        conn_extra = json.dumps(dict(connect_kwargs={'ansi': True}))
         hook = self.get_hook(conn_params=dict(extra=conn_extra))
         assert hook.connect_kwargs == {
             'ansi': True,

--- a/tests/providers/odbc/hooks/test_odbc.py
+++ b/tests/providers/odbc/hooks/test_odbc.py
@@ -161,7 +161,7 @@ class TestOdbcHook:
         """
         Bools will be parsed from uri as strings
         """
-        conn_extra = json.dumps(dict(connect_kwargs={'ansi': 'true'}))
+        conn_extra = json.dumps(dict(connect_kwargs={'ansi': true}))
         hook = self.get_hook(conn_params=dict(extra=conn_extra))
         assert hook.connect_kwargs == {
             'ansi': True,


### PR DESCRIPTION
This PR is related to #15016 issue.
OdbcHook returns None for non-boolean-like string values in connect_kwargs dict arg, however connect_kwarg values should remain as is in this case.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
