### PR TITLE
Fill the "job_id" field for `airflow task run` command.

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -88,6 +88,7 @@ def _run_task_by_executor(args, dag, ti):
             print(e)
             raise e
     executor = ExecutorLoader.get_default_executor()
+    executor.job_id = "manual"
     executor.start()
     print("Sending to executor.")
     executor.queue_task_instance(


### PR DESCRIPTION
I have encounter the same exception backtrace when running dag with Kubernetes executor in #13805, with airflow 2.0.2. This one-line change does fix the problem.

Fixes #13805, see also comment https://github.com/apache/airflow/issues/13805#issuecomment-844291902.