### PR TITLE
Bug fix for ExternalTaskSensor with failed_states, allowed_states, and execution_date_fn set

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -162,13 +162,14 @@ class ExternalTaskSensor(BaseSensorOperator):
         if self.failed_states:
             count_failed = self.get_count(dttm_filter, session, self.failed_states)
 
-        if count_failed == len(dttm_filter):
-            if self.external_task_id:
-                raise AirflowException(
-                    f'The external task {self.external_task_id} in DAG {self.external_dag_id} failed.'
-                )
-            else:
-                raise AirflowException(f'The external DAG {self.external_dag_id} failed.')
+            # Fail if anything in the list has failed.
+            if count_failed > 0:
+                if self.external_task_id:
+                    raise AirflowException(
+                        f'The external task {self.external_task_id} in DAG {self.external_dag_id} failed.'
+                    )
+                else:
+                    raise AirflowException(f'The external DAG {self.external_dag_id} failed.')
 
         return count_allowed == len(dttm_filter)
 


### PR DESCRIPTION
I believe this PR fixes #16204 where the `ExternalTaskSensor` would hang indefinitely when an `execution_date_fn` is used, `failed_states`/`allowed_states` are set, and external DAGs have mixed states upstream.

Apologies for not having a better handle on the unit tests to add coverage here, I don't have a good handle on the structure for this case and lack the time to dig deeper. Given the nature of the bug, I hope this PR is still useful.
