### PR TITLE
Don't die when masking `log.exception` when there is no exception

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -155,7 +155,7 @@ class SecretsMasker(logging.Filter):
                 if k in self._record_attrs_to_ignore:
                     continue
                 record.__dict__[k] = self.redact(v)
-            if record.exc_info:
+            if record.exc_info and record.exc_info[1] is not None:
                 exc = record.exc_info[1]
                 # I'm not sure if this is a good idea!
                 exc.args = (self.redact(v) for v in exc.args)

--- a/tests/utils/log/test_secrets_masker.py
+++ b/tests/utils/log/test_secrets_masker.py
@@ -97,6 +97,21 @@ class TestSecretsMasker:
             """
         )
 
+    def test_exception_not_raised(self, logger, caplog):
+        """
+        Test that when ``logger.exception`` is called when there is no current exception we still log.
+
+        (This is a "bug" in user code, but we shouldn't die because of it!)
+        """
+        logger.exception("Err")
+
+        assert caplog.text == textwrap.dedent(
+            """\
+            ERROR Err
+            NoneType: None
+            """
+        )
+
     @pytest.mark.xfail(reason="Cannot filter secrets in traceback source")
     def test_exc_tb(self, logger, caplog):
         """


### PR DESCRIPTION
It is possible that `exc_info` can be set, but contain no exception.

We shouldn't fail in this case, even if the output doesn't make sense as
shown by the test (the `NoneType: None` line is the exception being
logged.)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).