### PR TITLE
Add an optional `on_error` kwargs for `S3ToSnowflakeOperator`

### DIFF
--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -45,6 +45,8 @@ class S3ToSnowflakeOperator(BaseOperator):
     :type prefix: str
     :param file_format: reference to a specific file format
     :type file_format: str
+    :param on_error: const that specifies the action to perform when an error is encountered while loading data from a file
+    :type on_error: str
     :param warehouse: name of warehouse (will overwrite any warehouse
         defined in the connection's extra JSON)
     :type warehouse: str
@@ -70,6 +72,8 @@ class S3ToSnowflakeOperator(BaseOperator):
         the time you connect to Snowflake
     :type session_parameters: dict
     """
+    
+    template_fields = ("s3_keys",)
 
     def __init__(
         self,
@@ -79,6 +83,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         stage: str,
         prefix: Optional[str] = None,
         file_format: str,
+        on_error: Optional[str] = None,
         schema: Optional[str] = None,
         columns_array: Optional[list] = None,
         warehouse: Optional[str] = None,
@@ -98,6 +103,7 @@ class S3ToSnowflakeOperator(BaseOperator):
         self.stage = stage
         self.prefix = prefix
         self.file_format = file_format
+        self.on_error = on_error
         self.schema = schema
         self.columns_array = columns_array
         self.autocommit = autocommit
@@ -132,6 +138,9 @@ class S3ToSnowflakeOperator(BaseOperator):
             files = ", ".join(f"'{key}'" for key in self.s3_keys)
             sql_parts.append(f"files=({files})")
         sql_parts.append(f"file_format={self.file_format}")
+
+        if self.on_error:
+            sql_parts.append(f"on_error={self.on_error}")
 
         copy_query = "\n".join(sql_parts)
 

--- a/airflow/providers/snowflake/transfers/s3_to_snowflake.py
+++ b/airflow/providers/snowflake/transfers/s3_to_snowflake.py
@@ -72,8 +72,6 @@ class S3ToSnowflakeOperator(BaseOperator):
         the time you connect to Snowflake
     :type session_parameters: dict
     """
-    
-    template_fields = ("s3_keys",)
 
     def __init__(
         self,

--- a/tests/providers/snowflake/transfers/test_s3_to_snowflake.py
+++ b/tests/providers/snowflake/transfers/test_s3_to_snowflake.py
@@ -28,8 +28,9 @@ class TestS3ToSnowflakeTransfer:
     @pytest.mark.parametrize("s3_keys", [None, ['1.csv', '2.csv']])
     @pytest.mark.parametrize("prefix", [None, 'prefix'])
     @pytest.mark.parametrize("schema", [None, 'schema'])
+    @pytest.mark.parametrize("on_error", [None, 'CONTINUE'])
     @mock.patch("airflow.providers.snowflake.hooks.snowflake.SnowflakeHook.run")
-    def test_execute(self, mock_run, schema, prefix, s3_keys, columns_array):
+    def test_execute(self, mock_run, schema, prefix, s3_keys, columns_array, on_error):
         table = 'table'
         stage = 'stage'
         file_format = 'file_format'
@@ -59,6 +60,9 @@ class TestS3ToSnowflakeTransfer:
         if s3_keys:
             files = ", ".join(f"'{key}'" for key in s3_keys)
             copy_query += f"\nfiles=({files})"
+
+        if on_error:
+            copy_query += f"\non_error={on_error}"
 
         copy_query += f"\nfile_format={file_format}"
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adds an optional kwargs `on_error` that specifies the action Snowflake has to perform when an error is encountered while loading data from a file.

 