### PR TITLE
Silences confusing log for long running tasks: "dependency 'Task Instance Not Running' FAILED: Task is in the running state"

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -95,7 +95,9 @@ class LocalTaskJob(BaseJob):
             job_id=self.id,
             pool=self.pool,
         ):
-            self.log.info("Task is not able to be run")
+            if self.task_instance.state != State.RUNNING:
+                # Only log about this for non-running tasks.
+                self.log.info("Task is not able to be run")
             return
 
         try:

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -95,8 +95,9 @@ class LocalTaskJob(BaseJob):
             job_id=self.id,
             pool=self.pool,
         ):
-            if self.task_instance.state != State.RUNNING:
-                # Only log about this for non-running tasks.
+            if self.task_instance.state == State.RUNNING:
+                self.log.info("Task is still running")
+            else:
                 self.log.info("Task is not able to be run")
             return
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -864,12 +864,14 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         for dep_status in self.get_failed_dep_statuses(dep_context=dep_context, session=session):
             failed = True
 
-            verbose_aware_logger(
-                "Dependencies not met for %s, dependency '%s' FAILED: %s",
-                self,
-                dep_status.dep_name,
-                dep_status.reason,
-            )
+            if not (self.state == State.RUNNING and dep_status.dep_name in {"Task Instance State", "Task Instance Not Running"}):
+                # Do not log about ValidStateDep or TaskNotRunningDep for running tasks to avoid confusion.
+                verbose_aware_logger(
+                    "Dependencies not met for %s, dependency '%s' FAILED: %s",
+                    self,
+                    dep_status.dep_name,
+                    dep_status.reason,
+                )
 
         if failed:
             return False

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -864,8 +864,8 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         for dep_status in self.get_failed_dep_statuses(dep_context=dep_context, session=session):
             failed = True
 
-            if not (self.state == State.RUNNING and dep_status.dep_name in {"Task Instance State", "Task Instance Not Running"}):
-                # Do not log about ValidStateDep or TaskNotRunningDep for running tasks to avoid confusion.
+            if self.state != State.RUNNING:
+                # Only log about dependencies for non-running tasks.
                 verbose_aware_logger(
                     "Dependencies not met for %s, dependency '%s' FAILED: %s",
                     self,

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2189,9 +2189,6 @@ def test_task_instance_running(state, log_called):
     """
     Test that TaskInstance in running state does not cause redundant logging.
     """
-    from airflow.utils.state import State
-    from airflow.jobs.local_task_job import LocalTaskJob
-
     with DAG('test_task_instance_running', start_date=DEFAULT_DATE) as dag:
         task = DummyOperator(task_id='task')
 
@@ -2201,9 +2198,6 @@ def test_task_instance_running(state, log_called):
 
     ti.set_state(state)
 
-    run_job = LocalTaskJob(task_instance=ti)
-
     with mock.patch("airflow.models.taskinstance.TaskInstance.log") as mock_log:
-        run_job.run()
+        ti.check_and_change_state_before_execution()
         assert mock_log.info.called == log_called
-


### PR DESCRIPTION
closes: #16163

This PR silences these two lines of log for tasks that are running because they cause confusion for users. In other words, if a task is already running, do not log saying they can't be run. 

```
{taskinstance.py:874} INFO - Dependencies not met for <TaskInstance: ... [running]>, dependency 'Task Instance Not Running' FAILED: Task is in the running state
{taskinstance.py:874} INFO - Dependencies not met for <TaskInstance: ... [running]>, dependency 'Task Instance State' FAILED: Task is in the 'running' state which is not a valid state for execution. The task must be cleared in order to be run.
```