### PR TITLE
loadBalancerIP and annotations for both flower and webserver

### DIFF
--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -33,6 +33,10 @@ metadata:
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- with .Values.flower.service.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.flower.service.type }}
   selector:
@@ -43,6 +47,8 @@ spec:
     - name: flower-ui
       protocol: TCP
       port: {{ .Values.ports.flowerUI }}
-      targetPort: {{ .Values.ports.flowerUI }}
+  {{- if .Values.flower.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.flower.service.loadBalancerIP }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/webserver/webserver-service.yaml
+++ b/chart/templates/webserver/webserver-service.yaml
@@ -45,4 +45,6 @@ spec:
     - name: airflow-ui
       protocol: TCP
       port: {{ .Values.ports.airflowUI }}
-      targetPort: {{ .Values.ports.airflowUI }}
+  {{- if .Values.webserver.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.webserver.service.loadBalancerIP }}
+  {{- end }}

--- a/chart/tests/test_webserver.py
+++ b/chart/tests/test_webserver.py
@@ -282,3 +282,42 @@ class WebserverDeploymentTest(unittest.TestCase):
             "subPath": "airflow_local_settings.py",
             "readOnly": True,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
+
+
+class WebserverServiceTest(unittest.TestCase):
+    def test_default_service(self):
+        docs = render_chart(
+            show_only=["templates/webserver/webserver-service.yaml"],
+        )
+
+        assert "RELEASE-NAME-webserver" == jmespath.search("metadata.name", docs[0])
+        assert jmespath.search("metadata.annotations", docs[0]) is None
+        assert {"tier": "airflow", "component": "webserver", "release": "RELEASE-NAME"} == jmespath.search(
+            "spec.selector", docs[0]
+        )
+        assert "ClusterIP" == jmespath.search("spec.type", docs[0])
+        assert {"name": "airflow-ui", "protocol": "TCP", "port": 8080} in jmespath.search(
+            "spec.ports", docs[0]
+        )
+
+    def test_overrides(self):
+        docs = render_chart(
+            values={
+                "ports": {"airflowUI": 9000},
+                "webserver": {
+                    "service": {
+                        "type": "LoadBalancer",
+                        "loadBalancerIP": "127.0.0.1",
+                        "annotations": {"foo": "bar"},
+                    }
+                },
+            },
+            show_only=["templates/webserver/webserver-service.yaml"],
+        )
+
+        assert {"foo": "bar"} == jmespath.search("metadata.annotations", docs[0])
+        assert "LoadBalancer" == jmespath.search("spec.type", docs[0])
+        assert {"name": "airflow-ui", "protocol": "TCP", "port": 9000} in jmespath.search(
+            "spec.ports", docs[0]
+        )
+        assert "127.0.0.1" == jmespath.search("spec.loadBalancerIP", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1465,6 +1465,14 @@
                             "description": "Annotations for the webserver Service.",
                             "type": "object",
                             "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "description": "Webserver Service loadBalancerIP.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
                         }
                     }
                 },
@@ -1554,6 +1562,19 @@
                             "description": "Flower Service type.",
                             "type": "string",
                             "default": "ClusterIP"
+                        },
+                        "annotations": {
+                            "description": "Annotations for the flower Service.",
+                            "type": "object",
+                            "default": {}
+                        },
+                        "loadBalancerIP": {
+                            "description": "Flower Service loadBalancerIP.",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "default": null
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -577,6 +577,7 @@ webserver:
     type: ClusterIP
     ## service annotations
     annotations: {}
+    loadBalancerIP: ~
 
   # Select certain nodes for airflow webserver pods.
   nodeSelector: {}
@@ -618,6 +619,9 @@ flower:
 
   service:
     type: ClusterIP
+    ## service annotations
+    annotations: {}
+    loadBalancerIP: ~
 
   # Select certain nodes for airflow flower pods.
   nodeSelector: {}


### PR DESCRIPTION
This adds `loadBalancerIP` to both flower and webserver Service and adds
`annotations` to the flower Service.

Closes: #12751 