### PR TITLE
Rename to old "Experimental" API to deprecated in the docs.

### DIFF
--- a/docs/apache-airflow/deprecated-rest-api-ref.rst
+++ b/docs/apache-airflow/deprecated-rest-api-ref.rst
@@ -15,20 +15,21 @@
     specific language governing permissions and limitations
     under the License.
 
-Experimental REST API Reference
-===============================
-
-Airflow exposes an REST API. It is available through the webserver. Endpoints are
-available at ``/api/experimental/``.
+Deprecated REST API
+===================
 
 .. warning::
 
-  This REST API is deprecated since version 2.0. Please consider using :doc:`the stable REST API <stable-rest-api-ref>`.
+  This REST API is deprecated since version 2.0. Please consider using the :doc:`stable REST API <stable-rest-api-ref>`.
   For more information on migration, see `UPDATING.md <https://github.com/apache/airflow/blob/master/UPDATING.md>`_
+
+Before Airflow 2.0 this REST API was known as the "experimental" API, but now that the :doc:`stable REST API <stable-rest-api-ref>` is available, it has been renamed.
+
+The endpoints for this API are available at ``/api/experimental/``.
 
 .. versionchanged:: 2.0
 
-  The experimental REST API is disabled by default. To restore these APIs while migrating to
+  This REST API is disabled by default. To restore these APIs while migrating to
   the stable REST API, set ``enable_experimental_api`` option in ``[api]`` section to ``True``.
 
 Endpoints

--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -113,7 +113,7 @@ unit of work and continuity.
     CLI <cli-and-env-variables-ref>
     Macros <macros-ref>
     Python API <python-api-ref>
-    Experimental REST API <rest-api-ref>
     Stable REST API <stable-rest-api-ref>
+    deprecated-rest-api-ref
     Configurations <configurations-ref>
     Extra packages <extra-packages-ref>

--- a/docs/apache-airflow/integration.rst
+++ b/docs/apache-airflow/integration.rst
@@ -33,4 +33,4 @@ Airflow has a mechanism that allows you to expand its functionality and integrat
 * :doc:`Web UI Authentication backends </security/api>`
 
 It also has integration with :doc:`Sentry </logging-monitoring/errors>` service for error tracking. Other applications can also integrate using
-the :doc:`REST API <rest-api-ref>`.
+the :doc:`REST API <stable-rest-api-ref>`.

--- a/docs/apache-airflow/redirects.txt
+++ b/docs/apache-airflow/redirects.txt
@@ -43,6 +43,7 @@ start.rst start/index.rst
 # References
 cli-ref.rst cli-and-env-variables-ref.rst
 _api/index.rst python-api-ref.rst
+rest-api-ref.rst deprecated-rest-api-ref.rst
 
 # Concepts
 concepts.rst concepts/index.rst

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -76,7 +76,7 @@ user will have by default:
 
     AUTH_ROLE_PUBLIC = 'Admin'
 
-Be sure to checkout :doc:`/rest-api-ref` for securing the API.
+Be sure to checkout :doc:`/security/api` for securing the API.
 
 .. note::
 

--- a/docs/apache-airflow/usage-cli.rst
+++ b/docs/apache-airflow/usage-cli.rst
@@ -26,19 +26,6 @@ This document is meant to give an overview of all common tasks while using the C
 
 .. _cli-remote:
 
-Set Up connection to a remote Airflow instance
-----------------------------------------------
-
-For some functions the CLI can use :doc:`the REST API <rest-api-ref>`. To configure the CLI to use the API
-when available configure as follows:
-
-.. code-block:: ini
-
-    [cli]
-    api_client = airflow.api.client.json_client
-    endpoint_url = http://<WEBSERVER>:<PORT>
-
-
 Set Up Bash/Zsh Completion
 --------------------------
 


### PR DESCRIPTION
If you aren't familiar with the history of the APIs, then from looking at the titles it looks like the Experimental API might be the "next" one.

We don't want people to think that!


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).