### PR TITLE
Don't run migration for ad-hoc commands

### DIFF
--- a/docs/apache-airflow/start/airflow.sh
+++ b/docs/apache-airflow/start/airflow.sh
@@ -25,4 +25,8 @@ PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set -euo pipefail
 
 export COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yaml"
-exec docker-compose run --rm -e CONNECTION_CHECK_MAX_COUNT=0 airflow-worker "${@}"
+if [ $# -gt 0 ]; then
+    exec docker-compose run --rm airflow-cli "${@}"
+else
+    exec docker-compose run --rm airflow-cli
+fi

--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -150,6 +150,19 @@ services:
       _AIRFLOW_WWW_USER_USERNAME: ${_AIRFLOW_WWW_USER_USERNAME:-airflow}
       _AIRFLOW_WWW_USER_PASSWORD: ${_AIRFLOW_WWW_USER_PASSWORD:-airflow}
 
+  airflow-cli:
+    <<: *airflow-common
+    profiles:
+      - debug
+    environment:
+      <<: *airflow-common-env
+      CONNECTION_CHECK_MAX_COUNT: "0"
+    # Workaround for entrypoint issue. See: https://github.com/apache/airflow/issues/16252
+    command:
+      - bash
+      - -c
+      - airflow
+
   flower:
     <<: *airflow-common
     command: celery flower


### PR DESCRIPTION
which adds an additional check that the migrations were done before running other containers to improve the reliability of the environment.  This causes a problem for adhoc commands because this check is run on every command, killing productivity.  Now I have added a new container that does not have this check to speed up these commands.

Now, migrations will only run when the `airflow-worker`, `airflow-scheduler`, `airflow-webserver `and `flower` containers are started.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
