### PR TITLE
Reduce false-positives when detecting SQLite usage

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -244,7 +244,7 @@ def prepare_engine_args(disable_connection_pool=False):
     if disable_connection_pool or not pool_connections:
         engine_args['poolclass'] = NullPool
         log.debug("settings.prepare_engine_args(): Using NullPool")
-    elif 'sqlite' not in SQL_ALCHEMY_CONN:
+    elif not SQL_ALCHEMY_CONN.startswith('sqlite'):
         # Pool size engine args not supported by sqlite.
         # If no config value is defined for the pool size, select a reasonable value.
         # 0 means no limit, which could lead to exceeding the Database connection limit.

--- a/airflow/utils/dag_processing.py
+++ b/airflow/utils/dag_processing.py
@@ -525,7 +525,7 @@ class DagFileProcessorManager(LoggingMixin):  # pylint: disable=too-many-instanc
             os.set_blocking(self._signal_conn.fileno(), False)
 
         self._parallelism = conf.getint('scheduler', 'parsing_processes')
-        if 'sqlite' in conf.get('core', 'sql_alchemy_conn') and self._parallelism > 1:
+        if conf.get('core', 'sql_alchemy_conn').startswith('sqlite') and self._parallelism > 1:
             self.log.warning(
                 "Because we cannot use more than 1 thread (parsing_processes = "
                 "%d ) when using sqlite. So we set parallelism to 1.",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

While working on a different fix I noticed that we were checking for sqlite like so:

```
if 'sqlite' in conf.get('core', 'sql_alchemy_conn')
```

While I know that its unlikely, this could incorrectly detect sqlite if the string appears anywhere in the sqlalchemy connection string. For example, a postrges connection to a database called `not-sqlite`:
```
postgresql://user:pass@localhost:5432/not-sqlite
```

Anyways, using `.startswith('sqlite')` should be a little more reliable here, as the dialect is always specified at the very beginning of an sqlalchemy connection string. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
