### PR TITLE
Time range tolerance on external task sensor

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -235,7 +235,6 @@ class ExternalTaskSensor(BaseSensorOperator):
         :type states: list
         :return: count of record against the filters
         """
-
         if self.external_task_id is None:
             model = DagRun
         else:

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -20,8 +20,7 @@ import datetime
 import os
 from typing import Any, Callable, FrozenSet, Iterable, Optional, Union
 
-from sqlalchemy import func
-from sqlalchemy import or_
+from sqlalchemy import func, or_
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperatorLink, DagBag, DagModel, DagRun, TaskInstance

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -47,6 +47,7 @@ class TestExternalTaskSensor(unittest.TestCase):
     def test_time_sensor(self):
         op = TimeSensor(task_id=TEST_TASK_ID, target_time=time(0), dag=self.dag)
         op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        return op
 
     def test_external_task_sensor(self):
         self.test_time_sensor()
@@ -280,6 +281,47 @@ exit 0
             dag=self.dag,
         )
         op1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+
+    def test_external_task_sensor_with_tolerance_before(self):
+        self.test_time_sensor()
+        op = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id=TEST_DAG_ID,
+            external_task_id=TEST_TASK_ID,
+            execution_date_tolerance_before=timedelta(seconds=1),
+            timeout=1,
+            dag=self.dag,
+        )
+        date = DEFAULT_DATE + timedelta(seconds=1)
+        op.run(start_date=date, end_date=date, ignore_ti_state=True)
+
+    def test_external_task_sensor_with_tolerance_after(self):
+        self.test_time_sensor()
+        op = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id=TEST_DAG_ID,
+            external_task_id=TEST_TASK_ID,
+            execution_date_tolerance_after=timedelta(seconds=1),
+            timeout=1,
+            dag=self.dag,
+        )
+        date = DEFAULT_DATE - timedelta(seconds=1)
+        op.run(start_date=date, end_date=date, ignore_ti_state=True)
+
+    def test_external_task_sensor_with_tolerance_multiple(self):
+        sensor = self.test_time_sensor()
+        date = DEFAULT_DATE - timedelta(seconds=1)
+        sensor.run(start_date=date, end_date=date, ignore_ti_state=True)
+        op = ExternalTaskSensor(
+            task_id='test_external_task_sensor_check',
+            external_dag_id=TEST_DAG_ID,
+            external_task_id=TEST_TASK_ID,
+            execution_date_tolerance_after=timedelta(seconds=1),
+            timeout=1,
+            dag=self.dag,
+        )
+        date = DEFAULT_DATE - timedelta(seconds=1)
+        op.run(start_date=date, end_date=date, ignore_ti_state=True)
 
     def test_external_task_sensor_error_delta_and_fn(self):
         self.test_time_sensor()


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This pull request proposes to add two optional parameters `execution_date_tolerance_before` and `execution_date_tolerance_after` – allowing a non-exact time match on either a task or DAG run.

The use-case is using the sensor on a DAG where the schedule is out of step with the sensor task.

The issue has previously been brought up in [AIRFLOW-3107](https://issues.apache.org/jira/browse/AIRFLOW-3107) and the present pull request contains some code from a code snippet related to this issue by [omnilinguist](https://github.com/omnilinguist).

