### PR TITLE
Chart: Add extra ini config to pgbouncer

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -309,8 +309,8 @@ If release name contains chart name it will be used as a full name.
 {{- $pgMetadataHost := .Values.data.metadataConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
 {{- $pgResultBackendHost := $resultBackendConnection.host | default (printf "%s-%s.%s" .Release.Name "postgresql" .Release.Namespace) }}
 [databases]
-{{ .Release.Name }}-metadata = host={{ $pgMetadataHost }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }}
-{{ .Release.Name }}-result-backend = host={{ $pgResultBackendHost }} dbname={{ $resultBackendConnection.db }} port={{ $resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }}
+{{ .Release.Name }}-metadata = host={{ $pgMetadataHost }} dbname={{ .Values.data.metadataConnection.db }} port={{ .Values.data.metadataConnection.port }} pool_size={{ .Values.pgbouncer.metadataPoolSize }} {{ .Values.pgbouncer.extraIniMetadata | default "" }}
+{{ .Release.Name }}-result-backend = host={{ $pgResultBackendHost }} dbname={{ $resultBackendConnection.db }} port={{ $resultBackendConnection.port }} pool_size={{ .Values.pgbouncer.resultBackendPoolSize }} {{ .Values.pgbouncer.extraIniResultBackend | default "" }}
 
 [pgbouncer]
 pool_mode = transaction
@@ -338,6 +338,9 @@ server_tls_cert_file = /etc/pgbouncer/server.crt
 server_tls_key_file = /etc/pgbouncer/server.key
 {{- end }}
 
+{{- if .Values.pgbouncer.extraIni }}
+{{ .Values.pgbouncer.extraIni }}
+{{- end }}
 {{- end }}
 
 {{ define "pgbouncer_users" }}

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -227,7 +227,13 @@ class PgbouncerConfigTest(unittest.TestCase):
 
     def test_databases_override(self):
         values = {
-            "pgbouncer": {"enabled": True, "metadataPoolSize": 12, "resultBackendPoolSize": 7},
+            "pgbouncer": {
+                "enabled": True,
+                "metadataPoolSize": 12,
+                "resultBackendPoolSize": 7,
+                "extraIniMetadata": "reserve_pool = 5",
+                "extraIniResultBackend": "reserve_pool = 3",
+            },
             "data": {
                 "metadataConnection": {"host": "meta_host", "db": "meta_db", "port": 1111},
                 "resultBackendConnection": {
@@ -243,8 +249,14 @@ class PgbouncerConfigTest(unittest.TestCase):
         }
         ini = self._get_pgbouncer_ini(values)
 
-        assert "RELEASE-NAME-metadata = host=meta_host dbname=meta_db port=1111 pool_size=12" in ini
-        assert "RELEASE-NAME-result-backend = host=rb_host dbname=rb_db port=2222 pool_size=7" in ini
+        assert (
+            "RELEASE-NAME-metadata = host=meta_host dbname=meta_db port=1111 pool_size=12 reserve_pool = 5"
+            in ini
+        )
+        assert (
+            "RELEASE-NAME-result-backend = host=rb_host dbname=rb_db port=2222 pool_size=7 reserve_pool = 3"
+            in ini
+        )
 
     def test_config_defaults(self):
         ini = self._get_pgbouncer_ini({"pgbouncer": {"enabled": True}})
@@ -314,6 +326,13 @@ class PgbouncerConfigTest(unittest.TestCase):
             encoded = jmespath.search(f'data."{key}"', docs[0])
             value = base64.b64decode(encoded).decode()
             assert expected == value
+
+    def test_extra_ini_configs(self):
+        values = {"pgbouncer": {"enabled": True, "extraIni": "server_round_robin = 1\nstats_period = 30"}}
+        ini = self._get_pgbouncer_ini(values)
+
+        assert "server_round_robin = 1" in ini
+        assert "stats_period = 30" in ini
 
 
 class PgbouncerExporterTest(unittest.TestCase):

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1918,6 +1918,30 @@
                         }
                     }
                 },
+                "extraIniMetadata": {
+                    "description": "Add extra metadata database specific PgBouncer ini configuration: https://www.pgbouncer.org/config.html#section-databases",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
+                "extraIniResultBackend": {
+                    "description": "Add extra result backend database specific PgBouncer ini configuration: https://www.pgbouncer.org/config.html#section-databases",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
+                "extraIni": {
+                    "description": "Add extra general PgBouncer ini configuration: https://www.pgbouncer.org/config.html",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -682,9 +682,9 @@ statsd:
 
   uid: 65534
 
-# Pgbouncer settings
+# PgBouncer settings
 pgbouncer:
-  # Enable pgbouncer
+  # Enable PgBouncer
   enabled: false
 
   # Create ServiceAccount
@@ -705,7 +705,7 @@ pgbouncer:
   metadataPoolSize: 10
   resultBackendPoolSize: 5
 
-  # Maximum clients that can connect to pgbouncer (higher = more file descriptors)
+  # Maximum clients that can connect to PgBouncer (higher = more file descriptors)
   maxClientConn: 100
 
   # supply the name of existing secret with pgbouncer.ini and users.txt defined
@@ -723,7 +723,7 @@ pgbouncer:
   #
   configSecretName: ~
 
-  # Pgbouner pod disruption budget
+  # PgBouncer pod disruption budget
   podDisruptionBudget:
     enabled: false
 
@@ -731,7 +731,7 @@ pgbouncer:
     config:
       maxUnavailable: 1
 
-  # Limit the resources to pgbouncer.
+  # Limit the resources to PgBouncer.
   # When you specify the resource request the k8s scheduler uses this information to decide which node to
   # place the Pod on. When you specify a resource limit for a Container, the kubelet enforces those limits so
   # that the running container is not allowed to use more of that resource than the limit you set.
@@ -763,7 +763,14 @@ pgbouncer:
     cert: ~
     key: ~
 
-  # Select certain nodes for pgbouncer pods.
+  # Add extra PgBouncer ini configuration in the databases section:
+  # https://www.pgbouncer.org/config.html#section-databases
+  extraIniMetadata: ~
+  extraIniResultBackend: ~
+  # Add extra general PgBouncer ini configuration: https://www.pgbouncer.org/config.html
+  extraIni: ~
+
+  # Select certain nodes for PgBouncer pods.
   nodeSelector: {}
   affinity: {}
   tolerations: []

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -885,6 +885,7 @@ incompliancies
 infile
 infoType
 infoTypes
+ini
 init
 initcontainer
 initcontainers


### PR DESCRIPTION
This allows users to add extra ini config to pgbouncer, for example to
adjust how frequently pgbouncer stats are output or reserve_pool size.