### PR TITLE
Mark `test_send_tasks_to_celery_hang` as quarantined

### DIFF
--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -522,6 +522,7 @@ def register_signals():
     signal.signal(signal.SIGUSR2, orig_sigusr2)
 
 
+@pytest.mark.quarantined
 def test_send_tasks_to_celery_hang(register_signals):  # pylint: disable=unused-argument
     """
     Test that celery_executor does not hang after many runs.


### PR DESCRIPTION
The test_send_tasks_to_celery_hang hangs on self-hosted runners more
often than not.

It's been introduced in #15989 and while the test does not usually hang
on regular GitHub runners, or in case of running it locally (I could not
make it fail), it does hang almost always when run on self-hosted
runners.

Marking it as quarantined for now.

Issue #16168 created to keep track of it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
