### PR TITLE
Update `airflow tasks *` commands to lookup TaskInstances from DagRun Table

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -141,6 +141,7 @@ def positive_int(*, allow_zero):
 ARG_DAG_ID = Arg(("dag_id",), help="The id of the dag")
 ARG_TASK_ID = Arg(("task_id",), help="The id of the task")
 ARG_EXECUTION_DATE = Arg(("execution_date",), help="The execution date of the DAG", type=parsedate)
+ARG_DAG_RUN_ID = Arg(('dag_run_id',), help="The run_id of the DAGRun")
 ARG_TASK_REGEX = Arg(
     ("-t", "--task-regex"), help="The regex to filter specific task_ids to backfill (optional)"
 )
@@ -974,7 +975,7 @@ TASKS_COMMANDS = (
         name='state',
         help="Get the status of a task instance",
         func=lazy_load_command('airflow.cli.commands.task_command.task_state'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_DAG_RUN_ID, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='failed-deps',
@@ -985,13 +986,13 @@ TASKS_COMMANDS = (
             "and then run by an executor."
         ),
         func=lazy_load_command('airflow.cli.commands.task_command.task_failed_deps'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_DAG_RUN_ID, ARG_SUBDIR),
     ),
     ActionCommand(
         name='render',
         help="Render a task instance's template(s)",
         func=lazy_load_command('airflow.cli.commands.task_command.task_render'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE, ARG_SUBDIR, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_DAG_RUN_ID, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='run',
@@ -1000,7 +1001,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_EXECUTION_DATE,
+            ARG_DAG_RUN_ID,
             ARG_SUBDIR,
             ARG_MARK_SUCCESS,
             ARG_FORCE,
@@ -1030,7 +1031,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_EXECUTION_DATE,
+            ARG_DAG_RUN_ID,
             ARG_SUBDIR,
             ARG_DRY_RUN,
             ARG_TASK_PARAMS,
@@ -1042,7 +1043,7 @@ TASKS_COMMANDS = (
         name='states-for-dag-run',
         help="Get the status of all task instances in a dag run",
         func=lazy_load_command('airflow.cli.commands.task_command.task_states_for_dag_run'),
-        args=(ARG_DAG_ID, ARG_EXECUTION_DATE, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_DAG_RUN_ID, ARG_OUTPUT, ARG_VERBOSE),
     ),
 )
 POOLS_COMMANDS = (

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -141,7 +141,9 @@ def positive_int(*, allow_zero):
 ARG_DAG_ID = Arg(("dag_id",), help="The id of the dag")
 ARG_TASK_ID = Arg(("task_id",), help="The id of the task")
 ARG_EXECUTION_DATE = Arg(("execution_date",), help="The execution date of the DAG", type=parsedate)
-ARG_DAG_RUN_ID = Arg(('dag_run_id',), help="The run_id of the DAGRun")
+ARG_EXECUTION_DATE_OR_DAGRUN_ID = Arg(
+    ('execution_date_or_run_id',), help="The execution_date of the DAG or run_id of the DAGRun"
+)
 ARG_TASK_REGEX = Arg(
     ("-t", "--task-regex"), help="The regex to filter specific task_ids to backfill (optional)"
 )
@@ -975,7 +977,7 @@ TASKS_COMMANDS = (
         name='state',
         help="Get the status of a task instance",
         func=lazy_load_command('airflow.cli.commands.task_command.task_state'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_DAG_RUN_ID, ARG_SUBDIR, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='failed-deps',
@@ -986,13 +988,13 @@ TASKS_COMMANDS = (
             "and then run by an executor."
         ),
         func=lazy_load_command('airflow.cli.commands.task_command.task_failed_deps'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_DAG_RUN_ID, ARG_SUBDIR),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR),
     ),
     ActionCommand(
         name='render',
         help="Render a task instance's template(s)",
         func=lazy_load_command('airflow.cli.commands.task_command.task_render'),
-        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_DAG_RUN_ID, ARG_SUBDIR, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_TASK_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_SUBDIR, ARG_VERBOSE),
     ),
     ActionCommand(
         name='run',
@@ -1001,7 +1003,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_DAG_RUN_ID,
+            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
             ARG_SUBDIR,
             ARG_MARK_SUCCESS,
             ARG_FORCE,
@@ -1031,7 +1033,7 @@ TASKS_COMMANDS = (
         args=(
             ARG_DAG_ID,
             ARG_TASK_ID,
-            ARG_DAG_RUN_ID,
+            ARG_EXECUTION_DATE_OR_DAGRUN_ID,
             ARG_SUBDIR,
             ARG_DRY_RUN,
             ARG_TASK_PARAMS,
@@ -1043,7 +1045,7 @@ TASKS_COMMANDS = (
         name='states-for-dag-run',
         help="Get the status of all task instances in a dag run",
         func=lazy_load_command('airflow.cli.commands.task_command.task_states_for_dag_run'),
-        args=(ARG_DAG_ID, ARG_DAG_RUN_ID, ARG_OUTPUT, ARG_VERBOSE),
+        args=(ARG_DAG_ID, ARG_EXECUTION_DATE_OR_DAGRUN_ID, ARG_OUTPUT, ARG_VERBOSE),
     ),
 )
 POOLS_COMMANDS = (

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -374,22 +374,6 @@ def task_states_for_dag_run(args, session=None):
         },
     )
 
-    if dag_run is None:
-        raise AirflowException("DagRun does not exist.")
-    tis = dag_run.get_task_instances()
-    AirflowConsole().print_as(
-        data=tis,
-        output=args.output,
-        mapper=lambda ti: {
-            "dag_id": ti.dag_id,
-            "execution_date": ti.execution_date.isoformat(),
-            "task_id": ti.task_id,
-            "state": ti.state,
-            "start_date": ti.start_date.isoformat() if ti.start_date else "",
-            "end_date": ti.end_date.isoformat() if ti.end_date else "",
-        },
-    )
-
 
 @cli_utils.action_logging
 def task_test(args, dag=None):

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -51,7 +51,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session, provide_session
 
 
-def _get_ti(dag, task, exec_date_or_run_id):
+def _get_ti(dag, task_id, exec_date_or_run_id):
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way"""
     dag_run = dag.get_dagrun(run_id=exec_date_or_run_id)
     if not dag_run:

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -64,6 +64,8 @@ def _get_ti(task, exec_date_or_run_id):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
     ti = dag_run.get_task_instance(task.task_id)
     ti.task = task
+    ti.run_as_user = task.run_as_user
+    ti.execution_date = dag_run.execution_date
     return ti
 
 
@@ -360,6 +362,23 @@ def task_states_for_dag_run(args, session=None):
 
     if dag_run is None:
         raise AirflowException("DagRun does not exist.")
+    tis = dag_run.get_task_instances()
+    AirflowConsole().print_as(
+        data=tis,
+        output=args.output,
+        mapper=lambda ti: {
+            "dag_id": ti.dag_id,
+            "execution_date": ti.execution_date.isoformat(),
+            "task_id": ti.task_id,
+            "state": ti.state,
+            "start_date": ti.start_date.isoformat() if ti.start_date else "",
+            "end_date": ti.end_date.isoformat() if ti.end_date else "",
+        },
+    )
+
+    if dag_run is None:
+        raise AirflowException("DagRun does not exist.")
+
     tis = dag_run.get_task_instances()
     AirflowConsole().print_as(
         data=tis,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -362,7 +362,6 @@ def task_states_for_dag_run(args, session=None):
 
     if dag_run is None:
         raise AirflowException("DagRun does not exist.")
-
     tis = dag_run.get_task_instances()
     AirflowConsole().print_as(
         data=tis,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -51,22 +51,22 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session, provide_session
 
 
-def _get_ti(dag, task, exec_date_or_run_id):
+def _get_ti(task, exec_date_or_run_id):
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way"""
-    dag_run = dag.get_dagrun(run_id=exec_date_or_run_id)
+    dag_run = task.dag.get_dagrun(run_id=exec_date_or_run_id)
     if not dag_run:
         try:
             execution_date = timezone.parse(exec_date_or_run_id)
             # print("Warning: execution_date will be removed in
             # tasks command in the future. Please use DagRun.run_id")
             ti = TaskInstance(task, execution_date)
+            ti.refresh_from_db()
             return ti
         except (ParserError, TypeError):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
     ti = dag_run.get_task_instance(task.task_id)
     ti.task = task
-    ti.run_as_user = task.run_as_user
-    ti.execution_date = dag_run.execution_date
+    ti.refresh_from_db()
     return ti
 
 
@@ -245,8 +245,7 @@ def task_run(args, dag=None):
         # Use DAG from parameter
         pass
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(dag, task, args.execution_date_or_run_id)
-    ti.refresh_from_db()
+    ti = _get_ti(task, args.execution_date_or_run_id)
     ti.init_run_context(raw=args.raw)
 
     hostname = get_hostname()
@@ -274,7 +273,7 @@ def task_failed_deps(args):
     """
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(dag, task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id)
 
     dep_context = DepContext(deps=SCHEDULER_QUEUED_DEPS)
     failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
@@ -297,7 +296,7 @@ def task_state(args):
     """
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(dag, task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id)
     print(ti.current_state())
 
 
@@ -409,7 +408,7 @@ def task_test(args, dag=None):
     if args.task_params:
         passed_in_params = json.loads(args.task_params)
         task.params.update(passed_in_params)
-    ti = _get_ti(dag, task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id)
 
     try:
         if args.dry_run:
@@ -435,7 +434,7 @@ def task_render(args):
     """Renders and displays templated fields for a given task"""
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(dag, task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id)
     ti.render_templates()
     for attr in task.__class__.template_fields:
         print(

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -64,8 +64,6 @@ def _get_ti(task, exec_date_or_run_id):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
     ti = dag_run.get_task_instance(task.task_id)
     ti.task = task
-    ti.run_as_user = task.run_as_user
-    ti.execution_date = dag_run.execution_date
     return ti
 
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -57,8 +57,6 @@ def _get_ti(task, exec_date_or_run_id):
     if not dag_run:
         try:
             execution_date = timezone.parse(exec_date_or_run_id)
-            # print("Warning: execution_date will be removed in
-            # tasks command in the future. Please use DagRun.run_id")
             ti = TaskInstance(task, execution_date)
             ti.refresh_from_db()
             return ti
@@ -66,7 +64,6 @@ def _get_ti(task, exec_date_or_run_id):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
     ti = dag_run.get_task_instance(task.task_id)
     ti.task = task
-    ti.refresh_from_db()
     return ti
 
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -378,7 +378,6 @@ def task_states_for_dag_run(args, session=None):
 
     if dag_run is None:
         raise AirflowException("DagRun does not exist.")
-
     tis = dag_run.get_task_instances()
     AirflowConsole().print_as(
         data=tis,

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -56,10 +56,10 @@ def _get_ti(dag, task, task_id, run_id):
     dag_run = dag.get_dagrun(run_id=run_id)
     if not dag_run:
         try:
-            timezone.parse(run_id)
+            execution_date = timezone.parse(run_id)
             # print("Warning: execution_date will be removed in
             # tasks command in the future. Please use DagRun.run_id")
-            ti = TaskInstance(task, execution_date=run_id)
+            ti = TaskInstance(task, execution_date)
             return ti
         except (ParserError, TypeError):
             raise AirflowException(f"DagRun with run_id: {run_id} not found")

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -64,6 +64,9 @@ def _get_ti(dag, task, exec_date_or_run_id):
         except (ParserError, TypeError):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
     ti = dag_run.get_task_instance(task.task_id)
+    ti.task = task
+    ti.run_as_user = task.run_as_user
+    ti.execution_date = dag_run.execution_date
     return ti
 
 

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -24,7 +24,7 @@ import textwrap
 from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from typing import List
 
-from pendulum.parsing import ParserError
+from pendulum.parsing.exceptions import ParserError
 
 from airflow import settings
 from airflow.cli.simple_table import AirflowConsole

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -63,7 +63,7 @@ def _get_ti(dag, task, exec_date_or_run_id):
             return ti
         except (ParserError, TypeError):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
-    ti = TaskInstance(task, execution_date=dag_run.execution_date)
+    ti = dag_run.get_task_instance(task.task_id)
     return ti
 
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -934,7 +934,12 @@ class DAG(LoggingMixin):
         return query.scalar()
 
     @provide_session
-    def get_dagrun(self, execution_date: str = None, run_id: str = None, session=None):
+    def get_dagrun(
+        self,
+        execution_date: Optional[str] = None,
+        run_id: Optional[str] = None,
+        session: Optional[Session] = None,
+    ):
         """
         Returns the dag run for a given execution date or run_id if it exists, otherwise
         none.

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -934,22 +934,24 @@ class DAG(LoggingMixin):
         return query.scalar()
 
     @provide_session
-    def get_dagrun(self, execution_date, session=None):
+    def get_dagrun(self, execution_date: str = None, run_id: str = None, session=None):
         """
-        Returns the dag run for a given execution date if it exists, otherwise
+        Returns the dag run for a given execution date or run_id if it exists, otherwise
         none.
 
         :param execution_date: The execution date of the DagRun to find.
+        :param run_id: The run_id of the DagRun to find.
         :param session:
         :return: The DagRun if found, otherwise None.
         """
-        dagrun = (
-            session.query(DagRun)
-            .filter(DagRun.dag_id == self.dag_id, DagRun.execution_date == execution_date)
-            .first()
-        )
-
-        return dagrun
+        if not (execution_date or run_id):
+            raise AirflowException("You must provide either the execution_date or the run_id")
+        query = session.query(DagRun)
+        if execution_date:
+            query = query.filter(DagRun.dag_id == self.dag_id, DagRun.execution_date == execution_date)
+        if run_id:
+            query = query.filter(DagRun.dag_id == self.dag_id, DagRun.run_id == run_id)
+        return query.first()
 
     @provide_session
     def get_dagruns_between(self, start_date, end_date, session=None):

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -945,7 +945,7 @@ class DAG(LoggingMixin):
         :return: The DagRun if found, otherwise None.
         """
         if not (execution_date or run_id):
-            raise AirflowException("You must provide either the execution_date or the run_id")
+            raise TypeError("You must provide either the execution_date or the run_id")
         query = session.query(DagRun)
         if execution_date:
             query = query.filter(DagRun.dag_id == self.dag_id, DagRun.execution_date == execution_date)

--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -76,7 +76,7 @@ class StandardTaskRunner(BaseTaskRunner):
             self.log.info('Running: %s', self._command)
             self.log.info('Job %s: Subtask %s', self._task_instance.job_id, self._task_instance.task_id)
 
-            proc_title = "airflow task runner: {0.dag_id} {0.task_id} {0.execution_date}"
+            proc_title = "airflow task runner: {0.dag_id} {0.task_id} {0.execution_date_or_run_id}"
             if hasattr(args, "job_id"):
                 proc_title += " {0.job_id}"
             setproctitle(proc_title.format(args))

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -235,6 +235,7 @@ class TestCliTasks(unittest.TestCase):
             )
 
         output = stdout.getvalue()
+
         assert 'echo "2016-01-01"' in output
         assert 'echo "2016-01-08"' in output
         assert 'echo "Parameter I passed in"' in output
@@ -275,13 +276,16 @@ class TestCliTasks(unittest.TestCase):
     def test_task_states_for_dag_run(self):
 
         dag2 = DagBag().dags['example_python_operator']
+        task2 = dag2.get_task(task_id='print_the_context')
         default_date2 = timezone.make_aware(datetime(2016, 1, 9))
+        dag2.clear()
 
-        dag_run = dag2.get_dagrun(execution_date=default_date2)
-        tis = dag_run.get_task_instances()
-        ti2 = tis[0]
+        ti2 = TaskInstance(task2, default_date2)
+
+        ti2.set_state(State.SUCCESS)
         ti_start = ti2.start_date
         ti_end = ti2.end_date
+
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_states_for_dag_run(
                 self.parser.parse_args(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -36,7 +36,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils import timezone
 from airflow.utils.cli import get_dag
-from airflow.utils.session import create_session
+from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
@@ -351,7 +351,8 @@ class TestCliTasks(unittest.TestCase):
             )
         )
 
-    def test_task_states_for_dag_run(self):
+    @provide_session
+    def test_task_states_for_dag_run(self, session=None):
 
         dag2 = DagBag().dags['example_python_operator']
         task2 = dag2.get_task(task_id='print_the_context')

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -235,7 +235,6 @@ class TestCliTasks(unittest.TestCase):
             )
 
         output = stdout.getvalue()
-
         assert 'echo "2016-01-01"' in output
         assert 'echo "2016-01-08"' in output
         assert 'echo "Parameter I passed in"' in output
@@ -276,16 +275,13 @@ class TestCliTasks(unittest.TestCase):
     def test_task_states_for_dag_run(self):
 
         dag2 = DagBag().dags['example_python_operator']
-        task2 = dag2.get_task(task_id='print_the_context')
         default_date2 = timezone.make_aware(datetime(2016, 1, 9))
-        dag2.clear()
 
-        ti2 = TaskInstance(task2, default_date2)
-
-        ti2.set_state(State.SUCCESS)
+        dag_run = dag2.get_dagrun(execution_date=default_date2)
+        tis = dag_run.get_task_instances()
+        ti2 = tis[0]
         ti_start = ti2.start_date
         ti_end = ti2.end_date
-
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_states_for_dag_run(
                 self.parser.parse_args(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -36,7 +36,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils import timezone
 from airflow.utils.cli import get_dag
-from airflow.utils.session import create_session, provide_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
@@ -351,8 +351,7 @@ class TestCliTasks(unittest.TestCase):
             )
         )
 
-    @provide_session
-    def test_task_states_for_dag_run(self, session=None):
+    def test_task_states_for_dag_run(self):
 
         dag2 = DagBag().dags['example_python_operator']
         task2 = dag2.get_task(task_id='print_the_context')

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -64,6 +64,10 @@ class TestCliTasks(unittest.TestCase):
         cls.parser = cli_parser.get_parser()
         clear_db_runs()
 
+    @classmethod
+    def tearDownClass(cls) -> None:
+        clear_db_runs()
+
     def test_cli_list_tasks(self):
         for dag_id in self.dagbag.dags:
             args = self.parser.parse_args(['tasks', 'list', dag_id])

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -313,6 +313,7 @@ class TestCliTasks(unittest.TestCase):
             )
 
         output = stdout.getvalue()
+
         assert 'echo "2016-01-01"' in output
         assert 'echo "2016-01-08"' in output
         assert 'echo "Parameter I passed in"' in output
@@ -353,6 +354,7 @@ class TestCliTasks(unittest.TestCase):
     def test_task_states_for_dag_run(self):
 
         dag2 = DagBag().dags['example_python_operator']
+        task2 = dag2.get_task(task_id='print_the_context')
         default_date2 = timezone.make_aware(datetime(2016, 1, 9))
         dag2.clear()
         dagrun = dag2.create_dagrun(
@@ -365,6 +367,7 @@ class TestCliTasks(unittest.TestCase):
         ti2.set_state(State.SUCCESS)
         ti_start = ti2.start_date
         ti_end = ti2.end_date
+
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_states_for_dag_run(
                 self.parser.parse_args(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -313,7 +313,6 @@ class TestCliTasks(unittest.TestCase):
             )
 
         output = stdout.getvalue()
-
         assert 'echo "2016-01-01"' in output
         assert 'echo "2016-01-08"' in output
         assert 'echo "Parameter I passed in"' in output
@@ -354,7 +353,6 @@ class TestCliTasks(unittest.TestCase):
     def test_task_states_for_dag_run(self):
 
         dag2 = DagBag().dags['example_python_operator']
-        task2 = dag2.get_task(task_id='print_the_context')
         default_date2 = timezone.make_aware(datetime(2016, 1, 9))
         dag2.clear()
         dagrun = dag2.create_dagrun(
@@ -367,7 +365,6 @@ class TestCliTasks(unittest.TestCase):
         ti2.set_state(State.SUCCESS)
         ti_start = ti2.start_date
         ti_end = ti2.end_date
-
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_states_for_dag_run(
                 self.parser.parse_args(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -64,8 +64,7 @@ class TestCliTasks(unittest.TestCase):
         cls.parser = cli_parser.get_parser()
         clear_db_runs()
 
-    @classmethod
-    def tearDownClass(cls) -> None:
+    def tearDown(self) -> None:
         clear_db_runs()
 
     def test_cli_list_tasks(self):

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -36,7 +36,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DagBag, DagRun, TaskInstance
 from airflow.utils import timezone
 from airflow.utils.cli import get_dag
-from airflow.utils.session import create_session, provide_session
+from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
@@ -348,18 +348,12 @@ class TestCliTasks(unittest.TestCase):
             )
         )
 
-    @provide_session
-    def test_task_states_for_dag_run(self, session=None):
+    def test_task_states_for_dag_run(self):
 
         dag2 = DagBag().dags['example_python_operator']
         task2 = dag2.get_task(task_id='print_the_context')
         default_date2 = timezone.make_aware(datetime(2016, 1, 9))
         dag2.clear()
-        dr = DagRun.find(execution_date=default_date2)
-        if dr:
-            for dagrun in dr:
-                session.delete(dagrun)
-            session.commit()
         dagrun = dag2.create_dagrun(
             state=State.RUNNING,
             execution_date=default_date2,

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -169,6 +169,28 @@ class TestCliTasks(unittest.TestCase):
             pool=None,
         )
 
+    @mock.patch("airflow.cli.commands.task_command.LocalTaskJob")
+    def test_run_raises_when_theres_no_dagrun(self, mock_local_job):
+        """
+        Test that run raises when there's run_id but no dag_run
+        """
+        dag_id = 'test_run_ignores_all_dependencies'
+        dag = self.dagbag.get_dag(dag_id)
+        task0_id = 'test_run_dependent_task'
+        run_id = 'TEST_RUN_ID'
+        args0 = [
+            'tasks',
+            'run',
+            '--ignore-all-dependencies',
+            '--local',
+            dag_id,
+            task0_id,
+            run_id,
+        ]
+        with self.assertRaises(AirflowException) as err:
+            task_command.task_run(self.parser.parse_args(args0), dag=dag)
+        assert str(err.exception) == f"DagRun with run_id: {run_id} not found"
+
     def test_cli_test(self):
         task_command.task_test(
             self.parser.parse_args(

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -87,8 +87,7 @@ class TestCliTasks(unittest.TestCase):
         # Check that prints, and log messages, are shown
         assert "'example_python_operator__print_the_context__20180101'" in stdout.getvalue()
 
-    @mock.patch("airflow.models.taskinstance.TaskInstance._run_mini_scheduler_on_child_tasks")
-    def test_test_with_existing_dag_run(self, mock_run_mini_scheduler):
+    def test_test_with_existing_dag_run(self):
         """Test the `airflow test` command"""
         dag_id = 'example_python_operator'
         run_id = 'TEST_RUN_ID'
@@ -102,7 +101,6 @@ class TestCliTasks(unittest.TestCase):
         with redirect_stdout(io.StringIO()) as stdout:
             task_command.task_test(args)
 
-        mock_run_mini_scheduler.assert_not_called()
         # Check that prints, and log messages, are shown
         assert f"Marking task as SUCCESS. dag_id={dag_id}, task_id={task_id}" in stdout.getvalue()
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3938,7 +3938,7 @@ class TestSchedulerJob(unittest.TestCase):
         # Verify a DagRun is created with the correct execution_date
         # when Scheduler._do_scheduling is run in the Scheduler Loop
         self.scheduler_job._do_scheduling(session)
-        dr1 = dag.get_dagrun(DEFAULT_DATE, session)
+        dr1 = dag.get_dagrun(DEFAULT_DATE, session=session)
         assert dr1 is not None
         assert dr1.state == State.RUNNING
 


### PR DESCRIPTION
This change adds the ability to lookup TaskInstances using the DagRun.run_id


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
