### PR TITLE
Add link to Oracle Connection Docs

### DIFF
--- a/airflow/providers/google/cloud/transfers/oracle_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/oracle_to_gcs.py
@@ -36,7 +36,8 @@ class OracleToGCSOperator(BaseSQLToGCSOperator):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:OracleToGCSOperator`
 
-    :param oracle_conn_id: Reference to a specific Oracle hook.
+    :param oracle_conn_id: Reference to a specific
+        :ref:`Oracle hook <howto/connection:oracle>`.
     :type oracle_conn_id: str
     :param ensure_utc: Ensure TIMESTAMP columns exported as UTC. If set to
         `False`, TIMESTAMP columns will be exported using the Oracle server's

--- a/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py
+++ b/airflow/providers/microsoft/azure/transfers/oracle_to_azure_data_lake.py
@@ -40,7 +40,7 @@ class OracleToAzureDataLakeOperator(BaseOperator):
     :type azure_data_lake_conn_id: str
     :param azure_data_lake_path: destination path in azure data lake to put the file.
     :type azure_data_lake_path: str
-    :param oracle_conn_id: source Oracle connection.
+    :param oracle_conn_id: :ref:`Source Oracle connection <howto/connection:oracle>`.
     :type oracle_conn_id: str
     :param sql: SQL query to execute against the Oracle database. (templated)
     :type sql: str

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -29,7 +29,8 @@ class OracleHook(DbApiHook):
     """
     Interact with Oracle SQL.
 
-    :param oracle_conn_id: The Airflow connection used for Oracle credentials.
+    :param oracle_conn_id: The :ref:`Oracle connection id <howto/connection:oracle>`
+        used for Oracle credentials.
     :type oracle_conn_id: str
     """
 

--- a/airflow/providers/oracle/operators/oracle.py
+++ b/airflow/providers/oracle/operators/oracle.py
@@ -31,7 +31,8 @@ class OracleOperator(BaseOperator):
         Template reference are recognized by str ending in '.sql'
         (templated)
     :type sql: str or list[str]
-    :param oracle_conn_id: reference to a specific Oracle database
+    :param oracle_conn_id: The :ref:`Oracle connection id <howto/connection:oracle>`
+        reference to a specific Oracle database.
     :type oracle_conn_id: str
     :param parameters: (optional) the parameters to render the SQL query with.
     :type parameters: dict or iterable

--- a/airflow/providers/oracle/transfers/oracle_to_oracle.py
+++ b/airflow/providers/oracle/transfers/oracle_to_oracle.py
@@ -31,7 +31,7 @@ class OracleToOracleOperator(BaseOperator):
     :type oracle_destination_conn_id: str
     :param destination_table: destination table to insert rows.
     :type destination_table: str
-    :param oracle_source_conn_id: source Oracle connection.
+    :param oracle_source_conn_id: :ref:`Source Oracle connection <howto/connection:oracle>`.
     :type oracle_source_conn_id: str
     :param source_sql: SQL query to execute against the source Oracle
         database. (templated)

--- a/docs/apache-airflow-providers-oracle/connections/oracle.rst
+++ b/docs/apache-airflow-providers-oracle/connections/oracle.rst
@@ -17,6 +17,8 @@
 
 
 
+.. _howto/connection:oracle:
+
 Oracle Connection
 =================
 The Oracle connection type provides connection to a Oracle database.


### PR DESCRIPTION
This PR adds a Oracle Connection docs link to the docstrings of modules that use the oracle conn id. 
