### PR TITLE
Use updated _get_all_non_dag_permissions method.

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -216,7 +216,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
     def bulk_sync_roles(self, roles):
         """Sync the provided roles and permissions."""
         existing_roles = self._get_all_roles_with_permissions()
-        non_dag_perms = self._get_all_non_dag_permissionviews()
+        non_dag_perms = self._get_all_non_dag_permissions()
 
         for config in roles:
             role_name = config['role']
@@ -639,7 +639,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
             .all()
         )
 
-    def _get_all_non_dag_permissionviews(self) -> Dict[Tuple[str, str], PermissionView]:
+    def _get_all_non_dag_permissions(self) -> Dict[Tuple[str, str], PermissionView]:
         """
         Returns a dict with a key of (action_name, resource_name) and value of permission
         with all permissions except those that are for specific DAGs.

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -617,9 +617,9 @@ class TestSecurity(unittest.TestCase):
 
         assert ('can_read', 'Connections') in perms
 
-    def test_get_all_non_dag_permissionviews(self):
+    def test_get_all_non_dag_permissions(self):
         with assert_queries_count(1):
-            pvs = self.security_manager._get_all_non_dag_permissionviews()
+            pvs = self.security_manager._get_all_non_dag_permissions()
 
         assert isinstance(pvs, dict)
         for (perm_name, viewmodel_name), perm_view in pvs.items():


### PR DESCRIPTION
Modifies `_get_all_non_dag_permissionviews` to `_get_all_non_dag_permissions` so the updated permission names are used.