### PR TITLE
Add collapsible import errors

### DIFF
--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -43,7 +43,6 @@
   line-height: 14px; /* show only one line of 14px text */
   overflow: hidden;
   cursor: pointer;
-  margin-bottom: 14px;
 }
 
 .expanded-error {

--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -36,3 +36,16 @@
 #errorHeading {
   background-color: #d6d8d9; /* same color as Bootstrap's Dark Alert */
 }
+
+.dag-import-error {
+  white-space: pre;
+  height: 14px;
+  line-height: 14px; /* show only one line of 14px text */
+  overflow: hidden;
+  cursor: pointer;
+  margin-bottom: 14px;
+}
+
+.expanded-error {
+  height: 100%;
+}

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -329,10 +329,6 @@ label[for="timezone-other"],
   transform: rotate(180deg);
 }
 
-.dag-import-error {
-  white-space: pre;
-}
-
 /* stylelint-disable declaration-block-single-line-max-declarations */
 .hll { background-color: #ffc; }
 .c { color: #408080; font-style: italic; } /* Comment */

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -64,12 +64,22 @@
 
         <div id="alerts" class="panel-collapse collapse">
           <div class="panel-body">
-            {% for category, m in dag_import_errors %}
-              <div class="alert alert-error dag-import-error">{{ m }}</div>
-            {% endfor %}
+            <div class="alert alert-error">
+              {% for category, m in dag_import_errors %}
+                <div class="dag-import-error" onclick="toggleErrorMessage.call(this)">{{ m }}</div>
+              {% endfor %}
+            </div>
           </div>
         </div>
       </div>
     </div>
   {% endif %}
 {% endwith %}
+
+{% block tail %}
+  <script>
+    function toggleErrorMessage() {
+      $(this).toggleClass('expanded-error');
+    }
+  </script>
+{% endblock %}

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -64,11 +64,11 @@
 
         <div id="alerts" class="panel-collapse collapse">
           <div class="panel-body">
-            <div class="alert alert-error">
-              {% for category, m in dag_import_errors %}
+            {% for category, m in dag_import_errors %}
+              <div class="alert alert-error">
                 <div class="dag-import-error" onclick="toggleErrorMessage.call(this)">{{ m }}</div>
-              {% endfor %}
-            </div>
+              </div>
+            {% endfor %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Show only the first line of a DAG Import Error that will expand when clicked on
Closes #16042

<img width="612" alt="Screen Shot 2021-05-25 at 2 14 24 PM" src="https://user-images.githubusercontent.com/4600967/119555712-c9346c00-bd63-11eb-8a4a-0caa3dd98dbf.png">

<img width="648" alt="Screen Shot 2021-05-25 at 2 14 20 PM" src="https://user-images.githubusercontent.com/4600967/119555722-cb96c600-bd63-11eb-82d4-363318189aeb.png">

<img width="658" alt="Screen Shot 2021-05-25 at 2 14 29 PM" src="https://user-images.githubusercontent.com/4600967/119555732-cdf92000-bd63-11eb-8b4e-d19879f79948.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
