### PR TITLE
Skip failing for undefined variables in MacOS

### DIFF
--- a/scripts/ci/libraries/_script_init.sh
+++ b/scripts/ci/libraries/_script_init.sh
@@ -16,7 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -euo pipefail
+set -eo pipefail
+
+if [[ $(uname -s) != "Darwin" ]]; then
+    # do not fail with undefined variable on MacOS. The old Bash which is default on Mac OS
+    # fails with undefined variable when you are passing an empty variable and this causes
+    # problems for example when you try to pass empty list of arguments "${@}"
+    set -u
+fi
 
 export AIRFLOW_SOURCES="${AIRFLOW_SOURCES:=$( cd "$( dirname "${BASH_SOURCE[0]}" )/../../.." && pwd )}"
 readonly AIRFLOW_SOURCES


### PR DESCRIPTION
Failing with undefined variables is a good technique to avoid
typos in Bash, but for MacOS this is problematic as bash
used by default on MacOS fails with undefined variable
when there is an empty array passed - which is often needed,
for example when you pass "${@}" arguments.

This PR disables undefined variable check for MacOS.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
