### PR TITLE
Error earlier if virtualenv is not installed  and DAG has a PythonVirtualenvOperator

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -18,6 +18,7 @@
 import inspect
 import os
 import pickle
+import shutil
 import sys
 import types
 import warnings
@@ -325,6 +326,8 @@ class PythonVirtualenvOperator(PythonOperator):
                 "Passing op_args or op_kwargs is not supported across different Python "
                 "major versions for PythonVirtualenvOperator. Please use string_args."
             )
+        if not shutil.which("virtualenv"):
+            raise AirflowException('PythonVirtualenvOperator requires virtualenv, please install it.')
         super().__init__(
             python_callable=python_callable,
             op_args=op_args,


### PR DESCRIPTION
While trying to use `@task.virtualenv` I got this error:

```
 File "/Users/matt/src/airflow/airflow/models/taskinstance.py", line 1340, in _execute_task
    result = task_copy.execute(context=context)
  File "/Users/matt/src/airflow/airflow/decorators/base.py", line 138, in execute
    return_value = super().execute(context)
  File "/Users/matt/src/airflow/airflow/operators/python.py", line 350, in execute
    return super().execute(context=serializable_context)
  File "/Users/matt/src/airflow/airflow/operators/python.py", line 152, in execute
    return_value = self.execute_callable()
  File "/Users/matt/src/airflow/airflow/operators/python.py", line 362, in execute_callable
    prepare_virtualenv(
  File "/Users/matt/src/airflow/airflow/utils/python_virtualenv.py", line 95, in prepare_virtualenv
    execute_in_subprocess(virtualenv_cmd)
  File "/Users/matt/src/airflow/airflow/utils/process_utils.py", line 136, in execute_in_subprocess
    with subprocess.Popen(
  File "/usr/local/Cellar/python@3.9/3.9.4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/Cellar/python@3.9/3.9.4/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'virtualenv'
```

It was helpful enough that I was able to guess that `pip install virtualenv` would fix things for me, but:
 - The error could have come up earlier
 - `FileNotFoundError` made me doubt that it was a packaging issue

This PR checks if virtualenv is importable at init time and throws a more helpful exception.

I'm interested to know if there's a better way to handle things like this, but this is at least better than how it was.