### PR TITLE
Fix Snowflake support in SqlOperator

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -306,6 +306,9 @@ class Connection(Base, LoggingMixin):
         elif self.conn_type == 'grpc':
             from airflow.contrib.hooks.grpc_hook import GrpcHook
             return GrpcHook(grpc_conn_id=self.conn_id)
+        elif self.conn_type == 'snowflake':
+            from airflow.contrib.hooks.snowflake_hook import SnowflakeHook
+            return SnowflakeHook(snowflake_conn_id=self.conn_id)
         raise AirflowException("Unknown hook type {}".format(self.conn_type))
 
     def __repr__(self):


### PR DESCRIPTION
This PR closes #15948 by adding support for `snowflake` connection types to the list in `get_hook` in the Connection class.

Two comments for reviewers:

1. I wasn't sure if it was appropriate to add tests for this somewhere. It seems that either in `test_core.py` or `test_sql_sensor.py` would be appropriate, but none of the existing tests in either of those files seemed relevant to this sort of change (they don't exhaustively test the different hook types). Happy to add something if pointed in the right direction, though. As noted in the Issue, I have tested and implemented this change already in my company's internal environment.
2. I wasn't exactly sure what the right base branch was for a change that only seems to affect 1.10.x branches. I haven't used or looked at Airflow 2.x code in detail to know if the same issue exists there, but the code does seem refactored to remove this big if-else block in the master branch. Please let me know if this should have a different base branch.

Thanks for your review!

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
