### PR TITLE
Allows overriding versioned dirs when publishing documentation

### DIFF
--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -301,12 +301,13 @@ apache-airflow with doc extra:
 
 * `pip install apache-airflow[doc]`
 
-All providers:
+All providers (including overriding documentation for doc-only changes):
 
 ```shell script
 ./docs/publish_docs.py \
     --package-filter apache-airflow-providers \
-    --package-filter 'apache-airflow-providers-*'
+    --package-filter 'apache-airflow-providers-*' \
+    --override-versioned
 
 cd "${AIRFLOW_SITE_DIRECTORY}"
 ```

--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -27,7 +27,7 @@ from tabulate import tabulate
 
 from airflow.utils.helpers import partition
 from docs.exts.docs_build import dev_index_generator, lint_checks  # pylint: disable=no-name-in-module
-from docs.exts.docs_build.code_utils import CONSOLE_WIDTH, PROVIDER_INIT_FILE, TEXT_RED, TEXT_RESET
+from docs.exts.docs_build.code_utils import CONSOLE_WIDTH, PROVIDER_INIT_FILE
 from docs.exts.docs_build.docs_builder import (  # pylint: disable=no-name-in-module
     DOCS_DIR,
     AirflowDocsBuilder,
@@ -44,6 +44,9 @@ from docs.exts.docs_build.spelling_checks import (  # pylint: disable=no-name-in
     SpellingError,
     display_spelling_error_summary,
 )
+
+TEXT_RED = '\033[31m'
+TEXT_RESET = '\033[0m'
 
 if __name__ not in ("__main__", "__mp_main__"):
     raise SystemExit(

--- a/docs/exts/docs_build/code_utils.py
+++ b/docs/exts/docs_build/code_utils.py
@@ -27,11 +27,8 @@ DOCS_DIR = os.path.join(ROOT_PROJECT_DIR, "docs")
 AIRFLOW_DIR = os.path.join(ROOT_PROJECT_DIR, "airflow")
 
 ALL_PROVIDER_YAMLS = load_package_data()
-AIRFLOW_SITE_DIR = os.environ.get('AIRFLOW_SITE_DIRECTORY')
+AIRFLOW_SITE_DIR: str = os.environ.get('AIRFLOW_SITE_DIRECTORY') or ''
 PROCESS_TIMEOUT = 8 * 60  # 400 seconds
-
-TEXT_RED = '\033[31m'
-TEXT_RESET = '\033[0m'
 
 CONSOLE_WIDTH = 180
 
@@ -81,11 +78,8 @@ def prepare_code_snippet(file_path: str, line_no: int, context_lines_count: int 
 
 
 def pretty_format_path(path: str, start: str) -> str:
-    """Formats the path by marking the important part in bold."""
-    end = '\033[0m'
-    bold = '\033[1m'
-
+    """Formats path nicely."""
     relpath = os.path.relpath(path, start)
     if relpath == path:
-        return f"{bold}path{end}"
-    return f"{start}/{bold}{relpath}{end}"
+        return path
+    return f"{start}/{relpath}"

--- a/docs/exts/docs_build/docs_builder.py
+++ b/docs/exts/docs_build/docs_builder.py
@@ -271,7 +271,7 @@ class AirflowDocsBuilder:
             console.print(f"[blue]{self.package_name:60}:[/] [green]Finished docs building successfully[/]")
         return build_errors
 
-    def publish(self):
+    def publish(self, override_versioned: bool):
         """Copy documentation packages files to airflow-site repository."""
         console.print(f"Publishing docs for {self.package_name}")
         output_dir = os.path.join(AIRFLOW_SITE_DIR, self._publish_dir)
@@ -280,14 +280,16 @@ class AirflowDocsBuilder:
         console.print(f"Copy directory: {pretty_source} => {pretty_target}")
         if os.path.exists(output_dir):
             if self.is_versioned:
-                console.print(
-                    f"Skipping previously existing {output_dir}! "
-                    f"Delete it manually if you want to regenerate it!"
-                )
-                console.print()
-                return
-            else:
-                shutil.rmtree(output_dir)
+                if override_versioned:
+                    console.print(f"Overriding previously existing {output_dir}! ")
+                else:
+                    console.print(
+                        f"Skipping previously existing {output_dir}! "
+                        f"Delete it manually if you want to regenerate it!"
+                    )
+                    console.print()
+                    return
+            shutil.rmtree(output_dir)
         shutil.copytree(self._build_dir, output_dir)
         if self.is_versioned:
             with open(os.path.join(output_dir, "..", "stable.txt"), "w") as stable_file:

--- a/docs/publish_docs.py
+++ b/docs/publish_docs.py
@@ -66,6 +66,12 @@ def _get_parser():
         '--disable-checks', dest='disable_checks', action='store_true', help='Disables extra checks'
     )
     parser.add_argument(
+        '--override-versioned',
+        dest='override_versioned',
+        action='store_true',
+        help='Overrides versioned directories',
+    )
+    parser.add_argument(
         "--package-filter",
         action="append",
         help=(
@@ -90,7 +96,7 @@ def main():
     print()
     for package_name in current_packages:
         builder = AirflowDocsBuilder(package_name=package_name, for_production=True)
-        builder.publish()
+        builder.publish(override_versioned=args.override_versioned)
 
 
 main()


### PR DESCRIPTION
We are allowign doc-only-changes when releasing providers,
therefore we might want to regenerate documentation for latest
version of the provider packages when there are doc-only changes.

The new --override-versioned flag enables that.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
