### PR TITLE
Fixed Discord Webhook endpoint

### DIFF
--- a/airflow/providers/discord/hooks/discord_webhook.py
+++ b/airflow/providers/discord/hooks/discord_webhook.py
@@ -101,7 +101,7 @@ class DiscordWebhookHook(HttpHook):
                 'Expected Discord webhook endpoint in the form of "webhooks/{webhook.id}/{webhook.token}".'
             )
 
-        return endpoint
+        return f'https://discord.com/api/{endpoint}'
 
     def _build_discord_payload(self) -> str:
         """

--- a/airflow/providers/discord/hooks/discord_webhook.py
+++ b/airflow/providers/discord/hooks/discord_webhook.py
@@ -101,7 +101,7 @@ class DiscordWebhookHook(HttpHook):
                 'Expected Discord webhook endpoint in the form of "webhooks/{webhook.id}/{webhook.token}".'
             )
 
-        return f'https://discord.com/api/{endpoint}'
+        return f'https://discord.com/api/{endpoint}' if webhook_endpoint else endpoint
 
     def _build_discord_payload(self) -> str:
         """


### PR DESCRIPTION
The way the Discord webhook it's being built right now (as the documentation specifies) is incomplete.
You can see it on the exception raised by the `HttpHook` class, showing that the built endpoint is in the lines of:
```
https://webhooks/{webhook.id}/{webhook.token}
```
while it should be indeed
```
https://discord.com/api/webhooks/{webhook.id}/{webhook.token}
```

This branch is oriented to fix that small issue.
Another option would be, instead of changing the return point, changing the way the user inputs their hook (making them to write it on the working format instead of the previous one).

I don't really know which one would be better or which you would prefer, I'm open to both ones.