### PR TITLE
Correctly set `dag.fileloc` when using the `@dag` decorator

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2348,6 +2348,10 @@ def dag(*dag_args, **dag_kwargs):
                 for name, value in f_sig.arguments.items():
                     f_kwargs[name] = dag_obj.param(name, value)
 
+                # set file location to caller source path
+                back = sys._getframe().f_back
+                dag_obj.fileloc = back.f_code.co_filename if back else ""
+
                 # Invoke function to create operators in the DAG scope.
                 f(**f_kwargs)
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1805,6 +1805,16 @@ class TestDagDecorator(unittest.TestCase):
         super().tearDown()
         clear_db_runs()
 
+    def test_fileloc(self):
+        @dag_decorator(default_args=self.DEFAULT_ARGS)
+        def noop_pipeline():
+            ...
+
+        dag = noop_pipeline()
+        assert isinstance(dag, DAG)
+        assert dag.dag_id, 'noop_pipeline'
+        assert dag.fileloc == __file__
+
     def test_set_dag_id(self):
         """Test that checks you can set dag_id from decorator."""
 


### PR DESCRIPTION
Previously this was always showing up as `airflow/models/dag.py`!


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).