### PR TITLE
Add missing License details for ``Connexion``

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -220,6 +220,7 @@ at licenses/LICENSE-[project].txt.
     (ALv2 License) hue v4.3.0 (https://github.com/cloudera/hue/)
     (ALv2 License) jqclock v2.3.0 (https://github.com/JohnRDOrazio/jQuery-Clock-Plugin)
     (ALv2 License) bootstrap3-typeahead v4.0.2 (https://github.com/bassjobsen/Bootstrap-3-Typeahead)
+    (ALv2 License) connexion v2.7.0 (https://github.com/zalando/connexion)
 
 ========================================================================
 MIT licenses


### PR DESCRIPTION
This was missed in https://github.com/apache/airflow/pull/15781

Since "connexion" is Apache licensed, this is "not a blocker" for 2.1.0 as mentioned in https://www.apache.org/legal/release-policy.html#license-file

>When a package bundles code under several licenses, the LICENSE file MUST contain details of all these licenses. For each component which is not Apache licensed, details of the component MUST be appended to the LICENSE file. The component license itself MUST either be appended or else stored elsewhere in the package with a pointer to it from the LICENSE file, e.g. if the license is long.

As "connexton" is Apache 2 Licensed, this _might_ be OK.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
