### PR TITLE
Add usage for --package-filter option

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -57,16 +57,17 @@ or just to run documentation building
 
      ./breeze build-docs -- --docs-only
 
-Also, you can only build one documentation via ``--package-filter`` option.
+Also, you can only build one documentation via ``--package-filter``.
 
 .. code-block:: bash
 
     ./breeze build-docs -- --package-filter <PACKAGE-NAME>
-You can also see all the available commands via:
+
+You can also see all the available arguments via ``--help``.
 
 .. code-block:: bash
 
-        ./breeze build-docs -- --help
+    ./breeze build-docs -- --help
 
 Running the Docs Locally
 ------------------------

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -57,6 +57,12 @@ or just to run documentation building
 
      ./breeze build-docs -- --docs-only
 
+Also, you can only build one documentation via ``--package-filter`` option.
+
+.. code-block:: bash
+
+    ./breeze build-docs -- --package-filter <PACKAGE-NAME>
+
 Running the Docs Locally
 ------------------------
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -62,6 +62,11 @@ Also, you can only build one documentation via ``--package-filter`` option.
 .. code-block:: bash
 
     ./breeze build-docs -- --package-filter <PACKAGE-NAME>
+You can also see all the available commands via:
+
+.. code-block:: bash
+
+        ./breeze build-docs -- --help
 
 Running the Docs Locally
 ------------------------


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This is a suggestion pull request to add usage for `--package-filter` option.

Building the whole documentation is time-consuming and there is no easy way to know how to limit the number of documents to be built. `./breeze build-docs --help` shows possible extra args of `build-docs` sub-command, but doesn't show how to use them.

I think it is important that users can tell how to build only the documents they specify by reading `docs/README.rst` .

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
