### PR TITLE
extra docker-py update resolve docker op issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,7 @@ doc = [
     'sphinxcontrib-spelling==5.2.1',
 ]
 docker = [
-    'docker~=3.0',
+    'docker',
 ]
 druid = [
     'pydruid>=0.4.1',


### PR DESCRIPTION
Due to changes in the docker api in api version 1.41, the docker python
client needs an update to properly handle the filter param imagejson
endpoint.  Without this fix, the `DockerOperator` will not pull the image
unless `force_pull` is set to True.

closes: #13905

I am assuming the constraint branches get updated via another mechanism, so I validated by running `pip install docker~=4.4.1` in breeze and running the docker provider tests and testing a simple DAG that I had referencing an image I didn't have on my box.  I am not clear on why this was pinned on 3.x which makes me nervous.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
