### PR TITLE
Add Airflow Standalone command

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1604,6 +1604,12 @@ airflow_commands: List[CLICommand] = [
         ),
         subcommands=CELERY_COMMANDS,
     ),
+    ActionCommand(
+        name='standalone',
+        help='Run an all-in-one copy of Airflow',
+        func=lazy_load_command('airflow.cli.commands.standalone_command.standalone'),
+        args=tuple(),
+    ),
 ]
 ALL_COMMANDS_DICT: Dict[str, CLICommand] = {sp.name: sp for sp in airflow_commands}
 

--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -1,0 +1,275 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import logging
+import os
+import random
+import socket
+import subprocess
+import threading
+import time
+from collections import deque
+from typing import Dict, List
+
+from termcolor import colored
+
+from airflow.configuration import AIRFLOW_HOME, conf
+from airflow.executors import executor_constants
+from airflow.jobs.scheduler_job import SchedulerJob
+from airflow.utils import db
+from airflow.www.app import cached_app
+
+
+class StandaloneCommand:
+    """
+    Runs all components of Airflow under a single parent process.
+
+    Useful for local development.
+    """
+
+    @classmethod
+    def entrypoint(cls, args):
+        """CLI entrypoint, called by the main CLI system."""
+        StandaloneCommand().run()
+
+    def __init__(self):
+        self.subcommands = {}
+        self.output_queue = deque()
+        self.user_info = {}
+        self.ready_time = None
+        self.ready_delay = 3
+
+    def run(self):
+        """Main run loop"""
+        self.print_output("standalone", "Starting Airflow Standalone")
+        # Silence built-in logging at INFO
+        logging.getLogger("").setLevel(logging.WARNING)
+        # Startup checks and prep
+        env = self.calculate_env()
+        self.initialize_database()
+        # Set up commands to run
+        self.subcommands["scheduler"] = SubCommand(
+            self,
+            name="scheduler",
+            command=["scheduler"],
+            env=env,
+        )
+        self.subcommands["webserver"] = SubCommand(
+            self,
+            name="webserver",
+            command=["webserver", "--port", "8080"],
+            env=env,
+        )
+        # Run subcommand threads
+        for command in self.subcommands.values():
+            command.start()
+        # Run output loop
+        shown_ready = False
+        while True:
+            try:
+                # Print all the current lines onto the screen
+                self.update_output()
+                # Print info banner when all components are ready and the
+                # delay has passed
+                if not self.ready_time and self.is_ready():
+                    self.ready_time = time.monotonic()
+                if (
+                    not shown_ready
+                    and self.ready_time
+                    and time.monotonic() - self.ready_time > self.ready_delay
+                ):
+                    self.print_ready()
+                    shown_ready = True
+                # Ensure we idle-sleep rather than fast-looping
+                time.sleep(0.1)
+            except KeyboardInterrupt:
+                break
+        # Stop subcommand threads
+        self.print_output("standalone", "Shutting down components")
+        for command in self.subcommands.values():
+            command.stop()
+        for command in self.subcommands.values():
+            command.join()
+        self.print_output("standalone", "Complete")
+
+    def update_output(self):
+        """Drains the output queue and prints its contents to the screen"""
+        while self.output_queue:
+            # Extract info
+            name, line = self.output_queue.popleft()
+            # Make line printable
+            line_str = line.decode("utf8").strip()
+            self.print_output(name, line_str)
+
+    def print_output(self, name: str, output):
+        """
+        Prints an output line with name and colouring. You can pass multiple
+        lines to output if you wish; it will be split for you.
+        """
+        color = {
+            "webserver": "green",
+            "scheduler": "blue",
+            "standalone": "white",
+        }.get(name, "white")
+        colorised_name = colored("%10s" % name, color)
+        for line in output.split("\n"):
+            print(f"{colorised_name} | {line.strip()}")
+
+    def print_error(self, name: str, output):
+        """
+        Prints an error message to the console (this is the same as
+        print_output but with the text red)
+        """
+        self.print_output(name, colored(output, "red"))
+
+    def calculate_env(self):
+        """
+        Works out the environment variables needed to run subprocesses.
+        We override some settings as part of being standalone.
+        """
+        env = dict(os.environ)
+        # Make sure we're using a local executor flavour
+        if conf.get("core", "executor") not in [
+            executor_constants.LOCAL_EXECUTOR,
+            executor_constants.SEQUENTIAL_EXECUTOR,
+        ]:
+            if "sqlite" in conf.get("core", "sql_alchemy_conn"):
+                self.print_output("standalone", "Forcing executor to SequentialExecutor")
+                env["AIRFLOW__CORE__EXECUTOR"] = executor_constants.SEQUENTIAL_EXECUTOR
+            else:
+                self.print_output("standalone", "Forcing executor to LocalExecutor")
+                env["AIRFLOW__CORE__EXECUTOR"] = executor_constants.LOCAL_EXECUTOR
+        return env
+
+    def initialize_database(self):
+        """Makes sure all the tables are created."""
+        # Set up DB tables
+        self.print_output("standalone", "Checking database is initialized")
+        db.initdb()
+        self.print_output("standalone", "Database ready")
+        # See if a user needs creating
+        # We want a streamlined first-run experience, but we do not want to
+        # use a preset password as people will inevitably run this on a public
+        # server. Thus, we make a random password and store it in AIRFLOW_HOME,
+        # with the reasoning that if you can read that directory, you can see
+        # the database credentials anyway.
+        appbuilder = cached_app().appbuilder  # pylint: disable=no-member
+        user_exists = appbuilder.sm.find_user("admin")
+        password_path = os.path.join(AIRFLOW_HOME, "standalone_admin_password.txt")
+        we_know_password = os.path.isfile(password_path)
+        # If the user does not exist, make a random password and make it
+        if not user_exists:
+            self.print_output("standalone", "Creating admin user")
+            role = appbuilder.sm.find_role("Admin")
+            assert role is not None
+            password = "".join(
+                random.choice("abcdefghkmnpqrstuvwxyzABCDEFGHKMNPQRSTUVWXYZ23456789") for i in range(16)
+            )
+            with open(password_path, "w") as file:
+                file.write(password)
+            appbuilder.sm.add_user("admin", "Admin", "User", "admin@example.com", role, password)
+            self.print_output("standalone", "Created admin user")
+        # If the user does exist and we know its password, read the password
+        elif user_exists and we_know_password:
+            with open(password_path) as file:
+                password = file.read().strip()
+        # Otherwise we don't know the password
+        else:
+            password = None
+        # Store what we know about the user for printing later in startup
+        self.user_info = {"username": "admin", "password": password}
+
+    def is_ready(self):
+        """
+        Detects when all Airflow components are ready to serve.
+        For now, it's simply time-based.
+        """
+        return self.port_open(8080) and self.job_running(SchedulerJob)
+
+    def port_open(self, port):
+        """
+        Checks if the given port is listening on the local machine.
+        (used to tell if webserver is alive)
+        """
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            sock.connect(("127.0.0.1", port))
+            sock.close()
+        except (OSError, ValueError):
+            # Any exception means the socket is not available
+            return False
+        return True
+
+    def job_running(self, job):
+        """
+        Checks if the given job name is running and heartbeating correctly
+        (used to tell if scheduler is alive)
+        """
+        return job.most_recent_job().is_alive()
+
+    def print_ready(self):
+        """
+        Prints the banner shown when Airflow is ready to go, with login
+        details.
+        """
+        self.print_output("standalone", "")
+        self.print_output("standalone", "Airflow is ready")
+        if self.user_info["password"]:
+            self.print_output(
+                "standalone",
+                f"Login with username: {self.user_info['username']}  password: {self.user_info['password']}",
+            )
+        self.print_output(
+            "standalone",
+            "Airflow Standalone is for development purposes only. Do not use this in production!",
+        )
+        self.print_output("standalone", "")
+
+
+class SubCommand(threading.Thread):
+    """
+    Thread that launches a process and then streams its output back to the main
+    command. We use threads to avoid using select() and raw filehandles, and the
+    complex logic that brings doing line buffering.
+    """
+
+    def __init__(self, parent, name: str, command: List[str], env: Dict[str, str]):
+        super().__init__()
+        self.parent = parent
+        self.name = name
+        self.command = command
+        self.env = env
+
+    def run(self):
+        """Runs the actual process and captures it output to a queue"""
+        self.process = subprocess.Popen(  # pylint: disable=consider-using-with,attribute-defined-outside-init
+            ["airflow"] + self.command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=self.env,
+        )
+        for line in self.process.stdout:
+            self.parent.output_queue.append((self.name, line))
+
+    def stop(self):
+        """Call to stop this process (and thus this thread)"""
+        self.process.terminate()
+
+
+# Alias for use in the CLI parser
+standalone = StandaloneCommand.entrypoint

--- a/docs/apache-airflow/start/local.rst
+++ b/docs/apache-airflow/start/local.rst
@@ -40,11 +40,11 @@ constraint files to enable reproducible installation, so using ``pip`` and const
 .. code-block:: bash
     :substitutions:
 
-    # airflow needs a home, ~/airflow is the default,
-    # but you can lay foundation somewhere else if you prefer
-    # (optional)
+    # Airflow needs a home. `~/airflow` is the default, but you can put it
+    # somewhere else if you prefer (optional)
     export AIRFLOW_HOME=~/airflow
 
+    # Install Airflow using the constraints file
     AIRFLOW_VERSION=|version|
     PYTHON_VERSION="$(python --version | cut -d " " -f 2 | cut -d "." -f 1-2)"
     # For example: 3.6
@@ -52,25 +52,13 @@ constraint files to enable reproducible installation, so using ``pip`` and const
     # For example: https://raw.githubusercontent.com/apache/airflow/constraints-|version|/constraints-3.6.txt
     pip install "apache-airflow==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
-    # initialize the database
-    airflow db init
+    # The Standalone command will initialise the database, make a user,
+    # and start all components for you.
+    airflow standalone
 
-    airflow users create \
-        --username admin \
-        --firstname Peter \
-        --lastname Parker \
-        --role Admin \
-        --email spiderman@superhero.org
-
-    # start the web server, default port is 8080
-    airflow webserver --port 8080
-
-    # start the scheduler
-    # open a new terminal or else run webserver with ``-D`` option to run it as a daemon
-    airflow scheduler
-
-    # visit localhost:8080 in the browser and use the admin account you just
-    # created to login. Enable the example_bash_operator dag in the home page
+    # Visit localhost:8080 in the browser and use the admin account details
+    # shown on the terminal to login.
+    # Enable the example_bash_operator dag in the home page
 
 Upon running these commands, Airflow will create the ``$AIRFLOW_HOME`` folder
 and create the "airflow.cfg" file with defaults that will get you going fast.
@@ -87,6 +75,10 @@ only run task instances sequentially. While this is very limiting, it allows
 you to get up and running quickly and take a tour of the UI and the
 command line utilities.
 
+As you grow and deploy Airflow to production, you will also want to move away
+from the ``standalone`` command we use here to running the components
+separately. You can read more in :doc:`/production-deployment`.
+
 Here are a few commands that will trigger a few task instances. You should
 be able to see the status of the jobs change in the ``example_bash_operator`` DAG as you
 run the commands below.
@@ -99,6 +91,24 @@ run the commands below.
     airflow dags backfill example_bash_operator \
         --start-date 2015-01-01 \
         --end-date 2015-01-02
+
+If you want to run the individual parts of Airflow manually rather than using
+the all-in-one ``standalone`` command, you can instead run:
+
+.. code-block:: bash
+
+    airflow db init
+
+    airflow users create \
+        --username admin \
+        --firstname Peter \
+        --lastname Parker \
+        --role Admin \
+        --email spiderman@superhero.org
+
+    airflow webserver --port 8080
+
+    airflow scheduler
 
 What's Next?
 ''''''''''''


### PR DESCRIPTION
Runs all parts of an airflow deployment under one main process, providing an easier level of entry than Breeze and a very handy tool for local development.

Handles the following:
* Runs all database migrations/db init steps
* Creates an admin user if one is not present (with a randomised password)
* Runs the webserver
* Runs the scheduler
* Overrides the executor to be `LocalExecutor` or `SequentialExecutor` depending on the database in use

It will also be able to run the `triggerer` process from AIP-40 with a three-line change once that PR lands.

This diff also updates the quickstart guide to use this rather than the separate commands, since it makes the set of commands significantly shorter.
