### PR TITLE
Chart: Change default executor to ``CeleryExecutor``

### DIFF
--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -24,7 +24,7 @@ from parameterized import parameterized
 
 from tests.helm_template_generator import render_chart
 
-OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 22
+OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 30
 
 
 class TestBaseChartTest(unittest.TestCase):
@@ -55,13 +55,21 @@ class TestBaseChartTest(unittest.TestCase):
             ('RoleBinding', 'TEST-BASIC-pod-log-reader-rolebinding'),
             ('Service', 'TEST-BASIC-postgresql-headless'),
             ('Service', 'TEST-BASIC-postgresql'),
+            ('Service', 'TEST-BASIC-flower'),
+            ('Service', 'TEST-BASIC-redis'),
             ('Service', 'TEST-BASIC-statsd'),
             ('Service', 'TEST-BASIC-webserver'),
+            ('Service', 'TEST-BASIC-worker'),
+            ('Deployment', 'TEST-BASIC-flower'),
             ('Deployment', 'TEST-BASIC-scheduler'),
             ('Deployment', 'TEST-BASIC-statsd'),
             ('Deployment', 'TEST-BASIC-webserver'),
             ('StatefulSet', 'TEST-BASIC-postgresql'),
+            ('StatefulSet', 'TEST-BASIC-redis'),
+            ('StatefulSet', 'TEST-BASIC-worker'),
             ('Secret', 'TEST-BASIC-fernet-key'),
+            ('Secret', 'TEST-BASIC-redis-password'),
+            ('Secret', 'TEST-BASIC-broker-url'),
             ('Job', 'TEST-BASIC-create-user'),
             ('Job', 'TEST-BASIC-run-airflow-migrations'),
         ]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -110,7 +110,7 @@ rbacEnabled: true
 
 # Airflow executor
 # Options: LocalExecutor, CeleryExecutor, KubernetesExecutor, CeleryKubernetesExecutor
-executor: "KubernetesExecutor"
+executor: "CeleryExecutor"
 
 # If this is true and using LocalExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the scheduler's
 # service account will have access to communicate with the api-server and launch pods.

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -333,7 +333,8 @@ function kind::deploy_airflow_with_helm() {
         --set "defaultAirflowTag=${AIRFLOW_PROD_BASE_TAG}-kubernetes" -v 1 \
         --set "config.api.auth_backend=airflow.api.auth.backend.default" \
         --set "config.api.enable_experimental_api=true" \
-        --set "config.logging.logging_level=DEBUG"
+        --set "config.logging.logging_level=DEBUG" \
+        --set "executor=KubernetesExecutor"
     echo
     popd > /dev/null 2>&1|| exit 1
 }


### PR DESCRIPTION
``CeleryExecutor`` is currently the most stable of all, so it should be the default when using the Helm Chart.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
