### PR TITLE
Client-side filter dag dependencies

### DIFF
--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -18,7 +18,7 @@
  */
 
 /*
-  global $, d3, localStorage, dagreD3, dagNodes, edges, arrange, document,
+  global d3, localStorage, dagreD3, dagNodes, edges, arrange, document,
 */
 
 const highlightColor = '#000000';
@@ -209,7 +209,7 @@ const renderGraph = () => {
 };
 
 // rerender graph when filtering dags with dependencies or not
-$('#deps-filter').on('change', function onChange() {
+document.getElementById('deps-filter').addEventListener('change', function onChange() {
   // reset searchbox
   document.getElementById('searchbox').value = '';
   if (this.checked) {
@@ -224,4 +224,5 @@ $('#deps-filter').on('change', function onChange() {
 if (document.getElementById('deps-filter').checked) {
   nodes = filteredNodes;
 }
+
 renderGraph();

--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -214,11 +214,10 @@ $('#deps-filter').on('change', function onChange() {
   document.getElementById('searchbox').value = '';
   if (this.checked) {
     nodes = filteredNodes;
-    renderGraph();
   } else {
     nodes = fullNodes;
-    renderGraph();
   }
+  renderGraph();
 });
 
 // initial filter check and render

--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -18,7 +18,7 @@
  */
 
 /*
-  global d3, localStorage, dagreD3, nodes, edges, arrange, document,
+  global $, d3, localStorage, dagreD3, dagNodes, edges, arrange, document,
 */
 
 const highlightColor = '#000000';
@@ -28,8 +28,12 @@ const initialStrokeWidth = '3px';
 const highlightStrokeWidth = '5px';
 const duration = 500;
 
+let nodes = dagNodes;
+const fullNodes = nodes;
+const filteredNodes = nodes.filter((n) => edges.some((e) => e.u === n.id || e.v === n.id));
+
 // Preparation of DagreD3 data structures
-const g = new dagreD3.graphlib.Graph()
+let g = new dagreD3.graphlib.Graph()
   .setGraph({
     nodesep: 15,
     ranksep: 15,
@@ -37,21 +41,9 @@ const g = new dagreD3.graphlib.Graph()
   })
   .setDefaultEdgeLabel(() => ({ lineInterpolate: 'basis' }));
 
-// Set all nodes and styles
-nodes.forEach((node) => {
-  g.setNode(node.id, node.value);
-});
-
-// Set edges
-edges.forEach((edge) => {
-  g.setEdge(edge.u, edge.v);
-});
-
 const render = dagreD3.render();
 const svg = d3.select('#graph-svg');
 const innerSvg = d3.select('#graph-svg g');
-
-innerSvg.call(render, g);
 
 // Returns true if a node's id or its children's id matches search_text
 function nodeMatches(nodeId, searchText) {
@@ -59,8 +51,8 @@ function nodeMatches(nodeId, searchText) {
   return false;
 }
 
-function highlightNodes(nodes, color, strokeWidth) {
-  nodes.forEach((nodeid) => {
+function highlightNodes(nodesToHighlight, color, strokeWidth) {
+  nodesToHighlight.forEach((nodeid) => {
     const myNode = g.node(nodeid).elem;
     d3.select(myNode)
       .selectAll('rect,circle')
@@ -187,10 +179,50 @@ function searchboxHighlighting(s) {
   }
 }
 
-setUpNodeHighlighting();
-setUpZoomSupport();
-
 d3.select('#searchbox').on('keyup', () => {
   const s = document.getElementById('searchbox').value;
   searchboxHighlighting(s);
 });
+
+const renderGraph = () => {
+  g = new dagreD3.graphlib.Graph()
+    .setGraph({
+      nodesep: 15,
+      ranksep: 15,
+      rankdir: arrange,
+    })
+    .setDefaultEdgeLabel(() => ({ lineInterpolate: 'basis' }));
+
+  // set nodes
+  nodes.forEach((node) => {
+    g.setNode(node.id, node.value);
+  });
+
+  // Set edges
+  edges.forEach((edge) => {
+    g.setEdge(edge.u, edge.v);
+  });
+
+  innerSvg.call(render, g);
+  setUpNodeHighlighting();
+  setUpZoomSupport();
+};
+
+// rerender graph when filtering dags with dependencies or not
+$('#deps-filter').on('change', function onChange() {
+  // reset searchbox
+  document.getElementById('searchbox').value = '';
+  if (this.checked) {
+    nodes = filteredNodes;
+    renderGraph();
+  } else {
+    nodes = fullNodes;
+    renderGraph();
+  }
+});
+
+// initial filter check and render
+if (document.getElementById('deps-filter').checked) {
+  nodes = filteredNodes;
+}
+renderGraph();

--- a/airflow/www/templates/airflow/dag_dependencies.html
+++ b/airflow/www/templates/airflow/dag_dependencies.html
@@ -33,6 +33,9 @@ under the License.
   <div class="input-group" style="float: right">
     <input type="text" id="searchbox" class="form-control" placeholder="Search for..." onenter="null">
   </div>
+  <label for="deps-filter" class="h5" style="float: right; margin-right: 5px">
+    <input type="checkbox" id="deps-filter" checked> Only show DAGs with dependencies
+  </label>
 </h2>
 <hr/>
 <div class="legend-row">
@@ -67,7 +70,7 @@ under the License.
   <script src="{{ url_for_asset('d3-shape.min.js') }}"></script>
   <script src="{{ url_for_asset('d3-tip.js') }}"></script>
   <script>
-    let nodes = {{ nodes|tojson }};
+    let dagNodes = {{ nodes|tojson }};
     let edges = {{ edges|tojson }};
     const arrange = '{{ arrange }}';
   </script>


### PR DESCRIPTION
Problem: Many dags have no dependencies, adding a lot of noise to the Dag Dependencies view

Solution: Default to only showing dags with a dependency graph

<img width="1129" alt="Screen Shot 2021-06-03 at 1 09 13 PM" src="https://user-images.githubusercontent.com/4600967/120693643-df7eae00-c46e-11eb-8492-205d58143c43.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
