### PR TITLE
Add short description to BaseSQLToGCSOperator docstring

### DIFF
--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -32,6 +32,8 @@ from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
 class BaseSQLToGCSOperator(BaseOperator):
     """
+    Copy data from SQL to Google Cloud Storage in JSON or CSV format.
+    
     :param sql: The SQL to execute.
     :type sql: str
     :param bucket: The bucket to upload to.


### PR DESCRIPTION
BaseSQLToGCSOperator was missing a short description in the docstring - this PR adds a short description based on the classes that inherit from BaseSQLToGCSOperator.