### PR TITLE
Fix find task search in Graph View

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -299,7 +299,7 @@ d3.select('#searchbox').on('keyup', () => {
     setFocusMap();
   }
 
-  d3.selectAll('g.nodes g.node').forEach(function highlight(d) {
+  d3.selectAll('g.nodes g.node').filter(function highlight(d) {
     if (s === '') {
       d3.selectAll('g.edgePaths, g.edgeLabel').attr('data-highlight', null);
       d3.select(this).attr('data-highlight', null);
@@ -312,6 +312,8 @@ d3.select('#searchbox').on('keyup', () => {
         d3.select(this).attr('data-highlight', 'fade');
       }
     }
+    // We don't actually use the returned results from filter
+    return null;
   });
 
   // This moves the matched node to the center of the graph area


### PR DESCRIPTION
The "Find Task" searchbox in Graph View was broken. This PR fixes it by switching highlight array function from `.forEach()` to `.filter()`

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
