### PR TITLE
Enforce READ COMMITTED isolation when using mysql

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -287,6 +287,15 @@ def prepare_engine_args(disable_connection_pool=False):
         engine_args['pool_recycle'] = pool_recycle
         engine_args['pool_pre_ping'] = pool_pre_ping
         engine_args['max_overflow'] = max_overflow
+
+        # The default isolation level for MySQL (REPEATABLE READ) can introduce inconsistencies when
+        # running multiple schedulers, as repeated queries on the same session may read from stale snapshots.
+        # 'READ COMMITTED' is the default value for PostgreSQL.
+        # More information here:
+        # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html"
+        if SQL_ALCHEMY_CONN.startswith('mysql'):
+            engine_args['isolation_level'] = 'READ COMMITTED'
+
     return engine_args
 
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -288,13 +288,13 @@ def prepare_engine_args(disable_connection_pool=False):
         engine_args['pool_pre_ping'] = pool_pre_ping
         engine_args['max_overflow'] = max_overflow
 
-        # The default isolation level for MySQL (REPEATABLE READ) can introduce inconsistencies when
-        # running multiple schedulers, as repeated queries on the same session may read from stale snapshots.
-        # 'READ COMMITTED' is the default value for PostgreSQL.
-        # More information here:
-        # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html"
-        if SQL_ALCHEMY_CONN.startswith('mysql'):
-            engine_args['isolation_level'] = 'READ COMMITTED'
+    # The default isolation level for MySQL (REPEATABLE READ) can introduce inconsistencies when
+    # running multiple schedulers, as repeated queries on the same session may read from stale snapshots.
+    # 'READ COMMITTED' is the default value for PostgreSQL.
+    # More information here:
+    # https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html"
+    if SQL_ALCHEMY_CONN.startswith('mysql'):
+        engine_args['isolation_level'] = 'READ COMMITTED'
 
     return engine_args
 

--- a/tests/core/test_sqlalchemy_config.py
+++ b/tests/core/test_sqlalchemy_config.py
@@ -76,12 +76,15 @@ class TestSqlAlchemySettings(unittest.TestCase):
         }
         with conf_vars(config):
             settings.configure_orm()
+            engine_args = {}
+            if settings.SQL_ALCHEMY_CONN.startswith('mysql'):
+                engine_args['isolation_level'] = 'READ COMMITTED'
             mock_create_engine.assert_called_once_with(
                 settings.SQL_ALCHEMY_CONN,
                 connect_args=SQL_ALCHEMY_CONNECT_ARGS,
                 poolclass=NullPool,
                 encoding='utf-8',
-                isolation_level='READ COMMITTED',
+                **engine_args,
             )
 
     @patch('airflow.settings.setup_event_handlers')

--- a/tests/core/test_sqlalchemy_config.py
+++ b/tests/core/test_sqlalchemy_config.py
@@ -57,6 +57,7 @@ class TestSqlAlchemySettings(unittest.TestCase):
             pool_pre_ping=True,
             pool_recycle=1800,
             pool_size=5,
+            isolation_level='READ COMMITTED',
         )
 
     @patch('airflow.settings.setup_event_handlers')
@@ -80,6 +81,7 @@ class TestSqlAlchemySettings(unittest.TestCase):
                 connect_args=SQL_ALCHEMY_CONNECT_ARGS,
                 poolclass=NullPool,
                 encoding='utf-8',
+                isolation_level='READ COMMITTED',
             )
 
     @patch('airflow.settings.setup_event_handlers')

--- a/tests/www/test_app.py
+++ b/tests/www/test_app.py
@@ -223,6 +223,8 @@ class TestApp(unittest.TestCase):
     def test_should_set_sqlalchemy_engine_options(self):
         app = application.cached_app(testing=True)
         engine_params = {'pool_size': 3, 'pool_recycle': 120, 'pool_pre_ping': True, 'max_overflow': 5}
+        if app.config['SQLALCHEMY_DATABASE_URI'].startswith('mysql'):
+            engine_params['isolation_level'] = 'READ COMMITTED'
         assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == engine_params
 
     @conf_vars(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: https://github.com/apache/airflow/issues/15559

In the investigation in the above issue, we found that MySQL's default isolation level ended up causing some really weird issues when running multiple schedulers.

This ended up causing skipped tasks while backfilling and caused DAGs using `depends_on_past` to completely deadlock. 

By enforcing `READ COMMITTED` when using MySQL we should be able to avoid these issues entirely. I don't expect that this will introduce any issues when using MySQL 5.x and/or a single scheduler, as `READ COMMITTED` is the default isolation level used by PostgreSQL. 

I haven't had a chance to actually test this implementation as we fixed the errors in our production Airflow environment by updating the isolation level on the database itself. If you'd like, I can set replicate the issue with a default MySQL DB and ensure that this fix works as expected. 
 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
