### PR TITLE
Standardise dataproc location param to region

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -15,6 +15,16 @@
     specific language governing permissions and limitations
     under the License.
 
+Changelog
+---------
+
+4.1.0
+.....
+
+Bug Fixes
+~~~~~~~~~
+* ``Fix: Inconsistencies with Dataproc Operator parameters (#15622)``
+
 
 Changelog
 ---------

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -18,17 +18,6 @@
 Changelog
 ---------
 
-4.1.0
-.....
-
-Bug Fixes
-~~~~~~~~~
-* ``Fix: Inconsistencies with Dataproc Operator parameters (#15622)``
-
-
-Changelog
----------
-
 4.0.0
 .....
 

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -170,7 +170,7 @@ with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interva
         update_mask=UPDATE_MASK,
         graceful_decommission_timeout=TIMEOUT,
         project_id=PROJECT_ID,
-        location=REGION,
+        region=REGION,
     )
     # [END how_to_cloud_dataproc_update_cluster_operator]
 
@@ -179,7 +179,7 @@ with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interva
         task_id="create_workflow_template",
         template=WORKFLOW_TEMPLATE,
         project_id=PROJECT_ID,
-        location=REGION,
+        region=REGION,
     )
     # [END how_to_cloud_dataproc_create_workflow_template]
 
@@ -190,24 +190,24 @@ with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interva
     # [END how_to_cloud_dataproc_trigger_workflow_template]
 
     pig_task = DataprocSubmitJobOperator(
-        task_id="pig_task", job=PIG_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="pig_task", job=PIG_JOB, region=REGION, project_id=PROJECT_ID
     )
     spark_sql_task = DataprocSubmitJobOperator(
-        task_id="spark_sql_task", job=SPARK_SQL_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="spark_sql_task", job=SPARK_SQL_JOB, region=REGION, project_id=PROJECT_ID
     )
 
     spark_task = DataprocSubmitJobOperator(
-        task_id="spark_task", job=SPARK_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="spark_task", job=SPARK_JOB, region=REGION, project_id=PROJECT_ID
     )
 
     # [START cloud_dataproc_async_submit_sensor]
     spark_task_async = DataprocSubmitJobOperator(
-        task_id="spark_task_async", job=SPARK_JOB, location=REGION, project_id=PROJECT_ID, asynchronous=True
+        task_id="spark_task_async", job=SPARK_JOB, region=REGION, project_id=PROJECT_ID, asynchronous=True
     )
 
     spark_task_async_sensor = DataprocJobSensor(
         task_id='spark_task_async_sensor_task',
-        location=REGION,
+        region=REGION,
         project_id=PROJECT_ID,
         dataproc_job_id="{{task_instance.xcom_pull(task_ids='spark_task_async')}}",
         poke_interval=10,
@@ -216,20 +216,20 @@ with models.DAG("example_gcp_dataproc", start_date=days_ago(1), schedule_interva
 
     # [START how_to_cloud_dataproc_submit_job_to_cluster_operator]
     pyspark_task = DataprocSubmitJobOperator(
-        task_id="pyspark_task", job=PYSPARK_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="pyspark_task", job=PYSPARK_JOB, region=REGION, project_id=PROJECT_ID
     )
     # [END how_to_cloud_dataproc_submit_job_to_cluster_operator]
 
     sparkr_task = DataprocSubmitJobOperator(
-        task_id="sparkr_task", job=SPARKR_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="sparkr_task", job=SPARKR_JOB, region=REGION, project_id=PROJECT_ID
     )
 
     hive_task = DataprocSubmitJobOperator(
-        task_id="hive_task", job=HIVE_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="hive_task", job=HIVE_JOB, region=REGION, project_id=PROJECT_ID
     )
 
     hadoop_task = DataprocSubmitJobOperator(
-        task_id="hadoop_task", job=HADOOP_JOB, location=REGION, project_id=PROJECT_ID
+        task_id="hadoop_task", job=HADOOP_JOB, region=REGION, project_id=PROJECT_ID
     )
 
     # [START how_to_cloud_dataproc_delete_cluster_operator]

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -207,8 +207,18 @@ class DataprocHook(GoogleBaseHook):
     keyword arguments rather than positional.
     """
 
-    def get_cluster_client(self, region: Optional[str] = None) -> ClusterControllerClient:
+    def get_cluster_client(
+        self, region: Optional[str] = None, location: Optional[str] = None
+    ) -> ClusterControllerClient:
         """Returns ClusterControllerClient."""
+        if location is not None:
+            warnings.warn(
+                "Parameter `location` will be deprecated. "
+                "Please provide value through `region` parameter instead.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            region = location
         client_options = None
         if region and region != 'global':
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
@@ -217,8 +227,18 @@ class DataprocHook(GoogleBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
-    def get_template_client(self, region: Optional[str] = None) -> WorkflowTemplateServiceClient:
+    def get_template_client(
+        self, region: Optional[str] = None, location: Optional[str] = None
+    ) -> WorkflowTemplateServiceClient:
         """Returns WorkflowTemplateServiceClient."""
+        if location is not None:
+            warnings.warn(
+                "Parameter `location` will be deprecated. "
+                "Please provide value through `region` parameter instead.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            region = location
         client_options = None
         if region and region != 'global':
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
@@ -227,8 +247,18 @@ class DataprocHook(GoogleBaseHook):
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
-    def get_job_client(self, region: Optional[str] = None) -> JobControllerClient:
+    def get_job_client(
+        self, region: Optional[str] = None, location: Optional[str] = None
+    ) -> JobControllerClient:
         """Returns JobControllerClient."""
+        if location is not None:
+            warnings.warn(
+                "Parameter `location` will be deprecated. "
+                "Please provide value through `region` parameter instead.",
+                DeprecationWarning,
+                stacklevel=1,
+            )
+            region = location
         client_options = None
         if region and region != 'global':
             client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
@@ -479,11 +509,12 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def update_cluster(
         self,
-        region: str,
         cluster_name: str,
         cluster: Union[Dict, Cluster],
         update_mask: Union[Dict, FieldMask],
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         graceful_decommission_timeout: Optional[Union[Dict, Duration]] = None,
         request_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -497,6 +528,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param cluster_name: Required. The cluster name.
         :type cluster_name: str
         :param cluster: Required. The changes to the cluster.
@@ -548,6 +581,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         client = self.get_cluster_client(region=region)
         operation = client.update_cluster(
             request={
@@ -568,9 +612,10 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def create_workflow_template(
         self,
-        region: str,
         template: Union[Dict, WorkflowTemplate],
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
@@ -582,6 +627,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param template: The Dataproc workflow template to create. If a dict is provided,
             it must be of the same form as the protobuf message WorkflowTemplate.
         :type template: Union[dict, WorkflowTemplate]
@@ -594,6 +641,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         metadata = metadata or ()
         client = self.get_template_client(region)
         parent = f'projects/{project_id}/regions/{region}'
@@ -604,16 +662,17 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def instantiate_workflow_template(
         self,
-        region: str,
         template_name: str,
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         version: Optional[int] = None,
         request_id: Optional[str] = None,
         parameters: Optional[Dict[str, str]] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
-    ):
+    ):  # pylint: disable=too-many-arguments
         """
         Instantiates a template and begins execution.
 
@@ -623,6 +682,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param version: Optional. The version of workflow template to instantiate. If specified,
             the workflow will be instantiated only if the current version of
             the workflow template has the supplied version.
@@ -645,6 +706,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         metadata = metadata or ()
         client = self.get_template_client(region)
         name = f'projects/{project_id}/regions/{region}/workflowTemplates/{template_name}'
@@ -659,9 +731,10 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def instantiate_inline_workflow_template(
         self,
-        region: str,
         template: Union[Dict, WorkflowTemplate],
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         request_id: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
@@ -677,6 +750,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param request_id: Optional. A tag that prevents multiple concurrent workflow instances
             with the same tag from running. This mitigates risk of concurrent
             instances started due to retries.
@@ -690,6 +765,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         metadata = metadata or ()
         client = self.get_template_client(region)
         parent = f'projects/{project_id}/regions/{region}'
@@ -703,7 +789,13 @@ class DataprocHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     def wait_for_job(
-        self, job_id: str, region: str, project_id: str, wait_time: int = 10, timeout: Optional[int] = None
+        self,
+        job_id: str,
+        project_id: str,
+        wait_time: int = 10,
+        region: str = None,
+        location: Optional[str] = None,
+        timeout: Optional[int] = None,
     ) -> None:
         """
         Helper method which polls a job to check if it finishes.
@@ -714,11 +806,24 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param wait_time: Number of seconds between checks
         :type wait_time: int
         :param timeout: How many seconds wait for job to be ready. Used only if ``asynchronous`` is False
         :type timeout: int
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         state = None
         start = time.monotonic()
         while state not in (JobStatus.State.ERROR, JobStatus.State.DONE, JobStatus.State.CANCELLED):
@@ -739,9 +844,10 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def get_job(
         self,
-        region: str,
         job_id: str,
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
@@ -755,6 +861,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
             retried.
         :type retry: google.api_core.retry.Retry
@@ -764,6 +872,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         client = self.get_job_client(region=region)
         job = client.get_job(
             request={'project_id': project_id, 'region': region, 'job_id': job_id},
@@ -776,9 +895,10 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def submit_job(
         self,
-        region: str,
         job: Union[dict, Job],
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         request_id: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
@@ -794,6 +914,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param request_id: Optional. A tag that prevents multiple concurrent workflow instances
             with the same tag from running. This mitigates risk of concurrent
             instances started due to retries.
@@ -807,6 +929,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         client = self.get_job_client(region=region)
         return client.submit_job(
             request={'project_id': project_id, 'region': region, 'job': job, 'request_id': request_id},
@@ -846,6 +979,7 @@ class DataprocHook(GoogleBaseHook):
         job_id: str,
         project_id: str,
         region: Optional[str] = None,
+        location: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
@@ -857,6 +991,8 @@ class DataprocHook(GoogleBaseHook):
         :type project_id: str
         :param region: Required. The Cloud Dataproc region in which to handle the request.
         :type region: str
+        :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+        :type location: str
         :param job_id: Required. The job ID.
         :type job_id: str
         :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
@@ -868,6 +1004,16 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+
         if region is None:
             warnings.warn(
                 "Default region value `global` will be deprecated. Please, provide region value.",

--- a/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/airflow/providers/google/cloud/hooks/dataproc.py
@@ -207,31 +207,31 @@ class DataprocHook(GoogleBaseHook):
     keyword arguments rather than positional.
     """
 
-    def get_cluster_client(self, location: Optional[str] = None) -> ClusterControllerClient:
+    def get_cluster_client(self, region: Optional[str] = None) -> ClusterControllerClient:
         """Returns ClusterControllerClient."""
         client_options = None
-        if location and location != 'global':
-            client_options = {'api_endpoint': f'{location}-dataproc.googleapis.com:443'}
+        if region and region != 'global':
+            client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return ClusterControllerClient(
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
-    def get_template_client(self, location: Optional[str] = None) -> WorkflowTemplateServiceClient:
+    def get_template_client(self, region: Optional[str] = None) -> WorkflowTemplateServiceClient:
         """Returns WorkflowTemplateServiceClient."""
         client_options = None
-        if location and location != 'global':
-            client_options = {'api_endpoint': f'{location}-dataproc.googleapis.com:443'}
+        if region and region != 'global':
+            client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return WorkflowTemplateServiceClient(
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
         )
 
-    def get_job_client(self, location: Optional[str] = None) -> JobControllerClient:
+    def get_job_client(self, region: Optional[str] = None) -> JobControllerClient:
         """Returns JobControllerClient."""
         client_options = None
-        if location and location != 'global':
-            client_options = {'api_endpoint': f'{location}-dataproc.googleapis.com:443'}
+        if region and region != 'global':
+            client_options = {'api_endpoint': f'{region}-dataproc.googleapis.com:443'}
 
         return JobControllerClient(
             credentials=self._get_credentials(), client_info=self.client_info, client_options=client_options
@@ -291,7 +291,7 @@ class DataprocHook(GoogleBaseHook):
             "labels": labels,
         }
 
-        client = self.get_cluster_client(location=region)
+        client = self.get_cluster_client(region=region)
         result = client.create_cluster(
             request={
                 'project_id': project_id,
@@ -342,7 +342,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_cluster_client(location=region)
+        client = self.get_cluster_client(region=region)
         result = client.delete_cluster(
             request={
                 'project_id': project_id,
@@ -386,7 +386,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_cluster_client(location=region)
+        client = self.get_cluster_client(region=region)
         operation = client.diagnose_cluster(
             request={'project_id': project_id, 'region': region, 'cluster_name': cluster_name},
             retry=retry,
@@ -425,7 +425,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_cluster_client(location=region)
+        client = self.get_cluster_client(region=region)
         result = client.get_cluster(
             request={'project_id': project_id, 'region': region, 'cluster_name': cluster_name},
             retry=retry,
@@ -467,7 +467,7 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_cluster_client(location=region)
+        client = self.get_cluster_client(region=region)
         result = client.list_clusters(
             request={'project_id': project_id, 'region': region, 'filter': filter_, 'page_size': page_size},
             retry=retry,
@@ -479,7 +479,7 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def update_cluster(
         self,
-        location: str,
+        region: str,
         cluster_name: str,
         cluster: Union[Dict, Cluster],
         update_mask: Union[Dict, FieldMask],
@@ -495,8 +495,8 @@ class DataprocHook(GoogleBaseHook):
 
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param cluster_name: Required. The cluster name.
         :type cluster_name: str
         :param cluster: Required. The changes to the cluster.
@@ -548,11 +548,11 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_cluster_client(location=location)
+        client = self.get_cluster_client(region=region)
         operation = client.update_cluster(
             request={
                 'project_id': project_id,
-                'region': location,
+                'region': region,
                 'cluster_name': cluster_name,
                 'cluster': cluster,
                 'update_mask': update_mask,
@@ -568,7 +568,7 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def create_workflow_template(
         self,
-        location: str,
+        region: str,
         template: Union[Dict, WorkflowTemplate],
         project_id: str,
         retry: Optional[Retry] = None,
@@ -580,8 +580,8 @@ class DataprocHook(GoogleBaseHook):
 
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param template: The Dataproc workflow template to create. If a dict is provided,
             it must be of the same form as the protobuf message WorkflowTemplate.
         :type template: Union[dict, WorkflowTemplate]
@@ -595,8 +595,8 @@ class DataprocHook(GoogleBaseHook):
         :type metadata: Sequence[Tuple[str, str]]
         """
         metadata = metadata or ()
-        client = self.get_template_client(location)
-        parent = f'projects/{project_id}/regions/{location}'
+        client = self.get_template_client(region)
+        parent = f'projects/{project_id}/regions/{region}'
         return client.create_workflow_template(
             request={'parent': parent, 'template': template}, retry=retry, timeout=timeout, metadata=metadata
         )
@@ -604,7 +604,7 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def instantiate_workflow_template(
         self,
-        location: str,
+        region: str,
         template_name: str,
         project_id: str,
         version: Optional[int] = None,
@@ -621,8 +621,8 @@ class DataprocHook(GoogleBaseHook):
         :type template_name: str
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param version: Optional. The version of workflow template to instantiate. If specified,
             the workflow will be instantiated only if the current version of
             the workflow template has the supplied version.
@@ -646,8 +646,8 @@ class DataprocHook(GoogleBaseHook):
         :type metadata: Sequence[Tuple[str, str]]
         """
         metadata = metadata or ()
-        client = self.get_template_client(location)
-        name = f'projects/{project_id}/regions/{location}/workflowTemplates/{template_name}'
+        client = self.get_template_client(region)
+        name = f'projects/{project_id}/regions/{region}/workflowTemplates/{template_name}'
         operation = client.instantiate_workflow_template(
             request={'name': name, 'version': version, 'request_id': request_id, 'parameters': parameters},
             retry=retry,
@@ -659,7 +659,7 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def instantiate_inline_workflow_template(
         self,
-        location: str,
+        region: str,
         template: Union[Dict, WorkflowTemplate],
         project_id: str,
         request_id: Optional[str] = None,
@@ -675,8 +675,8 @@ class DataprocHook(GoogleBaseHook):
         :type template: Union[Dict, WorkflowTemplate]
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param request_id: Optional. A tag that prevents multiple concurrent workflow instances
             with the same tag from running. This mitigates risk of concurrent
             instances started due to retries.
@@ -691,8 +691,8 @@ class DataprocHook(GoogleBaseHook):
         :type metadata: Sequence[Tuple[str, str]]
         """
         metadata = metadata or ()
-        client = self.get_template_client(location)
-        parent = f'projects/{project_id}/regions/{location}'
+        client = self.get_template_client(region)
+        parent = f'projects/{project_id}/regions/{region}'
         operation = client.instantiate_inline_workflow_template(
             request={'parent': parent, 'template': template, 'request_id': request_id},
             retry=retry,
@@ -703,7 +703,7 @@ class DataprocHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     def wait_for_job(
-        self, job_id: str, location: str, project_id: str, wait_time: int = 10, timeout: Optional[int] = None
+        self, job_id: str, region: str, project_id: str, wait_time: int = 10, timeout: Optional[int] = None
     ) -> None:
         """
         Helper method which polls a job to check if it finishes.
@@ -712,8 +712,8 @@ class DataprocHook(GoogleBaseHook):
         :type job_id: str
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param wait_time: Number of seconds between checks
         :type wait_time: int
         :param timeout: How many seconds wait for job to be ready. Used only if ``asynchronous`` is False
@@ -726,7 +726,7 @@ class DataprocHook(GoogleBaseHook):
                 raise AirflowException(f"Timeout: dataproc job {job_id} is not ready after {timeout}s")
             time.sleep(wait_time)
             try:
-                job = self.get_job(project_id=project_id, location=location, job_id=job_id)
+                job = self.get_job(project_id=project_id, region=region, job_id=job_id)
                 state = job.status.state
             except ServerError as err:
                 self.log.info("Retrying. Dataproc API returned server error when waiting for job: %s", err)
@@ -739,7 +739,7 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def get_job(
         self,
-        location: str,
+        region: str,
         job_id: str,
         project_id: str,
         retry: Optional[Retry] = None,
@@ -753,8 +753,8 @@ class DataprocHook(GoogleBaseHook):
         :type job_id: str
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
             retried.
         :type retry: google.api_core.retry.Retry
@@ -764,9 +764,9 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_job_client(location=location)
+        client = self.get_job_client(region=region)
         job = client.get_job(
-            request={'project_id': project_id, 'region': location, 'job_id': job_id},
+            request={'project_id': project_id, 'region': region, 'job_id': job_id},
             retry=retry,
             timeout=timeout,
             metadata=metadata,
@@ -776,7 +776,7 @@ class DataprocHook(GoogleBaseHook):
     @GoogleBaseHook.fallback_to_default_project_id
     def submit_job(
         self,
-        location: str,
+        region: str,
         job: Union[dict, Job],
         project_id: str,
         request_id: Optional[str] = None,
@@ -792,8 +792,8 @@ class DataprocHook(GoogleBaseHook):
         :type job: Union[Dict, Job]
         :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param request_id: Optional. A tag that prevents multiple concurrent workflow instances
             with the same tag from running. This mitigates risk of concurrent
             instances started due to retries.
@@ -807,9 +807,9 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        client = self.get_job_client(location=location)
+        client = self.get_job_client(region=region)
         return client.submit_job(
-            request={'project_id': project_id, 'region': location, 'job': job, 'request_id': request_id},
+            request={'project_id': project_id, 'region': region, 'job': job, 'request_id': request_id},
             retry=retry,
             timeout=timeout,
             metadata=metadata,
@@ -836,16 +836,16 @@ class DataprocHook(GoogleBaseHook):
         """
         # TODO: Remover one day
         warnings.warn("This method is deprecated. Please use `submit_job`", DeprecationWarning, stacklevel=2)
-        job_object = self.submit_job(location=region, project_id=project_id, job=job)
+        job_object = self.submit_job(region=region, project_id=project_id, job=job)
         job_id = job_object.reference.job_id
-        self.wait_for_job(job_id=job_id, location=region, project_id=project_id)
+        self.wait_for_job(job_id=job_id, region=region, project_id=project_id)
 
     @GoogleBaseHook.fallback_to_default_project_id
     def cancel_job(
         self,
         job_id: str,
         project_id: str,
-        location: Optional[str] = None,
+        region: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
@@ -855,8 +855,8 @@ class DataprocHook(GoogleBaseHook):
 
         :param project_id: Required. The ID of the Google Cloud project that the job belongs to.
         :type project_id: str
-        :param location: Required. The Cloud Dataproc region in which to handle the request.
-        :type location: str
+        :param region: Required. The Cloud Dataproc region in which to handle the request.
+        :type region: str
         :param job_id: Required. The job ID.
         :type job_id: str
         :param retry: A retry object used to retry requests. If ``None`` is specified, requests will not be
@@ -868,17 +868,17 @@ class DataprocHook(GoogleBaseHook):
         :param metadata: Additional metadata that is provided to the method.
         :type metadata: Sequence[Tuple[str, str]]
         """
-        if location is None:
+        if region is None:
             warnings.warn(
-                "Default location value `global` will be deprecated. Please, provide location value.",
+                "Default region value `global` will be deprecated. Please, provide region value.",
                 DeprecationWarning,
                 stacklevel=2,
             )
-            location = 'global'
-        client = self.get_job_client(location=location)
+            region = 'global'
+        client = self.get_job_client(region=region)
 
         job = client.cancel_job(
-            request={'project_id': project_id, 'region': location, 'job_id': job_id},
+            request={'project_id': project_id, 'region': region, 'job_id': job_id},
             retry=retry,
             timeout=timeout,
             metadata=metadata,

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -1635,6 +1635,8 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
     :type project_id: str
     :param region: Required. The Cloud Dataproc region in which to handle the request.
     :type region: str
+    :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+    :type location: str
     :param template: The Dataproc workflow template to create. If a dict is provided,
         it must be of the same form as the protobuf message WorkflowTemplate.
     :type template: Union[dict, WorkflowTemplate]
@@ -1654,9 +1656,10 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
     def __init__(
         self,
         *,
-        region: str,
         template: Dict,
         project_id: str,
+        region: str = None,
+        location: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
@@ -1664,6 +1667,17 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ):
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         super().__init__(**kwargs)
         self.region = region
         self.template = template
@@ -1891,6 +1905,8 @@ class DataprocSubmitJobOperator(BaseOperator):
     :type project_id: str
     :param region: Required. The Cloud Dataproc region in which to handle the request.
     :type region: str
+    :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+    :type location: str
     :param job: Required. The job resource.
         If a dict is provided, it must be of the same form as the protobuf message
         :class:`~google.cloud.dataproc_v1beta2.types.Job`
@@ -1938,8 +1954,9 @@ class DataprocSubmitJobOperator(BaseOperator):
         self,
         *,
         project_id: str,
-        region: str,
         job: Dict,
+        region: str = None,
+        location: Optional[str] = None,
         request_id: Optional[str] = None,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
@@ -1951,6 +1968,17 @@ class DataprocSubmitJobOperator(BaseOperator):
         wait_timeout: Optional[int] = None,
         **kwargs,
     ) -> None:
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         super().__init__(**kwargs)
         self.project_id = project_id
         self.region = region
@@ -2015,6 +2043,8 @@ class DataprocUpdateClusterOperator(BaseOperator):
     :type project_id: str
     :param region: Required. The Cloud Dataproc region in which to handle the request.
     :type region: str
+    :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request.
+    :type location: str
     :param cluster_name: Required. The cluster name.
     :type cluster_name: str
     :param cluster: Required. The changes to the cluster.
@@ -2065,11 +2095,12 @@ class DataprocUpdateClusterOperator(BaseOperator):
     def __init__(
         self,
         *,
-        region: str,
         cluster_name: str,
         cluster: Union[Dict, Cluster],
         update_mask: Union[Dict, FieldMask],
         graceful_decommission_timeout: Union[Dict, Duration],
+        region: str = None,
+        location: Optional[str] = None,
         request_id: Optional[str] = None,
         project_id: Optional[str] = None,
         retry: Retry = None,
@@ -2079,6 +2110,17 @@ class DataprocUpdateClusterOperator(BaseOperator):
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
         **kwargs,
     ):
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         super().__init__(**kwargs)
         self.project_id = project_id
         self.region = region

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -838,7 +838,7 @@ class DataprocScaleClusterOperator(BaseOperator):
         )
         operation = hook.update_cluster(
             project_id=self.project_id,
-            location=self.region,
+            region=self.region,
             cluster_name=self.cluster_name,
             cluster=scaling_cluster_data,
             graceful_decommission_timeout=self._graceful_decommission_timeout_object,
@@ -1064,7 +1064,7 @@ class DataprocJobBaseOperator(BaseOperator):
             self.dataproc_job_id = self.job["job"]["reference"]["job_id"]
             self.log.info('Submitting %s job %s', self.job_type, self.dataproc_job_id)
             job_object = self.hook.submit_job(
-                project_id=self.project_id, job=self.job["job"], location=self.region
+                project_id=self.project_id, job=self.job["job"], region=self.region
             )
             job_id = job_object.reference.job_id
             self.log.info('Job %s submitted successfully.', job_id)
@@ -1077,7 +1077,7 @@ class DataprocJobBaseOperator(BaseOperator):
 
             if not self.asynchronous:
                 self.log.info('Waiting for job %s to complete', job_id)
-                self.hook.wait_for_job(job_id=job_id, location=self.region, project_id=self.project_id)
+                self.hook.wait_for_job(job_id=job_id, region=self.region, project_id=self.project_id)
                 self.log.info('Job %s completed successfully.', job_id)
             return job_id
         else:
@@ -1089,9 +1089,7 @@ class DataprocJobBaseOperator(BaseOperator):
         Cancel any running job.
         """
         if self.dataproc_job_id:
-            self.hook.cancel_job(
-                project_id=self.project_id, job_id=self.dataproc_job_id, location=self.region
-            )
+            self.hook.cancel_job(project_id=self.project_id, job_id=self.dataproc_job_id, region=self.region)
 
 
 class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
@@ -1635,8 +1633,8 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
 
     :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
     :type project_id: str
-    :param location: Required. The Cloud Dataproc region in which to handle the request.
-    :type location: str
+    :param region: Required. The Cloud Dataproc region in which to handle the request.
+    :type region: str
     :param template: The Dataproc workflow template to create. If a dict is provided,
         it must be of the same form as the protobuf message WorkflowTemplate.
     :type template: Union[dict, WorkflowTemplate]
@@ -1650,13 +1648,13 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
     :type metadata: Sequence[Tuple[str, str]]
     """
 
-    template_fields = ("location", "template")
+    template_fields = ("region", "template")
     template_fields_renderers = {"template": "json"}
 
     def __init__(
         self,
         *,
-        location: str,
+        region: str,
         template: Dict,
         project_id: str,
         retry: Optional[Retry] = None,
@@ -1667,7 +1665,7 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.location = location
+        self.region = region
         self.template = template
         self.project_id = project_id
         self.retry = retry
@@ -1681,7 +1679,7 @@ class DataprocCreateWorkflowTemplateOperator(BaseOperator):
         self.log.info("Creating template")
         try:
             workflow = hook.create_workflow_template(
-                location=self.location,
+                region=self.region,
                 template=self.template,
                 project_id=self.project_id,
                 retry=self.retry,
@@ -1779,7 +1777,7 @@ class DataprocInstantiateWorkflowTemplateOperator(BaseOperator):
         self.log.info('Instantiating template %s', self.template_id)
         operation = hook.instantiate_workflow_template(
             project_id=self.project_id,
-            location=self.region,
+            region=self.region,
             template_name=self.template_id,
             version=self.version,
             request_id=self.request_id,
@@ -1860,7 +1858,7 @@ class DataprocInstantiateInlineWorkflowTemplateOperator(BaseOperator):
         super().__init__(**kwargs)
         self.template = template
         self.project_id = project_id
-        self.location = region
+        self.region = region
         self.template = template
         self.request_id = request_id
         self.retry = retry
@@ -1875,7 +1873,7 @@ class DataprocInstantiateInlineWorkflowTemplateOperator(BaseOperator):
         operation = hook.instantiate_inline_workflow_template(
             template=self.template,
             project_id=self.project_id,
-            location=self.location,
+            region=self.region,
             request_id=self.request_id,
             retry=self.retry,
             timeout=self.timeout,
@@ -1891,8 +1889,8 @@ class DataprocSubmitJobOperator(BaseOperator):
 
     :param project_id: Required. The ID of the Google Cloud project that the job belongs to.
     :type project_id: str
-    :param location: Required. The Cloud Dataproc region in which to handle the request.
-    :type location: str
+    :param region: Required. The Cloud Dataproc region in which to handle the request.
+    :type region: str
     :param job: Required. The job resource.
         If a dict is provided, it must be of the same form as the protobuf message
         :class:`~google.cloud.dataproc_v1beta2.types.Job`
@@ -1931,7 +1929,7 @@ class DataprocSubmitJobOperator(BaseOperator):
     :type wait_timeout: int
     """
 
-    template_fields = ('project_id', 'location', 'job', 'impersonation_chain', 'request_id')
+    template_fields = ('project_id', 'region', 'job', 'impersonation_chain', 'request_id')
     template_fields_renderers = {"job": "json"}
 
     operator_extra_links = (DataprocJobLink(),)
@@ -1940,7 +1938,7 @@ class DataprocSubmitJobOperator(BaseOperator):
         self,
         *,
         project_id: str,
-        location: str,
+        region: str,
         job: Dict,
         request_id: Optional[str] = None,
         retry: Optional[Retry] = None,
@@ -1955,7 +1953,7 @@ class DataprocSubmitJobOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
-        self.location = location
+        self.region = region
         self.job = job
         self.request_id = request_id
         self.retry = retry
@@ -1974,7 +1972,7 @@ class DataprocSubmitJobOperator(BaseOperator):
         self.hook = DataprocHook(gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain)
         job_object = self.hook.submit_job(
             project_id=self.project_id,
-            location=self.location,
+            region=self.region,
             job=self.job,
             request_id=self.request_id,
             retry=self.retry,
@@ -1989,7 +1987,7 @@ class DataprocSubmitJobOperator(BaseOperator):
             key="job_conf",
             value={
                 "job_id": job_id,
-                "region": self.location,
+                "region": self.region,
                 "project_id": self.project_id,
             },
         )
@@ -1997,7 +1995,7 @@ class DataprocSubmitJobOperator(BaseOperator):
         if not self.asynchronous:
             self.log.info('Waiting for job %s to complete', job_id)
             self.hook.wait_for_job(
-                job_id=job_id, location=self.location, project_id=self.project_id, timeout=self.wait_timeout
+                job_id=job_id, region=self.region, project_id=self.project_id, timeout=self.wait_timeout
             )
             self.log.info('Job %s completed successfully.', job_id)
 
@@ -2006,7 +2004,7 @@ class DataprocSubmitJobOperator(BaseOperator):
 
     def on_kill(self):
         if self.job_id and self.cancel_on_kill:
-            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id, location=self.location)
+            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id, region=self.region)
 
 
 class DataprocUpdateClusterOperator(BaseOperator):
@@ -2015,8 +2013,8 @@ class DataprocUpdateClusterOperator(BaseOperator):
 
     :param project_id: Required. The ID of the Google Cloud project the cluster belongs to.
     :type project_id: str
-    :param location: Required. The Cloud Dataproc region in which to handle the request.
-    :type location: str
+    :param region: Required. The Cloud Dataproc region in which to handle the request.
+    :type region: str
     :param cluster_name: Required. The cluster name.
     :type cluster_name: str
     :param cluster: Required. The changes to the cluster.
@@ -2067,7 +2065,7 @@ class DataprocUpdateClusterOperator(BaseOperator):
     def __init__(
         self,
         *,
-        location: str,
+        region: str,
         cluster_name: str,
         cluster: Union[Dict, Cluster],
         update_mask: Union[Dict, FieldMask],
@@ -2083,7 +2081,7 @@ class DataprocUpdateClusterOperator(BaseOperator):
     ):
         super().__init__(**kwargs)
         self.project_id = project_id
-        self.location = location
+        self.region = region
         self.cluster_name = cluster_name
         self.cluster = cluster
         self.update_mask = update_mask
@@ -2103,14 +2101,14 @@ class DataprocUpdateClusterOperator(BaseOperator):
             key="cluster_conf",
             value={
                 "cluster_name": self.cluster_name,
-                "region": self.location,
+                "region": self.region,
                 "project_id": self.project_id,
             },
         )
         self.log.info("Updating %s cluster.", self.cluster_name)
         operation = hook.update_cluster(
             project_id=self.project_id,
-            location=self.location,
+            region=self.region,
             cluster_name=self.cluster_name,
             cluster=self.cluster,
             update_mask=self.update_mask,

--- a/airflow/providers/google/cloud/sensors/dataproc.py
+++ b/airflow/providers/google/cloud/sensors/dataproc.py
@@ -34,13 +34,13 @@ class DataprocJobSensor(BaseSensorOperator):
     :type project_id: str
     :param dataproc_job_id: The Dataproc job ID to poll. (templated)
     :type dataproc_job_id: str
-    :param location: Required. The Cloud Dataproc region in which to handle the request. (templated)
-    :type location: str
+    :param region: Required. The Cloud Dataproc region in which to handle the request. (templated)
+    :type region: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
     """
 
-    template_fields = ('project_id', 'location', 'dataproc_job_id')
+    template_fields = ('project_id', 'region', 'dataproc_job_id')
     ui_color = '#f0eee4'
 
     def __init__(
@@ -48,7 +48,7 @@ class DataprocJobSensor(BaseSensorOperator):
         *,
         project_id: str,
         dataproc_job_id: str,
-        location: str,
+        region: str,
         gcp_conn_id: str = 'google_cloud_default',
         **kwargs,
     ) -> None:
@@ -56,11 +56,11 @@ class DataprocJobSensor(BaseSensorOperator):
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id
         self.dataproc_job_id = dataproc_job_id
-        self.location = location
+        self.region = region
 
     def poke(self, context: dict) -> bool:
         hook = DataprocHook(gcp_conn_id=self.gcp_conn_id)
-        job = hook.get_job(job_id=self.dataproc_job_id, location=self.location, project_id=self.project_id)
+        job = hook.get_job(job_id=self.dataproc_job_id, region=self.region, project_id=self.project_id)
         state = job.status.state
 
         if state == JobStatus.State.ERROR:

--- a/airflow/providers/google/cloud/sensors/dataproc.py
+++ b/airflow/providers/google/cloud/sensors/dataproc.py
@@ -16,7 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains a Dataproc Job sensor."""
-
+# pylint: disable=C0302
+import warnings
+from typing import Optional
 
 from google.cloud.dataproc_v1beta2.types import JobStatus
 
@@ -36,6 +38,8 @@ class DataprocJobSensor(BaseSensorOperator):
     :type dataproc_job_id: str
     :param region: Required. The Cloud Dataproc region in which to handle the request. (templated)
     :type region: str
+    :param location: (To be deprecated). The Cloud Dataproc region in which to handle the request. (templated)
+    :type location: str
     :param gcp_conn_id: The connection ID to use connecting to Google Cloud Platform.
     :type gcp_conn_id: str
     """
@@ -48,10 +52,22 @@ class DataprocJobSensor(BaseSensorOperator):
         *,
         project_id: str,
         dataproc_job_id: str,
-        region: str,
+        region: str = None,
+        location: Optional[str] = None,
         gcp_conn_id: str = 'google_cloud_default',
         **kwargs,
     ) -> None:
+        if region is None:
+            if location is not None:
+                warnings.warn(
+                    "Parameter `location` will be deprecated. "
+                    "Please provide value through `region` parameter instead.",
+                    DeprecationWarning,
+                    stacklevel=1,
+                )
+                region = location
+            else:
+                raise TypeError("missing 1 required keyword argument: 'region'")
         super().__init__(**kwargs)
         self.project_id = project_id
         self.gcp_conn_id = gcp_conn_id

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -60,7 +60,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
     def test_get_cluster_client(self, mock_client, mock_client_info, mock_get_credentials):
-        self.hook.get_cluster_client(location=GCP_LOCATION)
+        self.hook.get_cluster_client(region=GCP_LOCATION)
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
             client_info=mock_client_info.return_value,
@@ -71,7 +71,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
     def test_get_cluster_client_region(self, mock_client, mock_client_info, mock_get_credentials):
-        self.hook.get_cluster_client(location='region1')
+        self.hook.get_cluster_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
             client_info=mock_client_info.return_value,
@@ -93,7 +93,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
     def test_get_template_client_region(self, mock_client, mock_client_info, mock_get_credentials):
-        _ = self.hook.get_template_client(location='region1')
+        _ = self.hook.get_template_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
             client_info=mock_client_info.return_value,
@@ -104,7 +104,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
     def test_get_job_client(self, mock_client, mock_client_info, mock_get_credentials):
-        self.hook.get_job_client(location=GCP_LOCATION)
+        self.hook.get_job_client(region=GCP_LOCATION)
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
             client_info=mock_client_info.return_value,
@@ -115,7 +115,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
     def test_get_job_client_region(self, mock_client, mock_client_info, mock_get_credentials):
-        self.hook.get_job_client(location='region1')
+        self.hook.get_job_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
             client_info=mock_client_info.return_value,
@@ -131,7 +131,7 @@ class TestDataprocHook(unittest.TestCase):
             cluster_config=CLUSTER_CONFIG,
             labels=LABELS,
         )
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.create_cluster.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
@@ -147,7 +147,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_delete_cluster(self, mock_client):
         self.hook.delete_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.delete_cluster.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
@@ -164,7 +164,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_diagnose_cluster(self, mock_client):
         self.hook.diagnose_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.diagnose_cluster.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
@@ -180,7 +180,7 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_get_cluster(self, mock_client):
         self.hook.get_cluster(project_id=GCP_PROJECT, region=GCP_LOCATION, cluster_name=CLUSTER_NAME)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.get_cluster.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
@@ -197,7 +197,7 @@ class TestDataprocHook(unittest.TestCase):
         filter_ = "filter"
 
         self.hook.list_clusters(project_id=GCP_PROJECT, region=GCP_LOCATION, filter_=filter_)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.list_clusters.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
@@ -215,12 +215,12 @@ class TestDataprocHook(unittest.TestCase):
         update_mask = "update-mask"
         self.hook.update_cluster(
             project_id=GCP_PROJECT,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             cluster=CLUSTER,
             cluster_name=CLUSTER_NAME,
             update_mask=update_mask,
         )
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.update_cluster.assert_called_once_with(
             request=dict(
                 project_id=GCP_PROJECT,
@@ -240,7 +240,7 @@ class TestDataprocHook(unittest.TestCase):
     def test_create_workflow_template(self, mock_client):
         template = {"test": "test"}
         parent = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}'
-        self.hook.create_workflow_template(location=GCP_LOCATION, template=template, project_id=GCP_PROJECT)
+        self.hook.create_workflow_template(region=GCP_LOCATION, template=template, project_id=GCP_PROJECT)
         mock_client.return_value.create_workflow_template.assert_called_once_with(
             request=dict(parent=parent, template=template), retry=None, timeout=None, metadata=()
         )
@@ -250,7 +250,7 @@ class TestDataprocHook(unittest.TestCase):
         template_name = "template_name"
         name = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}/workflowTemplates/{template_name}'
         self.hook.instantiate_workflow_template(
-            location=GCP_LOCATION, template_name=template_name, project_id=GCP_PROJECT
+            region=GCP_LOCATION, template_name=template_name, project_id=GCP_PROJECT
         )
         mock_client.return_value.instantiate_workflow_template.assert_called_once_with(
             request=dict(name=name, version=None, parameters=None, request_id=None),
@@ -264,7 +264,7 @@ class TestDataprocHook(unittest.TestCase):
         template = {"test": "test"}
         parent = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}'
         self.hook.instantiate_inline_workflow_template(
-            location=GCP_LOCATION, template=template, project_id=GCP_PROJECT
+            region=GCP_LOCATION, template=template, project_id=GCP_PROJECT
         )
         mock_client.return_value.instantiate_inline_workflow_template.assert_called_once_with(
             request=dict(parent=parent, template=template, request_id=None),
@@ -280,17 +280,17 @@ class TestDataprocHook(unittest.TestCase):
             mock.MagicMock(status=mock.MagicMock(state=JobStatus.State.ERROR)),
         ]
         with pytest.raises(AirflowException):
-            self.hook.wait_for_job(job_id=JOB_ID, location=GCP_LOCATION, project_id=GCP_PROJECT, wait_time=0)
+            self.hook.wait_for_job(job_id=JOB_ID, region=GCP_LOCATION, project_id=GCP_PROJECT, wait_time=0)
         calls = [
-            mock.call(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
-            mock.call(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
+            mock.call(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
+            mock.call(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
         ]
         mock_get_job.has_calls(calls)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
     def test_get_job(self, mock_client):
-        self.hook.get_job(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        self.hook.get_job(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.get_job.assert_called_once_with(
             request=dict(
                 region=GCP_LOCATION,
@@ -304,8 +304,8 @@ class TestDataprocHook(unittest.TestCase):
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
     def test_submit_job(self, mock_client):
-        self.hook.submit_job(location=GCP_LOCATION, job=JOB, project_id=GCP_PROJECT)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        self.hook.submit_job(region=GCP_LOCATION, job=JOB, project_id=GCP_PROJECT)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.submit_job.assert_called_once_with(
             request=dict(
                 region=GCP_LOCATION,
@@ -324,15 +324,13 @@ class TestDataprocHook(unittest.TestCase):
         mock_submit_job.return_value.reference.job_id = JOB_ID
         with pytest.warns(DeprecationWarning):
             self.hook.submit(project_id=GCP_PROJECT, job=JOB, region=GCP_LOCATION)
-        mock_submit_job.assert_called_once_with(location=GCP_LOCATION, project_id=GCP_PROJECT, job=JOB)
-        mock_wait_for_job.assert_called_once_with(
-            location=GCP_LOCATION, project_id=GCP_PROJECT, job_id=JOB_ID
-        )
+        mock_submit_job.assert_called_once_with(region=GCP_LOCATION, project_id=GCP_PROJECT, job=JOB)
+        mock_wait_for_job.assert_called_once_with(region=GCP_LOCATION, project_id=GCP_PROJECT, job_id=JOB_ID)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
     def test_cancel_job(self, mock_client):
-        self.hook.cancel_job(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
-        mock_client.assert_called_once_with(location=GCP_LOCATION)
+        self.hook.cancel_job(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
+        mock_client.assert_called_once_with(region=GCP_LOCATION)
         mock_client.return_value.cancel_job.assert_called_once_with(
             request=dict(
                 region=GCP_LOCATION,
@@ -348,7 +346,7 @@ class TestDataprocHook(unittest.TestCase):
     def test_cancel_job_deprecation_warning(self, mock_client):
         with pytest.warns(DeprecationWarning):
             self.hook.cancel_job(job_id=JOB_ID, project_id=GCP_PROJECT)
-        mock_client.assert_called_once_with(location='global')
+        mock_client.assert_called_once_with(region='global')
         mock_client.return_value.cancel_job.assert_called_once_with(
             request=dict(
                 region='global',

--- a/tests/providers/google/cloud/hooks/test_dataproc.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc.py
@@ -80,6 +80,25 @@ class TestDataprocHook(unittest.TestCase):
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
+    @mock.patch(DATAPROC_STRING.format("ClusterControllerClient"))
+    def test_get_cluster_client_region_deprecation_warning(
+        self, mock_client, mock_client_info, mock_get_credentials
+    ):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            self.hook.get_cluster_client(location='region1')
+            mock_client.assert_called_once_with(
+                credentials=mock_get_credentials.return_value,
+                client_info=mock_client_info.return_value,
+                client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
+            )
+            assert warning_message == str(warnings[0].message)
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
     def test_get_template_client_global(self, mock_client, mock_client_info, mock_get_credentials):
         _ = self.hook.get_template_client()
@@ -93,6 +112,25 @@ class TestDataprocHook(unittest.TestCase):
     @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
     @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
     def test_get_template_client_region(self, mock_client, mock_client_info, mock_get_credentials):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            _ = self.hook.get_template_client(location='region1')
+            mock_client.assert_called_once_with(
+                credentials=mock_get_credentials.return_value,
+                client_info=mock_client_info.return_value,
+                client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
+            )
+            assert warning_message == str(warnings[0].message)
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
+    @mock.patch(DATAPROC_STRING.format("WorkflowTemplateServiceClient"))
+    def test_get_template_client_region_deprecation_warning(
+        self, mock_client, mock_client_info, mock_get_credentials
+    ):
         _ = self.hook.get_template_client(region='region1')
         mock_client.assert_called_once_with(
             credentials=mock_get_credentials.return_value,
@@ -121,6 +159,25 @@ class TestDataprocHook(unittest.TestCase):
             client_info=mock_client_info.return_value,
             client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
         )
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook._get_credentials"))
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.client_info"), new_callable=mock.PropertyMock)
+    @mock.patch(DATAPROC_STRING.format("JobControllerClient"))
+    def test_get_job_client_region_deprecation_warning(
+        self, mock_client, mock_client_info, mock_get_credentials
+    ):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            self.hook.get_job_client(location='region1')
+            mock_client.assert_called_once_with(
+                credentials=mock_get_credentials.return_value,
+                client_info=mock_client_info.return_value,
+                client_options={'api_endpoint': 'region1-dataproc.googleapis.com:443'},
+            )
+            assert warning_message == str(warnings[0].message)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
     def test_create_cluster(self, mock_client):
@@ -215,7 +272,7 @@ class TestDataprocHook(unittest.TestCase):
         update_mask = "update-mask"
         self.hook.update_cluster(
             project_id=GCP_PROJECT,
-            region=GCP_LOCATION,
+            location=GCP_LOCATION,
             cluster=CLUSTER,
             cluster_name=CLUSTER_NAME,
             update_mask=update_mask,
@@ -236,6 +293,46 @@ class TestDataprocHook(unittest.TestCase):
             timeout=None,
         )
 
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_cluster_client"))
+    def test_update_cluster_depreciation_warning(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            update_mask = "update-mask"
+            self.hook.update_cluster(
+                project_id=GCP_PROJECT,
+                location=GCP_LOCATION,
+                cluster=CLUSTER,
+                cluster_name=CLUSTER_NAME,
+                update_mask=update_mask,
+            )
+            mock_client.assert_called_once_with(region=GCP_LOCATION)
+            mock_client.return_value.update_cluster.assert_called_once_with(
+                request=dict(
+                    project_id=GCP_PROJECT,
+                    region=GCP_LOCATION,
+                    cluster=CLUSTER,
+                    cluster_name=CLUSTER_NAME,
+                    update_mask=update_mask,
+                    graceful_decommission_timeout=None,
+                    request_id=None,
+                ),
+                metadata=None,
+                retry=None,
+                timeout=None,
+            )
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            self.hook.update_cluster(
+                project_id=GCP_PROJECT,
+                cluster=CLUSTER,
+                cluster_name=CLUSTER_NAME,
+                update_mask=update_mask,
+            )
+
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
     def test_create_workflow_template(self, mock_client):
         template = {"test": "test"}
@@ -244,6 +341,26 @@ class TestDataprocHook(unittest.TestCase):
         mock_client.return_value.create_workflow_template.assert_called_once_with(
             request=dict(parent=parent, template=template), retry=None, timeout=None, metadata=()
         )
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
+    def test_create_workflow_template_depreciation_warning(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            template = {"test": "test"}
+            parent = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}'
+            self.hook.create_workflow_template(
+                location=GCP_LOCATION, template=template, project_id=GCP_PROJECT
+            )
+            mock_client.return_value.create_workflow_template.assert_called_once_with(
+                request=dict(parent=parent, template=template), retry=None, timeout=None, metadata=()
+            )
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            self.hook.create_workflow_template(template=template, project_id=GCP_PROJECT)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
     def test_instantiate_workflow_template(self, mock_client):
@@ -260,18 +377,50 @@ class TestDataprocHook(unittest.TestCase):
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
-    def test_instantiate_inline_workflow_template(self, mock_client):
-        template = {"test": "test"}
-        parent = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}'
-        self.hook.instantiate_inline_workflow_template(
-            region=GCP_LOCATION, template=template, project_id=GCP_PROJECT
+    def test_instantiate_workflow_template_depreciation_warning(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
         )
-        mock_client.return_value.instantiate_inline_workflow_template.assert_called_once_with(
-            request=dict(parent=parent, template=template, request_id=None),
-            retry=None,
-            timeout=None,
-            metadata=(),
+        with pytest.warns(DeprecationWarning) as warnings:
+            template_name = "template_name"
+            name = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}/workflowTemplates/{template_name}'
+            self.hook.instantiate_workflow_template(
+                location=GCP_LOCATION, template_name=template_name, project_id=GCP_PROJECT
+            )
+            mock_client.return_value.instantiate_workflow_template.assert_called_once_with(
+                request=dict(name=name, version=None, parameters=None, request_id=None),
+                retry=None,
+                timeout=None,
+                metadata=(),
+            )
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            self.hook.instantiate_workflow_template(template_name=template_name, project_id=GCP_PROJECT)
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_template_client"))
+    def test_instantiate_inline_workflow_template_deprecation_warning(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
         )
+        with pytest.warns(DeprecationWarning) as warnings:
+            template = {"test": "test"}
+            parent = f'projects/{GCP_PROJECT}/regions/{GCP_LOCATION}'
+            self.hook.instantiate_inline_workflow_template(
+                location=GCP_LOCATION, template=template, project_id=GCP_PROJECT
+            )
+            mock_client.return_value.instantiate_inline_workflow_template.assert_called_once_with(
+                request=dict(parent=parent, template=template, request_id=None),
+                retry=None,
+                timeout=None,
+                metadata=(),
+            )
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            self.hook.instantiate_inline_workflow_template(template=template, project_id=GCP_PROJECT)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job"))
     def test_wait_for_job(self, mock_get_job):
@@ -286,6 +435,31 @@ class TestDataprocHook(unittest.TestCase):
             mock.call(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
         ]
         mock_get_job.has_calls(calls)
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job"))
+    def test_wait_for_job_deprecation_warning(self, mock_get_job):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            mock_get_job.side_effect = [
+                mock.MagicMock(status=mock.MagicMock(state=JobStatus.State.RUNNING)),
+                mock.MagicMock(status=mock.MagicMock(state=JobStatus.State.ERROR)),
+            ]
+            with pytest.raises(AirflowException):
+                self.hook.wait_for_job(
+                    job_id=JOB_ID, location=GCP_LOCATION, project_id=GCP_PROJECT, wait_time=0
+                )
+            calls = [
+                mock.call(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
+                mock.call(region=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT),
+            ]
+            mock_get_job.has_calls(calls)
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            self.hook.wait_for_job(job_id=JOB_ID, project_id=GCP_PROJECT, wait_time=0)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
     def test_get_job(self, mock_client):
@@ -303,6 +477,30 @@ class TestDataprocHook(unittest.TestCase):
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
+    def test_get_job_deprecation_warning(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            self.hook.get_job(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
+            mock_client.assert_called_once_with(region=GCP_LOCATION)
+            mock_client.return_value.get_job.assert_called_once_with(
+                request=dict(
+                    region=GCP_LOCATION,
+                    job_id=JOB_ID,
+                    project_id=GCP_PROJECT,
+                ),
+                retry=None,
+                timeout=None,
+                metadata=None,
+            )
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            self.hook.get_job(job_id=JOB_ID, project_id=GCP_PROJECT)
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
     def test_submit_job(self, mock_client):
         self.hook.submit_job(region=GCP_LOCATION, job=JOB, project_id=GCP_PROJECT)
         mock_client.assert_called_once_with(region=GCP_LOCATION)
@@ -317,6 +515,30 @@ class TestDataprocHook(unittest.TestCase):
             timeout=None,
             metadata=None,
         )
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
+    def test_submit_job_deprecation_warning(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            self.hook.submit_job(location=GCP_LOCATION, job=JOB, project_id=GCP_PROJECT)
+            mock_client.assert_called_once_with(region=GCP_LOCATION)
+            mock_client.return_value.submit_job.assert_called_once_with(
+                request=dict(
+                    region=GCP_LOCATION,
+                    job=JOB,
+                    project_id=GCP_PROJECT,
+                    request_id=None,
+                ),
+                retry=None,
+                timeout=None,
+                metadata=None,
+            )
+            assert warning_message == str(warnings[0].message)
+        with pytest.raises(TypeError):
+            self.hook.submit_job(job=JOB, project_id=GCP_PROJECT)
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.wait_for_job"))
     @mock.patch(DATAPROC_STRING.format("DataprocHook.submit_job"))
@@ -343,7 +565,7 @@ class TestDataprocHook(unittest.TestCase):
         )
 
     @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
-    def test_cancel_job_deprecation_warning(self, mock_client):
+    def test_cancel_job_deprecation_warning_default_region(self, mock_client):
         with pytest.warns(DeprecationWarning):
             self.hook.cancel_job(job_id=JOB_ID, project_id=GCP_PROJECT)
         mock_client.assert_called_once_with(region='global')
@@ -357,6 +579,27 @@ class TestDataprocHook(unittest.TestCase):
             timeout=None,
             metadata=None,
         )
+
+    @mock.patch(DATAPROC_STRING.format("DataprocHook.get_job_client"))
+    def test_cancel_job_deprecation_warning_param_rename(self, mock_client):
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+        with pytest.warns(DeprecationWarning) as warnings:
+            self.hook.cancel_job(location=GCP_LOCATION, job_id=JOB_ID, project_id=GCP_PROJECT)
+            mock_client.assert_called_once_with(region='global')
+            mock_client.return_value.cancel_job.assert_called_once_with(
+                request=dict(
+                    region='global',
+                    job_id=JOB_ID,
+                    project_id=GCP_PROJECT,
+                ),
+                retry=None,
+                timeout=None,
+                metadata=None,
+            )
+            assert warning_message == str(warnings[0].message)
 
 
 class TestDataProcJobBuilder(unittest.TestCase):

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -235,7 +235,7 @@ class DataprocJobTestBase(DataprocTestBase):
         super().setUpClass()
         cls.extra_links_expected_calls = [
             call.ti.xcom_push(execution_date=None, key='job_conf', value=DATAPROC_JOB_CONF_EXPECTED),
-            call.hook().wait_for_job(job_id=TEST_JOB_ID, location=GCP_LOCATION, project_id=GCP_PROJECT),
+            call.hook().wait_for_job(job_id=TEST_JOB_ID, region=GCP_LOCATION, project_id=GCP_PROJECT),
         ]
 
 
@@ -638,7 +638,7 @@ class TestDataprocClusterScaleOperator(DataprocClusterTestBase):
         }
         update_cluster_args = {
             'project_id': GCP_PROJECT,
-            'location': GCP_LOCATION,
+            'region': GCP_LOCATION,
             'cluster_name': CLUSTER_NAME,
             'cluster': cluster_update,
             'graceful_decommission_timeout': {"seconds": 600},
@@ -763,7 +763,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             execution_date=None, key='job_conf', value=DATAPROC_JOB_CONF_EXPECTED
         )
         wait_for_job_call = call.hook().wait_for_job(
-            job_id=TEST_JOB_ID, location=GCP_LOCATION, project_id=GCP_PROJECT, timeout=None
+            job_id=TEST_JOB_ID, region=GCP_LOCATION, project_id=GCP_PROJECT, timeout=None
         )
 
         job = {}
@@ -773,7 +773,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
 
         op = DataprocSubmitJobOperator(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             job=job,
             gcp_conn_id=GCP_CONN_ID,
@@ -796,7 +796,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
 
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             job=job,
             request_id=REQUEST_ID,
             retry=RETRY,
@@ -804,7 +804,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             metadata=METADATA,
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
-            job_id=TEST_JOB_ID, project_id=GCP_PROJECT, location=GCP_LOCATION, timeout=None
+            job_id=TEST_JOB_ID, project_id=GCP_PROJECT, region=GCP_LOCATION, timeout=None
         )
 
         self.mock_ti.xcom_push.assert_called_once_with(
@@ -819,7 +819,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
 
         op = DataprocSubmitJobOperator(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             job=job,
             gcp_conn_id=GCP_CONN_ID,
@@ -838,7 +838,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         )
         mock_hook.return_value.submit_job.assert_called_once_with(
             project_id=GCP_PROJECT,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             job=job,
             request_id=REQUEST_ID,
             retry=RETRY,
@@ -860,7 +860,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
 
         op = DataprocSubmitJobOperator(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             job=job,
             gcp_conn_id=GCP_CONN_ID,
@@ -879,7 +879,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         op.cancel_on_kill = True
         op.on_kill()
         mock_hook.return_value.cancel_job.assert_called_once_with(
-            project_id=GCP_PROJECT, location=GCP_LOCATION, job_id=job_id
+            project_id=GCP_PROJECT, region=GCP_LOCATION, job_id=job_id
         )
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
@@ -887,7 +887,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         mock_hook.return_value.project_id = GCP_PROJECT
         op = DataprocSubmitJobOperator(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             job={},
             gcp_conn_id=GCP_CONN_ID,
@@ -938,7 +938,7 @@ class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
         mock_hook.return_value.update_cluster.result.return_value = None
         cluster_decommission_timeout = {"graceful_decommission_timeout": "600s"}
         update_cluster_args = {
-            'location': GCP_LOCATION,
+            'region': GCP_LOCATION,
             'project_id': GCP_PROJECT,
             'cluster_name': CLUSTER_NAME,
             'cluster': CLUSTER,
@@ -955,7 +955,7 @@ class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
 
         op = DataprocUpdateClusterOperator(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             cluster_name=CLUSTER_NAME,
             cluster=CLUSTER,
             update_mask=UPDATE_MASK,
@@ -984,7 +984,7 @@ class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
     def test_operator_extra_links(self):
         op = DataprocUpdateClusterOperator(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             cluster_name=CLUSTER_NAME,
             cluster=CLUSTER,
             update_mask=UPDATE_MASK,
@@ -1059,7 +1059,7 @@ class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.instantiate_workflow_template.assert_called_once_with(
             template_name=template_id,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             version=version,
             parameters=parameters,
@@ -1091,7 +1091,7 @@ class TestDataprocWorkflowTemplateInstantiateInlineOperator(unittest.TestCase):
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.instantiate_inline_workflow_template.assert_called_once_with(
             template=template,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             request_id=REQUEST_ID,
             retry=RETRY,
@@ -1136,10 +1136,10 @@ class TestDataProcHiveOperator(unittest.TestCase):
         op.execute(context=MagicMock())
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.submit_job.assert_called_once_with(
-            project_id=GCP_PROJECT, job=self.job, location=GCP_LOCATION
+            project_id=GCP_PROJECT, job=self.job, region=GCP_LOCATION
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
-            job_id=self.job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=self.job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )
 
     @mock.patch(DATAPROC_PATH.format("uuid.uuid4"))
@@ -1195,10 +1195,10 @@ class TestDataProcPigOperator(unittest.TestCase):
         op.execute(context=MagicMock())
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.submit_job.assert_called_once_with(
-            project_id=GCP_PROJECT, job=self.job, location=GCP_LOCATION
+            project_id=GCP_PROJECT, job=self.job, region=GCP_LOCATION
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
-            job_id=self.job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=self.job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )
 
     @mock.patch(DATAPROC_PATH.format("uuid.uuid4"))
@@ -1260,10 +1260,10 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
         op.execute(context=MagicMock())
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.submit_job.assert_called_once_with(
-            project_id=GCP_PROJECT, job=self.job, location=GCP_LOCATION
+            project_id=GCP_PROJECT, job=self.job, region=GCP_LOCATION
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
-            job_id=self.job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=self.job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )
 
     @mock.patch(DATAPROC_PATH.format("uuid.uuid4"))
@@ -1286,10 +1286,10 @@ class TestDataProcSparkSqlOperator(unittest.TestCase):
         op.execute(context=MagicMock())
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.submit_job.assert_called_once_with(
-            project_id="other-project", job=self.other_project_job, location=GCP_LOCATION
+            project_id="other-project", job=self.other_project_job, region=GCP_LOCATION
         )
         mock_hook.return_value.wait_for_job.assert_called_once_with(
-            job_id=self.job_id, location=GCP_LOCATION, project_id="other-project"
+            job_id=self.job_id, region=GCP_LOCATION, project_id="other-project"
         )
 
     @mock.patch(DATAPROC_PATH.format("uuid.uuid4"))
@@ -1485,7 +1485,7 @@ class TestDataprocCreateWorkflowTemplateOperator:
             task_id=TASK_ID,
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             retry=RETRY,
             timeout=TIMEOUT,
@@ -1495,7 +1495,7 @@ class TestDataprocCreateWorkflowTemplateOperator:
         op.execute(context={})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_workflow_template.assert_called_once_with(
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             retry=RETRY,
             timeout=TIMEOUT,

--- a/tests/providers/google/cloud/operators/test_dataproc.py
+++ b/tests/providers/google/cloud/operators/test_dataproc.py
@@ -930,6 +930,84 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
         # Check for negative case
         self.assertEqual(op.get_extra_links(datetime(2020, 7, 20), DataprocJobLink.name), "")
 
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_location_deprecation_warning(self, mock_hook):
+        xcom_push_call = call.ti.xcom_push(
+            execution_date=None, key='job_conf', value=DATAPROC_JOB_CONF_EXPECTED
+        )
+        wait_for_job_call = call.hook().wait_for_job(
+            job_id=TEST_JOB_ID, region=GCP_LOCATION, project_id=GCP_PROJECT, timeout=None
+        )
+
+        job = {}
+        mock_hook.return_value.wait_for_job.return_value = None
+        mock_hook.return_value.submit_job.return_value.reference.job_id = TEST_JOB_ID
+        self.extra_links_manager_mock.attach_mock(mock_hook, 'hook')
+
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+
+        with pytest.warns(DeprecationWarning) as warnings:
+            op = DataprocSubmitJobOperator(
+                task_id=TASK_ID,
+                location=GCP_LOCATION,
+                project_id=GCP_PROJECT,
+                job=job,
+                gcp_conn_id=GCP_CONN_ID,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                request_id=REQUEST_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
+            )
+            op.execute(context=self.mock_context)
+
+            mock_hook.assert_called_once_with(
+                gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN
+            )
+
+            # Test whether xcom push occurs before polling for job
+            self.assertLess(
+                self.extra_links_manager_mock.mock_calls.index(xcom_push_call),
+                self.extra_links_manager_mock.mock_calls.index(wait_for_job_call),
+                msg='Xcom push for Job Link has to be done before polling for job status',
+            )
+
+            mock_hook.return_value.submit_job.assert_called_once_with(
+                project_id=GCP_PROJECT,
+                region=GCP_LOCATION,
+                job=job,
+                request_id=REQUEST_ID,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+            )
+            mock_hook.return_value.wait_for_job.assert_called_once_with(
+                job_id=TEST_JOB_ID, project_id=GCP_PROJECT, region=GCP_LOCATION, timeout=None
+            )
+
+            self.mock_ti.xcom_push.assert_called_once_with(
+                key="job_conf", value=DATAPROC_JOB_CONF_EXPECTED, execution_date=None
+            )
+
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            op = DataprocSubmitJobOperator(
+                task_id=TASK_ID,
+                project_id=GCP_PROJECT,
+                job=job,
+                gcp_conn_id=GCP_CONN_ID,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                request_id=REQUEST_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
+            )
+            op.execute(context=self.mock_context)
+
 
 class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
@@ -1032,6 +1110,80 @@ class TestDataprocUpdateClusterOperator(DataprocClusterTestBase):
         )
         # Check for negative case
         self.assertEqual(op.get_extra_links(datetime(2020, 7, 20), DataprocClusterLink.name), "")
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_location_deprecation_warning(self, mock_hook):
+        self.extra_links_manager_mock.attach_mock(mock_hook, 'hook')
+        mock_hook.return_value.update_cluster.result.return_value = None
+        cluster_decommission_timeout = {"graceful_decommission_timeout": "600s"}
+        update_cluster_args = {
+            'region': GCP_LOCATION,
+            'project_id': GCP_PROJECT,
+            'cluster_name': CLUSTER_NAME,
+            'cluster': CLUSTER,
+            'update_mask': UPDATE_MASK,
+            'graceful_decommission_timeout': cluster_decommission_timeout,
+            'request_id': REQUEST_ID,
+            'retry': RETRY,
+            'timeout': TIMEOUT,
+            'metadata': METADATA,
+        }
+        expected_calls = self.extra_links_expected_calls_base + [
+            call.hook().update_cluster(**update_cluster_args)
+        ]
+        warning_message = (
+            "Parameter `location` will be deprecated. "
+            "Please provide value through `region` parameter instead."
+        )
+
+        with pytest.warns(DeprecationWarning) as warnings:
+            op = DataprocUpdateClusterOperator(
+                task_id=TASK_ID,
+                location=GCP_LOCATION,
+                cluster_name=CLUSTER_NAME,
+                cluster=CLUSTER,
+                update_mask=UPDATE_MASK,
+                request_id=REQUEST_ID,
+                graceful_decommission_timeout=cluster_decommission_timeout,
+                project_id=GCP_PROJECT,
+                gcp_conn_id=GCP_CONN_ID,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                impersonation_chain=IMPERSONATION_CHAIN,
+            )
+            op.execute(context=self.mock_context)
+            mock_hook.assert_called_once_with(
+                gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN
+            )
+            mock_hook.return_value.update_cluster.assert_called_once_with(**update_cluster_args)
+            assert warning_message == str(warnings[0].message)
+
+            # Test whether the xcom push happens before updating the cluster
+            self.extra_links_manager_mock.assert_has_calls(expected_calls, any_order=False)
+
+            self.mock_ti.xcom_push.assert_called_once_with(
+                key="cluster_conf",
+                value=DATAPROC_CLUSTER_CONF_EXPECTED,
+                execution_date=None,
+            )
+
+        with pytest.raises(TypeError):
+            op = DataprocUpdateClusterOperator(
+                task_id=TASK_ID,
+                cluster_name=CLUSTER_NAME,
+                cluster=CLUSTER,
+                update_mask=UPDATE_MASK,
+                request_id=REQUEST_ID,
+                graceful_decommission_timeout=cluster_decommission_timeout,
+                project_id=GCP_PROJECT,
+                gcp_conn_id=GCP_CONN_ID,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                impersonation_chain=IMPERSONATION_CHAIN,
+            )
+            op.execute(context=self.mock_context)
 
 
 class TestDataprocWorkflowTemplateInstantiateOperator(unittest.TestCase):
@@ -1502,3 +1654,48 @@ class TestDataprocCreateWorkflowTemplateOperator:
             metadata=METADATA,
             template=WORKFLOW_TEMPLATE,
         )
+
+    @mock.patch(DATAPROC_PATH.format("DataprocHook"))
+    def test_location_deprecation_warning(self, mock_hook):
+        with pytest.warns(DeprecationWarning) as warnings:
+            warning_message = (
+                "Parameter `location` will be deprecated. "
+                "Please provide value through `region` parameter instead."
+            )
+            op = DataprocCreateWorkflowTemplateOperator(
+                task_id=TASK_ID,
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
+                location=GCP_LOCATION,
+                project_id=GCP_PROJECT,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                template=WORKFLOW_TEMPLATE,
+            )
+            op.execute(context={})
+            mock_hook.assert_called_once_with(
+                gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN
+            )
+            mock_hook.return_value.create_workflow_template.assert_called_once_with(
+                region=GCP_LOCATION,
+                project_id=GCP_PROJECT,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                template=WORKFLOW_TEMPLATE,
+            )
+            assert warning_message == str(warnings[0].message)
+
+        with pytest.raises(TypeError):
+            op = DataprocCreateWorkflowTemplateOperator(
+                task_id=TASK_ID,
+                gcp_conn_id=GCP_CONN_ID,
+                impersonation_chain=IMPERSONATION_CHAIN,
+                project_id=GCP_PROJECT,
+                retry=RETRY,
+                timeout=TIMEOUT,
+                metadata=METADATA,
+                template=WORKFLOW_TEMPLATE,
+            )
+            op.execute(context={})

--- a/tests/providers/google/cloud/sensors/test_dataproc.py
+++ b/tests/providers/google/cloud/sensors/test_dataproc.py
@@ -51,7 +51,7 @@ class TestDataprocJobSensor(unittest.TestCase):
 
         sensor = DataprocJobSensor(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             dataproc_job_id=job_id,
             gcp_conn_id=GCP_CONN_ID,
@@ -60,7 +60,7 @@ class TestDataprocJobSensor(unittest.TestCase):
         ret = sensor.poke(context={})
 
         mock_hook.return_value.get_job.assert_called_once_with(
-            job_id=job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )
         assert ret
 
@@ -72,7 +72,7 @@ class TestDataprocJobSensor(unittest.TestCase):
 
         sensor = DataprocJobSensor(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             dataproc_job_id=job_id,
             gcp_conn_id=GCP_CONN_ID,
@@ -83,7 +83,7 @@ class TestDataprocJobSensor(unittest.TestCase):
             sensor.poke(context={})
 
         mock_hook.return_value.get_job.assert_called_once_with(
-            job_id=job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )
 
     @mock.patch(DATAPROC_PATH.format("DataprocHook"))
@@ -94,7 +94,7 @@ class TestDataprocJobSensor(unittest.TestCase):
 
         sensor = DataprocJobSensor(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             dataproc_job_id=job_id,
             gcp_conn_id=GCP_CONN_ID,
@@ -103,7 +103,7 @@ class TestDataprocJobSensor(unittest.TestCase):
         ret = sensor.poke(context={})
 
         mock_hook.return_value.get_job.assert_called_once_with(
-            job_id=job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )
         assert not ret
 
@@ -115,7 +115,7 @@ class TestDataprocJobSensor(unittest.TestCase):
 
         sensor = DataprocJobSensor(
             task_id=TASK_ID,
-            location=GCP_LOCATION,
+            region=GCP_LOCATION,
             project_id=GCP_PROJECT,
             dataproc_job_id=job_id,
             gcp_conn_id=GCP_CONN_ID,
@@ -125,5 +125,5 @@ class TestDataprocJobSensor(unittest.TestCase):
             sensor.poke(context={})
 
         mock_hook.return_value.get_job.assert_called_once_with(
-            job_id=job_id, location=GCP_LOCATION, project_id=GCP_PROJECT
+            job_id=job_id, region=GCP_LOCATION, project_id=GCP_PROJECT
         )


### PR DESCRIPTION
Standardises DataProc hook & operators `location` parameter to `region` in line
with underlying google DataProc Python client library.

closes: #15622

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
