### PR TITLE
Add flower service annotations in helm chart

### DIFF
--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -33,6 +33,10 @@ metadata:
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
+{{- with .Values.flower.service.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.flower.service.type }}
   selector:

--- a/chart/tests/test_flower.py
+++ b/chart/tests/test_flower.py
@@ -195,7 +195,7 @@ class TestFlower:
             values={"flower": {"service": {"annotations": annotations}}} if annotations else None,
             show_only=["templates/flower/flower-service.yaml"],
         )
-        assert annotations == jmespath.search("metadata.annotations", docs[0])
+        assert jmespath.search("metadata.annotations", docs[0]) == annotations
 
     def test_flower_resources_are_not_added_by_default(self):
         docs = render_chart(

--- a/chart/tests/test_flower.py
+++ b/chart/tests/test_flower.py
@@ -17,6 +17,7 @@
 
 import jmespath
 import pytest
+from parameterized import parameterized
 
 from tests.helm_template_generator import render_chart
 
@@ -182,6 +183,19 @@ class TestFlower:
             "spec.template.spec.containers[0].resources.requests.memory", docs[0]
         )
         assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+    @parameterized.expand(
+        [
+            ({'my.custom.annotation': 'true', 'other.annotation': 'any-val'},),
+            (None,),
+        ]
+    )
+    def test_flower_service_annotations(self, annotations):
+        docs = render_chart(
+            values={"flower": {"service": {"annotations": annotations}}} if annotations else None,
+            show_only=["templates/flower/flower-service.yaml"],
+        )
+        assert annotations == jmespath.search("metadata.annotations", docs[0])
 
     def test_flower_resources_are_not_added_by_default(self):
         docs = render_chart(

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1554,6 +1554,11 @@
                             "description": "Flower Service type.",
                             "type": "string",
                             "default": "ClusterIP"
+                        },
+                        "annotations": {
+                            "description": "Annotations for the flower service.",
+                            "type": "object",
+                            "default": {}
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -618,6 +618,9 @@ flower:
 
   service:
     type: ClusterIP
+    ## service annotations
+    annotations: {}
+
 
   # Select certain nodes for airflow flower pods.
   nodeSelector: {}


### PR DESCRIPTION
Annotations are necessary to run flower with a load balancer in a private subnet.  Prior to this commit annotations were supported for webserver but not for flower.
