### PR TITLE
Restores apply_defaults import in base_sensor_operator

### DIFF
--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -36,6 +36,11 @@ from airflow.models.taskreschedule import TaskReschedule
 from airflow.ti_deps.deps.ready_to_reschedule import ReadyToRescheduleDep
 from airflow.utils import timezone
 
+# We need to keep the import here because GCSToLocalFilesystemOperator released in
+# Google Provider before 3.0.0 imported apply_defaults from here.
+# See  https://github.com/apache/airflow/issues/16035
+from airflow.utils.decorators import apply_defaults  # pylint: disable=unused-import
+
 
 class BaseSensorOperator(BaseOperator, SkipMixin):
     """


### PR DESCRIPTION
The GCSToLocalFilesystemOperator in Google Provider <=3.0.0 had wrong
import for apply_defaults. It used

`from airflow.sensors.base_sensor_operator import apply_defaults`

instead of

`from airflow.utils.decorators import apply_defaults`

When we removed apply_defaults in #15667, the base_sensor_operator
import was removed as well which made the GCSToLocalFilestystemOperator
stops working in 2.1.0

Fixes: #16035

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
