### PR TITLE
Add optional result handler to database hooks

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -43,6 +43,7 @@ New Features
 Improvements
 """"""""""""
 
+- Add optional result handler callback to ``DbApiHook`` (#15581)
 - Update Flask App Builder limit to recently released 3.3 (#15792)
 - Prevent creating flask sessions on REST API requests (#15295)
 - Sync DAG specific permissions when parsing (#15311)

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -152,7 +152,7 @@ class DbApiHook(BaseHook):
                     cur.execute(sql)
                 return cur.fetchone()
 
-    def run(self, sql, autocommit=False, parameters=None):
+    def run(self, sql, autocommit=False, parameters=None, handler=None):
         """
         Runs a command or a list of commands. Pass a list of sql
         statements to the sql parameter to get them to execute
@@ -166,8 +166,12 @@ class DbApiHook(BaseHook):
         :type autocommit: bool
         :param parameters: The parameters to render the SQL query with.
         :type parameters: dict or iterable
+        :param handler: The result handler which is called after each statement.
+        :type handler: Callable which gets a cursor object.
+        :return: query results if handler was provided.
         """
-        if isinstance(sql, str):
+        scalar = isinstance(sql, str)
+        if scalar:
             sql = [sql]
 
         with closing(self.get_conn()) as conn:
@@ -175,20 +179,37 @@ class DbApiHook(BaseHook):
                 self.set_autocommit(conn, autocommit)
 
             with closing(conn.cursor()) as cur:
+                results = []
                 for sql_statement in sql:
-
-                    self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
-                    if parameters:
-                        cur.execute(sql_statement, parameters)
-                    else:
-                        cur.execute(sql_statement)
-                    if hasattr(cur, 'rowcount'):
-                        self.log.info("Rows affected: %s", cur.rowcount)
+                    self._run_command(cur, sql_statement, parameters)
+                    if handler is not None:
+                        result = handler(cur)
+                        results.append(result)
 
             # If autocommit was set to False for db that supports autocommit,
             # or if db does not supports autocommit, we do a manual commit.
             if not self.get_autocommit(conn):
                 conn.commit()
+
+        if handler is None:
+            return None
+
+        if scalar:
+            return results[0]
+
+        return results
+
+    def _run_command(self, cur, sql_statement, parameters):
+        """Runs a statement using an already open cursor."""
+        self.log.info("Running statement: %s, parameters: %s", sql_statement, parameters)
+        if parameters:
+            cur.execute(sql_statement, parameters)
+        else:
+            cur.execute(sql_statement)
+
+        # According to PEP 249, this is -1 when query result is not applicable.
+        if cur.rowcount >= 0:
+            self.log.info("Rows affected: %s", cur.rowcount)
 
     def set_autocommit(self, conn, autocommit):
         """Sets the autocommit flag on the connection"""

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -166,7 +166,7 @@ class DbApiHook(BaseHook):
         :type autocommit: bool
         :param parameters: The parameters to render the SQL query with.
         :type parameters: dict or iterable
-        :param handler: The result handler which is called with the result of each statement. 
+        :param handler: The result handler which is called with the result of each statement.
         :type handler: callable
         :return: query results if handler was provided.
         """

--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -166,8 +166,8 @@ class DbApiHook(BaseHook):
         :type autocommit: bool
         :param parameters: The parameters to render the SQL query with.
         :type parameters: dict or iterable
-        :param handler: The result handler which is called after each statement.
-        :type handler: Callable which gets a cursor object.
+        :param handler: The result handler which is called with the result of each statement. 
+        :type handler: callable
         :return: query results if handler was provided.
         """
         scalar = isinstance(sql, str)

--- a/airflow/providers/oracle/operators/oracle.py
+++ b/airflow/providers/oracle/operators/oracle.py
@@ -23,7 +23,7 @@ from airflow.providers.oracle.hooks.oracle import OracleHook
 
 class OracleOperator(BaseOperator):
     """
-    Executes sql code in a specific Oracle database
+    Executes sql code in a specific Oracle database.
 
     :param sql: the sql code to be executed. Can receive a str representing a sql statement,
         a list of str (sql statements), or reference to a template file.

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -192,7 +192,7 @@ class TestDruidHook(unittest.TestCase):
 class TestDruidDbApiHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
-        self.cur = MagicMock()
+        self.cur = MagicMock(rowcount=0)
         self.conn = conn = MagicMock()
         self.conn.host = 'host'
         self.conn.port = '1000'

--- a/tests/providers/apache/pinot/hooks/test_pinot.py
+++ b/tests/providers/apache/pinot/hooks/test_pinot.py
@@ -212,7 +212,7 @@ class TestPinotDbApiHook(unittest.TestCase):
         self.conn.port = '1000'
         self.conn.conn_type = 'http'
         self.conn.extra_dejson = {'endpoint': 'query/sql'}
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn.cursor.return_value = self.cur
         self.conn.__enter__.return_value = self.cur
         self.conn.__exit__.return_value = None

--- a/tests/providers/elasticsearch/hooks/test_elasticsearch.py
+++ b/tests/providers/elasticsearch/hooks/test_elasticsearch.py
@@ -48,7 +48,7 @@ class TestElasticsearchHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -70,7 +70,7 @@ class TestExasolHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.execute.return_value = self.cur
         conn = self.conn

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -236,7 +236,7 @@ class TestMySqlHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -183,7 +183,7 @@ class TestOracleHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn
@@ -207,6 +207,18 @@ class TestOracleHook(unittest.TestCase):
         param = ('p1', 'p2')
         self.db_hook.run(sql, parameters=param)
         self.cur.execute.assert_called_once_with(sql, param)
+        assert self.conn.commit.called
+
+    def test_run_with_handler(self):
+        sql = 'SQL'
+        param = ('p1', 'p2')
+        called = 0
+        def handler(cur):
+            cur.execute.assert_called_once_with(sql, param)
+            nonlocal called
+            called += 1
+        self.db_hook.run(sql, parameters=param, handler=handler)
+        assert called == 1
         assert self.conn.commit.called
 
     def test_insert_rows_with_fields(self):

--- a/tests/providers/oracle/hooks/test_oracle.py
+++ b/tests/providers/oracle/hooks/test_oracle.py
@@ -209,18 +209,6 @@ class TestOracleHook(unittest.TestCase):
         self.cur.execute.assert_called_once_with(sql, param)
         assert self.conn.commit.called
 
-    def test_run_with_handler(self):
-        sql = 'SQL'
-        param = ('p1', 'p2')
-        called = 0
-        def handler(cur):
-            cur.execute.assert_called_once_with(sql, param)
-            nonlocal called
-            called += 1
-        self.db_hook.run(sql, parameters=param, handler=handler)
-        assert called == 1
-        assert self.conn.commit.called
-
     def test_insert_rows_with_fields(self):
         rows = [
             (

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -23,7 +23,7 @@ from airflow.providers.oracle.operators.oracle import OracleOperator
 
 
 class TestOracleOperator(unittest.TestCase):
-    @mock.patch.object(OracleHook, 'run')
+    @mock.patch.object(OracleHook, 'run', autospec=OracleHook.run)
     def test_execute(self, mock_run):
         sql = 'SELECT * FROM test_table'
         oracle_conn_id = 'oracle_default'
@@ -40,5 +40,7 @@ class TestOracleOperator(unittest.TestCase):
             task_id=task_id,
         )
         operator.execute(context=context)
-
-        mock_run.assert_called_once_with(sql, autocommit=autocommit, parameters=parameters)
+        assert len(mock_run.mock_calls) == 1
+        assert mock_run.mock_calls[0].args[1] == sql
+        assert mock_run.mock_calls[0].kwargs["autocommit"] is autocommit
+        assert mock_run.mock_calls[0].kwargs["parameters"] is parameters

--- a/tests/providers/oracle/operators/test_oracle.py
+++ b/tests/providers/oracle/operators/test_oracle.py
@@ -40,7 +40,9 @@ class TestOracleOperator(unittest.TestCase):
             task_id=task_id,
         )
         operator.execute(context=context)
-        assert len(mock_run.mock_calls) == 1
-        assert mock_run.mock_calls[0].args[1] == sql
-        assert mock_run.mock_calls[0].kwargs["autocommit"] is autocommit
-        assert mock_run.mock_calls[0].kwargs["parameters"] is parameters
+        mock_run.assert_called_once_with(
+            mock.ANY,
+            sql,
+            autocommit=autocommit,
+            parameters=parameters,
+        )

--- a/tests/providers/postgres/hooks/test_postgres.py
+++ b/tests/providers/postgres/hooks/test_postgres.py
@@ -148,7 +148,7 @@ class TestPostgresHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
 

--- a/tests/providers/presto/hooks/test_presto.py
+++ b/tests/providers/presto/hooks/test_presto.py
@@ -147,7 +147,7 @@ class TestPrestoHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -31,8 +31,8 @@ class TestSnowflakeHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
-        self.cur2 = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
+        self.cur2 = mock.MagicMock(rowcount=0)
 
         self.cur.sfqid = 'uuid'
         self.cur2.sfqid = 'uuid2'

--- a/tests/providers/sqlite/hooks/test_sqlite.py
+++ b/tests/providers/sqlite/hooks/test_sqlite.py
@@ -53,7 +53,7 @@ class TestSqliteHookConn(unittest.TestCase):
 class TestSqliteHook(unittest.TestCase):
     def setUp(self):
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn

--- a/tests/providers/trino/hooks/test_trino.py
+++ b/tests/providers/trino/hooks/test_trino.py
@@ -147,7 +147,7 @@ class TestTrinoHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn

--- a/tests/providers/vertica/hooks/test_vertica.py
+++ b/tests/providers/vertica/hooks/test_vertica.py
@@ -55,7 +55,7 @@ class TestVerticaHook(unittest.TestCase):
     def setUp(self):
         super().setUp()
 
-        self.cur = mock.MagicMock()
+        self.cur = mock.MagicMock(rowcount=0)
         self.conn = mock.MagicMock()
         self.conn.cursor.return_value = self.cur
         conn = self.conn


### PR DESCRIPTION
This is useful when executing a statement where out variables are required – for example a stored procedure.

Where an out parameter is required, pass a Python value of the required type (for example `0` for an integer, or "dummy" for a string).

Note that this scheme is supported by the Oracle driver itself. In the future, a more elaborate scheme can be implemented which could allow the use of https://cx-oracle.readthedocs.io/en/latest/api_manual/cursor.html#Cursor.var.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
