### PR TITLE
Small improvements for README.md files

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -908,8 +908,6 @@ Documentation
 
 Documentation for ``apache-airflow`` package and other packages that are closely related to it ie. providers packages are in ``/docs/`` directory. For detailed information on documentation development, see: `docs/README.rst <docs/README.rst>`_
 
-For Helm Chart documentation, see: `chart/README.md <chart/README.md>`__
-
 Static code checks
 ==================
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ through a more complete [tutorial](https://airflow.apache.org/docs/apache-airflo
 For more information on Airflow Improvement Proposals (AIPs), visit
 the [Airflow Wiki](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals).
 
-Official Docker (container) images for Apache Airflow are described in [IMAGES.rst](IMAGES.rst).
+Official Docker (container) images for Apache Airflow are described in [IMAGES.rst](https://github.com/apache/airflow/blob/main/IMAGES.rst).
 
 ## Installing from PyPI
 
@@ -173,9 +173,7 @@ correct Airflow tag/version/branch and Python versions in the URL.
 
 1. Installing just Airflow:
 
-NOTE!!!
-
-Only `pip` installation is currently officially supported.
+> Note: Only `pip` installation is currently officially supported.
 
 While they are some successes with using other tools like [poetry](https://python-poetry.org) or
 [pip-tools](https://pypi.org/project/pip-tools), they do not share the same workflow as
@@ -228,7 +226,7 @@ Those are - in the order of most common ways people install Airflow:
   `docker` tool, use them in Kubernetes, Helm Charts, `docker-compose`, `docker swarm` etc. You can
   read more about using, customising, and extending the images in the
   [Latest docs](https://airflow.apache.org/docs/apache-airflow/stable/production-deployment.html), and
-  learn details on the internals in the [IMAGES.rst](IMAGES.rst) document.
+  learn details on the internals in the [IMAGES.rst](https://github.com/apache/airflow/blob/main/IMAGES.rst) document.
 - [Tags in GitHub](https://github.com/apache/airflow/tags) to retrieve the git project sources that
   were used to generate official source packages via git
 
@@ -240,27 +238,27 @@ following the ASF Policy.
 
 - **DAGs**: Overview of all DAGs in your environment.
 
-  ![DAGs](/docs/apache-airflow/img/dags.png)
+  ![DAGs](https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/dags.png)
 
 - **Tree View**: Tree representation of a DAG that spans across time.
 
-  ![Tree View](/docs/apache-airflow/img/tree.png)
+  ![Tree View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/tree.png)
 
 - **Graph View**: Visualization of a DAG's dependencies and their current status for a specific run.
 
-  ![Graph View](/docs/apache-airflow/img/graph.png)
+  ![Graph View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/graph.png)
 
 - **Task Duration**: Total time spent on different tasks over time.
 
-  ![Task Duration](/docs/apache-airflow/img/duration.png)
+  ![Task Duration](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/duration.png)
 
 - **Gantt View**: Duration and overlap of a DAG.
 
-  ![Gantt View](/docs/apache-airflow/img/gantt.png)
+  ![Gantt View](https://raw.githubusercontent.com/apache/airflow/main/https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/gantt.png)
 
 - **Code View**:  Quick way to view source code of a DAG.
 
-  ![Code View](/docs/apache-airflow/img/code.png)
+  ![Code View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/code.png)
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ following the ASF Policy.
 
 - **Gantt View**: Duration and overlap of a DAG.
 
-  ![Gantt View](https://raw.githubusercontent.com/apache/airflow/main/https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/gantt.png)
+  ![Gantt View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/gantt.png)
 
 - **Code View**:  Quick way to view source code of a DAG.
 

--- a/README.md
+++ b/README.md
@@ -242,23 +242,23 @@ following the ASF Policy.
 
 - **Tree View**: Tree representation of a DAG that spans across time.
 
-  ![Tree View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/tree.png)
+  ![Tree View](https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/tree.png)
 
 - **Graph View**: Visualization of a DAG's dependencies and their current status for a specific run.
 
-  ![Graph View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/graph.png)
+  ![Graph View](https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/graph.png)
 
 - **Task Duration**: Total time spent on different tasks over time.
 
-  ![Task Duration](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/duration.png)
+  ![Task Duration](https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/duration.png)
 
 - **Gantt View**: Duration and overlap of a DAG.
 
-  ![Gantt View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/gantt.png)
+  ![Gantt View](https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/gantt.png)
 
 - **Code View**:  Quick way to view source code of a DAG.
 
-  ![Code View](https://raw.githubusercontent.com/apache/airflow/main//docs/apache-airflow/img/code.png)
+  ![Code View](https://raw.githubusercontent.com/apache/airflow/main/docs/apache-airflow/img/code.png)
 
 
 ## Contributing

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,6 +19,8 @@
 
 # Helm Chart for Apache Airflow
 
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/apache-airflow)](https://artifacthub.io/packages/search?repo=apache-airflow)
+
 [Apache Airflow](https://airflow.apache.org/) is a platform to programmatically author, schedule and monitor workflows.
 
 ## Introduction
@@ -50,11 +52,12 @@ cluster using the [Helm](https://helm.sh) package manager.
 
 ## Documentation
 
-Documentation for the released version can be found at https://airflow.apache.org/docs/helm-chart/.
+Full documentation for Helm Chart (latest **stable** release) lives [on the website](https://airflow.apache.org/docs/helm-chart/).
 
-The latest development version is published on:
-[http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/helm-chart/latest/index.html](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/helm-chart/latest/index.html)
+> Note: If you're looking for documentation for main branch (latest development branch): you can find it on [s.apache.org/airflow-docs/](http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/helm-chart/latest/index.html).
+> Source code for documentation is in [../docs/helm-chart](https://github.com/apache/airflow/tree/main/docs/helm-chart)
+>
 
 ## Contributing
 
-Want to help build Apache Airflow? Check out our [contributing documentation](../CONTRIBUTING.rst).
+Want to help build Apache Airflow? Check out our [contributing documentation](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst).

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -20,8 +20,6 @@ Documentation
 
 This directory contains documentation for the Apache Airflow project and other packages that are closely related to it ie. providers packages.  Documentation is built using `Sphinx <https://www.sphinx-doc.org/>`__.
 
-For Helm Chart, see: `/chart/README.md <../chart/README.md>`__
-
 Development documentation preview
 ==================================
 


### PR DESCRIPTION
In a few places, we've used relative references that cause compatibility problems e.g.
- on pypi, IMAGES links and images doesn't works. https://pypi.org/project/apache-airflow/
- on ArtifactHub, the contributor section doesn't have links: https://artifacthub.io/packages/helm/apache-airflow/airflow

Additionally, I added a link to ArtifactHub in README.md to make it easier to skip to this section and updated the documentation for Helm chart sections, because it had outdated info.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
