### PR TITLE
Look for the correct flash message on failure

### DIFF
--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -615,7 +615,6 @@ def test_task_instance_clear(session, admin_client):
     assert state == State.NONE
 
 
-@pytest.mark.xfail(reason="until #15980 is merged")
 def test_task_instance_clear_failure(admin_client):
     rowid = '["12345"]'  # F.A.B. crashes if the rowid is *too* invalid.
     resp = admin_client.post(
@@ -624,7 +623,7 @@ def test_task_instance_clear_failure(admin_client):
         follow_redirects=True,
     )
     assert resp.status_code == 200
-    check_content_in_response("Failed to clear state", resp)
+    check_content_in_response("Failed to clear task instances:", resp)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
See https://github.com/apache/airflow/pull/15980#issuecomment-858862521

Turns out I was just checking for the wrong thing.