### PR TITLE
Fix delete dag functions in UI

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global document, window, $, confirm, postAsForm, confirm */
+/* global document, window, $, confirm, postAsForm */
 
 import getMetaValue from './meta_value';
 
@@ -46,6 +46,7 @@ let taskId = '';
 let executionDate = '';
 let subdagId = '';
 const showExternalLogRedirect = getMetaValue('show_external_log_redirect') === 'True';
+const safeDagId = getMetaValue('safe_dag_id');
 
 const buttons = Array.from(document.querySelectorAll('a[id^="btn_"][data-base-url]')).reduce((obj, elm) => {
   obj[elm.id.replace('btn_', '')] = elm;
@@ -216,17 +217,16 @@ export function callModalDag(dag) {
   });
 }
 
-// eslint-disable-next-line no-unused-vars
-function confirmDeleteDag(link, id) {
-  // eslint-disable-next-line no-alert, no-restricted-globals
-  if (confirm(`Are you sure you want to delete '${id}' now?\n\
+$('#delete-dag').on('click', function deleteDag() {
+  // eslint-disable-next-line no-restricted-globals
+  if (confirm(`Are you sure you want to delete '${safeDagId}' now?\n\
     This option will delete ALL metadata, DAG runs, etc.\n\
     EXCEPT Log.\n\
     This cannot be undone.`)) {
-    postAsForm(link.href, {});
+    postAsForm(this.href, {});
   }
   return false;
-}
+});
 
 // Task Instance Modal actions
 $('form[data-action]').on('submit', function submit(e) {

--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -81,17 +81,17 @@ $('#page_size').on('change', function onPageSizeChange() {
   window.location = `${DAGS_INDEX}?page_size=${pSize}`;
 });
 
-// eslint-disable-next-line no-unused-vars
-function confirmDeleteDag(link, dagId) {
-  // eslint-disable-next-line no-alert, no-restricted-globals
+$('.delete-dag').on('click', function deleteDag(e) {
+  e.preventDefault();
+  const dagId = this.getAttribute('content');
+  // eslint-disable-next-line no-restricted-globals
   if (confirm(`Are you sure you want to delete '${dagId}' now?\n\
     This option will delete ALL metadata, DAG runs, etc.\n\
     EXCEPT Log.\n\
     This cannot be undone.`)) {
-    postAsForm(link.href, {});
+    postAsForm(this.href, {});
   }
-  return false;
-}
+});
 
 const encodedDagIds = new URLSearchParams();
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -34,6 +34,7 @@
   <meta name="logs_with_metadata_url" content="{{ url_for('Airflow.get_logs_with_metadata') }}">
   <meta name="external_log_url" content="{{ url_for('Airflow.redirect_to_external_log') }}">
   <meta name="extra_links_url" content="{{ url_for('Airflow.extra_links') }}">
+  <meta name="safe_dag_id" content="{{ dag.safe_dag_id }}">
   {% if show_external_log_redirect is defined %}
     <meta name="show_external_log_redirect" content="{{ show_external_log_redirect }}">
   {% endif %}
@@ -144,8 +145,7 @@
           <a href="{{ url_for('Airflow.refresh', dag_id=dag.dag_id) }}" title="Refresh DAG" aria-label="Refresh DAG" onclick="postAsForm(this.href); return false" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_edit }}">
             <span class="material-icons" aria-hidden="true">refresh</span>
           </a>
-          <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}" title="Delete&nbsp;DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_delete }}"
-            onclick="return confirmDeleteDag(this, '{{ dag.safe_dag_id }}')" aria-label="Delete DAG">
+          <a id="delete-dag" title="Delete&nbsp;DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_delete }}" aria-label="Delete DAG" href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}">
             <span class="material-icons text-danger" aria-hidden="true">delete_outline</span>
           </a>
         </div>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -199,7 +199,7 @@
                       </a>
                     {% endif %}
                     {# Use dag_id instead of dag.dag_id, because the DAG might not exist in the webserver's DagBag #}
-                    <a href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}" onclick="return confirmDeleteDag(this, '{{ dag.dag_id }}')" title="Delete&nbsp;DAG" aria-label="Delete DAG" class="btn btn-sm btn-default btn-icon-only {{ ' disabled' if not dag.can_delete }}">
+                    <a title="Delete&nbsp;DAG" aria-label="Delete DAG" class="btn btn-sm btn-default btn-icon-only {{ ' disabled' if not dag.can_delete }} delete-dag" content="{{ dag.dag_id }}" href="{{ url_for('Airflow.delete', dag_id=dag.dag_id) }}">
                       <span class="material-icons text-danger" aria-hidden="true">delete_outline</span>
                     </a>
                   </div>


### PR DESCRIPTION
The old `confirmDeleteDag` function was undefined in the html files. It is better practice to set up an onclick listener in js instead

Fixes: #15832

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
