### PR TITLE
Always deploy a gitsync init container

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -135,7 +135,7 @@ If release name contains chart name it will be used as a full name.
 
 {{/*  Git sync container */}}
 {{- define "git_sync_container"}}
-- name: {{ .Values.dags.gitSync.containerName }}
+- name: {{ .Values.dags.gitSync.containerName }}{{ if .is_init }}-init{{ end }}
   image: {{ template "git_sync_image" . }}
   imagePullPolicy: {{ .Values.images.gitSync.pullPolicy }}
   securityContext:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -113,6 +113,9 @@ spec:
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+        {{- if .Values.dags.gitSync.enabled }}
+        {{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | nindent 8 }}
+        {{- end }}
         {{- if .Values.scheduler.extraInitContainers }}
         {{- toYaml .Values.scheduler.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -107,6 +107,9 @@ spec:
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) (semverCompare "<2.0.0" .Values.airflowVersion) }}
+        {{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | nindent 8 }}
+        {{- end }}
         {{- if .Values.webserver.extraInitContainers }}
         {{- toYaml .Values.webserver.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -123,6 +123,9 @@ spec:
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+        {{- if and (.Values.dags.gitSync.enabled) (not .Values.dags.persistence.enabled) }}
+        {{- include "git_sync_container" (dict "Values" .Values "is_init" "true") | nindent 8 }}
+        {{- end }}
         {{- if .Values.workers.extraInitContainers }}
         {{- toYaml .Values.workers.extraInitContainers | nindent 8 }}
         {{- end }}

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -85,7 +85,7 @@ class PodTemplateFileTest(unittest.TestCase):
 
         assert re.search("Pod", docs[0]["kind"])
         assert {
-            "name": "git-sync-test",
+            "name": "git-sync-test-init",
             "securityContext": {"runAsUser": 65533},
             "image": "test-registry/test-repo:test-tag",
             "imagePullPolicy": "Always",

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -364,3 +364,20 @@ class SchedulerTest(unittest.TestCase):
 
         assert ["RELEASE-NAME"] == jmespath.search("spec.template.spec.containers[1].command", docs[0])
         assert ["Helm"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
+
+    @parameterized.expand(
+        [
+            ({"gitSync": {"enabled": True}},),
+            ({"gitSync": {"enabled": True}, "persistence": {"enabled": True}},),
+        ]
+    )
+    def test_dags_gitsync_sidecar_and_init_container(self, dags_values):
+        docs = render_chart(
+            values={"dags": dags_values},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert "git-sync" in [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        assert "git-sync-init" in [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]

--- a/chart/tests/test_webserver.py
+++ b/chart/tests/test_webserver.py
@@ -369,7 +369,7 @@ class WebserverDeploymentTest(unittest.TestCase):
             "readOnly": expected_read_only,
         } in jmespath.search("spec.template.spec.containers[0].volumeMounts", docs[0])
 
-    def test_dags_gitsync_volume_and_sidecar(self):
+    def test_dags_gitsync_volume_and_sidecar_and_init_container(self):
         docs = render_chart(
             values={"dags": {"gitSync": {"enabled": True}}, "airflowVersion": "1.10.15"},
             show_only=["templates/webserver/webserver-deployment.yaml"],
@@ -377,6 +377,9 @@ class WebserverDeploymentTest(unittest.TestCase):
 
         assert {"name": "dags", "emptyDir": {}} in jmespath.search("spec.template.spec.volumes", docs[0])
         assert "git-sync" in [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        assert "git-sync-init" in [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]
 
     @parameterized.expand(
         [
@@ -395,8 +398,9 @@ class WebserverDeploymentTest(unittest.TestCase):
             "name": "dags",
             "persistentVolumeClaim": {"claimName": expected_claim_name},
         } in jmespath.search("spec.template.spec.volumes", docs[0])
-        # No gitsync sidecar
+        # No gitsync sidecar or init container
         assert 1 == len(jmespath.search("spec.template.spec.containers", docs[0]))
+        assert 1 == len(jmespath.search("spec.template.spec.initContainers", docs[0]))
 
 
 class WebserverServiceTest(unittest.TestCase):

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -367,3 +367,28 @@ class WorkerTest(unittest.TestCase):
 
         assert ["RELEASE-NAME"] == jmespath.search("spec.template.spec.containers[1].command", docs[0])
         assert ["Helm"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
+
+    def test_dags_gitsync_sidecar_and_init_container(self):
+        docs = render_chart(
+            values={"dags": {"gitSync": {"enabled": True}}},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        assert "git-sync" in [c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])]
+        assert "git-sync-init" in [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]
+
+    def test_dags_gitsync_with_persistence_no_sidecar_or_init_container(self):
+        docs = render_chart(
+            values={"dags": {"gitSync": {"enabled": True}, "persistence": {"enabled": True}}},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        # No gitsync sidecar or init container
+        assert "git-sync" not in [
+            c["name"] for c in jmespath.search("spec.template.spec.containers", docs[0])
+        ]
+        assert "git-sync-init" not in [
+            c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
+        ]


### PR DESCRIPTION
We will always deploy a gitsync init container anywhere we deploy a
gitsync sidecar, that way we ensure the main container has the DAGs when
it starts.