### PR TITLE
Revert "Docs: Fix examples values in docs (#15878)"

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -541,12 +541,7 @@
             "x-docsSection": "Airflow",
             "default": null,
             "examples": [
-                [
-                    {
-                        "name": "AIRFLOW__CORE__LOAD_EXAMPLES",
-                        "value": "True"
-                    }
-                ]
+                "- name: AIRFLOW__CORE__LOAD_EXAMPLES\n   value: True"
             ]
         },
         "extraEnvFrom": {


### PR DESCRIPTION
This reverts commit b90bb6ed3a788ab28692a0d18adee4fbbe89ca44 from #15878.

The issue is the display of the example in the docs, _not_ the actual example in the schema. You'd write it in a values file yaml like this:

```
extraEnv: |
  - name: AIRFLOW__CORE__LOAD_EXAMPLES
    value: True
```

Note, `extraEnv` accepts a string:
https://github.com/apache/airflow/blob/b90bb6ed3a788ab28692a0d18adee4fbbe89ca44/chart/values.yaml#L217-L224

If one wanted a "list of dicts", `env` is what should be used:
https://github.com/apache/airflow/blob/b90bb6ed3a788ab28692a0d18adee4fbbe89ca44/chart/values.yaml#L173-L176