### PR TITLE
Unprotect "main" branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,9 +44,6 @@ github:
     master:
       required_pull_request_reviews:
         required_approving_review_count: 1
-    main:
-      required_pull_request_reviews:
-        required_approving_review_count: 1
     v1-10-stable:
       required_pull_request_reviews:
         required_approving_review_count: 1


### PR DESCRIPTION
Although we want this branch protected eventually, we need to unproctect
it for now so that we can delete it, and thus allow a GitHub org admin
to _rename_ the default branch to master -- they can't do this if the
branch already exists.
