### PR TITLE
Better multiline string formatting for chart docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -363,6 +363,12 @@ elif PACKAGE_NAME.startswith('apache-airflow-providers-'):
         extensions.append('sphinxcontrib.jinja')
 elif PACKAGE_NAME == 'helm-chart':
 
+    def _str_representer(dumper, data):
+        style = "|" if "\n" in data else None  # show as a block scalar if we have more than 1 line
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style)
+
+    yaml.add_representer(str, _str_representer)
+
     def _format_default(value: Any) -> str:
         if value == "":
             return '""'


### PR DESCRIPTION
This will properly format multiline strings in the helm chart parameter docs:

Before:
![Screen Shot 2021-05-16 at 12 11 58 AM](https://user-images.githubusercontent.com/66968678/118387594-7973d900-b5dc-11eb-92dc-a3b22acaf687.png)
![Screen Shot 2021-05-16 at 12 12 39 AM](https://user-images.githubusercontent.com/66968678/118387598-7d076000-b5dc-11eb-960f-249bdadf4345.png)

After:
![Screen Shot 2021-05-16 at 12 11 21 AM](https://user-images.githubusercontent.com/66968678/118387603-855f9b00-b5dc-11eb-8368-b2f5cc8f2d09.png)
![Screen Shot 2021-05-16 at 12 12 54 AM](https://user-images.githubusercontent.com/66968678/118387605-885a8b80-b5dc-11eb-98ed-b567b8100bae.png)

