### PR TITLE
Fix spacing in AwsBatchWaitersHook docstring

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_waiters.py
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.py
@@ -43,9 +43,8 @@ from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
 class AwsBatchWaitersHook(AwsBatchClientHook):
     """
     A utility to manage waiters for AWS batch services.
-    
-    Examples:
 
+    Examples:
     .. code-block:: python
 
         import random

--- a/airflow/providers/amazon/aws/hooks/batch_waiters.py
+++ b/airflow/providers/amazon/aws/hooks/batch_waiters.py
@@ -42,7 +42,8 @@ from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
 
 class AwsBatchWaitersHook(AwsBatchClientHook):
     """
-    A utility to manage waiters for AWS batch services
+    A utility to manage waiters for AWS batch services.
+    
     Examples:
 
     .. code-block:: python


### PR DESCRIPTION
Sphinx requires the short description to be separated by a newline, otherwise it considers all lines as the short description. See [the rendered docs](https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/_api/airflow/providers/amazon/aws/hooks/batch_waiters/index.html) for the issue - the one liner description is currently "A utility to manage waiters for AWS batch services **Examples:**".