### PR TITLE
Use resource and action names.

### DIFF
--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -41,9 +41,9 @@ def _check_action_and_resource(sm, perms):
     This function is intended for use in the REST API because it raise 400
     """
     for item in perms:
-        if not sm.find_permission(item[0]):
+        if not sm.get_action(item[0]):
             raise BadRequest(detail=f"The specified action: '{item[0]}' was not found")
-        if not sm.find_view_menu(item[1]):
+        if not sm.get_resource(item[1]):
             raise BadRequest(detail=f"The specified resource: '{item[1]}' was not found")
 
 

--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -24,7 +24,7 @@ from airflow.www.app import cached_app
 def sync_perm(args):
     """Updates permissions for existing roles and DAGs"""
     appbuilder = cached_app().appbuilder  # pylint: disable=no-member
-    print('Updating permission, view-menu for all existing roles')
+    print('Updating actions and resources for all existing roles')
     # Add missing permissions for all the Base Views _before_ syncing/creating roles
     appbuilder.add_permissions(update_perms=True)
     appbuilder.sm.sync_roles()

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -193,7 +193,7 @@ class DAG(LoggingMixin):
     :param on_success_callback: Much like the ``on_failure_callback`` except
         that it is executed when the dag succeeds.
     :type on_success_callback: callable
-    :param access_control: Specify optional DAG-level permissions, e.g.,
+    :param access_control: Specify optional DAG-level actions, e.g.,
         "{'role1': {'can_read'}, 'role2': {'can_read', 'can_edit'}}"
     :type access_control: dict
     :param is_paused_upon_creation: Specifies if the dag is paused when created for the first time.
@@ -411,9 +411,9 @@ class DAG(LoggingMixin):
     @staticmethod
     def _upgrade_outdated_dag_access_control(access_control=None):
         """
-        Looks for outdated dag level permissions (can_dag_read and can_dag_edit) in DAG
+        Looks for outdated dag level actions (can_dag_read and can_dag_edit) in DAG
         access_controls (for example, {'role1': {'can_dag_read'}, 'role2': {'can_dag_read', 'can_dag_edit'}})
-        and replaces them with updated permissions (can_read and can_edit).
+        and replaces them with updated actions (can_read and can_edit).
         """
         if not access_control:
             return None

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -199,7 +199,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
 
     def init_role(self, role_name, perms):
         """
-        Initialize the role with the actions and related resources.
+        Initialize the role with actions and related resources.
         :param role_name:
         :param perms:
         :return:
@@ -230,7 +230,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):  # pylint: disable=
                     self.add_permission_to_role(role, perm)
 
     def add_permissions(self, role, perms):
-        """Adds resource permissions to a given role."""
+        """Adds permissions to a given role."""
         for action_name, resource_name in perms:
             permission = self.create_permission(action_name, resource_name)
             self.add_permission_to_role(role, permission)


### PR DESCRIPTION
Part of the Resource/Action FAB Name epic.

Updates `role_and_permission_endpoint.py` to use the new naming scheme.