### PR TITLE
Finish refactor of DAG resource name helper

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -582,17 +582,17 @@ class DagBag(LoggingMixin):
         """Sync DAG specific permissions, if necessary"""
         from flask_appbuilder.security.sqla import models as sqla_models
 
-        from airflow.security.permissions import DAG_PERMS, permission_name_for_dag
+        from airflow.security.permissions import DAG_PERMS, resource_name_for_dag
 
         def needs_perm_views(dag_id: str) -> bool:
-            view_menu_name = permission_name_for_dag(dag_id)
+            dag_resource_name = resource_name_for_dag(dag_id)
             for permission_name in DAG_PERMS:
                 if not (
                     session.query(sqla_models.PermissionView)
                     .join(sqla_models.Permission)
                     .join(sqla_models.ViewMenu)
                     .filter(sqla_models.Permission.name == permission_name)
-                    .filter(sqla_models.ViewMenu.name == view_menu_name)
+                    .filter(sqla_models.ViewMenu.name == dag_resource_name)
                     .one_or_none()
                 ):
                     return True

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -63,8 +63,8 @@ DEPRECATED_ACTION_CAN_DAG_EDIT = "can_dag_edit"
 DAG_PERMS = {ACTION_CAN_READ, ACTION_CAN_EDIT}
 
 
-def permission_name_for_dag(dag_id):
-    """Returns the permission name for a DAG id."""
+def resource_name_for_dag(dag_id):
+    """Returns the resource name for a DAG id."""
     if dag_id == RESOURCE_DAG:
         return dag_id
 


### PR DESCRIPTION
This finishes moving `prefixed_dag_id` into `airflow.security.permissions.resource_name_for_dag`.