### PR TITLE
Pin `itsdangerous` to < 2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,7 +104,8 @@ install_requires =
     importlib_metadata~=1.7;python_version<"3.9" # We could work with 3.1, but argparse needs <2
     importlib_resources~=1.4
     iso8601>=0.1.12
-    itsdangerous>=1.1.0
+    # Logging is broken with itsdangerous > 2
+    itsdangerous>=1.1.0, <2.0
     jinja2>=2.10.1, <2.12.0
     jsonschema~=3.0
     lazy-object-proxy


### PR DESCRIPTION
Looks like new version of `itsdangerous` has broken some logging configs: https://itsdangerous.palletsprojects.com/en/2.0.x/changes/#version-2-0-0

Error as reported on Slack (https://apache-airflow.slack.com/archives/C0146STM600/p1620836191398100?thread_ts=1620833825.394600&cid=C0146STM600):

![image](https://user-images.githubusercontent.com/8811558/118010171-ae66fe00-b346-11eb-9225-1479ac67b61b.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
