### PR TITLE
Do not queue tasks when the DAG goes missing

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1713,7 +1713,7 @@
       description: |
         How often (in seconds) to check and fail task instances and dagruns whose corresponding
         DAG is missing
-      version_added: 2.1.1
+      version_added: 2.1.2
       type: float
       example: ~
       default: "15.0"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1709,6 +1709,14 @@
       type: float
       example: ~
       default: "15.0"
+    - name: clean_tis_without_dag
+      description: |
+        How often (in seconds) to check and fail task instances and dagruns whose corresponding
+        DAG is missing
+      version_added: 2.1.1
+      type: float
+      example: ~
+      default: "15.0"
     - name: scheduler_heartbeat_sec
       description: |
         The scheduler constantly tries to trigger new tasks (look at the

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1709,7 +1709,7 @@
       type: float
       example: ~
       default: "15.0"
-    - name: clean_tis_without_dag
+    - name: clean_tis_without_dag_interval
       description: |
         How often (in seconds) to check and fail task instances and dagruns whose corresponding
         DAG is missing

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -854,6 +854,10 @@ job_heartbeat_sec = 5
 # that no longer have a matching DagRun
 clean_tis_without_dagrun_interval = 15.0
 
+# How often (in seconds) to check and fail task instances and dagruns whose corresponding
+# DAG is missing
+clean_tis_without_dag = 15.0
+
 # The scheduler constantly tries to trigger new tasks (look at the
 # scheduler section in the docs for more information). This defines
 # how often the scheduler should run (in seconds).

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -856,7 +856,7 @@ clean_tis_without_dagrun_interval = 15.0
 
 # How often (in seconds) to check and fail task instances and dagruns whose corresponding
 # DAG is missing
-clean_tis_without_dag = 15.0
+clean_tis_without_dag_interval = 15.0
 
 # The scheduler constantly tries to trigger new tasks (look at the
 # scheduler section in the docs for more information). This defines

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -733,7 +733,7 @@ class SchedulerJob(BaseJob):
             self._clean_tis_without_dagrun,
         )
         timers.call_regular_interval(
-            conf.getfloat('scheduler', 'clean_tis_without_dag', fallback=15.0),
+            conf.getfloat('scheduler', 'clean_tis_without_dag_interval', fallback=15.0),
             self._clean_tis_without_dag,
         )
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -839,7 +839,7 @@ class SchedulerJob(BaseJob):
             )
             self.log.warning("Failing the corresponding DagRuns of the missing DAGs. DagRuns: %s", dag_runs)
             for dr in dag_runs:
-                dr.set_state(State.FAILED)
+                dr.state = State.FAILED
 
     def _do_scheduling(self, session) -> int:
         """

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -107,6 +107,7 @@ class State:
             FAILED,
             SKIPPED,
             UPSTREAM_FAILED,
+            REMOVED,
         ]
     )
     """

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1515,7 +1515,7 @@ class TestSchedulerJob(unittest.TestCase):
         self.scheduler_job.processor_agent = processor
 
         with mock.patch.object(settings, "USE_JOB_SCHEDULE", False), conf_vars(
-            {('scheduler', 'clean_tis_without_dag'): '0.001'}
+            {('scheduler', 'clean_tis_without_dag_interval'): '0.001'}
         ):
             self.scheduler_job._run_scheduler_loop()
 

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -879,7 +879,6 @@ class TestDagBag(unittest.TestCase):
 
         # We remove the dag from dag_bag.dags and ensure it returns True
         dag_bag.dags.pop(dag_id)
-        assert not dag_bag.dags.get(dag_id)
         assert dag_bag.has_dag(dag_id)
 
         # We removed dag_id from dag_bag.dags, let's add it back


### PR DESCRIPTION
Currently, if a dag goes missing, the scheduler continues to queue the task instances
until the executor reports the tasks as failed and then the scheduler would now set the state to failed.

This change ensures that tasks are not queued when the dag goes missing. Instead of waiting on the
executor to fail the task without explicit reason, the task fails here with the reason why it failed. Thanks to
this, the Pool's queued slots will be freed for other tasks to be queued

Closes: https://github.com/apache/airflow/issues/15488


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
