### PR TITLE
Fixes problem where conf variable was used before initialization

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -873,9 +873,6 @@ def initialize_config():
 
         log.info('Creating new FAB webserver config file in: %s', WEBSERVER_CONFIG)
         shutil.copy(_default_config_file_path('default_webserver_config.py'), WEBSERVER_CONFIG)
-
-    conf.validate()
-
     return conf
 
 
@@ -1114,6 +1111,7 @@ WEBSERVER_CONFIG = ''  # Set by initialize_config
 
 conf = initialize_config()
 secrets_backend_list = initialize_secrets_backends()
+conf.validate()
 
 
 PY37 = sys.version_info >= (3, 7)

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -44,7 +44,8 @@ def test_configuration_do_not_expose_config(admin_client):
 @mock.patch.dict(os.environ, {"AIRFLOW__CORE__UNIT_TEST_MODE": "False"})
 def test_configuration_expose_config(admin_client):
     # make sure config is initialized (without unit test mote)
-    initialize_config()
+    conf = initialize_config()
+    conf.validate()
     with conf_vars({('webserver', 'expose_config'): 'True'}):
         resp = admin_client.get('configuration', follow_redirects=True)
     check_content_in_response(['Airflow Configuration', 'Running Configuration'], resp)


### PR DESCRIPTION
There was a problem that when we initialized configuration, we've run
validate() which - among others - checkd if the connection is an `sqlite`
but when the SQLAlchemy connection was not configured via variable but
via secret manager, it has fallen back to secret_backend, which should
be configured via conf and initialized.
The problem is that the "conf" object is not yet created, because
the "validate()" method has not finished yet and
"initialize_configuration" has not yet returned.
This led to snake eating its own tail.

This PR defers the validate() method to after secret backends have
been initialized. The effect of it is that secret backends might
be initialized with configuration that is not valid, but there are
no real negative consequences of this.

Fixes: #16079
Fixes: #15685

starting

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
