### PR TITLE
Run helm chart tests in parallel

### DIFF
--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -83,16 +83,17 @@ def validate_k8s_object(instance):
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None):
+def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
     values = values or {}
+    chart_dir = chart_dir or sys.path[0]
     with NamedTemporaryFile() as tmp_file:
         content = yaml.dump(values)
         tmp_file.write(content.encode())
         tmp_file.flush()
-        command = ["helm", "template", name, sys.path[0], '--values', tmp_file.name]
+        command = ["helm", "template", name, chart_dir, '--values', tmp_file.name]
         if show_only:
             for i in show_only:
                 command.extend(["--show-only", i])

--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -242,9 +242,14 @@ EXTRA_PYTEST_ARGS=(
     "-rfEX"
 )
 
-if [[ "${TEST_TYPE}" != "Helm" ]]; then
+if [[ "${TEST_TYPE}" == "Helm" ]]; then
+    # Enable parallelism
     EXTRA_PYTEST_ARGS+=(
-    "--with-db-init"
+        "-n" "auto"
+    )
+else
+    EXTRA_PYTEST_ARGS+=(
+        "--with-db-init"
     )
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -484,6 +484,7 @@ devel = [
     'click~=7.1',
     'coverage',
     'docutils',
+    'filelock',
     'flake8>=3.6.0',
     'flake8-colors',
     'flaky',


### PR DESCRIPTION
The helm chart tests are pretty slow when run sequentially. Modifying
them so they can be run in parallel saves a lot of time, from 10 minutes
to 3 minutes on my machine with 8 cores.

The only test that needed modification was `test_pod_template_file.py`,
as it temporarily moves a file into the templates directory
which was causing other tests to fail as they weren't expecting any
objects from that temporary file. This is resolved by giving the
pod_template_file test an isolated chart directory it can modify.

`helm dep update` also doesn't work when it is called in parallel, so
the fixture responsible for running it now ensures we only run it one at
a time.