### PR TITLE
Keep confirmDeleteDag inline html

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global document, window, $, confirm, postAsForm, confirm */
+/* global document, window, $, */
 
 import getMetaValue from './meta_value';
 
@@ -214,18 +214,6 @@ export function callModalDag(dag) {
     dag_id: dag && dag.execution_date,
     execution_date: dag && dag.dag_id,
   });
-}
-
-// eslint-disable-next-line no-unused-vars
-function confirmDeleteDag(link, id) {
-  // eslint-disable-next-line no-alert, no-restricted-globals
-  if (confirm(`Are you sure you want to delete '${id}' now?\n\
-    This option will delete ALL metadata, DAG runs, etc.\n\
-    EXCEPT Log.\n\
-    This cannot be undone.`)) {
-    postAsForm(link.href, {});
-  }
-  return false;
 }
 
 // Task Instance Modal actions

--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global document, window, $, d3, STATE_COLOR, postAsForm, isoDateToTimeEl, confirm */
+/* global document, window, $, d3, STATE_COLOR, isoDateToTimeEl, */
 
 import getMetaValue from './meta_value';
 
@@ -80,18 +80,6 @@ $('#page_size').on('change', function onPageSizeChange() {
   const pSize = $(this).val();
   window.location = `${DAGS_INDEX}?page_size=${pSize}`;
 });
-
-// eslint-disable-next-line no-unused-vars
-function confirmDeleteDag(link, dagId) {
-  // eslint-disable-next-line no-alert, no-restricted-globals
-  if (confirm(`Are you sure you want to delete '${dagId}' now?\n\
-    This option will delete ALL metadata, DAG runs, etc.\n\
-    EXCEPT Log.\n\
-    This cannot be undone.`)) {
-    postAsForm(link.href, {});
-  }
-  return false;
-}
 
 const encodedDagIds = new URLSearchParams();
 

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -403,4 +403,16 @@
 {% block tail %}
   {{ super() }}
   <script src="{{ url_for_asset('dag.js') }}"></script>
+  <script>
+    // Tests rely on confirmDeleteDag to be in the html
+    function confirmDeleteDag(link, id) {
+      if (confirm(`Are you sure you want to delete '${id}' now?\n\
+        This option will delete ALL metadata, DAG runs, etc.\n\
+        EXCEPT Log.\n\
+        This cannot be undone.`)) {
+        postAsForm(link.href, {});
+      }
+      return false;
+    }
+  </script>
 {% endblock %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -277,5 +277,15 @@
   <script src="{{ url_for_asset('dags.js') }}"></script>
   <script>
     const STATE_COLOR = {{ state_color|tojson }};
+    // Tests rely on confirmDeleteDag to be in the html
+    function confirmDeleteDag(link, dagId) {
+      if (confirm(`Are you sure you want to delete '${dagId}' now?\n\
+        This option will delete ALL metadata, DAG runs, etc.\n\
+        EXCEPT Log.\n\
+        This cannot be undone.`)) {
+        postAsForm(link.href, {});
+      }
+      return false;
+    }
   </script>
 {% endblock %}


### PR DESCRIPTION
Tests and delete functionality rely on `confirmDeleteDag` to be inside the html.

It is simpler just to have it inline instead of refactoring all dependent tests to make it work in an external js file.

Fixes: #15832

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
