### PR TITLE
Move `airflowLocalSettings` to be a top level chart param

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -45,7 +45,7 @@ spec:
           mountPath: {{ template "airflow_config_path" . }}
           subPath: airflow.cfg
           readOnly: true
-{{- if .Values.scheduler.airflowLocalSettings }}
+{{- if .Values.airflowLocalSettings }}
         - name: config
           mountPath: {{ template "airflow_local_setting_path" . }}
           subPath: airflow_local_settings.py

--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -46,9 +46,9 @@ data:
     {{- end }}
     {{ end }}
 
+{{- if .Values.airflowLocalSettings }}
   airflow_local_settings.py: |
-{{- if .Values.scheduler.airflowLocalSettings }}
-    {{ .Values.scheduler.airflowLocalSettings | nindent 4 }}
+    {{ .Values.airflowLocalSettings | nindent 4 }}
 {{- end }}
 {{- if and .Values.dags.gitSync.enabled  .Values.dags.gitSync.knownHosts }}
   known_hosts: |

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -162,7 +162,7 @@ spec:
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
-{{- if .Values.scheduler.airflowLocalSettings }}
+{{- if .Values.airflowLocalSettings }}
             - name: config
               mountPath: {{ template "airflow_local_setting_path" . }}
               subPath: airflow_local_settings.py

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -128,7 +128,7 @@ spec:
               subPath: webserver_config.py
               readOnly: true
 {{- end }}
-{{- if .Values.scheduler.airflowLocalSettings }}
+{{- if .Values.airflowLocalSettings }}
             - name: config
               mountPath: {{ template "airflow_local_setting_path" . }}
               subPath: airflow_local_settings.py

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -156,7 +156,7 @@ spec:
               mountPath: {{ .Values.kerberos.ccacheMountPath | quote }}
               readOnly: true
             {{- end }}
-{{- if .Values.scheduler.airflowLocalSettings }}
+{{- if .Values.airflowLocalSettings }}
             - name: config
               mountPath: {{ template "airflow_local_setting_path" . }}
               subPath: airflow_local_settings.py
@@ -207,7 +207,7 @@ spec:
               mountPath: {{ .Values.kerberos.configPath | quote }}
               subPath: krb5.conf
               readOnly: true
-            {{- if .Values.scheduler.airflowLocalSettings }}
+            {{- if .Values.airflowLocalSettings }}
             - name: config
               mountPath: {{ template "airflow_local_setting_path" . }}
               subPath: airflow_local_settings.py

--- a/chart/tests/test_configmap.py
+++ b/chart/tests/test_configmap.py
@@ -45,3 +45,18 @@ class ConfigmapTest(unittest.TestCase):
         annotations = jmespath.search("metadata.annotations", docs[0])
         assert "value" == annotations.get("key")
         assert "value-two" == annotations.get("key-two")
+
+    def test_no_airflow_local_settings_by_default(self):
+        docs = render_chart(
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        assert "airflow_local_settings.py" not in jmespath.search("data", docs[0])
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": "# Well hello!"},
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        assert "# Well hello!" == jmespath.search('data."airflow_local_settings.py"', docs[0]).strip()

--- a/chart/tests/test_webserver_deployment.py
+++ b/chart/tests/test_webserver_deployment.py
@@ -265,3 +265,20 @@ class WebserverDeploymentTest(unittest.TestCase):
         )
 
         assert jmespath.search("spec.strategy", docs[0]) == expected_strategy
+
+    def test_no_airflow_local_settings_by_default(self):
+        docs = render_chart(show_only=["templates/webserver/webserver-deployment.yaml"])
+        volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts)
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": "# Well hello!"},
+            show_only=["templates/webserver/webserver-deployment.yaml"],
+        )
+        assert {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -231,3 +231,35 @@ class WorkerTest(unittest.TestCase):
             show_only=["templates/workers/worker-deployment.yaml"],
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
+
+    def test_no_airflow_local_settings_by_default(self):
+        docs = render_chart(show_only=["templates/workers/worker-deployment.yaml"])
+        volume_mounts = jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+        assert "airflow_local_settings.py" not in str(volume_mounts)
+
+    def test_airflow_local_settings(self):
+        docs = render_chart(
+            values={"airflowLocalSettings": "# Well hello!"},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+
+    def test_airflow_local_settings_kerberos_sidecar(self):
+        docs = render_chart(
+            values={
+                "airflowLocalSettings": "# Well hello!",
+                "workers": {"kerberosSidecar": {"enabled": True}},
+            },
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+        assert {
+            "name": "config",
+            "mountPath": "/opt/airflow/config/airflow_local_settings.py",
+            "subPath": "airflow_local_settings.py",
+            "readOnly": True,
+        } in jmespath.search("spec.template.spec.containers[2].volumeMounts", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -234,6 +234,15 @@
             "default": {},
             "x-docsSection": "Kubernetes"
         },
+        "airflowLocalSettings": {
+            "description": "`airflow_local_settings` file as a string.",
+            "type": [
+                "string",
+                "null"
+            ],
+            "x-docsSection": "Common",
+            "default": null
+        },
         "rbac": {
             "description": "Enable RBAC (default on most clusters these days).",
             "type": "object",
@@ -1130,15 +1139,6 @@
                             }
                         }
                     ]
-                },
-                "airflowLocalSettings": {
-                    "description": "`airflow_local_settings` file as a string.",
-                    "type": [
-                        "string",
-                        "null"
-                    ],
-                    "x-docsSection": "Common",
-                    "default": null
                 },
                 "safeToEvict": {
                     "description": "This setting tells Kubernetes that its ok to evict when it wants to scale a node down.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -152,6 +152,9 @@ airflowPodAnnotations: {}
 # main Airflow configmap
 airflowConfigAnnotations: {}
 
+# `airflow_local_settings` file as a string.
+airflowLocalSettings: ~
+
 # Enable RBAC (default on most clusters these days)
 rbac:
   # Specifies whether RBAC resources should be created
@@ -450,9 +453,6 @@ scheduler:
   #  requests:
   #   cpu: 100m
   #   memory: 128Mi
-
-  # `airflow_local_settings` file as a string.
-  airflowLocalSettings: ~
 
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.


### PR DESCRIPTION
Moving it to be a top level chart param makes sense as it is used in most of the Airflow components.