### PR TITLE
feat: Helm chart adding minReplicaCount to the Keda

### DIFF
--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -39,6 +39,7 @@ spec:
     name: {{ .Release.Name }}-worker
   pollingInterval:  {{ .Values.workers.keda.pollingInterval }}   # Optional. Default: 30 seconds
   cooldownPeriod: {{ .Values.workers.keda.cooldownPeriod }}    # Optional. Default: 300 seconds
+  minReplicaCount: {{ .Values.workers.keda.minReplicaCount }}   # Optional. Default: 0
   maxReplicaCount: {{ .Values.workers.keda.maxReplicaCount }}   # Optional. Default: 100
   triggers:
     - type: postgresql

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -929,6 +929,11 @@
                             "type": "integer",
                             "default": 30
                         },
+                        "minReplicaCount": {
+                            "description": "Minimum number of workers created by KEDA.",
+                            "type": "integer",
+                            "default": 0
+                        },
                         "maxReplicaCount": {
                             "description": "Maximum number of workers created by KEDA.",
                             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -364,6 +364,9 @@ workers:
     # Note that HPA has a separate cooldown period for scale-downs
     cooldownPeriod: 30
 
+    # Minimum number of workers created by keda
+    minReplicaCount: 0
+
     # Maximum number of workers created by keda
     maxReplicaCount: 10
 


### PR DESCRIPTION
Keda supports minReplicaCount (default value is 0). It would be great if the users would have the option in the helm chart to overwrite the default value.


closes: #16256

@mik-laj Please can you review it?