### PR TITLE
Set unique name on precommit hook and update schema

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -535,11 +535,11 @@ repos:
         require_serial: true
         additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
       - id: json-schema
-        name: Lint JSON Schema files with JSON Schema
+        name: Lint NodePort Service with JSON Schema
         entry: ./scripts/ci/pre_commit/pre_commit_json_schema.py
         args:
           - --spec-url
-          - https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.9/service-v1.json
+          - https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.18.15-standalone/service-v1.json
         language: python
         pass_filenames: true
         files: scripts/ci/kubernetes/nodeport.yaml


### PR DESCRIPTION
This renames a hook to better represent what it's doing and also
updates the schema to the earliest k8s version we test against.
It also moves to a schema from an active fork instead of the
abandoned original repo.