### PR TITLE
Always return a response in TI's action_clear view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3813,11 +3813,10 @@ class TaskInstanceModelView(AirflowModelView):
 
             session.commit()
             flash(f"{len(task_instances)} task instances have been cleared")
-            self.update_redirect()
-            return redirect(self.get_redirect())
         except Exception as e:  # noqa pylint: disable=broad-except
             flash(f'Failed to clear task instances: "{e}"', 'error')
-            return None
+        self.update_redirect()
+        return redirect(self.get_redirect())
 
     @provide_session
     def set_task_instance_state(self, tis, target_state, session=None):


### PR DESCRIPTION
A flask view should always return a response object, not None. This makes `TaskInstanceModelView.action_view` works like all other action views in the same class, redirecting to the previous page even after an exception (and show the exception as a flash).

This does *not* get #15775 resolved, but should make the error more obvious to the user, instead of masking it with another error.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
