### PR TITLE
Chart: Add unit tests for limits and resources

### DIFF
--- a/chart/tests/test_flower.py
+++ b/chart/tests/test_flower.py
@@ -127,3 +127,27 @@ class TestFlower:
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    def test_flower_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "flower": {
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    }
+                },
+            },
+            show_only=["templates/flower/flower-deployment.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_flower_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/flower/flower-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_kerberos.py
+++ b/chart/tests/test_kerberos.py
@@ -89,3 +89,9 @@ class KerberosTest(unittest.TestCase):
         )
         assert jmespath.search("spec.template.spec.containers[2].resources.limits.cpu", docs[0]) == "201m"
         assert jmespath.search("spec.template.spec.containers[2].resources.limits.memory", docs[0]) == "201Mi"
+
+    def test_keberos_sidecar_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_limit_ranges.py
+++ b/chart/tests/test_limit_ranges.py
@@ -30,3 +30,7 @@ class LimitRangesTest(unittest.TestCase):
         )
         assert "LimitRange" == jmespath.search("kind", docs[0])
         assert "500m" == jmespath.search("spec.limits[0].max.cpu", docs[0])
+
+    def test_limit_ranges_are_not_added_by_default(self):
+        docs = render_chart(show_only=["templates/limitrange.yaml"])
+        assert docs == []

--- a/chart/tests/test_limit_ranges.py
+++ b/chart/tests/test_limit_ranges.py
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import jmespath
+
+from chart.tests.helm_template_generator import render_chart
+
+
+class LimitRangesTest(unittest.TestCase):
+    def test_limit_ranges_template(self):
+        docs = render_chart(
+            values={"limits": [{"max": {"cpu": "500m"}, "min": {"min": "200m"}, "type": "Container"}]},
+            show_only=["templates/limitrange.yaml"],
+        )
+        assert "LimitRange" == jmespath.search("kind", docs[0])
+        assert "500m" == jmespath.search("spec.limits[0].max.cpu", docs[0])

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -105,3 +105,31 @@ class PgbouncerTest(unittest.TestCase):
             "name": "pgbouncer-config",
             "secret": {"secretName": "pgbouncer-config-secret"},
         } == jmespath.search("spec.template.spec.volumes[0]", docs[0])
+
+    def test_pgbouncer_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    },
+                },
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_pgbouncer_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {"enabled": True},
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_redis.py
+++ b/chart/tests/test_redis.py
@@ -275,3 +275,27 @@ class RedisTest(unittest.TestCase):
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    def test_redis_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "redis": {
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    }
+                },
+            },
+            show_only=["templates/redis/redis-statefulset.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_redis_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/redis/redis-statefulset.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_resource_quota.py
+++ b/chart/tests/test_resource_quota.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import jmespath
+
+from chart.tests.helm_template_generator import render_chart
+
+
+class ResourceQuotaTest(unittest.TestCase):
+    def test_resource_quota_template(self):
+        docs = render_chart(
+            values={
+                "quotas": {
+                    "configmaps": "10",
+                    "persistentvolumeclaims": "4",
+                    "pods": "4",
+                    "replicationcontrollers": "20",
+                    "secrets": "10",
+                    "services": "10",
+                }
+            },
+            show_only=["templates/resourcequota.yaml"],
+        )
+        assert "ResourceQuota" == jmespath.search("kind", docs[0])
+        assert "20" == jmespath.search("spec.hard.replicationcontrollers", docs[0])

--- a/chart/tests/test_resource_quota.py
+++ b/chart/tests/test_resource_quota.py
@@ -39,3 +39,9 @@ class ResourceQuotaTest(unittest.TestCase):
         )
         assert "ResourceQuota" == jmespath.search("kind", docs[0])
         assert "20" == jmespath.search("spec.hard.replicationcontrollers", docs[0])
+
+    def test_resource_quota_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/resourcequota.yaml"],
+        )
+        assert docs == []

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -192,3 +192,9 @@ class SchedulerTest(unittest.TestCase):
             "spec.template.spec.containers[0].resources.requests.memory", docs[0]
         )
         assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_scheduler_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -174,3 +174,21 @@ class SchedulerTest(unittest.TestCase):
         assert {"name": "logs", **expected_volume} == jmespath.search(
             "spec.template.spec.volumes[1]", docs[0]
         )
+
+    def test_scheduler_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "scheduler": {
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    }
+                },
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])

--- a/chart/tests/test_statsd.py
+++ b/chart/tests/test_statsd.py
@@ -94,3 +94,27 @@ class StatsdTest(unittest.TestCase):
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    def test_stastd_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "statsd": {
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    }
+                },
+            },
+            show_only=["templates/statsd/statsd-deployment.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_statsd_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/statsd/statsd-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_webserver_deployment.py
+++ b/chart/tests/test_webserver_deployment.py
@@ -216,3 +216,27 @@ class WebserverDeploymentTest(unittest.TestCase):
             assert "logs" not in [
                 v["name"] for v in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
             ]
+
+    def test_webserver_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    }
+                },
+            },
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_webserver_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -207,3 +207,27 @@ class WorkerTest(unittest.TestCase):
         assert {"name": "logs", **expected_volume} == jmespath.search(
             "spec.template.spec.volumes[1]", docs[0]
         )
+
+    def test_worker_resources_are_configurable(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "resources": {
+                        "limits": {"cpu": "200m", 'memory': "128Mi"},
+                        "requests": {"cpu": "300m", 'memory': "169Mi"},
+                    }
+                },
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.containers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    def test_worker_resources_are_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}


### PR DESCRIPTION
This change adds tests to validate limitrange and resourcequota templates including scheduler resources limits and requests configuration


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
