### PR TITLE
Pass parameters to PostgresHook from PostgresOperator

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -62,11 +62,16 @@ class PostgresOperator(BaseOperator):
         self.autocommit = autocommit
         self.parameters = parameters
         self.database = database
+        self.extra = kwargs.pop("extra", None)
         self.hook = None
 
     def execute(self, context):
         self.log.info('Executing: %s', self.sql)
-        self.hook = PostgresHook(postgres_conn_id=self.postgres_conn_id, schema=self.database)
+        self.hook = PostgresHook(
+            postgres_conn_id=self.postgres_conn_id,
+            schema=self.database,
+            extra=self.extra
+        )
         self.hook.run(self.sql, self.autocommit, parameters=self.parameters)
         for output in self.hook.conn.notices:
             self.log.info(output)


### PR DESCRIPTION
Passing extra kwargs from PostgresOperator to PostgresHook.

This shouldn't need extra tests because it is a minor update to the PostgresOperator that doesn't change core functionality, so the existing tests of this operator should still be sufficient.

There are no new dependencies introduced by this change and no backwards compatibility issues being introduced.

closes: #16340

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
