### PR TITLE
Add support cli delete user by email

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1295,7 +1295,7 @@ USERS_COMMANDS = (
         name='delete',
         help='Delete a user',
         func=lazy_load_command('airflow.cli.commands.user_command.users_delete'),
-        args=(ARG_USERNAME,),
+        args=(ARG_USERNAME_OPTIONAL, ARG_EMAIL_OPTIONAL),
     ),
     ActionCommand(
         name='add-role',

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -128,6 +128,84 @@ class TestCliUsers:
         )
         user_command.users_delete(args)
 
+    def test_cli_delete_user_by_email(self):
+        args = self.parser.parse_args(
+            [
+                'users',
+                'create',
+                '--username',
+                'test4',
+                '--lastname',
+                'doe',
+                '--firstname',
+                'jon',
+                '--email',
+                'jdoe2@example.com',
+                '--role',
+                'Viewer',
+                '--use-random-password',
+            ]
+        )
+        user_command.users_create(args)
+        args = self.parser.parse_args(
+            [
+                'users',
+                'delete',
+                '--email',
+                'jdoe2@example.com',
+            ]
+        )
+        user_command.users_delete(args)
+
+    @pytest.mark.parametrize(
+        'args,raise_match',
+        [
+            (
+                [
+                    'users',
+                    'delete',
+                ],
+                'Missing args: must supply one of --username or --email',
+            ),
+            (
+                [
+                    'users',
+                    'delete',
+                    '--username',
+                    'test',
+                    '--email',
+                    'jdoe2@example.com',
+                ],
+                'Conflicting args: must supply either --username or --email, but not both',
+            ),
+            (
+                [
+                    'users',
+                    'delete',
+                    '--username',
+                    'test',
+                ],
+                'User "test" does not exist',
+            ),
+            (
+                [
+                    'users',
+                    'delete',
+                    '--email',
+                    'jode2@example.com',
+                ],
+                'User "jode2@example.com" does not exist',
+            ),
+        ],
+    )
+    def test_find_user(self, args, raise_match):
+        args = self.parser.parse_args(args)
+        with pytest.raises(
+            SystemExit,
+            match=raise_match,
+        ):
+            user_command._find_user(args)
+
     def test_cli_list_users(self):
         for i in range(0, 3):
             args = self.parser.parse_args(


### PR DESCRIPTION
Like `airflow users add-role`, add support cli delete user by `--email` for consistency.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
