### PR TITLE
Update target branch in `boring-cyborg` for `checkUpToDate`

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -248,6 +248,8 @@ firstIssueWelcomeComment: >
   Thanks for opening your first issue here! Be sure to follow the issue template!
 
 checkUpToDate:
-  - airflow/migrations/*
-  - airflow/migrations/**/*
-  - airflow/alembic.ini
+  targetBranch: main
+  files:
+    - airflow/migrations/*
+    - airflow/migrations/**/*
+    - airflow/alembic.ini


### PR DESCRIPTION
If we don't update the `targetBranch` it uses `master` by default and gives wrong result.

Example:

![image](https://user-images.githubusercontent.com/8811558/120870269-67100e00-c590-11eb-8bd5-6f3bcbe0c533.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
