### PR TITLE
Show subdag code in subdag codeview

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1884,13 +1884,12 @@ class DAG(LoggingMixin):
             dag = dag_by_ids[orm_dag.dag_id]
             if dag.is_subdag:
                 orm_dag.is_subdag = True
-                orm_dag.fileloc = dag.parent_dag.fileloc  # type: ignore
                 orm_dag.root_dag_id = dag.parent_dag.dag_id  # type: ignore
                 orm_dag.owners = dag.parent_dag.owner  # type: ignore
             else:
                 orm_dag.is_subdag = False
-                orm_dag.fileloc = dag.fileloc
                 orm_dag.owners = dag.owner
+            orm_dag.fileloc = dag.fileloc
             orm_dag.is_active = True
             orm_dag.last_parsed_time = timezone.utcnow()
             orm_dag.default_view = dag.default_view

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -871,10 +871,13 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         """Dag Code."""
         all_errors = ""
         dag_orm = None
-        dag_id = None
+        dag_id = request.args.get('dag_id')
+        dag = current_app.dag_bag.get_dag(dag_id)
+        if not dag:
+            flash(f'DAG "{dag_id}" seems to be missing from DagBag.', "error")
+            return redirect(url_for('Airflow.index'))
 
         try:
-            dag_id = request.args.get('dag_id')
             dag_orm = DagModel.get_dagmodel(dag_id, session=session)
             code = DagCode.get_code_by_fileloc(dag_orm.fileloc)
             html_code = Markup(
@@ -895,7 +898,7 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         return self.render_template(
             'airflow/dag_code.html',
             html_code=html_code,
-            dag=dag_orm,
+            dag=dag,
             title=dag_id,
             root=request.args.get('root'),
             wrapped=conf.getboolean('webserver', 'default_wrap'),

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -79,6 +79,7 @@ class TestTaskInstanceEndpoint:
         clear_db_sla_miss()
         DagBag(include_examples=True, read_dags_from_db=False).sync_to_db()
         self.dagbag = DagBag(include_examples=True, read_dags_from_db=True)
+        configured_app.dag_bag = self.dagbag
 
     def create_task_instances(
         self,

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -732,12 +732,14 @@ class TestDag(unittest.TestCase):
             'dag',
             start_date=DEFAULT_DATE,
         )
+        dag.fileloc = 'dag_dummy_path'
         with dag:
             DummyOperator(task_id='task', owner='owner1')
             subdag = DAG(
                 'dag.subtask',
                 start_date=DEFAULT_DATE,
             )
+            subdag.fileloc = 'subdag_dummy_path'
             # parent_dag and is_subdag was set by DagBag. We don't use DagBag, so this value is not set.
             subdag.parent_dag = dag
             subdag.is_subdag = True
@@ -751,12 +753,13 @@ class TestDag(unittest.TestCase):
         assert orm_dag.default_view is not None
         assert orm_dag.default_view == conf.get('webserver', 'dag_default_view').lower()
         assert orm_dag.safe_dag_id == 'dag'
+        assert orm_dag.fileloc == 'dag_dummy_path'
 
         orm_subdag = session.query(DagModel).filter(DagModel.dag_id == 'dag.subtask').one()
         assert set(orm_subdag.owners.split(', ')) == {'owner1', 'owner2'}
         assert orm_subdag.is_active
         assert orm_subdag.safe_dag_id == 'dag__dot__subtask'
-        assert orm_subdag.fileloc == orm_dag.fileloc
+        assert orm_subdag.fileloc == 'subdag_dummy_path'
         session.close()
 
     def test_sync_to_db_default_view(self):


### PR DESCRIPTION
Code of subdag is helpful on the web-UI. closes: https://github.com/apache/airflow/issues/9994

In addition, I change codeview of subdag like follow for consistent with other view.
![image](https://user-images.githubusercontent.com/8097526/118907741-a9134000-b952-11eb-8362-2289104d575a.png)

before:
![image](https://user-images.githubusercontent.com/8097526/118908618-563a8800-b954-11eb-935c-c9ed4f955a1c.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
