### PR TITLE
Chart: Update Webserver update strategy based on Airflow Version

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -51,11 +51,13 @@ data:
     {{ .Values.dags.gitSync.knownHosts | nindent 4 }}
 {{- end }}
 {{- if or (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
+{{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
   pod_template_file.yaml: |-
 {{- if .Values.podTemplate }}
     {{ .Values.podTemplate | nindent 4 }}
 {{- else }}
 {{ tpl (.Files.Get "files/pod-template-file.kubernetes-helm-yaml") . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- if .Values.kerberos.enabled }}
   krb5.conf: |

--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -73,7 +73,11 @@ spec:
         - name: flower
           image: {{ template "flower_image" . }}
           imagePullPolicy: {{ .Values.images.flower.pullPolicy }}
-          args: ["bash", "-c", "airflow celery flower || airflow flower"]
+          {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+          args: ["bash", "-c", "airflow celery flower"]
+          {{- else }}
+          args: ["bash", "-c", "airflow flower"]
+          {{- end }}
           resources:
 {{ toYaml .Values.flower.resources | indent 12 }}
           volumeMounts:

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -68,8 +68,11 @@ spec:
           args:
             - "bash"
             - "-c"
-            # Support running against 1.10.x and 2.x
-            - 'airflow users create "$@" || airflow create_user "$@"'
+            {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+            - 'airflow users create "$@"'
+            {{- else }}
+            - 'airflow create_user "$@"'
+            {{- end }}
             - --
             - "-r"
             - {{ .Values.webserver.defaultUser.role }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -65,7 +65,11 @@ spec:
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           # Support running against 1.10.x and 2.x
-          args: ["bash", "-c", "airflow db upgrade || airflow upgradedb"]
+          {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+          args: ["bash", "-c", "airflow db upgrade"]
+          {{- else }}
+          args: ["bash", "-c", "airflow upgradedb"]
+          {{- end }}
           envFrom:
           {{- include "custom_airflow_environment_from" . | default "\n  []" | indent 10 }}
           env:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -150,10 +150,12 @@ spec:
           resources:
 {{ toYaml .Values.scheduler.resources | indent 12 }}
           volumeMounts:
+            {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
             - name: config
               mountPath: {{ include "airflow_pod_template_file" . }}/pod_template_file.yaml
               subPath: pod_template_file.yaml
               readOnly: true
+            {{- end }}
             - name: logs
               mountPath: {{ template "airflow_logs" . }}
             - name: config

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -37,9 +37,25 @@ metadata:
 spec:
   replicas: {{ .Values.webserver.replicas }}
   strategy:
+    {{- if .Values.webserver.strategy }}
+    {{- toYaml .Values.webserver.strategy | nindent 4 }}
+    {{- else }}
+    {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+    # Here we define the rolling update strategy
+    # - maxSurge define how many pod we can add at a time
+    # - maxUnavailable define how many pod can be unavailable
+    #   during the rolling update
+    # Setting maxUnavailable to 0 would make sure we have the appropriate
+    # capacity during the rolling update.
+    # You can also use percentage based value instead of integer.
     type: RollingUpdate
     rollingUpdate:
-      maxUnavailable: 1
+      maxSurge: 1
+      maxUnavailable: 0
+    {{- else }}
+    type: Recreate
+    {{- end}}
+    {{- end}}
   selector:
     matchLabels:
       tier: airflow

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -127,7 +127,11 @@ spec:
         - name: worker
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
-          args: ["bash", "-c", "airflow celery worker || airflow worker"]
+          {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}
+          args: [ "bash", "-c", "airflow celery worker" ]
+          {{- else }}
+          args: [ "bash", "-c", "airflow worker" ]
+          {{- end }}
           resources:
 {{ toYaml .Values.workers.resources | indent 12 }}
           ports:

--- a/chart/tests/test_flower.py
+++ b/chart/tests/test_flower.py
@@ -44,6 +44,43 @@ class TestFlower:
             assert "RELEASE-NAME-flower" == jmespath.search("metadata.name", docs[0])
             assert "flower" == jmespath.search("spec.template.spec.containers[0].name", docs[0])
 
+    @pytest.mark.parametrize(
+        "airflow_version, expected_arg",
+        [
+            (
+                "2.0.2",
+                "airflow celery flower",
+            ),
+            (
+                "1.10.14",
+                "airflow flower",
+            ),
+            (
+                "1.9.0",
+                "airflow flower",
+            ),
+            (
+                "2.1.0",
+                "airflow celery flower",
+            ),
+        ],
+    )
+    def test_args_with_airflow_version(self, airflow_version, expected_arg):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "flower": {"enabled": True},
+                "airflowVersion": airflow_version,
+            },
+            show_only=["templates/flower/flower-deployment.yaml"],
+        )
+
+        assert jmespath.search("spec.template.spec.containers[0].args", docs[0]) == [
+            "bash",
+            "-c",
+            expected_arg,
+        ]
+
     def test_should_create_flower_deployment_with_authorization(self):
         docs = render_chart(
             values={

--- a/chart/tests/test_webserver_deployment.py
+++ b/chart/tests/test_webserver_deployment.py
@@ -240,3 +240,28 @@ class WebserverDeploymentTest(unittest.TestCase):
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
+
+    @parameterized.expand(
+        [
+            ("2.0.2", {"type": "RollingUpdate", "rollingUpdate": {"maxSurge": 1, "maxUnavailable": 0}}),
+            ("1.10.14", {"type": "Recreate"}),
+            ("1.9.0", {"type": "Recreate"}),
+            ("2.1.0", {"type": "RollingUpdate", "rollingUpdate": {"maxSurge": 1, "maxUnavailable": 0}}),
+        ],
+    )
+    def test_default_update_strategy(self, airflow_version, expected_strategy):
+        docs = render_chart(
+            values={"airflowVersion": airflow_version},
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+
+        assert jmespath.search("spec.strategy", docs[0]) == expected_strategy
+
+    def test_update_strategy(self):
+        expected_strategy = {"type": "RollingUpdate", "rollingUpdate": {"maxUnavailable": 1}}
+        docs = render_chart(
+            values={"webserver": {"strategy": expected_strategy}},
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+
+        assert jmespath.search("spec.strategy", docs[0]) == expected_strategy

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -31,6 +31,10 @@
             "description": "Default airflow tag to deploy.",
             "type": "string"
         },
+        "airflowVersion": {
+            "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
+            "type": "string"
+        },
         "nodeSelector": {
             "description": "Select certain nodes for airflow pods.",
             "type": "object",
@@ -940,6 +944,10 @@
                 "replicas": {
                     "description": "How many Airflow webserver replicas should run.",
                     "type": "integer"
+                },
+                "strategy": {
+                    "description": "Specifies the strategy used to replace old Pods by new ones.",
+                    "type": ["null", "object"]
                 },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -39,6 +39,43 @@ defaultAirflowRepository: apache/airflow
 # Default airflow tag to deploy
 defaultAirflowTag: 2.0.2
 
+# Airflow version (Used to make some decisions based on Airflow Version being deployed)
+airflowVersion: 2.0.2
+
+# Images
+images:
+  airflow:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+  pod_template:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+  flower:
+    repository: ~
+    tag: ~
+    pullPolicy: IfNotPresent
+  statsd:
+    repository: apache/airflow
+    tag: airflow-statsd-exporter-2021.04.28-v0.17.0
+    pullPolicy: IfNotPresent
+  redis:
+    repository: redis
+    tag: 6-buster
+    pullPolicy: IfNotPresent
+  pgbouncer:
+    repository: apache/airflow
+    tag: airflow-pgbouncer-2021.04.28-1.14.0
+    pullPolicy: IfNotPresent
+  pgbouncerExporter:
+    repository: apache/airflow
+    tag: airflow-pgbouncer-exporter-2021.04.28-0.5.0
+    pullPolicy: IfNotPresent
+  gitSync:
+    repository: k8s.gcr.io/git-sync/git-sync
+    tag: v3.3.0
+    pullPolicy: IfNotPresent
 
 # Select certain nodes for airflow pods.
 nodeSelector: {}
@@ -125,41 +162,6 @@ executor: "CeleryExecutor"
 # If this is true and using CeleryExecutor/KubernetesExecutor/CeleryKubernetesExecutor, the workers
 # will be able to launch pods.
 allowPodLaunching: true
-
-# Images
-images:
-  airflow:
-    repository: ~
-    tag: ~
-    pullPolicy: IfNotPresent
-  pod_template:
-    repository: ~
-    tag: ~
-    pullPolicy: IfNotPresent
-  flower:
-    repository: ~
-    tag: ~
-    pullPolicy: IfNotPresent
-  statsd:
-    repository: apache/airflow
-    tag: airflow-statsd-exporter-2021.04.28-v0.17.0
-    pullPolicy: IfNotPresent
-  redis:
-    repository: redis
-    tag: 6-buster
-    pullPolicy: IfNotPresent
-  pgbouncer:
-    repository: apache/airflow
-    tag: airflow-pgbouncer-2021.04.28-1.14.0
-    pullPolicy: IfNotPresent
-  pgbouncerExporter:
-    repository: apache/airflow
-    tag: airflow-pgbouncer-exporter-2021.04.28-0.5.0
-    pullPolicy: IfNotPresent
-  gitSync:
-    repository: k8s.gcr.io/git-sync/git-sync
-    tag: v3.3.0
-    pullPolicy: IfNotPresent
 
 # Environment variables for all airflow containers
 env: []
@@ -519,6 +521,9 @@ webserver:
 
     # Annotations to add to webserver kubernetes service account.
     annotations: {}
+
+  # Allow overriding Update Strategy for Webserver
+  strategy: ~
 
   # Additional network policies as needed
   extraNetworkPolicies: []

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -83,64 +83,67 @@ The following tables lists the configurable parameters of the Airflow chart and 
      - ``1``
    * - ``defaultAirflowRepository``
      - Fallback docker repository to pull airflow image from
-     - ``1``
+     - ``apache/airflow``
    * - ``defaultAirflowTag``
      - Fallback docker image tag to deploy
-     - ``1``
+     - ``2.0.2``
+   * - ``airflowVersion``
+     - Airflow version (Used to make some decisions based on Airflow Version being deployed)
+     - ``2.0.2``
    * - ``images.airflow.repository``
      - Docker repository to pull image from. Update this to deploy a custom image
-     - ``1``
+     - ``~``
    * - ``images.airflow.tag``
      - Docker image tag to pull image from. Update this to deploy a new custom image tag
-     - ``1``
+     - ``~``
    * - ``images.airflow.pullPolicy``
      - PullPolicy for airflow image
-     - ``1``
+     - ``IfNotPresent``
    * - ``images.flower.repository``
      - Docker repository to pull image from. Update this to deploy a custom image
-     - ``1``
+     - ``~``
    * - ``images.flower.tag``
      - Docker image tag to pull image from. Update this to deploy a new custom image tag
-     - ``1``
+     - ``~``
    * - ``images.flower.pullPolicy``
      - PullPolicy for flower image
-     - ``1``
+     - ``IfNotPresent``
    * - ``images.statsd.repository``
      - Docker repository to pull image from. Update this to deploy a custom image
-     - ``1``
+     - ``apache/airflow``
    * - ``images.statsd.tag``
      - Docker image tag to pull image from. Update this to deploy a new custom image tag
-     - ``1``
+     - ``airflow-statsd-exporter-2021.04.28-v0.17.0``
    * - ``images.statsd.pullPolicy``
      - PullPolicy for statsd-exporter image
-     - ``1``
+     - ``IfNotPresent``
    * - ``images.redis.repository``
      - Docker repository to pull image from. Update this to deploy a custom image
-     - ``1``
+     - ``redis``
    * - ``images.redis.tag``
      - Docker image tag to pull image from. Update this to deploy a new custom image tag
-     - ``1``
+     - ``6-buster``
    * - ``images.redis.pullPolicy``
      - PullPolicy for redis image
-     - ``1``
+     - ``IfNotPresent``
    * - ``images.pgbouncer.repository``
      - Docker repository to pull image from. Update this to deploy a custom image
-     - ``1``
+     - ``apache/airflow``
    * - ``images.pgbouncer.tag``
      - Docker image tag to pull image from. Update this to deploy a new custom image tag
-     - ``1``
+     - ``airflow-pgbouncer-2021.04.28-1.14.0``
    * - ``images.pgbouncer.pullPolicy``
      - PullPolicy for PgBouncer image
-     - ``1``
+     - ``IfNotPresent``
    * - ``images.pgbouncerExporter.repository``
      - Docker repository to pull image from. Update this to deploy a custom image
-     - ``1``
+     - ``apache/airflow``
    * - ``images.pgbouncerExporter.tag``
      - Docker image tag to pull image from. Update this to deploy a new custom image tag
-     - ``1``
+     - ``airflow-pgbouncer-exporter-2021.04.28-0.5.0``
    * - ``images.pgbouncerExporter.pullPolicy``
      - PullPolicy for ``pgbouncer-exporter`` image
-     - ``1``
+     - ``IfNotPresent``
    * - ``env``
      - Environment variables key/values to mount into Airflow pods (deprecated, prefer using ``extraEnv``)
      - ``1``


### PR DESCRIPTION
This commit adds the following things:

- Add "airflowVersion" flag that will allow use to add some components
	that are just available or work with certain Airflow version.
	Example: pod_template_file is available for Airflow >= 1.10.12
- Update logic for selecting pre/post Airflow 2.0 CLI commands based
	on that flag
- Updates stragtegy of Airflow Webserver based on that flag as the
	webserver in Airflow >= 2 does not need access to DAG files, hence
	we don't need to recreate but can have a "true" rollingUpdate
- Allow overriding webserver udpate strategy

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
