### PR TITLE
Use f-string in custom operator docs

### DIFF
--- a/docs/apache-airflow/howto/custom-operator.rst
+++ b/docs/apache-airflow/howto/custom-operator.rst
@@ -53,7 +53,7 @@ Let's implement an example ``HelloOperator`` in a new file ``hello_operator.py``
                 self.name = name
 
             def execute(self, context):
-                message = "Hello {}".format(self.name)
+                message = f"Hello {self.name}"
                 print(message)
                 return message
 
@@ -117,7 +117,7 @@ Let's extend our previous example to fetch name from MySQL:
             hook = MySqlHook(mysql_conn_id=self.mysql_conn_id, schema=self.database)
             sql = "select name from user"
             result = hook.get_first(sql)
-            message = "Hello {}".format(result["name"])
+            message = f"Hello {result['name']}"
             print(message)
             return message
 
@@ -160,7 +160,7 @@ the operator.
                 self.name = name
 
             def execute(self, context):
-                message = "Hello from {}".format(self.name)
+                message = f"Hello from {self.name}"
                 print(message)
                 return message
 


### PR DESCRIPTION
Use f-string formatting to support good practices

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
