### PR TITLE
Fix: GCS To BigQuery source_object

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -42,9 +42,9 @@ class GCSToBigQueryOperator(BaseOperator):
 
     :param bucket: The bucket to load from. (templated)
     :type bucket: str
-    :param source_objects: List of Google Cloud Storage URIs to load from. (templated)
+    :param source_objects: String or List of Google Cloud Storage URIs to load from. (templated)
         If source_format is 'DATASTORE_BACKUP', the list must only contain a single URI.
-    :type source_objects: list[str]
+    :type source_objects: str, list[str]
     :param destination_project_dataset_table: The dotted
         ``(<project>.|<project>:)<dataset>.<table>`` BigQuery table to load data into.
         If ``<project>`` is not included, project will be the project defined in
@@ -286,7 +286,7 @@ class GCSToBigQueryOperator(BaseOperator):
         else:
             schema_fields = self.schema_fields
 
-        source_uris = [f'gs://{self.bucket}/{source_object}' for source_object in self.source_objects]
+        source_uris = [f'gs://{self.bucket}/{source_object}' for source_object in self.source_objects] if type(self.source_objects) is list else [f'gs://{self.bucket}/{self.source_objects}'] 
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -219,7 +219,7 @@ class GCSToBigQueryOperator(BaseOperator):
         if time_partitioning is None:
             time_partitioning = {}
         self.bucket = bucket
-        self.source_objects = source_objects
+        self.source_objects = source_objects if isinstance(source_objects, list) else [source_objects]
         self.schema_object = schema_object
 
         # BQ config
@@ -285,8 +285,8 @@ class GCSToBigQueryOperator(BaseOperator):
 
         else:
             schema_fields = self.schema_fields
-
-        source_uris = [f'gs://{self.bucket}/{source_object}' for source_object in self.source_objects] if type(self.source_objects) is list else [f'gs://{self.bucket}/{self.source_objects}'] 
+        
+        source_uris = [f'gs://{self.bucket}/{source_object}' for source_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -285,7 +285,7 @@ class GCSToBigQueryOperator(BaseOperator):
 
         else:
             schema_fields = self.schema_fields
-        
+
         source_uris = [f'gs://{self.bucket}/{source_object}' for source_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -26,6 +26,7 @@ TEST_EXPLICIT_DEST = 'test-project.dataset.table'
 TEST_BUCKET = 'test-bucket'
 MAX_ID_KEY = 'id'
 TEST_SOURCE_OBJECTS = ['test/objects/*']
+TEST_SOURCE_OBJECTS_AS_STRING = 'test/objects/*'
 LABELS = {'k1': 'v1'}
 DESCRIPTION = "Test Description"
 
@@ -216,3 +217,75 @@ class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
                 description=DESCRIPTION,
             )
         # fmt: on
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
+    def test_source_objects_as_list(self, bq_hook):
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+        )
+
+        operator.execute(None)
+
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.run_load.assert_called_once_with(
+            destination_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=[f'gs://{TEST_BUCKET}/{source_object}' for source_object in TEST_SOURCE_OBJECTS],
+            source_format=mock.ANY,
+            autodetect=mock.ANY,
+            create_disposition=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            write_disposition=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            schema_update_options=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            time_partitioning=mock.ANY,
+            cluster_fields=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=mock.ANY,
+            description=mock.ANY,
+        )
+
+    @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
+    def test_source_objects_as_string(self, bq_hook):
+        operator = GCSToBigQueryOperator(
+            task_id=TASK_ID,
+            bucket=TEST_BUCKET,
+            source_objects=TEST_SOURCE_OBJECTS_AS_STRING,
+            destination_project_dataset_table=TEST_EXPLICIT_DEST,
+        )
+
+        operator.execute(None)
+
+        bq_hook.return_value.get_conn.return_value.cursor.return_value.run_load.assert_called_once_with(
+            destination_project_dataset_table=mock.ANY,
+            schema_fields=mock.ANY,
+            source_uris=[f'gs://{TEST_BUCKET}/{TEST_SOURCE_OBJECTS_AS_STRING}'],
+            source_format=mock.ANY,
+            autodetect=mock.ANY,
+            create_disposition=mock.ANY,
+            skip_leading_rows=mock.ANY,
+            write_disposition=mock.ANY,
+            field_delimiter=mock.ANY,
+            max_bad_records=mock.ANY,
+            quote_character=mock.ANY,
+            ignore_unknown_values=mock.ANY,
+            allow_quoted_newlines=mock.ANY,
+            allow_jagged_rows=mock.ANY,
+            encoding=mock.ANY,
+            schema_update_options=mock.ANY,
+            src_fmt_configs=mock.ANY,
+            time_partitioning=mock.ANY,
+            cluster_fields=mock.ANY,
+            encryption_configuration=mock.ANY,
+            labels=mock.ANY,
+            description=mock.ANY,
+        )


### PR DESCRIPTION
Fixes https://github.com/apache/airflow/issues/16008 GCS To BigQuery Operator's parameter `source_object` to accept both str and list

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
