### PR TITLE
Fix breeze k8s tests on mac

### DIFF
--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -93,7 +93,7 @@ function create_virtualenv() {
     pip install pytest freezegun pytest-cov \
       --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${HOST_PYTHON_VERSION}.txt"
 
-    pip install -e ".[kubernetes]" \
+    pip install -e ".[cncf.kubernetes,postgres]" \
       --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${HOST_PYTHON_VERSION}.txt"
 }
 
@@ -103,7 +103,9 @@ function run_tests() {
 
 cd "${AIRFLOW_SOURCES}" || exit 1
 
+set +u
 parse_tests_to_run "${@}"
+set -u
 
 create_virtualenv
 


### PR DESCRIPTION
I'm not sure if there is a better fix, but I needed these to be able to run the k8s tests via breeze on my mac.

Without these changes, I get:
```
scripts/ci/kubernetes/ci_run_kubernetes_tests.sh: line 107: @: unbound variable
```

Once past that, I get:
```
___ ERROR collecting kubernetes_tests/test_kubernetes_pod_operator.py ___
...                                                                                                                                                                                                                                         
E   ModuleNotFoundError: No module named 'psycopg2'
```

And another error that also goes away with the postgres extra:
```
___ ERROR collecting kubernetes_tests/test_kubernetes_pod_operator_backcompat.py ___
...
ValueError: Unable to configure formatter 'airflow_coloured'
```