### PR TITLE
Adds labels to k8s worker pods

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -19,6 +19,13 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: dummy-name
+  labels:
+    tier: airflow
+    component: worker
+    release: {{ .Release.Name }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
   {{- if .Values.airflowPodAnnotations }}
   annotations:
   {{- toYaml .Values.airflowPodAnnotations | nindent 4 }}

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -438,3 +438,18 @@ class PodTemplateFileTest(unittest.TestCase):
             "name": "test-init-container",
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.initContainers[-1]", docs[0])
+
+    def test_should_add_pod_labels(self):
+        docs = render_chart(
+            values={"labels": {"label1": "value1", "label2": "value2"}},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert {
+            "label1": "value1",
+            "label2": "value2",
+            "release": "RELEASE-NAME",
+            "component": "worker",
+            "tier": "airflow",
+        } == jmespath.search("metadata.labels", docs[0])


### PR DESCRIPTION
We want to set labels on the KubernetesExecutor worker pods as well as
one would expect those pods to show up when, say, filtering running pods
by release name.