### PR TITLE
Fix parallelism after KubeExecutor pod adoption

### DIFF
--- a/airflow/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/kubernetes/kubernetes_helper_functions.py
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import logging
+from typing import Dict, Optional
+
+from dateutil import parser
+
+from airflow.models.taskinstance import TaskInstanceKey
+
+log = logging.getLogger(__name__)
+
 
 def _strip_unsafe_kubernetes_special_chars(string: str) -> str:
     """
@@ -44,3 +53,14 @@ def create_pod_id(dag_id: str, task_id: str) -> str:
     safe_dag_id = _strip_unsafe_kubernetes_special_chars(dag_id)
     safe_task_id = _strip_unsafe_kubernetes_special_chars(task_id)
     return safe_dag_id + safe_task_id
+
+
+def annotations_to_key(annotations: Dict[str, str]) -> Optional[TaskInstanceKey]:
+    """Build a TaskInstanceKey based on pod annotations"""
+    log.debug("Creating task key for annotations %s", annotations)
+    dag_id = annotations['dag_id']
+    task_id = annotations['task_id']
+    try_number = int(annotations['try_number'])
+    execution_date = parser.parse(annotations['execution_date'])
+
+    return TaskInstanceKey(dag_id, task_id, execution_date, try_number)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -77,7 +77,6 @@ try:
     from kubernetes.client.api_client import ApiClient
 
     from airflow.kubernetes.kube_config import KubeConfig
-    from airflow.kubernetes.kubernetes_helper_functions import create_pod_id
     from airflow.kubernetes.pod_generator import PodGenerator
 except ImportError:
     ApiClient = None
@@ -1776,6 +1775,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
 
     def render_k8s_pod_yaml(self) -> Optional[dict]:
         """Render k8s pod yaml"""
+        from airflow.kubernetes.kubernetes_helper_functions import create_pod_id  # Circular import
+
         kube_config = KubeConfig()
         pod = PodGenerator.construct_pod(
             dag_id=self.dag_id,


### PR DESCRIPTION
This fixes a bug where adopted pods didn't count as being run by the
executor for the purposes of honoring parallelism, nor for metrics being
exported. Now adopted tasks will be reflected like a task the executor
actually started.

