### PR TITLE
podAntiAffinity for scheduler, webserver, and workers

### DIFF
--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -145,6 +145,16 @@ class SchedulerTest(unittest.TestCase):
             docs[0],
         )
 
+    def test_should_create_default_affinity(self):
+        docs = render_chart(show_only=["templates/scheduler/scheduler-deployment.yaml"])
+
+        assert {"component": "scheduler"} == jmespath.search(
+            "spec.template.spec.affinity.podAntiAffinity."
+            "preferredDuringSchedulingIgnoredDuringExecution[0]."
+            "podAffinityTerm.labelSelector.matchLabels",
+            docs[0],
+        )
+
     def test_livenessprobe_values_are_configurable(self):
         docs = render_chart(
             values={

--- a/chart/tests/test_webserver.py
+++ b/chart/tests/test_webserver.py
@@ -198,6 +198,16 @@ class WebserverDeploymentTest(unittest.TestCase):
             docs[0],
         )
 
+    def test_should_create_default_affinity(self):
+        docs = render_chart(show_only=["templates/webserver/webserver-deployment.yaml"])
+
+        assert {"component": "webserver"} == jmespath.search(
+            "spec.template.spec.affinity.podAntiAffinity."
+            "preferredDuringSchedulingIgnoredDuringExecution[0]."
+            "podAffinityTerm.labelSelector.matchLabels",
+            docs[0],
+        )
+
     @parameterized.expand(
         [
             ({"enabled": False}, None),

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -200,6 +200,16 @@ class WorkerTest(unittest.TestCase):
             docs[0],
         )
 
+    def test_should_create_default_affinity(self):
+        docs = render_chart(show_only=["templates/workers/worker-deployment.yaml"])
+
+        assert {"component": "worker"} == jmespath.search(
+            "spec.template.spec.affinity.podAntiAffinity."
+            "preferredDuringSchedulingIgnoredDuringExecution[0]."
+            "podAffinityTerm.labelSelector.matchLabels",
+            docs[0],
+        )
+
     @parameterized.expand(
         [
             ({"enabled": False}, {"emptyDir": {}}),

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1058,7 +1058,7 @@
                 "affinity": {
                     "description": "Specify scheduling constraints for worker pods.",
                     "type": "object",
-                    "default": {}
+                    "default": "See values.yaml"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for worker pods.",
@@ -1298,7 +1298,7 @@
                 "affinity": {
                     "description": "Specify scheduling constraints for scheduler pods.",
                     "type": "object",
-                    "default": {}
+                    "default": "See values.yaml"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for scheduler pods.",
@@ -1678,7 +1678,7 @@
                 "affinity": {
                     "description": "Specify scheduling constraints for webserver pods.",
                     "type": "object",
-                    "default": {}
+                    "default": "See values.yaml"
                 },
                 "tolerations": {
                     "description": "Specify Tolerations for webserver pods.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -421,7 +421,15 @@ workers:
 
   # Select certain nodes for airflow worker pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                component: worker
+            topologyKey: "kubernetes.io/hostname"
   tolerations: []
   # hostAliases to use in worker pods.
   # See:
@@ -507,7 +515,15 @@ scheduler:
 
   # Select certain nodes for airflow scheduler pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                component: scheduler
+            topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
   logGroomerSidecar:
@@ -637,7 +653,15 @@ webserver:
 
   # Select certain nodes for airflow webserver pods.
   nodeSelector: {}
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                component: webserver
+            topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
 # Flower settings


### PR DESCRIPTION
Set default podAntiAffinity for the components that can scale, as in
most cases you'd want them spread across available nodes.