### PR TITLE
Use DAG_ACTIONS constant.

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -618,11 +618,11 @@ class DagBag(LoggingMixin):
         """Sync DAG specific permissions, if necessary"""
         from flask_appbuilder.security.sqla import models as sqla_models
 
-        from airflow.security.permissions import DAG_PERMS, resource_name_for_dag
+        from airflow.security.permissions import DAG_ACTIONS, resource_name_for_dag
 
         def needs_perm_views(dag_id: str) -> bool:
             dag_resource_name = resource_name_for_dag(dag_id)
-            for permission_name in DAG_PERMS:
+            for permission_name in DAG_ACTIONS:
                 if not (
                     session.query(sqla_models.PermissionView)
                     .join(sqla_models.Permission)

--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -62,7 +62,7 @@ ACTION_CAN_ACCESS_MENU = "menu_access"
 DEPRECATED_ACTION_CAN_DAG_READ = "can_dag_read"
 DEPRECATED_ACTION_CAN_DAG_EDIT = "can_dag_edit"
 
-DAG_PERMS = {ACTION_CAN_READ, ACTION_CAN_EDIT}
+DAG_ACTIONS = {ACTION_CAN_READ, ACTION_CAN_EDIT}
 
 
 def resource_name_for_dag(dag_id):

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -463,7 +463,7 @@ class TestSecurity(unittest.TestCase):
 
     def test_access_control_with_invalid_permission(self):
         invalid_permissions = [
-            'can_varimport',  # a real permission, but not a member of DAG_PERMS
+            'can_varimport',  # a real permission, but not a member of DAG_ACTIONS
             'can_eat_pudding',  # clearly not a real permission
         ]
         username = "LaUser"


### PR DESCRIPTION
The previous PR (#16212) uses the updated naming scheme for local variables inside FAB methods. This PR continues that work, as well as updating the names in FAB constants and uses the newly named FAB methods.

Successor to #16212 and the next step in #15398.

This PR can be merged whenever it passes.