### PR TITLE
remove retry for now

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -221,7 +221,6 @@ class ECSOperator(BaseOperator):  # pylint: disable=too-many-instance-attributes
 
         return None
 
-    @AwsBaseHook.retry(should_retry)
     def _start_task(self):
         run_opts = {
             'cluster': self.cluster,


### PR DESCRIPTION
We started to use `@AwsBaseHook.retry(should_retry)` on `_start_task` of the `ECSOperator` in Airflow 2.1.0 (or providers-amazon >= 1.3.0). https://github.com/apache/airflow/blob/304e174674ff6921cb7ed79c0158949b50eff8fe/airflow/providers/amazon/aws/operators/ecs.py#L224
which is a little bit tricky according to AWS support:
* The `response['failures']` is not always reliable, which means an ECS task may still be provisioned successfully even when we get "failures" in the `response`. The only way to be sure is to use `DescribeTasks` to see if the task is provisioned correctly.

With the `@AwsBaseHook.retry(should_retry)` on `_start_task()`, i started to see my Airflow sending multiple `RunTask` events to AWS for the same task and I ended up with multiple instances running and they are interfering with each other since they require the same back-end resources. This also creates many "ghost" ECS tasks that are not under Airflow's radar and quite difficult to debug :crying_cat_face:

I don't know if using the retry is a way of dealing with this https://github.com/apache/airflow/issues/15000 issue.
But i'd rather go back to the old way at the moment.

Happy to discuss further on this.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
