### PR TITLE
Add in extra columns to TaskInstance.refresh_from_db

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -622,7 +622,10 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
             self.priority_weight = ti.priority_weight
             self.operator = ti.operator
             self.queued_dttm = ti.queued_dttm
+            self.queued_by_job_id = ti.queued_by_job_id
             self.pid = ti.pid
+            self.executor_config = ti.executor_config
+            self.external_executor_id = ti.external_executor_id
         else:
             self.state = None
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2066,7 +2066,8 @@ def test_refresh_from_db():
     ti = TI(task=task, execution_date=datetime.datetime.now())
 
     # We only care about columns that are not primary keys
-    columns = [column for column in ti.__table__.columns if not column.primary_key]
+    # pylint: disable=no-member
+    columns = [column for column in TI.__table__.columns if not column.primary_key]
 
     for column in columns:
         setattr(ti, column.name, 'NOT_REFRESHED')

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2057,6 +2057,26 @@ def test_refresh_from_task(pool_override):
     assert ti.operator == DummyOperator.__name__
 
 
+def test_refresh_from_db():
+    """
+    Test that all columns defined on the TaskInstance are refreshed form the db
+    """
+    dag = DAG('dag', start_date=DEFAULT_DATE)
+    task = DummyOperator(task_id='op', dag=dag)
+    ti = TI(task=task, execution_date=datetime.datetime.now())
+
+    # We only care about columns that are not primary keys
+    columns = [column for column in ti.__table__.columns if not column.primary_key]
+
+    for column in columns:
+        setattr(ti, column.name, 'NOT_REFRESHED')
+
+    ti.refresh_from_db()
+
+    for column in columns:
+        assert getattr(ti, column.name) != 'NOT_REFRESHED'
+
+
 class TestRunRawTaskQueriesCount(unittest.TestCase):
     """
     These tests are designed to detect changes in the number of queries executed

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2059,9 +2059,9 @@ def test_refresh_from_task(pool_override):
 
 def test_refresh_from_db():
     """
-    Test that all columns defined on the TaskInstance are refreshed form the db
+    Test that all columns defined on the TaskInstance are refreshed from the db
     """
-    dag = DAG('dag', start_date=DEFAULT_DATE)
+    dag = DAG('test_refresh_from_db', start_date=DEFAULT_DATE)
     task = DummyOperator(task_id='op', dag=dag)
     ti = TI(task=task, execution_date=datetime.datetime.now())
 


### PR DESCRIPTION
Incorrect values where showing in the TaskInstance detail view because these columns where missing from the refresh_from_db method
