### PR TITLE
Docs: Replace 'airflow' to 'apache-airflow' to install extra

### DIFF
--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -63,7 +63,7 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         except Exception as e:  # pylint: disable=broad-except
             self.log.error(
                 'Could not create an AwsLogsHook with connection id "%s". '
-                'Please make sure that airflow[aws] is installed and '
+                'Please make sure that apache-airflow[aws] is installed and '
                 'the Cloudwatch logs connection exists. Exception: "%s"',
                 remote_conn_id,
                 e,

--- a/airflow/providers/amazon/aws/log/s3_task_handler.py
+++ b/airflow/providers/amazon/aws/log/s3_task_handler.py
@@ -53,7 +53,7 @@ class S3TaskHandler(FileTaskHandler, LoggingMixin):
         except Exception as e:  # pylint: disable=broad-except
             self.log.exception(
                 'Could not create an S3Hook with connection id "%s". '
-                'Please make sure that airflow[aws] is installed and '
+                'Please make sure that apache-airflow[aws] is installed and '
                 'the S3 connection exists. Exception : "%s"',
                 remote_conn_id,
                 e,

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -66,7 +66,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
         except AzureHttpError:
             self.log.exception(
                 'Could not create an WasbHook with connection id "%s".'
-                ' Please make sure that airflow[azure] is installed'
+                ' Please make sure that apache-airflow[azure] is installed'
                 ' and the Wasb connection exists.',
                 remote_conn_id,
             )

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -92,7 +92,7 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
 
             mock_error.assert_called_once_with(
                 'Could not create an AwsLogsHook with connection id "%s". Please make '
-                'sure that airflow[aws] is installed and the Cloudwatch '
+                'sure that apache-airflow[aws] is installed and the Cloudwatch '
                 'logs connection exists. Exception: "%s"',
                 'aws_default',
                 ANY,

--- a/tests/providers/amazon/aws/log/test_s3_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_s3_task_handler.py
@@ -93,7 +93,7 @@ class TestS3TaskHandler(unittest.TestCase):
 
             mock_error.assert_called_once_with(
                 'Could not create an S3Hook with connection id "%s". Please make '
-                'sure that airflow[aws] is installed and the S3 connection exists. Exception : "%s"',
+                'sure that apache-airflow[aws] is installed and the S3 connection exists. Exception : "%s"',
                 'aws_default',
                 ANY,
                 exc_info=True,

--- a/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
+++ b/tests/providers/microsoft/azure/log/test_wasb_task_handler.py
@@ -71,7 +71,7 @@ class TestWasbTaskHandler(unittest.TestCase):
 
             mock_error.assert_called_once_with(
                 'Could not create an WasbHook with connection id "%s".'
-                ' Please make sure that airflow[azure] is installed'
+                ' Please make sure that apache-airflow[azure] is installed'
                 ' and the Wasb connection exists.',
                 'wasb_default',
                 exc_info=True,


### PR DESCRIPTION
Some of the docs advised to use 'airflow[azure]' whereas it should be
apache-airflow[azure]

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
