### PR TITLE
Support job level annotations; fix jobs scheduling config

### DIFF
--- a/chart/UPDATING.md
+++ b/chart/UPDATING.md
@@ -59,3 +59,8 @@ If you have them set in your values file you can safely remove them.
 
 The `dags.gitSync.excludeWebserver` parameter was mistakenly included in the charts `values.schema.json`. If you have it set in your values file,
 you can safely remove it.
+
+### `nodeSelector`, `affinity` and `tolerations` on `migrateDatabaseJob` and `createUserJob` jobs
+
+The `migrateDatabaseJob` and `createUserJob` jobs were incorrectly using the `webserver`'s `nodeSelector`, `affinity`
+and `tolerations` (if set). Each job is now configured separately.

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -19,9 +19,9 @@
 ## Airflow Create User Job
 #################################
 {{- if .Values.webserver.defaultUser.enabled }}
-{{- $nodeSelector := or .Values.webserver.nodeSelector .Values.nodeSelector }}
-{{- $affinity := or .Values.webserver.affinity .Values.affinity }}
-{{- $tolerations := or .Values.webserver.tolerations .Values.tolerations }}
+{{- $nodeSelector := or .Values.createUserJob.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.createUserJob.affinity .Values.affinity }}
+{{- $tolerations := or .Values.createUserJob.tolerations .Values.tolerations }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,6 +39,9 @@ metadata:
     "helm.sh/hook": post-install
     "helm.sh/hook-weight": "2"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if .Values.createUserJob.jobAnnotations }}
+    {{- toYaml .Values.createUserJob.jobAnnotations | nindent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -18,9 +18,9 @@
 ################################
 ## Airflow Run Migrations
 #################################
-{{- $nodeSelector := or .Values.webserver.nodeSelector .Values.nodeSelector }}
-{{- $affinity := or .Values.webserver.affinity .Values.affinity }}
-{{- $tolerations := or .Values.webserver.tolerations .Values.tolerations }}
+{{- $nodeSelector := or .Values.migrateDatabaseJob.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.migrateDatabaseJob.affinity .Values.affinity }}
+{{- $tolerations := or .Values.migrateDatabaseJob.tolerations .Values.tolerations }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -38,6 +38,9 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if .Values.migrateDatabaseJob.jobAnnotations }}
+    {{- toYaml .Values.migrateDatabaseJob.jobAnnotations | nindent 4 }}
+    {{- end }}
 spec:
   template:
     metadata:

--- a/chart/tests/test_create_user_job.py
+++ b/chart/tests/test_create_user_job.py
@@ -31,9 +31,56 @@ class CreateUserJobTest(unittest.TestCase):
 
     def test_should_support_annotations(self):
         docs = render_chart(
-            values={"createUserJob": {"annotations": {"foo": "bar"}}},
+            values={"createUserJob": {"annotations": {"foo": "bar"}, "jobAnnotations": {"fiz": "fuz"}}},
             show_only=["templates/jobs/create-user-job.yaml"],
         )
         annotations = jmespath.search("spec.template.metadata.annotations", docs[0])
         assert "foo" in annotations
         assert "bar" == annotations["foo"]
+        job_annotations = jmespath.search("metadata.annotations", docs[0])
+        assert "fiz" in job_annotations
+        assert "fuz" == job_annotations["fiz"]
+
+    def test_should_create_valid_affinity_tolerations_and_node_selector(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "affinity": {
+                        "nodeAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "nodeSelectorTerms": [
+                                    {
+                                        "matchExpressions": [
+                                            {"key": "foo", "operator": "In", "values": ["true"]},
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "tolerations": [
+                        {"key": "dynamic-pods", "operator": "Equal", "value": "true", "effect": "NoSchedule"}
+                    ],
+                    "nodeSelector": {"diskType": "ssd"},
+                }
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+
+        assert "Job" == jmespath.search("kind", docs[0])
+        assert "foo" == jmespath.search(
+            "spec.template.spec.affinity.nodeAffinity."
+            "requiredDuringSchedulingIgnoredDuringExecution."
+            "nodeSelectorTerms[0]."
+            "matchExpressions[0]."
+            "key",
+            docs[0],
+        )
+        assert "ssd" == jmespath.search(
+            "spec.template.spec.nodeSelector.diskType",
+            docs[0],
+        )
+        assert "dynamic-pods" == jmespath.search(
+            "spec.template.spec.tolerations[0].key",
+            docs[0],
+        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1354,6 +1354,11 @@
                     "type": "object",
                     "default": {}
                 },
+                "jobAnnotations": {
+                    "description": "Annotations to add to the create user job job.",
+                    "type": "object",
+                    "default": {}
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",
@@ -1377,6 +1382,24 @@
                             "default": {}
                         }
                     }
+                },
+                "nodeSelector": {
+                    "description": "Select certain nodes for the create user job pod.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "affinity": {
+                    "description": "Specify scheduling constraints for the create user job pod.",
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "description": "Specify Tolerations for the create user job pod.",
+                    "type": "array",
+                    "default": []
                 }
             }
         },
@@ -1388,6 +1411,11 @@
             "properties": {
                 "annotations": {
                     "description": "Annotations to add to the migrate database job pod.",
+                    "type": "object",
+                    "default": {}
+                },
+                "jobAnnotations": {
+                    "description": "Annotations to add to the migrate database job.",
                     "type": "object",
                     "default": {}
                 },
@@ -1414,6 +1442,24 @@
                             "default": {}
                         }
                     }
+                },
+                "nodeSelector": {
+                    "description": "Select certain nodes for the migrate database job pod.",
+                    "type": "object",
+                    "default": {},
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "affinity": {
+                    "description": "Specify scheduling constraints for the migrate database job pod.",
+                    "type": "object",
+                    "default": {}
+                },
+                "tolerations": {
+                    "description": "Specify Tolerations for the migrate database job pod.",
+                    "type": "array",
+                    "default": []
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -522,6 +522,8 @@ scheduler:
 createUserJob:
   # Annotations on the create user job pod
   annotations: {}
+  # jobAnnotations are annotations on the create user job
+  jobAnnotations: {}
 
   # Create ServiceAccount
   serviceAccount:
@@ -534,10 +536,16 @@ createUserJob:
     # Annotations to add to create user kubernetes service account.
     annotations: {}
 
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
 # Airflow database migration job settings
 migrateDatabaseJob:
   # Annotations on the database migration pod
   annotations: {}
+  # jobAnnotations are annotations on the database migration job
+  jobAnnotations: {}
 
   # Create ServiceAccount
   serviceAccount:
@@ -549,6 +557,10 @@ migrateDatabaseJob:
 
     # Annotations to add to migrate database job kubernetes service account.
     annotations: {}
+
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 # Airflow webserver settings
 webserver:


### PR DESCRIPTION
Add job level annotations as some tooling needs to be able to add them.

Also fix jobs to use their own nodeSelector, affinity, and
tolerations.

Related to #16291