### PR TITLE
Add both airflow and extra annotations to jobs

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -46,6 +46,15 @@ spec:
         tier: airflow
         component: create-user-job
         release: {{ .Release.Name }}
+      {{- if or .Values.airflowPodAnnotations .Values.createUserJob.annotations }}
+      annotations:
+        {{- if .Values.airflowPodAnnotations }}
+        {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.createUserJob.annotations }}
+        {{- toYaml .Values.createUserJob.annotations | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       securityContext:
           runAsUser: {{ .Values.uid }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -45,6 +45,15 @@ spec:
         tier: airflow
         component: run-airflow-migrations
         release: {{ .Release.Name }}
+      {{- if or .Values.airflowPodAnnotations .Values.migrateDatabaseJob.annotations }}
+      annotations:
+        {{- if .Values.airflowPodAnnotations }}
+        {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.migrateDatabaseJob.annotations }}
+        {{- toYaml .Values.migrateDatabaseJob.annotations | nindent 8 }}
+        {{- end }}
+      {{- end }}
     spec:
       securityContext:
           runAsUser: {{ .Values.uid }}

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -217,11 +217,13 @@ class TestBaseChartTest(unittest.TestCase):
                 "templates/workers/worker-deployment.yaml",
                 "templates/webserver/webserver-deployment.yaml",
                 "templates/flower/flower-deployment.yaml",
+                "templates/jobs/create-user-job.yaml",
+                "templates/jobs/migrate-database-job.yaml",
             ],
         )
         # pod_template_file is tested separately as it has extra setup steps
 
-        assert 4 == len(k8s_objects)
+        assert 6 == len(k8s_objects)
 
         for k8s_object in k8s_objects:
             annotations = k8s_object["spec"]["template"]["metadata"]["annotations"]

--- a/chart/tests/test_create_user_job.py
+++ b/chart/tests/test_create_user_job.py
@@ -25,5 +25,15 @@ from chart.tests.helm_template_generator import render_chart
 class CreateUserJobTest(unittest.TestCase):
     def test_should_run_by_default(self):
         docs = render_chart(show_only=["templates/jobs/create-user-job.yaml"])
+        assert "Job" == docs[0]["kind"]
         assert "create-user" == jmespath.search("spec.template.spec.containers[0].name", docs[0])
         assert 50000 == jmespath.search("spec.template.spec.securityContext.runAsUser", docs[0])
+
+    def test_should_support_annotations(self):
+        docs = render_chart(
+            values={"createUserJob": {"annotations": {"foo": "bar"}}},
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+        annotations = jmespath.search("spec.template.metadata.annotations", docs[0])
+        assert "foo" in annotations
+        assert "bar" == annotations["foo"]

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1199,6 +1199,11 @@
             "x-docsSection": "Jobs",
             "additionalProperties": false,
             "properties": {
+                "annotations": {
+                    "description": "Annotations to add to the create user job pod.",
+                    "type": "object",
+                    "default": {}
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",
@@ -1231,6 +1236,11 @@
             "x-docsSection": "Jobs",
             "additionalProperties": false,
             "properties": {
+                "annotations": {
+                    "description": "Annotations to add to the migrate database job pod.",
+                    "type": "object",
+                    "default": {}
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -475,6 +475,9 @@ scheduler:
 
 # Airflow create user job settings
 createUserJob:
+  # Annotations on the create user job pod
+  annotations: {}
+
   # Create ServiceAccount
   serviceAccount:
     # Specifies whether a ServiceAccount should be created
@@ -488,6 +491,8 @@ createUserJob:
 
 # Airflow database migration job settings
 migrateDatabaseJob:
+  # Annotations on the database migration pod
+  annotations: {}
 
   # Create ServiceAccount
   serviceAccount:


### PR DESCRIPTION
Our create user and database migrations jobs were missing the airflow
annotations and didnt support adding extra annotations.