### PR TITLE
Ensure datasetReference key exists in BigQueryHook.create_empty_dataset

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -437,6 +437,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         :type exists_ok: bool
         """
         dataset_reference = dataset_reference or {"datasetReference": {}}
+        if "datasetReference" not in dataset_reference:
+            dataset_reference["datasetReference"] = {}
 
         for param, value in zip(["datasetId", "projectId"], [dataset_id, project_id]):
             specified_param = dataset_reference["datasetReference"].get(param)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Ensure expected key is in `datasetReference` dictionary

The `create_empty_dataset()` method of the `BigQueryHook` class expects that
`datasetReference` will be a key in the `dataset_reference` argument, and that
its associated value will be a dictionary. If the user pases a dictionary without that key,
the function fails.  This is not clear in the documentation for the operator that relies 
on this method, `BigQueryCreateEmptyDatasetOperator`. This issue was raised in https://github.com/apache/airflow/issues/16101.

This PR checks the passed dictionary for the (`datasetReference`, `{}`) key/value
pair. If it's missing, it's added.
