### PR TITLE
fix flask-ouathlib to flask-oauthlib

### DIFF
--- a/docs/apache-airflow/upgrading-to-2.rst
+++ b/docs/apache-airflow/upgrading-to-2.rst
@@ -336,7 +336,7 @@ the only supported UI.
     to use randomly generated secret keys instead of an insecure default and may break existing
     deployments that rely on the default.
 
-The ``flask-ouathlib`` has been replaced with ``authlib`` because ``flask-outhlib`` has
+The ``flask-oauthlib`` has been replaced with ``authlib`` because ``flask-oauthlib`` has
 been deprecated in favor of ``authlib``.
 The Old and New provider configuration keys that have changed are as follows
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
flask-ouathlib is not exists on pypi. https://pypi.org/search/?q=flask-ouath
 So it may be mistyped.
It may be correct to [Flask-OAuthlib](https://pypi.org/project/Flask-OAuthlib/)

