### PR TITLE
Add warning about missing knownHosts

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -65,3 +65,17 @@ You can get Fernet Key value by running the following:
     echo Fernet Key: $(kubectl get secret --namespace {{ .Release.Namespace }} {{ .Release.Name }}-fernet-key -o jsonpath="{.data.fernet-key}" | base64 --decode)
 
 {{- end }}
+
+{{- if and .Values.dags.gitSync.enabled .Values.dags.gitSync.sshKeySecret (not .Values.dags.gitSync.knownHosts)}}
+
+#####################################################
+#  WARNING: You should set dags.gitSync.knownHosts  #
+#####################################################
+
+You are using ssh authentication for your gitsync repo, however you currently have SSH known_hosts verification disabled,
+making you susceptible to man-in-the-middle attacks!
+
+Information on how to set knownHosts can be found here:
+https://airflow.apache.org/docs/helm-chart/latest/production-guide.html#knownhosts
+
+{{- end }}

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -72,6 +72,38 @@ DAG Files
 
 See :doc:`manage-dags-files`.
 
+.. _production-guide:knownhosts:
+
+knownHosts
+^^^^^^^^^^
+
+If you are using ``dags.gitSync.sshKeySecret``, you should also set ``dags.gitSync.knownHosts``. Here we will show the process
+for GitHub, but the same can be done for any provider:
+
+Grab GitHub's public key:
+
+.. code-block:: bash
+
+    ssh-keyscan -t rsa github.com > github_public_key
+
+Next, print the fingerprint for the public key:
+
+.. code-block:: bash
+
+    ssh-keygen -lf github_public_key
+
+Compare that output with `GitHub's SSH key fingerprints <https://docs.github.com/en/github/authenticating-to-github/githubs-ssh-key-fingerprints>`_.
+
+They match, right? Good. Now, add the public key to your values. It'll look something like this:
+
+.. code-block:: yaml
+
+    dags:
+      gitSync:
+        knownHosts: |
+          github.com ssh-rsa AAAA...FAaQ==
+
+
 Accessing the Airflow UI
 ------------------------
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -945,6 +945,7 @@ keytab
 killMode
 kinit
 kms
+knownHosts
 krb
 kube
 kubeclient


### PR DESCRIPTION
Also document knownHosts in production guide, and refactor private
gitsync dags docs to use `extraSecrets` instead of a separate secret.