### PR TITLE
Removes unnecessary packages from setup_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,10 +68,7 @@ include_package_data = True
 python_requires = ~=3.6
 packages = find:
 setup_requires =
-    bowler
-    docutils
     gitpython
-    setuptools
     wheel
 #####################################################################################################
 # IMPORTANT NOTE!!!!!!!!!!!!!!!
@@ -94,6 +91,12 @@ install_requires =
     cryptography>=0.9.3
     dataclasses;python_version<"3.7"
     dill>=0.2.2, <0.4
+    # Sphinx RTD theme 0.5.2. introduced limitation to docutils to account for some docutils markup
+    # change:
+    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1112
+    # This limitation can be removed after this issue is closed:
+    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
+    docutils<0.17
     flask>=1.1.0, <2.0
     flask-appbuilder~=3.3
     flask-caching>=1.5.0, <2.0.0

--- a/setup.py
+++ b/setup.py
@@ -502,12 +502,6 @@ devel = [
     'bowler',
     'click~=7.1',
     'coverage',
-    # Sphinx RTD theme 0.5.2. introduced limitation to docutils to account for some docutils markup
-    # change:
-    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1112
-    # This limitation can be removed after this issue is closed:
-    #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
-    'docutils<0.17',
     'filelock',
     'flake8>=3.6.0',
     'flake8-colors',


### PR DESCRIPTION
This change removes unnecessary dependencies from setup_requires:

* docutils are not needed in setup requires and actually
  having them here caused harmful upgrade even if docutils
  are limited to <0.17 elsewhere
* setup_tools should not be needed in setup_requires (by
  the time setup_requires are parsed, they should be already
  installed
* bowler is not needed any more in setup.py (we got rid of it
  when we got rid of backport packages.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
