### PR TITLE
Explicitly point Jinja2 documentation to 2.11.x

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -211,7 +211,7 @@ class DAG(LoggingMixin):
             )
 
         **See**: `Jinja Environment documentation
-        <https://jinja.palletsprojects.com/en/master/api/#jinja2.Environment>`_
+        <https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment>`_
 
     :type jinja_environment_kwargs: dict
     :param tags: List of tags to help filtering DAGS in the UI.

--- a/docs/apache-airflow/concepts/operators.rst
+++ b/docs/apache-airflow/concepts/operators.rst
@@ -140,7 +140,7 @@ You can pass custom options to the Jinja ``Environment`` when creating your DAG.
         },
     )
 
-See the `Jinja documentation <https://jinja.palletsprojects.com/en/master/api/#jinja2.Environment>`_ to find all available options.
+See the `Jinja documentation <https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment>`_ to find all available options.
 
 Rendering Fields as Native Python Objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -131,7 +131,7 @@ otherwise Airflow will raise an exception.
 Templating with Jinja
 ---------------------
 Airflow leverages the power of
-`Jinja Templating <https://jinja.palletsprojects.com/>`_  and provides
+`Jinja Templating <https://jinja.palletsprojects.com/en/2.11.x/>`_ and provides
 the pipeline author
 with a set of built-in parameters and macros. Airflow also provides
 hooks for the pipeline author to define their own parameters, macros and

--- a/docs/exts/docs_build/third_party_inventories.py
+++ b/docs/exts/docs_build/third_party_inventories.py
@@ -19,7 +19,7 @@ THIRD_PARTY_INDEXES = {
     'boto3': 'https://boto3.amazonaws.com/v1/documentation/api/latest',
     'celery': 'https://docs.celeryproject.org/en/stable',
     'hdfs': 'https://hdfscli.readthedocs.io/en/latest',
-    'jinja2': 'https://jinja.palletsprojects.com/en/master',
+    'jinja2': 'https://jinja.palletsprojects.com/en/2.11.x',
     'mongodb': 'https://pymongo.readthedocs.io/en/3.11.3',
     'pandas': 'https://pandas.pydata.org/pandas-docs/stable',
     'python': 'https://docs.python.org/3',


### PR DESCRIPTION
Noticed when building documentation locally.

It seems Jinja2 recently restructured the documentation and no longer publishes the master branch, so some of the links are now 404.

Since we’re explicltly pinning Jinja2 to <2.12, documentation should point to the 2.11.x series as well (latest is 3.0.x).

https://github.com/apache/airflow/blob/bcfa0cbbfc941cae705a39cfbdd6330a5ba0578e/setup.cfg#L109

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
