### PR TITLE
When installing providers from the context folder, use `pip --find-links`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ARG AIRFLOW_GID="50000"
 
 ARG PYTHON_BASE_IMAGE="python:3.6-slim-buster"
 
-ARG AIRFLOW_PIP_VERSION=21.1
+ARG AIRFLOW_PIP_VERSION=21.1.1
 
 # By default PIP has progress bar but you can disable it.
 ARG PIP_PROGRESS_BAR="on"


### PR DESCRIPTION
Without this change it is impossible for one of the providers to depend upon the "dev"/current version of Airflow -- pip instead would try and go out to PyPI to find the version (which almost certainly wont exist, as it hasn't been released yet)

This was noticed in my draft PR #15667 and caused the prod images to fail to build.

I tested this change locally with `./breeze build-image --production-image --disable-pypi-when-building --install-from-docker-context-files`:


```
+ pip install --user --upgrade pip==21.1.1
Requirement already satisfied: pip==21.1.1 in /usr/local/lib/python3.6/site-packages (21.1.1)
WARNING: Running pip as root will break packages and permissions. You should install packages reliably by using venv: https://pip.pypa.io/warnings/venv
+ pip install --user --upgrade --upgrade-strategy only-if-needed 'apache-airflow[async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,ldap,google,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0' /docker-context-files/apache_airflow_providers_amazon-1.4.0-py3-none-any.whl /docker-context-files/apache_airflow_providers_cncf_kubernetes-1.2.0-py3-none-any.whl /docker-context-files/apache_airflow_providers_docker-1.2.0-py3-none-any.whl /docker-context-files/apache_airflow_providers_elasticsearch-1.0.4-py3-none-any.whl /docker-context-files/apache_airflow_providers_ftp-1.1.0-py3-none-any.whl /docker-context-files/apache_airflow_providers_google-3.0.0-py3-none-any.whl /docker-context-files/apache_airflow_providers_microsoft_azure-2.0.0-py3-none-any.whl /docker-context-files/apache_airflow_providers_postgres-1.0.2-py3-none-any.whl /docker-context-files/apache_airflow_providers_sftp-1.2.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_amazon-1.4.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_cncf_kubernetes-1.2.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_docker-1.2.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_elasticsearch-1.0.4-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_ftp-1.1.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_google-3.0.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_microsoft_azure-2.0.0-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_postgres-1.0.2-py3-none-any.whl
Processing /docker-context-files/apache_airflow_providers_sftp-1.2.0-py3-none-any.whl
Requirement already satisfied: apache-airflow[amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0 in /root/.local/lib/python3.6/site-packages (2.1.0.dev0)
...
Requirement already satisfied: zope.interface in /root/.local/lib/python3.6/site-packages (from gevent>=0.13->apache-airflow[amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0) (5.4.0)
Requirement already satisfied: google-auth-oauthlib<1.0.0,>=0.0.1 in /root/.local/lib/python3.6/site-packages (from google-ads<8.0.0,>=4.0.0->apache-airflow-providers-google==3.0.0) (0.4.4)
Requirement already satisfied: googleapis-common-protos<2.0.0,>=1.5.8 in /root/.local/lib/python3.6/site-packages (from google-ads<8.0.0,>=4.0.0->apache-airflow-providers-google==3.0.0) (1.53.0)
Requirement already satisfied: grpcio<2.0.0,>=1.18.0 in /root/.local/lib/python3.6/site-packages (from google-ads<8.0.0,>=4.0.0->apache-airflow-providers-google==3.0.0) (1.37.0)
Requirement already satisfied: packaging>=14.3 in /root/.local/lib/python3.6/site-packages (from google-api-core<2.0.0,>=1.25.1->apache-airflow-providers-google==3.0.0) (20.9)
Requirement already satisfied: protobuf>=3.12.0 in /root/.local/lib/python3.6/site-packages (from google-api-core<2.0.0,>=1.25.1->apache-airflow-providers-google==3.0.0) (3.15.8)
Requirement already satisfied: httplib2<1dev,>=0.15.0 in /root/.local/lib/python3.6/site-packages (from google-api-python-client<2.0.0,>=1.6.0->apache-airflow-providers-google==3.0.0) (0.17.4)
Requirement already satisfied: uritemplate<4dev,>=3.0.0 in /root/.local/lib/python3.6/site-packages (from google-api-python-client<2.0.0,>=1.6.0->apache-airflow-providers-google==3.0.0) (3.0.1)
Requirement already satisfied: pyasn1-modules>=0.2.1 in /root/.local/lib/python3.6/site-packages (from google-auth<2.0.0,>=1.0.0->apache-airflow-providers-google==3.0.0) (0.2.8)
Requirement already satisfied: cachetools<5.0,>=2.0.0 in /root/.local/lib/python3.6/site-packages (from google-auth<2.0.0,>=1.0.0->apache-airflow-providers-google==3.0.0) (4.2.1)
Requirement already satisfied: rsa<5,>=3.1.4 in /root/.local/lib/python3.6/site-packages (from google-auth<2.0.0,>=1.0.0->apache-airflow-providers-google==3.0.0) (4.7.2)
Requirement already satisfied: requests-oauthlib>=0.7.0 in /root/.local/lib/python3.6/site-packages (from google-auth-oauthlib<1.0.0,>=0.0.1->google-ads<8.0.0,>=4.0.0->apache-airflow-providers-google==3.0.0) (1.1.0)
Requirement already satisfied: proto-plus>=1.10.0 in /root/.local/lib/python3.6/site-packages (from google-cloud-automl<3.0.0,>=2.1.0->apache-airflow-providers-google==3.0.0) (1.18.1)
Requirement already satisfied: google-cloud-core<2.0dev,>=1.4.1 in /root/.local/lib/python3.6/site-packages (from google-cloud-bigtable<2.0.0,>=1.0.0->apache-airflow-providers-google==3.0.0) (1.6.0)
Requirement already satisfied: grpc-google-iam-v1<0.13dev,>=0.12.3 in /root/.local/lib/python3.6/site-packages (from google-cloud-bigtable<2.0.0,>=1.0.0->apache-airflow-providers-google==3.0.0) (0.12.3)
Requirement already satisfied: libcst>=0.2.5 in /root/.local/lib/python3.6/site-packages (from google-cloud-datacatalog<4.0.0,>=3.0.0->apache-airflow-providers-google==3.0.0) (0.3.18)
Requirement already satisfied: google-resumable-media<2.0dev,>=1.2.0 in /root/.local/lib/python3.6/site-packages (from google-cloud-storage<2.0.0,>=1.30->apache-airflow-providers-google==3.0.0) (1.2.0)
Requirement already satisfied: google-crc32c<2.0dev,>=1.0 in /root/.local/lib/python3.6/site-packages (from google-resumable-media<2.0dev,>=1.2.0->google-cloud-storage<2.0.0,>=1.30->apache-airflow-providers-google==3.0.0) (1.1.2)
Requirement already satisfied: zipp>=0.5 in /root/.local/lib/python3.6/site-packages (from importlib-metadata~=1.7->apache-airflow[amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0) (3.4.1)
Requirement already satisfied: pyrsistent>=0.14.0 in /root/.local/lib/python3.6/site-packages (from jsonschema~=3.0->apache-airflow[amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0) (0.17.3)
Requirement already satisfied: certifi>=14.05.14 in /root/.local/lib/python3.6/site-packages (from kubernetes<12.0.0,>=3.0.0->apache-airflow-providers-cncf-kubernetes==1.2.0) (2020.12.5)
Requirement already satisfied: pyasn1>=0.4.6 in /root/.local/lib/python3.6/site-packages (from ldap3>=2.5.1->apache-airflow[amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0) (0.4.8)
Requirement already satisfied: typing-inspect>=0.4.0 in /root/.local/lib/python3.6/site-packages (from libcst>=0.2.5->google-cloud-datacatalog<4.0.0,>=3.0.0->apache-airflow-providers-google==3.0.0) (0.6.0)
Requirement already satisfied: portalocker~=1.0 in /root/.local/lib/python3.6/site-packages (from msal-extensions~=0.3.0->azure-identity>=1.3.1->apache-airflow-providers-microsoft-azure==2.0.0) (1.7.1)
Requirement already satisfied: isodate>=0.6.0 in /root/.local/lib/python3.6/site-packages (from msrest>=0.5.0->azure-batch>=8.0.0->apache-airflow-providers-microsoft-azure==2.0.0) (0.6.0)
Requirement already satisfied: openapi-schema-validator in /root/.local/lib/python3.6/site-packages (from openapi-spec-validator>=0.2.4->connexion[flask,swagger-ui]<3,>=2.6.0->apache-airflow[amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,grpc,hashicorp,http,ldap,microsoft.azure,mysql,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv]==2.1.0.dev0) (0.1.5)
...
apache-airflow-providers-amazon is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-cncf-kubernetes is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-docker is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-elasticsearch is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-ftp is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-google is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-microsoft-azure is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-postgres is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
apache-airflow-providers-sftp is already installed with the same version as the provided wheel. Use --force-reinstall to force an installation of the wheel.
```
<detail>

</detail>

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).