### PR TITLE
SSHHook: Using correct hostname for host_key when using non-default ssh port

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -241,8 +241,10 @@ class SSHHook(BaseHook):
         else:
             if self.host_key is not None:
                 client_host_keys = client.get_host_keys()
-                remote_host = f"[{self.remote_host}]:{self.port}" if self.port != SSH_PORT else self.remote_host
-                client_host_keys.add(remote_host, self.host_key.get_name(), self.host_key)
+                if self.port == SSH_PORT:
+                    client_host_keys.add(self.remote_host, self.host_key.get_name(), self.host_key)
+                else:
+                    client_host_keys.add(f"[{self.remote_host}]:{self.port}", self.host_key.get_name(), self.host_key)
             else:
                 pass  # will fallback to system host keys if none explicitly specified in conn extra
 

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -241,7 +241,8 @@ class SSHHook(BaseHook):
         else:
             if self.host_key is not None:
                 client_host_keys = client.get_host_keys()
-                client_host_keys.add(self.remote_host, self.host_key.get_name(), self.host_key)
+                remote_host = f"[{self.remote_host}]:{self.port}" if self.port != SSH_PORT else self.remote_host
+                client_host_keys.add(remote_host, self.host_key.get_name(), self.host_key)
             else:
                 pass  # will fallback to system host keys if none explicitly specified in conn extra
 

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -244,7 +244,9 @@ class SSHHook(BaseHook):
                 if self.port == SSH_PORT:
                     client_host_keys.add(self.remote_host, self.host_key.get_name(), self.host_key)
                 else:
-                    client_host_keys.add(f"[{self.remote_host}]:{self.port}", self.host_key.get_name(), self.host_key)
+                    client_host_keys.add(
+                        f"[{self.remote_host}]:{self.port}", self.host_key.get_name(), self.host_key
+                    )
             else:
                 pass  # will fallback to system host keys if none explicitly specified in conn extra
 


### PR DESCRIPTION
 <!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
When using the SSHHook to connect to an ssh server on a non default port, the host_key setting was not added with the correct hostname to the list of known hosts. In more detail:

```python
from airflow.providers.ssh.hooks.ssh import SSHHook
import paramiko
from base64 import decodebytes

hook = SSHHook(remote_host="1.2.3.4", port=1234, username="user")
# Usually, host_key would come from the connection_extras, for the sake of this example we set the value manually:
host_key = "abc" # Some public key
hook.host_key = paramiko.RSAKey(data=decodebytes(host_key.encode("utf-8")))
hook.no_host_key_check = False

conn = hook.get_conn()
```

yielded the exception

    paramiko.ssh_exception.SSHException: Server '[1.2.3.4]:1234' not found in known_hosts

closes: #15963
