### PR TITLE
Template airflowLocalSettings and webserver.webserverConfig

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -48,7 +48,7 @@ data:
 
 {{- if .Values.airflowLocalSettings }}
   airflow_local_settings.py: |
-    {{ .Values.airflowLocalSettings | nindent 4 }}
+    {{ tpl .Values.airflowLocalSettings . | nindent 4 }}
 {{- end }}
 {{- if and .Values.dags.gitSync.enabled  .Values.dags.gitSync.knownHosts }}
   known_hosts: |

--- a/chart/templates/configmaps/webserver-configmap.yaml
+++ b/chart/templates/configmaps/webserver-configmap.yaml
@@ -34,5 +34,5 @@ metadata:
 {{- end }}
 data:
   webserver_config.py: |
-    {{- .Values.webserver.webserverConfig | nindent 4 }}
+    {{- tpl .Values.webserver.webserverConfig . | nindent 4 }}
 {{- end }}

--- a/chart/tests/test_configmap.py
+++ b/chart/tests/test_configmap.py
@@ -55,8 +55,11 @@ class ConfigmapTest(unittest.TestCase):
 
     def test_airflow_local_settings(self):
         docs = render_chart(
-            values={"airflowLocalSettings": "# Well hello!"},
+            values={"airflowLocalSettings": "# Well hello {{ .Release.Name }}!"},
             show_only=["templates/configmaps/configmap.yaml"],
         )
 
-        assert "# Well hello!" == jmespath.search('data."airflow_local_settings.py"', docs[0]).strip()
+        assert (
+            "# Well hello RELEASE-NAME!"
+            == jmespath.search('data."airflow_local_settings.py"', docs[0]).strip()
+        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -235,7 +235,7 @@
             "x-docsSection": "Kubernetes"
         },
         "airflowLocalSettings": {
-            "description": "`airflow_local_settings` file as a string.",
+            "description": "`airflow_local_settings` file as a string (can be templated).",
             "type": [
                 "string",
                 "null"
@@ -1450,7 +1450,7 @@
                     "default": []
                 },
                 "webserverConfig": {
-                    "description": "This will be mounted into the Airflow webserver as a custom `webserver_config.py`. You can bake a `webserver_config.py` in to your image instead.",
+                    "description": "This string (can be templated) will be mounted into the Airflow webserver as a custom `webserver_config.py`. You can bake a `webserver_config.py` in to your image instead.",
                     "type": [
                         "string",
                         "null"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -152,7 +152,7 @@ airflowPodAnnotations: {}
 # main Airflow configmap
 airflowConfigAnnotations: {}
 
-# `airflow_local_settings` file as a string.
+# `airflow_local_settings` file as a string (can be templated).
 airflowLocalSettings: ~
 
 # Enable RBAC (default on most clusters these days)
@@ -565,9 +565,8 @@ webserver:
   extraVolumes: []
   extraVolumeMounts: []
 
-  # This will be mounted into the Airflow Webserver as a custom
-  # webserver_config.py. You can bake a webserver_config.py in to your image
-  # instead
+  # This string (can be templated) will be mounted into the Airflow Webserver as a custom
+  # webserver_config.py. You can bake a webserver_config.py in to your image instead.
   webserverConfig: ~
   # webserverConfig: |
   #   from airflow import configuration as conf


### PR DESCRIPTION
By templating `airflowLocalSettings` and `webserver.webserverConfig`, we
allow users to more easily create reusable values. For example:

```
airflowLocalSettings: |
  def pod_mutation_hook(pod):
      pod.spec.containers[0].env.append({
          "name": "HELM_RELEASE",
          "value": "{{ .Release.Name }}",
      })
```
