### PR TITLE
Remove unused internal function left over form Scheduler HA work

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1164,46 +1164,6 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         return len(queued_tis)
 
     @provide_session
-    def _change_state_for_tasks_failed_to_execute(self, session: Session = None):
-        """
-        If there are tasks left over in the executor,
-        we set them back to SCHEDULED to avoid creating hanging tasks.
-
-        :param session: session for ORM operations
-        """
-        if not self.executor.queued_tasks:
-            return
-
-        filter_for_ti_state_change = [
-            and_(
-                TI.dag_id == dag_id,
-                TI.task_id == task_id,
-                TI.execution_date == execution_date,
-                # The TI.try_number will return raw try_number+1 since the
-                # ti is not running. And we need to -1 to match the DB record.
-                TI._try_number == try_number - 1,  # pylint: disable=protected-access
-                TI.state == State.QUEUED,
-            )
-            for dag_id, task_id, execution_date, try_number in self.executor.queued_tasks.keys()
-        ]
-        ti_query = session.query(TI).filter(or_(*filter_for_ti_state_change))
-        tis_to_set_to_scheduled: List[TI] = with_row_locks(ti_query, session=session).all()
-        if not tis_to_set_to_scheduled:
-            return
-
-        # set TIs to queued state
-        filter_for_tis = TI.filter_for_tis(tis_to_set_to_scheduled)
-        session.query(TI).filter(filter_for_tis).update(
-            {TI.state: State.SCHEDULED, TI.queued_dttm: None}, synchronize_session=False
-        )
-
-        for task_instance in tis_to_set_to_scheduled:
-            self.executor.queued_tasks.pop(task_instance.key)
-
-        task_instance_str = "\n\t".join(repr(x) for x in tis_to_set_to_scheduled)
-        self.log.info("Set the following tasks to scheduled state:\n\t%s", task_instance_str)
-
-    @provide_session
     def _process_executor_events(self, session: Session = None) -> int:
         """Respond to executor events."""
         if not self.processor_agent:


### PR DESCRIPTION
As of AIP-15 this function is not called anymore and should have been
deleted then.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).