### PR TITLE
FIX: unnecessary downloads in GCSToLocalFilesystemOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import sys
 import warnings
 from typing import Optional, Sequence, Union
 
@@ -133,8 +132,9 @@ class GCSToLocalFilesystemOperator(BaseOperator):
         )
 
         if self.store_to_xcom_key:
-            file_bytes = hook.download(bucket_name=self.bucket, object_name=self.object_name)
-            if sys.getsizeof(file_bytes) < MAX_XCOM_SIZE:
+            file_size = hook.get_size(bucket_name=self.bucket, object_name=self.object_name)
+            if file_size < MAX_XCOM_SIZE:
+                file_bytes = hook.download(bucket_name=self.bucket, object_name=self.object_name)
                 context['ti'].xcom_push(key=self.store_to_xcom_key, value=str(file_bytes))
             else:
                 raise AirflowException('The size of the downloaded file is too large to push to XCom!')


### PR DESCRIPTION
Fixes #15005 GCSToLocalFilesystemOperator unnecessarily downloads objects when it checks object size.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
