### PR TITLE
Fix chart DAG gitsync and persistence with KubernetesExecutor

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -20,7 +20,7 @@ kind: Pod
 metadata:
   name: dummy-name
 spec:
-{{- if .Values.dags.gitSync.enabled }}
+{{- if and .Values.dags.gitSync.enabled (not .Values.dags.persistence.enabled) }}
   initContainers:
 {{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | indent 4 }}
 {{- end }}
@@ -61,16 +61,10 @@ spec:
           name: git-sync-ssh-key
           subPath: ssh
 {{- end }}
-{{- if .Values.dags.persistence.enabled }}
+{{- if or .Values.dags.gitSync.enabled .Values.dags.persistence.enabled }}
         - mountPath: {{ include "airflow_dags_mount_path" . }}
           name: dags
           readOnly: true
-{{- end }}
-{{- if .Values.dags.gitSync.enabled }}
-        - mountPath: {{ include "airflow_dags" . }}
-          name: dags
-          readOnly: true
-          subPath: {{.Values.dags.gitSync.dest }}/{{ .Values.dags.gitSync.subPath }}
 {{- end }}
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 8 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -158,7 +158,7 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
 {{- end }}
-{{- if  or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
+{{- if or .Values.dags.persistence.enabled .Values.dags.gitSync.enabled }}
             - name: dags
               mountPath: {{ template "airflow_dags_mount_path" . }}
 {{- end }}


### PR DESCRIPTION
This prevents a gitsync contianer from being created in the
KubernetesExecutor worker if DAG persistence is enabled as the DAG will
already be on the volume. This also only mounts the DAGs volume once in
the worker.

closes: #10646