### PR TITLE
Modify return value check in python virtualenv jinja template

### DIFF
--- a/airflow/utils/python_virtualenv_script.jinja2
+++ b/airflow/utils/python_virtualenv_script.jinja2
@@ -50,5 +50,5 @@ res = {{ python_callable }}(*arg_dict["args"], **arg_dict["kwargs"])
 
 # Write output
 with open(sys.argv[2], "wb") as file:
-    if res:
+    if res is not None:
         {{ pickling_library }}.dump(res, file)

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -904,14 +904,14 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             return None
 
         task = self._run_as_operator(f)
-        assert task.execute_callable is None
+        assert task.execute_callable() is None
 
     def test_return_false(self):
         def f():
             return False
 
         task = self._run_as_operator(f)
-        assert task.execute_callable == False
+        assert task.execute_callable() == False
 
     def test_lambda(self):
         with pytest.raises(AirflowException):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -905,6 +905,12 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
 
         self._run_as_operator(f)
 
+    def test_return_false(self):
+        def f():
+            return False
+
+        self._run_as_operator(f)
+
     def test_lambda(self):
         with pytest.raises(AirflowException):
             PythonVirtualenvOperator(python_callable=lambda x: 4, task_id='task', dag=self.dag)

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -903,13 +903,15 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         def f():
             return None
 
-        self._run_as_operator(f)
+        task = self._run_as_operator(f)
+        assert task.execute_callable is None
 
     def test_return_false(self):
         def f():
             return False
 
-        self._run_as_operator(f)
+        task = self._run_as_operator(f)
+        assert task.execute_callable == False
 
     def test_lambda(self):
         with pytest.raises(AirflowException):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -911,7 +911,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             return False
 
         task = self._run_as_operator(f)
-        assert task.execute_callable() == False
+        assert task.execute_callable() is False
 
     def test_lambda(self):
         with pytest.raises(AirflowException):


### PR DESCRIPTION
This PR fixes #16022 by changing the check on the return value of a python callable run by the `PythonVirtualEnvOperator`


