### PR TITLE
Remove ``[core] store_dag_code`` & use DB to get Dag Code

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -180,7 +180,7 @@ While DAG Serialization is a strict requirements since Airflow 2, we allowed use
 where the Webserver looked for when showing the **Code View**.
 
 If `[core] store_dag_code` was set to `True`, the Scheduler stored the code in the DAG file in the
-DB (in `dag_code` table) as plain string. And the webserver just read it from the same table.
+DB (in `dag_code` table) as a plain string, and the webserver just read it from the same table.
 If the value was set to `False`, the webserver read it from the DAG file.
 
 While this setting made sense for Airflow < 2, it caused some confusion to some users where they thought

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -174,6 +174,20 @@ with DAG(dag_id="task_concurrency_example"):
 
 When marking a task success/failed in Graph View, its downstream tasks that are in failed/upstream_failed state are automatically cleared.
 
+### `[core] store_dag_code` has been removed
+
+While DAG Serialization is a strict requirements since Airflow 2, we allowed users to control
+where the Webserver looked for when showing the **Code View**.
+
+If `[core] store_dag_code` was set to `True`, the Scheduler stored the code in the DAG file in the
+DB (in `dag_code` table) as plain string. And the webserver just read it from the same table.
+If the value was set to `False`, the webserver read it from the DAG file.
+
+While this setting made sense for Airflow < 2, it caused some confusion to some users where they thought
+this setting controlled DAG Serialization.
+
+From Airflow 2.2, Airflow will only look for DB when a user clicks on **Code View** for a DAG.
+
 ### Clearing a running task sets its state to `RESTARTING`
 
 Previously, clearing a running task sets its state to `SHUTDOWN`. The task gets killed and goes into `FAILED` state. After [#16681](https://github.com/apache/airflow/pull/16681), clearing a running task sets its state to `RESTARTING`. The task is eligible for retry without going into `FAILED` state.

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -360,16 +360,6 @@
       type: string
       example: ~
       default: "10"
-    - name: store_dag_code
-      description: |
-        Whether to persist DAG files code in DB.
-        If set to True, Webserver reads file contents from DB instead of
-        trying to access files in a DAG folder.
-        (Default is ``True``)
-      version_added: 1.10.10
-      type: string
-      example: "True"
-      default: "True"
     - name: max_num_rendered_ti_fields_per_task
       description: |
         Maximum number of Rendered Task Instance Fields (Template Fields) per task to store

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -209,13 +209,6 @@ min_serialized_dag_update_interval = 30
 # read rate. This config controls when your DAGs are updated in the Webserver
 min_serialized_dag_fetch_interval = 10
 
-# Whether to persist DAG files code in DB.
-# If set to True, Webserver reads file contents from DB instead of
-# trying to access files in a DAG folder.
-# (Default is ``True``)
-# Example: store_dag_code = True
-store_dag_code = True
-
 # Maximum number of Rendered Task Instance Fields (Template Fields) per task to store
 # in the Database.
 # All the template_fields for each of Task Instance are stored in the Database.

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -42,7 +42,6 @@ from airflow.dag_processing.processor import DagFileProcessorProcess
 from airflow.models import DagModel, errors
 from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance
-from airflow.settings import STORE_DAG_CODE
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.callback_requests import CallbackRequest, SlaCallbackRequest, TaskCallbackRequest
@@ -443,8 +442,6 @@ class DagFileProcessorManager(LoggingMixin):
         # How many seconds do we wait for tasks to heartbeat before mark them as zombies.
         self._zombie_threshold_secs = conf.getint('scheduler', 'scheduler_zombie_task_threshold')
 
-        # Should store dag file source in a database?
-        self.store_dag_code = STORE_DAG_CODE
         # Map from file path to the processor
         self._processors: Dict[str, DagFileProcessorProcess] = {}
 
@@ -667,10 +664,9 @@ class DagFileProcessorManager(LoggingMixin):
             SerializedDagModel.remove_deleted_dags(self._file_paths)
             DagModel.deactivate_deleted_dags(self._file_paths)
 
-            if self.store_dag_code:
-                from airflow.models.dagcode import DagCode
+            from airflow.models.dagcode import DagCode
 
-                DagCode.remove_deleted_code(self._file_paths)
+            DagCode.remove_deleted_code(self._file_paths)
 
     def _print_stat(self):
         """Occasionally print out stats about how fast the files are getting processed"""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2253,8 +2253,7 @@ class DAG(LoggingMixin):
                         orm_dag.tags.append(dag_tag_orm)
                         session.add(dag_tag_orm)
 
-        if settings.STORE_DAG_CODE:
-            DagCode.bulk_sync_to_db(filelocs)
+        DagCode.bulk_sync_to_db(filelocs)
 
         # Issue SQL/finish "Unit of Work", but let @provide_session commit (or if passed a session, let caller
         # decide when to commit

--- a/airflow/models/dagcode.py
+++ b/airflow/models/dagcode.py
@@ -25,7 +25,6 @@ from sqlalchemy.sql.expression import literal
 
 from airflow.exceptions import AirflowException, DagCodeNotFound
 from airflow.models.base import Base
-from airflow.settings import STORE_DAG_CODE
 from airflow.utils import timezone
 from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import provide_session
@@ -38,9 +37,6 @@ class DagCode(Base):
     """A table for DAGs code.
 
     dag_code table contains code of DAG files synchronized by scheduler.
-    This feature is controlled by:
-
-    * ``[core] store_dag_code = True``: enable this feature
 
     For details on dag serialization see SerializedDagModel
     """
@@ -165,10 +161,7 @@ class DagCode(Base):
 
         :return: source code as string
         """
-        if STORE_DAG_CODE:
-            return cls._get_code_from_db(fileloc)
-        else:
-            return cls._get_code_from_file(fileloc)
+        return cls._get_code_from_db(fileloc)
 
     @staticmethod
     def _get_code_from_file(fileloc):

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -477,10 +477,6 @@ MIN_SERIALIZED_DAG_UPDATE_INTERVAL = conf.getint('core', 'min_serialized_dag_upd
 # read rate. This config controls when your DAGs are updated in the Webserver
 MIN_SERIALIZED_DAG_FETCH_INTERVAL = conf.getint('core', 'min_serialized_dag_fetch_interval', fallback=10)
 
-# Whether to persist DAG files code in DB. If set to True, Webserver reads file contents
-# from DB instead of trying to access files in a DAG folder.
-STORE_DAG_CODE = conf.getboolean("core", "store_dag_code", fallback=True)
-
 # If donot_modify_handlers=True, we do not modify logging handlers in task_run command
 # If the flag is set to False, we remove all handlers from the root logger
 # and add all handlers from 'airflow.task' logger to the root Logger. This is done

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -947,7 +947,9 @@ class Airflow(AirflowBaseView):
                 "Exception encountered during "
                 + f"dag_id retrieval/dag retrieval fallback/code highlighting:\n\n{e}\n"
             )
-            html_code = Markup('<p>Failed to load file.</p><p>Details: {}</p>').format(escape(all_errors))
+            html_code = Markup('<p>Failed to load DAG file Code.</p><p>Details: {}</p>').format(
+                escape(all_errors)
+            )
 
         return self.render_template(
             'airflow/dag_code.html',

--- a/docs/apache-airflow/dag-serialization.rst
+++ b/docs/apache-airflow/dag-serialization.rst
@@ -71,15 +71,12 @@ Add the following settings in ``airflow.cfg``:
 .. code-block:: ini
 
     [core]
-    store_dag_code = True
 
     # You can also update the following default configurations based on your needs
     min_serialized_dag_update_interval = 30
     min_serialized_dag_fetch_interval = 10
     max_num_rendered_ti_fields_per_task = 30
 
-*   ``store_dag_code``: This option decides whether to persist DAG files code in DB.
-    If set to True, the Webserver reads file contents from the DB instead of trying to access files in the DAG folder.
 *   ``min_serialized_dag_update_interval``: This flag sets the minimum interval (in seconds) after which
     the serialized DAGs in the DB should be updated. This helps in reducing database write rate.
 *   ``min_serialized_dag_fetch_interval``: This option controls how often the Serialized DAG will be re-fetched

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -653,21 +653,3 @@ notacommand = OK
 
     def test_confirm_unittest_mod(self):
         assert conf.get('core', 'unit_test_mode')
-
-    @conf_vars({})
-    def test_store_dag_code_default_config(self):
-        store_dag_code = conf.getboolean("core", "store_dag_code")
-        assert conf.has_option("core", "store_dag_code")
-        assert store_dag_code
-
-    @conf_vars({("core", "store_dag_code"): "True"})
-    def test_store_dag_code_config_when_set_to_true(self):
-        store_dag_code = conf.getboolean("core", "store_dag_code")
-        assert conf.has_option("core", "store_dag_code")
-        assert store_dag_code
-
-    @conf_vars({("core", "store_dag_code"): "False"})
-    def test_store_dag_code_config_when_set(self):
-        store_dag_code = conf.getboolean("core", "store_dag_code")
-        assert conf.has_option("core", "store_dag_code")
-        assert not store_dag_code

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -119,12 +119,9 @@ class TestSchedulerJob:
         self.null_exec = MockExecutor()
 
         # Since we don't want to store the code for the DAG defined in this file
-        with patch('airflow.dag_processing.manager.SerializedDagModel.remove_deleted_dags'), patch.object(
-            settings,
-            "STORE_DAG_CODE",
-            False,
+        with patch('airflow.dag_processing.manager.SerializedDagModel.remove_deleted_dags'), patch(
+            'airflow.models.dag.DagCode.bulk_sync_to_db'
         ):
-
             yield
 
         if self.scheduler_job and self.scheduler_job.processor_agent:
@@ -3305,7 +3302,6 @@ class TestSchedulerJobQueriesCount:
         ), conf_vars(
             {
                 ('scheduler', 'use_job_schedule'): 'True',
-                ('core', 'store_serialized_dags'): 'True',
                 # For longer running tests under heavy load, the min_serialized_dag_fetch_interval
                 # and min_serialized_dag_update_interval might kick-in and re-retrieve the record.
                 # This will increase the count of serliazied_dag.py.get() count.

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -70,7 +70,7 @@ class TestDag(unittest.TestCase):
     def setUp(self) -> None:
         clear_db_runs()
         clear_db_dags()
-        self.patcher_dag_code = patch.object(settings, "STORE_DAG_CODE", False)
+        self.patcher_dag_code = mock.patch('airflow.models.dag.DagCode.bulk_sync_to_db')
         self.patcher_dag_code.start()
 
     def tearDown(self) -> None:
@@ -939,7 +939,7 @@ class TestDag(unittest.TestCase):
         )
         dag.fileloc = dag_fileloc
         session = settings.Session()
-        with mock.patch.object(settings, "STORE_DAG_CODE", False):
+        with mock.patch('airflow.models.dag.DagCode.bulk_sync_to_db'):
             dag.sync_to_db(session=session)
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one()

--- a/tests/models/test_dagcode.py
+++ b/tests/models/test_dagcode.py
@@ -28,7 +28,6 @@ from airflow.models.dagcode import DagCode
 # To move it to a shared module.
 from airflow.utils.file import open_maybe_zipped
 from airflow.utils.session import create_session
-from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dag_code
 
 
@@ -55,8 +54,6 @@ class TestDagCode(unittest.TestCase):
         DagCode(xcom_dag.fileloc).sync_to_db()
         return [bash_dag, xcom_dag]
 
-    @conf_vars({('core', 'store_dag_code'): 'True'})
-    @patch("airflow.models.dag.settings.STORE_DAG_CODE", True)
     def _write_example_dags(self):
         example_dags = make_example_dags(example_dags_module)
         for dag in example_dags.values():
@@ -69,7 +66,6 @@ class TestDagCode(unittest.TestCase):
 
         self._compare_example_dags(example_dags)
 
-    @conf_vars({('core', 'store_dag_code'): 'True'})
     def test_bulk_sync_to_db(self):
         """Dg code can be bulk written into database."""
         example_dags = make_example_dags(example_dags_module)
@@ -80,7 +76,6 @@ class TestDagCode(unittest.TestCase):
 
         self._compare_example_dags(example_dags)
 
-    @conf_vars({('core', 'store_dag_code'): 'True'})
     def test_bulk_sync_to_db_half_files(self):
         """Dg code can be bulk written into database."""
         example_dags = make_example_dags(example_dags_module)
@@ -122,9 +117,6 @@ class TestDagCode(unittest.TestCase):
                     source_code = source.read()
                 assert result.source_code == source_code
 
-    @conf_vars({('core', 'store_dag_code'): 'True'})
-    @patch("airflow.models.dag.settings.STORE_DAG_CODE", True)
-    @patch("airflow.models.dagcode.STORE_DAG_CODE", True)
     def test_code_can_be_read_when_no_access_to_file(self):
         """
         Test that code can be retrieved from DB when you do not have access to Code file.
@@ -141,8 +133,6 @@ class TestDagCode(unittest.TestCase):
             for test_string in ['example_bash_operator', 'also_run_this', 'run_this_last']:
                 assert test_string in dag_code
 
-    @conf_vars({('core', 'store_dag_code'): 'True'})
-    @patch("airflow.models.dag.settings.STORE_DAG_CODE", True)
     def test_db_code_updated_on_dag_file_change(self):
         """Test if DagCode is updated in DB when DAG file is changed"""
         example_dag = make_example_dags(example_dags_module).get('example_bash_operator')

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -111,7 +111,7 @@ def dags(log_app):
     bag.bag_dag(dag=dag_removed, root_dag=dag_removed)
 
     # Since we don't want to store the code for the DAG defined in this file
-    with unittest.mock.patch.object(settings, "STORE_DAG_CODE", False):
+    with unittest.mock.patch('airflow.models.dag.DagCode.bulk_sync_to_db'):
         dag.sync_to_db()
         dag_removed.sync_to_db()
         bag.sync_to_db()

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -309,40 +309,26 @@ def test_last_dagruns_success_when_selecting_dags(admin_client):
 def test_code(admin_client):
     url = 'code?dag_id=example_bash_operator'
     resp = admin_client.get(url, follow_redirects=True)
-    check_content_not_in_response('Failed to load file', resp)
+    check_content_not_in_response('Failed to load DAG file Code', resp)
     check_content_in_response('example_bash_operator', resp)
 
 
-def test_code_no_file(admin_client):
-    url = 'code?dag_id=example_bash_operator'
-    mock_open_patch = unittest.mock.mock_open(read_data='')
-    mock_open_patch.side_effect = FileNotFoundError
-    with unittest.mock.patch('builtins.open', mock_open_patch), unittest.mock.patch(
-        "airflow.models.dagcode.STORE_DAG_CODE", False
-    ):
-        resp = admin_client.get(url, follow_redirects=True)
-        check_content_in_response('Failed to load file', resp)
-        check_content_in_response('example_bash_operator', resp)
-
-
-@conf_vars({("core", "store_dag_code"): "True"})
 def test_code_from_db(admin_client):
     dag = DagBag(include_examples=True).get_dag("example_bash_operator")
     DagCode(dag.fileloc, DagCode._get_code_from_file(dag.fileloc)).sync_to_db()
     url = 'code?dag_id=example_bash_operator'
     resp = admin_client.get(url)
-    check_content_not_in_response('Failed to load file', resp)
+    check_content_not_in_response('Failed to load DAG file Code', resp)
     check_content_in_response('example_bash_operator', resp)
 
 
-@conf_vars({("core", "store_dag_code"): "True"})
 def test_code_from_db_all_example_dags(admin_client):
     dagbag = DagBag(include_examples=True)
     for dag in dagbag.dags.values():
         DagCode(dag.fileloc, DagCode._get_code_from_file(dag.fileloc)).sync_to_db()
     url = 'code?dag_id=example_bash_operator'
     resp = admin_client.get(url)
-    check_content_not_in_response('Failed to load file', resp)
+    check_content_not_in_response('Failed to load DAG file Code', resp)
     check_content_in_response('example_bash_operator', resp)
 
 


### PR DESCRIPTION
While DAG Serialization is a strict requirements since Airflow 2, we allowed users to control
where the Webserver looked for when showing the **Code View**.

If `[core] store_dag_code` was set to `True`, the Scheduler stored the code in the DAG file in the
DB (in `dag_code` table) as plain string. And the webserver just read it from the same table.
If the value was set to `False`, the webserver read it from the DAG file.

While this setting made sense for Airflow < 2, it caused some confusion to some users where they thought
this setting controlled DAG Serialization.

From Airflow 2.2, Airflow will only look for DB when a user clicks on **Code View** for a DAG.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
