### PR TITLE
Chart: Update the default Airflow Version to ``2.1.0``

### DIFF
--- a/chart/UPDATING.md
+++ b/chart/UPDATING.md
@@ -48,6 +48,10 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Default Airflow version is updated to ``2.1.0``
+
+The default Airflow version that is installed with the Chart is now ``2.1.0``, previously it was ``2.0.2``.
+
 ### Removed `dags.gitSync.root`, `dags.gitSync.dest`, and `dags.gitSync.excludeWebserver` parameters
 
 The `dags.gitSync.root` and `dags.gitSync.dest` parameters didn't provide any useful behaviors to chart users so they have been removed.

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -60,13 +60,13 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.0.2",
+            "default": "2.1.0",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
             "type": "string",
-            "default": "2.0.2",
+            "default": "2.1.0",
             "x-docsSection": "Common"
         },
         "nodeSelector": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,10 +37,10 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.0.2"
+defaultAirflowTag: "2.1.0"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.0.2"
+airflowVersion: "2.1.0"
 
 # Images
 images:


### PR DESCRIPTION
Since 2.1.0 is released we should make it default

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
