### PR TITLE
Add transparency for unsupported connection type

### DIFF
--- a/airflow/sensors/sql.py
+++ b/airflow/sensors/sql.py
@@ -87,7 +87,7 @@ class SqlSensor(BaseSensorOperator):
         }
         if conn.conn_type not in allowed_conn_type:
             raise AirflowException(
-                "The connection type is not supported by SqlSensor. "
+                f"Connection type ({conn.conn_type}) is not supported by SqlSensor. "
                 + f"Supported connection types: {list(allowed_conn_type)}"
             )
         return conn.get_hook()


### PR DESCRIPTION
Very simple pull request. I ran into an issue when trying to create a connection in airflow where I had trouble debugging what connection type airflow thought I was trying to use. I just added the connection type to the error message.