### PR TITLE
Fixes location of mssql volume to only empty data

### DIFF
--- a/scripts/ci/docker-compose/backend-mssql.yml
+++ b/scripts/ci/docker-compose/backend-mssql.yml
@@ -31,8 +31,6 @@ services:
     environment:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Airflow123
-    volumes:
-      - mssql-db-volume:/var/opt/mssql/data
     healthcheck:
       test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost",
              "-U", "sa", "-P", "Airflow123", "-Q", "SELECT 1"]

--- a/scripts/ci/docker-compose/backend-mssql.yml
+++ b/scripts/ci/docker-compose/backend-mssql.yml
@@ -32,7 +32,7 @@ services:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Airflow123
     volumes:
-      - mssql-db-volume:/var/opt/mssql
+      - mssql-db-volume:/var/opt/mssql/data
     healthcheck:
       test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost",
              "-U", "sa", "-P", "Airflow123", "-Q", "SELECT 1"]

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -38,4 +38,3 @@ volumes:
   sqlite-db-volume:
   postgres-db-volume:
   mysql-db-volume:
-  mssql-db-volume:


### PR DESCRIPTION
Seems that running mssql on self-hosted runner makes mssql
container fail with empty volume. This PR is to check if
just providing the empty 'data' and not removing logs folder
causes the failure.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
