### PR TITLE
Add a calendar field to choose the execution date of the DAG when triggering it

### DIFF
--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -31,6 +31,8 @@ from airflow.utils.session import create_session
 
 T = TypeVar("T", bound=Callable)
 
+logger = logging.getLogger(__name__)
+
 
 def action_logging(f: T) -> T:
     """Decorator to log user actions"""
@@ -59,7 +61,9 @@ def action_logging(f: T) -> T:
                 try:
                     log.execution_date = pendulum.parse(execution_date_value, strict=False)
                 except ParserError:
-                    logging.error(f"Failed to parse execution_date from the request: {execution_date_value}")
+                    logger.exception(
+                        "Failed to parse execution_date from the request: %s", execution_date_value
+                    )
                     pass
 
             session.add(log)

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -23,6 +23,7 @@ from typing import Callable, TypeVar, cast
 
 import pendulum
 from flask import after_this_request, g, request
+from pendulum.parsing.exceptions import ParserError
 
 from airflow.models import Log
 from airflow.utils.session import create_session
@@ -53,7 +54,10 @@ def action_logging(f: T) -> T:
             )
 
             if 'execution_date' in request.values:
-                log.execution_date = pendulum.parse(request.values.get('execution_date'), strict=False)
+                try:
+                    log.execution_date = pendulum.parse(request.values.get('execution_date'), strict=False)
+                except ParserError:
+                    pass
 
             session.add(log)
 

--- a/airflow/www/decorators.py
+++ b/airflow/www/decorators.py
@@ -18,6 +18,7 @@
 
 import functools
 import gzip
+import logging
 from io import BytesIO as IO
 from typing import Callable, TypeVar, cast
 
@@ -54,9 +55,11 @@ def action_logging(f: T) -> T:
             )
 
             if 'execution_date' in request.values:
+                execution_date_value = request.values.get('execution_date')
                 try:
-                    log.execution_date = pendulum.parse(request.values.get('execution_date'), strict=False)
+                    log.execution_date = pendulum.parse(execution_date_value, strict=False)
                 except ParserError:
+                    logging.error(f"Failed to parse execution_date from the request: {execution_date_value}")
                     pass
 
             session.add(log)

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -34,6 +34,14 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <input type="hidden" name="dag_id" value="{{ dag_id }}">
     <input type="hidden" name="origin" value="{{ origin }}">
+
+    <div class="form-group">
+      <label class="sr-only" for="execution_date">Execution date</label>
+      <div class="input-group">
+        {{ form.execution_date(class_="form-control", disabled=False) }}
+      </div>
+    </div>
+
     <div class="form-group">
       <label for="conf">Configuration JSON (Optional, must be a dict object)</label>
       <textarea class="form-control" name="conf" id="json">{{ conf }}</textarea>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1479,7 +1479,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.values.get('dag_id')
         origin = get_safe_url(request.values.get('origin'))
         request_conf = request.values.get('conf')
-        request_execution_date = request.values.get('execution_date', default=None)
+        request_execution_date = request.values.get('execution_date', default=timezone.utcnow().isoformat())
 
         if request.method == 'GET':
             # Populate conf textarea with conf requests parameter, or dag.params
@@ -1487,7 +1487,7 @@ class Airflow(AirflowBaseView):
 
             dag = current_app.dag_bag.get_dag(dag_id)
             doc_md = wwwutils.wrapped_markdown(getattr(dag, 'doc_md', None))
-            form = DateTimeForm(data={'execution_date': timezone.utcnow()})
+            form = DateTimeForm(data={'execution_date': request_execution_date})
 
             if request_conf:
                 default_conf = request_conf
@@ -1510,10 +1510,7 @@ class Airflow(AirflowBaseView):
             flash(f"Cannot find dag {dag_id}")
             return redirect(origin)
 
-        if request_execution_date is not None:
-            execution_date = timezone.parse(request_execution_date)
-        else:
-            execution_date = timezone.utcnow()
+        execution_date = timezone.parse(request_execution_date)
 
         dr = DagRun.find(dag_id=dag_id, execution_date=execution_date, run_type=DagRunType.MANUAL)
         if dr:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1479,7 +1479,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.values.get('dag_id')
         origin = get_safe_url(request.values.get('origin'))
         request_conf = request.values.get('conf')
-        request_execution_date = request.values.get('execution_date')
+        request_execution_date = request.values.get('execution_date', default=None)
 
         if request.method == 'GET':
             # Populate conf textarea with conf requests parameter, or dag.params
@@ -1531,8 +1531,9 @@ class Airflow(AirflowBaseView):
                     )
             except json.decoder.JSONDecodeError:
                 flash("Invalid JSON configuration, not parseable", "error")
+                form = DateTimeForm(data={'execution_date': execution_date})
                 return self.render_template(
-                    'airflow/trigger.html', dag_id=dag_id, origin=origin, conf=request_conf
+                    'airflow/trigger.html', dag_id=dag_id, origin=origin, conf=request_conf, form=form
                 )
 
         dag = current_app.dag_bag.get_dag(dag_id)

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -21,6 +21,7 @@ import pytest
 
 from airflow.models import DagBag, DagRun
 from airflow.security import permissions
+from airflow.utils import timezone
 from airflow.utils.session import create_session
 from airflow.utils.types import DagRunType
 from tests.test_utils.www import check_content_in_response
@@ -87,6 +88,20 @@ def test_trigger_dag_conf_not_dict(admin_client):
     with create_session() as session:
         run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
     assert run is None
+
+
+def test_trigger_dag_execution_date(admin_client):
+    test_dag_id = "example_bash_operator"
+    exec_date = timezone.utcnow()
+
+    admin_client.post(f'trigger?dag_id={test_dag_id}', data={'execution_date': exec_date.isoformat()})
+
+    with create_session() as session:
+        run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
+    assert run is not None
+    assert DagRunType.MANUAL in run.run_id
+    assert run.run_type == DagRunType.MANUAL
+    assert run.execution_date == exec_date
 
 
 def test_trigger_dag_form(admin_client):

--- a/tests/www/views/test_views_trigger_dag.py
+++ b/tests/www/views/test_views_trigger_dag.py
@@ -90,6 +90,17 @@ def test_trigger_dag_conf_not_dict(admin_client):
     assert run is None
 
 
+def test_trigger_dag_wrong_execution_date(admin_client):
+    test_dag_id = "example_bash_operator"
+
+    response = admin_client.post(f'trigger?dag_id={test_dag_id}', data={'execution_date': "not_a_date"})
+    check_content_in_response("Invalid execution date", response)
+
+    with create_session() as session:
+        run = session.query(DagRun).filter(DagRun.dag_id == test_dag_id).first()
+    assert run is None
+
+
 def test_trigger_dag_execution_date(admin_client):
     test_dag_id = "example_bash_operator"
     exec_date = timezone.utcnow()


### PR DESCRIPTION
Currently the Trigger DAG always triggers a DAG run with `now()` as execution date. Since `execution_date` is a parameter of the dagrun the same way `conf` is, it makes sense to be able to change it in the UI as well.
![image](https://user-images.githubusercontent.com/2581298/120002951-94c7e680-bfd5-11eb-9fc6-f8a40da47375.png)
