### PR TITLE
Expose snowflake query_id in snowflake hook and operator, support multiple statements in sql string

### DIFF
--- a/airflow/providers/snowflake/example_dags/example_snowflake.py
+++ b/airflow/providers/snowflake/example_dags/example_snowflake.py
@@ -88,10 +88,10 @@ snowflake_op_sql_list = SnowflakeOperator(
 )
 
 snowflake_op_sql_multiple_stmts = SnowflakeOperator(
-    task_id='snowflake_op_sql_multiple_stmts', 
-    dag=dag, 
-    snowflake_conn_id=SNOWFLAKE_CONN_ID, 
-    sql=SNOWFLAKE_MULTIPLE_STMTS
+    task_id='snowflake_op_sql_multiple_stmts',
+    dag=dag,
+    snowflake_conn_id=SNOWFLAKE_CONN_ID,
+    sql=SQL_MULTIPLE_STMTS,
 )
 
 snowflake_op_template_file = SnowflakeOperator(

--- a/airflow/providers/snowflake/example_dags/example_snowflake.py
+++ b/airflow/providers/snowflake/example_dags/example_snowflake.py
@@ -88,7 +88,10 @@ snowflake_op_sql_list = SnowflakeOperator(
 )
 
 snowflake_op_sql_multiple_stmts = SnowflakeOperator(
-    task_id='snowflake_op_sql_list', dag=dag, snowflake_conn_id=SNOWFLAKE_CONN_ID, sql=SQL_LIST
+    task_id='snowflake_op_sql_multiple_stmts', 
+    dag=dag, 
+    snowflake_conn_id=SNOWFLAKE_CONN_ID, 
+    sql=SNOWFLAKE_MULTIPLE_STMTS
 )
 
 snowflake_op_template_file = SnowflakeOperator(

--- a/airflow/providers/snowflake/example_dags/example_snowflake.py
+++ b/airflow/providers/snowflake/example_dags/example_snowflake.py
@@ -41,6 +41,7 @@ CREATE_TABLE_SQL_STRING = (
 )
 SQL_INSERT_STATEMENT = f"INSERT INTO {SNOWFLAKE_SAMPLE_TABLE} VALUES ('name', %(id)s)"
 SQL_LIST = [SQL_INSERT_STATEMENT % {"id": n} for n in range(0, 10)]
+SQL_MULTIPLE_STMTS = "; ".join(SQL_LIST)
 SNOWFLAKE_SLACK_SQL = f"SELECT name, id FROM {SNOWFLAKE_SAMPLE_TABLE} LIMIT 10;"
 SNOWFLAKE_SLACK_MESSAGE = (
     "Results in an ASCII table:\n```{{ results_df | tabulate(tablefmt='pretty', headers='keys') }}```"
@@ -83,6 +84,10 @@ snowflake_op_with_params = SnowflakeOperator(
 )
 
 snowflake_op_sql_list = SnowflakeOperator(
+    task_id='snowflake_op_sql_list', dag=dag, snowflake_conn_id=SNOWFLAKE_CONN_ID, sql=SQL_LIST
+)
+
+snowflake_op_sql_multiple_stmts = SnowflakeOperator(
     task_id='snowflake_op_sql_list', dag=dag, snowflake_conn_id=SNOWFLAKE_CONN_ID, sql=SQL_LIST
 )
 
@@ -130,6 +135,7 @@ slack_report = SnowflakeToSlackOperator(
         snowflake_op_sql_list,
         snowflake_op_template_file,
         copy_into_table,
+        snowflake_op_sql_multiple_stmts,
     ]
     >> slack_report
 )

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -141,7 +141,7 @@ class SnowflakeHook(DbApiHook):
         self.schema = kwargs.pop("schema", None)
         self.authenticator = kwargs.pop("authenticator", None)
         self.session_parameters = kwargs.pop("session_parameters", None)
-        self.query_id = None
+        self.query_ids = []
 
     def _get_conn_params(self) -> Dict[str, Optional[str]]:
         """
@@ -254,8 +254,8 @@ class SnowflakeHook(DbApiHook):
         statements to the sql parameter to get them to execute
         sequentially
 
-        :param sql: the sql statement to be executed (str) or a list of
-            sql statements to execute
+        :param sql: the sql string to be executed with possibly multiple statements,
+          or a list of sql statements to execute
         :type sql: str or list
         :param autocommit: What to set the connection's autocommit setting to
             before executing the query.
@@ -263,22 +263,35 @@ class SnowflakeHook(DbApiHook):
         :param parameters: The parameters to render the SQL query with.
         :type parameters: dict or iterable
         """
-        if isinstance(sql, str):
-            sql = [sql]
+        self.query_ids = []
 
-        with closing(self.get_conn()) as conn:
+        # with self.get_conn() as conn:
+        for x in [1]:
+            conn = self.get_conn()
             self.set_autocommit(conn, autocommit)
 
-            with closing(conn.cursor()) as cur:
-                for sql_statement in sql:
+            if isinstance(sql, str):
+                cursors = conn.execute_string(sql, return_cursors=True)
+                for cur in cursors:
+                    self.query_ids.append(cur.sfqid)
 
-                    self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
-                    if parameters:
-                        cur.execute(sql_statement, parameters)
-                    else:
-                        cur.execute(sql_statement)
                     self.log.info("Rows affected: %s", cur.rowcount)
-                    self.query_id = cur.sfqid
+                    self.log.info("Snowflake query id: %s", cur.sfqid)
+                    cur.close()
+
+            elif isinstance(sql, list):
+                self.log.debug("Executing %d statements against Snowflake DB", len(sql))
+                with closing(conn.cursor()) as cur:
+                    for sql_statement in sql:
+
+                        self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
+                        if parameters:
+                            cur.execute(sql_statement, parameters)
+                        else:
+                            cur.execute(sql_statement)
+                        self.log.info("Rows affected: %s", cur.rowcount)
+                        self.log.info("Snowflake query id: %s", cur.sfqid)
+                        self.query_ids.append(cur.sfqid)
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -15,7 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Optional, Tuple
+from contextlib import closing
+from typing import Any, Dict, Optional, Tuple, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -140,6 +141,7 @@ class SnowflakeHook(DbApiHook):
         self.schema = kwargs.pop("schema", None)
         self.authenticator = kwargs.pop("authenticator", None)
         self.session_parameters = kwargs.pop("session_parameters", None)
+        self.query_id = None
 
     def _get_conn_params(self) -> Dict[str, Optional[str]]:
         """
@@ -245,3 +247,40 @@ class SnowflakeHook(DbApiHook):
 
     def get_autocommit(self, conn):
         return getattr(conn, 'autocommit_mode', False)
+
+    def run(self, sql: Union[str, list], autocommit: bool = False, parameters: Optional[dict] = None):
+        """
+        Runs a command or a list of commands. Pass a list of sql
+        statements to the sql parameter to get them to execute
+        sequentially
+
+        :param sql: the sql statement to be executed (str) or a list of
+            sql statements to execute
+        :type sql: str or list
+        :param autocommit: What to set the connection's autocommit setting to
+            before executing the query.
+        :type autocommit: bool
+        :param parameters: The parameters to render the SQL query with.
+        :type parameters: dict or iterable
+        """
+        if isinstance(sql, str):
+            sql = [sql]
+
+        with closing(self.get_conn()) as conn:
+            self.set_autocommit(conn, autocommit)
+
+            with closing(conn.cursor()) as cur:
+                for sql_statement in sql:
+
+                    self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
+                    if parameters:
+                        cur.execute(sql_statement, parameters)
+                    else:
+                        cur.execute(sql_statement)
+                    self.log.info("Rows affected: %s", cur.rowcount)
+                    self.query_id = cur.sfqid
+
+            # If autocommit was set to False for db that supports autocommit,
+            # or if db does not supports autocommit, we do a manual commit.
+            if not self.get_autocommit(conn):
+                conn.commit()

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -265,8 +265,7 @@ class SnowflakeHook(DbApiHook):
         """
         self.query_ids = []
 
-        # with self.get_conn() as conn:
-        for x in [1]:
+        with self.get_conn() as conn:
             conn = self.get_conn()
             self.set_autocommit(conn, autocommit)
 

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -98,7 +98,7 @@ class SnowflakeOperator(BaseOperator):
         self.schema = schema
         self.authenticator = authenticator
         self.session_parameters = session_parameters
-        self.query_id = None
+        self.query_ids = []
 
     def get_hook(self) -> SnowflakeHook:
         """
@@ -121,4 +121,4 @@ class SnowflakeOperator(BaseOperator):
         self.log.info('Executing: %s', self.sql)
         hook = self.get_hook()
         hook.run(self.sql, autocommit=self.autocommit, parameters=self.parameters)
-        self.query_id = hook.query_id
+        self.query_ids = hook.query_ids

--- a/airflow/providers/snowflake/operators/snowflake.py
+++ b/airflow/providers/snowflake/operators/snowflake.py
@@ -98,6 +98,7 @@ class SnowflakeOperator(BaseOperator):
         self.schema = schema
         self.authenticator = authenticator
         self.session_parameters = session_parameters
+        self.query_id = None
 
     def get_hook(self) -> SnowflakeHook:
         """
@@ -120,3 +121,4 @@ class SnowflakeOperator(BaseOperator):
         self.log.info('Executing: %s', self.sql)
         hook = self.get_hook()
         hook.run(self.sql, autocommit=self.autocommit, parameters=self.parameters)
+        self.query_id = hook.query_id

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -32,10 +32,14 @@ class TestSnowflakeHook(unittest.TestCase):
         super().setUp()
 
         self.cur = mock.MagicMock()
-        self.cur.sfqid = "uuid"
+        self.cur2 = mock.MagicMock()
+
+        self.cur.sfqid = 'uuid'
+        self.cur2.sfqid = 'uuid2'
 
         self.conn = conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
+        self.conn.execute_string.return_value = [self.cur, self.cur2]
 
         self.conn.login = 'user'
         self.conn.password = 'pw'
@@ -91,9 +95,18 @@ class TestSnowflakeHook(unittest.TestCase):
         )
         assert uri_shouldbe == self.db_hook.get_uri()
 
-    def test_get_query_id(self):
-        self.db_hook.run('select * from table')
-        assert self.db_hook.query_id == 'uuid'
+    def test_single_element_list_calls_execute(self):
+        self.db_hook.run(['select * from table'])
+        self.cur.execute.assert_called()
+        assert self.db_hook.query_ids == ['uuid']
+
+    def test_passed_string_calls_execute_string(self):
+        self.db_hook.run('select * from table; select * from table2')
+
+        assert self.db_hook.query_ids == ['uuid', 'uuid2']
+        self.conn.execute_string.assert_called()
+        self.cur.close.assert_called()
+        self.cur2.close.assert_called()
 
     def test_get_conn_params(self):
         conn_params_shouldbe = {

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -32,6 +32,8 @@ class TestSnowflakeHook(unittest.TestCase):
         super().setUp()
 
         self.cur = mock.MagicMock()
+        self.cur.sfqid = "uuid"
+
         self.conn = conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
 
@@ -88,6 +90,10 @@ class TestSnowflakeHook(unittest.TestCase):
             'snowflake://user:pw@airflow/db/public?warehouse=af_wh&role=af_role&authenticator=snowflake'
         )
         assert uri_shouldbe == self.db_hook.get_uri()
+
+    def test_get_query_id(self):
+        self.db_hook.run('select * from table')
+        assert self.db_hook.query_id == 'uuid'
 
     def test_get_conn_params(self):
         conn_params_shouldbe = {


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Expose snowflake query id to snowflake hook and snowflake operator. 
This will allow us to collect data lineage for snowflake operator in [Marquez](https://github.com/MarquezProject/marquez) project.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
