### PR TITLE
Remove gitsync root and dest params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,7 +147,8 @@ repos:
     hooks:
       - id: doctoc
         name: Add TOC for md files
-        files: ^README\.md$|^CONTRIBUTING\.md$|^UPDATING.*\.md$|^dev/.*\.md$|^dev/.*\.rst$
+        files:
+          ^README\.md$|^CONTRIBUTING\.md$|^UPDATING.*\.md$|^chart/UPDATING.*\.md$|^dev/.*\.md$|^dev/.*\.rst$
         exclude: ^airflow/_vendor/
         args:
           - "--maxlevel"

--- a/chart/UPDATING.md
+++ b/chart/UPDATING.md
@@ -1,0 +1,54 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+# Updating the Airflow Helm Chart
+
+This file documents any backwards-incompatible changes in the Airflow Helm chart and
+assists users migrating to a new version.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of contents**
+
+- [Master](#master)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Master
+
+<!--
+
+I'm glad you want to write a new note. Remember that this note is intended for users.
+Make sure it contains the following information:
+
+- [ ] Previous behaviors
+- [ ] New behaviors
+- [ ] If possible, a simple example of how to migrate. This may include a simple code example.
+- [ ] If possible, the benefit for the user after migration e.g. "we want to make these changes to unify class names."
+- [ ] If possible, the reason for the change, which adds more context to that interested, e.g. reference for Airflow Improvement Proposal.
+
+More tips can be found in the guide:
+https://developers.google.com/style/inclusive-documentation
+
+-->
+
+### Removed `dags.gitSync.root` and `dags.gitSync.dest` parameters
+
+The `dags.gitSync.root` and `dags.gitSync.dest` parameters didn't provide any useful behaviors to chart users so they have been removed.
+If you have them set in your values file you can safely remove them.

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -176,9 +176,9 @@ If release name contains chart name it will be used as a full name.
     - name: GIT_SYNC_DEPTH
       value: {{ .Values.dags.gitSync.depth | quote }}
     - name: GIT_SYNC_ROOT
-      value: {{ .Values.dags.gitSync.root | quote }}
+      value: "/git"
     - name: GIT_SYNC_DEST
-      value: {{ .Values.dags.gitSync.dest | quote }}
+      value: "repo"
     - name: GIT_SYNC_ADD_USER
       value: "true"
     - name: GIT_SYNC_WAIT
@@ -195,7 +195,7 @@ If release name contains chart name it will be used as a full name.
     {{- end }}
   volumeMounts:
   - name: dags
-    mountPath: {{ .Values.dags.gitSync.root }}
+    mountPath: /git
   {{- if and  .Values.dags.gitSync.enabled  .Values.dags.gitSync.sshKeySecret }}
   - name: git-sync-ssh-key
     mountPath: /etc/git-secret/ssh
@@ -363,7 +363,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
 
 {{ define "airflow_dags" -}}
 {{- if .Values.dags.gitSync.enabled -}}
-{{ (printf "%s/dags/%s/%s" .Values.airflowHome .Values.dags.gitSync.dest .Values.dags.gitSync.subPath ) }}
+{{ (printf "%s/dags/repo/%s" .Values.airflowHome .Values.dags.gitSync.subPath) }}
 {{- else -}}
 {{ (printf "%s/dags" .Values.airflowHome) }}
 {{- end -}}

--- a/chart/tests/test_git_sync_scheduler.py
+++ b/chart/tests/test_git_sync_scheduler.py
@@ -67,8 +67,6 @@ class GitSyncSchedulerTest(unittest.TestCase):
                         "wait": 66,
                         "maxFailures": 70,
                         "subPath": "path1/path2",
-                        "dest": "test-dest",
-                        "root": "/git-root",
                         "rev": "HEAD",
                         "depth": 1,
                         "repo": "https://github.com/apache/airflow.git",
@@ -93,13 +91,13 @@ class GitSyncSchedulerTest(unittest.TestCase):
                 {"name": "GIT_SYNC_BRANCH", "value": "test-branch"},
                 {"name": "GIT_SYNC_REPO", "value": "https://github.com/apache/airflow.git"},
                 {"name": "GIT_SYNC_DEPTH", "value": "1"},
-                {"name": "GIT_SYNC_ROOT", "value": "/git-root"},
-                {"name": "GIT_SYNC_DEST", "value": "test-dest"},
+                {"name": "GIT_SYNC_ROOT", "value": "/git"},
+                {"name": "GIT_SYNC_DEST", "value": "repo"},
                 {"name": "GIT_SYNC_ADD_USER", "value": "true"},
                 {"name": "GIT_SYNC_WAIT", "value": "66"},
                 {"name": "GIT_SYNC_MAX_SYNC_FAILURES", "value": "70"},
             ],
-            "volumeMounts": [{"mountPath": "/git-root", "name": "dags"}],
+            "volumeMounts": [{"mountPath": "/git", "name": "dags"}],
         } == jmespath.search("spec.template.spec.containers[1]", docs[0])
 
     def test_validate_if_ssh_params_are_added(self):

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -69,8 +69,6 @@ class PodTemplateFileTest(unittest.TestCase):
                         "wait": 66,
                         "maxFailures": 70,
                         "subPath": "path1/path2",
-                        "dest": "test-dest",
-                        "root": "/git-root",
                         "rev": "HEAD",
                         "depth": 1,
                         "repo": "https://github.com/apache/airflow.git",
@@ -96,14 +94,14 @@ class PodTemplateFileTest(unittest.TestCase):
                 {"name": "GIT_SYNC_BRANCH", "value": "test-branch"},
                 {"name": "GIT_SYNC_REPO", "value": "https://github.com/apache/airflow.git"},
                 {"name": "GIT_SYNC_DEPTH", "value": "1"},
-                {"name": "GIT_SYNC_ROOT", "value": "/git-root"},
-                {"name": "GIT_SYNC_DEST", "value": "test-dest"},
+                {"name": "GIT_SYNC_ROOT", "value": "/git"},
+                {"name": "GIT_SYNC_DEST", "value": "repo"},
                 {"name": "GIT_SYNC_ADD_USER", "value": "true"},
                 {"name": "GIT_SYNC_WAIT", "value": "66"},
                 {"name": "GIT_SYNC_MAX_SYNC_FAILURES", "value": "70"},
                 {"name": "GIT_SYNC_ONE_TIME", "value": "true"},
             ],
-            "volumeMounts": [{"mountPath": "/git-root", "name": "dags"}],
+            "volumeMounts": [{"mountPath": "/git", "name": "dags"}],
         } == jmespath.search("spec.initContainers[0]", docs[0])
 
     def test_should_not_add_init_container_if_dag_persistence_is_true(self):

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2344,16 +2344,6 @@
                             "type": "string",
                             "default": "HEAD"
                         },
-                        "root": {
-                            "description": "Root directory.",
-                            "type": "string",
-                            "default": "/git"
-                        },
-                        "dest": {
-                            "description": "Destination folder.",
-                            "type": "string",
-                            "default": "repo"
-                        },
                         "depth": {
                             "description": "Repository depth.",
                             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -965,8 +965,6 @@ dags:
     repo: https://github.com/apache/airflow.git
     branch: v2-1-stable
     rev: HEAD
-    root: "/git"
-    dest: "repo"
     depth: 1
     # the number of consecutive failures allowed before aborting
     maxFailures: 0


### PR DESCRIPTION
We can simplify gitsync by not exposing these to the end user, as they
don't provide any useful behaviors.