### PR TITLE
Add download links to provider documentation

### DIFF
--- a/dev/provider_packages/PROVIDER_INDEX_TEMPLATE.rst.jinja2
+++ b/dev/provider_packages/PROVIDER_INDEX_TEMPLATE.rst.jinja2
@@ -73,6 +73,17 @@ You can install such cross-provider dependencies when installing from PyPI. For 
 
 {{ CROSS_PROVIDERS_DEPENDENCIES_TABLE_RST | safe }}
 
+Downloading official packages
+-----------------------------
+
+You can download officially released packages and verify their checksums and signatures from the
+`Official Apache Download site <https://downloads.apache.org/airflow/providers/>`_
+
+* `The {{ PACKAGE_PIP_NAME }} {{ RELEASE }}{{ VERSION_SUFFIX }} sdist package <https://downloads.apache.org/airflow/providers/{{ PACKAGE_PIP_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz>`_ (`asc <https://downloads.apache.org/airflow/providers/{{ PACKAGE_PIP_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/{{ PACKAGE_PIP_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}.tar.gz.sha512>`__)
+* `The {{ PACKAGE_PIP_NAME }} {{ RELEASE }}{{ VERSION_SUFFIX }} wheel package <https://downloads.apache.org/airflow/providers/{{ PACKAGE_WHEEL_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl>`_ (`asc <https://downloads.apache.org/airflow/providers/{{ PACKAGE_WHEEL_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl.asc>`__, `sha512 <https://downloads.apache.org/airflow/providers/{{ PACKAGE_WHEEL_NAME }}-{{ RELEASE }}{{ VERSION_SUFFIX }}-py3-none-any.whl.sha512>`__)
+
+
+
 {%- endif %}
 
 {{ CHANGELOG | safe }}

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -153,6 +153,11 @@ option_verbose = click.option(
     is_flag=True,
     help="Print verbose information about performed steps",
 )
+option_force = click.option(
+    "--force",
+    is_flag=True,
+    help="Forces regeneration of already generated documentation",
+)
 argument_package_id = click.argument('package_id')
 
 
@@ -310,6 +315,16 @@ def get_pip_package_name(provider_package_id: str) -> str:
     :return: the name of pip package
     """
     return "apache-airflow-providers-" + provider_package_id.replace(".", "-")
+
+
+def get_wheel_package_name(provider_package_id: str) -> str:
+    """
+    Returns PIP package name for the package id.
+
+    :param provider_package_id: id of the package
+    :return: the name of pip package
+    """
+    return "apache_airflow_providers_" + provider_package_id.replace(".", "_")
 
 
 def get_long_description(provider_package_id: str) -> str:
@@ -1503,6 +1518,7 @@ def get_provider_jinja_context(
         "README_FILE": "README.rst",
         "PROVIDER_PACKAGE_ID": provider_details.provider_package_id,
         "PACKAGE_PIP_NAME": get_pip_package_name(provider_details.provider_package_id),
+        "PACKAGE_WHEEL_NAME": get_wheel_package_name(provider_details.provider_package_id),
         "FULL_PACKAGE_NAME": provider_details.full_package_name,
         "PROVIDER_PATH": provider_details.full_package_name.replace(".", "/"),
         "RELEASE": current_release_version,
@@ -1575,6 +1591,7 @@ def mark_latest_changes_as_documentation_only(
 def update_release_notes(
     provider_package_id: str,
     version_suffix: str,
+    force: bool,
     verbose: bool,
     interactive: bool,
 ) -> bool:
@@ -1583,6 +1600,7 @@ def update_release_notes(
 
     :param provider_package_id: id of the package
     :param version_suffix: version suffix corresponding to the version in the code
+    :param force: regenerate already released documentation
     :param verbose: whether to print verbose messages
     :param interactive: whether the script should ask the user in case of doubt
     :returns False if the package should be skipped, True if everything generated properly
@@ -1603,18 +1621,21 @@ def update_release_notes(
         provider_details.source_provider_package_path,
         verbose,
     )
-    if proceed:
-        if interactive and not confirm("Provider marked for release. Proceed?"):
+    if not force:
+        if proceed:
+            if interactive and not confirm("Provider marked for release. Proceed?"):
+                return False
+        elif not latest_change:
+            print()
+            print(
+                f"[yellow]Provider: {provider_package_id} - skipping documentation generation. No changes![/]"
+            )
+            print()
             return False
-    elif not latest_change:
-        print()
-        print(f"[yellow]Provider: {provider_package_id} - skipping documentation generation. No changes![/]")
-        print()
-        return False
-    else:
-        if interactive and confirm("Are those changes documentation-only?"):
-            mark_latest_changes_as_documentation_only(provider_details, latest_change)
-        return False
+        else:
+            if interactive and confirm("Are those changes documentation-only?"):
+                mark_latest_changes_as_documentation_only(provider_details, latest_change)
+            return False
 
     jinja_context["DETAILED_CHANGES_RST"] = changes
     jinja_context["DETAILED_CHANGES_PRESENT"] = len(changes) > 0
@@ -1842,12 +1863,14 @@ def list_providers_packages():
 @option_git_update
 @option_interactive
 @argument_package_id
+@option_force
 @option_verbose
 def update_package_documentation(
     version_suffix: str,
     git_update: bool,
     interactive: bool,
     package_id: str,
+    force: bool,
     verbose: bool,
 ):
     """
@@ -1861,7 +1884,7 @@ def update_package_documentation(
         print("Updating documentation for the latest release version.")
         make_sure_remote_apache_exists_and_fetch(git_update, verbose)
         if not update_release_notes(
-            provider_package_id, version_suffix, verbose=verbose, interactive=interactive
+            provider_package_id, version_suffix, force=force, verbose=verbose, interactive=interactive
         ):
             # Returns 64 in case of skipped package
             sys.exit(64)


### PR DESCRIPTION
This PR adds links in the provider documentation to
the official Apache Airflow Download
site including checksum and signature links.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
