### PR TITLE
Adds log persistence to helm chart

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -328,6 +328,14 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{ (printf "%s/logs" .Values.airflowHome) }}
 {{- end }}
 
+{{ define "airflow_logs_volume_claim" -}}
+{{- if .Values.logs.persistence.existingClaim -}}
+{{ .Values.logs.persistence.existingClaim }}
+{{- else -}}
+{{ .Release.Name }}-logs
+{{- end -}}
+{{- end -}}
+
 {{ define "airflow_dags" -}}
 {{- if .Values.dags.gitSync.enabled -}}
 {{ (printf "%s/dags/%s/%s" .Values.airflowHome .Values.dags.gitSync.dest .Values.dags.gitSync.subPath ) }}

--- a/chart/templates/logs-persistent-volume-claim.yaml
+++ b/chart/templates/logs-persistent-volume-claim.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if and (not .Values.logs.persistence.existingClaim ) .Values.logs.persistence.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "airflow_logs_volume_claim" . }}
+  labels:
+    tier: airflow
+    component: logs-pvc
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+spec:
+  accessModes: ["ReadWriteMany"]
+  resources:
+    requests:
+      storage: {{ .Values.logs.persistence.size | quote }}
+  {{- if .Values.logs.persistence.storageClassName }}
+  {{- if (eq "-" .Values.logs.persistence.storageClassName) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.logs.persistence.storageClassName }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -205,7 +205,11 @@ spec:
 {{- if .Values.scheduler.extraVolumes }}
 {{ toYaml .Values.scheduler.extraVolumes | indent 8 }}
 {{- end }}
-{{- if not $stateful }}
+{{- if .Values.logs.persistence.enabled }}
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ template "airflow_logs_volume_claim" . }}
+{{- else if not $stateful }}
         - name: logs
           emptyDir: {}
 {{- else }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -122,6 +122,10 @@ spec:
             - name: dags
               mountPath: {{ template "airflow_dags_mount_path" . }}
 {{- end }}
+{{- if .Values.logs.persistence.enabled }}
+            - name: logs
+              mountPath: {{ template "airflow_logs" . }}
+{{- end }}
 {{- if .Values.webserver.extraVolumeMounts }}
 {{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}
 {{- end }}
@@ -181,6 +185,11 @@ spec:
         {{- if  .Values.dags.gitSync.sshKeySecret }}
         {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
+        {{- end }}
+        {{- if .Values.logs.persistence.enabled }}
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ template "airflow_logs_volume_claim" . }}
         {{- end }}
 {{- if .Values.webserver.extraVolumes }}
 {{ toYaml .Values.webserver.extraVolumes | indent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -256,7 +256,11 @@ spec:
         {{- include "git_sync_ssh_key_volume" . | indent 8 }}
         {{- end }}
         {{- end }}
-{{- if not $persistence }}
+{{- if .Values.logs.persistence.enabled }}
+        - name: logs
+          persistentVolumeClaim:
+            claimName: {{ template "airflow_logs_volume_claim" . }}
+{{- else if not $persistence }}
         - name: logs
           emptyDir: {}
 {{- else }}

--- a/chart/tests/test_logs_persistent_volume_claim.py
+++ b/chart/tests/test_logs_persistent_volume_claim.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import jmespath
+
+from tests.helm_template_generator import render_chart
+
+
+class LogsPersistentVolumeClaimTest(unittest.TestCase):
+    def test_should_not_generate_a_document_if_persistence_is_disabled(self):
+        docs = render_chart(
+            values={"logs": {"persistence": {"enabled": False}}},
+            show_only=["templates/logs-persistent-volume-claim.yaml"],
+        )
+
+        assert 0 == len(docs)
+
+    def test_should_not_generate_a_document_when_using_an_existing_claim(self):
+        docs = render_chart(
+            values={"logs": {"persistence": {"enabled": True, "existingClaim": "test-claim"}}},
+            show_only=["templates/logs-persistent-volume-claim.yaml"],
+        )
+
+        assert 0 == len(docs)
+
+    def test_should_generate_a_document_if_persistence_is_enabled_and_not_using_an_existing_claim(self):
+        docs = render_chart(
+            values={"logs": {"persistence": {"enabled": True, "existingClaim": None}}},
+            show_only=["templates/logs-persistent-volume-claim.yaml"],
+        )
+
+        assert 1 == len(docs)
+
+    def test_should_set_pvc_details_correctly(self):
+        docs = render_chart(
+            values={
+                "logs": {
+                    "persistence": {
+                        "enabled": True,
+                        "size": "1G",
+                        "existingClaim": None,
+                        "storageClassName": "MyStorageClass",
+                    }
+                }
+            },
+            show_only=["templates/logs-persistent-volume-claim.yaml"],
+        )
+
+        assert {
+            "accessModes": ["ReadWriteMany"],
+            "resources": {"requests": {"storage": "1G"}},
+            "storageClassName": "MyStorageClass",
+        } == jmespath.search("spec", docs[0])

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -183,3 +183,27 @@ class WorkerTest(unittest.TestCase):
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    @parameterized.expand(
+        [
+            ({"enabled": False}, {"emptyDir": {}}),
+            ({"enabled": True}, {"persistentVolumeClaim": {"claimName": "RELEASE-NAME-logs"}}),
+            (
+                {"enabled": True, "existingClaim": "test-claim"},
+                {"persistentVolumeClaim": {"claimName": "test-claim"}},
+            ),
+        ]
+    )
+    def test_logs_persistence_changes_volume(self, log_persistence_values, expected_volume):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "workers": {"persistence": {"enabled": False}},
+                "logs": {"persistence": log_persistence_values},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert {"name": "logs", **expected_volume} == jmespath.search(
+            "spec.template.spec.volumes[1]", docs[0]
+        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1520,6 +1520,42 @@
                     }
                 }
             }
+        },
+        "logs": {
+            "description": "Logs settings.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "persistence": {
+                    "description": "Persistence configuration.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "description": "Enable persistent volume for storing logs.",
+                            "type": "boolean"
+                        },
+                        "size": {
+                            "description": "Volume size for logs.",
+                            "type": "string"
+                        },
+                        "storageClassName": {
+                            "description": "If using a custom storageClass, pass name here.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
+                        "existingClaim": {
+                            "description": "The name of an existing PVC to use.",
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -886,3 +886,14 @@ dags:
     containerName: git-sync
     uid: 65533
     extraVolumeMounts: []
+
+logs:
+  persistence:
+    # Enable persistent volume for storing logs
+    enabled: false
+    # Volume size for logs
+    size: 100Gi
+    # If using a custom storageClass, pass name here
+    storageClassName:
+    ## the name of an existing PVC to use
+    existingClaim:

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -28,6 +28,7 @@ Helm Chart for Apache Airflow
     quick-start
     airflow-configuration
     manage-dags-files
+    manage-logs
     keda
     external-redis
     using-additional-containers

--- a/docs/helm-chart/manage-logs.rst
+++ b/docs/helm-chart/manage-logs.rst
@@ -1,0 +1,76 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Manage logs
+=================
+
+You have a number of options when it comes to managing your Airflow logs.
+
+No persistence
+-----------------
+
+With this option, Airflow will log locally to each pod. As such, the logs will only be available during the lifetime of the pod.
+
+.. code-block:: bash
+
+    helm upgrade airflow . \
+      --set logs.persistence.enabled=false
+      # --set workers.persistence.enabled=false (also needed if using ``CeleryExecutor``)
+
+Celery worker log persistence
+-----------------------------
+
+If you are using ``CeleryExecutor``, workers persist logs by default to a volume claim created with a ``volumeClaimTemplate``.
+
+You can modify the template:
+
+.. code-block:: bash
+
+    helm upgrade airflow . \
+      --set executor=CeleryExecutor \
+      --set workers.persistence.size=10Gi
+
+Note with this option only task logs are persisted, unlike when log persistence is enabled which will also persist scheduler logs.
+
+Log persistence enabled
+-----------------------
+
+This option will provision a PersistentVolumeClaim with an access mode of ``ReadWriteMany``. Each component of Airflow will
+then log onto the same volume.
+
+Not all volume plugins have support for ``ReadWriteMany`` access mode.
+Refer `Persistent Volume Access Modes <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`__
+for details.
+
+.. code-block:: bash
+
+    helm upgrade airflow . \
+      --set logs.persistence.enabled=true
+      # you can also override the other persistence
+      # by setting the logs.persistence.* values
+      # Please refer to values.yaml for details
+
+Externally provisioned PVC
+--------------------------
+
+In this approach, Airflow will log to an existing ``ReadWriteMany`` PVC. You pass in the name of the volume claim to the chart.
+
+.. code-block:: bash
+
+    helm upgrade airflow . \
+      --set logs.persistence.enabled=true \
+      --set logs.persistence.existingClaim=my-volume-claim

--- a/docs/helm-chart/manage-logs.rst
+++ b/docs/helm-chart/manage-logs.rst
@@ -49,7 +49,7 @@ Note with this option only task logs are persisted, unlike when log persistence 
 Log persistence enabled
 -----------------------
 
-This option will provision a PersistentVolumeClaim with an access mode of ``ReadWriteMany``. Each component of Airflow will
+This option will provision a ``PersistentVolumeClaim`` with an access mode of ``ReadWriteMany``. Each component of Airflow will
 then log onto the same volume.
 
 Not all volume plugins have support for ``ReadWriteMany`` access mode.

--- a/docs/helm-chart/manage-logs.rst
+++ b/docs/helm-chart/manage-logs.rst
@@ -74,3 +74,16 @@ In this approach, Airflow will log to an existing ``ReadWriteMany`` PVC. You pas
     helm upgrade airflow . \
       --set logs.persistence.enabled=true \
       --set logs.persistence.existingClaim=my-volume-claim
+
+Elasticsearch
+-------------
+
+If your cluster forwards logs to Elasticsearch, you can configure Airflow to retrieve task logs from it.
+See the :doc:`Elasticsearch providers guide <apache-airflow-providers-elasticsearch:logging>` for more details.
+
+.. code-block:: bash
+
+    helm upgrade airflow . \
+      --set elasticsearch.enabled=true \
+      --set elasticsearch.secretName=my-es-secret
+      # Other choices exist. Please refer to values.yaml for details.

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -480,6 +480,9 @@ The following tables lists the configurable parameters of the Airflow chart and 
    * - ``dags.gitSync.*``
      - Git sync configuration
      - Please refer to ``values.yaml``
+   * - ``logs.persistence.*``
+     - Log persistence configuration
+     - Please refer to ``values.yaml``
    * - ``multiNamespaceMode``
      - Whether the KubernetesExecutor can launch pods in multiple namespaces
      - ``1``


### PR DESCRIPTION
This adds the option to use a PVC (one provisioned by the chart or an
existing claim) to persist Airflow logs. This provides an executor
agnostic way to persist all of the Airflow logs.
