### PR TITLE
Remove `dags.gitSync.excludeWebserver` from chart values.schema.json

### DIFF
--- a/chart/UPDATING.md
+++ b/chart/UPDATING.md
@@ -48,7 +48,10 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
-### Removed `dags.gitSync.root` and `dags.gitSync.dest` parameters
+### Removed `dags.gitSync.root`, `dags.gitSync.dest`, and `dags.gitSync.excludeWebserver` parameters
 
 The `dags.gitSync.root` and `dags.gitSync.dest` parameters didn't provide any useful behaviors to chart users so they have been removed.
 If you have them set in your values file you can safely remove them.
+
+The `dags.gitSync.excludeWebserver` parameter was mistakenly included in the charts `values.schema.json`. If you have it set in your values file,
+you can safely remove it.

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2345,11 +2345,6 @@
                             "type": "boolean",
                             "default": false
                         },
-                        "excludeWebserver": {
-                            "description": "Disable Git sync on webserver as it is not needed when DAG Serialization is enabled.",
-                            "type": "boolean",
-                            "default": false
-                        },
                         "repo": {
                             "description": "Git repository.",
                             "type": "string",


### PR DESCRIPTION
This was mistakenly added back to the schema and can safely be removed.