### PR TITLE
A bunch of web UI backend tests

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import collections
 import copy
 import itertools
 import json
@@ -3808,12 +3809,11 @@ class TaskInstanceModelView(AirflowModelView):
     def action_clear(self, task_instances, session=None):
         """Clears the action."""
         try:
-            dag_to_tis = {}
+            dag_to_tis = collections.defaultdict(list)
 
             for ti in task_instances:
                 dag = current_app.dag_bag.get_dag(ti.dag_id)
-                task_instances_to_clean = dag_to_tis.setdefault(dag, [])
-                task_instances_to_clean.append(ti)
+                dag_to_tis[dag].append(ti)
 
             for dag, task_instances_list in dag_to_tis.items():
                 models.clear_task_instances(task_instances_list, session, dag=dag)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3349,11 +3349,7 @@ class VariableModelView(AirflowModelView):
     def varimport(self):
         """Import variables"""
         try:
-            out = request.files['file'].read()
-            if isinstance(out, bytes):
-                variable_dict = json.loads(out.decode('utf-8'))
-            else:
-                variable_dict = json.loads(out)
+            variable_dict = json.loads(request.files['file'].read())
         except Exception:  # noqa pylint: disable=broad-except
             self.update_redirect()
             flash("Missing file or syntax error.", 'error')

--- a/tests/www/views/test_views_pool.py
+++ b/tests/www/views/test_views_pool.py
@@ -22,6 +22,12 @@ from airflow.models import Pool
 from airflow.utils.session import create_session
 from tests.test_utils.www import check_content_in_response, check_content_not_in_response
 
+POOL = {
+    'pool': 'test-pool',
+    'slots': 777,
+    'description': 'test-pool-description',
+}
+
 
 @pytest.fixture(autouse=True)
 def clear_pools():
@@ -30,43 +36,45 @@ def clear_pools():
 
 
 @pytest.fixture()
-def pool():
-    return {
-        'pool': 'test-pool',
-        'slots': 777,
-        'description': 'test-pool-description',
-    }
+def pool_factory(session):
+    def factory(**values):
+        pool = Pool(**{**POOL, **values})  # Passed in values override defaults.
+        session.add(pool)
+        session.commit()
+        return pool
+
+    return factory
 
 
-def test_create_pool_with_same_name(admin_client, pool):
+def test_create_pool_with_same_name(admin_client):
     # create test pool
-    resp = admin_client.post('/pool/add', data=pool, follow_redirects=True)
+    resp = admin_client.post('/pool/add', data=POOL, follow_redirects=True)
     check_content_in_response('Added Row', resp)
 
     # create pool with the same name
-    resp = admin_client.post('/pool/add', data=pool, follow_redirects=True)
+    resp = admin_client.post('/pool/add', data=POOL, follow_redirects=True)
     check_content_in_response('Already exists.', resp)
 
 
-def test_create_pool_with_empty_name(admin_client, pool):
-    pool['pool'] = ''
-    resp = admin_client.post('/pool/add', data=pool, follow_redirects=True)
+def test_create_pool_with_empty_name(admin_client):
+    resp = admin_client.post(
+        '/pool/add',
+        data={**POOL, "pool": ""},
+        follow_redirects=True,
+    )
     check_content_in_response('This field is required.', resp)
 
 
-def test_odd_name(session, admin_client, pool):
-    pool['pool'] = 'test-pool<script></script>'
-    session.add(Pool(**pool))
-    session.commit()
+def test_odd_name(admin_client, pool_factory):
+    pool_factory(pool="test-pool<script></script>")
     resp = admin_client.get('/pool/list/')
     check_content_in_response('test-pool&lt;script&gt;', resp)
     check_content_not_in_response('test-pool<script>', resp)
 
 
-def test_list(app, session, admin_client, pool):
-    pool['pool'] = 'test-pool'
-    session.add(Pool(**pool))
-    session.commit()
+def test_list(app, admin_client, pool_factory):
+    pool_factory(pool="test-pool")
+
     resp = admin_client.get('/pool/list/')
     # We should see this link
     with app.test_request_context():
@@ -77,3 +85,27 @@ def test_list(app, session, admin_client, pool):
         queued_tag = flask.Markup("<a href='{url}'>{slots}</a>").format(url=url, slots=0)
     check_content_in_response(used_tag, resp)
     check_content_in_response(queued_tag, resp)
+
+
+def test_pool_muldelete(session, admin_client, pool_factory):
+    pool = pool_factory()
+
+    resp = admin_client.post(
+        "/pool/action_post",
+        data={"action": "muldelete", "rowid": [pool.id]},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert session.query(Pool).filter(Pool.id == pool.id).count() == 0
+
+
+def test_pool_muldelete_default(session, admin_client, pool_factory):
+    pool = pool_factory(pool="default_pool")
+
+    resp = admin_client.post(
+        "/pool/action_post",
+        data={"action": "muldelete", "rowid": [pool.id]},
+        follow_redirects=True,
+    )
+    check_content_in_response("default_pool cannot be deleted", resp)
+    assert session.query(Pool).filter(Pool.id == pool.id).count() == 1

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -33,6 +33,7 @@ from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
+from airflow.www.views import TaskInstanceModelView
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_runs
 from tests.test_utils.www import check_content_in_response, check_content_not_in_response
@@ -574,3 +575,43 @@ def test_show_external_log_redirect_link_with_external_log_handler(
         ctx = templates[0].local_context
         assert ctx['show_external_log_redirect']
         assert ctx['external_log_name'] == _ExternalHandler.LOG_NAME
+
+
+def _get_appbuilder_pk_string(model_view_cls, instance) -> str:
+    """Utility to get Flask-Appbuilder's string format "pk" for an object.
+
+    Used to generate requests to FAB action views without *too* much difficulty.
+    The implementation relies on FAB internals, but unfortunately I don't see
+    a better way around it.
+
+    Example usage::
+
+        >>> from airflow.www.views import TaskInstanceModelView
+        >>> ti = session.Query(TaskInstance).filter(...).one()
+        >>> pk = _get_appbuilder_pk_string(TaskInstanceModelView, ti)
+        >>> client.post("...", data={"action": "...", "rowid": pk})
+    """
+    pk_value = model_view_cls.datamodel.get_pk_value(instance)
+    return model_view_cls._serialize_pk_if_composite(model_view_cls, pk_value)
+
+
+def test_task_instance_clear(session, admin_client):
+    task_id = "runme_0"
+
+    # Set the state to success for clearing.
+    ti_q = session.query(TaskInstance).filter(TaskInstance.task_id == task_id)
+    ti_q.update({"state": State.SUCCESS})
+    session.commit()
+
+    # Send a request to clear.
+    rowid = _get_appbuilder_pk_string(TaskInstanceModelView, ti_q.one())
+    resp = admin_client.post(
+        "/taskinstance/action_post",
+        data={"action": "clear", "rowid": rowid},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+
+    # Now the state should be None.
+    state = session.query(TaskInstance.state).filter(TaskInstance.task_id == task_id).scalar()
+    assert state == State.NONE

--- a/tests/www/views/test_views_variable.py
+++ b/tests/www/views/test_views_variable.py
@@ -102,3 +102,28 @@ def test_description_retrieval(session, admin_client):
 
     row = session.query(Variable.key, Variable.description).first()
     assert row.key == 'test_key' and row.description == 'test_description'
+
+
+@pytest.fixture()
+def variable(session):
+    variable = Variable(
+        key=VARIABLE["key"],
+        val=VARIABLE["val"],
+        description=VARIABLE["description"],
+    )
+    session.add(variable)
+    session.commit()
+    yield variable
+    session.query(Variable).filter(Variable.key == VARIABLE["key"]).delete()
+    session.commit()
+
+
+def test_action_export(admin_client, variable):
+    resp = admin_client.post(
+        "/variable/action_post",
+        data={"action": "varexport", "rowid": [variable.id]},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"] == "application/json; charset=utf-8"
+    assert resp.headers["Content-Disposition"] == "attachment; filename=variables.json"
+    assert resp.json == {"test_key": "text_val"}

--- a/tests/www/views/test_views_variable.py
+++ b/tests/www/views/test_views_variable.py
@@ -127,3 +127,14 @@ def test_action_export(admin_client, variable):
     assert resp.headers["Content-Type"] == "application/json; charset=utf-8"
     assert resp.headers["Content-Disposition"] == "attachment; filename=variables.json"
     assert resp.json == {"test_key": "text_val"}
+
+
+def test_action_muldelete(session, admin_client, variable):
+    var_id = variable.id
+    resp = admin_client.post(
+        "/variable/action_post",
+        data={"action": "muldelete", "rowid": [var_id]},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert session.query(Variable).filter(Variable.id == var_id).count() == 0


### PR DESCRIPTION
Toward #15525. See individual commit messages for what views exactly were covered.

This brings the coverage of `airflow.www.views` to 85%.

There's one test marked as xfail due to an existing bug, see #15980.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
