### PR TITLE
Properly set the try_number when rescheduling

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -196,6 +196,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
 
     def execute(self, context: Dict) -> Any:
         started_at = None
+        try_number = 1
 
         if self.reschedule:
 
@@ -220,7 +221,6 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
                 nonlocal started_at
                 return time.monotonic() - started_at
 
-        try_number = 1
         log_dag_id = self.dag.dag_id if self.has_dag() else ""
 
         while not self.poke(context):


### PR DESCRIPTION
When a sensor is set to `rescheduling` mode, try_number is incremented but then immediately reset to 1, which in turn breaks exponential_backoff. 