### PR TITLE
Fix modal actions

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -211,9 +211,10 @@ export function callModal(t, d, extraLinks, tryNumbers, sd) {
 export function callModalDag(dag) {
   $('#dagModal').modal({});
   $('#dagModal').css('margin-top', '0');
+  executionDate = dag.execution_date;
   updateButtonUrl(buttons.dag_graph_view, {
-    dag_id: dag && dag.execution_date,
-    execution_date: dag && dag.dag_id,
+    dag_id: dag && dag.dag_id,
+    execution_date: dag && dag.execution_date,
   });
 }
 
@@ -221,25 +222,31 @@ export function callModalDag(dag) {
 $('form[data-action]').on('submit', function submit(e) {
   e.preventDefault();
   const form = $(this).get(0);
-  form.execution_date.value = executionDate;
-  form.origin.value = window.location;
-  if (form.task_id) {
-    form.task_id.value = taskId;
+  // Somehow submit is fired twice. Only once is the executionDate valid
+  if (executionDate) {
+    form.execution_date.value = executionDate;
+    form.origin.value = window.location;
+    if (form.task_id) {
+      form.task_id.value = taskId;
+    }
+    form.action = $(this).data('action');
+    form.submit();
   }
-  form.action = $(this).data('action');
-  form.submit();
 });
 
 // DAG Modal actions
 $('form button[data-action]').on('click', function onClick() {
   const form = $(this).closest('form').get(0);
-  form.execution_date.value = executionDate;
-  form.origin.value = window.location;
-  if (form.task_id) {
-    form.task_id.value = taskId;
+  // Somehow submit is fired twice. Only once is the executionDate valid
+  if (executionDate) {
+    form.execution_date.value = executionDate;
+    form.origin.value = window.location;
+    if (form.task_id) {
+      form.task_id.value = taskId;
+    }
+    form.action = $(this).data('action');
+    form.submit();
   }
-  form.action = $(this).data('action');
-  form.submit();
 });
 
 $('#pause_resume').on('change', function onChange() {


### PR DESCRIPTION
This fixes a bug introduced from moving all javascript in `dag.html` to `dag.js`

Modal events are triggering twice. Once, with an executionDate, and again without. Now the submit function will check that an executionDate exists before doing an action.

Also, fixing the dagId and executionDate that are set when opening up the dagrun modal.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
