### PR TITLE
Fix docstring formatting on SlackHook

### DIFF
--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -27,10 +27,10 @@ from airflow.hooks.base import BaseHook
 class SlackHook(BaseHook):  # noqa
     """
     Creates a Slack connection to be used for calls.
-    
+
     Takes both Slack API token directly and connection that has Slack API token. If both are
     supplied, Slack API token will be used. Also exposes the rest of slack.WebClient args.
-    
+
     Examples:
 
     .. code-block:: python

--- a/airflow/providers/slack/hooks/slack.py
+++ b/airflow/providers/slack/hooks/slack.py
@@ -26,9 +26,11 @@ from airflow.hooks.base import BaseHook
 
 class SlackHook(BaseHook):  # noqa
     """
-    Creates a Slack connection, to be used for calls. Takes both Slack API token directly and
-    connection that has Slack API token. If both supplied, Slack API token will be used.
-    Exposes also the rest of slack.WebClient args
+    Creates a Slack connection to be used for calls.
+    
+    Takes both Slack API token directly and connection that has Slack API token. If both are
+    supplied, Slack API token will be used. Also exposes the rest of slack.WebClient args.
+    
     Examples:
 
     .. code-block:: python


### PR DESCRIPTION
Fixes formatting on SlackHook's docstring to adhere to Sphinx standards. See [the Airflow docs](https://airflow.apache.org/docs/apache-airflow-providers-slack/1.0.0/_api/airflow/providers/slack/hooks/slack/index.html) for the current rendering - the short description is currently:

"Creates a Slack connection, to be used for calls. Takes both Slack API token directly and connection that has Slack API token. If both supplied, Slack API token will be used. Exposes also the rest of slack.WebClient args **Examples**:"

Also fixes minor grammatical issues.