### PR TITLE
Fixes building pre-2.1 Airflow images from 2.1 Dockerfiles.

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -95,8 +95,7 @@ RUN mkdir -pv /usr/share/man/man1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Only copy install_mysql.sh to not invalidate cache on other script changes
-COPY scripts/docker/install_mysql.sh /scripts/docker/install_mysql.sh
+COPY scripts/docker/*.sh /scripts/docker/
 RUN bash /scripts/docker/install_mysql.sh dev \
     && adduser airflow \
     && echo "airflow ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/airflow \
@@ -190,9 +189,6 @@ RUN curl -sSL https://github.com/bats-core/bats-core/archive/v${BATS_VERSION}.ta
     && curl -sSL https://github.com/bats-core/bats-file/archive/v${BATS_FILE_VERSION}.tar.gz -o /tmp/bats-file.tgz \
     && tar -zxf /tmp/bats-file.tgz -C /opt/bats/lib/bats-file --strip 1 && rm -rf /tmp/*
 
-# Additional scripts for managing BATS addons
-COPY scripts/docker/load.bash /opt/bats/lib/
-
 ARG AIRFLOW_REPO=apache/airflow
 ARG AIRFLOW_BRANCH=master
 # Airflow Extras installed
@@ -211,7 +207,7 @@ ARG AIRFLOW_PRE_CACHED_PIP_PACKAGES="true"
 # By default in the image, we are installing all providers when installing from sources
 ARG INSTALL_PROVIDERS_FROM_SOURCES="true"
 ARG INSTALL_FROM_PYPI="true"
-ARG AIRFLOW_PIP_VERSION=21.1
+ARG AIRFLOW_PIP_VERSION=21.1.1
 # Setup PIP
 # By default PIP install run without cache to make image smaller
 ARG PIP_NO_CACHE_DIR="true"
@@ -253,14 +249,6 @@ ENV AIRFLOW_REPO=${AIRFLOW_REPO}\
     CASS_DRIVER_BUILD_CONCURRENCY=${CASS_DRIVER_BUILD_CONCURRENCY} \
     CASS_DRIVER_NO_CYTHON=${CASS_DRIVER_NO_CYTHON}
 
-RUN pip install --no-cache-dir --upgrade "pip==${AIRFLOW_PIP_VERSION}"
-
-# Only copy common.sh to not invalidate further layers
-COPY scripts/docker/common.sh /scripts/docker/common.sh
-
-# Only copy install_airflow_from_branch_tip.sh to not invalidate cache on other script changes
-COPY scripts/docker/install_airflow_from_branch_tip.sh /scripts/docker/install_airflow_from_branch_tip.sh
-
 # Those are additional constraints that are needed for some extras but we do not want to
 # force them on the main Airflow package. Those limitations are:
 # * chardet<4: required by snowflake provider
@@ -281,7 +269,8 @@ ENV EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS=${EAGER_UPGRADE_ADDITIONAL_REQUIREMENT
 # are uninstalled, only dependencies remain.
 # the cache is only used when "upgrade to newer dependencies" is not set to automatically
 # account for removed dependencies (we do not install them in the first place)
-RUN if [[ ${AIRFLOW_PRE_CACHED_PIP_PACKAGES} == "true" && \
+RUN bash /scripts/docker/install_pip_version.sh; \
+    if [[ ${AIRFLOW_PRE_CACHED_PIP_PACKAGES} == "true" && \
           ${UPGRADE_TO_NEWER_DEPENDENCIES} == "false" ]]; then \
         bash /scripts/docker/install_airflow_from_branch_tip.sh; \
     fi
@@ -314,9 +303,6 @@ COPY airflow/__init__.py ${AIRFLOW_SOURCES}/airflow/__init__.py
 
 ARG CONTINUE_ON_PIP_CHECK_FAILURE="false"
 
-# Only copy install_airflow.sh to not invalidate cache on other script changes
-COPY scripts/docker/install_airflow.sh /scripts/docker/install_airflow.sh
-
 # The goal of this line is to install the dependencies from the most current setup.py from sources
 # This will be usually incremental small set of packages in CI optimized build, so it will be very fast
 # In non-CI optimized build this will install all dependencies before installing sources.
@@ -338,6 +324,8 @@ RUN bash airflow/www/compile_assets.sh
 
 COPY scripts/in_container/entrypoint_ci.sh /entrypoint
 RUN chmod a+x /entrypoint
+
+COPY scripts/docker/load.bash /opt/bats/lib/
 
 # We can copy everything here. The Context is filtered by dockerignore. This makes sure we are not
 # copying over stuff that is accidentally generated or that we do not need (such as egg-info)
@@ -366,8 +354,9 @@ RUN SYSTEM=$(uname -s | tr '[:upper:]' '[:lower:]') \
 # Additional python deps to install
 ARG ADDITIONAL_PYTHON_DEPS=""
 
-RUN if [[ -n "${ADDITIONAL_PYTHON_DEPS}" ]]; then \
-        pip install --no-cache-dir ${ADDITIONAL_PYTHON_DEPS}; \
+RUN bash /scripts/docker/install_pip_version.sh; \
+    if [[ -n "${ADDITIONAL_PYTHON_DEPS}" ]]; then \
+            bash /scripts/docker/install_additional_dependencies.sh; \
     fi
 
 ARG BUILD_ID

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -117,6 +117,10 @@ You should be aware, about a few things:
   in runtime, will have ``GID=0`` and will be group-writable.
 
 .. note::
+  When you build image for Airflow version < ``2.1`` (for example 2.0.2 or 1.10.15) the image is build with
+  PIP 20.2.4 because ``PIP21+`` is only supported for ``Airflow 2.1+``
+
+.. note::
   Only as of ``2.0.2`` the default group of ``airflow`` user is ``root``. Previously it was ``airflow``,
   so if you are building your images based on an earlier image, you need to manually change the default
   group for airflow user:

--- a/docs/docker-stack/docker-examples/restricted/restricted_environments.sh
+++ b/docs/docker-stack/docker-examples/restricted/restricted_environments.sh
@@ -27,6 +27,9 @@ rm docker-context-files/*.whl docker-context-files/*.tar.gz docker-context-files
 curl -Lo "docker-context-files/constraints-3.7.txt" \
     https://raw.githubusercontent.com/apache/airflow/constraints-2.0.2/constraints-3.7.txt
 
+# For Airflow pre 2.1 you need to use PIP 20.2.4 to install/download Airflow packages.
+pip install pip==20.2.4
+
 pip download --dest docker-context-files \
     --constraint docker-context-files/constraints-3.7.txt  \
     "apache-airflow[async,aws,azure,celery,dask,elasticsearch,gcp,kubernetes,postgres,redis,slack,ssh,statsd,virtualenv]==2.0.2"

--- a/scripts/docker/common.sh
+++ b/scripts/docker/common.sh
@@ -33,6 +33,15 @@ function common::get_airflow_version_specification() {
     fi
 }
 
+function common::override_pip_version_if_needed() {
+    if [[ -n ${AIRFLOW_VERSION} ]]; then
+        if [[ ${AIRFLOW_VERSION} =~ ^2\.0.* || ${AIRFLOW_VERSION} =~ ^1\.* ]]; then
+            export AIRFLOW_PIP_VERSION="20.2.4"
+        fi
+    fi
+}
+
+
 function common::get_constraints_location() {
     # auto-detect Airflow-constraint reference and location
     if [[ -z "${AIRFLOW_CONSTRAINTS_REFERENCE}" ]]; then

--- a/scripts/docker/install_additional_dependencies.sh
+++ b/scripts/docker/install_additional_dependencies.sh
@@ -25,6 +25,10 @@ test -v AIRFLOW_INSTALL_USER_FLAG
 test -v AIRFLOW_PIP_VERSION
 test -v CONTINUE_ON_PIP_CHECK_FAILURE
 
+# shellcheck source=scripts/docker/common.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/common.sh"
+
+
 set -x
 
 # Installs additional dependencies passed as Argument to the Docker build command
@@ -50,5 +54,9 @@ function install_additional_dependencies() {
         pip check || ${CONTINUE_ON_PIP_CHECK_FAILURE}
     fi
 }
+
+common::get_airflow_version_specification
+common::override_pip_version_if_needed
+common::get_constraints_location
 
 install_additional_dependencies

--- a/scripts/docker/install_airflow.sh
+++ b/scripts/docker/install_airflow.sh
@@ -82,7 +82,7 @@ function install_airflow() {
 }
 
 common::get_airflow_version_specification
-
+common::override_pip_version_if_needed
 common::get_constraints_location
 
 install_airflow

--- a/scripts/docker/install_airflow_from_branch_tip.sh
+++ b/scripts/docker/install_airflow_from_branch_tip.sh
@@ -50,6 +50,8 @@ function install_airflow_from_branch_tip() {
     pip uninstall --yes apache-airflow
 }
 
+common::get_airflow_version_specification
+common::override_pip_version_if_needed
 common::get_constraints_location
 
 install_airflow_from_branch_tip

--- a/scripts/docker/install_from_docker_context_files.sh
+++ b/scripts/docker/install_from_docker_context_files.sh
@@ -119,6 +119,8 @@ install_all_other_packages_from_docker_context_files() {
     fi
 }
 
+common::get_airflow_version_specification
+common::override_pip_version_if_needed
 common::get_constraints_location
 
 install_airflow_and_providers_from_docker_context_files

--- a/scripts/docker/install_pip_version.sh
+++ b/scripts/docker/install_pip_version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Install airflow using regular 'pip install' command. This install airflow depending on the arguments:
+# AIRFLOW_INSTALLATION_METHOD - determines where to install airflow form:
+#             "." - installs airflow from local sources
+#             "apache-airflow" - installs airflow from PyPI 'apache-airflow' package
+# AIRFLOW_VERSION_SPECIFICATION - optional specification for Airflow version to install (
+#                                 might be ==2.0.2 for example or <3.0.0
+# UPGRADE_TO_NEWER_DEPENDENCIES - determines whether eager-upgrade should be performed with the
+#                                 dependencies (with EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS added)
+#
+# shellcheck disable=SC2086
+# shellcheck source=scripts/docker/common.sh
+. "$( dirname "${BASH_SOURCE[0]}" )/common.sh"
+
+function install_pip_version() {
+    pip install --no-cache-dir --upgrade "pip==${AIRFLOW_PIP_VERSION}" && mkdir -p /root/.local/bin
+}
+
+common::get_airflow_version_specification
+common::override_pip_version_if_needed
+common::get_constraints_location
+
+install_pip_version


### PR DESCRIPTION
Airflow in version pre 2.1 is not compatible with PIP 21. If you
try to build image for Airflow 2.0* using master Dockerfile
(soon released in 2.1) Airflow will not build properly.

This change will automatically fall-back to PIP 20.2.4
in case Dockerfile is built with Airflow 2.0 or below.

Fixes: #15790

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
