### PR TITLE
Add support for non-RSA type client host key

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -132,7 +132,7 @@ class SFTPHook(SSHHook):
                 cnopts.hostkeys = None
             else:
                 if self.host_key is not None:
-                    cnopts.hostkeys.add(self.remote_host, 'ssh-rsa', self.host_key)
+                    cnopts.hostkeys.add(self.remote_host, self.host_key.get_name(), self.host_key)
                 else:
                     pass  # will fallback to system host keys if none explicitly specified in conn extra
 

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -178,7 +178,7 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
                 if host_key is not None:
                     if host_key.startswith("ssh-"):
                         key_type, host_key = host_key.split(None)[:2]
-                        key_constructor = _host_key_mappings[key_type[4:]]
+                        key_constructor = self._host_key_mappings[key_type[4:]]
                     else:
                         key_constructor = paramiko.RSAKey
                     decoded_host_key = decodebytes(host_key.encode('utf-8'))

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -218,7 +218,7 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
         else:
             if self.host_key is not None:
                 client_host_keys = client.get_host_keys()
-                client_host_keys.add(self.remote_host, 'ssh-rsa', self.host_key)
+                client_host_keys.add(self.remote_host, self.host_key.get_name(), self.host_key)
             else:
                 pass  # will fallback to system host keys if none explicitly specified in conn extra
 

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -93,7 +93,7 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
             },
         }
 
-    def __init__(  # pylint: disable=too-many-statements
+    def __init__(  # pylint: disable=too-many-statements, too-many-branches
         self,
         ssh_conn_id: Optional[str] = None,
         remote_host: Optional[str] = None,
@@ -127,7 +127,7 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
         self.client = None
 
         # Use connection to override defaults
-        if self.ssh_conn_id is not None:
+        if self.ssh_conn_id is not None:  # pylint: disable=too-many-nested-blocks
             conn = self.get_connection(self.ssh_conn_id)
             if self.username is None:
                 self.username = conn.login

--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -177,7 +177,7 @@ class SSHHook(BaseHook):  # pylint: disable=too-many-instance-attributes
 
                 if host_key is not None:
                     if host_key.startswith("ssh-"):
-                        key_type, host_key = host_key.split(" ")[:2]
+                        key_type, host_key = host_key.split(None)[:2]
                         key_constructor = _host_key_mappings[key_type[4:]]
                     else:
                         key_constructor = paramiko.RSAKey

--- a/docs/apache-airflow-providers-ssh/connections/ssh.rst
+++ b/docs/apache-airflow-providers-ssh/connections/ssh.rst
@@ -49,10 +49,10 @@ Extra (optional)
     * ``private_key_passphrase`` - Content of the private key passphrase used to decrypt the private key.
     * ``timeout`` - An optional timeout (in seconds) for the TCP connect. Default is ``10``.
     * ``compress`` - ``true`` to ask the remote client/server to compress traffic; ``false`` to refuse compression. Default is ``true``.
-    * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with either no entries in ``~/.ssh/known_hosts`` (Hosts file) or not present in the ``host_key`` extra. This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
+    * ``no_host_key_check`` - Set to ``false`` to restrict connecting to hosts with no entries in ``~/.ssh/known_hosts`` (Hosts file). This provides maximum protection against trojan horse attacks, but can be troublesome when the ``/etc/ssh/ssh_known_hosts`` file is poorly maintained or connections to new hosts are frequently made. This option forces the user to manually add all new hosts. Default is ``true``, ssh will automatically add new host keys to the user known hosts files.
     * ``allow_host_key_change`` - Set to ``true`` if you want to allow connecting to hosts that has host key changed or when you get 'REMOTE HOST IDENTIFICATION HAS CHANGED' error.  This wont protect against Man-In-The-Middle attacks. Other possible solution is to remove the host entry from ``~/.ssh/known_hosts`` file. Default is ``false``.
     * ``look_for_keys`` - Set to ``false`` if you want to disable searching for discoverable private key files in ``~/.ssh/``
-    * ``host_key`` - The base64 encoded ssh-rsa public key of the host, as you would find in the ``known_hosts`` file. Specifying this, along with ``no_host_key_check=False`` allows you to only make the connection if the public key of the endpoint matches this value.
+    * ``host_key`` - The base64 encoded ssh-rsa public key of the host or "ssh-<key type> <key data>" (as you would find in the ``known_hosts`` file). Specifying this allows making the connection if and only if the public key of the endpoint matches this value.
 
     Example "extras" field:
 
@@ -63,7 +63,6 @@ Extra (optional)
           "timeout": "10",
           "compress": "false",
           "look_for_keys": "false",
-          "no_host_key_check": "false",
           "allow_host_key_change": "false",
           "host_key": "AAAHD...YDWwq=="
        }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import os
 import subprocess
 import sys

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -211,6 +211,17 @@ class TestSFTPHook(unittest.TestCase):
         assert hook.host_key.get_base64() == TEST_HOST_KEY
 
     @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
+    def test_host_key_with_type(self, get_connection):
+        connection = Connection(
+            login='login',
+            host='host',
+            extra=json.dumps({"host_key": "ssh-rsa " + TEST_HOST_KEY, "no_host_key_check": False}),
+        )
+        get_connection.return_value = connection
+        hook = SFTPHook()
+        assert hook.host_key.get_base64() == TEST_HOST_KEY
+
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
     def test_host_key_with_no_host_key_check(self, get_connection):
         connection = Connection(login='login', host='host', extra=json.dumps({"host_key": TEST_HOST_KEY}))
         get_connection.return_value = connection

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -204,7 +204,7 @@ class TestSFTPHook(unittest.TestCase):
         connection = Connection(
             login='login',
             host='host',
-            extra=json.dumps({"host_key": TEST_HOST_KEY, "no_host_key_check": False}),
+            extra=json.dumps({"host_key": TEST_HOST_KEY}),
         )
         get_connection.return_value = connection
         hook = SFTPHook()
@@ -215,7 +215,7 @@ class TestSFTPHook(unittest.TestCase):
         connection = Connection(
             login='login',
             host='host',
-            extra=json.dumps({"host_key": "ssh-rsa " + TEST_HOST_KEY, "no_host_key_check": False}),
+            extra=json.dumps({"host_key": "ssh-rsa " + TEST_HOST_KEY}),
         )
         get_connection.return_value = connection
         hook = SFTPHook()
@@ -226,7 +226,7 @@ class TestSFTPHook(unittest.TestCase):
         connection = Connection(login='login', host='host', extra=json.dumps({"host_key": TEST_HOST_KEY}))
         get_connection.return_value = connection
         hook = SFTPHook()
-        assert hook.host_key is None
+        assert hook.host_key is not None
 
     @parameterized.expand(
         [

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -77,6 +77,7 @@ class TestSSHHook(unittest.TestCase):
     CONN_SSH_WITH_EXTRA = 'ssh_with_extra'
     CONN_SSH_WITH_EXTRA_FALSE_LOOK_FOR_KEYS = 'ssh_with_extra_false_look_for_keys'
     CONN_SSH_WITH_HOST_KEY_EXTRA = 'ssh_with_host_key_extra'
+    CONN_SSH_WITH_HOST_KEY_EXTRA_WITH_TYPE = 'ssh_with_host_key_extra_with_type'
     CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE = 'ssh_with_host_key_and_no_host_key_check_false'
     CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_TRUE = 'ssh_with_host_key_and_no_host_key_check_true'
     CONN_SSH_WITH_NO_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE = 'ssh_with_no_host_key_and_no_host_key_check_false'
@@ -90,6 +91,7 @@ class TestSSHHook(unittest.TestCase):
                 cls.CONN_SSH_WITH_PRIVATE_KEY_ECDSA_EXTRA,
                 cls.CONN_SSH_WITH_EXTRA,
                 cls.CONN_SSH_WITH_HOST_KEY_EXTRA,
+                cls.CONN_SSH_WITH_HOST_KEY_EXTRA_WITH_TYPE,
                 cls.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE,
                 cls.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_TRUE,
                 cls.CONN_SSH_WITH_NO_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE,
@@ -153,6 +155,14 @@ class TestSSHHook(unittest.TestCase):
                 host='localhost',
                 conn_type='ssh',
                 extra=json.dumps({"private_key": TEST_PRIVATE_KEY, "host_key": TEST_HOST_KEY}),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id=cls.CONN_SSH_WITH_HOST_KEY_EXTRA_WITH_TYPE,
+                host='localhost',
+                conn_type='ssh',
+                extra=json.dumps({"private_key": TEST_PRIVATE_KEY, "host_key": "ssh-rsa " + TEST_HOST_KEY}),
             )
         )
         db.merge_conn(
@@ -438,6 +448,14 @@ class TestSSHHook(unittest.TestCase):
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_extra(self, ssh_client):
         hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_EXTRA)
+        assert hook.host_key is None  # Since default no_host_key_check = True unless explicit override
+        with hook.get_conn():
+            assert ssh_client.return_value.connect.called is True
+            assert ssh_client.return_value.get_host_keys.return_value.add.called is False
+
+    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
+    def test_ssh_connection_with_host_key_extra_with_type(self, ssh_client):
+        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_EXTRA_WITH_TYPE)
         assert hook.host_key is None  # Since default no_host_key_check = True unless explicit override
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -448,34 +448,21 @@ class TestSSHHook(unittest.TestCase):
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_extra(self, ssh_client):
         hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_EXTRA)
-        assert hook.host_key is None  # Since default no_host_key_check = True unless explicit override
+        assert hook.host_key is not None
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
-            assert ssh_client.return_value.get_host_keys.return_value.add.called is False
+            assert ssh_client.return_value.get_host_keys.return_value.add.called
+            assert ssh_client.return_value.get_host_keys.return_value.add.call_args == mock.call(
+                hook.remote_host, 'ssh-rsa', hook.host_key
+            )
 
     @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
     def test_ssh_connection_with_host_key_extra_with_type(self, ssh_client):
         hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_EXTRA_WITH_TYPE)
-        assert hook.host_key is None  # Since default no_host_key_check = True unless explicit override
+        assert hook.host_key is not None
         with hook.get_conn():
             assert ssh_client.return_value.connect.called is True
-            assert ssh_client.return_value.get_host_keys.return_value.add.called is False
-
-    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
-    def test_ssh_connection_with_host_key_where_no_host_key_check_is_true(self, ssh_client):
-        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_TRUE)
-        assert hook.host_key is None
-        with hook.get_conn():
-            assert ssh_client.return_value.connect.called is True
-            assert ssh_client.return_value.get_host_keys.return_value.add.called is False
-
-    @mock.patch('airflow.providers.ssh.hooks.ssh.paramiko.SSHClient')
-    def test_ssh_connection_with_host_key_where_no_host_key_check_is_false(self, ssh_client):
-        hook = SSHHook(ssh_conn_id=self.CONN_SSH_WITH_HOST_KEY_AND_NO_HOST_KEY_CHECK_FALSE)
-        assert hook.host_key.get_base64() == TEST_HOST_KEY
-        with hook.get_conn():
-            assert ssh_client.return_value.connect.called is True
-            assert ssh_client.return_value.get_host_keys.return_value.add.called is True
+            assert ssh_client.return_value.get_host_keys.return_value.add.called
             assert ssh_client.return_value.get_host_keys.return_value.add.call_args == mock.call(
                 hook.remote_host, 'ssh-rsa', hook.host_key
             )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This adds support for specifying an SSH client host key along with its type, e.g.

```
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGTA+qK7VvFL3oZTgbVwFYcp5ZrPiRkPQd8YhVZDH946
```

Previously, only an RSA key was supported.

A key name (which is optional in the _known hosts_ format) is allowed  – but ignored.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
