### PR TITLE
Fix API List DAGs inconsistent with UI/CLI

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -64,11 +64,11 @@ def get_dags(limit, session, offset=0):
     """Get all DAGs."""
     dags_query = session.query(DagModel).filter(~DagModel.is_subdag, DagModel.is_active)
 
-    readable_dags = current_app.appbuilder.sm.get_readable_dags(g.user)
-    total_entries = readable_dags.count()
+    readable_dags = current_app.appbuilder.sm.get_accessible_dag_ids(g.user)
 
     dags_query = dags_query.filter(DagModel.dag_id.in_(readable_dags))
     dags = dags_query.order_by(DagModel.dag_id).offset(offset).limit(limit).all()
+    total_entries = len(dags)
 
     return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
 

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -59,11 +59,16 @@ def get_dag_details(dag_id):
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 @format_parameters({'limit': check_limit})
-def get_dags(limit, offset=0):
+@provide_session
+def get_dags(limit, session, offset=0):
     """Get all DAGs."""
+    dags_query = session.query(DagModel).filter(~DagModel.is_subdag, DagModel.is_active)
+
     readable_dags = current_app.appbuilder.sm.get_readable_dags(g.user)
-    dags = readable_dags.order_by(DagModel.dag_id).offset(offset).limit(limit).all()
     total_entries = readable_dags.count()
+
+    dags_query = dags_query.filter(DagModel.dag_id.in_(readable_dags))
+    dags = dags_query.order_by(DagModel.dag_id).offset(offset).limit(limit).all()
 
     return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
 

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -67,8 +67,9 @@ def get_dags(limit, session, offset=0):
     readable_dags = current_app.appbuilder.sm.get_accessible_dag_ids(g.user)
 
     dags_query = dags_query.filter(DagModel.dag_id.in_(readable_dags))
+    total_entries = len(dags_query.all())
+
     dags = dags_query.order_by(DagModel.dag_id).offset(offset).limit(limit).all()
-    total_entries = len(dags)
 
     return dags_collection_schema.dump(DAGCollection(dags=dags, total_entries=total_entries))
 

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -126,8 +126,8 @@ class TestDagEndpoint:
     @provide_session
     def _create_deactivated_dag(self, session=None):
         dag_model = DagModel(
-            dag_id=f"TEST_DAG_DELETED_{num}",
-            fileloc=f"/tmp/dag_del_{num}.py",
+            dag_id=f"TEST_DAG_DELETED_1",
+            fileloc=f"/tmp/dag_del_1.py",
             schedule_interval="2 2 * * *",
             is_active=False,
         )

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -123,6 +123,7 @@ class TestDagEndpoint:
                 schedule_interval="2 2 * * *",
             )
             session.add(dag_model)
+
     @provide_session
     def _create_deactivated_dag(self, session=None):
         dag_model = DagModel(

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -123,6 +123,15 @@ class TestDagEndpoint:
                 schedule_interval="2 2 * * *",
             )
             session.add(dag_model)
+    @provide_session
+    def _create_deactivated_dag(self, session=None):
+        dag_model = DagModel(
+            dag_id=f"TEST_DAG_DELETED_{num}",
+            fileloc=f"/tmp/dag_del_{num}.py",
+            schedule_interval="2 2 * * *",
+            is_active=False,
+        )
+        session.add(dag_model)
 
 
 class TestGetDag(TestDagEndpoint):
@@ -387,6 +396,7 @@ class TestGetDagDetails(TestDagEndpoint):
 class TestGetDags(TestDagEndpoint):
     def test_should_respond_200(self):
         self._create_dag_models(2)
+        self._create_deactivated_dag()
 
         response = self.client.get("api/v1/dags", environ_overrides={'REMOTE_USER': "test"})
         file_token = SERIALIZER.dumps("/tmp/dag_1.py")

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -121,6 +121,7 @@ class TestDagEndpoint:
                 dag_id=f"TEST_DAG_{num}",
                 fileloc=f"/tmp/dag_{num}.py",
                 schedule_interval="2 2 * * *",
+                owners['test', 'airflow'],
             )
             session.add(dag_model)
 
@@ -130,6 +131,7 @@ class TestDagEndpoint:
             dag_id="TEST_DAG_DELETED_1",
             fileloc="/tmp/dag_del_1.py",
             schedule_interval="2 2 * * *",
+            owners['test', 'airflow'],
             is_active=False,
         )
         session.add(dag_model)

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -121,7 +121,7 @@ class TestDagEndpoint:
                 dag_id=f"TEST_DAG_{num}",
                 fileloc=f"/tmp/dag_{num}.py",
                 schedule_interval="2 2 * * *",
-                owners=['test', 'airflow'],
+                is_active=True,
             )
             session.add(dag_model)
 
@@ -131,7 +131,6 @@ class TestDagEndpoint:
             dag_id="TEST_DAG_DELETED_1",
             fileloc="/tmp/dag_del_1.py",
             schedule_interval="2 2 * * *",
-            owners=['test', 'airflow'],
             is_active=False,
         )
         session.add(dag_model)

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -121,7 +121,7 @@ class TestDagEndpoint:
                 dag_id=f"TEST_DAG_{num}",
                 fileloc=f"/tmp/dag_{num}.py",
                 schedule_interval="2 2 * * *",
-                owners['test', 'airflow'],
+                owners=['test', 'airflow'],
             )
             session.add(dag_model)
 
@@ -131,7 +131,7 @@ class TestDagEndpoint:
             dag_id="TEST_DAG_DELETED_1",
             fileloc="/tmp/dag_del_1.py",
             schedule_interval="2 2 * * *",
-            owners['test', 'airflow'],
+            owners=['test', 'airflow'],
             is_active=False,
         )
         session.add(dag_model)


### PR DESCRIPTION
related: #16228

`/api/v1/dags` should yield the same output as the Web UI and CLI, namely:
- show all dags
- that the user has access to
- which are present as DAG (can be scheduled, source file available)

The current implementation does only list DAGs that the user has access to, but fails to get the true DAG bag list. Which means the API endpoint is showing many more, deleted DAGs, that the UI and Web CLI do not.

