### PR TITLE
Unset PIP_USER in prod entrypoint.

### DIFF
--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -277,6 +277,12 @@ function check_uid_gid() {
     fi
 }
 
+# In Airflow image we are setting PIP_USER variable to true, in order to install all the packages
+# by default with the ``--user`` flag. However this is a problem if a virtualenv is created later
+# which happens in PythonVirtualenvOperator. We are unsetting this variable here, so that it is
+# not set when PIP is run by Airflow later on
+unset PIP_USER
+
 check_uid_gid
 
 # Set umask to 0002 to make all the directories created by the current user group-writeable
@@ -304,6 +310,7 @@ fi
 if [[ -n "${_AIRFLOW_WWW_USER_CREATE=}" ]] ; then
     create_www_user
 fi
+
 
 # The `bash` and `python` commands should also verify the basic connections
 # So they are run after the DB check


### PR DESCRIPTION
In Airflow image we are setting PIP_USER variable to true, in order to
install all the packages by default with the ``--user`` flag. However
this is a problem if a virtualenv is created later which happens in
PythonVirtualenvOperator. We are unsetting this variable here, so that
it is not set when PIP is run by Airflow later on.

Fixes: #15768
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
