### PR TITLE
Fix Celery executor getting stuck randomly because of reset_signals in multiprocessing

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -671,6 +671,14 @@ class DagFileProcessor(LoggingMixin):
         return len(dagbag.dags), len(dagbag.import_errors)
 
 
+def _is_parent_process():
+    """
+    Returns True if the current process is the parent process. False if the current process is a child
+    process started by multiprocessing.
+    """
+    return multiprocessing.current_process().name == 'MainProcess'
+
+
 class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
     """
     This SchedulerJob runs for a specific time interval and schedules the jobs
@@ -746,21 +754,24 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
 
     def _exit_gracefully(self, signum, frame) -> None:  # pylint: disable=unused-argument
         """Helper method to clean up processor_agent to avoid leaving orphan processes."""
-        self.log.info("Exiting gracefully upon receiving signal %s", signum)
-        if self.processor_agent:
-            self.processor_agent.end()
-        sys.exit(os.EX_OK)
+        if _is_parent_process():
+            # Only the parent process should perform the cleanup.
+            self.log.info("Exiting gracefully upon receiving signal %s", signum)
+            if self.processor_agent:
+                self.processor_agent.end()
+            sys.exit(os.EX_OK)
 
     def _debug_dump(self, signum, frame):  # pylint: disable=unused-argument
-        try:
-            sig_name = signal.Signals(signum).name  # pylint: disable=no-member
-        except Exception:  # pylint: disable=broad-except
-            sig_name = str(signum)
+        if _is_parent_process():
+            try:
+                sig_name = signal.Signals(signum).name  # pylint: disable=no-member
+            except Exception:  # pylint: disable=broad-except
+                sig_name = str(signum)
 
-        self.log.info("%s\n%s received, printing debug\n%s", "-" * 80, sig_name, "-" * 80)
+            self.log.info("%s\n%s received, printing debug\n%s", "-" * 80, sig_name, "-" * 80)
 
-        self.executor.debug_dump()
-        self.log.info("-" * 80)
+            self.executor.debug_dump()
+            self.log.info("-" * 80)
 
     def is_alive(self, grace_multiplier: Optional[float] = None) -> bool:
         """

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -34,6 +34,8 @@ services:
     ports:
       - "${WEBSERVER_HOST_PORT}:8080"
       - "${FLOWER_HOST_PORT}:5555"
+    cap_add:
+      - SYS_PTRACE
 volumes:
   sqlite-db-volume:
   postgres-db-volume:

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -503,6 +503,15 @@ class MockTask:
 
         return 1
 
+import signal
+
+def handle_pdb(sig, frame):
+    print('handle_pdb')
+    import pdb
+    pdb.Pdb().set_trace(frame)
+
+signal.signal(signal.SIGUSR1, handle_pdb)
+
 def test_send_tasks_to_celery_hang():
     def _exit_gracefully(signum, frame):
         print(f"{os.getpid()} Exiting gracefully upon receiving signal {signum}")
@@ -510,7 +519,6 @@ def test_send_tasks_to_celery_hang():
 
     def register_signals():
         """Register signals that stop child processes"""
-        import signal
 
         print(f"{os.getpid()} register_signals()")
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -508,9 +508,6 @@ def register_signals():
     Register the same signals as scheduler does to test celery_executor to make sure it does not
     hang.
     """
-
-    print(f"{os.getpid()} register_signals()")
-
     orig_sigint = orig_sigterm = orig_sigusr2 = signal.SIG_DFL
 
     orig_sigint = signal.signal(signal.SIGINT, _exit_gracefully)


### PR DESCRIPTION
Fixes #15938

`multiprocessing.Pool` is known to often become stuck. It causes celery_executor to hang randomly. This happens at least on Debian, Ubuntu using Python 3.8.7 and Python 3.8.10. The issue is reproducible by running `test_send_tasks_to_celery_hang` in this PR several times (with db backend set to something other than sqlite because sqlite disables some parallelization) 

The issue goes away once switched to `concurrent.futures.ProcessPoolExecutor`. In python 3.6 and earlier, `ProcessPoolExecutor` has no `initializer` argument. Fortunately, it's not needed because `reset_signal` is no longer needed because the signal handler now checks if the current process is the parent.