### PR TITLE
MongoToS3Operator failed when running with a single query (not aggregate pipeline)

### DIFF
--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -50,7 +50,7 @@ class MongoToS3Operator(BaseOperator):
     :param replace: whether or not to replace the file in S3 if it previously existed
     :type replace: bool
     :param allow_disk_use: enables writing to temporary files in the case you are handling large dataset
-        when running an aggregate pipeline.
+        This only takes effect when `mongo_query` is a list - running an aggregate pipeline
     :type allow_disk_use: bool
     :param compression: type of compression to use for output file in S3. Currently only gzip is supported.
     :type compression: str

--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -40,7 +40,7 @@ class MongoToS3Operator(BaseOperator):
     :param mongo_collection: reference to a specific collection in your mongo db
     :type mongo_collection: str
     :param mongo_query: query to execute. A list including a dict of the query
-    :type mongo_query: list
+    :type mongo_query: Union[list, dict]
     :param s3_bucket: reference to a specific S3 bucket to store the data
     :type s3_bucket: str
     :param s3_key: in which S3 key the file will be stored
@@ -49,7 +49,7 @@ class MongoToS3Operator(BaseOperator):
     :type mongo_db: str
     :param replace: whether or not to replace the file in S3 if it previously existed
     :type replace: bool
-    :param allow_disk_use: enables writing to temporary files in the case you are handling large dataset
+    :param allow_disk_use: enables writing to temporary files in the case you are handling large dataset.
         This only takes effect when `mongo_query` is a list - running an aggregate pipeline
     :type allow_disk_use: bool
     :param compression: type of compression to use for output file in S3. Currently only gzip is supported.

--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -49,8 +49,8 @@ class MongoToS3Operator(BaseOperator):
     :type mongo_db: str
     :param replace: whether or not to replace the file in S3 if it previously existed
     :type replace: bool
-    :param allow_disk_use: in the case you are retrieving a lot of data, you may have
-        to use the disk to save it instead of saving all in the RAM
+    :param allow_disk_use: enables writing to temporary files in the case you are handling large dataset
+        when running an aggregate pipeline.
     :type allow_disk_use: bool
     :param compression: type of compression to use for output file in S3. Currently only gzip is supported.
     :type compression: str
@@ -115,7 +115,6 @@ class MongoToS3Operator(BaseOperator):
                 mongo_collection=self.mongo_collection,
                 query=cast(dict, self.mongo_query),
                 mongo_db=self.mongo_db,
-                allowDiskUse=self.allow_disk_use,
             )
 
         # Performs transform then stringifies the docs results into json format

--- a/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_mongo_to_s3.py
@@ -94,7 +94,7 @@ class TestMongoToS3Operator(unittest.TestCase):
         operator.execute(None)
 
         mock_mongo_hook.return_value.find.assert_called_once_with(
-            mongo_collection=MONGO_COLLECTION, query=MONGO_QUERY, mongo_db=None, allowDiskUse=False
+            mongo_collection=MONGO_COLLECTION, query=MONGO_QUERY, mongo_db=None
         )
 
         op_stringify = self.mock_operator._stringify
@@ -117,7 +117,7 @@ class TestMongoToS3Operator(unittest.TestCase):
         operator.execute(None)
 
         mock_mongo_hook.return_value.find.assert_called_once_with(
-            allowDiskUse=False, mongo_collection=MONGO_COLLECTION, query=MONGO_QUERY, mongo_db=None
+            mongo_collection=MONGO_COLLECTION, query=MONGO_QUERY, mongo_db=None
         )
 
         op_stringify = self.mock_operator._stringify


### PR DESCRIPTION
Remove invalid `allowDiskUse` argument when calling `find`. This method does not expect that argument according to official documentation [here](https://pymongo.readthedocs.io/en/stable/api/pymongo/collection.html?highlight=allowDiskUse#pymongo.collection.Collection.find).

closes #15679 