### PR TITLE
Removes arrow higher limits for plexus provider

### DIFF
--- a/airflow/providers/plexus/hooks/plexus.py
+++ b/airflow/providers/plexus/hooks/plexus.py
@@ -67,7 +67,7 @@ class PlexusHook(BaseHook):
     def token(self) -> Any:
         """Returns users token"""
         if self.__token is not None:
-            if arrow.get(self.__token_exp) <= arrow.now():
+            if not self.__token_exp or arrow.get(self.__token_exp) <= arrow.now():
                 self.__token = self._generate_token()
             return self.__token
         else:

--- a/setup.py
+++ b/setup.py
@@ -416,7 +416,7 @@ pinot = [
     'pinotdb>0.1.2,<1.0.0',
 ]
 plexus = [
-    'arrow>=0.16.0,<1.0.0',
+    'arrow>=0.16.0',
 ]
 postgres = [
     'psycopg2-binary>=2.7.4',


### PR DESCRIPTION
Plexus provider needlessly limits arrow to <1.0.0. This was added
in #14781 to fix failing tests, but Plexus uses arrow in a very
limited way and it turned out that just checking for None value
before running arrow.get(), fixes the problem (and we can upgrade
to latest version of arrow as well).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
