### PR TITLE
Prevent running `airflow db init` migrations and setup in parallel.

### DIFF
--- a/airflow/migrations/env.py
+++ b/airflow/migrations/env.py
@@ -98,15 +98,7 @@ def run_migrations_online():
         )
 
         with context.begin_transaction():
-            if connection.dialect.name == 'mysql' and connection.dialect.server_version_info >= (5, 6):
-                connection.execute("select GET_LOCK('alembic',1800);")
-            if connection.dialect.name == 'postgresql':
-                context.get_context()._ensure_version_table()
-                connection.execute("LOCK TABLE alembic_version IN ACCESS EXCLUSIVE MODE")
             context.run_migrations()
-            if connection.dialect.name == 'mysql' and connection.dialect.server_version_info >= (5, 6):
-                connection.execute("select RELEASE_LOCK('alembic');")
-            # for Postgres lock is released when transaction ends
 
 
 if context.is_offline_mode():


### PR DESCRIPTION
Make sure that multiple db initialization processes on the same db are executed one after another.

Tested manually by running airflow db init in 2 separate bash sessions.
Made sure that migrations only started in one command line and the other resumed after the first has finished and did nothing.

closes: #16310
related PR: #10151
