### PR TITLE
Test coverage on the autocomplete view

### DIFF
--- a/airflow/www/extensions/init_views.py
+++ b/airflow/www/extensions/init_views.py
@@ -49,7 +49,7 @@ def init_appbuilder_views(app):
     # Remove the session from scoped_session registry to avoid
     # reusing a session with a disconnected connection
     appbuilder.session.remove()
-    appbuilder.add_view_no_menu(views.DagModelView())
+    appbuilder.add_view_no_menu(views.AutocompleteView())
     appbuilder.add_view_no_menu(views.Airflow())
     appbuilder.add_view(
         views.DagRunModelView,

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -29,7 +29,7 @@
   <meta name="dags_index" content="{{ url_for('Airflow.index') }}">
   <meta name="paused_url" content="{{ url_for('Airflow.paused') }}">
   <meta name="status_filter" content="{{ status_filter }}">
-  <meta name="autocomplete_url" content="{{ url_for('DagModelView.autocomplete') }}">
+  <meta name="autocomplete_url" content="{{ url_for('AutocompleteView.autocomplete') }}">
   <meta name="graph_url" content="{{ url_for('Airflow.graph') }}">
   <meta name="dag_run_url" content="{{ url_for('DagRunModelView.list') }}">
   <meta name="task_instance_url" content="{{ url_for('TaskInstanceModelView.list') }}">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -82,7 +82,7 @@ from pendulum.datetime import DateTime
 from pendulum.parsing.exceptions import ParserError
 from pygments import highlight, lexers
 from pygments.formatters import HtmlFormatter
-from sqlalchemy import Date, and_, desc, func, or_, union_all
+from sqlalchemy import Date, and_, desc, func, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 from wtforms import SelectField, validators
@@ -4184,58 +4184,12 @@ class TaskInstanceModelView(AirflowModelView):
         return redirect(self.get_redirect())
 
 
-class DagModelView(AirflowModelView):
-    """View to show records from DAG table"""
+class AutocompleteView(AirflowBaseView):
+    """View to provide autocomplete results"""
 
-    route_base = '/dagmodel'
-
-    datamodel = AirflowModelView.CustomSQLAInterface(DagModel)  # type: ignore
-
-    class_permission_name = permissions.RESOURCE_DAG
-    method_permission_name = {
-        'list': 'read',
-        'show': 'read',
-    }
-    base_permissions = [
-        permissions.ACTION_CAN_READ,
-        permissions.ACTION_CAN_EDIT,
-        permissions.ACTION_CAN_DELETE,
-    ]
-
-    list_columns = [
-        'dag_id',
-        'is_paused',
-        'last_parsed_time',
-        'last_expired',
-        'scheduler_lock',
-        'fileloc',
-        'owners',
-    ]
-
-    formatters_columns = {'dag_id': wwwutils.dag_link}
-
-    base_filters = [['dag_id', DagFilter, lambda: []]]
-
-    def get_query(self):
-        """Default filters for model"""
-        return (
-            super()
-            .get_query()
-            .filter(or_(models.DagModel.is_active, models.DagModel.is_paused))
-            .filter(~models.DagModel.is_subdag)
-        )
-
-    def get_count_query(self):
-        """Default filters for model"""
-        return super().get_count_query().filter(models.DagModel.is_active).filter(~models.DagModel.is_subdag)
-
-    @auth.has_access(
-        [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
-        ]
-    )
+    @auth.has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
     @provide_session
-    @expose('/autocomplete')
+    @expose('/dagmodel/autocomplete')
     def autocomplete(self, session=None):
         """Autocomplete."""
         query = unquote(request.args.get('query', ''))


### PR DESCRIPTION
Continuing #15525. This does two things:

1. Make all branches in the `autocomplete` view properly covered.
2. Convert the `DagModelView` class into a non-model base view class, and rename it to `AutocompleteView` to reflect its usage. Nothing in the class (it has only one view function `autocomplete`) ever used any of the model-related features, so all dead code and should go away.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
