### PR TITLE
Properly remove user for test_create_user for it to work against a dirty database

### DIFF
--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -333,11 +333,13 @@ def test_views_post_access_denied(viewer_client, url):
 @pytest.fixture()
 def non_exist_username(app):
     username = "fake_username"
-    if app.appbuilder.sm.find_user(username):
-        app.appbuilder.sm.del_register_user(username)
+    user = app.appbuilder.sm.find_user(username)
+    if user is not None:
+        app.appbuilder.sm.del_register_user(user)
     yield username
-    if app.appbuilder.sm.find_user(username):
-        app.appbuilder.sm.del_register_user(username)
+    user = app.appbuilder.sm.find_user(username)
+    if user is not None:
+        app.appbuilder.sm.del_register_user(user)
 
 
 def test_create_user(app, admin_client, non_exist_username):


### PR DESCRIPTION
I didn't implement the user cleanup fixture correctly, but the error was not noticed before since a clean-slate DB (as on CI and `./breeze tests`) wouldn't need them.

Can't wait for the time I can start using the walrus operator 😛 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
