### PR TITLE
Allow chart to work with custom cluster domains

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -300,8 +300,8 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{ define "pgbouncer_config" }}
-{{- $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s.svc.cluster.local" .Release.Name "postgresql" .Release.Namespace) }}
-{{- $pgResultBackendHost := .Values.data.resultBackendConnection.host | default (printf "%s-%s.%s.svc.cluster.local" .Release.Name "postgresql" .Release.Namespace) }}
+{{- $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
+{{- $pgResultBackendHost := .Values.data.resultBackendConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
 [databases]
 {{ .Release.Name }}-metadata = host={{ $pgMetadataHost }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }}
 {{ .Release.Name }}-result-backend = host={{ $pgResultBackendHost }} dbname={{ .Values.data.resultBackendConnection.db }} port={{ .Values.data.resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -300,8 +300,8 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{ define "pgbouncer_config" }}
-{{- $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
-{{- $pgResultBackendHost := .Values.data.resultBackendConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
+{{- $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
+{{- $pgResultBackendHost := .Values.data.resultBackendConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
 [databases]
 {{ .Release.Name }}-metadata = host={{ $pgMetadataHost }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }}
 {{ .Release.Name }}-result-backend = host={{ $pgResultBackendHost }} dbname={{ .Values.data.resultBackendConnection.db }} port={{ .Values.data.resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -19,8 +19,8 @@
 ## Airflow Metadata Secret
 #################################
 {{- if not .Values.data.metadataSecretName }}
-{{- $metadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
-{{- $pgbouncerHost := (printf "%s-%s" .Release.Name "pgbouncer") }}
+{{- $metadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
+{{- $pgbouncerHost := (printf "%s-%s.%s" .Release.Name "pgbouncer" .Release.Namespace) }}
 {{- $host := ternary $pgbouncerHost $metadataHost .Values.pgbouncer.enabled }}
 {{- $port := ((ternary .Values.ports.pgbouncer .Values.data.metadataConnection.port .Values.pgbouncer.enabled) | toString) }}
 {{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}

--- a/chart/templates/secrets/metadata-connection-secret.yaml
+++ b/chart/templates/secrets/metadata-connection-secret.yaml
@@ -19,8 +19,8 @@
 ## Airflow Metadata Secret
 #################################
 {{- if not .Values.data.metadataSecretName }}
-{{- $metadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s.svc.cluster.local" .Release.Name "postgresql" .Release.Namespace) }}
-{{- $pgbouncerHost := (printf "%s-%s.%s.svc.cluster.local" .Release.Name "pgbouncer" .Release.Namespace) }}
+{{- $metadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s" .Release.Name "postgresql") }}
+{{- $pgbouncerHost := (printf "%s-%s" .Release.Name "pgbouncer") }}
 {{- $host := ternary $pgbouncerHost $metadataHost .Values.pgbouncer.enabled }}
 {{- $port := ((ternary .Values.ports.pgbouncer .Values.data.metadataConnection.port .Values.pgbouncer.enabled) | toString) }}
 {{- $database := (ternary (printf "%s-%s" .Release.Name "metadata") .Values.data.metadataConnection.db .Values.pgbouncer.enabled) }}

--- a/chart/tests/test_metadata_connection_secret.py
+++ b/chart/tests/test_metadata_connection_secret.py
@@ -53,8 +53,8 @@ class MetadataConnectionSecretTest(unittest.TestCase):
         connection = self._get_connection({})
 
         assert (
-            "postgresql://postgres:postgres@RELEASE-NAME-postgresql.default.svc.cluster.local:5432"
-            "/postgres?sslmode=disable" == connection
+            "postgresql://postgres:postgres@RELEASE-NAME-postgresql:5432/postgres?sslmode=disable"
+            == connection
         )
 
     def test_should_set_pgbouncer_overrides_when_enabled(self):
@@ -63,8 +63,8 @@ class MetadataConnectionSecretTest(unittest.TestCase):
 
         # host, port, dbname get overridden
         assert (
-            "postgresql://postgres:postgres@RELEASE-NAME-pgbouncer.default.svc.cluster.local:6543"
-            "/RELEASE-NAME-metadata?sslmode=disable" == connection
+            "postgresql://postgres:postgres@RELEASE-NAME-pgbouncer:6543/RELEASE-NAME-metadata?sslmode=disable"
+            == connection
         )
 
     def test_should_set_pgbouncer_overrides_with_non_chart_database_when_enabled(self):
@@ -76,8 +76,8 @@ class MetadataConnectionSecretTest(unittest.TestCase):
 
         # host, port, dbname still get overridden even with an non-chart db
         assert (
-            "postgresql://someuser:somepass@RELEASE-NAME-pgbouncer.default.svc.cluster.local:6543"
-            "/RELEASE-NAME-metadata?sslmode=disable" == connection
+            "postgresql://someuser:somepass@RELEASE-NAME-pgbouncer:6543/RELEASE-NAME-metadata?sslmode=disable"
+            == connection
         )
 
     def test_should_correctly_use_non_chart_database(self):

--- a/chart/tests/test_metadata_connection_secret.py
+++ b/chart/tests/test_metadata_connection_secret.py
@@ -53,7 +53,7 @@ class MetadataConnectionSecretTest(unittest.TestCase):
         connection = self._get_connection({})
 
         assert (
-            "postgresql://postgres:postgres@RELEASE-NAME-postgresql:5432/postgres?sslmode=disable"
+            "postgresql://postgres:postgres@RELEASE-NAME-postgresql.default:5432/postgres?sslmode=disable"
             == connection
         )
 
@@ -63,8 +63,8 @@ class MetadataConnectionSecretTest(unittest.TestCase):
 
         # host, port, dbname get overridden
         assert (
-            "postgresql://postgres:postgres@RELEASE-NAME-pgbouncer:6543/RELEASE-NAME-metadata?sslmode=disable"
-            == connection
+            "postgresql://postgres:postgres@RELEASE-NAME-pgbouncer.default:6543"
+            "/RELEASE-NAME-metadata?sslmode=disable" == connection
         )
 
     def test_should_set_pgbouncer_overrides_with_non_chart_database_when_enabled(self):
@@ -76,8 +76,8 @@ class MetadataConnectionSecretTest(unittest.TestCase):
 
         # host, port, dbname still get overridden even with an non-chart db
         assert (
-            "postgresql://someuser:somepass@RELEASE-NAME-pgbouncer:6543/RELEASE-NAME-metadata?sslmode=disable"
-            == connection
+            "postgresql://someuser:somepass@RELEASE-NAME-pgbouncer.default:6543"
+            "/RELEASE-NAME-metadata?sslmode=disable" == connection
         )
 
     def test_should_correctly_use_non_chart_database(self):

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -147,12 +147,12 @@ class PgbouncerConfigTest(unittest.TestCase):
         ini = base64.b64decode(encoded_ini).decode()
 
         assert (
-            "RELEASE-NAME-metadata = host=RELEASE-NAME-postgresql dbname=postgres port=5432 pool_size=10"
-            in ini
+            "RELEASE-NAME-metadata = host=RELEASE-NAME-postgresql.default dbname=postgres port=5432"
+            " pool_size=10" in ini
         )
         assert (
-            "RELEASE-NAME-result-backend = host=RELEASE-NAME-postgresql dbname=postgres port=5432 pool_size=5"
-            in ini
+            "RELEASE-NAME-result-backend = host=RELEASE-NAME-postgresql.default dbname=postgres port=5432"
+            " pool_size=5" in ini
         )
 
     def test_hostname_override(self):

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import base64
 import unittest
 
 import jmespath
@@ -133,3 +134,41 @@ class PgbouncerTest(unittest.TestCase):
             show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
+
+
+class PgbouncerConfigTest(unittest.TestCase):
+    def test_databases_default(self):
+        docs = render_chart(
+            values={"pgbouncer": {"enabled": True}},
+            show_only=["templates/secrets/pgbouncer-config-secret.yaml"],
+        )
+
+        encoded_ini = jmespath.search('data."pgbouncer.ini"', docs[0])
+        ini = base64.b64decode(encoded_ini).decode()
+
+        assert (
+            "RELEASE-NAME-metadata = host=RELEASE-NAME-postgresql dbname=postgres port=5432 pool_size=10"
+            in ini
+        )
+        assert (
+            "RELEASE-NAME-result-backend = host=RELEASE-NAME-postgresql dbname=postgres port=5432 pool_size=5"
+            in ini
+        )
+
+    def test_hostname_override(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {"enabled": True, "metadataPoolSize": 12, "resultBackendPoolSize": 7},
+                "data": {
+                    "metadataConnection": {"host": "meta_host", "db": "meta_db", "port": 1111},
+                    "resultBackendConnection": {"host": "rb_host", "db": "rb_db", "port": 2222},
+                },
+            },
+            show_only=["templates/secrets/pgbouncer-config-secret.yaml"],
+        )
+
+        encoded_ini = jmespath.search('data."pgbouncer.ini"', docs[0])
+        ini = base64.b64decode(encoded_ini).decode()
+
+        assert "RELEASE-NAME-metadata = host=meta_host dbname=meta_db port=1111 pool_size=12" in ini
+        assert "RELEASE-NAME-result-backend = host=rb_host dbname=rb_db port=2222 pool_size=7" in ini


### PR DESCRIPTION
K8s clusters can use a different cluster domain than the default
`cluster.local`. This change will make the chart compatible with those
clusters as well.