### PR TITLE
Add pre-commit hook for Boring Cyborg

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -129,7 +129,6 @@ labelPRBasedOnFilePath:
     - airflow/ui/**/*
 
   area:CLI:
-    - airflow/bin/cli.py
     - airflow/cli/**/*.py
     - tests/cli/**/*.py
     - docs/apache-airflow/cli-and-env-variables-ref.rst
@@ -160,7 +159,7 @@ labelPRBasedOnFilePath:
     - airflow/task/task_runner/**/*
     - airflow/utils/dag_processing.py
     - docs/apache-airflow/executor/**/*
-    - docs/apache-airflow/scheduler.rst
+    - docs/apache-airflow/concepts/scheduler.rst
     - tests/executors/**/*
     - tests/jobs/**/*
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -447,6 +447,13 @@ repos:
         files: ^airflow/migrations/versions/.*\.(py)$
         pass_filenames: false
         require_serial: true
+      - id: boring-cyborg
+        name: Checks for Boring Cyborg configuration consistency
+        language: python
+        entry: ./scripts/ci/pre_commit/pre_commit_boring_cyborg.py
+        pass_filenames: false
+        require_serial: true
+        additional_dependencies: ['pyyaml', 'termcolor==1.1.0', 'wcmatch==8.2']
       - id: sort-in-the-wild
         name: Sort INTHEWILD.md alphabetically
         entry: ./scripts/ci/pre_commit/pre_commit_sort_in_the_wild.sh

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2233,20 +2233,21 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  all all-but-pylint airflow-config-yaml airflow-providers-available
                  airflow-provider-yaml-files-ok base-operator bats-tests bats-in-container-tests
-                 black blacken-docs build build-providers-dependencies check-apache-license
-                 check-builtin-literals check-executables-have-shebangs check-hooks-apply
-                 check-integrations check-merge-conflict check-xml consistent-pylint
-                 daysago-import-check debug-statements detect-private-key doctoc dont-use-safe-filter
-                 end-of-file-fixer fix-encoding-pragma flake8 flynt forbid-tabs helm-lint identity
-                 incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
-                 lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
-                 no-providers-in-core-examples no-relative-imports pre-commit-descriptions
-                 pre-commit-hook-names pretty-format-json provide-create-sessions providers-init-file
-                 provider-yamls pydevd pydocstyle pylint pylint-tests python-no-log-warn pyupgrade
-                 restrict-start_date rst-backticks setup-order setup-extra-packages shellcheck
-                 sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace ui-lint
-                 update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
-                 verify-db-migrations-documented version-sync www-lint yamllint
+                 black blacken-docs boring-cyborg build build-providers-dependencies
+                 check-apache-license check-builtin-literals check-executables-have-shebangs
+                 check-hooks-apply check-integrations check-merge-conflict check-xml
+                 consistent-pylint daysago-import-check debug-statements detect-private-key doctoc
+                 dont-use-safe-filter end-of-file-fixer fix-encoding-pragma flake8 flynt forbid-tabs
+                 helm-lint identity incorrect-use-of-LoggingMixin insert-license isort json-schema
+                 language-matters lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending
+                 mypy mypy-helm no-providers-in-core-examples no-relative-imports
+                 pre-commit-descriptions pre-commit-hook-names pretty-format-json
+                 provide-create-sessions providers-init-file provider-yamls pydevd pydocstyle pylint
+                 pylint-tests python-no-log-warn pyupgrade restrict-start_date rst-backticks
+                 setup-order setup-extra-packages shellcheck sort-in-the-wild sort-spelling-wordlist
+                 stylelint trailing-whitespace ui-lint update-breeze-file update-extras
+                 update-local-yml-file update-setup-cfg-file verify-db-migrations-documented
+                 version-sync www-lint yamllint
 
         You can pass extra arguments including options to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -62,6 +62,8 @@ require Breeze Docker images to be installed locally:
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``blacken-docs``                      Run black on python code blocks in documentation files
 ----------------------------------- ---------------------------------------------------------------- ------------
+``boring-cyborg``                     Checks for Boring Cyborg configuration consistency
+----------------------------------- ---------------------------------------------------------------- ------------
 ``build``                             Builds image for mypy, pylint, flake8                                *
 ----------------------------------- ---------------------------------------------------------------- ------------
 ``build-providers-dependencies``      Regenerates the JSON file with cross-provider dependencies

--- a/breeze-complete
+++ b/breeze-complete
@@ -86,6 +86,7 @@ bats-tests
 bats-in-container-tests
 black
 blacken-docs
+boring-cyborg
 build
 build-providers-dependencies
 check-apache-license

--- a/scripts/ci/pre_commit/pre_commit_boring_cyborg.py
+++ b/scripts/ci/pre_commit/pre_commit_boring_cyborg.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from termcolor import colored
+from wcmatch import glob
+
+if __name__ not in ("__main__", "__mp_main__"):
+    raise SystemExit(
+        "This file is intended to be executed as an executable program. You cannot use it as a module."
+        f"To run this script, run the ./{__file__} command"
+    )
+
+current_files = subprocess.check_output(["git", "ls-files"]).decode().splitlines()
+cyborg_config_path = Path(__file__).absolute().parent.parent.parent.parent / ".github" / "boring-cyborg.yml"
+cyborg_config = yaml.safe_load(cyborg_config_path.read_text())
+if 'labelPRBasedOnFilePath' not in cyborg_config:
+    raise SystemExit("Missing section labelPRBasedOnFilePath")
+
+labels_dict = cyborg_config['labelPRBasedOnFilePath']
+errors = []
+for label, patterns in labels_dict.items():
+    for pattern in patterns:
+        if not glob.globfilter(current_files, pattern, flags=glob.G | glob.E):
+            yaml_path = f'labelPRBasedOnFilePath.{label}'
+            errors.append(
+                f"Unused pattern [{colored(pattern, 'cyan')}] in [{colored(yaml_path, 'cyan')}] section."
+            )
+
+if errors:
+    print(f"Found {colored(str(len(errors)), 'red')} problems:")
+    print("\n".join(errors))
+    sys.exit(1)
+else:
+    print("No found problems. Have a good day!")

--- a/scripts/ci/pre_commit/pre_commit_boring_cyborg.py
+++ b/scripts/ci/pre_commit/pre_commit_boring_cyborg.py
@@ -33,7 +33,7 @@ if __name__ not in ("__main__", "__mp_main__"):
 CONFIG_KEY = 'labelPRBasedOnFilePath'
 
 current_files = subprocess.check_output(["git", "ls-files"]).decode().splitlines()
-git_root = Path(subprocess.check_output(['git', 'rev-parse', '--show-toplevel']))
+git_root = Path(subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode().strip())
 cyborg_config_path = git_root / ".github" / "boring-cyborg.yml"
 cyborg_config = yaml.safe_load(cyborg_config_path.read_text())
 if CONFIG_KEY not in cyborg_config:


### PR DESCRIPTION
I noticed that the cyborg configuration contains frequently unused patterns that result from moving files. To spot these problems before merging, I add a pre-commit hook that checks to see if each pattern has at least one match.

@kaxil Feel free to copy this hook to your repository. Unfortunately, I cannot do this from my Github account.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
