### PR TITLE
Fix KEDA Autoscaler connectionFromEnv

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -124,9 +124,6 @@ spec:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
       containers:
-        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
-        {{- include "git_sync_container" . | indent 8 }}
-        {{- end }}
         - name: worker
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
@@ -176,6 +173,9 @@ spec:
             - name: KRB5CCNAME
               value:  {{ include "kerberos_ccache_path" . | quote }}
           {{- end }}
+        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
+        {{- include "git_sync_container" . | indent 8 }}
+        {{- end }}
 {{- if $persistence }}
         - name: worker-gc
           image: {{ template "airflow_image" . }}

--- a/chart/tests/test_git_sync_worker.py
+++ b/chart/tests/test_git_sync_worker.py
@@ -59,7 +59,7 @@ class GitSyncWorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        assert "git-sync" == jmespath.search("spec.template.spec.containers[1].name", docs[1])
+        assert "git-sync" == jmespath.search("spec.template.spec.containers[1].name", docs[0])
 
     def test_should_not_add_sync_container_to_worker_if_git_sync_and_persistence_are_enabled(self):
         docs = render_chart(
@@ -73,4 +73,4 @@ class GitSyncWorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        assert "git-sync" != jmespath.search("spec.template.spec.containers[1].name", docs[1])
+        assert "git-sync" != jmespath.search("spec.template.spec.containers[1].name", docs[0])

--- a/chart/tests/test_git_sync_worker.py
+++ b/chart/tests/test_git_sync_worker.py
@@ -59,7 +59,7 @@ class GitSyncWorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        assert "git-sync" == jmespath.search("spec.template.spec.containers[0].name", docs[0])
+        assert "git-sync" == jmespath.search("spec.template.spec.containers[1].name", docs[1])
 
     def test_should_not_add_sync_container_to_worker_if_git_sync_and_persistence_are_enabled(self):
         docs = render_chart(
@@ -73,4 +73,4 @@ class GitSyncWorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
 
-        assert "git-sync" != jmespath.search("spec.template.spec.containers[0].name", docs[0])
+        assert "git-sync" != jmespath.search("spec.template.spec.containers[1].name", docs[1])


### PR DESCRIPTION
If i use git-sync sidecar container with keda autoscaler, git-sync will be [0] in containers array, and not contain connection env's, then KEDA could not get AIRFLOW_CONN_AIRFLOW_DB variable from git-sync sidecar in worker deployment(git-sync not contain it).
Resolution: the worker container must always be [0] in the container array, because it contain all connection env's, git-sync moves to [1]
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
