### PR TITLE
Adding extra requirements for build and runtime of the PROD image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -264,6 +264,13 @@ RUN if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then \
     find /root/.local -executable -print0 | xargs --null chmod g+x; \
     find /root/.local -print0 | xargs --null chmod g+rw
 
+# In case there is a requirements.txt file in "docker-context-files" it will be installed
+# during the build additionally to whatever has been installed so far. It is recommended that
+# the requirements.txt contains only dependencies with == version specification
+RUN if [[ -f /docker-context-files/requirements.txt ]]; then \
+        pip install --no-cache-dir --user -r /docker-context-files/requirements.txt; \
+    fi
+
 ARG BUILD_ID
 ARG COMMIT_SHA
 ARG AIRFLOW_IMAGE_REPOSITORY="https://github.com/apache/airflow"

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -495,7 +495,7 @@ additional apt dev and runtime dependencies.
     --build-arg ADDITIONAL_PYTHON_DEPS="pandas"
     --build-arg ADDITIONAL_DEV_APT_DEPS="gcc g++"
     --build-arg ADDITIONAL_RUNTIME_APT_DEPS="default-jre-headless"
-    --tag my-image
+    --tag my-image:0.0.1
 
 
 the same image can be built using ``breeze`` (it supports auto-completion of the options):
@@ -533,7 +533,7 @@ based on example in `this comment <https://github.com/apache/airflow/issues/8605
     --build-arg ADDITIONAL_RUNTIME_APT_COMMAND="curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add --no-tty - && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list" \
     --build-arg ADDITIONAL_RUNTIME_APT_DEPS="msodbcsql17 unixodbc git procps vim" \
     --build-arg ADDITIONAL_RUNTIME_ENV_VARS="ACCEPT_EULA=Y" \
-    --tag my-image
+    --tag my-image:0.0.1
 
 CI image build arguments
 ------------------------
@@ -664,7 +664,7 @@ This builds the CI image in version 3.7 with default extras ("all").
 
 .. code-block:: bash
 
-  docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster"
+  docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" --tag my-image:0.0.1
 
 
 This builds the CI image in version 3.6 with "gcp" extra only.
@@ -672,7 +672,7 @@ This builds the CI image in version 3.6 with "gcp" extra only.
 .. code-block:: bash
 
   docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
-    --build-arg AIRFLOW_EXTRAS=gcp
+    --build-arg AIRFLOW_EXTRAS=gcp --tag my-image:0.0.1
 
 
 This builds the CI image in version 3.6 with "apache-beam" extra added.
@@ -680,28 +680,29 @@ This builds the CI image in version 3.6 with "apache-beam" extra added.
 .. code-block:: bash
 
   docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
-    --build-arg ADDITIONAL_AIRFLOW_EXTRAS="apache-beam"
+    --build-arg ADDITIONAL_AIRFLOW_EXTRAS="apache-beam" --tag my-image:0.0.1
 
 This builds the CI image in version 3.6 with "mssql" additional package added.
 
 .. code-block:: bash
 
   docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
-    --build-arg ADDITIONAL_PYTHON_DEPS="mssql"
+    --build-arg ADDITIONAL_PYTHON_DEPS="mssql" --tag my-image:0.0.1
 
 This builds the CI image in version 3.6 with "gcc" and "g++" additional apt dev dependencies added.
 
 .. code-block::
 
   docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
-    --build-arg ADDITIONAL_DEV_APT_DEPS="gcc g++"
+    --build-arg ADDITIONAL_DEV_APT_DEPS="gcc g++" --tag my-image:0.0.1
 
 This builds the CI image in version 3.6 with "jdbc" extra and "default-jre-headless" additional apt runtime dependencies added.
 
 .. code-block::
 
   docker build . -f Dockerfile.ci --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
-    --build-arg AIRFLOW_EXTRAS=jdbc --build-arg ADDITIONAL_RUNTIME_DEPS="default-jre-headless"
+    --build-arg AIRFLOW_EXTRAS=jdbc --build-arg ADDITIONAL_RUNTIME_DEPS="default-jre-headless" \
+    --tag my-image:0.0.1
 
 CI Image manifests
 ------------------

--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -601,14 +601,14 @@ USER ${AIRFLOW_UID}
 To build an image build and run a shell, run:
 
 ```shell script
-docker build . -t my-airflow
+docker build . --tag my-image:0.0.1
 docker run  -ti \
     --rm \
     -v "$PWD/data:/opt/airflow/" \
     -v "$PWD/keys/:/keys/" \
     -p 8080:8080 \
     -e AIRFLOW__CORE__LOAD_EXAMPLES=True \
-    my-airflow bash
+    my-image:0.0.1 bash
 ```
 
 ### Additional Verification

--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -47,7 +47,7 @@ RUN pip install "apache-airflow-upgrade-check=={}"
 
 
 DOCKER_CMD = """
-docker build -t local/airflow .
+docker build --tag local/airflow .
 docker local/airflow info
 """
 
@@ -80,7 +80,7 @@ def create_docker(txt: str):
     print("\n[bold]To check installation run:[/bold]")
     print(
         """\
-        docker build -f Dockerfile.pmc -t local/airflow .
+        docker build -f Dockerfile.pmc --tag local/airflow .
         docker run local/airflow info
         """
     )

--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -101,7 +101,6 @@ unit of work and continuity.
     changelog
     best-practices
     production-deployment
-    backport-providers
     faq
     privacy_notice
 

--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -23,16 +23,21 @@
 # This configuration supports basic configuration using environment variables or an .env file
 # The following variables are supported:
 #
-# AIRFLOW_IMAGE_NAME         - Docker image name used to run Airflow.
-#                              Default: apache/airflow:|version|
-# AIRFLOW_UID                - User ID in Airflow containers
-#                              Default: 50000
-# AIRFLOW_GID                - Group ID in Airflow containers
-#                              Default: 50000
-# _AIRFLOW_WWW_USER_USERNAME - Username for the administrator account.
-#                              Default: airflow
-# _AIRFLOW_WWW_USER_PASSWORD - Password for the administrator account.
-#                              Default: airflow
+# AIRFLOW_IMAGE_NAME           - Docker image name used to run Airflow.
+#                                Default: apache/airflow:|version|
+# AIRFLOW_UID                  - User ID in Airflow containers
+#                                Default: 50000
+# AIRFLOW_GID                  - Group ID in Airflow containers
+#                                Default: 50000
+#
+# Those configurations are useful mostly in case of standalone testing/running Airflow in test/try-out mode
+#
+# _AIRFLOW_WWW_USER_USERNAME   - Username for the administrator account (if requested).
+#                                Default: airflow
+# _AIRFLOW_WWW_USER_PASSWORD   - Password for the administrator account (if requested).
+#                                Default: airflow
+# _PIP_ADDITIONAL_REQUIREMENTS - Additional PIP requirements to add when starting all containers.
+#                                Default: ''
 #
 # Feel free to modify this file to suit your needs.
 ---
@@ -50,6 +55,7 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
     AIRFLOW__API__AUTH_BACKEND: 'airflow.api.auth.backend.basic_auth'
+    _PIP_ADDITIONAL_REQUIREMENTS: ${_PIP_ADDITIONAL_REQUIREMENTS:-}
   volumes:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -15,6 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
+.. _running-airflow-in-docker:
+
 Running Airflow in Docker
 #########################
 
@@ -73,7 +75,8 @@ Some directories in the container are mounted, which means that their contents a
 - ``./logs`` - contains logs from task execution and scheduler.
 - ``./plugins`` - you can put your :doc:`custom plugins </plugins>` here.
 
-This file uses the latest Airflow image (`apache/airflow <https://hub.docker.com/r/apache/airflow>`__). If you need install a new Python library or system library, you can :doc:`customize and extend it <docker-stack:index>`.
+This file uses the latest Airflow image (`apache/airflow <https://hub.docker.com/r/apache/airflow>`__).
+If you need install a new Python library or system library, you can :doc:`build your image <docker-stack:index>`.
 
 .. _initializing_docker_compose_environment:
 
@@ -260,13 +263,26 @@ runtime user id which is unknown at the time of building the image.
 |                                | you want to use different UID than default it must  |                          |
 |                                | be set to ``0``.                                    |                          |
 +--------------------------------+-----------------------------------------------------+--------------------------+
-| ``_AIRFLOW_WWW_USER_USERNAME`` | Username for the administrator UI account.          |                          |
-|                                | If this value is specified, admin UI user gets      |                          |
-|                                | created automatically. This is only useful when     |                          |
-|                                | you want to run Airflow for a test-drive and        |                          |
-|                                | want to start a container with embedded development |                          |
-|                                | database.                                           |                          |
-+--------------------------------+-----------------------------------------------------+--------------------------+
-| ``_AIRFLOW_WWW_USER_PASSWORD`` | Password for the administrator UI account.          |                          |
-|                                | Only used when ``_AIRFLOW_WWW_USER_USERNAME`` set.  |                          |
-+--------------------------------+-----------------------------------------------------+--------------------------+
+
+Those additional variables are useful in case you are trying out/testing Airflow installation via docker compose.
+They are not intended to be used in production, but they make the environment faster to bootstrap for first time
+users with the most common customizations.
+
++----------------------------------+-----------------------------------------------------+--------------------------+
+|   Variable                       | Description                                         | Default                  |
++==================================+=====================================================+==========================+
+| ``_AIRFLOW_WWW_USER_USERNAME``   | Username for the administrator UI account.          | airflow                  |
+|                                  | If this value is specified, admin UI user gets      |                          |
+|                                  | created automatically. This is only useful when     |                          |
+|                                  | you want to run Airflow for a test-drive and        |                          |
+|                                  | want to start a container with embedded development |                          |
+|                                  | database.                                           |                          |
++----------------------------------+-----------------------------------------------------+--------------------------+
+| ``_AIRFLOW_WWW_USER_PASSWORD``   | Password for the administrator UI account.          | airflow                  |
+|                                  | Only used when ``_AIRFLOW_WWW_USER_USERNAME`` set.  |                          |
++----------------------------------+-----------------------------------------------------+--------------------------+
+| ``_PIP_ADDITIONAL_REQUIREMENTS`` | If not empty, airflow containers will attempt to    |                          |
+|                                  | install requirements specified in the variable.     |                          |
+|                                  | example: ``lxml==4.6.3 charset-normalizer==1.4.1``. |                          |
+|                                  | Available in Airflow image 2.1.1 and above.         |                          |
++----------------------------------+-----------------------------------------------------+--------------------------+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -258,9 +258,14 @@ if PACKAGE_NAME == 'apache-airflow':
     html_extra_with_substitutions = [
         f"{ROOT_DIR}/docs/apache-airflow/start/docker-compose.yaml",
     ]
+    # Replace "|version|" in links
     manual_substitutions_in_generated_html = [
         "installation.html",
     ]
+
+if PACKAGE_NAME == 'docker-stack':
+    # Replace "|version|" inside ```` quotes
+    manual_substitutions_in_generated_html = ["build.html"]
 
 # -- Theme configuration -------------------------------------------------------
 # Custom sidebar templates, maps document names to template names.

--- a/docs/docker-stack/docker-examples/customizing/add-build-essential-custom.sh
+++ b/docs/docker-stack/docker-examples/customizing/add-build-essential-custom.sh
@@ -28,6 +28,6 @@ docker build . \
     --build-arg ADDITIONAL_PYTHON_DEPS="mpi4py" \
     --build-arg ADDITIONAL_DEV_APT_DEPS="libopenmpi-dev" \
     --build-arg ADDITIONAL_RUNTIME_APT_DEPS="openmpi-common" \
-    --tag "$(basename "$0")"
+    --tag "my-build-essential-image:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-build-essential-image:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/custom-sources.sh
+++ b/docs/docker-stack/docker-examples/customizing/custom-sources.sh
@@ -43,6 +43,6 @@ docker build . -f Dockerfile \
     curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list" \
     --build-arg ADDITIONAL_RUNTIME_APT_ENV="ACCEPT_EULA=Y" \
     --build-arg ADDITIONAL_RUNTIME_APT_DEPS="msodbcsql17 unixodbc git procps vim" \
-    --tag "$(basename "$0")"
+    --tag "my-custom-sources-image:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-custom-sources-image:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/github-different-repository.sh
+++ b/docs/docker-stack/docker-examples/customizing/github-different-repository.sh
@@ -26,6 +26,6 @@ docker build . \
     --build-arg AIRFLOW_INSTALLATION_METHOD="https://github.com/potiuk/airflow/archive/main.tar.gz#egg=apache-airflow" \
     --build-arg AIRFLOW_CONSTRAINTS_REFERENCE="constraints-main" \
     --build-arg CONSTRAINTS_GITHUB_REPOSITORY="potiuk/airflow" \
-    --tag "$(basename "$0")"
+    --tag "github-different-repository-image:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "github-different-repository-image:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/github-main.sh
+++ b/docs/docker-stack/docker-examples/customizing/github-main.sh
@@ -26,6 +26,6 @@ docker build . \
     --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
     --build-arg AIRFLOW_INSTALLATION_METHOD="https://github.com/apache/airflow/archive/main.tar.gz#egg=apache-airflow" \
     --build-arg AIRFLOW_CONSTRAINTS_REFERENCE="constraints-main" \
-    --tag "$(basename "$0")"
+    --tag "my-github-main:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-github-main:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/github-v2-1-test.sh
+++ b/docs/docker-stack/docker-examples/customizing/github-v2-1-test.sh
@@ -26,6 +26,6 @@ docker build . \
     --build-arg PYTHON_BASE_IMAGE="python:3.8-slim-buster" \
     --build-arg AIRFLOW_INSTALLATION_METHOD="https://github.com/apache/airflow/archive/v2-1-test.tar.gz#egg=apache-airflow" \
     --build-arg AIRFLOW_CONSTRAINTS_REFERENCE="constraints-2-0" \
-    --tag "$(basename "$0")"
+    --tag "my-github-v2-1:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-github-v2-1:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/pypi-dev-runtime-deps.sh
+++ b/docs/docker-stack/docker-examples/customizing/pypi-dev-runtime-deps.sh
@@ -29,6 +29,6 @@ docker build . \
     --build-arg ADDITIONAL_PYTHON_DEPS="pandas" \
     --build-arg ADDITIONAL_DEV_APT_DEPS="gcc g++" \
     --build-arg ADDITIONAL_RUNTIME_APT_DEPS="default-jre-headless" \
-    --tag "$(basename "$0")"
+    --tag "my-pypi-dev-runtime:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-pypi-dev-runtime:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/pypi-extras-and-deps.sh
+++ b/docs/docker-stack/docker-examples/customizing/pypi-extras-and-deps.sh
@@ -27,6 +27,6 @@ docker build . \
     --build-arg AIRFLOW_VERSION="2.0.2" \
     --build-arg ADDITIONAL_AIRFLOW_EXTRAS="mssql,hdfs" \
     --build-arg ADDITIONAL_PYTHON_DEPS="oauth2client" \
-    --tag "$(basename "$0")"
+    --tag "my-pypi-extras-and-deps:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-pypi-extras-and-deps:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/pypi-selected-version.sh
+++ b/docs/docker-stack/docker-examples/customizing/pypi-selected-version.sh
@@ -25,6 +25,6 @@ cd "${AIRFLOW_SOURCES}"
 docker build . \
     --build-arg PYTHON_BASE_IMAGE="python:3.7-slim-buster" \
     --build-arg AIRFLOW_VERSION="2.0.2" \
-    --tag "$(basename "$0")"
+    --tag "my-pypi-selected-version:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-pypi-selected-version:0.0.1"

--- a/docs/docker-stack/docker-examples/customizing/stable-airflow.sh
+++ b/docs/docker-stack/docker-examples/customizing/stable-airflow.sh
@@ -23,6 +23,6 @@ cd "${AIRFLOW_SOURCES}"
 
 # [START build]
 docker build . \
-    --tag "$(basename "$0")"
+    --tag "my-stable-airflow:0.0.1"
 # [END build]
-docker rmi --force "$(basename "$0")"
+docker rmi --force "my-stable-airflow:0.0.1"

--- a/docs/docker-stack/docker-examples/extending/add-apt-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-apt-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.0.2
+FROM apache/airflow
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-build-essential-extend/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-build-essential-extend/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.0.2
+FROM apache/airflow
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-pypi-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-pypi-packages/Dockerfile
@@ -15,6 +15,6 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.0.2
+FROM apache/airflow
 RUN pip install --no-cache-dir lxml
 # [END Dockerfile]

--- a/docs/docker-stack/docker-examples/extending/embedding-dags/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/embedding-dags/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.0.2
+FROM apache/airflow
 
 COPY --chown=airflow:root test_dag.py /opt/airflow/dags
 

--- a/docs/docker-stack/docker-examples/extending/writable-directory/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/writable-directory/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow:2.0.2
+FROM apache/airflow
 RUN umask 0002; \
     mkdir -p ~/writeable-directory
 # [END Dockerfile]

--- a/docs/docker-stack/docker-examples/restricted/restricted_environments.sh
+++ b/docs/docker-stack/docker-examples/restricted/restricted_environments.sh
@@ -43,5 +43,6 @@ docker build . \
     --build-arg INSTALL_MYSQL_CLIENT="false" \
     --build-arg AIRFLOW_PRE_CACHED_PIP_PACKAGES="false" \
     --build-arg INSTALL_FROM_DOCKER_CONTEXT_FILES="true" \
-    --build-arg AIRFLOW_CONSTRAINTS_LOCATION="/docker-context-files/constraints-3.7.txt"
+    --build-arg AIRFLOW_CONSTRAINTS_LOCATION="/docker-context-files/constraints-3.7.txt" \
+    --tag my-restricted-environment:0.0.1
 # [END build]

--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -38,15 +38,32 @@ Docker Image for Apache Airflow
 For the ease of deployment in production, the community releases a production-ready reference container
 image.
 
-The docker image provided (as convenience binary package) in the
-`apache/airflow DockerHub <https://hub.docker.com/r/apache/airflow>`_ is a bare image
-that has a few external dependencies and extras installed..
 
-The Apache Airflow image provided as convenience package is optimized for size, so
+The Apache Airflow community, releases Docker Images which are ``reference images`` for Apache Airflow.
+Every time a new version of Airflow is released, the images are prepared in the
+`apache/airflow DockerHub <https://hub.docker.com/r/apache/airflow>`_
+for all the supported Python versions.
+
+You can find the following images there (Assuming Airflow version |version|):
+
+* ``apache/airflow:latest``              - the latest released Airflow image with default Python version (3.6 currently)
+* ``apache/airflow:latest-pythonX.Y``    - the latest released Airflow image with specific Python version
+* ``apache/airflow:|version|``           - the versioned Airflow image with default Python version (3.6 currently)
+* ``apache/airflow:|version|-pythonX.Y`` - the versioned Airflow image with specific Python version
+
+Those are "reference" images. They contain the most common set of extras, dependencies and providers that are
+often used by the users and they are good to "try-things-out" when you want to just take airflow for a spin,
+
+The Apache Airflow image provided as convenience package is optimized for size, and
 it provides just a bare minimal set of the extras and dependencies installed and in most cases
-you want to either extend or customize the image. You can see all possible extras in
-:doc:`extra-packages-ref`. The set of extras used in Airflow Production image are available in the
-`Dockerfile <https://github.com/apache/airflow/blob/2c6c7fdb2308de98e142618836bdf414df9768c8/Dockerfile#L39>`_.
+you want to either extend or customize the image. You can see all possible extras in :doc:`extra-packages-ref`.
+The set of extras used in Airflow Production image are available in the
+`Dockerfile <https://github.com/apache/airflow/blob/2c6c7fdb2308de98e142618836bdf414df9768c8/Dockerfile#L37>`_.
+
+However, Airflow has more than 60 community-managed providers (installable via extras) and some of the
+default extras/providers installed are not used by everyone, sometimes others extras/providers
+are needed, sometimes (very often actually) you need to add your own custom dependencies,
+packages or even custom providers. You can learn how to do it in :ref:`Building the image <build:build_image>`.
 
 The production images are build in DockerHub from released version and release candidates. There
 are also images published from branches but they are used mainly for development and testing purpose.

--- a/docs/docker-stack/recipes.rst
+++ b/docs/docker-stack/recipes.rst
@@ -41,7 +41,7 @@ Then build a new image.
 
   docker build . \
     --build-arg BASE_AIRFLOW_IMAGE="apache/airflow:2.0.2" \
-    -t my-airflow-image
+    --tag my-airflow-image:0.0.1
 
 
 Apache Hadoop Stack installation
@@ -67,4 +67,4 @@ Then build a new image.
 
   docker build . \
     --build-arg BASE_AIRFLOW_IMAGE="apache/airflow:2.0.2" \
-    -t my-airflow-image
+    --tag my-airflow-image:0.0.1

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -67,8 +67,31 @@ Depending on the size of you Airflow instance, you may want to adjust the follow
     # The maximum number of server connections to the result backend database from PgBouncer
     resultBackendPoolSize: 5
 
-DAG Files
----------
+Extending and customizing Airflow Image
+---------------------------------------
+
+The Apache Airflow community, releases Docker Images which are ``reference images`` for Apache Airflow.
+However, Airflow has more than 60 community managed providers (installable via extras) and some of the
+default extras/providers installed are not used by everyone, sometimes others extras/providers
+are needed, sometimes (very often actually) you need to add your own custom dependencies,
+packages or even custom providers, or add custom tools and binaries that are needed in
+your deployment.
+
+In Kubernetes and Docker terms this means that you need another image with your specific requirements.
+This is why you should learn how to build your own ``Docker`` (or more properly ``Container``) image.
+
+Typical scenarios where you would like to use your custom image:
+
+* Adding ``apt`` packages
+* Adding ``PyPI`` packages
+* Adding binary resources necessary for your deployment
+* Adding custom tools needed in your deployment
+
+See `Building the image <https://airflow.apache.org/docs/docker-stack/build.html>`_ for more
+details on how you can extend and customize the Airflow image.
+
+Managing DAG Files
+------------------
 
 See :doc:`manage-dags-files`.
 

--- a/docs/helm-chart/quick-start.rst
+++ b/docs/helm-chart/quick-start.rst
@@ -65,8 +65,17 @@ Run ``kubectl port-forward svc/airflow-webserver 8080:8080 -n airflow``
 to port-forward the Airflow UI to http://localhost:8080/ to confirm
 Airflow is working.
 
-Build a Docker image from your DAGs
------------------------------------
+Extending Airflow Image
+-----------------------
+
+The Apache Airflow community, releases Docker Images which are ``reference images`` for Apache Airflow.
+However when you try it out you want to add your own DAGS, custom dependencies,
+packages or even custom providers.
+
+The best way to achieve it, is to build your own, custom image.
+
+Adding DAGs to your image
+.........................
 
 1. Create a project
 
@@ -84,7 +93,7 @@ Build a Docker image from your DAGs
 
     .. code-block:: bash
 
-        docker build -t my-dags:0.0.1 .
+        docker build --tag my-dags:0.0.1 .
 
 
 3. Load the image into kind:
@@ -100,3 +109,90 @@ Build a Docker image from your DAGs
       helm upgrade $RELEASE_NAME apache-airflow/airflow --namespace $NAMESPACE \
           --set images.airflow.repository=my-dags \
           --set images.airflow.tag=0.0.1
+
+Adding ``apt`` packages to your image
+.....................................
+
+Example below adds ``vim`` apt package.
+
+1. Create a project
+
+    .. code-block:: bash
+
+        mkdir my-airflow-project && cd my-airflow-project
+        cat <<EOM > Dockerfile
+        FROM apache/airflow
+        USER root
+        RUN apt-get update \
+          && apt-get install -y --no-install-recommends \
+                 vim \
+          && apt-get autoremove -yqq --purge \
+          && apt-get clean \
+          && rm -rf /var/lib/apt/lists/*
+        USER airflow
+        EOM
+
+
+2. Then build the image:
+
+    .. code-block:: bash
+
+        docker build --tag my-image:0.0.1 .
+
+
+3. Load the image into kind:
+
+    .. code-block:: bash
+
+      kind load docker-image my-image:0.0.1
+
+4. Upgrade Helm deployment:
+
+    .. code-block:: bash
+
+      helm upgrade $RELEASE_NAME apache-airflow/airflow --namespace $NAMESPACE \
+          --set images.airflow.repository=my-image \
+          --set images.airflow.tag=0.0.1
+
+Adding ``PyPI`` packages to your image
+......................................
+
+Example below adds ``lxml`` PyPI package.
+
+1. Create a project
+
+    .. code-block:: bash
+
+        mkdir my-airflow-project && cd my-airflow-project
+        cat <<EOM > Dockerfile
+        FROM apache/airflow
+        RUN pip install --no-cache-dir lxml
+        EOM
+
+
+2. Then build the image:
+
+    .. code-block:: bash
+
+        docker build --tag my-image:0.0.1 .
+
+
+3. Load the image into kind:
+
+    .. code-block:: bash
+
+      kind load docker-image my-image:0.0.1
+
+4. Upgrade Helm deployment:
+
+    .. code-block:: bash
+
+      helm upgrade $RELEASE_NAME apache-airflow/airflow --namespace $NAMESPACE \
+          --set images.airflow.repository=my-image \
+          --set images.airflow.tag=0.0.1
+
+Further extending and customizing the image
+...........................................
+
+See `Building the image <https://airflow.apache.org/docs/docker-stack/build.html>`_ for more
+details on how you can extend and customize the Airflow image.

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -311,6 +311,22 @@ if [[ -n "${_AIRFLOW_WWW_USER_CREATE=}" ]] ; then
     create_www_user
 fi
 
+if [[ -n "${_PIP_ADDITIONAL_REQUIREMENTS=}" ]] ; then
+    >&2 echo
+    >&2 echo "!!!!!  Installing additional requirements: '${_PIP_ADDITIONAL_REQUIREMENTS}' !!!!!!!!!!!!"
+    >&2 echo
+    >&2 echo "WARNING: This is a developpment/test feature only. NEVER use it in production!"
+    >&2 echo "         Instead, build a custom image as described in"
+    >&2 echo
+    >&2 echo "         https://airflow.apache.org/docs/docker-stack/build.html"
+    >&2 echo
+    >&2 echo "         Adding requirements at container startup is fragile and is done every time"
+    >&2 echo "         the container starts, so it is onlny useful for testing and trying out"
+    >&2 echo "         of adding dependencies."
+    >&2 echo
+    pip install --no-cache-dir --user "${_PIP_ADDITIONAL_REQUIREMENTS=}"
+fi
+
 
 # The `bash` and `python` commands should also verify the basic connections
 # So they are run after the DB check


### PR DESCRIPTION
This PR adds capability of adding extra requirements to PROD image:

1) During the build by placing requirements.txt in the
   ``docker-context-files`` folder

2) During execution of the container - by passing
   _PIP_ADDITIONAL_REQUIREMENTS variable

The second case is only useful durint quick test/development and
should not be used in production.

Also updated documentation to contain all development/test
variables for docker compose and clarifying that the options
starting with _ are ment to be only used for quick testing.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
