### PR TITLE
Fix dags table overflow

### DIFF
--- a/airflow/www/static/css/dags.css
+++ b/airflow/www/static/css/dags.css
@@ -31,6 +31,8 @@
 .dags-table-body {
   margin: 0 1px;
   overflow-x: auto;
+  padding-bottom: 55px;
+  margin-bottom: -55px;
 }
 
 .dags-table-more {

--- a/airflow/www/static/css/dags.css
+++ b/airflow/www/static/css/dags.css
@@ -31,6 +31,8 @@
 .dags-table-body {
   margin: 0 1px;
   overflow-x: auto;
+
+  /* This allows small dropdowns to overlap the table element */
   padding-bottom: 55px;
   margin-bottom: -55px;
 }


### PR DESCRIPTION
Adds a false bottom to the table element so we can have overlap on the final row. 

Fixes #15656

<img width="299" alt="Screen Shot 2021-05-04 at 6 10 33 PM" src="https://user-images.githubusercontent.com/4600967/117076206-a6321180-acfb-11eb-8201-2b90803e7cc9.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
