### PR TITLE
Cattrs 1.7.0 released by the end of May 2021 break lineage usage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,7 +83,8 @@ install_requires =
     cached_property~=1.5;python_version<="3.7"
     # cattrs >= 1.1.0 dropped support for Python 3.6
     cattrs>=1.0, <1.1.0;python_version<="3.6"
-    cattrs~=1.1;python_version>"3.6"
+    # cattrs >= 1.7.0 break lineage - see https://github.com/apache/airflow/issues/16172
+    cattrs~=1.1, <1.7.0;python_version>"3.6"
     # Required by vendored-in connexion
     clickclick>=1.2
     colorlog>=4.0.2


### PR DESCRIPTION
See https://github.com/apache/airflow/issues/16172

For now we limit the cattrs to < 1.7.0

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
