### PR TITLE
Update example dag task to try more before failing

### DIFF
--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -61,12 +61,17 @@ try:
             """
             Tests whether the volume has been mounted.
             """
-            with open('/foo/volume_mount_test.txt', 'w') as foo:
-                foo.write('Hello')
-
-            return_code = os.system("cat /foo/volume_mount_test.txt")
-            if return_code != 0:
-                raise ValueError(f"Error when checking volume mount. Return code {return_code}")
+            for i in range(5):
+                try:
+                    return_code = os.system("cat /foo/volume_mount_test.txt")
+                    if return_code != 0:
+                        raise ValueError(f"Error when checking volume mount. Return code {return_code}")
+                    else:
+                        with open('/foo/volume_mount_test.txt', 'w') as foo:
+                            foo.write('Hello')
+                except ValueError as e:
+                    if i > 4:
+                        raise e
 
         # You can use annotations on your kubernetes pods!
         start_task = PythonOperator(


### PR DESCRIPTION
This change will have the `task_with_volume` task try to mount volume more times before
failing. The same idea is used in sharedvolume mount in the same dag.

It will help us to run the kubernetes_tests with other executors
as it was found that this fails on the first few tries in other executors.

Also, we will no longer develop separate integration tests for each executor
but add more tests and ensure the executors passes the tests.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
