### PR TITLE
Fail tasks in scheduler when executor reports they failed

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1239,6 +1239,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                     "task says its %s. (Info: %s) Was the task killed externally?"
                 )
                 self.log.error(msg, ti, state, ti.state, info)
+                self.log.info('Setting task instance %s state to %s as reported by executor', ti, state)
+                ti.set_state(state)
                 request = TaskCallbackRequest(
                     full_filepath=ti.dag_model.fileloc,
                     simple_task_instance=SimpleTaskInstance(ti),

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1239,14 +1239,14 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
                     "task says its %s. (Info: %s) Was the task killed externally?"
                 )
                 self.log.error(msg, ti, state, ti.state, info)
-                self.log.info('Setting task instance %s state to %s as reported by executor', ti, state)
-                ti.set_state(state)
+
                 request = TaskCallbackRequest(
                     full_filepath=ti.dag_model.fileloc,
                     simple_task_instance=SimpleTaskInstance(ti),
                     msg=msg % (ti, state, ti.state, info),
                 )
-
+                self.log.info('Setting task instance %s state to %s as reported by executor', ti, state)
+                ti.set_state(state)
                 self.processor_agent.send_callback_to_execute(request)
 
         return len(event_buffer)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -907,13 +907,13 @@ class TestSchedulerJob(unittest.TestCase):
 
         self.scheduler_job._process_executor_events(session=session)
         ti1.refresh_from_db()
-        assert ti1.state == State.QUEUED
+        assert ti1.state == State.FAILED
         mock_task_callback.assert_called_once_with(
             full_filepath='/test_path1/',
             simple_task_instance=mock.ANY,
             msg='Executor reports task instance '
-            '<TaskInstance: test_process_executor_events.dummy_task 2016-01-01 00:00:00+00:00 [queued]> '
-            'finished (failed) although the task says its queued. (Info: None) '
+            '<TaskInstance: test_process_executor_events.dummy_task 2016-01-01 00:00:00+00:00 [failed]> '
+            'finished (failed) although the task says its failed. (Info: None) '
             'Was the task killed externally?',
         )
         self.scheduler_job.processor_agent.send_callback_to_execute.assert_called_once_with(task_callback)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -912,8 +912,8 @@ class TestSchedulerJob(unittest.TestCase):
             full_filepath='/test_path1/',
             simple_task_instance=mock.ANY,
             msg='Executor reports task instance '
-            '<TaskInstance: test_process_executor_events.dummy_task 2016-01-01 00:00:00+00:00 [failed]> '
-            'finished (failed) although the task says its failed. (Info: None) '
+            '<TaskInstance: test_process_executor_events.dummy_task 2016-01-01 00:00:00+00:00 [queued]> '
+            'finished (failed) although the task says its queued. (Info: None) '
             'Was the task killed externally?',
         )
         self.scheduler_job.processor_agent.send_callback_to_execute.assert_called_once_with(task_callback)


### PR DESCRIPTION
When a task fails in executor while still queued in scheduler, the executor reports
this failure but scheduler doesn't change the task state resulting in the task
being queued until the scheduler is restarted. This commit fixes it by ensuring
that when a task is reported to have failed in the executor, the task is failed
in scheduler


This can be reproduced with CeleryExecutor in breeze
1. Start breeze without redis integration
2. start the webserver and scheduler
3. Run a dag e.g example_bash_operator.py
4. The CeleryExecutor will raise exceptions and fails the task
4. Notice that the tasks remain queued


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
