### PR TITLE
Fix Helm git sync secrets typo

### DIFF
--- a/docs/helm-chart/manage-dags-files.rst
+++ b/docs/helm-chart/manage-dags-files.rst
@@ -171,8 +171,8 @@ In this example, you will create a yaml file called ``override-values.yaml`` to 
         subPath: ""
         sshKeySecret: airflow-ssh-secret
     extraSecrets:
-      airflow-ssh-secret: |
-        data:
+      airflow-ssh-secret:
+        data: |
           gitSshKey: '<base64-converted-ssh-private-key>'
 
 Don't forget to copy in your private key base64 string.


### PR DESCRIPTION
I think just a small typo as `airflow-ssh-secret` should be an object and `data` is the one that needs to be a string. 

Matches example:
https://github.com/apache/airflow/blob/fc821a83399c4bb462e562e9f6eea47bd5c25b69/chart/values.yaml#L191-L200.