### PR TITLE
Fix append mode for WASB remote logging on v12

### DIFF
--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -189,7 +189,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
                 log,
                 self.wasb_container,
                 remote_log_location,
-                overwrite=True
+                overwrite=append
             )
         except AzureHttpError:
             self.log.exception('Could not write logs to %s', remote_log_location)

--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -189,6 +189,7 @@ class WasbTaskHandler(FileTaskHandler, LoggingMixin):
                 log,
                 self.wasb_container,
                 remote_log_location,
+                overwrite=True
             )
         except AzureHttpError:
             self.log.exception('Could not write logs to %s', remote_log_location)


### PR DESCRIPTION
Fix the append mode for wasb remote logging.

closes: https://github.com/apache/airflow/issues/15907
