### PR TITLE
Add more tests for the kubernetes executor

### DIFF
--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -28,6 +28,7 @@ from kubernetes.client import models as k8s
 from kubernetes.client.rest import ApiException
 from urllib3 import HTTPResponse
 
+from airflow import AirflowException
 from airflow.utils import timezone
 from tests.test_utils.config import conf_vars
 
@@ -760,3 +761,27 @@ class TestKubernetesJobWatcher(unittest.TestCase):
 
         self._run()
         self.watcher.watcher_queue.put.assert_not_called()
+
+    @mock.patch.object(KubernetesJobWatcher, 'process_error')
+    def test_process_error_event_for_410(self, mock_process_error):
+        message = "too old resource version: 27272 (43334)"
+        self.pod.status.phase = 'Pending'
+        self.pod.metadata.resource_version = '0'
+        mock_process_error.return_value = '0'
+        raw_object = {"code": 410, "message": message}
+        self.events.append({"type": "ERROR", "object": self.pod, "raw_object": raw_object})
+        self._run()
+        mock_process_error.assert_called_once_with(self.events[0])
+
+    def test_process_error_event_for_raise_if_not_410(self):
+        message = "Failure message"
+        self.pod.status.phase = 'Pending'
+        raw_object = {"code": 422, "message": message, "reason": "Test"}
+        self.events.append({"type": "ERROR", "object": self.pod, "raw_object": raw_object})
+        with self.assertRaises(AirflowException) as e:
+            self._run()
+        assert str(e.exception) == 'Kubernetes failure for {} with code {} and message: {}'.format(
+            raw_object['reason'],
+            raw_object['code'],
+            raw_object['message'],
+        )


### PR DESCRIPTION
This change adds tests to improve coverage for the Kubernetes executor
Part of https://github.com/apache/airflow/issues/15523

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
