### PR TITLE
Only create dagruns when max_active_runs is not reached

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1549,8 +1549,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
 
     def _create_dag_runs(self, dag_models: Iterable[DagModel], session: Session) -> None:
         """
-        Unconditionally create a DAG run for the given DAG, and update the dag_model's fields to control
-        if/when the next DAGRun should be created
+        Create a DAG run for the given DAG if max_active_runs is not reached, and
+        update the dag_model's fields to control if/when the next DAGRun should be created
         """
         # Bulk Fetch DagRuns with dag_id and execution_date same
         # as DagModel.dag_id and DagModel.next_dagrun
@@ -1623,7 +1623,8 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         """
         Bulk update the next_dagrun and next_dagrun_create_after for all the dags.
 
-        We batch the select queries to get info about all the dags at once
+        The select queries are no longer badged because it causes a collission
+        with manual triggering of dagruns
         """
         for dag_model in dag_models:
             # Get the DAG in a try_except to not stop the Scheduler when a Serialized DAG is not found

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3940,8 +3940,6 @@ class TestSchedulerJob(unittest.TestCase):
         assert dag.get_last_dagrun(session) == dagrun
         assert dag2.get_last_dagrun(session) == dagrun2
 
-        # This poll interval is large, bug the scheduler doesn't sleep that
-        # long, instead we hit the update_dagrun_state_for_paused_dag_interval instead
         self.scheduler_job = SchedulerJob(num_runs=2, processor_poll_interval=30)
         self.scheduler_job.dagbag = dagbag
         executor = MockExecutor(do_update=False)


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/9975

Currently, we create dagruns unconditionaly when a DAG is unpaused or
when a dagrun is manually triggered. Because of this, when we set max_active_runs=1
and trigger a dagrun manually, the scheduled run will start at its time without respecting 
the max_active_runs
    
This change fixes it and only create dagruns when the conditions are right.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
