### PR TITLE
Fix pause/unpause Dag on dag view

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -42,6 +42,7 @@ export const dagTZ = getMetaValue('dag_timezone');
 const logsWithMetadataUrl = getMetaValue('logs_with_metadata_url');
 const externalLogUrl = getMetaValue('external_log_url');
 const extraLinksUrl = getMetaValue('extra_links_url');
+const pausedUrl = getMetaValue('paused_url');
 let taskId = '';
 let executionDate = '';
 let subdagId = '';
@@ -245,7 +246,7 @@ $('#pause_resume').on('change', function onChange() {
   const $input = $(this);
   const id = $input.data('dag-id');
   const isPaused = $input.is(':checked');
-  const url = `{{ url_for('Airflow.paused') }}?is_paused=${isPaused}&dag_id=${encodeURIComponent(id)}`;
+  const url = `${pausedUrl}?is_paused=${isPaused}&dag_id=${encodeURIComponent(id)}`;
   $input.removeClass('switch-input--error');
   $.post(url).fail(() => {
     setTimeout(() => {

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -34,6 +34,7 @@
   <meta name="logs_with_metadata_url" content="{{ url_for('Airflow.get_logs_with_metadata') }}">
   <meta name="external_log_url" content="{{ url_for('Airflow.redirect_to_external_log') }}">
   <meta name="extra_links_url" content="{{ url_for('Airflow.extra_links') }}">
+  <meta name="paused_url" content="{{ url_for('Airflow.paused') }}">
   {% if show_external_log_redirect is defined %}
     <meta name="show_external_log_redirect" content="{{ show_external_log_redirect }}">
   {% endif %}


### PR DESCRIPTION
This PR adds a `pausedUrl` via `<meta>` tag that is readable by js instead of a jinja template. This was causing a bug where a user couldn't pause/unpause a dag from the dag page.

Note: `dag.js` isn't included in 2.1.0 so this isn't "work on the weekend" urgent

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
