### PR TITLE
Set num of retries for google cloud connection to 3.

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -277,6 +277,7 @@ def create_default_connections(session=None):
             conn_id="google_cloud_default",
             conn_type="google_cloud_platform",
             schema="default",
+            extra='{"extra__google_cloud_platform__num_retries": 3}',
         ),
         session,
     )


### PR DESCRIPTION
Can be useful in case of a connection being kept alive for
a very long time, for example because underneth it waits for a dataflow job.

related: #1397
