### PR TITLE
Add close/open indicator for import dag errors

### DIFF
--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -38,6 +38,7 @@
 }
 
 .dag-import-error {
+  position: relative;
   white-space: pre;
   height: 14px;
   line-height: 14px; /* show only one line of 14px text */
@@ -47,4 +48,26 @@
 
 .expanded-error {
   height: 100%;
+}
+
+.dag-import-error::after {
+  /* symbol for "opening" panels */
+  font-family: FontAwesome;/* stylelint-disable-line font-family-no-missing-generic-family-keyword */
+  content: "\f078";
+  float: right;
+  color: #e43921;
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.dag-import-error.expanded-error::after {
+  /* symbol for "closing" panels */
+  font-family: FontAwesome;/* stylelint-disable-line font-family-no-missing-generic-family-keyword */
+  content: "\f054";
+  float: right;
+  color: #e43921;
+  position: absolute;
+  top: 0;
+  right: 0;
 }

--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -63,11 +63,5 @@
 
 .dag-import-error.expanded-error::after {
   /* symbol for "closing" panels */
-  font-family: FontAwesome;/* stylelint-disable-line font-family-no-missing-generic-family-keyword */
   content: "\f054";
-  float: right;
-  color: #e43921;
-  position: absolute;
-  top: 0;
-  right: 0;
 }


### PR DESCRIPTION
Make it clear to a user that they can open and close each import error by adding an icon to the right.

<img width="1228" alt="Screen Shot 2021-05-25 at 3 39 45 PM" src="https://user-images.githubusercontent.com/4600967/119565621-cd668680-bd6f-11eb-95a2-98b920bd156d.png">

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
