### PR TITLE
Fix elasticsearch secret created without elastticsearch enabled

### DIFF
--- a/chart/templates/check-values.yaml
+++ b/chart/templates/check-values.yaml
@@ -49,3 +49,14 @@ The sole purpose of this yaml file is it to check the values file is consistent 
     {{- end }}
 
   {{- end }}
+
+  {{- if and .Values.elasticsearch.enabled  }}
+    {{- if and .Values.elasticsearch.secretName .Values.elasticsearch.connection }}
+      {{ required "You must not set both values elasticsearch.secretName and elasticsearch.connection" nil }}
+    {{- end }}
+
+    {{- if not (or .Values.elasticsearch.secretName .Values.elasticsearch.connection) }}
+      {{ required "You must set one of the values elasticsearch.secretName or elasticsearch.connection when using a Elasticsearch" nil }}
+    {{- end }}
+
+  {{- end }}

--- a/chart/templates/check-values.yaml
+++ b/chart/templates/check-values.yaml
@@ -50,7 +50,7 @@ The sole purpose of this yaml file is it to check the values file is consistent 
 
   {{- end }}
 
-  {{- if and .Values.elasticsearch.enabled  }}
+  {{- if .Values.elasticsearch.enabled  }}
     {{- if and .Values.elasticsearch.secretName .Values.elasticsearch.connection }}
       {{ required "You must not set both values elasticsearch.secretName and elasticsearch.connection" nil }}
     {{- end }}

--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -18,7 +18,7 @@
 ################################
 ## Elasticsearch Secret
 #################################
-{{- if (and .Values.elasticsearch.connection (not .Values.elasticsearch.secretName)) }}
+{{- if (and .Values.elasticsearch.enabled (not .Values.elasticsearch.secretName)) }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -45,8 +45,8 @@ class ElasticsearchSecretTest(unittest.TestCase):
                 show_only=["templates/secrets/elasticsearch-secret.yaml"],
             )
         assert (
-            "You must set one of the values elasticsearch.secretName or elasticsearch.connection when using a Elasticsearch"
-            in ex_ctx.exception.stderr.decode()
+            "You must set one of the values elasticsearch.secretName or elasticsearch.connection "
+            "when using a Elasticsearch" in ex_ctx.exception.stderr.decode()
         )
 
     def test_should_raise_error_when_conflicting_options(self):

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -17,6 +17,7 @@
 
 import base64
 import unittest
+from subprocess import CalledProcessError
 
 import jmespath
 
@@ -24,6 +25,51 @@ from tests.helm_template_generator import render_chart
 
 
 class ElasticsearchSecretTest(unittest.TestCase):
+    def test_should_not_generate_a_document_if_elasticsearch_disabled(self):
+
+        docs = render_chart(
+            values={"elasticsearch": {"enabled": False}},
+            show_only=["templates/secrets/elasticsearch-secret.yaml"],
+        )
+
+        assert 0 == len(docs)
+
+    def test_should_raise_error_when_connection_not_provided(self):
+        with self.assertRaises(CalledProcessError) as ex_ctx:
+            render_chart(
+                values={
+                    "elasticsearch": {
+                        "enabled": True,
+                    }
+                },
+                show_only=["templates/secrets/elasticsearch-secret.yaml"],
+            )
+        assert (
+            "You must set one of the values elasticsearch.secretName or elasticsearch.connection when using a Elasticsearch"
+            in ex_ctx.exception.stderr.decode()
+        )
+
+    def test_should_raise_error_when_conflicting_options(self):
+        with self.assertRaises(CalledProcessError) as ex_ctx:
+            render_chart(
+                values={
+                    "elasticsearch": {
+                        "enabled": True,
+                        "secretName": "my-test",
+                        "connection": {
+                            "user": "username!@#$%%^&*()",
+                            "pass": "password!@#$%%^&*()",
+                            "host": "elastichostname",
+                        },
+                    },
+                },
+                show_only=["templates/secrets/elasticsearch-secret.yaml"],
+            )
+        assert (
+            "You must not set both values elasticsearch.secretName and elasticsearch.connection"
+            in ex_ctx.exception.stderr.decode()
+        )
+
     def _get_connection(self, values: dict) -> str:
         docs = render_chart(
             values=values,
@@ -36,11 +82,12 @@ class ElasticsearchSecretTest(unittest.TestCase):
         connection = self._get_connection(
             {
                 "elasticsearch": {
+                    "enabled": True,
                     "connection": {
                         "user": "username!@#$%%^&*()",
                         "pass": "password!@#$%%^&*()",
                         "host": "elastichostname",
-                    }
+                    },
                 }
             }
         )


### PR DESCRIPTION
When Elasticsearch is not enabled, we should ignore all configuration options in its section. 

Additionally, I added validations for two incorrect configurations to improve DX.

Similar to: https://github.com/apache/airflow/pull/16011 CC: @Junnplus 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
