### PR TITLE
Replace requests with httpx

### DIFF
--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -19,6 +19,17 @@
 Changelog
 ---------
 
+2.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+The Airbyte Hook derives now from the new version of Hook in Http Provider.
+
+TODO: Add extra dependency to 2.0.0 version of http Provider.
+
+
 1.0.0
 .....
 

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -22,6 +22,7 @@ description: |
   `Airbyte <https://airbyte.io/>`__
 
 versions:
+  - 2.0.0
   - 1.0.0
 
 integrations:

--- a/airflow/providers/apache/livy/CHANGELOG.rst
+++ b/airflow/providers/apache/livy/CHANGELOG.rst
@@ -19,6 +19,14 @@
 Changelog
 ---------
 
+2.0.0
+.....
+
+The Livy Hook derives now from the new version of Http Hook in Http Provider.
+
+TODO: Add extra dependency to 2.0.0 version of http Provider.
+
+
 1.1.0
 .....
 

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Apache Livy <https://livy.apache.org/>`__
 
 versions:
+  - 2.0.0
   - 1.1.0
   - 1.0.1
   - 1.0.0

--- a/airflow/providers/http/CHANGELOG.rst
+++ b/airflow/providers/http/CHANGELOG.rst
@@ -19,6 +19,36 @@
 Changelog
 ---------
 
+
+2.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+Due to licencing issues, the HTTP provider switched from ``requests`` to ``httpx`` library.
+In case you use an authentication method different than default Basic Authenticaton,
+you will need to change it to use the httpx-compatible one.
+
+HttpHook's run() method passes any kwargs passed to underlying httpx.Requests object rather than
+to requests.Requests. They largely compatible (for example json kwarg is supported in both) but not fully.
+The ``content`` and ``auth`` parameters are not supported in ``httpx``.
+
+The "verify", "proxie" and "cert" extra parameters
+
+The get_conn() method of HttpHook returns ``httpx.Client`` rather than ``requests.Session``.
+
+The get_conn() method of HttpHook has extra parameters: verify ,proxies and cert which are executed by the
+run() method, so if your hook derives from the HttpHook it should be updated.
+
+The ``run_and_check`` method is gone. PreparedRequests are not supported in ``httpx`` and this method
+used it. Instead, run method simply creates and executes the full request instance.
+
+While ``httpx`` does not support ``REQUESTS_CA_BUNDLE`` variable overriding ca crt, we backported
+the requests behaviour to HTTPHook and it respects the variable if set. More details on that variable
+can be found `here <https://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification`_
+
+
 1.1.1
 .....
 

--- a/airflow/providers/http/example_dags/example_http.py
+++ b/airflow/providers/http/example_dags/example_http.py
@@ -75,7 +75,7 @@ task_get_op_response_filter = SimpleHttpOperator(
     task_id='get_op_response_filter',
     method='GET',
     endpoint='get',
-    response_filter=lambda response: response.json()['nested']['property'],
+    response_filter=lambda response: response.json()['headers']['Host'],
     dag=dag,
 )
 # [END howto_operator_http_task_get_op_response_filter]

--- a/airflow/providers/http/operators/http.py
+++ b/airflow/providers/http/operators/http.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+
 from typing import Any, Callable, Dict, Optional, Type
 
-from requests.auth import AuthBase, HTTPBasicAuth
+from httpx import Auth, BasicAuth
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
@@ -86,7 +86,7 @@ class SimpleHttpOperator(BaseOperator):
         extra_options: Optional[Dict[str, Any]] = None,
         http_conn_id: str = 'http_default',
         log_response: bool = False,
-        auth_type: Type[AuthBase] = HTTPBasicAuth,
+        auth_type: Type[Auth] = BasicAuth,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Hypertext Transfer Protocol (HTTP) <https://www.w3.org/Protocols/>`__
 
 versions:
+  - 2.0.0
   - 1.1.1
   - 1.1.0
   - 1.0.0

--- a/airflow/providers/opsgenie/CHANGELOG.rst
+++ b/airflow/providers/opsgenie/CHANGELOG.rst
@@ -19,6 +19,16 @@
 Changelog
 ---------
 
+2.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+The OpsGenie Hook derives now from the new version of Http Hook in Http Provider.
+
+TODO: Add extra dependency to 2.0.0 version of http Provider.
+
 1.0.2
 .....
 

--- a/airflow/providers/opsgenie/provider.yaml
+++ b/airflow/providers/opsgenie/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Opsgenie <https://www.opsgenie.com/>`__
 
 versions:
+  - 2.0.0
   - 1.0.2
   - 1.0.1
   - 1.0.0

--- a/setup.py
+++ b/setup.py
@@ -343,20 +343,7 @@ hive = [
     'pyhive[hive]>=0.6.0',
     'thrift>=0.9.2',
 ]
-http = [
-    'requests>=2.20.0',
-]
-http_provider = [
-    # NOTE ! The HTTP provider is NOT preinstalled by default when Airflow is installed - because it
-    #        depends on `requests` library and until `chardet` is mandatory dependency of `requests`
-    #        See https://github.com/psf/requests/pull/5797
-    #        This means that providers that depend on Http and cannot work without it, have to have
-    #        explicit dependency on `apache-airflow-providers-http` which needs to be pulled in for them.
-    #        Other cross-provider-dependencies are optional (usually cross-provider dependencies only enable
-    #        some features of providers and majority of those providers works). They result with an extra,
-    #        not with the `install-requires` dependency.
-    'apache-airflow-providers-http',
-]
+http = []
 jdbc = [
     'jaydebeapi>=1.1.1',
 ]
@@ -543,7 +530,7 @@ devel_hadoop = devel_minreq + hdfs + hive + kerberos + presto + webhdfs
 
 # Dict of all providers which are part of the Apache Airflow repository together with their requirements
 PROVIDERS_REQUIREMENTS: Dict[str, List[str]] = {
-    'airbyte': http_provider,
+    'airbyte': http,
     'amazon': amazon,
     'apache.beam': apache_beam,
     'apache.cassandra': cassandra,
@@ -551,7 +538,7 @@ PROVIDERS_REQUIREMENTS: Dict[str, List[str]] = {
     'apache.hdfs': hdfs,
     'apache.hive': hive,
     'apache.kylin': kylin,
-    'apache.livy': http_provider,
+    'apache.livy': http,
     'apache.pig': [],
     'apache.pinot': pinot,
     'apache.spark': spark,
@@ -584,7 +571,7 @@ PROVIDERS_REQUIREMENTS: Dict[str, List[str]] = {
     'neo4j': neo4j,
     'odbc': odbc,
     'openfaas': [],
-    'opsgenie': http_provider,
+    'opsgenie': http,
     'oracle': oracle,
     'pagerduty': pagerduty,
     'papermill': papermill,

--- a/tests/providers/slack/hooks/test_slack_webhook.py
+++ b/tests/providers/slack/hooks/test_slack_webhook.py
@@ -18,9 +18,6 @@
 #
 import json
 import unittest
-from unittest import mock
-
-from requests.exceptions import MissingSchema
 
 from airflow.models import Connection
 from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
@@ -129,41 +126,22 @@ class TestSlackWebhookHook(unittest.TestCase):
         # Then
         assert self.expected_message_dict == json.loads(message)
 
-    @mock.patch('requests.Session')
-    @mock.patch('requests.Request')
-    def test_url_generated_by_http_conn_id(self, mock_request, mock_session):
+
+class TestSlackWebhookMockHttpx:
+    expected_url = 'https://hooks.slack.com/services/T000/B000/XXX'
+    expected_method = 'POST'
+
+    def test_url_generated_by_http_conn_id(self, httpx_mock):
+        httpx_mock.add_response(url=self.expected_url, method=self.expected_method)
         hook = SlackWebhookHook(http_conn_id='slack-webhook-url')
-        try:
-            hook.execute()
-        except MissingSchema:
-            pass
-        mock_request.assert_called_once_with(
-            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
-        )
-        mock_request.reset_mock()
+        hook.execute()
 
-    @mock.patch('requests.Session')
-    @mock.patch('requests.Request')
-    def test_url_generated_by_endpoint(self, mock_request, mock_session):
+    def test_url_generated_by_endpoint(self, httpx_mock):
+        httpx_mock.add_response(url=self.expected_url, method=self.expected_method)
         hook = SlackWebhookHook(webhook_token=self.expected_url)
-        try:
-            hook.execute()
-        except MissingSchema:
-            pass
-        mock_request.assert_called_once_with(
-            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
-        )
-        mock_request.reset_mock()
+        hook.execute()
 
-    @mock.patch('requests.Session')
-    @mock.patch('requests.Request')
-    def test_url_generated_by_http_conn_id_and_endpoint(self, mock_request, mock_session):
+    def test_url_generated_by_http_conn_id_and_endpoint(self, httpx_mock):
+        httpx_mock.add_response(url=self.expected_url, method=self.expected_method)
         hook = SlackWebhookHook(http_conn_id='slack-webhook-host', webhook_token='B000/XXX')
-        try:
-            hook.execute()
-        except MissingSchema:
-            pass
-        mock_request.assert_called_once_with(
-            self.expected_method, self.expected_url, headers=mock.ANY, data=mock.ANY
-        )
-        mock_request.reset_mock()
+        hook.execute()


### PR DESCRIPTION
This change replaces `requests` with httpx in the providers
that are derived from http provider. This change is related
to apache#15781 and was introduced initially to handle problem
described in:

https://issues.apache.org/jira/browse/LEGAL-572

However since we have a PR in progress to make chardet
an optional dependency in `requests` library

psf/requests#5797

and changing `requests` to `http` introduced backwards-incompatibility,
we might decide not to merge this PR - depending on how
quickly (if) `requests` library adopts the change.

Providers affected:

* http
* airbyte
* apache.livy
* opsgenie
* slack

Depends on #15781 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
