### PR TITLE
Move images needed only during CI to `airflow-ci` DockerHub

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -236,7 +236,7 @@ for details.
   ./breeze
 
 The First time you run Breeze, it pulls and builds a local version of Docker images.
-It pulls the latest Airflow CI images from `Airflow DockerHub <https://hub.docker.com/r/apache/airflow>`_
+It pulls the latest Airflow CI images from `Airflow DockerHub <https://hub.docker.com/r/apache/airflow-ci>`_
 and uses them to build your local Docker images. Note that the first run (per python) might take up to 10
 minutes on a fast connection to start. Subsequent runs should be much faster.
 
@@ -538,10 +538,10 @@ Building CI images
 With Breeze you can build images that are used by Airflow CI and production ones.
 
 For all development tasks, unit tests, integration tests, and static code checks, we use the
-**CI image** maintained on the DockerHub in the ``apache/airflow`` repository.
+**CI image** maintained on the DockerHub in the ``apache/airflow-ci`` repository.
 This Docker image contains a lot of test-related packages (size of ~1GB).
 Its tag follows the pattern of ``<BRANCH>-python<PYTHON_MAJOR_MINOR_VERSION>-ci``
-(for example, ``apache/airflow:master-python3.6-ci`` or ``apache/airflow:v2-1-test-python3.6-ci``).
+(for example, ``apache/airflow:master-python3.6-ci`` or ``apache/airflow-ci:v2-1-test-python3.6-ci``).
 The image is built using the `<Dockerfile.ci>`_ Dockerfile.
 
 The CI image is built automatically as needed, however it can be rebuilt manually with
@@ -634,11 +634,12 @@ default is to build ``both`` type of packages ``sdist`` and ``wheel``.
 Building Production images
 --------------------------
 
-The **Production image** is also maintained on the DockerHub in the
-``apache/airflow`` repository. This Docker image (and Dockerfile) contains size-optimised Airflow
-installation with selected extras and dependencies. Its tag follows the pattern of
-``<BRANCH>-python<PYTHON_MAJOR_MINOR_VERSION>`` (for example, ``apache/airflow:master-python3.6``
-or ``apache/airflow:v2-1-test-python3.6``).
+The **Production image** is also maintained on the DockerHub in both ``apache/airflow`` (for tagged and latest
+releases) or ``apache/airflow-ci`` repository (for branches). This Docker image (built using official
+Dockerfile) contains size-optimised Airflow installation with selected extras and dependencies. Its tag follows
+the pattern of ``<BRANCH>-python<PYTHON_MAJOR_MINOR_VERSION>`` (for example, ``apache/airflow-ci:master-python3.6``
+or ``apache/airflow-ci:v2-1-test-python3.6``) or in case of production images tagged with releases
+``apache/airflow:2.1.2-python3.8`` or ``apache/airflow:latest`` or ``apache/airflow:latest-python3.8``.
 
 However in many cases you want to add your own custom version of the image - with added apt dependencies,
 python dependencies, additional Airflow extras. Breeze's ``build-image`` command helps to build your own,
@@ -1437,7 +1438,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           DockerHub user used to pull, push and build images. Default: apache.
 
   -H, --dockerhub-repo DOCKERHUB_REPO
-          DockerHub repository used to pull, push, build images. Default: airflow.
+          DockerHub repository used to pull, push, build images. Default: airflow-ci.
 
   -c, --use-github-registry
           If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not
@@ -1611,7 +1612,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           DockerHub user used to pull, push and build images. Default: apache.
 
   -H, --dockerhub-repo DOCKERHUB_REPO
-          DockerHub repository used to pull, push, build images. Default: airflow.
+          DockerHub repository used to pull, push, build images. Default: airflow-ci.
 
   -c, --use-github-registry
           If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not
@@ -2676,7 +2677,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
           DockerHub user used to pull, push and build images. Default: apache.
 
   -H, --dockerhub-repo DOCKERHUB_REPO
-          DockerHub repository used to pull, push, build images. Default: airflow.
+          DockerHub repository used to pull, push, build images. Default: airflow-ci.
 
   -c, --use-github-registry
           If GitHub registry is enabled, pulls and pushes are done from the GitHub registry not

--- a/CI.rst
+++ b/CI.rst
@@ -491,13 +491,13 @@ If ``USE_GITHUB_REGISTRY`` is set to "false" you can interact directly with Dock
 you pull from/push to "apache/airflow" DockerHub repository, but you can change
 that to your own repository by setting those environment variables:
 
-+----------------+-------------+-----------------------------------+
-| Variable       | Default     | Comment                           |
-+================+=============+===================================+
-| DOCKERHUB_USER | ``apache``  | Name of the DockerHub user to use |
-+----------------+-------------+-----------------------------------+
-| DOCKERHUB_REPO | ``airflow`` | Name of the DockerHub repo to use |
-+----------------+-------------+-----------------------------------+
++----------------+----------------+-----------------------------------+
+| Variable       | Default        | Comment                           |
++================+================+===================================+
+| DOCKERHUB_USER | ``apache``     | Name of the DockerHub user to use |
++----------------+----------------+-----------------------------------+
+| DOCKERHUB_REPO | ``airflow-ci`` | Name of the DockerHub repo to use |
++----------------+----------------+-----------------------------------+
 
 CI Architecture
 ===============
@@ -521,7 +521,7 @@ The following components are part of the CI infrastructure
 * **GitHub Private Image Registry**- image registry used as build cache for CI  jobs.
   It is at https://docker.pkg.github.com/apache/airflow/airflow
 * **DockerHub Public Image Registry** - publicly available image registry at DockerHub.
-  It is at https://hub.docker.com/r/apache/airflow
+  It is at https://hub.docker.com/r/apache/airflow-ci
 * **DockerHub Build Workers** - virtual machines running build jibs at DockerHub
 * **Official Images** (future) - these are official images that are prominently visible in DockerHub.
   We aim our images to become official images so that you will be able to pull them

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -64,7 +64,15 @@ Image naming conventions
 
 The images are named as follows:
 
-``apache/airflow:<BRANCH_OR_TAG>-python<PYTHON_MAJOR_MINOR_VERSION>[-ci][-manifest]``
+``apache/airflow-ci:<BRANCH>-python<PYTHON_MAJOR_MINOR_VERSION>[-ci][-manifest]``
+
+For production images tagged with official releases:
+
+``apache/airflow:<TAG>-python<PYTHON_MAJOR_MINOR_VERSION>``
+
+And for production images with ``latest`` tag:
+
+````apache/airflow:latest[-python<PYTHON_MAJOR_MINOR_VERSION>]``
 
 where:
 
@@ -82,7 +90,7 @@ the CI images. Each CI image, when built uses current Python version of the base
 python images are regularly updated (with bugfixes/security fixes), so for example Python 3.8 from
 last week might be a different image than Python 3.8 today. Therefore whenever we push CI image
 to airflow repository, we also push the Python image that was used to build it this image is stored
-as ``apache/airflow:python<PYTHON_MAJOR_MINOR_VERSION>-<BRANCH_OR_TAG>``.
+as ``apache/airflow-ci:python<PYTHON_MAJOR_MINOR_VERSION>-<BRANCH_OR_TAG>``.
 
 Since those are simply snapshots of the existing Python images, DockerHub does not create a separate
 copy of those images - all layers are mounted from the original Python images and those are merely
@@ -269,26 +277,48 @@ registry by setting ``GITHUB_REGISTRY`` to ``docker.pkg.github.com`` for GitHub 
 Default is the GitHub Package Registry one. The Pull Request forks have no access to the secret but they
 auto-detect the registry used when they wait for the images.
 
-Our images are named like that:
+Our images are named following conventions below.
+
+Images used during CI builds:
 
 .. code-block:: bash
 
-  apache/airflow:<BRANCH_OR_TAG>-pythonX.Y         - for production images
-  apache/airflow:<BRANCH_OR_TAG>-pythonX.Y-ci      - for CI images
-  apache/airflow:<BRANCH_OR_TAG>-pythonX.Y-build   - for production build stage
-  apache/airflow:pythonX.Y-<BRANCH_OR_TAG>         - for Python base image used for both CI and PROD image
+  apache/airflow-ci:<BRANCH>-pythonX.Y         - for production images
+  apache/airflow-ci:<BRANCH>-pythonX.Y-ci      - for CI images
+  apache/airflow-ci:<BRANCH>-pythonX.Y-build   - for production build stage
+  apache/airflow-ci:pythonX.Y-<BRANCH>         - for Python base image used for both CI and PROD image
 
 For example:
 
 .. code-block:: bash
 
-  apache/airflow:master-python3.6                - production "latest" image from current master
-  apache/airflow:master-python3.6-ci             - CI "latest" image from current master
-  apache/airflow:v2-1-test-python3.6-ci          - CI "latest" image from current v2-1-test branch
-  apache/airflow:2.1.0-python3.6                 - production image for 2.1.0 release
+  apache/airflow-ci:master-python3.6                - production "master" image from current master
+  apache/airflow-ci:master-python3.6-ci             - CI "master" image from current master
+  apache/airflow-ci:v2-1-test-python3.6-ci          - CI "master" image from current v2-1-test branch
   apache/airflow:python3.6-master                - base Python image for the master branch
 
-You can see DockerHub images at `<https://hub.docker.com/r/apache/airflow>`_
+You can see those CI DockerHub images at `<https://hub.docker.com/r/apache/airflow-ci>`_
+
+Released, production images
+
+.. code-block:: bash
+
+  apache/airflow:<TAG>-pythonX.Y         - for tagged released production images
+  apache/airflow:<TAG>                   - for default Python version released production images
+  apache/airflow:latest-pythonX.Y        - for latest released production images
+  apache/airflow:latest                  - for default Python version of latest released production images
+
+For example:
+
+.. code-block:: bash
+
+  apache/airflow:2.1.0-python3.8         - for regular released 2.1.0 production image with Python 3.8
+  apache/airflow:2.1.0                   - for default Python version of 2.1.0 production image
+  apache/airflow:latest-python3.8        - for latest released Python 3.8 production image
+  apache/airflow:latest                  - for latest released default Python production image
+
+You can see those CI DockerHub images at `<https://hub.docker.com/r/apache/airflow>`_
+
 
 Using GitHub registries as build cache
 --------------------------------------

--- a/breeze
+++ b/breeze
@@ -3071,18 +3071,6 @@ function breeze::read_saved_environment_variables() {
 
     MSSQL_VERSION="${MSSQL_VERSION:=$(parameters::read_from_file MSSQL_VERSION)}"
     MSSQL_VERSION=${MSSQL_VERSION:=${_breeze_default_mssql_version}}
-
-    # Here you read DockerHub user/account that you use
-    # You can populate your own images in DockerHub this way and work with the,
-    # You can override it with "--dockerhub-user" option and it will be stored in .build directory
-    DOCKERHUB_USER="${DOCKERHUB_USER:=$(parameters::read_from_file DOCKERHUB_USER)}"
-    DOCKERHUB_USER="${DOCKERHUB_USER:=${_breeze_default_dockerhub_user}}"
-
-    # Here you read DockerHub repo that you use
-    # You can populate your own images in DockerHub this way and work with them
-    # You can override it with "--dockerhub-repo" option and it will be stored in .build directory
-    DOCKERHUB_REPO="${DOCKERHUB_REPO:=$(parameters::read_from_file DOCKERHUB_REPO)}"
-    DOCKERHUB_REPO="${DOCKERHUB_REPO:=${_breeze_default_dockerhub_repo}}"
 }
 
 #######################################################################################################
@@ -3144,11 +3132,6 @@ function breeze::check_and_save_all_params() {
 
     parameters::check_allowed_param TEST_TYPE "Type of tests" "--test-type"
     parameters::check_allowed_param PACKAGE_FORMAT "Format of packages to build" "--package-format"
-
-
-    # Can't verify those - they can be anything, so let's just save them
-    parameters::save_to_file DOCKERHUB_USER
-    parameters::save_to_file DOCKERHUB_REPO
 }
 
 #######################################################################################################

--- a/breeze-complete
+++ b/breeze-complete
@@ -155,7 +155,7 @@ EOF
 )
 
 _breeze_default_dockerhub_user="apache"
-_breeze_default_dockerhub_repo="airflow"
+_breeze_default_dockerhub_repo="airflow-ci"
 _breeze_default_github_repository="apache/airflow"
 _breeze_default_github_image_id="latest"
 

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -212,6 +212,7 @@ In case you need, you can also build and push the images manually:
 ```shell script
 export VERSION=<VERSION_HERE>
 export DOCKER_REPO=docker.io/apache/airflow
+export DEFAULT_PYTHON_VERSION=3.6
 for python_version in "3.6" "3.7" "3.8"
 (
   export DOCKER_TAG=${VERSION}-python${python_version}
@@ -222,9 +223,21 @@ for python_version in "3.6" "3.7" "3.8"
 Once this succeeds you should push the "${VERSION}" image:
 
 ```shell script
-docker tag apache/airflow:${VERSION}-python3.6 apache/airflow:${VERSION}
+docker tag apache/airflow:${VERSION}-python${DEFAULT_PYTHON_VERSION} apache/airflow:${VERSION}
 docker push apache/airflow:${VERSION}
 ```
+
+And latest images:
+
+```shell script
+for python_version in "3.6" "3.7" "3.8"
+(
+    docker tag apache/airflow:${VERSION}-python{python_version} apache/airflow:latest-python{python-version}
+    docker push apache/airflow:latest-python{python-version}
+)
+docker tag apache/airflow:${VERSION}-python${DEFAULT_PYTHON_VERSION} apache/airflow:latest
+```
+
 
 This will wipe Breeze cache and docker-context-files in order to make sure the build is "clean". It
 also performs image verification before the images are pushed.

--- a/dev/retag_docker_images.py
+++ b/dev/retag_docker_images.py
@@ -21,16 +21,17 @@
 # This scripts re-tags images from one branch to another. Since we keep
 # images "per-branch" we sometimes need to "clone" the current
 # images to provide a starting cache image to build images in the
-# new branch. This can be usful in a few situations:
+# new branch. This can be useful in a few situations:
 #
 # * when starting new release branch (for example `v2-1-test`)
 # * when renaming a branch (for example `master->main`)
 #
 # Docker registries we are using:
 #
-# * DockerHub - we keep `apache/airflow` image with distinct tags
+# * DockerHub - we keep `apache/airflow-ci` image with distinct tags
 #   that determine type of the image, because in DockerHub we only
-#   have access to `apache/airflow` image
+#   have access to `apache/airflow-ci` and `apache/airflow-ci` image
+#   and we want to keep the CI images and prod images separately.
 #
 # * GitHub Docker Registries: (depends on the type of registry) we have
 #   more flexibility:
@@ -51,8 +52,6 @@ from typing import List
 import click
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8"]
-
-DOCKERHUB_PREFIX = "apache/airflow"
 
 DOCKERHUB_IMAGES = [
     "{prefix}:python{python_version}-{branch}",
@@ -81,11 +80,17 @@ GHCR_IO_IMAGES = [
 
 
 # noinspection StrFormat
-def pull_push_all_images(prefix: str, images: List[str], source_branch: str, target_branch: str):
+def pull_push_all_images(
+    source_prefix: str, target_prefix: str, images: List[str], source_branch: str, target_branch: str
+):
     for python_version in PYTHON_VERSIONS:
         for image in images:
-            source_image = image.format(prefix=prefix, branch=source_branch, python_version=python_version)
-            target_image = image.format(prefix=prefix, branch=target_branch, python_version=python_version)
+            source_image = image.format(
+                prefix=source_prefix, branch=source_branch, python_version=python_version
+            )
+            target_image = image.format(
+                prefix=target_prefix, branch=target_branch, python_version=python_version
+            )
             print(f"Copying image: {source_image} -> {target_image}")
             subprocess.run(["docker", "pull", source_image], check=True)
             subprocess.run(["docker", "tag", source_image, target_image], check=True)
@@ -93,12 +98,40 @@ def pull_push_all_images(prefix: str, images: List[str], source_branch: str, tar
 
 
 @click.group(invoke_without_command=True)
+@click.option(
+    "--source-dockerhub", type=str, default="apache/airflow-ci", help="Source repo [apache/airflow-ci]"
+)
+@click.option(
+    "--target-dockerhub", type=str, default="apache/airflow-ci", help="Target repo [apache/airflow-ci]"
+)
 @click.option("--source-branch", type=str, default="master", help="Source branch name [master]")
 @click.option("--target-branch", type=str, default="main", help="Target branch name [main]")
-def main(source_branch: str, target_branch: str):
-    pull_push_all_images(DOCKERHUB_PREFIX, DOCKERHUB_IMAGES, source_branch, target_branch)
-    pull_push_all_images(GITHUB_DOCKER_REGISTRY_PREFIX, GITHUB_REGISTRY_IMAGES, source_branch, target_branch)
-    pull_push_all_images(GHCR_IO_PREFIX, GHCR_IO_IMAGES, source_branch, target_branch)
+@click.option("--dockerhub/--no-dockerhub", default=True, help="Whether to synchronize DockerHub")
+@click.option("--registry/--no-registry", default=True, help="Whether to synchronize GitHub registry")
+@click.option("--ghcr-io/--no-ghcr-io", default=True, help="Whether to synchronize ghcr.io")
+def main(
+    source_dockerhub: str,
+    target_dockerhub: str,
+    source_branch: str,
+    target_branch: str,
+    dockerhub: bool,
+    registry: bool,
+    ghcr_io: bool,
+):
+    if dockerhub:
+        pull_push_all_images(
+            source_dockerhub, target_dockerhub, DOCKERHUB_IMAGES, source_branch, target_branch
+        )
+    if registry:
+        pull_push_all_images(
+            GITHUB_DOCKER_REGISTRY_PREFIX,
+            GITHUB_DOCKER_REGISTRY_PREFIX,
+            GITHUB_REGISTRY_IMAGES,
+            source_branch,
+            target_branch,
+        )
+    if ghcr_io:
+        pull_push_all_images(GHCR_IO_PREFIX, GHCR_IO_PREFIX, GHCR_IO_IMAGES, source_branch, target_branch)
 
 
 if __name__ == "__main__":

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -872,7 +872,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                         'command': ['stress'],
                         'env': [],
                         'envFrom': [],
-                        'image': 'apache/airflow:stress-2021.04.28-1.0.4',
+                        'image': 'apache/airflow-ci:stress-2021.04.28-1.0.4',
                         'imagePullPolicy': 'IfNotPresent',
                         'name': 'base',
                         'ports': [],

--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -18,7 +18,7 @@
 version: "2.2"
 services:
   trino:
-    image: apache/airflow:trino-2021.04.28
+    image: apache/airflow-ci:trino-2021.04.28
     container_name: trino
     hostname: trino
     domainname: example.com

--- a/scripts/ci/dockerfiles/apache-rat/build_and_push.sh
+++ b/scripts/ci/dockerfiles/apache-rat/build_and_push.sh
@@ -17,7 +17,7 @@
 # under the License.
 set -euo pipefail
 DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
-DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow-ci"}
 readonly DOCKERHUB_USER
 readonly DOCKERHUB_REPO
 

--- a/scripts/ci/dockerfiles/bats/build_and_push.sh
+++ b/scripts/ci/dockerfiles/bats/build_and_push.sh
@@ -17,7 +17,7 @@
 # under the License.
 set -euo pipefail
 DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
-DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow-ci"}
 readonly DOCKERHUB_USER
 readonly DOCKERHUB_REPO
 

--- a/scripts/ci/dockerfiles/krb5-kdc-server/build_and_push.sh
+++ b/scripts/ci/dockerfiles/krb5-kdc-server/build_and_push.sh
@@ -17,7 +17,7 @@
 # under the License.
 set -euo pipefail
 DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
-DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow-ci"}
 readonly DOCKERHUB_USER
 readonly DOCKERHUB_REPO
 

--- a/scripts/ci/dockerfiles/stress/build_and_push.sh
+++ b/scripts/ci/dockerfiles/stress/build_and_push.sh
@@ -17,7 +17,7 @@
 # under the License.
 set -euo pipefail
 DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
-DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow-ci"}
 readonly DOCKERHUB_USER
 readonly DOCKERHUB_REPO
 STRESS_VERSION="1.0.4"

--- a/scripts/ci/dockerfiles/trino/build_and_push.sh
+++ b/scripts/ci/dockerfiles/trino/build_and_push.sh
@@ -17,7 +17,7 @@
 # under the License.
 set -euo pipefail
 DOCKERHUB_USER=${DOCKERHUB_USER:="apache"}
-DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow-ci"}
 readonly DOCKERHUB_USER
 readonly DOCKERHUB_REPO
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -184,7 +184,7 @@ function initialization::initialize_dockerhub_variables() {
 
     # You can override DOCKERHUB_REPO to use your own DockerHub repository and play with your
     # own docker images. In this case you can build images locally and push them
-    export DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow"}
+    export DOCKERHUB_REPO=${DOCKERHUB_REPO:="airflow-ci"}
 }
 
 # Determine available integrations

--- a/scripts/ci/static_checks/bats_tests.sh
+++ b/scripts/ci/static_checks/bats_tests.sh
@@ -55,14 +55,14 @@ function run_bats_tests() {
     if [[ ${#@} == "0" ]]; then
         # Run al tests
         docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
-            apache/airflow:bats-2021.04.28-1.2.1 --tap /airflow/tests/bats/
+            apache/airflow-ci:bats-2021.04.28-1.2.1 --tap /airflow/tests/bats/
     elif [[ ${#bats_arguments} == "0" ]]; then
         # Skip running anything if all filtered out
         true
     else
         # Run selected tests
         docker run --workdir /airflow -v "$(pwd):/airflow" --rm \
-            apache/airflow:bats-2021.04.28-1.2.1 --tap "${bats_arguments[@]}"
+            apache/airflow-ci:bats-2021.04.28-1.2.1 --tap "${bats_arguments[@]}"
     fi
 }
 

--- a/scripts/ci/static_checks/check_license.sh
+++ b/scripts/ci/static_checks/check_license.sh
@@ -34,7 +34,7 @@ function run_check_license() {
     if ! docker_v run -v "${AIRFLOW_SOURCES}:/opt/airflow" -t \
             --user "$(id -ur):$(id -gr)" \
             --rm --env-file "${AIRFLOW_SOURCES}/scripts/ci/docker-compose/_docker.env" \
-            apache/airflow:apache-rat-2021.04.28-0.13 \
+            apache/airflow-ci:apache-rat-2021.04.28-0.13 \
             --exclude-file /opt/airflow/.rat-excludes \
             --d /opt/airflow | tee "${AIRFLOW_SOURCES}/logs/rat-results.txt" ; then
         echo

--- a/tests/kubernetes/pod.yaml
+++ b/tests/kubernetes/pod.yaml
@@ -23,7 +23,7 @@ metadata:
 spec:
   containers:
     - name: memory-demo-ctr
-      image: apache/airflow:stress-2021.04.28-1.0.4
+      image: apache/airflow-ci:stress-2021.04.28-1.0.4
       resources:
         limits:
           memory: "200Mi"

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -50,7 +50,7 @@ class TestPodGenerator(unittest.TestCase):
                     {
                         'args': ['--vm', '1', '--vm-bytes', '150M', '--vm-hang', '1'],
                         'command': ['stress'],
-                        'image': 'apache/airflow:stress-2021.04.28-1.0.4',
+                        'image': 'apache/airflow-ci:stress-2021.04.28-1.0.4',
                         'name': 'memory-demo-ctr',
                         'resources': {'limits': {'memory': '200Mi'}, 'requests': {'memory': '100Mi'}},
                     }
@@ -688,7 +688,7 @@ metadata:
 spec:
   containers:
     - name: memory-demo-ctr
-      image: apache/airflow:stress-2021.04.28-1.0.4
+      image: apache/airflow-ci:stress-2021.04.28-1.0.4
       resources:
         limits:
           memory: "200Mi"


### PR DESCRIPTION
We have now separate `apache/airflow-ci` DockerHub repo and we
move all our images needed only during CI there.

The images from the main `apache/airflow` remaining are:

* airflow tagged and latest tagged production images
* images neded by the Helm Chart

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
