### PR TITLE
Move `UPDATING.md` to `updating` directory in `docs/apache-airflow`

### DIFF
--- a/docs/apache-airflow/index.rst
+++ b/docs/apache-airflow/index.rst
@@ -98,7 +98,8 @@ unit of work and continuity.
     dag-serialization
     modules_management
     Release policies <release-process>
-    changelog
+    updating/changelog
+    updating/updating
     best-practices
     production-deployment
     faq

--- a/docs/apache-airflow/updating/changelog.rst
+++ b/docs/apache-airflow/updating/changelog.rst
@@ -20,4 +20,4 @@
 Changelog
 =========
 
-.. include:: ../../CHANGELOG.txt
+.. include:: ../../../CHANGELOG.txt

--- a/docs/apache-airflow/updating/updating.rst
+++ b/docs/apache-airflow/updating/updating.rst
@@ -1,0 +1,23 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+
+
+
+Updating
+=========
+
+.. mdinclude:: ../../../UPDATING.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,7 +138,12 @@ extensions = [
     'sphinx_airflow_theme',
     'redirects',
     'substitution_extensions',
+    'm2r2',
 ]
+
+# source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
+
 if PACKAGE_NAME == 'apache-airflow':
     extensions.extend(
         [


### PR DESCRIPTION
To allow for the centrality of information regarding Airflow releases
and updates, docs/apache-airflow/updating/ needs to be created to house
changelog and a link to UPDATING.md`.

In this PR, changelog.rst was moved from
`docs/apache-airflow/changelog.rst` to
`docs/apache-airflow/updating/changelog.rst`.

Similarly, `docs/apache-airflow/updating/updating.rst` now contains a
link to `UPDATING.md`. This was made possible by adding `m2r2` extension
 support to `docs/conf.py`.

fixes #15996

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
