### PR TITLE
Make secrets normal resources, not hooks

### DIFF
--- a/chart/templates/configmaps/extra-configmaps.yaml
+++ b/chart/templates/configmaps/extra-configmaps.yaml
@@ -29,10 +29,6 @@ metadata:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
 {{- with $Global.Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/chart/templates/secrets/extra-secrets.yaml
+++ b/chart/templates/secrets/extra-secrets.yaml
@@ -29,10 +29,6 @@ metadata:
     release: {{ $Global.Release.Name }}
     chart: "{{ $Global.Chart.Name }}-{{ $Global.Chart.Version }}"
     heritage: {{ $Global.Release.Service }}
-  annotations:
-    "helm.sh/hook": "pre-install,pre-upgrade"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
 {{- with $Global.Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/chart/templates/secrets/fernetkey-secret.yaml
+++ b/chart/templates/secrets/fernetkey-secret.yaml
@@ -32,10 +32,6 @@ metadata:
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
 type: Opaque
 data:
   fernet-key: {{ (default $generated_fernet_key .Values.fernetKey) | b64enc | quote }}

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -35,10 +35,6 @@ metadata:
 {{- with .Values.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
 type: Opaque
 data:
   password: {{ (default $random_redis_password .Values.redis.password) | b64enc | quote }}
@@ -61,10 +57,6 @@ metadata:
     {{- with .Values.labels }}
     {{ toYaml . | nindent 4 }}
     {{- end }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
 type: Opaque
 data:
 {{- if .Values.redis.enabled }}

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -40,29 +40,32 @@ class TestBaseChartTest(unittest.TestCase):
                 "fullnameOverride": "TEST-BASIC",
             },
         )
-        list_of_kind_names_tuples = [
+        list_of_kind_names_tuples = {
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
-        ]
-        assert list_of_kind_names_tuples == [
-            ('ServiceAccount', 'TEST-BASIC-flower'),
+        }
+        assert list_of_kind_names_tuples == {
             ('ServiceAccount', 'TEST-BASIC-create-user-job'),
+            ('ServiceAccount', 'TEST-BASIC-flower'),
             ('ServiceAccount', 'TEST-BASIC-migrate-database-job'),
             ('ServiceAccount', 'TEST-BASIC-redis'),
             ('ServiceAccount', 'TEST-BASIC-scheduler'),
             ('ServiceAccount', 'TEST-BASIC-statsd'),
             ('ServiceAccount', 'TEST-BASIC-webserver'),
             ('ServiceAccount', 'TEST-BASIC-worker'),
-            ('Secret', 'TEST-BASIC-postgresql'),
             ('Secret', 'TEST-BASIC-airflow-metadata'),
             ('Secret', 'TEST-BASIC-airflow-result-backend'),
+            ('Secret', 'TEST-BASIC-broker-url'),
+            ('Secret', 'TEST-BASIC-fernet-key'),
+            ('Secret', 'TEST-BASIC-postgresql'),
+            ('Secret', 'TEST-BASIC-redis-password'),
             ('ConfigMap', 'TEST-BASIC-airflow-config'),
             ('Role', 'TEST-BASIC-pod-launcher-role'),
             ('Role', 'TEST-BASIC-pod-log-reader-role'),
             ('RoleBinding', 'TEST-BASIC-pod-launcher-rolebinding'),
             ('RoleBinding', 'TEST-BASIC-pod-log-reader-rolebinding'),
+            ('Service', 'TEST-BASIC-flower'),
             ('Service', 'TEST-BASIC-postgresql-headless'),
             ('Service', 'TEST-BASIC-postgresql'),
-            ('Service', 'TEST-BASIC-flower'),
             ('Service', 'TEST-BASIC-redis'),
             ('Service', 'TEST-BASIC-statsd'),
             ('Service', 'TEST-BASIC-webserver'),
@@ -74,12 +77,9 @@ class TestBaseChartTest(unittest.TestCase):
             ('StatefulSet', 'TEST-BASIC-postgresql'),
             ('StatefulSet', 'TEST-BASIC-redis'),
             ('StatefulSet', 'TEST-BASIC-worker'),
-            ('Secret', 'TEST-BASIC-fernet-key'),
-            ('Secret', 'TEST-BASIC-redis-password'),
-            ('Secret', 'TEST-BASIC-broker-url'),
             ('Job', 'TEST-BASIC-create-user'),
             ('Job', 'TEST-BASIC-run-airflow-migrations'),
-        ]
+        }
         assert OBJECT_COUNT_IN_BASIC_DEPLOYMENT == len(k8s_objects)
         for k8s_object in k8s_objects:
             labels = jmespath.search('metadata.labels', k8s_object) or {}


### PR DESCRIPTION
By making secrets (and extra configmaps) normal resources instead of
hooks, Helm will properly clean up the resources when deleting the
release.

Using pre-install hooks also prevented updating a release from
KubernetesExecutor to CeleryExecutor, as the necessary secrets would
only be created during install, not upgrade.

We do not currently have any hooks that would require these resources to
be present early, so they don't need to be hooks.
