### PR TITLE
Bug Fix Pod-Template Affinity Ignored due to empty Affinity K8S Object

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -257,7 +257,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         else:
             self.node_selector = {}
         self.annotations = annotations or {}
-        self.affinity = convert_affinity(affinity) if affinity else k8s.V1Affinity()
+        self.affinity = convert_affinity(affinity) if affinity else {} 
         self.k8s_resources = convert_resources(resources) if resources else {}
         self.config_file = config_file
         self.image_pull_secrets = convert_image_pull_secrets(image_pull_secrets) if image_pull_secrets else []

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -257,7 +257,7 @@ class KubernetesPodOperator(BaseOperator):  # pylint: disable=too-many-instance-
         else:
             self.node_selector = {}
         self.annotations = annotations or {}
-        self.affinity = convert_affinity(affinity) if affinity else {} 
+        self.affinity = convert_affinity(affinity) if affinity else {}
         self.k8s_resources = convert_resources(resources) if resources else {}
         self.config_file = config_file
         self.image_pull_secrets = convert_image_pull_secrets(image_pull_secrets) if image_pull_secrets else []

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -343,7 +343,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
                         operator: In
                         values:
                         - foo
-                        - bar 
+                        - bar
                   preferredDuringSchedulingIgnoredDuringExecution:
                   - weight: 1
                     preference:

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -386,43 +386,34 @@ class TestKubernetesPodOperator(unittest.TestCase):
             assert pod.spec.containers[0].image == "ubuntu:16.04"
             assert pod.spec.containers[0].command == ["something"]
             affinity = {
-                       'node_affinity': {
-                           'preferred_during_scheduling_ignored_during_execution': [
-                               {
-                                   'preference': {
-                                        'match_expressions': [
-                                            {
-                                                'key': 'kubernetes.io/role',
-                                                'operator': 'In',
-                                                'values': ['foo', 'bar']
-                                            }
-                                        ],
-                                        'match_fields': None
-                                   },
-                                   'weight': 1
-                               }
-                           ],
-                           'required_during_scheduling_ignored_during_execution': {
-                               'node_selector_terms': [
-                                   {
-                                       'match_expressions': [
-                                           {
-                                               'key': 'kubernetes.io/role',
-                                               'operator': 'In',
-                                               'values': ['foo', 'bar']
-                                           }
-                                        ],
-                                        'match_fields': None
-                                   }
-                               ]
-                           }
-                       },
-                       'pod_affinity': None,
-                       'pod_anti_affinity': None
-                   }
+                'node_affinity': {
+                    'preferred_during_scheduling_ignored_during_execution': [
+                        {
+                            'preference': {
+                                'match_expressions': [
+                                    {'key': 'kubernetes.io/role', 'operator': 'In', 'values': ['foo', 'bar']}
+                                ],
+                                'match_fields': None,
+                            },
+                            'weight': 1,
+                        }
+                    ],
+                    'required_during_scheduling_ignored_during_execution': {
+                        'node_selector_terms': [
+                            {
+                                'match_expressions': [
+                                    {'key': 'kubernetes.io/role', 'operator': 'In', 'values': ['foo', 'bar']}
+                                ],
+                                'match_fields': None,
+                            }
+                        ]
+                    },
+                },
+                'pod_affinity': None,
+                'pod_anti_affinity': None,
+            }
 
             assert pod.spec.affinity.to_dict() == affinity
-
 
             # kwargs take precedence, however
             image = "some.custom.image:andtag"

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -20,7 +20,6 @@ from tempfile import NamedTemporaryFile
 from unittest import mock
 
 import pendulum
-import json
 import pytest
 from kubernetes.client import ApiClient, models as k8s
 


### PR DESCRIPTION
**Issue**:
KubernetesPodOperator pod-template files with pod affinities are ignored, even if no affinities are passed to the KubernetesPodOperator object. 

**Cause** 
During the pod-initialization an empty k8s.Affinity object is created if no affinities are supplied. This will later prevent the pod-template affinities to be used, because during the pod_reconciliation the empty k8s.Affinity object takes precedence. 
All other attributes such as
`self.k8s_resources = convert_resources(resources) if resources else {}`
`self.image_pull_secrets = convert_image_pull_secrets(image_pull_secrets) if image_pull_secrets else []`

handle it properly.