### PR TITLE
Fix on_failure_callback when task receive SIGKILL

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-import os
 import signal
 from typing import Optional
 
@@ -154,6 +153,10 @@ class LocalTaskJob(BaseJob):
         # task exited by itself, so we need to check for error file
         # incase it failed due to runtime exception/error
         error = None
+        if self.task_instance.state == State.RUNNING:
+            # This is for a case where the task received a sigkill
+            # While running
+            self.task_instance.set_state(State.FAILED)
         if self.task_instance.state != State.SUCCESS:
             error = self.task_runner.deserialize_run_error()
         self.task_instance._run_finished_callback(error=error)  # pylint: disable=protected-access
@@ -184,9 +187,9 @@ class LocalTaskJob(BaseJob):
                 )
                 raise AirflowException("Hostname of job runner does not match")
 
-            current_pid = os.getpid()
+            current_pid = self.task_runner.process.pid
             same_process = ti.pid == current_pid
-            if not same_process:
+            if ti.pid is not None and not same_process:
                 self.log.warning("Recorded pid %s does not match " "the current pid %s", ti.pid, current_pid)
                 raise AirflowException("PID of job runner does not match")
         elif self.task_runner.return_code() is None and hasattr(self.task_runner, 'process'):

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -155,7 +155,7 @@ class LocalTaskJob(BaseJob):
         error = None
         if self.task_instance.state == State.RUNNING:
             # This is for a case where the task received a sigkill
-            # While running
+            # while running
             self.task_instance.set_state(State.FAILED)
         if self.task_instance.state != State.SUCCESS:
             error = self.task_runner.deserialize_run_error()

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1072,7 +1072,6 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         if not test_mode:
             session.add(Log(State.RUNNING, self))
         self.state = State.RUNNING
-        self.pid = os.getpid()
         self.end_date = None
         if not test_mode:
             session.merge(self)
@@ -1127,7 +1126,9 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         self.refresh_from_db(session=session)
         self.job_id = job_id
         self.hostname = get_hostname()
-
+        self.pid = os.getpid()
+        session.merge(self)
+        session.commit()
         actual_start_date = timezone.utcnow()
         Stats.incr(f'ti.start.{task.dag_id}.{task.task_id}')
         try:

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -613,7 +613,7 @@ class TestLocalTaskJob(unittest.TestCase):
         process = multiprocessing.Process(target=job1.run)
         process.start()
 
-        for _ in range(0, 10):
+        for _ in range(0, 20):
             ti.refresh_from_db()
             if ti.state == State.RUNNING:
                 break

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -550,12 +550,13 @@ class TestLocalTaskJob(unittest.TestCase):
         process = multiprocessing.Process(target=job1.run)
         process.start()
 
-        for _ in range(0, 10):
+        for _ in range(0, 20):
             ti.refresh_from_db()
-            if ti.state == State.RUNNING:
+            if ti.state == State.RUNNING and ti.pid is not None:
                 break
             time.sleep(0.2)
         assert ti.state == State.RUNNING
+        assert ti.pid is not None
         os.kill(ti.pid, signal.SIGTERM)
         process.join(timeout=10)
         assert failure_callback_called.value == 1
@@ -615,10 +616,11 @@ class TestLocalTaskJob(unittest.TestCase):
 
         for _ in range(0, 20):
             ti.refresh_from_db()
-            if ti.state == State.RUNNING:
+            if ti.state == State.RUNNING and ti.pid is not None:
                 break
             time.sleep(0.2)
         assert ti.state == State.RUNNING
+        assert ti.pid is not None
         os.kill(ti.pid, signal.SIGKILL)
         process.join(timeout=10)
         assert failure_callback_called.value == 1

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2073,8 +2073,8 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
     @parameterized.expand(
         [
             # Expected queries, mark_success
-            (10, False),
-            (5, True),
+            (12, False),
+            (7, True),
         ]
     )
     def test_execute_queries_count(self, expected_query_count, mark_success):
@@ -2110,7 +2110,7 @@ class TestRunRawTaskQueriesCount(unittest.TestCase):
                 session=session,
             )
 
-        with assert_queries_count(10):
+        with assert_queries_count(12):
             ti._run_raw_task()
 
     def test_operator_field_with_serialization(self):


### PR DESCRIPTION
This PR fixes a case where a task would not call the on_failure_callback
when there's a case of OOM. The issue was that task PID was being set
at the wrong place and the local task job heartbeat was not checking the
correct PID of the process runner and task.

Now, instead of setting the task PID in check_and_change_state_before_execution method,
it's now set correctly at the _run_raw_task method

Closes: #11086


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
