### PR TITLE
Replace DockerOperator's 'volumes' arg for 'mounts'

### DIFF
--- a/airflow/providers/docker/CHANGELOG.rst
+++ b/airflow/providers/docker/CHANGELOG.rst
@@ -19,6 +19,22 @@
 Changelog
 ---------
 
+2.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Change in ``DockerOperator`` and ``DockerSwarmOperator``
+````````````````````````````````````````````````````````
+
+The ``volumes`` parameter in
+:class:`~airflow.providers.docker.operators.docker.DockerOperator` and
+:class:`~airflow.providers.docker.operators.docker_swarm.DockerSwarmOperator`
+was replaced by the ``mounts`` parameter, which uses the newer
+`mount syntax <https://docs.docker.com/storage/>`__ instead of ``--bind``.
+
+
 1.2.0
 .....
 

--- a/airflow/providers/docker/example_dags/example_docker_copy_data.py
+++ b/airflow/providers/docker/example_dags/example_docker_copy_data.py
@@ -27,6 +27,8 @@ TODO: Review the workflow, change it accordingly to
 
 from datetime import timedelta
 
+from docker.types import Mount
+
 from airflow import DAG
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import ShortCircuitOperator
@@ -80,9 +82,9 @@ t_move = DockerOperator(
     docker_url="tcp://localhost:2375",  # replace it with swarm/docker endpoint
     image="centos:latest",
     network_mode="bridge",
-    volumes=[
-        "/your/host/input_dir/path:/your/input_dir/path",
-        "/your/host/output_dir/path:/your/output_dir/path",
+    mounts=[
+        Mount(source="/your/host/input_dir/path", target="/your/input_dir/path", type="bind"),
+        Mount(source="/your/host/output_dir/path", target="/your/output_dir/path", type="bind"),
     ],
     command=[
         "/bin/bash",
@@ -105,7 +107,7 @@ t_print = DockerOperator(
     api_version="1.19",
     docker_url="tcp://localhost:2375",
     image="centos:latest",
-    volumes=["/your/host/output_dir/path:/your/output_dir/path"],
+    mounts=[Mount(source="/your/host/output_dir/path", target="/your/output_dir/path", type="bind")],
     command=print_templated_cmd,
     task_id="print",
     dag=dag,

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -117,6 +117,7 @@ class DockerSwarmOperator(DockerOperator):
                 container_spec=types.ContainerSpec(
                     image=self.image,
                     command=self.format_command(self.command),
+                    mounts=self.mounts,
                     env=self.environment,
                     user=self.user,
                     tty=self.tty,

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Docker <https://docs.docker.com/install/>`__
 
 versions:
+  - 2.0.0
   - 1.2.0
   - 1.1.0
   - 1.0.2

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -521,6 +521,7 @@ intersphinx_mapping = {
     for pkg_name in [
         'boto3',
         'celery',
+        'docker',
         'hdfs',
         'jinja2',
         'mongodb',

--- a/docs/exts/docs_build/third_party_inventories.py
+++ b/docs/exts/docs_build/third_party_inventories.py
@@ -18,6 +18,7 @@
 THIRD_PARTY_INDEXES = {
     'boto3': 'https://boto3.amazonaws.com/v1/documentation/api/latest',
     'celery': 'https://docs.celeryproject.org/en/stable',
+    'docker': 'https://docker-py.readthedocs.io/en/stable',
     'hdfs': 'https://hdfscli.readthedocs.io/en/latest',
     'jinja2': 'https://jinja.palletsprojects.com/en/2.11.x',
     'mongodb': 'https://pymongo.readthedocs.io/en/3.11.3',

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -25,6 +25,7 @@ from airflow.exceptions import AirflowException
 
 try:
     from docker import APIClient
+    from docker.types import Mount
 
     from airflow.providers.docker.hooks.docker import DockerHook
     from airflow.providers.docker.operators.docker import DockerOperator
@@ -66,7 +67,7 @@ class TestDockerOperator(unittest.TestCase):
             network_mode='bridge',
             owner='unittest',
             task_id='unittest',
-            volumes=['/host/path:/container/path'],
+            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
             entrypoint='["sh", "-c"]',
             working_dir='/container/path',
             shm_size=1000,

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -93,7 +93,10 @@ class TestDockerOperator(unittest.TestCase):
             tty=True,
         )
         self.client_mock.create_host_config.assert_called_once_with(
-            binds=['/host/path:/container/path', '/mkdtemp:/tmp/airflow'],
+            mounts=[
+                Mount(source='/host/path', target='/container/path', type='bind'),
+                Mount(source='/mkdtemp', target='/tmp/airflow', type='bind'),
+            ],
             network_mode='bridge',
             shm_size=1000,
             cpu_shares=1024,
@@ -239,7 +242,7 @@ class TestDockerOperator(unittest.TestCase):
             'network_mode': 'bridge',
             'owner': 'unittest',
             'task_id': 'unittest',
-            'volumes': ['/host/path:/container/path'],
+            'mounts': [Mount(source='/host/path', target='/container/path', type='bind')],
             'working_dir': '/container/path',
             'shm_size': 1000,
             'host_tmp_dir': '/host/airflow',

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -77,6 +77,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             image='ubuntu:latest',
             command='env',
             user='unittest',
+            mounts=[],
             tty=True,
             env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'},
         )

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -22,6 +22,7 @@ from unittest import mock
 import pytest
 import requests
 from docker import APIClient
+from docker.types import Mount
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
@@ -65,6 +66,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             mem_limit='128m',
             user='unittest',
             task_id='unittest',
+            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
             auto_remove=True,
             tty=True,
         )
@@ -77,7 +79,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             image='ubuntu:latest',
             command='env',
             user='unittest',
-            mounts=[],
+            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
             tty=True,
             env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'},
         )


### PR DESCRIPTION
Fix #9047, close #15815. I *think this can also resolve #12537 (less sure about that).

All existing `volumes` usages are also migrated to use `mounts` instead.

This also includes a fix to `DockerSwamOperator`’s inability to mount things into the container; the new argument is also passed to Swam, so users can mount by setting `mounts` on `DockerSwamOprerator` as well.

Should I add entries to the Docker provider’s changelog now, or is it done when the provider is released?

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
