### PR TITLE
`func.sum` may returns `Decimal` that break rest APIs.

### DIFF
--- a/airflow/models/pool.py
+++ b/airflow/models/pool.py
@@ -161,12 +161,13 @@ class Pool(Base):
         """
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
 
-        return (
+        return int(
             session.query(func.sum(TaskInstance.pool_slots))
             .filter(TaskInstance.pool == self.pool)
             .filter(TaskInstance.state.in_(list(EXECUTION_STATES)))
             .scalar()
-        ) or 0
+            or 0
+        )
 
     @provide_session
     def running_slots(self, session: Session):
@@ -178,12 +179,13 @@ class Pool(Base):
         """
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
 
-        return (
+        return int(
             session.query(func.sum(TaskInstance.pool_slots))
             .filter(TaskInstance.pool == self.pool)
             .filter(TaskInstance.state == State.RUNNING)
             .scalar()
-        ) or 0
+            or 0
+        )
 
     @provide_session
     def queued_slots(self, session: Session):
@@ -195,12 +197,13 @@ class Pool(Base):
         """
         from airflow.models.taskinstance import TaskInstance  # Avoid circular import
 
-        return (
+        return int(
             session.query(func.sum(TaskInstance.pool_slots))
             .filter(TaskInstance.pool == self.pool)
             .filter(TaskInstance.state == State.QUEUED)
             .scalar()
-        ) or 0
+            or 0
+        )
 
     @provide_session
     def open_slots(self, session: Session) -> float:


### PR DESCRIPTION
`sqlalchemy.func.sum` has a known *"issue"* that it **may** returns `Decimal` value (_in my case MySQL 5.7_).

This will cause problem when calling [rest APIs](https://airflow.apache.org/docs/apache-airflow/stable/stable-rest-api-ref.html#tag/Pool). E.g.
```http
GET /airflow/api/v1/pools?limit=100

...
TypeError: Object of type 'Decimal' is not JSON serializable
```

@ashb and @kaxil please have a review, thanks!