### PR TITLE
Ensure that secrets are masked no matter what logging config is in use

### DIFF
--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -53,9 +53,20 @@ def configure_logging():
         log.debug('Unable to load custom logging, using default config instead')
 
     try:
+        # Ensure that the password masking filter is applied to the 'task' handler
+        # no matter what the user did.
+        if 'filters' in logging_config and 'mask_secrets' in logging_config['filters']:
+            # But if they replace the logging config _entirely_, don't try to set this, it won't work
+            task_handler_config = logging_config['handlers']['task']
+
+            task_handler_config.setdefault('filters', [])
+
+            if 'mask_secrets' not in task_handler_config['filters']:
+                task_handler_config['filters'].append('mask_secrets')
+
         # Try to init logging
         dictConfig(logging_config)
-    except ValueError as e:
+    except (ValueError, KeyError) as e:
         log.error('Unable to load the config, contains a configuration error.')
         # When there is an error in the config, escalate the exception
         # otherwise Airflow would silently fall back on the default config


### PR DESCRIPTION
And rather than only applying the filters for the current known remote
backends, I have applied the filter to the task handler "globally" so
that all task logs are filtered, even for custom remote back ends.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).