### PR TITLE
Use latest version of `git-sync` image

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -149,7 +149,7 @@ images:
     tag: airflow-pgbouncer-exporter-2021.04.28-0.5.0
     pullPolicy: IfNotPresent
   gitSync:
-    repository: k8s.gcr.io/git-sync
+    repository: k8s.gcr.io/git-sync/git-sync
     tag: v3.3.0
     pullPolicy: IfNotPresent
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -150,7 +150,7 @@ images:
     pullPolicy: IfNotPresent
   gitSync:
     repository: k8s.gcr.io/git-sync
-    tag: v3.1.6
+    tag: v3.3.0
     pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers


### PR DESCRIPTION
This commit changes `git-sync` container image from `3.1.6` to `3.3.0` (the latest version)

https://github.com/kubernetes/git-sync/releases

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
