### PR TITLE
Remove Version suffix for SVN while releasing

### DIFF
--- a/.github/workflows/build-images-workflow-run.yml
+++ b/.github/workflows/build-images-workflow-run.yml
@@ -410,7 +410,6 @@ jobs:
       FORCE_PULL_BASE_PYTHON_IMAGE: >
         ${{ needs.cancel-workflow-runs.sourceEvent == 'schedule' && 'true' || 'false' }}
       VERSION_SUFFIX_FOR_PYPI: ".dev0"
-      VERSION_SUFFIX_FOR_SVN: ".dev0"
     steps:
       - name: >
           Checkout [${{ needs.cancel-workflow-runs.outputs.sourceEvent }}]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,7 +521,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       AIRFLOW_EXTRAS: "all"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
       VERSION_SUFFIX_FOR_PYPI: ".dev0"
-      VERSION_SUFFIX_FOR_SVN: ".dev0"
       GITHUB_REGISTRY: ${{ needs.ci-images.outputs.githubRegistry }}
     if: needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'master'
     steps:
@@ -570,7 +569,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
       AIRFLOW_EXTRAS: "all"
       PYTHON_MAJOR_MINOR_VERSION: ${{needs.build-info.outputs.defaultPythonVersion}}
       VERSION_SUFFIX_FOR_PYPI: ".dev0"
-      VERSION_SUFFIX_FOR_SVN: ".dev0"
       GITHUB_REGISTRY: ${{ needs.ci-images.outputs.githubRegistry }}
     if: needs.build-info.outputs.image-build == 'true' && needs.build-info.outputs.default-branch == 'master'
     steps:

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1717,18 +1717,13 @@ This is the current syntax for  `./breeze <./breeze>`_:
         prepare-provider-packages command cleans up the dist folder, so if you want also
         to generate provider packages, make sure you run prepare-provider-packages first,
         and prepare-airflow-packages second. You can specify optional
-        --version-suffix-for-svn flag to generate rc candidate packages to upload to SVN or
-        --version-suffix-for-pypi flag to generate rc candidates for PyPI packages. You can also
-        provide both suffixes in case you prepare alpha/beta versions. The packages are prepared in
-        dist folder
+        --version-suffix-for-pypi flag to generate rc candidates for PyPI packages.
+        The packages are prepared in dist folder
 
         Examples:
 
         'breeze prepare-airflow-packages --package-format wheel' or
-        'breeze prepare-airflow-packages --version-suffix-for-svn rc1' or
         'breeze prepare-airflow-packages --version-suffix-for-pypi rc1'
-        'breeze prepare-airflow-packages --version-suffix-for-pypi a1
-                                              --version-suffix-for-svn a1'
 
   Flags:
 

--- a/CI.rst
+++ b/CI.rst
@@ -258,9 +258,6 @@ You can use those variables when you try to reproduce the build locally.
 | ``VERSION_SUFFIX_FOR_PYPI``             |             |             |            | Version suffix used during provider             |
 |                                         |             |             |            | package preparation for PyPI builds.            |
 +-----------------------------------------+-------------+-------------+------------+-------------------------------------------------+
-| ``VERSION_SUFFIX_FOR_SVN``              |             |             |            | Version suffix used during provider             |
-|                                         |             |             |            | package preparation for SVN builds.             |
-+-----------------------------------------+-------------+-------------+------------+-------------------------------------------------+
 |                                                            Git variables                                                           |
 +-----------------------------------------+-------------+-------------+------------+-------------------------------------------------+
 | COMMIT_SHA                              |             | GITHUB_SHA  | GITHUB_SHA | SHA of the commit of the build is run           |

--- a/breeze
+++ b/breeze
@@ -1190,12 +1190,6 @@ function breeze::parse_arguments() {
             echo
             shift 2
             ;;
-        -N | --version-suffix-for-svn)
-            export VERSION_SUFFIX_FOR_SVN="${2}"
-            echo "Version suffix for SVN ${VERSION_SUFFIX_FOR_SVN}"
-            echo
-            shift 2
-            ;;
         --load-example-dags)
             export LOAD_EXAMPLES="true"
             echo "Include Airflow sample dags"
@@ -1880,18 +1874,13 @@ ${CMDNAME} prepare-airflow-packages [FLAGS]
       prepare-provider-packages command cleans up the dist folder, so if you want also
       to generate provider packages, make sure you run prepare-provider-packages first,
       and prepare-airflow-packages second. You can specify optional
-      --version-suffix-for-svn flag to generate rc candidate packages to upload to SVN or
-      --version-suffix-for-pypi flag to generate rc candidates for PyPI packages. You can also
-      provide both suffixes in case you prepare alpha/beta versions. The packages are prepared in
-      dist folder
+      --version-suffix-for-pypi flag to generate rc candidates for PyPI packages.
+      The packages are prepared in dist folder
 
       Examples:
 
       '${CMDNAME} prepare-airflow-packages --package-format wheel' or
-      '${CMDNAME} prepare-airflow-packages --version-suffix-for-svn rc1' or
       '${CMDNAME} prepare-airflow-packages --version-suffix-for-pypi rc1'
-      '${CMDNAME} prepare-airflow-packages --version-suffix-for-pypi a1
-                                            --version-suffix-for-svn a1'
 
 Flags:
 $(breeze::flag_packages)

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -57,6 +57,7 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
     # Set Version
     export VERSION=2.0.2rc3
     export VERSION_SUFFIX=rc3
+    export VERSION_WITHOUT_RC=${VERSION/rc?/}
 
     # Set AIRFLOW_REPO_ROOT to the path of your git repo
     export AIRFLOW_REPO_ROOT=$(pwd)
@@ -87,14 +88,16 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
 - Tarball the repo
 
     ```shell script
-    git archive --format=tar.gz ${VERSION} --prefix=apache-airflow-${VERSION}/ -o dist/apache-airflow-${VERSION}-source.tar.gz
+    git archive --format=tar.gz ${VERSION} \
+        --prefix=apache-airflow-${VERSION_WITHOUT_RC}/ \
+        -o dist/apache-airflow-${VERSION_WITHOUT_RC}-source.tar.gz
     ```
 
 
 - Generate SHA512/ASC (If you have not generated a key yet, generate it by following instructions on http://www.apache.org/dev/openpgp.html#key-gen-generate-key)
 
     ```shell script
-    ./breeze prepare-airflow-packages --package-format both --version-suffix-for-svn "${VERSION_SUFFIX}"
+    ./breeze prepare-airflow-packages --package-format both
     ${AIRFLOW_REPO_ROOT}/dev/sign.sh dist/*
     ```
 
@@ -126,7 +129,7 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
 ## Prepare PyPI convenience "snapshot" packages
 
 At this point we have the artefact that we vote on, but as a convenience to developers we also want to
-publish "snapshots" of the RC builds to pypi for installing via pip. Also those packages
+publish "snapshots" of the RC builds to PyPI for installing via pip. Also those packages
 are used to build the production docker image in DockerHub, so we need to upload the packages
 before we push the tag to GitHub. Pushing the tag to GitHub automatically triggers image building in
 DockerHub.
@@ -145,7 +148,7 @@ To do this we need to
     twine check dist/*
     ```
 
-- Upload the package to PyPi's test environment:
+- Upload the package to PyPI's test environment:
 
     ```shell script
     twine upload -r pypitest dist/*
@@ -154,7 +157,7 @@ To do this we need to
 - Verify that the test package looks good by downloading it and installing it into a virtual environment. The package download link is available at:
 https://test.pypi.org/project/apache-airflow/#files
 
-- Upload the package to PyPi's production environment:
+- Upload the package to PyPI's production environment:
 `twine upload -r pypi dist/*`
 
 - Again, confirm that the package is available here:
@@ -476,18 +479,18 @@ Hello,
 Apache Airflow 2.0.2 (based on RC3) has been accepted.
 
 4 “+1” binding votes received:
-- Kaxil Naik  (binding)
-- Bolke de Bruin (binding)
-- Ash Berlin-Taylor (binding)
-- Tao Feng (binding)
+- Kaxil Naik
+- Bolke de Bruin
+- Ash Berlin-Taylor
+- Tao Feng
 
 
 4 "+1" non-binding votes received:
 
-- Deng Xiaodong (non-binding)
-- Stefan Seelmann (non-binding)
-- Joshua Patchus (non-binding)
-- Felix Uellendall (non-binding)
+- Deng Xiaodong
+- Stefan Seelmann
+- Joshua Patchus
+- Felix Uellendall
 
 Vote thread:
 https://lists.apache.org/thread.html/736404ca3d2b2143b296d0910630b9bd0f8b56a0c54e3a05f4c8b5fe@%3Cdev.airflow.apache.org%3E
@@ -513,13 +516,13 @@ cd <YOUR_AIRFLOW_SOURCES>
 export AIRFLOW_SOURCES=$(pwd)
 
 # GO to Checked out DEV repo. Should be checked out before via:
-# svn checkout https://dist.apache.org/repos/dist/dev/airflow airflow-release
+# svn checkout https://dist.apache.org/repos/dist/dev/airflow airflow-dev
 cd <YOUR_AIFLOW_DEV_SVN>
 svn update
 export AIRFLOW_DEV_SVN=$(pwd)
 
 # GO to Checked out RELEASE repo. Should be checked out before via:
-# svn checkout https://dist.apache.org/repos/dist/dev/airflow airflow-release
+# svn checkout https://dist.apache.org/repos/dist/release/airflow airflow-release
 cd <YOUR_AIFLOW_RELEASE_SVN>
 svn update
 
@@ -561,7 +564,7 @@ previously released RC candidates in "${AIRFLOW_SOURCES}/dist":
     twine check dist/*
     ```
 
-- Upload the package to PyPi's test environment:
+- Upload the package to PyPI's test environment:
 
     ```shell script
     twine upload -r pypitest dist/*
@@ -570,7 +573,7 @@ previously released RC candidates in "${AIRFLOW_SOURCES}/dist":
 - Verify that the test package looks good by downloading it and installing it into a virtual environment.
     The package download link is available at: https://test.pypi.org/project/apache-airflow/#files
 
-- Upload the package to PyPi's production environment:
+- Upload the package to PyPI's production environment:
 
     ```shell script
     twine upload -r pypi dist/*
@@ -692,7 +695,7 @@ here:
 
 https://dist.apache.org/repos/dist/release/airflow/${VERSION}/
 
-We also made this version available on PyPi for convenience (`pip install apache-airflow`):
+We also made this version available on PyPI for convenience (`pip install apache-airflow`):
 
 https://pypi.python.org/pypi/apache-airflow
 

--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -126,13 +126,13 @@ rm -rf ${AIRFLOW_REPO_ROOT}/dist/*
 * Release candidate packages:
 
 ```shell script
-./breeze prepare-provider-packages --version-suffix-for-svn rc1 --package-format both
+./breeze prepare-provider-packages --package-format both
 ```
 
 if you ony build few packages, run:
 
 ```shell script
-./breeze prepare-provider-packages --version-suffix-for-svn rc1 --package-format both PACKAGE PACKAGE ....
+./breeze prepare-provider-packages --package-format both PACKAGE PACKAGE ....
 ```
 
 * Sign all your packages
@@ -791,7 +791,7 @@ We also made those versions available on PyPi for convenience ('pip install apac
 
 https://pypi.org/search/?q=apache-airflow-providers
 
-The documentation is available at http://airflow.apache.org/docs/ and linked from the PyPI packages:
+The documentation is available at https://airflow.apache.org/docs/ and linked from the PyPI packages:
 
 <PASTE TWINE UPLOAD LINKS HERE. SORT THEM BEFORE!>
 

--- a/scripts/ci/images/ci_build_dockerhub.sh
+++ b/scripts/ci/images/ci_build_dockerhub.sh
@@ -52,11 +52,10 @@ if [[ ! "${DOCKER_TAG}" =~ ^[0-9].* ]]; then
     echo
     echo "Building airflow from branch or non-release tag: ${DOCKER_TAG}"
     echo
-    # All the packages: Airflow and providers will have a "dev" version suffix in the imaage that
+    # All the packages: Airflow and providers will have a "dev" version suffix in the image that
     # is built from non-release tag. If this is not set, then building images from locally build
     # packages fails, because the packages with non-dev version are skipped (as they are already released)
     export VERSION_SUFFIX_FOR_PYPI=".dev0"
-    export VERSION_SUFFIX_FOR_SVN=".dev0"
     # Only build and push CI image for the nightly-master, v2-0-test branches
     # for tagged releases we build everything from PyPI, so we do not need CI images
     # For development images, we have to build all packages from current sources because we want to produce

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -477,8 +477,6 @@ function initialization::initialize_image_build_variables() {
 function initialization::initialize_provider_package_building() {
     # Version suffix for PyPI packaging
     export VERSION_SUFFIX_FOR_PYPI="${VERSION_SUFFIX_FOR_PYPI=}"
-    # Artifact name suffix for SVN packaging
-    export VERSION_SUFFIX_FOR_SVN="${VERSION_SUFFIX_FOR_SVN=}"
 
 }
 
@@ -665,7 +663,6 @@ Host variables:
 Version suffix variables:
 
     VERSION_SUFFIX_FOR_PYPI=${VERSION_SUFFIX_FOR_PYPI}
-    VERSION_SUFFIX_FOR_SVN=${VERSION_SUFFIX_FOR_SVN}
 
 Git variables:
 
@@ -873,7 +870,6 @@ function initialization::make_constants_read_only() {
     readonly EXTRA_STATIC_CHECK_OPTIONS
 
     readonly VERSION_SUFFIX_FOR_PYPI
-    readonly VERSION_SUFFIX_FOR_SVN
 
     readonly PYTHON_BASE_IMAGE_VERSION
     readonly PYTHON_BASE_IMAGE

--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -370,96 +370,6 @@ function setup_provider_packages() {
     readonly PACKAGE_PREFIX_HYPHEN
 }
 
-function verify_suffix_versions_for_package_preparation() {
-    group_start "Verify suffixes"
-    TARGET_VERSION_SUFFIX=""
-    FILE_VERSION_SUFFIX=""
-
-    VERSION_SUFFIX_FOR_PYPI=${VERSION_SUFFIX_FOR_PYPI:=""}
-    readonly VERSION_SUFFIX_FOR_PYPI
-
-    VERSION_SUFFIX_FOR_SVN=${VERSION_SUFFIX_FOR_SVN:=""}
-
-    if [[ -n "${VERSION_SUFFIX_FOR_PYPI}" ]]; then
-        echo
-        echo "Version suffix for PyPI = ${VERSION_SUFFIX_FOR_PYPI}"
-        echo
-    fi
-    if [[ -n "${VERSION_SUFFIX_FOR_SVN}" ]]; then
-        echo
-        echo "Version suffix for SVN  = ${VERSION_SUFFIX_FOR_SVN}"
-        echo
-    fi
-
-    if [[ ${VERSION_SUFFIX_FOR_SVN} =~ ^rc ]]; then
-        echo """
-${COLOR_YELLOW}WARNING: The version suffix for SVN is used only for file names.
-         The version inside the packages has no version suffix.
-         This way we can just rename files when they graduate to final release.
-${COLOR_RESET}
-"""
-        echo
-        echo "This suffix is added '${VERSION_SUFFIX_FOR_SVN}' "
-        echo
-        FILE_VERSION_SUFFIX=${VERSION_SUFFIX_FOR_SVN}
-        VERSION_SUFFIX_FOR_SVN=""
-    fi
-    readonly FILE_VERSION_SUFFIX
-    readonly VERSION_SUFFIX_FOR_SVN
-
-    export FILE_VERSION_SUFFIX
-    export VERSION_SUFFIX_FOR_SVN
-    export VERSION_SUFFIX_FOR_PYPI
-
-    if [[ ${VERSION_SUFFIX_FOR_PYPI} != '' && ${VERSION_SUFFIX_FOR_SVN} != '' ]]; then
-        if [[ ${VERSION_SUFFIX_FOR_PYPI} != "${VERSION_SUFFIX_FOR_SVN}" ]]; then
-            echo
-            echo "${COLOR_RED}ERROR: If you specify both PyPI and SVN version suffixes they must match  ${COLOR_RESET}"
-            echo
-            echo "However they are different: PyPI:'${VERSION_SUFFIX_FOR_PYPI}' vs. SVN:'${VERSION_SUFFIX_FOR_SVN}'"
-            echo
-            exit 1
-        else
-            if [[ ${VERSION_SUFFIX_FOR_PYPI} =~ ^rc ]]; then
-                echo
-                echo "${COLOR_RED}ERROR: If you prepare an RC candidate, you need to specify only PyPI suffix  ${COLOR_RESET}"
-                echo
-                echo "However you specified both: PyPI'${VERSION_SUFFIX_FOR_PYPI}' and SVN '${VERSION_SUFFIX_FOR_SVN}'"
-                echo
-                exit 2
-            fi
-            # Just use one of them - they are both the same:
-            TARGET_VERSION_SUFFIX=${VERSION_SUFFIX_FOR_PYPI}
-        fi
-    else
-        if [[ ${VERSION_SUFFIX_FOR_PYPI} == '' && ${VERSION_SUFFIX_FOR_SVN} == '' ]]; then
-            # Preparing "official version"
-            TARGET_VERSION_SUFFIX=""
-        else
-
-            if [[ ${VERSION_SUFFIX_FOR_PYPI} == '' ]]; then
-                echo
-                echo "${COLOR_RED}ERROR: You should never specify version for PyPI only.  ${COLOR_RESET}"
-                echo
-                echo "You specified PyPI suffix: '${VERSION_SUFFIX_FOR_PYPI}'"
-                echo
-                exit 3
-            fi
-            TARGET_VERSION_SUFFIX=${VERSION_SUFFIX_FOR_PYPI}${VERSION_SUFFIX_FOR_SVN}
-            if [[ ! ${TARGET_VERSION_SUFFIX} =~ rc.* ]]; then
-                echo
-                echo "${COLOR_RED}ERROR: If you prepare an alpha/beta release, you need to specify both PyPI/SVN suffixes and they have to match.  ${COLOR_RESET}"
-                echo
-                echo "And they have to match. You specified only one suffix:  ${TARGET_VERSION_SUFFIX}."
-                echo
-                exit 4
-            fi
-        fi
-    fi
-    readonly TARGET_VERSION_SUFFIX
-    export TARGET_VERSION_SUFFIX
-    group_end
-}
 
 function install_supported_pip_version() {
     group_start "Install supported PIP version ${AIRFLOW_PIP_VERSION}"
@@ -559,27 +469,6 @@ function check_missing_providers() {
         exit 1
     fi
     rm "$LIST_OF_DIRS_FILE"
-}
-
-function rename_packages_if_needed() {
-    cd "${AIRFLOW_SOURCES}" || exit 1
-    pushd dist >/dev/null 2>&1 || exit 1
-    if [[ -n "${FILE_VERSION_SUFFIX}" ]]; then
-        # In case we have FILE_VERSION_SUFFIX we rename prepared files
-        if [[ "${PACKAGE_FORMAT}" == "sdist" || "${PACKAGE_FORMAT}" == "both" ]]; then
-            for FILE in *.tar.gz
-            do
-                mv "${FILE}" "${FILE//\.tar\.gz/${FILE_VERSION_SUFFIX}.tar.gz}"
-            done
-        fi
-        if [[ "${PACKAGE_FORMAT}" == "wheel" || "${PACKAGE_FORMAT}" == "both" ]]; then
-            for FILE in *.whl
-            do
-                mv "${FILE}" "${FILE//\-py3/${FILE_VERSION_SUFFIX}-py3}"
-            done
-        fi
-    fi
-    popd >/dev/null || exit 1
 }
 
 function get_providers_to_act_on() {

--- a/scripts/in_container/run_prepare_airflow_packages.sh
+++ b/scripts/in_container/run_prepare_airflow_packages.sh
@@ -20,27 +20,13 @@
 
 function prepare_airflow_packages() {
     echo "-----------------------------------------------------------------------------------"
-    if [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' && "${VERSION_SUFFIX_FOR_SVN}" == ''
-            && ${FILE_VERSION_SUFFIX} == '' ]]; then
+    if [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' ]]; then
         echo
         echo "Preparing official version of provider with no suffixes"
         echo
-    elif [[ ${FILE_VERSION_SUFFIX} != '' ]]; then
-        echo
-        echo " Preparing release candidate of providers with file version suffix only (resulting file will be renamed): ${FILE_VERSION_SUFFIX}"
-        echo
-    elif [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' ]]; then
-        echo
-        echo " Package Version of providers of set for SVN version): ${TARGET_VERSION_SUFFIX}"
-        echo
-    elif [[ "${VERSION_SUFFIX_FOR_SVN}" == '' ]]; then
-        echo
-        echo " Package Version of providers suffix set for PyPI version: ${TARGET_VERSION_SUFFIX}"
-        echo
     else
-        # Both SV/PYPI are set to the same version here!
         echo
-        echo " Pre-release version (alpha beta) suffix set in both SVN/PyPI: ${TARGET_VERSION_SUFFIX}"
+        echo " Package Version of providers suffix set for PyPI version: ${VERSION_SUFFIX_FOR_PYPI}"
         echo
     fi
     echo "-----------------------------------------------------------------------------------"
@@ -59,8 +45,7 @@ function prepare_airflow_packages() {
         packages+=("sdist")
     fi
     local tag_build=()
-    if [[ -z "${VERSION_SUFFIX_FOR_SVN}" && -n ${VERSION_SUFFIX_FOR_PYPI} ||
-          -n "${VERSION_SUFFIX_FOR_SVN}" && -n "${VERSION_SUFFIX_FOR_PYPI}" ]]; then
+    if [[ -n ${VERSION_SUFFIX_FOR_PYPI} ]]; then
         # only adds suffix to setup.py if version suffix for PyPI is set but the SVN one is not set
         # (so when rc is prepared)
         # or when they are both set (so when we prepare alpha/beta/dev)
@@ -99,14 +84,9 @@ function prepare_airflow_packages() {
     echo
 }
 
-
-
-verify_suffix_versions_for_package_preparation
-
 install_supported_pip_version
 
 prepare_airflow_packages
-rename_packages_if_needed
 
 echo
 echo "${COLOR_GREEN}All good! Airflow packages are prepared in dist folder${COLOR_RESET}"

--- a/scripts/in_container/run_prepare_provider_documentation.sh
+++ b/scripts/in_container/run_prepare_provider_documentation.sh
@@ -46,7 +46,7 @@ function run_prepare_documentation() {
         # There is a separate group created in logs for each provider package
         python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
             update-package-documentation \
-            --version-suffix "${TARGET_VERSION_SUFFIX}" \
+            --version-suffix "${VERSION_SUFFIX_FOR_PYPI}" \
             --no-git-update \
             "${OPTIONAL_VERBOSE_FLAG[@]}" \
             "${OPTIONAL_RELEASE_VERSION_ARGUMENT[@]}" \
@@ -110,8 +110,6 @@ setup_provider_packages
 cd "${AIRFLOW_SOURCES}" || exit 1
 
 export PYTHONPATH="${AIRFLOW_SOURCES}"
-
-verify_suffix_versions_for_package_preparation
 
 install_supported_pip_version
 import_all_provider_classes

--- a/scripts/in_container/run_prepare_provider_packages.sh
+++ b/scripts/in_container/run_prepare_provider_packages.sh
@@ -44,27 +44,13 @@ function build_provider_packages() {
     local error_packages=()
 
     echo "-----------------------------------------------------------------------------------"
-    if [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' && "${VERSION_SUFFIX_FOR_SVN}" == ''
-            && ${FILE_VERSION_SUFFIX} == '' ]]; then
+    if [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' ]]; then
         echo
         echo "Preparing official version of provider with no suffixes"
         echo
-    elif [[ ${FILE_VERSION_SUFFIX} != '' ]]; then
-        echo
-        echo " Preparing release candidate of providers with file version suffix only (resulting file will be renamed): ${FILE_VERSION_SUFFIX}"
-        echo
-    elif [[ "${VERSION_SUFFIX_FOR_PYPI}" == '' ]]; then
-        echo
-        echo " Package Version of providers of set for SVN version): ${TARGET_VERSION_SUFFIX}"
-        echo
-    elif [[ "${VERSION_SUFFIX_FOR_SVN}" == '' ]]; then
-        echo
-        echo " Package Version of providers suffix set for PyPI version: ${TARGET_VERSION_SUFFIX}"
-        echo
     else
-        # Both SV/PYPI are set to the same version here!
         echo
-        echo " Pre-release version (alpha beta) suffix set in both SVN/PyPI: ${TARGET_VERSION_SUFFIX}"
+        echo " Package Version of providers suffix set for PyPI version: ${VERSION_SUFFIX_FOR_PYPI}"
         echo
     fi
     echo "-----------------------------------------------------------------------------------"
@@ -96,11 +82,8 @@ function build_provider_packages() {
         fi
         set +e
         package_suffix=""
-        if [[ -z "${VERSION_SUFFIX_FOR_SVN}" && -n ${VERSION_SUFFIX_FOR_PYPI} ||
-              -n "${VERSION_SUFFIX_FOR_SVN}" && -n "${VERSION_SUFFIX_FOR_PYPI}" ]]; then
-            # only adds suffix to setup.py if version suffix for PyPI is set but the SVN one is not set
-            # (so when rc is prepared)
-            # or when they are both set (so when we prepare alpha/beta/dev)
+        if [[ -n ${VERSION_SUFFIX_FOR_PYPI} ]]; then
+            # only adds suffix to setup.py if version suffix for PyPI is set
             package_suffix="${VERSION_SUFFIX_FOR_PYPI}"
         fi
         python3 "${PROVIDER_PACKAGES_DIR}/prepare_provider_packages.py" \
@@ -152,8 +135,6 @@ setup_provider_packages
 
 cd "${PROVIDER_PACKAGES_DIR}" || exit 1
 
-verify_suffix_versions_for_package_preparation
-
 install_supported_pip_version
 
 PROVIDER_PACKAGES=("${@}")
@@ -161,7 +142,6 @@ get_providers_to_act_on "${@}"
 
 copy_sources
 build_provider_packages
-rename_packages_if_needed
 
 echo
 echo "${COLOR_GREEN}All good! Airflow packages are prepared in dist folder${COLOR_RESET}"


### PR DESCRIPTION
Reason explained in https://lists.apache.org/thread.html/rca430c836e5286b6d848831bdbc4f37fe5d6620ee9757e93b401495a%40%3Cdev.airflow.apache.org%3E

While working on the Helm Chart release, I was verifying what we were doing for "apache-airflow/python dists" over the weekend, which is "wrong".

We should be renaming the files as the SHA512 check fails on "Release" repo: https://dist.apache.org/repos/dist/release/airflow/2.0.2/

For example, check out 2.0.2 release on Airflow:

Since the SHA512 were generated with the original filename (with rc in it), it fails now in filename part:

```shell
❯ for i in *.sha512
do
    echo "Checking $i"; shasum -a 512 `basename $i .sha512 ` | diff - $i
done
Checking apache-airflow-2.0.2-bin.tar.gz.sha512
1c1
< 4281b3ff5d5b483c74970f8128d7ad8ba699081086fd098e10b12f8b52a7d0f92a205d7ea334c29e813ac06af7a26de416294fd18c3a1a949388a4824955ce2e  apache-airflow-2.0.2-bin.tar.gz
---
> 4281b3ff5d5b483c74970f8128d7ad8ba699081086fd098e10b12f8b52a7d0f92a205d7ea334c29e813ac06af7a26de416294fd18c3a1a949388a4824955ce2e  apache-airflow-2.0.2rc1-bin.tar.gz
Checking apache-airflow-2.0.2-source.tar.gz.sha512
1c1
< ca783369f9044796bc575bf18b986ac86998b007d01f8ff2a8c9635454d05f39fb09ce010d62249cf91badc83fd5b38c04f2b39e32830ccef70f601c5829dcb7  apache-airflow-2.0.2-source.tar.gz
---
> ca783369f9044796bc575bf18b986ac86998b007d01f8ff2a8c9635454d05f39fb09ce010d62249cf91badc83fd5b38c04f2b39e32830ccef70f601c5829dcb7  apache-airflow-2.0.2rc1-source.tar.gz
Checking apache_airflow-2.0.2-py3-none-any.whl.sha512
1c1
< 779563fd88256980ff8a994a9796d7fd18e579853c33d61e1603b084f4d150e83b3209bf1a9cd438c4dd08240b1ee48b139690ee208f80478b5b2465b7183e50  apache_airflow-2.0.2-py3-none-any.whl
---
> 779563fd88256980ff8a994a9796d7fd18e579853c33d61e1603b084f4d150e83b3209bf1a9cd438c4dd08240b1ee48b139690ee208f80478b5b2465b7183e50  apache_airflow-2.0.2rc1-py3-none-any.whl
```

I was also checking how other projects did it, Apache Spark for instance, they also just have the "rc" name in the directory
and that is all: https://dist.apache.org/repos/dist/dev/spark/v2.4.8-rc3-bin/ so it is easy to
"just move" from "dev" to "release" without changing anything.

For Airflow releases since we already do it in a directory that is named "VERSION-rcX" (example: `2.1.0rc1` in https://dist.apache.org/repos/dist/dev/airflow/2.1.0rc1/)
we don't need to add rcX in the filename of the artifact.

This helps us just moving files without renaming and changing filenames in SHA512 and is released exactly with what was voted on.

For Providers, looks like we were never adding suffix anyway:  example: https://dist.apache.org/repos/dist/dev/airflow/providers/

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
