### PR TITLE
Removes unnecessary AzureContainerInstance connection type

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
@@ -44,7 +44,7 @@ with DAG(
 ) as dag:
 
     t1 = AzureContainerInstancesOperator(
-        ci_conn_id='azure_container_instances_default',
+        ci_conn_id='azure_default',
         registry_conn_id=None,
         resource_group='resource-group',
         name='aci-test-{{ ds }}',

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -18,7 +18,7 @@
 #
 
 import warnings
-from typing import Any, Dict
+from typing import Any
 
 from azure.mgmt.containerinstance import ContainerInstanceManagementClient
 from azure.mgmt.containerinstance.models import ContainerGroup
@@ -36,60 +36,13 @@ class AzureContainerInstanceHook(AzureBaseHook):
     client_id (Application ID) as login, the generated password as password,
     and tenantId and subscriptionId in the extra's field as a json.
 
-    :param azure_conn_id: :ref:`Azure connection id<howto/connection:azure>` of
+    :param conn_id: :ref:`Azure connection id<howto/connection:azure>` of
         a service principal which will be used to start the container instance.
     :type azure_conn_id: str
     """
 
-    conn_name_attr = 'azure_conn_id'
-    default_conn_name = 'azure_default'
-    conn_type = 'azure_container_instances'
-    hook_name = 'Azure Container Instance'
-
-    @staticmethod
-    def get_connection_form_widgets() -> Dict[str, Any]:
-        """Returns connection widgets to add to connection form"""
-        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
-        from flask_babel import lazy_gettext
-        from wtforms import StringField
-
-        return {
-            "extra__azure__tenantId": StringField(
-                lazy_gettext('Azure Tenant ID'), widget=BS3TextFieldWidget()
-            ),
-            "extra__azure__subscriptionId": StringField(
-                lazy_gettext('Azure Subscription ID'), widget=BS3TextFieldWidget()
-            ),
-        }
-
-    @staticmethod
-    def get_ui_field_behaviour() -> Dict:
-        """Returns custom field behaviour"""
-        import json
-
-        return {
-            "hidden_fields": ['schema', 'port', 'host'],
-            "relabeling": {
-                'login': 'Azure Client ID',
-                'password': 'Azure Secret',
-            },
-            "placeholders": {
-                'extra': json.dumps(
-                    {
-                        "key_path": "path to json file for auth",
-                        "key_json": "specifies json dict for auth",
-                    },
-                    indent=1,
-                ),
-                'login': 'client id (token credentials auth)',
-                'password': 'secret (token credentials auth)',
-                'extra__azure__tenantId': 'tenant id (token credentials auth)',
-                'extra__azure__subscriptionId': 'subscription id (token credentials auth)',
-            },
-        }
-
-    def __init__(self, conn_id: str = default_conn_name) -> None:
-        super().__init__(sdk_client=ContainerInstanceManagementClient, conn_id=conn_id)
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(sdk_client=ContainerInstanceManagementClient, *args, **kwargs)
         self.connection = self.get_conn()
 
     def create_or_update(self, resource_group: str, name: str, container_group: ContainerGroup) -> None:

--- a/airflow/providers/microsoft/azure/hooks/base_azure.py
+++ b/airflow/providers/microsoft/azure/hooks/base_azure.py
@@ -31,7 +31,7 @@ class AzureBaseHook(BaseHook):
 
     :param sdk_client: The SDKClient to use.
     :type sdk_client: Optional[str]
-    :param azure_conn_id: The :ref:`Azure connection id<howto/connection:azure>`
+    :param conn_id: The :ref:`Azure connection id<howto/connection:azure>`
         which refers to the information to connect to the service.
     :type: str
     """
@@ -78,7 +78,7 @@ class AzureBaseHook(BaseHook):
                 ),
                 'login': 'client_id (token credentials auth)',
                 'password': 'secret (token credentials auth)',
-                'extra__azure__tenantId': 'tenentId (token credentials auth)',
+                'extra__azure__tenantId': 'tenantId (token credentials auth)',
                 'extra__azure__subscriptionId': 'subscriptionId (token credentials auth)',
             },
         }

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -111,14 +111,6 @@ def create_default_connections(session=None):
     )
     merge_conn(
         Connection(
-            conn_id="azure_container_instances_default",
-            conn_type="azure_container_instances",
-            extra='{"tenantId": "<TENANT>", "subscriptionId": "<SUBSCRIPTION ID>" }',
-        ),
-        session,
-    )
-    merge_conn(
-        Connection(
             conn_id="azure_cosmos_default",
             conn_type="azure_cosmos",
             extra='{"database_name": "<DATABASE_NAME>", "collection_name": "<COLLECTION_NAME>" }',
@@ -141,6 +133,13 @@ def create_default_connections(session=None):
             conn_id="azure_data_lake_default",
             conn_type="azure_data_lake",
             extra='{"tenant": "<TENANT>", "account_name": "<ACCOUNTNAME>" }',
+        ),
+        session,
+    )
+    merge_conn(
+        Connection(
+            conn_id="azure_default",
+            conn_type="azure",
         ),
         session,
     )

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -118,7 +118,7 @@ function discover_all_hooks() {
     group_start "Listing available hooks via 'airflow providers hooks'"
     COLUMNS=180 airflow providers hooks
 
-    local expected_number_of_hooks=65
+    local expected_number_of_hooks=64
     local actual_number_of_hooks
     actual_number_of_hooks=$(airflow providers hooks --output table | grep -c "| apache" | xargs)
     if [[ ${actual_number_of_hooks} != "${expected_number_of_hooks}" ]]; then
@@ -176,7 +176,7 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-    local expected_number_of_connections_with_behaviours=21
+    local expected_number_of_connections_with_behaviours=20
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -93,7 +93,6 @@ CONNECTIONS_LIST = [
     'aws',
     'azure',
     'azure_batch',
-    'azure_container_instances',
     'azure_container_registry',
     'azure_cosmos',
     'azure_data_explorer',
@@ -205,7 +204,6 @@ CONNECTION_FORM_WIDGETS = [
 CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
     'azure',
     'azure_batch',
-    'azure_container_instances',
     'azure_container_registry',
     'azure_cosmos',
     'azure_data_explorer',


### PR DESCRIPTION
The AzureContainerInstanceHook was derived from AzureBaseHook
and it did not add any new connection fields. Instead
it duplicated the tennantId and subscriptionId extr behaviour,
but it never worked, because it duplicated the fields
from the AzureBaseHook - and caused a lot of warnings when
AzureProvider was added.

This change sets the default connection type for the
AzureContainerInstanceHook to be azure_default and the
connection type to be 'azure'.

Those defaults are much more 'sane'. The existing connections
will continue to work, only when you open them in the UI, they
will display the extras directly rather than in dedicated fields
until the user changes the connection type to "azure" which will
fix the display.

So no disruptions, just temporary UI/Editing glitch. No more warnings
printed when Azure provider is added.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
