### PR TITLE
Applied permissions to self._error_file

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -17,9 +17,10 @@
 # under the License.
 """Base task runner"""
 import os
-from pwd import getpwnam
 import subprocess
 import threading
+
+from pwd import getpwnam
 from tempfile import NamedTemporaryFile
 from typing import Optional, Union
 

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -19,7 +19,6 @@
 import os
 import subprocess
 import threading
-
 from pwd import getpwnam
 from tempfile import NamedTemporaryFile
 from typing import Optional, Union

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -89,7 +89,10 @@ class BaseTaskRunner(LoggingMixin):
         
         # Avoid executing chown when run_as_user is set to None
         if self.run_as_user:
-            os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)
+            try:
+                os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)
+            except Exception:
+                pass
   
         self._cfg_path = cfg_path
         self._command = (

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -17,11 +17,11 @@
 # under the License.
 """Base task runner"""
 import os
+from pwd import getpwnam
 import subprocess
 import threading
 from tempfile import NamedTemporaryFile
 from typing import Optional, Union
-from pwd import getpwnam
 
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
@@ -86,14 +86,14 @@ class BaseTaskRunner(LoggingMixin):
             cfg_path = tmp_configuration_copy(chmod=0o600)
 
         self._error_file = NamedTemporaryFile(delete=True)
-        
+
         # Avoid executing chown when run_as_user is set to None
         if self.run_as_user:
             try:
                 os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)
             except Exception:
                 pass
-  
+
         self._cfg_path = cfg_path
         self._command = (
             popen_prepend

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -85,6 +85,7 @@ class BaseTaskRunner(LoggingMixin):
             cfg_path = tmp_configuration_copy(chmod=0o600)
 
         self._error_file = NamedTemporaryFile(delete=True)
+        os.chmod(self._error_file.name, 0o0777)
         self._cfg_path = cfg_path
         self._command = (
             popen_prepend

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -86,8 +86,6 @@ class BaseTaskRunner(LoggingMixin):
             cfg_path = tmp_configuration_copy(chmod=0o600)
 
         self._error_file = NamedTemporaryFile(delete=True)
-
-        # Avoid executing chown when run_as_user is set to None
         if self.run_as_user:
             try:
                 os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -87,10 +87,7 @@ class BaseTaskRunner(LoggingMixin):
 
         self._error_file = NamedTemporaryFile(delete=True)
         if self.run_as_user:
-            try:
-                os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)
-            except Exception:
-                pass
+            os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)
 
         self._cfg_path = cfg_path
         self._command = (


### PR DESCRIPTION
As explained at the issue [#15946](https://github.com/apache/airflow/issues/15946) the Web UI does not show the log for tasks that failed when the owner of the DAG is not airflow or the DAG is being executed by another user (run_as_user parameter). When airflow is dumping the error to the temporary file, it opens the file for writing and raises a Permission Denied error, since it's created with restricted permissions. Any default user cannot write into the file, only read.

The NamedTemporaryFile created at the base_task_runner creates the file with the umask 600 and that module does not allow to pass custom permissions when creating the object. 

To avoid this problem, i've added a os.chmod after creating the NamedTemporaryFile at the base_task_runner module. After that, no Permission Denied is thrown when a task fails and the log is accessible through the Web UI.

No major changes were made, only the chmod being applied solved the problem.

Closes https://github.com/apache/airflow/issues/15946