### PR TITLE
Allow disable SSL for TableauHook

### DIFF
--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -60,8 +60,9 @@ class TableauHook(BaseHook):
         super().__init__()
         self.tableau_conn_id = tableau_conn_id
         self.conn = self.get_connection(self.tableau_conn_id)
-        self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
-        self.server = Server(self.conn.host, use_server_version=True)
+        self.server = Server(self.conn.host)
+        self.server.add_http_options({'verify': self.conn.extra_dejson.get('verify', False)})
+        self.server.use_server_version()
         self.tableau_conn = None
 
     def __enter__(self):

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -21,6 +21,7 @@ from tableauserverclient import Pager, PersonalAccessTokenAuth, Server, TableauA
 from tableauserverclient.server import Auth
 
 from airflow.hooks.base import BaseHook
+from distutils.util import strtobool
 
 
 class TableauJobFinishCode(Enum):
@@ -58,7 +59,12 @@ class TableauHook(BaseHook):
         self.conn = self.get_connection(self.tableau_conn_id)
         self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
         self.server = Server(self.conn.host)
-        self.server.add_http_options(options_dict={'verify': self.conn.extra_dejson.get('verify', True),
+        verify = self.conn.extra_dejson.get('verify', 'True')
+        try:
+            verify = bool(strtobool(verify))
+        except ValueError:
+            pass
+        self.server.add_http_options(options_dict={'verify': verify,
                                                    'cert': self.conn.extra_dejson.get('cert', None)})
         self.server.use_server_version()
         self.tableau_conn = None

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -62,7 +62,7 @@ class TableauHook(BaseHook):
         self.conn = self.get_connection(self.tableau_conn_id)
         self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
         self.server = Server(self.conn.host)
-        self.server.add_http_options({'verify': self.conn.extra_dejson.get('verify', False)})
+        self.server.add_http_options(options_dict={'verify': self.conn.extra_dejson.get('verify', False)})
         self.server.use_server_version()
         self.tableau_conn = None
 

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -60,6 +60,7 @@ class TableauHook(BaseHook):
         super().__init__()
         self.tableau_conn_id = tableau_conn_id
         self.conn = self.get_connection(self.tableau_conn_id)
+        self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
         self.server = Server(self.conn.host)
         self.server.add_http_options({'verify': self.conn.extra_dejson.get('verify', False)})
         self.server.use_server_version()

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -39,7 +39,8 @@ class TableauJobFinishCode(Enum):
 class TableauHook(BaseHook):
     """
     Connects to the Tableau Server Instance and allows to communicate with it.
-    .. seealso:: https://tableau.github.io/server-client-python/docs/
+    .. see also:: https://tableau.github.io/server-client-python/docs/
+
     :param site_id: The id of the site where the workbook belongs to.
         It will connect to the default site if you don't provide an id.
     :type site_id: Optional[str]
@@ -107,7 +108,8 @@ class TableauHook(BaseHook):
     def get_all(self, resource_name: str) -> Pager:
         """
         Get all items of the given resource.
-        .. seealso:: https://tableau.github.io/server-client-python/docs/page-through-results
+        .. see also:: https://tableau.github.io/server-client-python/docs/page-through-results
+
         :param resource_name: The name of the resource to paginate.
             For example: jobs or workbooks
         :type resource_name: str

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -26,9 +26,7 @@ from airflow.hooks.base import BaseHook
 class TableauJobFinishCode(Enum):
     """
     The finish code indicates the status of the job.
-
     .. seealso:: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#query_job
-
     """
 
     PENDING = -1
@@ -40,9 +38,7 @@ class TableauJobFinishCode(Enum):
 class TableauHook(BaseHook):
     """
     Connects to the Tableau Server Instance and allows to communicate with it.
-
     .. seealso:: https://tableau.github.io/server-client-python/docs/
-
     :param site_id: The id of the site where the workbook belongs to.
         It will connect to the default site if you don't provide an id.
     :type site_id: Optional[str]
@@ -62,7 +58,8 @@ class TableauHook(BaseHook):
         self.conn = self.get_connection(self.tableau_conn_id)
         self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
         self.server = Server(self.conn.host)
-        self.server.add_http_options(options_dict={'verify': self.conn.extra_dejson.get('verify', False)})
+        self.server.add_http_options(options_dict={'verify': self.conn.extra_dejson.get('verify', True),
+                                                   'cert': self.conn.extra_dejson.get('cert', None)})
         self.server.use_server_version()
         self.tableau_conn = None
 
@@ -77,7 +74,6 @@ class TableauHook(BaseHook):
     def get_conn(self) -> Auth.contextmgr:
         """
         Signs in to the Tableau Server and automatically signs out if used as ContextManager.
-
         :return: an authorized Tableau Server Context Manager object.
         :rtype: tableauserverclient.server.Auth.contextmgr
         """
@@ -104,9 +100,7 @@ class TableauHook(BaseHook):
     def get_all(self, resource_name: str) -> Pager:
         """
         Get all items of the given resource.
-
         .. seealso:: https://tableau.github.io/server-client-python/docs/page-through-results
-
         :param resource_name: The name of the resource to paginate.
             For example: jobs or workbooks
         :type resource_name: str

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from distutils.util import strtobool
 from enum import Enum
 from typing import Any, Optional
 
@@ -21,7 +22,6 @@ from tableauserverclient import Pager, PersonalAccessTokenAuth, Server, TableauA
 from tableauserverclient.server import Auth
 
 from airflow.hooks.base import BaseHook
-from distutils.util import strtobool
 
 
 class TableauJobFinishCode(Enum):
@@ -64,8 +64,9 @@ class TableauHook(BaseHook):
             verify = bool(strtobool(verify))
         except ValueError:
             pass
-        self.server.add_http_options(options_dict={'verify': verify,
-                                                   'cert': self.conn.extra_dejson.get('cert', None)})
+        self.server.add_http_options(
+            options_dict={'verify': verify, 'cert': self.conn.extra_dejson.get('cert', None)}
+        )
         self.server.use_server_version()
         self.tableau_conn = None
 

--- a/docs/apache-airflow-providers-tableau/connections/tableau.rst
+++ b/docs/apache-airflow-providers-tableau/connections/tableau.rst
@@ -71,6 +71,9 @@ Extra (optional)
       This is used with token authentication.
     * ``personal_access_token``: The personal access token value.
       This is used with token authentication.
+    * ``verify``: Either a boolean, in which case it controls whether we verify the server’s TLS certificate, or a string, in which case it must be a path to a CA bundle to use. Defaults to True.
+    * ``cert``: if String, path to ssl client cert file (.pem). If Tuple, (‘cert’, ‘key’) pair.
+
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -54,12 +54,12 @@ class TestTableauHook(unittest.TestCase):
         )
         db.merge_conn(
             models.Connection(
-                conn_id='tableau_test_ssl_connection_verify_path',
+                conn_id='tableau_test_ssl_connection_certificates_path',
                 conn_type='tableau',
                 host='tableau',
                 login='user',
                 password='password',
-                extra='{"verify": "my_cert_path", "cert": "my_client_cert"}',
+                extra='{"verify": "my_cert_path", "cert": "my_client_cert_path"}',
             )
         )
         db.merge_conn(
@@ -124,8 +124,11 @@ class TestTableauHook(unittest.TestCase):
         with TableauHook(tableau_conn_id='tableau_test_ssl_connection_verify_path') as tableau_hook:
             mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_server.return_value.add_http_options.assert_called_once_with(
-                options_dict={'verify': tableau_hook.conn.extra_dejson['verify'],
-                              'cert': tableau_hook.conn.extra_dejson['cert']})
+                options_dict={
+                    'verify': tableau_hook.conn.extra_dejson['verify'],
+                    'cert': tableau_hook.conn.extra_dejson['cert'],
+                }
+            )
             mock_tableau_auth.assert_called_once_with(
                 username=tableau_hook.conn.login,
                 password=tableau_hook.conn.password,
@@ -143,8 +146,8 @@ class TestTableauHook(unittest.TestCase):
         with TableauHook(tableau_conn_id='tableau_test_ssl_connection_default') as tableau_hook:
             mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_server.return_value.add_http_options.assert_called_once_with(
-                options_dict={'verify': True,
-                              'cert': None})
+                options_dict={'verify': True, 'cert': None}
+            )
             mock_tableau_auth.assert_called_once_with(
                 token_name=tableau_hook.conn.extra_dejson['token_name'],
                 personal_access_token=tableau_hook.conn.extra_dejson['personal_access_token'],
@@ -164,8 +167,8 @@ class TestTableauHook(unittest.TestCase):
         with TableauHook(tableau_conn_id='tableau_test_ssl_false_connection') as tableau_hook:
             mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_server.return_value.add_http_options.assert_called_once_with(
-                options_dict={'verify': False,
-                              'cert': None})
+                options_dict={'verify': False, 'cert': None}
+            )
             mock_tableau_auth.assert_called_once_with(
                 username=tableau_hook.conn.login,
                 password=tableau_hook.conn.password,

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -121,7 +121,7 @@ class TestTableauHook(unittest.TestCase):
         """
         Test get conn with SSL parameters, verify as path
         """
-        with TableauHook(tableau_conn_id='tableau_test_ssl_connection_verify_path') as tableau_hook:
+        with TableauHook(tableau_conn_id='tableau_test_ssl_connection_certificates_path') as tableau_hook:
             mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_server.return_value.add_http_options.assert_called_once_with(
                 options_dict={

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -60,7 +60,7 @@ class TestTableauHook(unittest.TestCase):
         Test get conn auth via password
         """
         with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
-            mock_server.assert_called_once_with(tableau_hook.conn.host, use_server_version=True)
+            mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_tableau_auth.assert_called_once_with(
                 username=tableau_hook.conn.login,
                 password=tableau_hook.conn.password,
@@ -76,7 +76,7 @@ class TestTableauHook(unittest.TestCase):
         Test get conn auth via token
         """
         with TableauHook(site_id='test', tableau_conn_id='tableau_test_token') as tableau_hook:
-            mock_server.assert_called_once_with(tableau_hook.conn.host, use_server_version=True)
+            mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_tableau_auth.assert_called_once_with(
                 token_name=tableau_hook.conn.extra_dejson['token_name'],
                 personal_access_token=tableau_hook.conn.extra_dejson['personal_access_token'],

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -52,6 +52,24 @@ class TestTableauHook(unittest.TestCase):
                 extra='{"token_name": "my_token", "personal_access_token": "my_personal_access_token"}',
             )
         )
+        db.merge_conn(
+            models.Connection(
+                conn_id='tableau_test_ssl_connection',
+                conn_type='tableau',
+                host='tableau',
+                login='user',
+                password='password',
+                extra='{"verify": "my_cert", "cert": "my_client_cert"}',
+            )
+        )
+        db.merge_conn(
+            models.Connection(
+                conn_id='tableau_test_ssl_connection_default',
+                conn_type='tableau',
+                host='tableau',
+                extra='{"token_name": "my_token", "personal_access_token": "my_personal_access_token"}',
+            )
+        )
 
     @patch('airflow.providers.tableau.hooks.tableau.TableauAuth')
     @patch('airflow.providers.tableau.hooks.tableau.Server')
@@ -81,6 +99,46 @@ class TestTableauHook(unittest.TestCase):
                 token_name=tableau_hook.conn.extra_dejson['token_name'],
                 personal_access_token=tableau_hook.conn.extra_dejson['personal_access_token'],
                 site_id=tableau_hook.site_id,
+            )
+            mock_server.return_value.auth.sign_in_with_personal_access_token.assert_called_once_with(
+                mock_tableau_auth.return_value
+            )
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch('airflow.providers.tableau.hooks.tableau.TableauAuth')
+    @patch('airflow.providers.tableau.hooks.tableau.Server')
+    def test_get_conn_ssl(self, mock_server, mock_tableau_auth):
+        """
+        Test get conn with SSL parameters
+        """
+        with TableauHook(tableau_conn_id='tableau_test_ssl_connection') as tableau_hook:
+            mock_server.assert_called_once_with(tableau_hook.conn.host)
+            mock_server.return_value.add_http_options.assert_called_once_with(
+                options_dict={'verify': tableau_hook.conn.extra_dejson['verify'],
+                              'cert': tableau_hook.conn.extra_dejson['cert']})
+            mock_tableau_auth.assert_called_once_with(
+                username=tableau_hook.conn.login,
+                password=tableau_hook.conn.password,
+                site_id='',
+            )
+            mock_server.return_value.auth.sign_in.assert_called_once_with(mock_tableau_auth.return_value)
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch('airflow.providers.tableau.hooks.tableau.PersonalAccessTokenAuth')
+    @patch('airflow.providers.tableau.hooks.tableau.Server')
+    def test_get_conn_ssl_default(self, mock_server, mock_tableau_auth):
+        """
+        Test get conn with default SSL parameters
+        """
+        with TableauHook(tableau_conn_id='tableau_test_ssl_connection_default') as tableau_hook:
+            mock_server.assert_called_once_with(tableau_hook.conn.host)
+            mock_server.return_value.add_http_options.assert_called_once_with(
+                options_dict={'verify': True,
+                              'cert': None})
+            mock_tableau_auth.assert_called_once_with(
+                token_name=tableau_hook.conn.extra_dejson['token_name'],
+                personal_access_token=tableau_hook.conn.extra_dejson['personal_access_token'],
+                site_id='',
             )
             mock_server.return_value.auth.sign_in_with_personal_access_token.assert_called_once_with(
                 mock_tableau_auth.return_value


### PR DESCRIPTION
Hello all,
~~with the current implementation of the Tableau Hook is not possible to connect to a Tableau Server through SSL.~~ with the current implementation of the Tableau Hook is not possible to connect to a Tableau Server without SSL. This issue is due that the implementation of the hook does not consider the possibility to specify the certificate to verify.

With the new implementation, it is possible to specify that in extra parameter in HTTP or Tableau connection:

![image](https://user-images.githubusercontent.com/18025873/121507575-0bf17780-c9e5-11eb-885a-2d8d1a32f3aa.png)

I also updated the tests for Tableau Hook in order to adapt them to the new implementation.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).


Fixes: https://github.com/apache/airflow/issues/16306