### PR TITLE
Fix TI success/failure links

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -533,12 +533,13 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
         iso = quote(self.execution_date.isoformat())
         base_url = conf.get('webserver', 'BASE_URL')
         return base_url + (
-            "/success"
+            "/confirm"
             f"?task_id={self.task_id}"
             f"&dag_id={self.dag_id}"
             f"&execution_date={iso}"
             "&upstream=false"
             "&downstream=false"
+            "&state=success"
         )
 
     @provide_session

--- a/airflow/utils/strings.py
+++ b/airflow/utils/strings.py
@@ -27,4 +27,4 @@ def get_random_string(length=8, choices=string.ascii_letters + string.digits):
 
 def to_boolean(astring):
     """Convert a string to a boolean"""
-    return astring.lower() in ['true', 't', 'y', 'yes', '1']
+    return False if astring is None else astring.lower() in ['true', 't', 'y', 'yes', '1']

--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -28,10 +28,14 @@
       <pre><code>{{ details }}</code></pre>
     {% endif %}
   </div>
-  <form method="POST">
+  {% if endpoint %}
+    <form method="POST" action="{{ endpoint }}">
+  {% else %}
+    <form method="POST">
+  {% endif %}
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
     <input type="hidden" name="confirmed" value="true">
-    {% for name,val in request.form.items() if name != "csrf_token" %}
+    {% for name,val in request.values.items() if name != "csrf_token" %}
       <input type="hidden" name="{{ name }}" value="{{ val }}">
     {% endfor %}
     <button type="submit" class="btn btn-primary">OK!</button>

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -284,12 +284,12 @@
             </div>
           </form>
           <hr style="margin-bottom: 8px;">
-          <form method="POST" data-action="{{ url_for('Airflow.failed') }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <form method="GET" data-action="{{ url_for('Airflow.confirm') }}">
             <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
             <input type="hidden" name="task_id">
             <input type="hidden" name="execution_date">
             <input type="hidden" name="origin" value="{{ request.base_url }}">
+            <input type="hidden" name="state" value="failed">
             <div class="row">
               <span class="btn-group col-xs-12 col-sm-9 task-instance-modal-column" data-toggle="buttons">
                 <label class="btn btn-default">
@@ -317,12 +317,12 @@
             </div>
           </form>
           <hr style="margin-bottom: 8px;">
-          <form method="POST" data-action="{{ url_for('Airflow.success') }}">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <form method="GET" data-action="{{ url_for('Airflow.confirm') }}">
             <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
             <input type="hidden" name="task_id">
             <input type="hidden" name="execution_date">
             <input type="hidden" name="origin" value="{{ request.base_url }}">
+            <input type="hidden" name="state" value="success">
             <div class="row">
               <span class="btn-group col-xs-12 col-sm-9 task-instance-modal-column" data-toggle="buttons">
                 <label class="btn btn-default">

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -223,7 +223,6 @@ def test_mark_task_instance_state(test_app):
             task_id=task_1.task_id,
             origin="",
             execution_date=start_date.isoformat(),
-            confirmed=True,
             upstream=False,
             downstream=False,
             future=False,

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -690,8 +690,8 @@ def test_failed_success(client_all_dags_edit_tis):
         future="false",
         past="false",
     )
-    resp = client_all_dags_edit_tis.post('failed', data=form)
-    check_content_in_response('example_bash_operator', resp)
+    resp = client_all_dags_edit_tis.post('failed', data=form, follow_redirects=True)
+    check_content_in_response('Marked failed on 1 task instances', resp)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is to fix the issue https://github.com/apache/airflow/issues/15234.

As of now, TI success & failure endpoints are POST only and behave differently as per the `confirmed` flag. They either render a confirmation page or updates the TI states on the basis of that flag, something which is not a great design. 

Also, as these endpoints are POST only, they throw a 404 error when someone clicks on the link received via email. 

To fix the issue, extracting the rendering functionalities into a diff endpoint `/confirm` & keeping these endpoints as pure POST endpoints. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
