### PR TITLE
Correctly implement autocomplete early return

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3942,7 +3942,7 @@ class DagModelView(AirflowModelView):
         query = unquote(request.args.get('query', ''))
 
         if not query:
-            wwwutils.json_response([])
+            return wwwutils.json_response([])
 
         # Provide suggestions of dag_ids and owners
         dag_ids_query = session.query(DagModel.dag_id.label('item')).filter(  # pylint: disable=no-member
@@ -4162,7 +4162,7 @@ class CustomUserDBModelView(UserDBModelView):
         """Returns appropriate permission name depending on request method name."""
         if request:
             action_name = request.view_args.get("name")
-            _, method_name = request.url_rule.endpoint.split(".")
+            _, method_name = request.url_rule.endpoint.rsplit(".", 1)
             if method_name == 'action' and action_name:
                 return self.class_permission_name_mapping.get(action_name, self._class_permission_name)
             if method_name:

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -258,6 +258,23 @@ def test_dag_autocomplete_success(client_all_dags):
     check_content_not_in_response('example_subdag_operator', resp)
 
 
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        (None, []),
+        ("", []),
+        ("no-found", []),
+    ],
+    ids=["none", "empty", "not-found"],
+)
+def test_dag_autocomplete_empty(client_all_dags, query, expected):
+    url = "dagmodel/autocomplete"
+    if query is not None:
+        url = f"{url}?query={query}"
+    resp = client_all_dags.get(url, follow_redirects=False)
+    assert resp.json == expected
+
+
 @pytest.fixture(scope="module")
 def user_all_dags_dagruns(acl_app):
     return create_user(


### PR DESCRIPTION
Found this bug while working on #15525. This is properly tested now.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
