### PR TITLE
Improve Test Coverage for Kubernetes Executor

### DIFF
--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -127,7 +127,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         self, mock_watcher, mock_client, mock_kube_client
     ):  # pylint: disable=unused-argument
         pod_id = "my-pod-1"
-        namespace = "my-namespace"
+        namespace = "my-namespace-1"
 
         mock_delete_namespace = mock.MagicMock()
         mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespace
@@ -147,7 +147,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         self, mock_watcher, mock_client, mock_kube_client
     ):  # pylint: disable=unused-argument
         pod_id = "my-pod-1"
-        namespace = "my-namespace"
+        namespace = "my-namespace-2"
 
         mock_delete_namespace = mock.MagicMock()
         mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespace
@@ -170,7 +170,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         self, mock_watcher, mock_client, mock_kube_client
     ):  # pylint: disable=unused-argument
         pod_id = "my-pod-1"
-        namespace = "my-namespace"
+        namespace = "my-namespace-3"
 
         mock_delete_namespace = mock.MagicMock()
         mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespace
@@ -206,9 +206,9 @@ class TestKubernetesExecutor(unittest.TestCase):
         # When a quota is exceeded this is the ApiException we get
         response = HTTPResponse(
             body='{"kind": "Status", "apiVersion": "v1", "metadata": {}, "status": "Failure", '
-                 '"message": "pods \\"podname\\" is forbidden: exceeded quota: compute-resources, '
-                 'requested: limits.memory=4Gi, used: limits.memory=6508Mi, limited: limits.memory=10Gi", '
-                 '"reason": "Forbidden", "details": {"name": "podname", "kind": "pods"}, "code": 403}'
+            '"message": "pods \\"podname\\" is forbidden: exceeded quota: compute-resources, '
+            'requested: limits.memory=4Gi, used: limits.memory=6508Mi, limited: limits.memory=10Gi", '
+            '"reason": "Forbidden", "details": {"name": "podname", "kind": "pods"}, "code": 403}'
         )
         response.status = 403
         response.reason = "Forbidden"

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -25,14 +25,13 @@ from unittest import mock
 
 import pytest
 from kubernetes.client import models as k8s
+from kubernetes.client.rest import ApiException
 from urllib3 import HTTPResponse
 
 from airflow.utils import timezone
 from tests.test_utils.config import conf_vars
 
 try:
-    from kubernetes.client.rest import ApiException
-
     from airflow.executors.kubernetes_executor import (
         AirflowKubernetesScheduler,
         KubernetesExecutor,
@@ -120,6 +119,71 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
 
         assert datetime_obj == new_datetime_obj
 
+    @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
+    @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
+    @mock.patch('airflow.executors.kubernetes_executor.client')
+    @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
+    def test_delete_pod_successfully(
+        self, mock_watcher, mock_client, mock_kube_client
+    ):  # pylint: disable=unused-argument
+        pod_id = "my-pod-1"
+        namespace = "my-namespace"
+
+        kube_client = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = kube_client
+
+        kube_executor = KubernetesExecutor()
+        kube_executor.job_id = "test-job-id"
+        kube_executor.start()
+        kube_executor.kube_scheduler.delete_pod(pod_id, namespace)
+
+        kube_client.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
+
+    @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
+    @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
+    @mock.patch('airflow.executors.kubernetes_executor.client')
+    @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
+    def test_delete_pod_raises_404(
+        self, mock_watcher, mock_client, mock_kube_client
+    ):  # pylint: disable=unused-argument
+        pod_id = "my-pod-1"
+        namespace = "my-namespace"
+
+        kube_client = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = kube_client
+
+        # ApiException is raised because status is not 404
+        mock_kube_client.return_value.delete_namespaced_pod.side_effect = ApiException(status=400)
+        kube_executor = KubernetesExecutor()
+        kube_executor.job_id = "test-job-id"
+        kube_executor.start()
+
+        with pytest.raises(ApiException):
+            kube_executor.kube_scheduler.delete_pod(pod_id, namespace)
+            kube_client.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
+
+    @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
+    @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
+    @mock.patch('airflow.executors.kubernetes_executor.client')
+    @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
+    def test_delete_pod_404_not_raised(
+        self, mock_watcher, mock_client, mock_kube_client
+    ):  # pylint: disable=unused-argument
+        pod_id = "my-pod-1"
+        namespace = "my-namespace"
+
+        kube_client = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = kube_client
+
+        # ApiException not raised because the status is 404
+        mock_kube_client.return_value.delete_namespaced_pod.side_effect = ApiException(status=404)
+        kube_executor = KubernetesExecutor()
+        kube_executor.job_id = "test-job-id"
+        kube_executor.start()
+
+        kube_executor.kube_scheduler.delete_pod(pod_id, namespace)
+        kube_client.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
+
 
 class TestKubernetesExecutor(unittest.TestCase):
     """
@@ -160,7 +224,6 @@ class TestKubernetesExecutor(unittest.TestCase):
             ('kubernetes', 'pod_template_file'): path,
         }
         with conf_vars(config):
-
             kubernetes_executor = self.kubernetes_executor
             kubernetes_executor.start()
             # Execute a task while the Api Throws errors

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -129,15 +129,15 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         pod_id = "my-pod-1"
         namespace = "my-namespace"
 
-        kube_client = mock.MagicMock()
-        mock_kube_client.return_value.delete_namespaced_pod = kube_client
+        mock_delete_namespace = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespace
 
         kube_executor = KubernetesExecutor()
         kube_executor.job_id = "test-job-id"
         kube_executor.start()
         kube_executor.kube_scheduler.delete_pod(pod_id, namespace)
 
-        kube_client.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
+        mock_delete_namespace.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
 
     @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
     @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
@@ -149,8 +149,8 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         pod_id = "my-pod-1"
         namespace = "my-namespace"
 
-        kube_client = mock.MagicMock()
-        mock_kube_client.return_value.delete_namespaced_pod = kube_client
+        mock_delete_namespace = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespace
 
         # ApiException is raised because status is not 404
         mock_kube_client.return_value.delete_namespaced_pod.side_effect = ApiException(status=400)
@@ -160,7 +160,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
 
         with pytest.raises(ApiException):
             kube_executor.kube_scheduler.delete_pod(pod_id, namespace)
-            kube_client.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
+            mock_delete_namespace.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
 
     @unittest.skipIf(AirflowKubernetesScheduler is None, 'kubernetes python package is not installed')
     @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
@@ -172,8 +172,8 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         pod_id = "my-pod-1"
         namespace = "my-namespace"
 
-        kube_client = mock.MagicMock()
-        mock_kube_client.return_value.delete_namespaced_pod = kube_client
+        mock_delete_namespace = mock.MagicMock()
+        mock_kube_client.return_value.delete_namespaced_pod = mock_delete_namespace
 
         # ApiException not raised because the status is 404
         mock_kube_client.return_value.delete_namespaced_pod.side_effect = ApiException(status=404)
@@ -182,7 +182,7 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
         kube_executor.start()
 
         kube_executor.kube_scheduler.delete_pod(pod_id, namespace)
-        kube_client.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
+        mock_delete_namespace.assert_called_with(pod_id, namespace, body=mock_client.V1DeleteOptions())
 
 
 class TestKubernetesExecutor(unittest.TestCase):
@@ -206,9 +206,9 @@ class TestKubernetesExecutor(unittest.TestCase):
         # When a quota is exceeded this is the ApiException we get
         response = HTTPResponse(
             body='{"kind": "Status", "apiVersion": "v1", "metadata": {}, "status": "Failure", '
-            '"message": "pods \\"podname\\" is forbidden: exceeded quota: compute-resources, '
-            'requested: limits.memory=4Gi, used: limits.memory=6508Mi, limited: limits.memory=10Gi", '
-            '"reason": "Forbidden", "details": {"name": "podname", "kind": "pods"}, "code": 403}'
+                 '"message": "pods \\"podname\\" is forbidden: exceeded quota: compute-resources, '
+                 'requested: limits.memory=4Gi, used: limits.memory=6508Mi, limited: limits.memory=10Gi", '
+                 '"reason": "Forbidden", "details": {"name": "podname", "kind": "pods"}, "code": 403}'
         )
         response.status = 403
         response.reason = "Forbidden"


### PR DESCRIPTION
According to the current stats of codecov.io assessment of the Airflow code base, the test coverage for
the kubernetes_executor.py module is about 63%. This metric definitely
needs to be improved upon.

This PR addresses the unit test coverage for the `delete_pod` method in the `AirflowKubernetesScheduler` class in the kubernetes_executor.py module. And when merged will help to improve the test coverage metric.

fixes part of #15523 


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
