### PR TITLE
Pins docutils to <0.17 until breaking behaviour is fixed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -502,7 +502,12 @@ devel = [
     'bowler',
     'click~=7.1',
     'coverage',
-    'docutils',
+    # Sphinx RTD theme 0.5.2. introduced limitation to docutils to account for some docutils markup
+    # change:
+    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1112
+    # This limitation can be removed after this issue is closed:
+    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+    'docutils<0.17',
     'filelock',
     'flake8>=3.6.0',
     'flake8-colors',


### PR DESCRIPTION
Sphinx RTD theme 0.5.2. introduced limitation to docutils to account for
some docutils markup change:

https://github.com/readthedocs/sphinx_rtd_theme/issues/1112

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
