### PR TITLE
Fix bigquery type error when export format is parquet

### DIFF
--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -20,7 +20,7 @@ import abc
 import json
 import warnings
 from tempfile import NamedTemporaryFile
-from typing import Optional, Sequence, Union
+from typing import Dict, Optional, Sequence, Union
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -289,7 +289,7 @@ class BaseSQLToGCSOperator(BaseOperator):
         """Execute DBAPI query."""
 
     @abc.abstractmethod
-    def field_to_bigquery(self, field):
+    def field_to_bigquery(self, field) -> Dict[str, str]:
         """Convert a DBAPI field to BigQuery schema format."""
 
     @abc.abstractmethod

--- a/airflow/providers/google/cloud/transfers/sql_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/sql_to_gcs.py
@@ -278,7 +278,8 @@ class BaseSQLToGCSOperator(BaseOperator):
         }
 
         columns = [field[0] for field in cursor.description]
-        bq_types = [self.field_to_bigquery(field) for field in cursor.description]
+        bq_fields = [self.field_to_bigquery(field) for field in cursor.description]
+        bq_types = [bq_field.get('type') if bq_field is not None else None for bq_field in bq_fields]
         pq_types = [type_map.get(bq_type, pa.string()) for bq_type in bq_types]
         parquet_schema = pa.schema(zip(columns, pq_types))
         return parquet_schema

--- a/tests/providers/google/cloud/transfers/test_sql_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_sql_to_gcs.py
@@ -17,6 +17,7 @@
 
 import json
 import unittest
+from typing import Dict
 from unittest import mock
 from unittest.mock import MagicMock, Mock
 
@@ -62,8 +63,12 @@ OUTPUT_DF = pd.DataFrame([['convert_type_return_value'] * 3] * 3, columns=COLUMN
 
 
 class DummySQLToGCSOperator(BaseSQLToGCSOperator):
-    def field_to_bigquery(self, field):
-        pass
+    def field_to_bigquery(self, field) -> Dict[str, str]:
+        return {
+            'name': field[0],
+            'type': 'STRING',
+            'mode': 'NULLABLE',
+        }
 
     def convert_type(self, value, schema_type):
         return 'convert_type_return_value'


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

When uploading parquet to gcs using sql_to_gcs.py, converting fields fails with the error unhashable type dict as field_to_bigquery method returns dictionary.
To avoid this error we only need to use type information of returned dictionary

Related Issues #14871


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
