### PR TITLE
Bump pylint CI step to 60m timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           VERBOSE: false
 
   static-checks-pylint:
-    timeout-minutes: 30
+    timeout-minutes: 60
     name: "Pylint"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, ci-images]


### PR DESCRIPTION
The pylint step has been pretty consistenly timing out for me lately, so
bump the timeout higher. We can always reduce it later once things are
running more smoothly.

e.g:
https://github.com/apache/airflow/pull/16315/checks?check_run_id=2775624960
https://github.com/apache/airflow/pull/16315/checks?check_run_id=2774889367
https://github.com/apache/airflow/pull/16305/checks?check_run_id=2766223671
https://github.com/apache/airflow/pull/16305/checks?check_run_id=2775626584
