### PR TITLE
Fix docs for ``dag_concurrency``

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -167,10 +167,8 @@
       default: "32"
     - name: dag_concurrency
       description: |
-        The maximum number of task instances allowed to run concurrently in each DAG. To calculate
-        the number of tasks that is running concurrently for a DAG, add up the number of running
-        tasks for all DAG runs of the DAG. This is configurable at the DAG level with ``concurrency``,
-        which is defaulted as ``dag_concurrency``.
+        The maximum number of task instances allowed to run concurrently in each DAG Run for that
+        DAG. Can be overridden by ``concurrency`` on DAG level.
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -113,10 +113,8 @@ sql_alchemy_schema =
 # the number of task instances with the running state in the metadata database.
 parallelism = 32
 
-# The maximum number of task instances allowed to run concurrently in each DAG. To calculate
-# the number of tasks that is running concurrently for a DAG, add up the number of running
-# tasks for all DAG runs of the DAG. This is configurable at the DAG level with ``concurrency``,
-# which is defaulted as ``dag_concurrency``.
+# The maximum number of task instances allowed to run concurrently in each DAG Run for that
+# DAG. Can be overridden by ``concurrency`` on DAG level.
 dag_concurrency = 16
 
 # Are DAGs paused by default at creation

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -167,7 +167,7 @@ class DAG(LoggingMixin):
         params can be overridden at the task level.
     :type params: dict
     :param concurrency: the number of task instances allowed to run
-        concurrently
+        concurrently in a single DagRun
     :type concurrency: int
     :param max_active_runs: maximum number of active DAG runs, beyond this
         number of DAG runs in a running state, the scheduler won't create


### PR DESCRIPTION
The docs were incorrect. Bug introduced in https://github.com/apache/airflow/pull/15183/
unfortunately. The description is for ``task_concurrency`` not ``dag_concurrency``

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
