### PR TITLE
fix dag dependency search

### DIFF
--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -136,7 +136,7 @@ function setUpNodeHighlighting(focusItem = null) {
 function searchboxHighlighting(s) {
   let match = null;
 
-  d3.selectAll('g.nodes g.node').forEach(function forEach(d) {
+  d3.selectAll('g.nodes g.node').filter(function forEach(d) {
     if (s === '') {
       d3.select('g.edgePaths')
         .transition().duration(duration)
@@ -165,6 +165,7 @@ function searchboxHighlighting(s) {
           .style('stroke-width', initialStrokeWidth);
       }
     }
+    return null;
   });
 
   // This moves the matched node to the center of the graph area


### PR DESCRIPTION
Similar to #15901. Use `.filter()` instead of `.forEach()` when highlighting nodes in dag dependency view

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
