### PR TITLE
Add Docs for ``default_pool`` slots

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -72,6 +72,16 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Default Task Pools Slots can be updated using ``[core] default_pool_task_slot_count``
+
+By default tasks are running in `default_pool`. `default_pool` is initialized with `128` slots and user can change the
+number of slots through UI/CLI/API for an existing deployment.
+
+For new deployments, you can use `default_pool_task_slot_count` setting in `[core]` section. This setting would
+not have any effect in an existing deployment where the ``default_pool`` already exists.
+
+Previously this was controlled by `non_pooled_task_slot_count` in `[core]` section, which was not documented.
+
 ## Airflow 2.1.0
 
 ### New "deprecated_api" extra

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -72,7 +72,7 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
-### Default Task Pools Slots can be updated using ``[core] default_pool_task_slot_count``
+### Default Task Pools Slots can be set using ``[core] default_pool_task_slot_count``
 
 By default tasks are running in `default_pool`. `default_pool` is initialized with `128` slots and user can change the
 number of slots through UI/CLI/API for an existing deployment.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -435,6 +435,15 @@
       type: string
       example: ~
       default: ""
+    - name: default_pool_task_slot_count
+      description: |
+        Task Slot counts for ``default_pool``. This setting would not have any effect in an existing
+        deployment where the ``default_pool`` is already created. For existing deployments, users can
+        change the number of slots using Webserver, API or the CLI
+      version_added: 2.2.0
+      type: string
+      example: ~
+      default: "128"
 
 - name: logging
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -250,6 +250,11 @@ hide_sensitive_var_conn_fields = True
 # extra JSON.
 sensitive_var_conn_names =
 
+# Task Slot counts for ``default_pool``. This setting would not have any effect in an existing
+# deployment where the ``default_pool`` is already created. For existing deployments, users can
+# change the number of slots using Webserver, API or the CLI
+default_pool_task_slot_count = 128
+
 [logging]
 # The folder where airflow should store its log files
 # This path must be absolute

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -162,6 +162,7 @@ class AirflowConfigParser(ConfigParser):  # pylint: disable=too-many-ancestors
         ('operators', 'default_queue'): ('celery', 'default_queue', '2.1.0'),
         ('core', 'hide_sensitive_var_conn_fields'): ('admin', 'hide_sensitive_variable_fields', '2.1.0'),
         ('core', 'sensitive_var_conn_names'): ('admin', 'sensitive_variable_fields', '2.1.0'),
+        ('core', 'default_pool_task_slot_count'): ('core', 'non_pooled_task_slot_count', '1.10.4'),
     }
 
     # A mapping of old default values that we want to change and warn the user

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -72,7 +72,7 @@ def add_default_pool_if_not_exists(session=None):
     if not Pool.get_pool(Pool.DEFAULT_POOL_NAME, session=session):
         default_pool = Pool(
             pool=Pool.DEFAULT_POOL_NAME,
-            slots=conf.getint(section='core', key='default_pool_task_slot_count', fallback=128),
+            slots=conf.getint(section='core', key='default_pool_task_slot_count'),
             description="Default pool",
         )
         session.add(default_pool)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -72,7 +72,7 @@ def add_default_pool_if_not_exists(session=None):
     if not Pool.get_pool(Pool.DEFAULT_POOL_NAME, session=session):
         default_pool = Pool(
             pool=Pool.DEFAULT_POOL_NAME,
-            slots=conf.getint(section='core', key='non_pooled_task_slot_count', fallback=128),
+            slots=conf.getint(section='core', key='default_pool_task_slot_count', fallback=128),
             description="Default pool",
         )
         session.add(default_pool)


### PR DESCRIPTION
Until now this was undocumented, however it was used in:
https://github.com/apache/airflow/blob/aa4713e43f92d3e4c68c3ad00e2d44caaf29aafe/airflow/utils/db.py#L75

This was done in 1.10.4 in https://github.com/apache/airflow/commit/2c99ec624bd66e9fa38e9f0087d46ef4d7f05aec
commit. This commit also updates the name from `non_pooled_task_slot_count` to `default_pool_task_slot_count` as
this is what it actually does.

This will help Helm Chart users as mentioned in https://github.com/airflow-helm/charts/issues/211#issuecomment-846278780

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
