### PR TITLE
Relax the version constraint of rich

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -136,7 +136,7 @@ install_requires =
     # More info: https://github.com/apache/airflow/issues/13149#issuecomment-748705193
     python3-openid~=3.2
     requests>=2.20.0
-    rich==9.2.0
+    rich>=9.2.0
     setproctitle>=1.1.8, <2
     # SQLAlchemy 1.4 breaks sqlalchemy-utils https://github.com/kvesteri/sqlalchemy-utils/issues/505
     sqlalchemy>=1.3.18, <1.4


### PR DESCRIPTION
`rich` is used in cli to print tables to the terminal, as well as in settings.py to print deprecation warnings. Neither uses require the version constraint.

fixes #15529