### PR TITLE
Fix multiple issues in Microsoft AzureContainerInstancesOperator

### DIFF
--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -316,19 +316,20 @@ class AzureContainerInstancesOperator(BaseOperator):
                         c_state.exit_code,
                         c_state.detail_status,
                     )
-
-                    messages = [event.message for event in instance_view.events]
-                    last_message_logged = self._log_last(messages, last_message_logged)
                 else:
                     state = cg_state.provisioning_state
                     exit_code = 0
                     detail_status = "Provisioning"
 
+                if instance_view is not None and instance_view.events is not None:
+                    messages = [event.message for event in instance_view.events]
+                    last_message_logged = self._log_last(messages, last_message_logged)
+
                 if state != last_state:
                     self.log.info("Container group state changed to %s", state)
                     last_state = state
 
-                if state in ["Running", "Terminated"]:
+                if state in ["Running", "Terminated", "Succeeded"]:
                     try:
                         logs = self._ci_hook.get_logs(resource_group, name)
                         last_line_logged = self._log_last(logs, last_line_logged)
@@ -337,8 +338,8 @@ class AzureContainerInstancesOperator(BaseOperator):
                             "Exception while getting logs from container instance, retrying..."
                         )
 
-                if state == "Terminated":
-                    self.log.error("Container exited with detail_status %s", detail_status)
+                if state in ["Terminated"]:
+                    self.log.info("Container exited with detail_status %s", detail_status)
                     return exit_code
 
                 if state == "Failed":
@@ -360,7 +361,7 @@ class AzureContainerInstancesOperator(BaseOperator):
             except Exception:  # pylint: disable=broad-except
                 self.log.exception("Exception while getting container groups")
 
-        sleep(1)
+            sleep(1)
 
     def _log_last(self, logs: Optional[list], last_line_logged: Any) -> Optional[Any]:
         if logs:

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -338,7 +338,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                             "Exception while getting logs from container instance, retrying..."
                         )
 
-                if state in ["Terminated"]:
+                if state == "Terminated":
                     self.log.info("Container exited with detail_status %s", detail_status)
                     return exit_code
 

--- a/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
@@ -48,6 +48,24 @@ def make_mock_cg(container_state, events=None):
     return container_g
 
 
+def make_mock_cg_with_missing_events(container_state):
+    """
+    Make a mock Container Group as the underlying azure Models have read-only attributes
+    See https://docs.microsoft.com/en-us/rest/api/container-instances/containergroups
+    This creates the Container Group without events.
+    This can happen, when the container group is provisioned, but not started.
+    """
+    instance_view_dict = {"current_state": container_state, "events": None}
+    instance_view = namedtuple("InstanceView", instance_view_dict.keys())(*instance_view_dict.values())
+
+    container_dict = {"instance_view": instance_view}
+    container = namedtuple("Container", container_dict.keys())(*container_dict.values())
+
+    container_g_dict = {"containers": [container]}
+    container_g = namedtuple("ContainerGroup", container_g_dict.keys())(*container_g_dict.values())
+    return container_g
+
+
 class TestACIOperator(unittest.TestCase):
     @mock.patch(
         "airflow.providers.microsoft.azure.operators." "azure_container_instances.AzureContainerInstanceHook"
@@ -157,12 +175,14 @@ class TestACIOperator(unittest.TestCase):
     )
     def test_execute_with_messages_logs(self, aci_mock):
         events = [Event(message="test"), Event(message="messages")]
-        expected_c_state1 = ContainerState(state='Running', exit_code=0, detail_status='test')
+        expected_c_state1 = ContainerState(state='Succeeded', exit_code=0, detail_status='test')
         expected_cg1 = make_mock_cg(expected_c_state1, events)
-        expected_c_state2 = ContainerState(state='Terminated', exit_code=0, detail_status='test')
+        expected_c_state2 = ContainerState(state='Running', exit_code=0, detail_status='test')
         expected_cg2 = make_mock_cg(expected_c_state2, events)
+        expected_c_state3 = ContainerState(state='Terminated', exit_code=0, detail_status='test')
+        expected_cg3 = make_mock_cg(expected_c_state3, events)
 
-        aci_mock.return_value.get_state.side_effect = [expected_cg1, expected_cg2]
+        aci_mock.return_value.get_state.side_effect = [expected_cg1, expected_cg2, expected_cg3]
         aci_mock.return_value.get_logs.return_value = ["test", "logs"]
         aci_mock.return_value.exists.return_value = False
 
@@ -178,8 +198,8 @@ class TestACIOperator(unittest.TestCase):
         aci.execute(None)
 
         assert aci_mock.return_value.create_or_update.call_count == 1
-        assert aci_mock.return_value.get_state.call_count == 2
-        assert aci_mock.return_value.get_logs.call_count == 2
+        assert aci_mock.return_value.get_state.call_count == 3
+        assert aci_mock.return_value.get_logs.call_count == 3
 
         assert aci_mock.return_value.delete.call_count == 1
 
@@ -310,3 +330,59 @@ class TestACIOperator(unittest.TestCase):
             "Please set one of 'Always', 'OnFailure','Never' as the restart_policy. "
             "Found `Everyday`"
         )
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.azure_container_instances.AzureContainerInstanceHook"
+    )
+    @mock.patch(
+        'airflow.providers.microsoft.azure.operators.azure_container_instances.sleep'
+    )
+    def test_execute_correct_sleep_cycle(self, sleep_mock, aci_mock):
+        expected_c_state1 = ContainerState(state='Running', exit_code=0, detail_status='test')
+        expected_cg1 = make_mock_cg(expected_c_state1)
+        expected_c_state2 = ContainerState(state='Terminated', exit_code=0, detail_status='test')
+        expected_cg2 = make_mock_cg(expected_c_state2)
+
+        aci_mock.return_value.get_state.side_effect = [expected_cg1, expected_cg1, expected_cg2]
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id=None,
+            registry_conn_id=None,
+            resource_group='resource-group',
+            name='container-name',
+            image='container-image',
+            region='region',
+            task_id='task',
+        )
+        aci.execute(None)
+
+        # sleep is called at the end of cycles. Thus, the Terminated call does not trigger sleep
+        assert sleep_mock.call_count == 2
+
+    @mock.patch(
+        "airflow.providers.microsoft.azure.operators.azure_container_instances.AzureContainerInstanceHook"
+    )
+    @mock.patch("logging.Logger.exception")
+    def test_execute_with_missing_events(self, log_mock, aci_mock):
+        expected_c_state1 = ContainerState(state='Running', exit_code=0, detail_status='test')
+        expected_cg1 = make_mock_cg_with_missing_events(expected_c_state1)
+        expected_c_state2 = ContainerState(state='Terminated', exit_code=0, detail_status='test')
+        expected_cg2 = make_mock_cg(expected_c_state2)
+
+        aci_mock.return_value.get_state.side_effect = [expected_cg1, expected_cg2]
+        aci_mock.return_value.exists.return_value = False
+
+        aci = AzureContainerInstancesOperator(
+            ci_conn_id=None,
+            registry_conn_id=None,
+            resource_group='resource-group',
+            name='container-name',
+            image='container-image',
+            region='region',
+            task_id='task',
+        )
+
+        aci.execute(None)
+
+        assert log_mock.call_count == 0

--- a/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_container_instances.py
@@ -334,9 +334,7 @@ class TestACIOperator(unittest.TestCase):
     @mock.patch(
         "airflow.providers.microsoft.azure.operators.azure_container_instances.AzureContainerInstanceHook"
     )
-    @mock.patch(
-        'airflow.providers.microsoft.azure.operators.azure_container_instances.sleep'
-    )
+    @mock.patch('airflow.providers.microsoft.azure.operators.azure_container_instances.sleep')
     def test_execute_correct_sleep_cycle(self, sleep_mock, aci_mock):
         expected_c_state1 = ContainerState(state='Running', exit_code=0, detail_status='test')
         expected_cg1 = make_mock_cg(expected_c_state1)

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# pylint: disable=no-member
+
 import unittest
 from datetime import timedelta
 from unittest.mock import Mock, patch

--- a/tests/sensors/test_smart_sensor_operator.py
+++ b/tests/sensors/test_smart_sensor_operator.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# pylint: disable=no-member
+
 import datetime
 import logging
 import os


### PR DESCRIPTION
After having worked with with Airflow in Azure using the AzureContainerInstancesOperator I encountered some issues. 
- The sleep command seems to be indented wrongly and not run periodically.
- When log messages are collected, a check for None is missing.
- One possible state for logging is missing.
- Container exits are logged as error, should be info.
