### PR TITLE
Update KubeExecutor pod templates to allow access to IAM token files

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml
@@ -65,6 +65,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: 50000
+    fsGroup: 50000
   nodeSelector:
     {}
   affinity:

--- a/airflow/kubernetes/pod_template_file_examples/dags_in_volume_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/dags_in_volume_template.yaml
@@ -62,6 +62,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: 50000
+    fsGroup: 50000
   nodeSelector:
     {}
   affinity:

--- a/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/git_sync_template.yaml
@@ -86,6 +86,7 @@ spec:
   restartPolicy: Never
   securityContext:
     runAsUser: 50000
+    fsGroup: 50000
   nodeSelector:
     {}
   affinity:


### PR DESCRIPTION
If AWS's Identity-based IAM policies are in use on the cluster they
token file will be mounted in to the pod (via the service account) and,
prior to this change, will be owned by root.

Specifying `fsGroup` makes the file group-readable by the `airflow`
user.

We already specify this in our helm chart, so this change is just for
anyone looking at the docs.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).