### PR TITLE
Redirect forked process output to logger

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -114,12 +114,7 @@ class BaseTaskRunner(LoggingMixin):
 
     def _stream_reader(self, stream):
         """Reading from the stream and log into task logs"""
-        while True:
-            line = stream.readline()
-            if isinstance(line, bytes):
-                line = line.decode('utf-8')
-            if not line:
-                break
+        for line in iter(stream.readline, ""):
             self.log.info(
                 'Job %s: Subtask %s %s',
                 self._task_instance.job_id,
@@ -127,7 +122,7 @@ class BaseTaskRunner(LoggingMixin):
                 line.rstrip('\n'),
             )
 
-    def read_task_logs(self, stream):
+    def _read_task_logs(self, stream):
         """Start a daemon thread to read subprocess logging output"""
         log_reader = threading.Thread(target=self._stream_reader, args=(stream,), daemon=True)
         log_reader.start()
@@ -156,7 +151,7 @@ class BaseTaskRunner(LoggingMixin):
             env=os.environ.copy(),
             preexec_fn=os.setsid,
         )
-        self.read_task_logs(proc.stdout)
+        self._read_task_logs(proc.stdout)
         return proc
 
     def start(self):

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -113,9 +113,7 @@ class BaseTaskRunner(LoggingMixin):
         return load_error_file(self._error_file)
 
     def _stream_reader(self, stream):
-        """
-        Reading from the stream and log into task logs
-        """
+        """Reading from the stream and log into task logs"""
         while True:
             line = stream.readline()
             if isinstance(line, bytes):
@@ -130,13 +128,8 @@ class BaseTaskRunner(LoggingMixin):
             )
 
     def read_task_logs(self, stream):
-        """
-        Start a thread to read subprocess logging output
-        """
-        log_reader = threading.Thread(
-            target=self._stream_reader,
-            args=(stream,),
-        )
+        """Start a daemon thread to read subprocess logging output"""
+        log_reader = threading.Thread(target=self._stream_reader, args=(stream,), daemon=True)
         log_reader.start()
 
     def run_command(self, run_with=None):

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -112,7 +112,10 @@ class BaseTaskRunner(LoggingMixin):
         """Return task runtime error if its written to provided error file."""
         return load_error_file(self._error_file)
 
-    def _read_task_logs(self, stream):
+    def _stream_reader(self, stream):
+        """
+        Reading from the stream and log into task logs
+        """
         while True:
             line = stream.readline()
             if isinstance(line, bytes):
@@ -125,6 +128,16 @@ class BaseTaskRunner(LoggingMixin):
                 self._task_instance.task_id,
                 line.rstrip('\n'),
             )
+
+    def read_task_logs(self, stream):
+        """
+        Start a thread to read subprocess logging output
+        """
+        log_reader = threading.Thread(
+            target=self._stream_reader,
+            args=(stream,),
+        )
+        log_reader.start()
 
     def run_command(self, run_with=None):
         """
@@ -150,14 +163,7 @@ class BaseTaskRunner(LoggingMixin):
             env=os.environ.copy(),
             preexec_fn=os.setsid,
         )
-
-        # Start daemon thread to read subprocess logging output
-        log_reader = threading.Thread(
-            target=self._read_task_logs,
-            args=(proc.stdout,),
-        )
-        log_reader.daemon = True
-        log_reader.start()
+        self.read_task_logs(proc.stdout)
         return proc
 
     def start(self):

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -52,7 +52,7 @@ class StandardTaskRunner(BaseTaskRunner):
         if pid:
             self.log.info("Started process %d to run task", pid)
             os.close(wpipe)
-            self.read_task_logs(os.fdopen(rpipe))
+            self._read_task_logs(os.fdopen(rpipe))
             return psutil.Process(pid)
         else:
             import signal

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -89,8 +89,8 @@ class StandardTaskRunner(BaseTaskRunner):
                 os.close(rpipe)
                 sys.stdout.flush()
                 # replace fds for the stdout/stderr with the newly created pipe
-                os.dup2(wpipe, 1)
-                os.dup2(wpipe, 2)
+                os.dup2(wpipe, sys.__stdout__.fileno())
+                os.dup2(wpipe, sys.__stderr__.fileno())
                 os.close(wpipe)
                 args.func(args, dag=self.dag)
                 return_code = 0

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -87,6 +87,7 @@ class StandardTaskRunner(BaseTaskRunner):
 
             try:
                 os.close(rpipe)
+                sys.stdout.flush()
                 # replace fds for the stdout/stderr with the newly created pipe
                 os.dup2(wpipe, 1)
                 os.dup2(wpipe, 2)

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -90,8 +90,6 @@ class StreamLogWriter:
     def close(self):
         """
         Provide close method, for compatibility with the io.IOBase interface.
-
-        This is a no-op method.
         """
         self.flush()
 

--- a/airflow/utils/log/logging_mixin.py
+++ b/airflow/utils/log/logging_mixin.py
@@ -93,6 +93,7 @@ class StreamLogWriter:
 
         This is a no-op method.
         """
+        self.flush()
 
     @property
     def closed(self):

--- a/tests/dags/test_subprocess.py
+++ b/tests/dags/test_subprocess.py
@@ -1,0 +1,20 @@
+import shlex
+import subprocess
+from datetime import datetime
+
+from airflow.models import DAG
+from airflow.operators.python import PythonOperator
+
+
+def _sub_process(ds, **context):
+    cmd = "python -c 'print(\"Test subprocess log.\")'"
+    p = subprocess.run(shlex.split(cmd))
+    ret = p.returncode
+    if ret == 0:
+        print("Task Completed With Success")
+    else:
+        print("Error")
+
+
+dag = DAG(dag_id='test_subprocess', start_date=datetime(2020, 1, 1))
+dag_task = PythonOperator(task_id='subprocess_task', python_callable=_sub_process)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This is an attempt to close: #14813

TODO:
- [ ] Add tests

The root cause of the original problem is that subprocess inherits the *FDs for stdout/stderr* but not the *sys.stdout/stderr file objects*. When the `StandardTaskRunner` call .`start` (which runs `airflow tasks run --raw ...` under the hood), it tries to "redirect" the sys.stdout file object to the custom [StreamLogWriter](https://github.com/apache/airflow/blob/d627dfa72b4395740f9a4948f549bf53a89b2285/airflow/cli/commands/task_command.py#L236) which writes everything into the task logger. However, when the process tries to start a new subprocess, the sys.stdout/stderr file objects are restored, and point to the original FDs. Here is a simple script that shows this behavior:

```python
from contextlib import redirect_stdout
import io
import subprocess

s_io = io.StringIO()
with redirect_stdout(s_io):
    print('this is captured')
    subprocess.run(['echo', 'this is not'])

print('Captured by redirect: ', s_io.getvalue())

# this is not
# Captured by redirect:  this is captured
```

Note: So why there are *sys.stdout/stderr file objects*? They are used to **buffer** outputs before flushing them together to the system. (because system calls are expensive)

Before the change in #6627, the `--raw` command is started as a subprocess with the stdout/stderr replaced with PIPE at the FDs level, so all stdout/stderr of subsequent subprocesses (i.e. the subprocess spawned by the python callable in the PythonOperator) will go into the PIPE.  A separate thread is also spawned to read from this stream and log into the task logs using `self.log.info`
https://github.com/apache/airflow/blob/25caeda58b50eae6ef425a52e794504bc63855d1/airflow/task/task_runner/base_task_runner.py#L137-L153

However, in the fork path, the FD is left unchanged, so all subsequent subprocess will still write to the original FDs (print to the console). This PR essentially tries to create new PIPEs that replace the original FDs, so we can read the logs from the PIPE similar to the `subprocess.Popen` path.

https://github.com/apache/airflow/blob/25caeda58b50eae6ef425a52e794504bc63855d1/airflow/task/task_runner/standard_task_runner.py#L49

Potentially, a better approach is to rewrite the `StreamLogWriter` to replace the FDs under the hood. But currently, I'm still wrapping my head around the whole FDs thing. Unless someone can point me a direction on how to rewrite the `StreamLogWriter` or suggest an alternative approach, I will leave it to another day and another PR...

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
