### PR TITLE
Fix S3 Select payload join

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -411,9 +411,9 @@ class S3Hook(AwsBaseHook):
             OutputSerialization=output_serialization,
         )
 
-        return ''.join(
-            event['Records']['Payload'].decode('utf-8') for event in response['Payload'] if 'Records' in event
-        )
+        return b''.join(
+            event['Records']['Payload'] for event in response['Payload'] if 'Records' in event
+        ).decode('utf-8')
 
     @provide_bucket_name
     @unify_bucket_name_and_key

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -193,7 +193,7 @@ class TestAwsS3Hook:
     @mock.patch('airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.get_client_type')
     def test_select_key(self, mock_get_client_type, s3_bucket):
         mock_get_client_type.return_value.select_object_content.return_value = {
-            'Payload': [{'Records': {'Payload': b'Cont\xC3\xA9nt'}}]
+            'Payload': [{'Records': {'Payload': b'Cont\xC3'}}, {'Records': {'Payload': b'\xA9nt'}}]
         }
         hook = S3Hook()
         assert hook.select_key('my_key', s3_bucket) == 'Contént'


### PR DESCRIPTION
The original code has a potential bug that decodes fail if the payload is split in the middle of a multibyte character.
This can be avoided by joining and then decoding.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
