### PR TITLE
Fix building assets on ``breeze start-airflow``

### DIFF
--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -54,7 +54,7 @@ tmux send-keys 'airflow webserver' C-m
 if [[ -z "${USE_AIRFLOW_VERSION=}" ]]; then
     tmux select-pane -t 0
     tmux split-window -h
-    tmux send-keys 'cd /opt/airflow/airflow/www/; yarn dev' C-m
+    tmux send-keys 'cd /opt/airflow/airflow/www/; yarn install --frozen-lockfile; yarn dev' C-m
 fi
 
 # Attach Session, on the Main window


### PR DESCRIPTION
Error because `webpack` is not install because `yarn install --frozen-lockfile` is not run:

```
root@f5fc5cfc9a43:/opt/airflow# cd /opt/airflow/airflow/www/; yarn dev
yarn run v1.22.5
$ NODE_ENV=dev webpack --watch --colors --progress --debug --output-pathinfo --devtool eval-cheap-source-map -
-mode development
/bin/sh: 1: webpack: not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
root@f5fc5cfc9a43:/opt/airflow/airflow/www#
```

![image](https://user-images.githubusercontent.com/8811558/117090726-07380480-ad51-11eb-8dc8-432c7b9e918a.png)


This commits adds `yarn install --frozen-lockfile` to the command which fixes it.

This was missed in https://github.com/apache/airflow/pull/13313/files

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
