### PR TITLE
Change helm chart logging level back to default (INFO)

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -761,7 +761,6 @@ config:
   logging:
     remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
     colored_console_log: 'False'
-    logging_level: DEBUG
   metrics:
     statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
     statsd_port: 9125

--- a/docs/helm-chart/airflow-configuration.rst
+++ b/docs/helm-chart/airflow-configuration.rst
@@ -50,7 +50,6 @@ application. See the bottom line of the example:
      logging:
        remote_logging: '{{- ternary "True" "False" .Values.elasticsearch.enabled }}'
        colored_console_log: 'False'
-       logging_level: DEBUG
      metrics:
        statsd_on: '{{ ternary "True" "False" .Values.statsd.enabled }}'
        statsd_port: 9125

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -332,7 +332,8 @@ function kind::deploy_airflow_with_helm() {
         --set "images.airflow.tag=${AIRFLOW_PROD_BASE_TAG}-kubernetes" -v 1 \
         --set "defaultAirflowTag=${AIRFLOW_PROD_BASE_TAG}-kubernetes" -v 1 \
         --set "config.api.auth_backend=airflow.api.auth.backend.default" \
-        --set "config.api.enable_experimental_api=true"
+        --set "config.api.enable_experimental_api=true" \
+        --set "config.logging.logging_level=DEBUG"
     echo
     popd > /dev/null 2>&1|| exit 1
 }


### PR DESCRIPTION
The chart shouldn't default the logging level to DEBUG. Instead, we will
elect DEBUG when we are running with breeze and let normal releases use
the Airflow default of INFO.