### PR TITLE
Add memory usage warning in quick-start documentation

### DIFF
--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -30,6 +30,19 @@ Follow these steps to install the necessary tools.
 
 Older versions of ``docker-compose`` do not support all features required by ``docker-compose.yaml`` file, so double check that it meets the minimum version requirements.
 
+.. warning::
+    Default amount of memory available for Docker on MacOS is often not enough to get Airflow up and running.
+    If you have not enough memory available it might lead to airflow webserver continuously restarting.
+    You should have at least 4GB memory allocated for the Docker Engine (ideally 8GB). You can check
+    and change the amount of memory in `Resources <https://docs.docker.com/docker-for-mac/#resources>`_
+
+    You can also check if you have enough memory by running this command:
+
+    .. code-block:: bash
+
+        docker run --rm "debian:buster-slim" bash -c 'numfmt --to iec $(echo $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE))))'
+
+
 ``docker-compose.yaml``
 =======================
 


### PR DESCRIPTION
Users of docker quickstart on MacOS often complain that Airlfow
does not start.

Examples: #15961 #15927

This PR adds warning about it in the docs and provides
instruction on how to check and change the limits.

Fixes: #15941

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
