### PR TITLE
Fix import order for task_instance_mutation_hook

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -41,7 +41,6 @@ from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.models.base import ID_LEN, Base
 from airflow.models.taskinstance import TaskInstance as TI
-from airflow.settings import task_instance_mutation_hook
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
@@ -633,6 +632,8 @@ class DagRun(Base, LoggingMixin):
         :param session: Sqlalchemy ORM Session
         :type session: Session
         """
+        from airflow.settings import task_instance_mutation_hook
+
         dag = self.get_dag()
         tis = self.get_task_instances(session=session)
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -611,7 +611,7 @@ class TestDagRun(unittest.TestCase):
             assert State.NONE == first_ti.state
 
     @parameterized.expand([(state,) for state in State.task_states])
-    @mock.patch('airflow.models.dagrun.task_instance_mutation_hook')
+    @mock.patch('airflow.settings.task_instance_mutation_hook')
     def test_task_instance_mutation_hook(self, state, mock_hook):
         def mutate_task_instance(task_instance):
             if task_instance.queue == 'queue1':


### PR DESCRIPTION
Fixed https://github.com/apache/airflow/issues/15698

import from `airflow.models.dagrun` module may cause `task_instance_mutation_hook` to be overwritten.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
