### PR TITLE
Improve argument handling in entrypoint_prod.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -477,4 +477,4 @@ LABEL org.apache.airflow.distro="debian" \
 
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
-CMD ["--help"]
+CMD []

--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -100,6 +100,21 @@ function verify_image::verify_prod_image_commands() {
     output=$(docker_v run --rm \
             -e COLUMNS=180 \
             "${DOCKER_IMAGE}" \
+            python --version | grep "Python 3." 2>&1)
+    local res=$?
+    if [[ ${res} == "0" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+    echo -n "Feature: Checking 'bash --version' command  It should return zero exit code."
+    output=$(docker_v run --rm \
+            -e COLUMNS=180 \
+            "${DOCKER_IMAGE}" \
             bash --version | grep "GNU bash, " 2>&1)
     local res=$?
     if [[ ${res} == "0" ]]; then

--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -44,6 +44,77 @@ function verify_image::check_command() {
     set -e
 }
 
+function verify_image::verify_prod_image_commands() {
+    start_end::group_start "Checking command supports"
+    set +e
+
+    echo -n "Feature: Checking the image without a command. It should return non-zero exit code."
+    local output
+    output=$(docker_v run --rm \
+            -e COLUMNS=180 \
+            "${DOCKER_IMAGE}" \
+            2>&1)
+    local res=$?
+    if [[ ${res} == "2" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+    echo -n "Feature: Checking 'airflow' command  It should return non-zero exit code."
+    output=$(docker_v run --rm \
+            -e COLUMNS=180 \
+            "${DOCKER_IMAGE}" \
+            "airflow" 2>&1)
+    local res=$?
+    if [[ ${res} == "2" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+
+    echo -n "Feature: Checking 'airflow version' command  It should return zero exit code."
+    output=$(docker_v run --rm \
+            -e COLUMNS=180 \
+            "${DOCKER_IMAGE}" \
+            "airflow" "version" 2>&1)
+    local res=$?
+    if [[ ${res} == "0" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+
+    echo -n "Feature: Checking 'python --version' command  It should return zero exit code."
+    output=$(docker_v run --rm \
+            -e COLUMNS=180 \
+            "${DOCKER_IMAGE}" \
+            bash --version | grep "GNU bash, " 2>&1)
+    local res=$?
+    if [[ ${res} == "0" ]]; then
+        echo "${COLOR_GREEN}OK${COLOR_RESET}"
+    else
+        echo "${COLOR_RED}NOK${COLOR_RESET}"
+        echo "${COLOR_BLUE}========================= OUTPUT start ============================${COLOR_RESET}"
+        echo "${output}"
+        echo "${COLOR_BLUE}========================= OUTPUT end   ===========================${COLOR_RESET}"
+        IMAGE_VALID="false"
+    fi
+
+    set -e
+}
+
 function verify_image::verify_prod_image_has_airflow_and_providers() {
     start_end::group_start "Verify prod image: ${DOCKER_IMAGE}"
     echo
@@ -274,6 +345,8 @@ function verify_image::display_result {
 function verify_image::verify_prod_image {
     IMAGE_VALID="true"
     DOCKER_IMAGE="${1}"
+    verify_image::verify_prod_image_commands
+
     verify_image::verify_prod_image_has_airflow_and_providers
 
     verify_image::verify_production_image_python_modules

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 # Might be empty
-AIRFLOW_COMMAND="${1}"
+AIRFLOW_COMMAND="${1:-}"
 
 set -euo pipefail
 
@@ -339,14 +339,14 @@ exec_to_bash_or_python_command_if_specified "${@}"
 #     docker run IMAGE webserver
 #
 if [[ ${AIRFLOW_COMMAND} == "airflow" ]]; then
-   AIRFLOW_COMMAND="${2}"
+   AIRFLOW_COMMAND="${2:-}"
    shift
 fi
 
 # Note: the broker backend configuration concerns only a subset of Airflow components
 if [[ ${AIRFLOW_COMMAND} =~ ^(scheduler|celery|worker|flower)$ ]] \
     && [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
-    wait_for_celery_backend "${@}"
+    wait_for_celery_backend
 fi
 
 exec "airflow" "${@}"


### PR DESCRIPTION
I've slightly improved the argument handling to better handle edge cases.

Now, the following command has the same exit code and output
```
docker run --rm my-airflow:2.1.0
docker run --rm my-airflow:2.1.0 airflow
airflow
```
The previous one, each of these commands, behaved a bit differently.

``docker run --rm my-airflow:2.1.0``behaved identically to `airflow --help` coomand i.e. zero exit code and no warning about missing argument.
``docker run --rm my-airflow:2.1.0 airflow`` displayed error - ``/entrypoint: line 326: 2: unbound variable`` and returns non-zero exit code. Close: https://github.com/apache/airflow/issues/16252
``docker run --rm my-airflow:2.1.0 bash -c "airflow"`` had behavior identical to the `airflow` command

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
