### PR TITLE
Chart: Avoid `git-sync` sidecar on Websever when Airflow>=2.0.0

### DIFF
--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -108,7 +108,7 @@ spec:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
       containers:
-{{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) (not .Values.dags.gitSync.excludeWebserver) }}
+{{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) (semverCompare "<2.0.0" .Values.airflowVersion) }}
 {{- include "git_sync_container" . | indent 8 }}
 {{- end }}
         - name: webserver
@@ -134,7 +134,7 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
 {{- end }}
-{{- if or (and .Values.dags.gitSync.enabled (not .Values.dags.gitSync.excludeWebserver)) .Values.dags.persistence.enabled }}
+{{- if or (and .Values.dags.gitSync.enabled (semverCompare "<2.0.0" .Values.airflowVersion)) .Values.dags.persistence.enabled }}
             - name: dags
               mountPath: {{ template "airflow_dags_mount_path" . }}
 {{- end }}
@@ -195,7 +195,7 @@ spec:
         - name: dags
           persistentVolumeClaim:
             claimName: {{ template "airflow_dags_volume_claim" . }}
-        {{- else if and (.Values.dags.gitSync.enabled) (not .Values.dags.gitSync.excludeWebserver) }}
+        {{- else if and (.Values.dags.gitSync.enabled) (semverCompare "<2.0.0" .Values.airflowVersion) }}
         - name: dags
           emptyDir: {}
         {{- if  .Values.dags.gitSync.sshKeySecret }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1677,10 +1677,6 @@
                             "description": "Enable Git sync.",
                             "type": "boolean"
                         },
-                        "excludeWebserver": {
-                            "description": "Disable Git sync on webserver as it is not needed when DAG Serialization is enabled.",
-                            "type": "boolean"
-                        },
                         "repo": {
                             "description": "Git repository.",
                             "type": "string"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -955,12 +955,6 @@ dags:
   gitSync:
     enabled: false
 
-    # Change it to true when DAG Serialization is turned on. This will exclude git sync containers
-    # from Webserver as DAGs are fetched from the DB. DAG Serialization was introduced in
-    # 1.10.7 and is optional for <2.0.0.
-    # https://airflow.apache.org/docs/apache-airflow/1.10.15/dag-serialization.html
-    excludeWebserver: false
-
     # git repo clone url
     # ssh examples ssh://git@github.com/apache/airflow.git
     # git@github.com:apache/airflow.git

--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -82,7 +82,7 @@ Mounting DAGs using Git-Sync sidecar with Persistence enabled
 
 This option will use a Persistent Volume Claim with an access mode of ``ReadWriteMany``.
 The scheduler pod will sync DAGs from a git repository onto the PVC every configured number of
-seconds. The other pods will read the synced DAGs. Not all volume  plugins have support for
+seconds. The other pods will read the synced DAGs. Not all volume plugins have support for
 ``ReadWriteMany`` access mode.
 Refer `Persistent Volume Access Modes <https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes>`__
 for details.
@@ -96,17 +96,11 @@ for details.
       # by setting the  dags.persistence.* and dags.gitSync.* values
       # Please refer to values.yaml for details
 
-When using ``apache-airflow>=2.0.0``, :ref:`DAG Serialization <apache-airflow:dag-serialization>` is enabled by default,
-hence Webserver does not need access to DAG files, so you can turn off ``git-sync`` for Webserver by setting
-``dags.gitSync.excludeWebserver`` to ``true``.
-This is also recommended when enabling DAG Serialization for ``apache-airflow>=1.10.11,<2``.
-
 .. code-block:: bash
 
     helm upgrade airflow . \
       --set dags.persistence.enabled=true \
       --set dags.gitSync.enabled=true \
-      --set dags.gitSync.excludeWebserver=true
       # you can also override the other persistence or gitSync values
       # by setting the  dags.persistence.* and dags.gitSync.* values
       # Please refer to values.yaml for details
@@ -114,7 +108,8 @@ This is also recommended when enabling DAG Serialization for ``apache-airflow>=1
 Mounting DAGs using Git-Sync sidecar without Persistence
 --------------------------------------------------------
 
-This option will use an always running Git-Sync sidecar on every scheduler, webserver and worker pods.
+This option will use an always running Git-Sync sidecar on every scheduler, webserver (if ``airflowVersion < 2.0.0``)
+and worker pods.
 The Git-Sync sidecar containers will sync DAGs from a git repository every configured number of
 seconds. If you are using the ``KubernetesExecutor``, Git-sync will run as an init container on your worker pods.
 
@@ -126,6 +121,9 @@ seconds. If you are using the ``KubernetesExecutor``, Git-sync will run as an in
       # you can also override the other gitSync values
       # by setting the  dags.gitSync.* values
       # Refer values.yaml for details
+
+When using ``apache-airflow>=2.0.0``, :ref:`DAG Serialization <apache-airflow:dag-serialization>` is enabled by default,
+hence Webserver does not need access to DAG files, so ``git-sync`` sidecar is not run on Webserver.
 
 Mounting DAGs from an externally populated PVC
 ----------------------------------------------


### PR DESCRIPTION
For `apache-airflow>=2.0.0`, DAG Serialization is enabled by default
and we don't need to have a sidecar on Websserver.

Previously this was done using `gitSync.excludeWebserver`. However
with https://github.com/apache/airflow/pull/15627 - we now have
`airflowVerson` so we can just do a comparison of the version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
