### PR TITLE
Add back-compat shim for BranchDateTimeOperator rename

### DIFF
--- a/airflow/operators/datetime_branch.py
+++ b/airflow/operators/datetime_branch.py
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""This module is deprecated. Please use :mod:`airflow.operators.datetime`."""
+
+import warnings
+
+from airflow.operators.datetime import BranchDateTimeOperator
+
+warnings.warn(
+    "This module is deprecated. Please use `airflow.operators.datetime`.", DeprecationWarning, stacklevel=2
+)
+
+
+class DateTimeBranchOperator(BranchDateTimeOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.operators.datetime.BranchDateTimeOperator`.
+    """
+
+    def __init__(self, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use `airflow.operators.datetime.BranchDateTimeOperator`.""",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(**kwargs)

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -1113,6 +1113,10 @@ OPERATORS = [
         'airflow.operators.branch_operator.BaseBranchOperator',
     ),
     (
+        'airflow.operators.datetime.BranchDateTimeOperator',
+        'airflow.operators.datetime_branch.DateTimeBranchOperator',
+    ),
+    (
         'airflow.operators.bash.BashOperator',
         'airflow.operators.bash_operator.BashOperator',
     ),


### PR DESCRIPTION
/cc @eladkal We should have added this in #14720, otherwise that is a breaking change to some users
