### PR TITLE
SFTP hook to prefer the SSH paramiko key over the key file path

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -135,8 +135,13 @@ class SFTPHook(SSHHook):
             }
             if self.password and self.password.strip():
                 conn_params['password'] = self.password
-            if self.key_file:
+
+            # Try to use the paramiko key from the SSH hook
+            if self.pkey:
+                conn_params['private_key'] = self.pkey
+            elif self.key_file:
                 conn_params['private_key'] = self.key_file
+
             if self.private_key_pass:
                 conn_params['private_key_pass'] = self.private_key_pass
 


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/16323

The SFTP hook does not allow for a SSH private key string to be used, only a private key file path. As it is based on the SSH hook, which does allow for a private key string to be used, a small change could align these two hooks.

This change first checks if a paramiko object is present after the SSH hook has been initialised, and the prefers that rather than the ssh key file path.

This is more a working idea than a finished PR, If this approach is deemed acceptable I'll be happy to turn this into a fully formed code change.

Thanks in advance.
