### PR TITLE
More verbose logs when running `airflow check_migrations`

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -613,7 +613,10 @@ def check_migrations(timeout):
             if source_heads == db_heads:
                 break
             if ticker >= timeout:
-                raise TimeoutError(f"There are still unapplied migrations after {ticker} seconds.")
+                raise TimeoutError(
+                    f"There are still unapplied migrations after {ticker} seconds. "
+                    f"Migration Head(s) in DB: {db_heads} | Migration Head(s) in Source Code: {source_heads}"
+                )
             ticker += 1
             time.sleep(1)
             log.info('Waiting for migrations... %s second(s)', ticker)


### PR DESCRIPTION
Currently it just shows "TimeoutError: There are still unapplied migrations after 60 seconds. " which is not that helpful.

This commit adds more info to show the difference in migrations in DB and source code running `check_migrations`:

Now:

```
TimeoutError: There are still unapplied migrations after 60 seconds. Migration Head(s) in DB: {'e165e7455d70'} | Migration Head(s) in Source Code: {'a13f7613ad25'}
```

closes https://github.com/apache/airflow/issues/15650

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
