### PR TITLE
Add ``serve-logs`` CLI command to serve logs

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1560,6 +1560,12 @@ airflow_commands: List[CLICommand] = [
         subcommands=ROLES_COMMANDS,
     ),
     ActionCommand(
+        name='serve-logs',
+        help='Serve logs in a sub-process.',
+        func=lazy_load_command('airflow.cli.commands.serve_logs_command.serve_logs'),
+        args=(),
+    ),
+    ActionCommand(
         name='sync-perm',
         help="Update permissions for existing roles and optionally DAGs",
         func=lazy_load_command('airflow.cli.commands.sync_perm_command.sync_perm'),

--- a/airflow/cli/commands/serve_logs_command.py
+++ b/airflow/cli/commands/serve_logs_command.py
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Serve logs command"""
+from multiprocessing import Process
+
+from airflow.utils import cli as cli_utils
+from airflow.utils.serve_logs import serve_logs as serve_logs_utils
+
+
+@cli_utils.action_logging
+def serve_logs(args):
+    """Updates permissions for existing roles and DAGs"""
+    sub_proc = Process(target=serve_logs_utils)
+    sub_proc.start()

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -184,7 +184,7 @@ spec:
         - name: scheduler-logs
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          args: ["serve_logs"]
+          args: ["bash", "-c", "airflow serve-logs || airflow serve_logs"]
           ports:
             - name: worker-logs
               containerPort: {{ .Values.ports.workerLogs }}

--- a/tests/cli/commands/test_serve_logs_command.py
+++ b/tests/cli/commands/test_serve_logs_command.py
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import unittest
+from unittest import mock
+
+from airflow.cli import cli_parser
+from airflow.cli.commands import serve_logs_command
+from airflow.utils.serve_logs import serve_logs
+
+
+class TestCliServeLogs(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = cli_parser.get_parser()
+
+    @mock.patch("airflow.cli.commands.serve_logs_command.Process")
+    def test_cli_sync_perm(self, mock_process):
+        args = self.parser.parse_args(['serve-logs'])
+        serve_logs_command.serve_logs(args)
+        mock_process.assert_called_once_with(target=serve_logs)


### PR DESCRIPTION
Currently, the `serve_logs` endpoint only exists on Celery workers. This
means if someone launches Airflow with the `LocalExecutor` and wants to
grab the logs from the scheduler, there is no way to move that to the
webserver if it is on a different pod/machine.

closes https://github.com/apache/airflow/pull/15070
closes https://github.com/apache/airflow/issues/13331
closes https://github.com/apache/airflow/issues/15071
closes https://github.com/apache/airflow/issues/14222

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
