### PR TITLE
Update copy command for s3 to redshift

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -99,7 +99,7 @@ class S3ToRedshiftOperator(BaseOperator):
         self.truncate_table = truncate_table
 
     def _build_copy_query(self, credentials_block: str, copy_options: str) -> str:
-        column_names = "(" + ", ".join(self.column_list) + ")" if self.column_list else None
+        column_names = "(" + ", ".join(self.column_list) + ")" if self.column_list else ''
         return f"""
                     COPY {self.schema}.{self.table} {column_names}
                     FROM 's3://{self.s3_bucket}/{self.s3_key}'

--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -57,13 +57,15 @@ class S3ToRedshiftOperator(BaseOperator):
                  You can specify this argument if you want to use a different
                  CA cert bundle than the one used by botocore.
     :type verify: bool or str
+    :param column_list: list of column names to load
+    :type column_list: List[str]
     :param copy_options: reference to a list of COPY options
     :type copy_options: list
     :param truncate_table: whether or not to truncate the destination table before the copy
     :type truncate_table: bool
     """
 
-    template_fields = ('s3_bucket', 's3_key', 'schema', 'table', 'copy_options')
+    template_fields = ('s3_bucket', 's3_key', 'schema', 'table', 'column_list', 'copy_options')
     template_ext = ()
     ui_color = '#99e699'
 
@@ -77,6 +79,7 @@ class S3ToRedshiftOperator(BaseOperator):
         redshift_conn_id: str = 'redshift_default',
         aws_conn_id: str = 'aws_default',
         verify: Optional[Union[bool, str]] = None,
+        column_list: Optional[List[str]] = None,
         copy_options: Optional[List] = None,
         autocommit: bool = False,
         truncate_table: bool = False,
@@ -90,13 +93,15 @@ class S3ToRedshiftOperator(BaseOperator):
         self.redshift_conn_id = redshift_conn_id
         self.aws_conn_id = aws_conn_id
         self.verify = verify
+        self.column_list = column_list
         self.copy_options = copy_options or []
         self.autocommit = autocommit
         self.truncate_table = truncate_table
 
     def _build_copy_query(self, credentials_block: str, copy_options: str) -> str:
+        column_names = "(" + ", ".join(self.column_list) + ")" if self.column_list else None
         return f"""
-                    COPY {self.schema}.{self.table}
+                    COPY {self.schema}.{self.table} {column_names}
                     FROM 's3://{self.s3_bucket}/{self.s3_key}'
                     with credentials
                     '{credentials_block}'

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -23,7 +23,6 @@ from unittest import mock
 from boto3.session import Session
 
 from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
-from airflow.providers.amazon.aws.utils.redshift import build_credentials_block
 from tests.test_utils.asserts import assert_equal_ignore_multiple_spaces
 
 
@@ -56,18 +55,13 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
             dag=None,
         )
         op.execute(None)
-
-        credentials_block = build_credentials_block(mock_session.return_value)
-        copy_query = op._build_copy_query(credentials_block, copy_options)
-        expected_copy_query = '''
-                                COPY schema.table
-                                FROM 's3://bucket/key'
-                                with credentials
-                                'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
-                                ;
-                             '''
-        assert_equal_ignore_multiple_spaces(self, expected_copy_query, copy_query)
-
+        copy_query = '''
+                        COPY schema.table
+                        FROM 's3://bucket/key'
+                        with credentials
+                        'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
+                        ;
+                     '''
         assert mock_run.call_count == 1
         assert access_key in copy_query
         assert secret_key in copy_query
@@ -103,18 +97,13 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
             dag=None,
         )
         op.execute(None)
-
-        credentials_block = build_credentials_block(mock_session.return_value)
-        copy_query = op._build_copy_query(credentials_block, copy_options)
-        expected_copy_query = '''
-                                COPY schema.table (column_1, column_2)
-                                FROM 's3://bucket/key'
-                                with credentials
-                                'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
-                                ;
-                             '''
-        assert_equal_ignore_multiple_spaces(self, expected_copy_query, copy_query)
-
+        copy_query = '''
+                        COPY schema.table (column_1, column_2)
+                        FROM 's3://bucket/key'
+                        with credentials
+                        'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
+                        ;
+                     '''
         assert mock_run.call_count == 1
         assert access_key in copy_query
         assert secret_key in copy_query
@@ -149,10 +138,13 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
             dag=None,
         )
         op.execute(None)
-
-        credentials_block = build_credentials_block(mock_session.return_value)
-        copy_statement = op._build_copy_query(credentials_block, copy_options)
-
+        copy_statement = '''
+                        COPY schema.table
+                        FROM 's3://bucket/key'
+                        with credentials
+                        'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
+                        ;
+                     '''
         truncate_statement = f'TRUNCATE TABLE {schema}.{table};'
         transaction = f"""
                     BEGIN;
@@ -192,11 +184,14 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
             task_id="task_id",
             dag=None,
         )
-
-        credentials_block = build_credentials_block(mock_session.return_value)
-        copy_statement = op._build_copy_query(credentials_block, copy_options)
         op.execute(None)
-
+        copy_statement = '''
+                            COPY schema.table
+                            FROM 's3://bucket/key'
+                            with credentials
+                            'aws_access_key_id=ASIA_aws_access_key_id;aws_secret_access_key=aws_secret_access_key;token=aws_secret_token'
+                            ;
+                         '''
         assert access_key in copy_statement
         assert secret_key in copy_statement
         assert token in copy_statement

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -59,6 +59,14 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
 
         credentials_block = build_credentials_block(mock_session.return_value)
         copy_query = op._build_copy_query(credentials_block, copy_options)
+        expected_copy_query = '''
+                                COPY schema.table
+                                FROM 's3://bucket/key'
+                                with credentials
+                                'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
+                                ;
+                             '''
+        assert_equal_ignore_multiple_spaces(self, expected_copy_query, copy_query)
 
         assert mock_run.call_count == 1
         assert access_key in copy_query
@@ -98,6 +106,14 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
 
         credentials_block = build_credentials_block(mock_session.return_value)
         copy_query = op._build_copy_query(credentials_block, copy_options)
+        expected_copy_query = '''
+                                COPY schema.table (column_1, column_2)
+                                FROM 's3://bucket/key'
+                                with credentials
+                                'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
+                                ;
+                             '''
+        assert_equal_ignore_multiple_spaces(self, expected_copy_query, copy_query)
 
         assert mock_run.call_count == 1
         assert access_key in copy_query


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Update copy command for s3_to_redshift to be able to select column names while copying files from s3 to redshift.

```sql
COPY tablename (column1 [,column2, ...]) 
```

Related aws documentation ([Link](https://docs.aws.amazon.com/ko_kr/redshift/latest/dg/r_COPY.html)),




---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
