### PR TITLE
Fix add quotes to extraConfigMaps/extraSecrets

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -187,7 +187,7 @@ extraSecrets: {}
 #       AIRFLOW_CONN_AWS: 'base64_encoded_aws_conn_string'
 #     stringData: |
 #       AIRFLOW_CONN_OTHER: 'other_conn'
-#   {{ .Release.Name }}-other-secret-name-suffix: |
+#   '{{ .Release.Name }}-other-secret-name-suffix': |
 #     data: |
 #        ...
 

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -181,7 +181,7 @@ secret: []
 extraSecrets: {}
 # eg:
 # extraSecrets:
-#   {{ .Release.Name }}-airflow-connections:
+#   '{{ .Release.Name }}-airflow-connections':
 #     data: |
 #       AIRFLOW_CONN_GCP: 'base64_encoded_gcp_conn_string'
 #       AIRFLOW_CONN_AWS: 'base64_encoded_aws_conn_string'
@@ -200,7 +200,7 @@ extraSecrets: {}
 extraConfigMaps: {}
 # eg:
 # extraConfigMaps:
-#   {{ .Release.Name }}-airflow-variables:
+#   '{{ .Release.Name }}-airflow-variables':
 #     data: |
 #       AIRFLOW_VAR_HELLO_MESSAGE: "Hi!"
 #       AIRFLOW_VAR_KUBERNETES_NAMESPACE: "{{ .Release.Namespace }}"


### PR DESCRIPTION
Without quotes we gets helm error when **extraSecrets** and/or **extraConfigMaps** used with **{{ .Release.Name }}-somename**:
`Error: failed to parse ./values.yaml: error converting YAML to JSON: yaml: line 234: did not find expected key
helm.go:94: [debug] error converting YAML to JSON: yaml: line 234: did not find expected key
`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
