### PR TITLE
Add insert_args for support transfer replace

### DIFF
--- a/airflow/operators/generic_transfer.py
+++ b/airflow/operators/generic_transfer.py
@@ -41,6 +41,8 @@ class GenericTransfer(BaseOperator):
     :param preoperator: sql statement or list of statements to be
         executed prior to loading the data. (templated)
     :type preoperator: str or list[str]
+    :param insert_args: extra params for `insert_rows` method.
+    :type insert_args: dict
     """
 
     template_fields = ('sql', 'destination_table', 'preoperator')
@@ -59,6 +61,7 @@ class GenericTransfer(BaseOperator):
         source_conn_id: str,
         destination_conn_id: str,
         preoperator: Optional[Union[str, List[str]]] = None,
+        insert_args: Optional[dict] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -67,6 +70,7 @@ class GenericTransfer(BaseOperator):
         self.source_conn_id = source_conn_id
         self.destination_conn_id = destination_conn_id
         self.preoperator = preoperator
+        self.insert_args = insert_args or {}
 
     def execute(self, context):
         source_hook = BaseHook.get_hook(self.source_conn_id)
@@ -82,4 +86,4 @@ class GenericTransfer(BaseOperator):
             destination_hook.run(self.preoperator)
 
         self.log.info("Inserting rows into %s", self.destination_conn_id)
-        destination_hook.insert_rows(table=self.destination_table, rows=results)
+        destination_hook.insert_rows(table=self.destination_table, rows=results, **self.insert_args)


### PR DESCRIPTION
GenericTransfer does not support replace now, add `insert_args` for support.
closes: https://github.com/apache/airflow/issues/12736


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
