### PR TITLE
Fix k8s tests in master: Worker ServiceAccount is needed for KubernetesExecutor

### DIFF
--- a/chart/templates/workers/worker-serviceaccount.yaml
+++ b/chart/templates/workers/worker-serviceaccount.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Airflow Worker ServiceAccount
 #################################
-{{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
+{{- if and .Values.workers.serviceAccount.create (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") (eq .Values.executor "KubernetesExecutor")) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:


### PR DESCRIPTION
KubernetesExecutor is also in the list of executors who needs a worker
ServiceAccount.

This was introduced in #14152.

(getting CI going now, but will take a look at unit tests to cover this, maybe in a follow up PR)