### PR TITLE
Enforce formatting on helm chart json schema files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -47,3 +47,6 @@ indent_size = 2
 
 [*.{htm,html}]
 indent_size = 2
+
+[*.json]
+indent_size = 4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -180,6 +180,14 @@ repos:
         exclude: ^airflow/_vendor/
         args:
           - --remove
+      - id: pretty-format-json
+        args:
+          - --autofix
+          - --no-sort-keys
+          - --indent
+          - "4"
+        files: ^chart/values\.schema\.json$|^chart/values_schema\.schema\.json$
+        pass_filenames: true
   - repo: https://github.com/asottile/pyupgrade
     rev: v2.13.0
     hooks:

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2265,8 +2265,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
                  lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
                  no-providers-in-core-examples no-relative-imports pre-commit-descriptions
-                 pre-commit-hook-names provide-create-sessions providers-init-file provider-yamls
-                 pydevd pydocstyle pylint pylint-tests python-no-log-warn pyupgrade
+                 pre-commit-hook-names pretty-format-json provide-create-sessions providers-init-file
+                 provider-yamls pydevd pydocstyle pylint pylint-tests python-no-log-warn pyupgrade
                  restrict-start_date rst-backticks setup-order setup-extra-packages shellcheck
                  sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace ui-lint
                  update-breeze-file update-extras update-local-yml-file update-setup-cfg-file

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -138,6 +138,8 @@ require Breeze Docker images to be installed locally:
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``pre-commit-hook-names``             Check that hook names are not overly long
 ----------------------------------- ---------------------------------------------------------------- ------------
+``pretty-format-json``                Formats json files
+----------------------------------- ---------------------------------------------------------------- ------------
 ``provide-create-sessions``           Make sure provide-session and create-session imports are OK
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``providers-init-file``               Check that provider's __init__.py file is removed

--- a/breeze-complete
+++ b/breeze-complete
@@ -121,6 +121,7 @@ no-providers-in-core-examples
 no-relative-imports
 pre-commit-descriptions
 pre-commit-hook-names
+pretty-format-json
 provide-create-sessions
 providers-init-file
 provider-yamls


### PR DESCRIPTION
This enables a json formatter on the helm chart json schema files. I'm not dead-set on having this but after working in the schema a bit lately having an enforced and consistent format would be nice.