### PR TITLE
Fixing ParamValidationError when executing load_file in Glue hooks/operators

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -178,7 +178,7 @@ class AwsGlueJobHook(AwsBaseHook):
                     Name=self.job_name,
                     Description=self.desc,
                     LogUri=s3_log_path,
-                    Role=execution_role['Role']['RoleName'],
+                    Role=execution_role['Role']['Arn'],
                     ExecutionProperty={"MaxConcurrentRuns": self.concurrent_run_limit},
                     Command={"Name": "glueetl", "ScriptLocation": self.script_location},
                     MaxRetries=self.retry_limit,

--- a/airflow/providers/amazon/aws/hooks/glue_crawler.py
+++ b/airflow/providers/amazon/aws/hooks/glue_crawler.py
@@ -105,7 +105,8 @@ class AwsGlueCrawlerHook(AwsBaseHook):
         """
         crawler_name = crawler_kwargs['Name']
         self.log.info("Creating crawler: %s", crawler_name)
-        return self.glue_client.create_crawler(**crawler_kwargs)['Crawler']['Name']
+        crawler = self.glue_client.create_crawler(**crawler_kwargs)
+        return crawler
 
     def start_crawler(self, crawler_name: str) -> dict:
         """

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -104,7 +104,9 @@ class AwsGlueJobOperator(BaseOperator):
         if self.script_location and not self.script_location.startswith(self.s3_protocol):
             s3_hook = S3Hook(aws_conn_id=self.aws_conn_id)
             script_name = os.path.basename(self.script_location)
-            s3_hook.load_file(self.script_location, self.s3_artifacts_prefix + script_name, bucket_name=self.s3_bucket)
+            s3_hook.load_file(
+                self.script_location, self.s3_artifacts_prefix + script_name, bucket_name=self.s3_bucket
+            )
             s3_script_location = f"s3://{self.s3_bucket}/{self.s3_artifacts_prefix}{script_name}"
         else:
             s3_script_location = self.script_location

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -104,16 +104,15 @@ class AwsGlueJobOperator(BaseOperator):
         if self.script_location and not self.script_location.startswith(self.s3_protocol):
             s3_hook = S3Hook(aws_conn_id=self.aws_conn_id)
             script_name = os.path.basename(self.script_location)
-            s3_hook.load_file(
-                filename=self.script_location,
-                key=self.s3_artifacts_prefix + script_name,
-                bucket_name=self.s3_bucket,
-            )
+            s3_hook.load_file(self.script_location, self.s3_artifacts_prefix + script_name, bucket_name=self.s3_bucket)
+            s3_script_location = f"s3://{self.s3_bucket}/{self.s3_artifacts_prefix}{script_name}"
+        else:
+            s3_script_location = self.script_location
         glue_job = AwsGlueJobHook(
             job_name=self.job_name,
             desc=self.job_desc,
             concurrent_run_limit=self.concurrent_run_limit,
-            script_location=self.script_location,
+            script_location=s3_script_location,
             retry_limit=self.retry_limit,
             num_of_dpus=self.num_of_dpus,
             aws_conn_id=self.aws_conn_id,

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -53,6 +53,9 @@ class TestGlueJobHook(unittest.TestCase):
         )
         iam_role = hook.get_iam_execution_role()
         assert iam_role is not None
+        assert "Role" in iam_role
+        assert "Arn" in iam_role['Role']
+        assert iam_role['Role']['Arn'] == "arn:aws:iam::123456789012:role/my_test_role"
 
     @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
     @mock.patch.object(AwsGlueJobHook, "get_conn")

--- a/tests/providers/amazon/aws/hooks/test_glue_crawler.py
+++ b/tests/providers/amazon/aws/hooks/test_glue_crawler.py
@@ -128,8 +128,9 @@ class TestAwsGlueCrawlerHook(unittest.TestCase):
     def test_create_crawler(self, mock_get_conn):
         mock_get_conn.return_value.create_crawler.return_value = {'Crawler': {'Name': mock_crawler_name}}
         glue_crawler = self.hook.create_crawler(**mock_config)
-
-        self.assertEqual(glue_crawler, mock_crawler_name)
+        self.assertIn("Crawler", glue_crawler)
+        self.assertIn("Name", glue_crawler["Crawler"])
+        self.assertEqual(glue_crawler["Crawler"]["Name"], mock_crawler_name)
 
     @mock.patch.object(AwsGlueCrawlerHook, "get_conn")
     def test_start_crawler(self, mock_get_conn):

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -35,8 +35,8 @@ class TestAwsGlueJobOperator(unittest.TestCase):
 
     @parameterized.expand(
         [
-            "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
             "/glue-examples/glue-scripts/sample_aws_glue_job.py",
+            "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
         ]
     )
     @mock.patch.object(AwsGlueJobHook, 'get_job_state')

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -17,6 +17,7 @@
 
 import unittest
 from unittest import mock
+
 from parameterized import parameterized
 
 from airflow import configuration
@@ -32,19 +33,18 @@ class TestAwsGlueJobOperator(unittest.TestCase):
 
         self.glue_hook_mock = glue_hook_mock
 
-    @parameterized.expand([
-        "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
-        "/glue-examples/glue-scripts/sample_aws_glue_job.py"])
+    @parameterized.expand(
+        [
+            "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
+            "/glue-examples/glue-scripts/sample_aws_glue_job.py",
+        ]
+    )
     @mock.patch.object(AwsGlueJobHook, 'get_job_state')
     @mock.patch.object(AwsGlueJobHook, 'initialize_job')
     @mock.patch.object(AwsGlueJobHook, "get_conn")
     @mock.patch.object(S3Hook, "load_file")
     def test_execute_without_failure(
-        self, script_location,
-        mock_load_file,
-        mock_get_conn,
-        mock_initialize_job,
-        mock_get_job_state
+        self, script_location, mock_load_file, mock_get_conn, mock_initialize_job, mock_get_job_state
     ):
         glue = AwsGlueJobOperator(
             task_id='test_glue_operator',
@@ -55,8 +55,7 @@ class TestAwsGlueJobOperator(unittest.TestCase):
             s3_bucket='some_bucket',
             iam_role_name='my_test_role',
         )
-        mock_initialize_job.return_value = {'JobRunState' : 'RUNNING',
-                                            'JobRunId' : '11111'}
+        mock_initialize_job.return_value = {'JobRunState': 'RUNNING', 'JobRunId': '11111'}
         mock_get_job_state.return_value = 'SUCCEEDED'
         glue.execute(None)
         mock_initialize_job.assert_called_once_with({})

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -17,6 +17,7 @@
 
 import unittest
 from unittest import mock
+from parameterized import parameterized
 
 from airflow import configuration
 from airflow.providers.amazon.aws.hooks.glue import AwsGlueJobHook
@@ -30,27 +31,33 @@ class TestAwsGlueJobOperator(unittest.TestCase):
         configuration.load_test_config()
 
         self.glue_hook_mock = glue_hook_mock
-        some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
-        self.glue = AwsGlueJobOperator(
-            task_id='test_glue_operator',
-            job_name='my_test_job',
-            script_location=some_script,
-            aws_conn_id='aws_default',
-            region_name='us-west-2',
-            s3_bucket='some_bucket',
-            iam_role_name='my_test_role',
-        )
 
+    @parameterized.expand([
+        "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
+        "/glue-examples/glue-scripts/sample_aws_glue_job.py"])
     @mock.patch.object(AwsGlueJobHook, 'get_job_state')
     @mock.patch.object(AwsGlueJobHook, 'initialize_job')
     @mock.patch.object(AwsGlueJobHook, "get_conn")
     @mock.patch.object(S3Hook, "load_file")
     def test_execute_without_failure(
-        self, mock_load_file, mock_get_conn, mock_initialize_job, mock_get_job_state
+        self, script_location,
+        mock_load_file,
+        mock_get_conn,
+        mock_initialize_job,
+        mock_get_job_state
     ):
-        mock_initialize_job.return_value = {'JobRunState': 'RUNNING', 'JobRunId': '11111'}
+        glue = AwsGlueJobOperator(
+            task_id='test_glue_operator',
+            job_name='my_test_job',
+            script_location=script_location,
+            aws_conn_id='aws_default',
+            region_name='us-west-2',
+            s3_bucket='some_bucket',
+            iam_role_name='my_test_role',
+        )
+        mock_initialize_job.return_value = {'JobRunState' : 'RUNNING',
+                                            'JobRunId' : '11111'}
         mock_get_job_state.return_value = 'SUCCEEDED'
-        self.glue.execute(None)
-
+        glue.execute(None)
         mock_initialize_job.assert_called_once_with({})
-        assert self.glue.job_name == 'my_test_job'
+        assert glue.job_name == 'my_test_job'

--- a/tests/providers/amazon/aws/operators/test_glue.py
+++ b/tests/providers/amazon/aws/operators/test_glue.py
@@ -35,8 +35,8 @@ class TestAwsGlueJobOperator(unittest.TestCase):
 
     @parameterized.expand(
         [
-            "/glue-examples/glue-scripts/sample_aws_glue_job.py",
             "s3://glue-examples/glue-scripts/sample_aws_glue_job.py",
+            "/glue-examples/glue-scripts/sample_aws_glue_job.py",
         ]
     )
     @mock.patch.object(AwsGlueJobHook, 'get_job_state')


### PR DESCRIPTION
Use of s3Hook load_file is wrong and leads to an error
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid bucket name "artifacts/glue-scripts/myscript.py": Bucket name must match the regex "^[a-zA-Z0-9.\-_]{1,255}$" or be an ARN matching the regex "^arn:(aws).*:(s3|s3-object-lambda):[a-z\-0-9]+:[0-9]{12}:accesspoint[/:][a-zA-Z0-9\-]{1,63}$|^arn:(aws).*:s3-outposts:[a-z\-0-9]+:[0-9]{12}:outpost[/:][a-zA-Z0-9\-]{1,63}[/:]accesspoint[/:][a-zA-Z0-9\-]{1,63}$"
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
