### PR TITLE
Fix issue with parsing error logs in the KPO

### DIFF
--- a/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
@@ -17,6 +17,7 @@
 import unittest
 from unittest import mock
 
+import pendulum
 import pytest
 from kubernetes.client.rest import ApiException
 from requests.exceptions import BaseHTTPError
@@ -198,12 +199,15 @@ class TestPodLauncher(unittest.TestCase):
             self.pod_launcher.read_pod(mock.sentinel)
 
     def test_parse_log_line(self):
-        timestamp, message = self.pod_launcher.parse_log_line(
-            '2020-10-08T14:16:17.793417674Z Valid message\n'
-        )
+        log_message = "This should return no timestamp"
+        timestamp, line = self.pod_launcher.parse_log_line(log_message)
+        self.assertEqual(timestamp, None)
+        self.assertEqual(line, log_message)
 
-        assert timestamp == '2020-10-08T14:16:17.793417674Z'
-        assert message == 'Valid message'
+        real_timestamp = "2020-10-08T14:16:17.793417674Z"
+        timestamp, line = self.pod_launcher.parse_log_line(" ".join([real_timestamp, log_message]))
+        self.assertEqual(timestamp, pendulum.parse(real_timestamp))
+        self.assertEqual(line, log_message)
 
         with pytest.raises(Exception):
             self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674ZInvalidmessage\n')


### PR DESCRIPTION
This fixes an issue where logs that do not have timestamps cause the
KubernetesPodOperator to crash. Basically error logs created by airflow
do not have timestamps, which was causing an unhandled exception that
    would kill the task. This PR handles that exception and ensures
    continued task processing

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
