### PR TITLE
Make DAG dependency detector configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1885,6 +1885,12 @@
       type: string
       example: ~
       default: "False"
+    - name: dependency_detector
+      description: DAG dependency detector class to use
+      version_added: ~
+      type: string
+      example: ~
+      default: "airflow.serialization.serialized_objects.DependencyDetector"
 - name: kerberos
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -946,6 +946,9 @@ use_job_schedule = True
 # Only has effect if schedule_interval is set to None in DAG
 allow_trigger_in_future = False
 
+# DAG dependency detector class to use
+dependency_detector = airflow.serialization.serialized_objects.DependencyDetector
+
 [kerberos]
 ccache = /tmp/airflow_krb5_ccache
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -35,6 +35,7 @@ except ImportError:
     cache = lru_cache(maxsize=None)
 from pendulum.tz.timezone import Timezone
 
+from airflow.configuration import conf
 from airflow.exceptions import AirflowException, SerializationError
 from airflow.models.baseoperator import BaseOperator, BaseOperatorLink
 from airflow.models.connection import Connection
@@ -374,7 +375,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         if v.default is not v.empty
     }
 
-    dependency_detector = DependencyDetector
+    dependency_detector = conf.getimport('scheduler', 'dependency_detector')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -603,3 +603,6 @@ with different execution dates. The **Dag Dependencies** view
 ``Menu -> Browse -> DAG Dependencies`` helps visualize dependencies between DAGs. The dependencies
 are calculated by the scheduler during DAG serialization and the webserver uses them to build
 the dependency graph.
+
+The dependency detector is configurable, so you can implement your own logic different than the defaults in
+:class:`~airflow.serialization.serialized_objects.DependencyDetector`


### PR DESCRIPTION
This PR allows users to implement their own logic of dependency detector in the new DAG dependencies functionality.