### PR TITLE
Refactor building of results backend connection secret

### DIFF
--- a/chart/templates/secrets/result-backend-connection-secret.yaml
+++ b/chart/templates/secrets/result-backend-connection-secret.yaml
@@ -20,7 +20,12 @@
 #################################
 {{- if not .Values.data.resultBackendSecretName }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-{{- $host := .Values.data.resultBackendConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
+
+{{- $resultBackendHost := .Values.data.resultBackendConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
+{{- $pgbouncerHost := printf "%s-%s" .Release.Name "pgbouncer" }}
+{{- $host := ternary $pgbouncerHost $resultBackendHost .Values.pgbouncer.enabled }}
+{{- $port := (ternary .Values.ports.pgbouncer .Values.data.resultBackendConnection.port .Values.pgbouncer.enabled) | toString }}
+{{- $database := ternary (printf "%s-%s" .Release.Name "result-backend") .Values.data.resultBackendConnection.db .Values.pgbouncer.enabled }}
 {{- $extras := ternary (printf "?sslmode=%s" .Values.data.resultBackendConnection.sslmode) "" (eq .Values.data.resultBackendConnection.protocol "postgresql") }}
 kind: Secret
 apiVersion: v1
@@ -35,6 +40,6 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  connection: {{ (printf "db+%s://%s:%s@%s:%s/%s%s" .Values.data.resultBackendConnection.protocol .Values.data.resultBackendConnection.user .Values.data.resultBackendConnection.pass (ternary (printf "%s-%s" .Release.Name "pgbouncer") $host .Values.pgbouncer.enabled) ((ternary .Values.ports.pgbouncer .Values.data.resultBackendConnection.port .Values.pgbouncer.enabled) | toString) (ternary (printf "%s-%s" .Release.Name "result-backend") .Values.data.resultBackendConnection.db .Values.pgbouncer.enabled) $extras) | b64enc | quote }}
+  connection: {{ (printf "db+%s://%s:%s@%s:%s/%s%s" .Values.data.resultBackendConnection.protocol .Values.data.resultBackendConnection.user .Values.data.resultBackendConnection.pass $host $port $database $extras) | b64enc | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Minor refactor of how the results backend connection secret is built. This moves logic out of an already long line, like it is already done in the metadata connection secret.