### PR TITLE
Add Connection Documentation for the Hive Provider

### DIFF
--- a/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
+++ b/airflow/providers/amazon/aws/transfers/hive_to_dynamodb.py
@@ -49,7 +49,8 @@ class HiveToDynamoDBOperator(BaseOperator):
     :type region_name: str
     :param schema: hive database schema
     :type schema: str
-    :param hiveserver2_conn_id: source hive connection
+    :param hiveserver2_conn_id: Reference to the
+        :ref: `Hive Server2 thrift service connection id <howto/connection:hiveserver2>`.
     :type hiveserver2_conn_id: str
     :param aws_conn_id: aws connection
     :type aws_conn_id: str

--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -68,6 +68,9 @@ class HiveCliHook(BaseHook):
     The extra connection parameter ``auth`` gets passed as in the ``jdbc``
     connection string as is.
 
+    :param hive_cli_conn_id: Reference to the
+        :ref:`Hive CLI connection id <howto/connection:hive_cli>`.
+    :type hive_cli_conn_id: str
     :param mapred_queue: queue used by the Hadoop Scheduler (Capacity or Fair)
     :type  mapred_queue: str
     :param mapred_queue_priority: priority within the job queue.
@@ -466,7 +469,13 @@ class HiveCliHook(BaseHook):
 
 
 class HiveMetastoreHook(BaseHook):
-    """Wrapper to interact with the Hive Metastore"""
+    """
+    Wrapper to interact with the Hive Metastore
+
+    :param metastore_conn_id: reference to the
+        :ref: `metastore thrift service connection id <howto/connection:hive_metastore>`.
+    :type metastore_conn_id: str
+    """
 
     # java short max val
     MAX_PART_COUNT = 32767
@@ -811,6 +820,12 @@ class HiveServer2Hook(DbApiHook):
     * the default for run_set_variable_statements is true, if you
     are using impala you may need to set it to false in the
     ``extra`` of your connection in the UI
+
+    :param hiveserver2_conn_id: Reference to the
+        :ref: `Hive Server2 thrift service connection id <howto/connection:hiveserver2>`.
+    :type hiveserver2_conn_id: str
+    :param schema: Hive database name.
+    :type schema: Optional[str]
     """
 
     conn_name_attr = 'hiveserver2_conn_id'

--- a/airflow/providers/apache/hive/operators/hive.py
+++ b/airflow/providers/apache/hive/operators/hive.py
@@ -35,7 +35,8 @@ class HiveOperator(BaseOperator):
         a relative path from the dag file of a (template) hive
         script. (templated)
     :type hql: str
-    :param hive_cli_conn_id: reference to the Hive database. (templated)
+    :param hive_cli_conn_id: Reference to the
+        :ref:`Hive CLI connection id <howto/connection:hive_cli>`. (templated)
     :type hive_cli_conn_id: str
     :param hiveconfs: if defined, these key value pairs will be passed
         to hive as ``-hiveconf "key"="value"``

--- a/airflow/providers/apache/hive/operators/hive_stats.py
+++ b/airflow/providers/apache/hive/operators/hive_stats.py
@@ -41,6 +41,9 @@ class HiveStatsCollectionOperator(BaseOperator):
             value BIGINT
         );
 
+    :param metastore_conn_id: Reference to the
+        :ref:`Hive Metastore connection id <howto/connection:hive_metastore>`.
+    :type metastore_conn_id: str
     :param table: the source table, in the format ``database.table_name``. (templated)
     :type table: str
     :param partition: the source partition. (templated)

--- a/airflow/providers/apache/hive/sensors/hive_partition.py
+++ b/airflow/providers/apache/hive/sensors/hive_partition.py
@@ -38,8 +38,8 @@ class HivePartitionSensor(BaseSensorOperator):
         and apparently supports SQL like notation as in ``ds='2015-01-01'
         AND type='value'`` and comparison operators as in ``"ds>=2015-01-01"``
     :type partition: str
-    :param metastore_conn_id: reference to the metastore thrift service
-        connection id
+    :param metastore_conn_id: reference to the
+        :ref: `metastore thrift service connection id <howto/connection:hive_metastore>`
     :type metastore_conn_id: str
     """
 

--- a/airflow/providers/apache/hive/sensors/named_hive_partition.py
+++ b/airflow/providers/apache/hive/sensors/named_hive_partition.py
@@ -33,8 +33,8 @@ class NamedHivePartitionSensor(BaseSensorOperator):
         you cannot use logical or comparison operators as in
         HivePartitionSensor.
     :type partition_names: list[str]
-    :param metastore_conn_id: reference to the metastore thrift service
-        connection id
+    :param metastore_conn_id: Reference to the
+        :ref:`metastore thrift service connection id <howto/connection:hive_metastore>`.
     :type metastore_conn_id: str
     """
 

--- a/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -40,8 +40,9 @@ class HiveToMySqlOperator(BaseOperator):
     :type mysql_table: str
     :param mysql_conn_id: source mysql connection
     :type mysql_conn_id: str
-    :param hiveserver2_conn_id: destination hive connection
-    :type hiveserver2_conn_id: str
+    :param metastore_conn_id: Reference to the
+        :ref:`metastore thrift service connection id <howto/connection:hive_metastore>`.
+    :type metastore_conn_id: str
     :param mysql_preoperator: sql statement to run against mysql prior to
         import, typically use to truncate of delete in place
         of the data coming in, allowing the task to be idempotent (running

--- a/airflow/providers/apache/hive/transfers/hive_to_samba.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_samba.py
@@ -38,7 +38,8 @@ class HiveToSambaOperator(BaseOperator):
     :type destination_filepath: str
     :param samba_conn_id: reference to the samba destination
     :type samba_conn_id: str
-    :param hiveserver2_conn_id: reference to the hiveserver2 service
+    :param hiveserver2_conn_id: Reference to the
+        :ref: `Hive Server2 thrift service connection id <howto/connection:hiveserver2>`.
     :type hiveserver2_conn_id: str
     """
 

--- a/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -63,8 +63,9 @@ class MsSqlToHiveOperator(BaseOperator):
     :type delimiter: str
     :param mssql_conn_id: source Microsoft SQL Server connection
     :type mssql_conn_id: str
-    :param hive_conn_id: destination hive connection
-    :type hive_conn_id: str
+    :param hive_cli_conn_id: Reference to the
+        :ref:`Hive CLI connection id <howto/connection:hive_cli>`.
+    :type hive_cli_conn_id: str
     :param tblproperties: TBLPROPERTIES of the hive table being created
     :type tblproperties: dict
     """

--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -71,8 +71,9 @@ class MySqlToHiveOperator(BaseOperator):
     :type escapechar: str
     :param mysql_conn_id: source mysql connection
     :type mysql_conn_id: str
-    :param hive_conn_id: destination hive connection
-    :type hive_conn_id: str
+    :param hive_cli_conn_id: Reference to the
+        :ref:`Hive CLI connection id <howto/connection:hive_cli>`.
+    :type hive_cli_conn_id: str
     :param tblproperties: TBLPROPERTIES of the hive table being created
     :type tblproperties: dict
     """

--- a/airflow/providers/apache/hive/transfers/s3_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/s3_to_hive.py
@@ -88,7 +88,8 @@ class S3ToHiveOperator(BaseOperator):  # pylint: disable=too-many-instance-attri
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type verify: bool or str
-    :param hive_cli_conn_id: destination hive connection
+    :param hive_cli_conn_id: Reference to the
+        :ref:`Hive CLI connection id <howto/connection:hive_cli>`.
     :type hive_cli_conn_id: str
     :param input_compressed: Boolean to determine if file decompression is
         required to process headers

--- a/airflow/providers/apache/hive/transfers/vertica_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/vertica_to_hive.py
@@ -60,8 +60,9 @@ class VerticaToHiveOperator(BaseOperator):
     :type delimiter: str
     :param vertica_conn_id: source Vertica connection
     :type vertica_conn_id: str
-    :param hive_conn_id: destination hive connection
-    :type hive_conn_id: str
+    :param hive_cli_conn_id: Reference to the
+        :ref:`Hive CLI connection id <howto/connection:hive_cli>`.
+    :type hive_cli_conn_id: str
 
     """
 

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
@@ -30,12 +30,15 @@ Authenticating to Hive CLI
 There are two ways to connect to Hive using Airflow.
 
 1. Use the `Hive Beeline
-  <https://docs.cloudera.com/HDPDocuments/HDP2/HDP-2.1.5/bk_dataintegration/content/ch_using-hive-clients-examples.html>`_.
-  i.e. make a jdbc connection string with host, port, and schema. Optionally you can connect with a proxy user, and specify a login and password.
+   <https://docs.cloudera.com/HDPDocuments/HDP2/HDP-2.1.5/bk_dataintegration/content/ch_using-hive-clients-examples.html>`_.
+   i.e. make a jdbc connection string with host, port, and schema. Optionally you can connect with a proxy user, and specify a login and password.
 
 2. Use the `Hive CLI
-  <https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.4/starting-hive/content/hive_start_a_command_line_query_locally.html>`_.
-  i.e. specify hive cli params in the extras field.
+   <https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.4/starting-hive/content/hive_start_a_command_line_query_locally.html>`_.
+   i.e. specify hive cli params in the extras field.
+
+Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
+configure multiple connections.
 
 Default Connection IDs
 ----------------------

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_cli.rst
@@ -1,0 +1,90 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:hive_cli:
+
+Hive CLI Connection
+===================
+
+The Hive CLI connection type enables the Hive CLI Integrations.
+
+Authenticating to Hive CLI
+--------------------------
+
+There are two ways to connect to Hive using Airflow.
+
+1. Use the `Hive Beeline
+  <https://docs.cloudera.com/HDPDocuments/HDP2/HDP-2.1.5/bk_dataintegration/content/ch_using-hive-clients-examples.html>`_.
+  i.e. make a jdbc connection string with host, port, and schema. Optionally you can connect with a proxy user, and specify a login and password.
+
+2. Use the `Hive CLI
+  <https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.4/starting-hive/content/hive_start_a_command_line_query_locally.html>`_.
+  i.e. specify hive cli params in the extras field.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Hive_CLI use ``hive_cli_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login (optional)
+    Specify your username for a proxy user or for the Beeline CLI.
+
+Password (optional)
+    Specify your Beeline CLI password.
+
+Host (optional)
+    Specify your jdbc hive host that is used for Hive Beeline.
+
+Port (optional)
+    Specify your jdbc hive port that is used for Hive Beeline.
+
+Schema (optional)
+    Specify your jdbc hive database that you want to connect to with Beeline
+    or specify a schema for an HQL statement to run with the Hive CLI.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Hive CLI connection.
+    The following parameters are all optional:
+
+    * ``hive_cli_params``
+      Specify an object CLI params for use with Beeline CLI and Hive CLI.
+    * ``use_beeline``
+      Specify as ``True`` if using the Beeline CLI. Default is ``False``.
+    * ``auth``
+      Specify the auth type for use with Hive Beeline CLI.
+    * ``proxy_user``
+      Specify a proxy user as an ``owner`` or ``login`` or keep blank if using a
+      custom proxy user.
+    * ``principal``
+      Specify the jdbc hive principal to be used with Hive Beeline.
+
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_HIVE_CLI_DEFAULT='hive-cli://beeline-username:beeline-password@jdbc-hive-host:80/hive-database?hive_cli_params=params&use_beeline=True&auth=noSasl&principal=hive%2F_HOST%40EXAMPLE.COM'

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst
@@ -28,9 +28,9 @@ Authenticating to Hive Metastore
 --------------------------------
 
 Authentication with the Hive Metastore through `Apache Thrift Hive Server
-https://cwiki.apache.org/confluence/display/Hive/HiveServer`_
+<https://cwiki.apache.org/confluence/display/Hive/HiveServer>`_
 and the `hmsclient
-https://pypi.org/project/hmsclient/`_.
+<https://pypi.org/project/hmsclient/>`_.
 
 
 Default Connection IDs

--- a/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst
@@ -1,0 +1,69 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:hive_metastore:
+
+Hive Metastore Connection
+=========================
+
+The Hive Metastore connection type enables the Hive Metastore Integrations.
+
+Authenticating to Hive Metastore
+--------------------------------
+
+Authentication with the Hive Metastore through `Apache Thrift Hive Server
+https://cwiki.apache.org/confluence/display/Hive/HiveServer`_
+and the `hmsclient
+https://pypi.org/project/hmsclient/`_.
+
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to the Hive Metastore use ``metastore_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Host (optional)
+    The host of your Hive Metastore node.
+
+Port (optional)
+    Your Hive Metastore port number.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Hive Metastore connection.
+    The following parameters are all optional:
+
+    * ``auth_mechanism``
+      Specify the mechanism for authentication the default is ``NOSASL``.
+    * ``kerberos_service_name``
+      Specify The kerberos service name the default is ``hive``.
+
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_METASTORE_DEFAULT='hive-metastore://hive-metastore-node:80?auth_mechanism=NOSASL'

--- a/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst
@@ -1,0 +1,78 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+.. _howto/connection:hiveserver2:
+
+Hive Server2 Connection
+=========================
+
+The Hive Server2 connection type enables the Hive Server2 Integrations.
+
+Authenticating to Hive Server2
+------------------------------
+
+Connect to Hive Server2 using `PyHive
+https://pypi.org/project/PyHive/`_.
+Choose between authenticating via LDAP, kerberos, or custom.
+
+Default Connection IDs
+----------------------
+
+All hooks and operators related to Hive Server2 use ``hiveserver2_default`` by default.
+
+Configuring the Connection
+--------------------------
+
+Login (optional)
+    Specify your Hive Server2 username.
+
+Password (optional)
+    Specify your Hive password for use with LDAP and custom authentication.
+
+Host (optional)
+    Specify the host node for Hive Server2.
+
+Port (optional)
+    Specify your Hive Server2 port number.
+
+Schema (optional)
+    Specify the name fo the database you would like to connect to with Hive Server2.
+
+Extra (optional)
+    Specify the extra parameters (as json dictionary) that can be used in Hive Server2 connection.
+    The following parameters are all optional:
+
+    * ``auth_mechanism``
+      Specify the authentication method for PyHive choose between ``PLAIN``, ``LDAP``, ``KERBEROS`` or, ``Custom`` the default is ``PLAIN``.
+    * ``kerberos_service_name``
+      If authenticating with kerberos specify the kerberos service name the default is ``hive``.
+    * ``run_set_variable_statements``
+      Specify the if you want to run set variable statements the default is ```True``.
+
+
+When specifying the connection in environment variable you should specify
+it using URI syntax.
+
+Note that all components of the URI should be URL-encoded.
+
+For example:
+
+.. code-block:: bash
+
+   export AIRFLOW_CONN_HIVESERVER2_DEFAULT='hiveserver2://username:password@hiveserver2-node:80/database?auth_mechanism=LDAP'

--- a/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hiveserver2.rst
@@ -28,7 +28,7 @@ Authenticating to Hive Server2
 ------------------------------
 
 Connect to Hive Server2 using `PyHive
-https://pypi.org/project/PyHive/`_.
+<https://pypi.org/project/PyHive/>`_.
 Choose between authenticating via LDAP, kerberos, or custom.
 
 Default Connection IDs

--- a/docs/apache-airflow-providers-apache-hive/connections/index.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/index.rst
@@ -1,0 +1,25 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Connection Types
+----------------
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+
+    *

--- a/docs/apache-airflow-providers-apache-hive/index.rst
+++ b/docs/apache-airflow-providers-apache-hive/index.rst
@@ -24,6 +24,12 @@ Content
 
 .. toctree::
     :maxdepth: 1
+    :caption: Guides
+
+    Connection types <connections/index>
+
+.. toctree::
+    :maxdepth: 1
     :caption: References
 
     Python API <_api/airflow/providers/apache/hive/index>

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1039,6 +1039,7 @@ nodeName
 nodeSelector
 nonterminal
 noqa
+nosasl
 notificationChannels
 npm
 ntlm


### PR DESCRIPTION
This PR adds connection documentation for the Hive CLI, metastore, and server2 connections. It also adds links to the documentation for modules that use hive connections.
