### PR TITLE
Uses bind volume instead of docker volume for MSSQL docker in tmpfs

### DIFF
--- a/breeze
+++ b/breeze
@@ -673,6 +673,22 @@ function breeze::prepare_command_files() {
     local remove_sources_docker_compose_file=${SCRIPTS_CI_DIR}/docker-compose/remove-sources.yml
     local forward_credentials_docker_compose_file=${SCRIPTS_CI_DIR}/docker-compose/forward-credentials.yml
 
+    if [[ ${BACKEND} == "mssql" ]]; then
+        local docker_filesystem
+        docker_filesystem=$(stat "-f" "-c" "%T" /var/lib/docker || echo "unknown")
+        if [[ ${docker_filesystem} == "tmpfs" ]]; then
+            # In case of tmpfs backend for docker, mssql fails because TMPFS does not support
+            # O_DIRECT parameter for direct writing to the filesystem
+            # https://github.com/microsoft/mssql-docker/issues/13
+            # so we need to mount an external volume for its db location
+            # specified by MSSQL_DATA_VOLUME
+            backend_docker_compose_file="${backend_docker_compose_file}:${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-bind-volume.yml"
+        else
+            backend_docker_compose_file="${backend_docker_compose_file}:${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-docker-volume.yml"
+        fi
+    fi
+
+
     local compose_ci_file=${main_ci_docker_compose_file}:${backend_docker_compose_file}:${files_docker_compose_file}
     local compose_prod_file=${main_prod_docker_compose_file}:${backend_docker_compose_file}:${files_docker_compose_file}
 
@@ -1422,6 +1438,13 @@ function breeze::parse_arguments() {
                     INTEGRATIONS+=("${INTEGRATION}")
                 fi
             done
+            # In case of tmpfs backend for docker, mssql fails because TMPFS does not support
+            # O_DIRECT parameter for direct writing to the filesystem
+            # https://github.com/microsoft/mssql-docker/issues/13
+            # so we need to mount an external volume for its db location
+            # the external db must allow for parallel testing so external volume is mapped
+            # to the data volume. Stop should also clean the volume
+            rm -rf "${MSSQL_DATA_VOLUME:?"MSSQL_DATA_VOLUME should never be empty!"}"/*
             shift
             ;;
         restart)

--- a/scripts/ci/docker-compose/backend-mssql-bind-volume.yml
+++ b/scripts/ci/docker-compose/backend-mssql-bind-volume.yml
@@ -17,24 +17,12 @@
 ---
 version: "2.2"
 services:
-  airflow:
-    environment:
-      - BACKEND=mssql
-      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=mssql+pyodbc://sa:Airflow123@mssql:1433/master?driver=ODBC+Driver+17+for+SQL+Server
-      - AIRFLOW__CELERY__RESULT_BACKEND=db+mssql+pyodbc://sa:Airflow123@mssql:1433/master?driver=ODBC+Driver+17+for+SQL+Server
-      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
-    depends_on:
-      mssql:
-        condition: service_healthy
   mssql:
-    image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION}
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Airflow123
-    healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost",
-             "-U", "sa", "-P", "Airflow123", "-Q", "SELECT 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
-    restart: always
+    volumes:
+      # In case of tmpfs backend for docker, mssql fails because TMPFS does not support
+      # O_DIRECT parameter for direct writing to the filesystem
+      # https://github.com/microsoft/mssql-docker/issues/13
+      # so we need to mount an external volume for its db location
+      # the external db must allow for parallel testing so external volume is mapped
+      # to the data volume
+      - ${MSSQL_DATA_VOLUME}:/var/opt/mssql

--- a/scripts/ci/docker-compose/backend-mssql-docker-volume.yml
+++ b/scripts/ci/docker-compose/backend-mssql-docker-volume.yml
@@ -17,24 +17,6 @@
 ---
 version: "2.2"
 services:
-  airflow:
-    environment:
-      - BACKEND=mssql
-      - AIRFLOW__CORE__SQL_ALCHEMY_CONN=mssql+pyodbc://sa:Airflow123@mssql:1433/master?driver=ODBC+Driver+17+for+SQL+Server
-      - AIRFLOW__CELERY__RESULT_BACKEND=db+mssql+pyodbc://sa:Airflow123@mssql:1433/master?driver=ODBC+Driver+17+for+SQL+Server
-      - AIRFLOW__CORE__EXECUTOR=LocalExecutor
-    depends_on:
-      mssql:
-        condition: service_healthy
   mssql:
-    image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION}
-    environment:
-      - ACCEPT_EULA=Y
-      - SA_PASSWORD=Airflow123
-    healthcheck:
-      test: ["CMD", "/opt/mssql-tools/bin/sqlcmd", "-S", "localhost",
-             "-U", "sa", "-P", "Airflow123", "-Q", "SELECT 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 10
-    restart: always
+    volumes:
+      - mssql-db-volume:/var/opt/mssql


### PR DESCRIPTION
Seems that MSSQL is not able to use data volume when it is mounted
from tmpfs filesystem. See https://github.com/microsoft/mssql-docker/issues/13

In such case, instead of mounting docker-created volume we mount
a volume mounted from home directory of the user which is unlikely
to be a tmpfs volume.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
