### PR TITLE
Add description about secret_key when Webserver > 1

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -993,8 +993,9 @@
       default: "False"
     - name: secret_key
       description: |
-        Secret key used to run your flask app
-        It should be as random as possible
+        Secret key used to run your flask app. It should be as random as possible. However, when running
+        more than 1 instances of webserver, make sure all of them use the same ``secret_key`` otherwise
+        one of them will error with "CSRF session token is missing".
       version_added: ~
       type: string
       sensitive: true

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -505,8 +505,9 @@ worker_refresh_interval = 6000
 # then reload the gunicorn.
 reload_on_plugin_change = False
 
-# Secret key used to run your flask app
-# It should be as random as possible
+# Secret key used to run your flask app. It should be as random as possible. However, when running
+# more than 1 instances of webserver, make sure all of them use the same ``secret_key`` otherwise
+# one of them will error with "CSRF session token is missing".
 secret_key = {SECRET_KEY}
 
 # Number of workers to run the Gunicorn web server


### PR DESCRIPTION
when running more than 1 intances of websever, make sure all of them use the same ``secret_key`` otherwise one of them will error with "CSRF session token is missing".

closes https://github.com/apache/airflow/issues/15532

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
