### PR TITLE
Add ability to quickly trigger a DAG

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -464,3 +464,29 @@ label[for="timezone-other"],
 .loading-dots.refresh-loading {
   display: none;
 }
+
+.trigger-dropdown-btn {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+  border-right-width: 0;
+}
+
+.trigger-dropdown-menu {
+  left: -80px;
+}
+
+.dropdown-form-btn {
+  padding: 3px 20px;
+  line-height: 1.428571429;
+  color: #51504f;
+  background-color: white;
+  border: none;
+  width: 100%;
+  text-align: left;
+}
+
+.dropdown-form-btn:hover,
+.dropdown-form-btn:focus {
+  color: #262626;
+  background-color: #f5f5f5;
+}

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -114,9 +114,22 @@
       </div>
       <div class="col-md-2">
         <div class="btn-group pull-right">
-          <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for('Airflow.' + dag.default_view, dag_id=dag.dag_id)) }}" title="Trigger DAG" aria-label="Trigger DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_trigger }}">
-            <span class="material-icons" aria-hidden="true">play_arrow</span>
-          </a>
+          <div class="dropdown">
+            <a aria-label="Trigger DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_trigger }} trigger-dropdown-btn" data-toggle="dropdown">
+              <span class="material-icons" aria-hidden="true">play_arrow</span>
+            </a>
+            <ul class="dropdown-menu trigger-dropdown-menu">
+              <li>
+                <form method="POST" action="{{ url_for('Airflow.trigger') }}">
+                  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                  <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
+                  <input type="hidden" name="origin" value="{{ url_for('Airflow.' + dag.default_view, dag_id=dag.dag_id) }}">
+                  <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
+                </form>
+              </li>
+              <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id, origin=url_for('Airflow.' + dag.default_view, dag_id=dag.dag_id)) }}">Trigger DAG w/ config</a></li>
+            </ul>
+          </div>
           <a href="{{ url_for('Airflow.refresh', dag_id=dag.dag_id) }}" title="Refresh DAG" aria-label="Refresh DAG" onclick="postAsForm(this.href); return false" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_edit }}">
             <span class="material-icons" aria-hidden="true">refresh</span>
           </a>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -179,9 +179,21 @@
                 <td class="text-center">
                   <div class="btn-group">
                     {% if dag %}
-                      <a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id) }}" title="Trigger DAG" aria-label="Trigger DAG" class="btn btn-sm btn-default btn-icon-only {{ ' disabled' if not dag.can_trigger }}">
+                    <div class="dropdown">
+                      <a aria-label="Trigger DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_trigger }} trigger-dropdown-btn" data-toggle="dropdown">
                         <span class="material-icons" aria-hidden="true">play_arrow</span>
                       </a>
+                      <ul class="dropdown-menu trigger-dropdown-menu">
+                        <li>
+                          <form method="POST" action="{{ url_for('Airflow.trigger') }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                            <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
+                            <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
+                          </form>
+                        </li>
+                        <li><a href="{{ url_for('Airflow.trigger', dag_id=dag.dag_id) }}">Trigger DAG w/ config</a></li>
+                      </ul>
+                    </div>
                       <a href="{{ url_for('Airflow.refresh', dag_id=dag.dag_id) }}" onclick="postAsForm(this.href); return false" title="Refresh DAG" aria-label="Refresh DAG" class="btn btn-sm btn-default btn-icon-only {{ ' disabled' if not dag.can_edit }}">
                         <span class="material-icons" aria-hidden="true">refresh</span>
                       </a>


### PR DESCRIPTION
From talking with some Airflow users, most of the time people don't need to edit the config when manually triggering a DAG.

To save users from an unnecessary step, I turned the `Trigger DAG` button to a dropdown that allows you to do an immediate trigger and a second option that will still direct you to the trigger DAG page to edit `conf`.


<img width="225" alt="Screen Shot 2021-04-28 at 2 07 32 PM" src="https://user-images.githubusercontent.com/4600967/116573250-40e0b980-a8d2-11eb-95f8-efcc90cbd9ac.png">

![Apr-29-2021 11-06-11](https://user-images.githubusercontent.com/4600967/116573645-9b7a1580-a8d2-11eb-8f73-e9901a0d6e55.gif)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
