### PR TITLE
Fixup - Return output of last task from task_group wrapper.

### DIFF
--- a/airflow/decorators/task_group.py
+++ b/airflow/decorators/task_group.py
@@ -58,12 +58,9 @@ def task_group(python_callable: Optional[Callable] = None, *tg_args, **tg_kwargs
             # Initialize TaskGroup with bound arguments
             with TaskGroup(
                 *task_group_bound_args.args, add_suffix_on_collision=True, **task_group_bound_args.kwargs
-            ) as tg_obj:
+            ):
                 # Invoke function to run Tasks inside the TaskGroup
-                f(*args, **kwargs)
-
-            # Return task_group object such that it's accessible in Globals.
-            return tg_obj
+                return f(*args, **kwargs)
 
         return cast(T, factory)
 


### PR DESCRIPTION
### Current behavior
task_group decorator returns the task_group instance

### Expected Behavior
task_group decorator returns the output of the final task in the group.

Closes https://github.com/apache/airflow/issues/15708