### PR TITLE
Fix 500 error from updateTaskInstancesState API endpoint when `dry_run` not passed

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -82,6 +82,7 @@ Improvements
 Bug Fixes
 """""""""
 
+- Fix 500 error from updateTaskInstancesState API endpoint when ``dry_run`` not passed (#15889)
 - Ensure that task preceding a PythonVirtualenvOperator doesn't fail (#15822)
 - Prevent mixed case env vars from crashing processes like worker (#14380)
 - Fixed type annotations in DAG decorator (#15778)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -82,7 +82,7 @@ Improvements
 Bug Fixes
 """""""""
 
-- Fix 500 error from updateTaskInstancesState API endpoint when ``dry_run`` not passed (#15889)
+- Fix 500 error from ``updateTaskInstancesState`` API endpoint when ``dry_run`` not passed (#15889)
 - Ensure that task preceding a PythonVirtualenvOperator doesn't fail (#15822)
 - Prevent mixed case env vars from crashing processes like worker (#14380)
 - Fixed type annotations in DAG decorator (#15778)

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -97,7 +97,7 @@ class TaskInstanceBatchFormSchema(Schema):
 class ClearTaskInstanceFormSchema(Schema):
     """Schema for handling the request of clearing task instance of a Dag"""
 
-    dry_run = fields.Boolean(default=True)
+    dry_run = fields.Boolean(missing=True)
     start_date = fields.DateTime(missing=None, validate=validate_istimezone)
     end_date = fields.DateTime(missing=None, validate=validate_istimezone)
     only_failed = fields.Boolean(missing=True)

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -840,6 +840,26 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
                 },
                 4,
             ),
+            (
+                "dry_run default",
+                "example_python_operator",
+                [
+                    {"execution_date": DEFAULT_DATETIME_1, "state": State.FAILED},
+                    {
+                        "execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=1),
+                        "state": State.FAILED,
+                    },
+                    {
+                        "execution_date": DEFAULT_DATETIME_1 + dt.timedelta(days=2),
+                        "state": State.RUNNING,
+                    },
+                ],
+                "example_python_operator",
+                {
+                    "only_failed": True,
+                },
+                2,
+            ),
         ]
     )
     @provide_session


### PR DESCRIPTION
The `default` schema parameter is for converting back to JSON, `missing` is the one that takes effect when converting to Python dict.

Fixes https://github.com/apache/airflow/issues/15885