### PR TITLE
Make job name check optional in SageMakerTrainingOperator

### DIFF
--- a/airflow/providers/amazon/aws/operators/sagemaker_training.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_training.py
@@ -113,19 +113,15 @@ class SageMakerTrainingOperator(SageMakerBaseOperator):
 
     def _check_if_job_exists(self) -> None:
         training_job_name = self.config["TrainingJobName"]
-        training_jobs = self.hook.list_training_jobs(
-            name_contains=training_job_name)
+        training_jobs = self.hook.list_training_jobs(name_contains=training_job_name)
 
         # Check if given TrainingJobName already exists
-        if training_job_name in [tj["TrainingJobName"] for tj in
-                                 training_jobs]:
+        if training_job_name in [tj["TrainingJobName"] for tj in training_jobs]:
             if self.action_if_job_exists == "increment":
-                self.log.info("Found existing training job with name '%s'.",
-                              training_job_name)
+                self.log.info("Found existing training job with name '%s'.", training_job_name)
                 new_training_job_name = f"{training_job_name}-{len(training_jobs) + 1}"
                 self.config["TrainingJobName"] = new_training_job_name
-                self.log.info("Incremented training job name to '%s'.",
-                              new_training_job_name)
+                self.log.info("Incremented training job name to '%s'.", new_training_job_name)
             elif self.action_if_job_exists == "fail":
                 raise AirflowException(
                     f"A SageMaker training job with name {training_job_name} already exists."

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -86,12 +86,33 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
 
     @mock.patch.object(SageMakerHook, 'get_conn')
     @mock.patch.object(SageMakerHook, 'create_training_job')
-    def test_execute(self, mock_training, mock_client):
+    def test_execute_with_check_if_job_exists(self, mock_training, mock_client):
         mock_training.return_value = {
             'TrainingJobArn': 'testarn',
             'ResponseMetadata': {'HTTPStatusCode': 200},
         }
+        self.sagemaker._check_if_job_exists = mock.MagicMock()
         self.sagemaker.execute(None)
+        self.sagemaker._check_if_job_exists.assert_called_once()
+        mock_training.assert_called_once_with(
+            create_training_params,
+            wait_for_completion=False,
+            print_log=True,
+            check_interval=5,
+            max_ingestion_time=None,
+        )
+
+    @mock.patch.object(SageMakerHook, 'get_conn')
+    @mock.patch.object(SageMakerHook, 'create_training_job')
+    def test_execute_without_check_if_job_exists(self, mock_training, mock_client):
+        mock_training.return_value = {
+            'TrainingJobArn': 'testarn',
+            'ResponseMetadata': {'HTTPStatusCode': 200},
+        }
+        self.sagemaker.check_if_job_exists = False
+        self.sagemaker._check_if_job_exists = mock.MagicMock()
+        self.sagemaker.execute(None)
+        self.sagemaker._check_if_job_exists.assert_not_called()
         mock_training.assert_called_once_with(
             create_training_params,
             wait_for_completion=False,
@@ -110,38 +131,29 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
         with pytest.raises(AirflowException):
             self.sagemaker.execute(None)
 
-    # pylint: enable=unused-argument
-
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "list_training_jobs")
-    @mock.patch.object(SageMakerHook, "create_training_job")
-    def test_execute_with_existing_job_increment(
-        self, mock_create_training_job, mock_list_training_jobs, mock_client
+    def test_check_if_job_exists_increment(
+        self, mock_list_training_jobs, mock_client
     ):
+        self.sagemaker.check_if_job_exists = True
         self.sagemaker.action_if_job_exists = "increment"
-        mock_create_training_job.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
         mock_list_training_jobs.return_value = [{"TrainingJobName": job_name}]
-        self.sagemaker.execute(None)
+        self.sagemaker._check_if_job_exists()
 
         expected_config = create_training_params.copy()
         # Expect to see TrainingJobName suffixed with "-2" because we return one existing job
         expected_config["TrainingJobName"] = f"{job_name}-2"
-        mock_create_training_job.assert_called_once_with(
-            expected_config,
-            wait_for_completion=False,
-            print_log=True,
-            check_interval=5,
-            max_ingestion_time=None,
-        )
+        assert self.sagemaker.config == expected_config
+
 
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "list_training_jobs")
-    @mock.patch.object(SageMakerHook, "create_training_job")
-    def test_execute_with_existing_job_fail(
-        self, mock_create_training_job, mock_list_training_jobs, mock_client
+    def test_check_if_job_exists_fail(
+        self, mock_list_training_jobs, mock_client
     ):
+        self.sagemaker.check_if_job_exists = True
         self.sagemaker.action_if_job_exists = "fail"
-        mock_create_training_job.return_value = {"ResponseMetadata": {"HTTPStatusCode": 200}}
         mock_list_training_jobs.return_value = [{"TrainingJobName": job_name}]
         with pytest.raises(AirflowException):
-            self.sagemaker.execute(None)
+            self.sagemaker._check_if_job_exists()

--- a/tests/providers/amazon/aws/operators/test_sagemaker_training.py
+++ b/tests/providers/amazon/aws/operators/test_sagemaker_training.py
@@ -133,9 +133,7 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
 
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "list_training_jobs")
-    def test_check_if_job_exists_increment(
-        self, mock_list_training_jobs, mock_client
-    ):
+    def test_check_if_job_exists_increment(self, mock_list_training_jobs, mock_client):
         self.sagemaker.check_if_job_exists = True
         self.sagemaker.action_if_job_exists = "increment"
         mock_list_training_jobs.return_value = [{"TrainingJobName": job_name}]
@@ -146,12 +144,9 @@ class TestSageMakerTrainingOperator(unittest.TestCase):
         expected_config["TrainingJobName"] = f"{job_name}-2"
         assert self.sagemaker.config == expected_config
 
-
     @mock.patch.object(SageMakerHook, "get_conn")
     @mock.patch.object(SageMakerHook, "list_training_jobs")
-    def test_check_if_job_exists_fail(
-        self, mock_list_training_jobs, mock_client
-    ):
+    def test_check_if_job_exists_fail(self, mock_list_training_jobs, mock_client):
         self.sagemaker.check_if_job_exists = True
         self.sagemaker.action_if_job_exists = "fail"
         mock_list_training_jobs.return_value = [{"TrainingJobName": job_name}]


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #16299

In this PR I make it possible to avoid listing existing training jobs by adding a `check_if_job_exists` parameter to the SageMakerTrainingOperator.