### PR TITLE
Add support for extra parameters to samba client

### DIFF
--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -36,6 +36,19 @@ class SambaHook(BaseHook):
         self.conn = self.get_connection(samba_conn_id)
 
     def get_conn(self) -> SambaClient:
+        """
+        Return a samba client object.
+
+        You can provide optional parameters in the extra fields of
+        your connection.
+
+        :param logdir: Base directory name for log/debug files.
+        :param kerberos: Try to authenticate with kerberos.
+        :param workgroup: Set the SMB domain of the username.
+        :param netbios_name:
+            This option allows you to override the NetBIOS name that
+            Samba uses for itself.
+        """
         samba = SambaClient(
             server=self.conn.host,
             share=self.conn.schema,

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -44,16 +44,16 @@ class SambaHook(BaseHook):
 
         Below is an inexhaustive list of these parameters:
 
-        logdir
+        `logdir`
           Base directory name for log/debug files.
 
-        kerberos
+        `kerberos`
           Try to authenticate with kerberos.
 
-        workgroup
+        `workgroup`
           Set the SMB domain of the username.
 
-        netbios_name
+        `netbios_name`
           This option allows you to override the NetBIOS name that
           Samba uses for itself.
 

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -42,6 +42,7 @@ class SambaHook(BaseHook):
             username=self.conn.login,
             ip=self.conn.host,
             password=self.conn.password,
+            **self.conn.extra_dejson,
         )
         return samba
 

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -42,12 +42,22 @@ class SambaHook(BaseHook):
         You can provide optional parameters in the extra fields of
         your connection.
 
-        :param logdir: Base directory name for log/debug files.
-        :param kerberos: Try to authenticate with kerberos.
-        :param workgroup: Set the SMB domain of the username.
-        :param netbios_name:
-            This option allows you to override the NetBIOS name that
-            Samba uses for itself.
+        Below is an inexhaustive list of these parameters:
+
+        logdir
+          Base directory name for log/debug files.
+
+        kerberos
+          Try to authenticate with kerberos.
+
+        workgroup
+          Set the SMB domain of the username.
+
+        netbios_name
+          This option allows you to override the NetBIOS name that
+          Samba uses for itself.
+
+        For additional details, see `smbclient.SambaClient`.
         """
         samba = SambaClient(
             server=self.conn.host,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -191,6 +191,7 @@ IdP
 ImageAnnotatorClient
 Imap
 Imberman
+inexhaustive
 InsecureClient
 InspectContentResponse
 InspectTemplate

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -191,7 +191,6 @@ IdP
 ImageAnnotatorClient
 Imap
 Imberman
-inexhaustive
 InsecureClient
 InspectContentResponse
 InspectTemplate
@@ -884,6 +883,7 @@ img
 imgcat
 impyla
 incompliancies
+inexhaustive
 infile
 infoType
 infoTypes

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -265,6 +265,7 @@ Naik
 Namenode
 Namespace
 Neo4j
+NetBIOS
 Nextdoor
 Nones
 NotFound

--- a/tests/providers/samba/hooks/test_samba.py
+++ b/tests/providers/samba/hooks/test_samba.py
@@ -16,13 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json
 import unittest
 from unittest import mock
 from unittest.mock import call
 
-import json
 import pytest
-import smbclient
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This adds the option to use the _extra_ field for adding additional parameters to the `SambaClient` constructor such as `workgroup` using JSON-formatting.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
