### PR TITLE
Refactor `dag.clear` method

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -248,8 +248,10 @@ def post_clear_task_instances(dag_id: str, session=None):
         error_message = f"Dag id {dag_id} not found"
         raise NotFound(error_message)
     reset_dag_runs = data.pop('reset_dag_runs')
-    task_instances = dag.clear(get_tis=True, **data)
-    if not data["dry_run"]:
+    dry_run = data.pop('dry_run')
+    # We always pass dry_run here, otherwise this would try to confirm on the terminal!
+    task_instances = dag.clear(dry_run=True, dag_bag=current_app.dag_bag, **data)
+    if not dry_run:
         clear_task_instances(
             task_instances, session, dag=dag, dag_run_state=State.RUNNING if reset_dag_runs else False
         )

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -34,7 +34,7 @@ import jinja2
 import lazy_object_proxy
 import pendulum
 from jinja2 import TemplateAssertionError, UndefinedError
-from sqlalchemy import Column, Float, Index, Integer, PickleType, String, and_, func, or_
+from sqlalchemy import Column, Float, Index, Integer, PickleType, String, and_, func, or_, tuple_
 from sqlalchemy.orm import reconstructor, relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.elements import BooleanClauseList
@@ -246,7 +246,7 @@ class TaskInstanceKey(NamedTuple):
     dag_id: str
     task_id: str
     execution_date: datetime
-    try_number: int
+    try_number: int = 1
 
     @property
     def primary(self) -> Tuple[str, str, datetime]:
@@ -261,6 +261,14 @@ class TaskInstanceKey(NamedTuple):
     def with_try_number(self, try_number: int) -> 'TaskInstanceKey':
         """Returns TaskInstanceKey with provided ``try_number``"""
         return TaskInstanceKey(self.dag_id, self.task_id, self.execution_date, try_number)
+
+    @property
+    def key(self) -> "TaskInstanceKey":
+        """For API-compatibly with TaskInstance.
+
+        Returns self
+        """
+        return self
 
 
 class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
@@ -1949,11 +1957,14 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
     @staticmethod
     def filter_for_tis(tis: Iterable[Union["TaskInstance", TaskInstanceKey]]) -> Optional[BooleanClauseList]:
         """Returns SQLAlchemy filter to query selected task instances"""
+        # DictKeys type, (what we often pass here from the scheduler) is not directly indexable :(
+        # Or it might be a generator, but we need to be able to iterate over it more than once
+        tis = list(tis)
+
         if not tis:
             return None
 
-        # DictKeys type, (what we often pass here from the scheduler) is not directly indexable :(
-        first = list(tis)[0]
+        first = tis[0]
 
         dag_id = first.dag_id
         execution_date = first.execution_date
@@ -1972,14 +1983,20 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                 TaskInstance.execution_date.in_(t.execution_date for t in tis),
                 TaskInstance.task_id == first_task_id,
             )
-        return or_(
-            and_(
-                TaskInstance.dag_id == ti.dag_id,
-                TaskInstance.task_id == ti.task_id,
-                TaskInstance.execution_date == ti.execution_date,
+
+        if settings.Session.bind.dialect.name == 'mssql':
+            return or_(
+                and_(
+                    TaskInstance.dag_id == ti.dag_id,
+                    TaskInstance.task_id == ti.task_id,
+                    TaskInstance.execution_date == ti.execution_date,
+                )
+                for ti in tis
             )
-            for ti in tis
-        )
+        else:
+            return tuple_(TaskInstance.dag_id, TaskInstance.task_id, TaskInstance.execution_date).in_(
+                [ti.key.primary for ti in tis]
+            )
 
 
 # State of the task instance.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -632,6 +632,15 @@ autoapi_root = '_api'
 # TOC tree entry yourself.
 autoapi_add_toctree_entry = False
 
+# By default autoapi will include private members -- we don't want that!
+autoapi_options = [
+    'members',
+    'undoc-members',
+    'show-inheritance',
+    'show-module-summary',
+    'special-members',
+]
+
 # -- Options for ext.exampleinclude --------------------------------------------
 exampleinclude_sourceroot = os.path.abspath('..')
 


### PR DESCRIPTION
There were a number of "internal" parameters that were to do with
getting the TIs which should not have been exposed via the public API.

Additionally this method and `get_task_instances` shared a lot of
similar code (albeit the later was simpler) -- they now both use a
internal method to do the actual querying.

Extracted out of @andrewgodwin's AIP-40 PR