### PR TITLE
Fix modal import in graph.js

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -20,12 +20,13 @@
  */
 
 /*
-  global d3, document, call_modal, nodes, taskInstances, tasks, edges, dagreD3, localStorage, $
+  global d3, document, nodes, taskInstances, tasks, edges, dagreD3, localStorage, $
 */
 
 import getMetaValue from './meta_value';
 import { escapeHtml } from './main';
 import tiTooltip, { taskNoInstanceTooltip } from './task_instances';
+import { callModal } from './dag';
 
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
@@ -155,8 +156,8 @@ function draw() {
       if (nodeId in taskInstances) tryNumber = taskInstances[nodeId].tryNumber;
       else tryNumber = 0;
 
-      if (task.task_type === 'SubDagOperator') call_modal(nodeId, executionDate, task.extra_links, tryNumber, true);
-      else call_modal(nodeId, executionDate, task.extra_links, tryNumber, undefined);
+      if (task.task_type === 'SubDagOperator') callModal(nodeId, executionDate, task.extra_links, tryNumber, true);
+      else callModal(nodeId, executionDate, task.extra_links, tryNumber, undefined);
     } else {
       // join node between TaskGroup. Ignore.
     }


### PR DESCRIPTION
Modals weren't opening in Graph View. `call_modal` no longer existed. Switching to import `callModal` instead.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
