### PR TITLE
Fix argument ordering and type of bucket and object

### DIFF
--- a/airflow/providers/google/cloud/hooks/gcs.py
+++ b/airflow/providers/google/cloud/hooks/gcs.py
@@ -265,8 +265,8 @@ class GCSHook(GoogleBaseHook):
 
     def download(
         self,
+        bucket_name: str,
         object_name: str,
-        bucket_name: Optional[str],
         filename: Optional[str] = None,
         chunk_size: Optional[int] = None,
         timeout: Optional[int] = DEFAULT_TIMEOUT,
@@ -280,10 +280,10 @@ class GCSHook(GoogleBaseHook):
         returns the location. For file sizes that exceed the available memory it is recommended
         to write to a file.
 
-        :param object_name: The object to fetch.
-        :type object_name: str
         :param bucket_name: The bucket to fetch from.
         :type bucket_name: str
+        :param object_name: The object to fetch.
+        :type object_name: str
         :param filename: If set, a local file path where the file should be written to.
         :type filename: str
         :param chunk_size: Blob chunk size.


### PR DESCRIPTION
This fixes the argument ordering of bucket_name and object_name in GCSHook.download.
All other methods defined on GCSHook have bucket_name before object_name except download.
GoogleCloudStorageHook.download in Airflow 1.0 also defined bucket_name first instead of object_name.

Using object_name, bucket_name causes an issue in BigQueryCreateExternalTableOperator and mlengine_operator_utils.create_evaluate_ops where the parameters to GCSHook.download in those operators are passed positionally.

Additionally, bucket_name is not an optional parameter in the underlying API and is not represented as such in other methods of GCSHook.

Found this while debugging a workflow using BigQueryCreateExternalTableOperator with @FedericaLionetto and stumbling on this log line:
```
google.api_core.exceptions.NotFound: 404 GET https://storage.googleapis.com/download/storage/v1/b/OBJECT_NAME_REDACTED/o/BUCKET_NAME_REDACTED?alt=media: Not Found: ('Request failed with status code', 404, 'Expected one of', <HTTPStatus.OK: 200>, <HTTPStatus.PARTIAL_CONTENT: 206>
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
