### PR TITLE
Support extra env vars on the gitsync container

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -189,6 +189,12 @@ If release name contains chart name it will be used as a full name.
     - name: GIT_SYNC_ONE_TIME
       value: "true"
     {{- end }}
+    {{- range $key, $val := .Values.dags.gitSync.extraEnvVars }}
+    {{- if $val }}
+    - name: {{ tpl $key $ }}
+      value: {{ tpl $val $ | quote }}
+    {{- end }}
+    {{- end }}
   volumeMounts:
   - name: dags
     mountPath: {{ .Values.dags.gitSync.root }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2403,6 +2403,22 @@
                                 "<host1>,<ip1> <key1>\n<host2>,<ip2> <key2>",
                                 "<host1>,<ip1> <key1>"
                             ]
+                        },
+                        "extraEnvVars": {
+                            "description": "Extra environment variables for the git sync container (templated).",
+                            "type": "object",
+                            "default": {},
+                            "additionalProperties": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "examples": [
+                                {
+                                    "GIT_SYNC_TIMEOUT": "60"
+                                }
+                            ]
                         }
                     }
                 }

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1009,6 +1009,9 @@ dags:
     containerName: git-sync
     uid: 65533
     extraVolumeMounts: []
+    # Extra env vars for the git sync container (templated)
+    extraEnvVars: {}
+    #  GIT_SYNC_TIMEOUT: "60"
 
 logs:
   persistence:


### PR DESCRIPTION
Related: #15786

This takes a different approach to suporting extra env vars than taken with `env` and `extraEnv`. This uses a map instead of a list, which allows helm to merge extra env vars together from multiple values files. If we are happy with this approach, I'll refactor the rest to follow this same approach.