### PR TITLE
Fixes AzureFileShare connection extras

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.py
@@ -47,7 +47,7 @@ with DAG(
         share_name=AZURE_SHARE_NAME,
         dest_gcs=DEST_GCS_BUCKET,
         directory_name=AZURE_DIRECTORY_NAME,
-        wasb_conn_id='azure_fileshare_default',
+        azure_fileshare_conn_id='azure_fileshare_default',
         gcp_conn_id='google_cloud_default',
         replace=False,
         gzip=True,

--- a/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/azure_fileshare_to_gcs.py
@@ -38,8 +38,8 @@ class AzureFileShareToGCSOperator(BaseOperator):
     :param prefix: Prefix string which filters objects whose name begin with
         such prefix. (templated)
     :type prefix: str
-    :param wasb_conn_id: The source WASB connection
-    :type wasb_conn_id: str
+    :param azure_fileshare_conn_id: The source WASB connection
+    :type azure_fileshare_conn_id: str
     :param gcp_conn_id: (Optional) The connection ID used to connect to Google Cloud.
     :type gcp_conn_id: str
     :param dest_gcs: The destination Google Cloud Storage bucket and prefix
@@ -82,7 +82,7 @@ class AzureFileShareToGCSOperator(BaseOperator):
         dest_gcs: str,
         directory_name: Optional[str] = None,
         prefix: str = '',
-        wasb_conn_id: str = 'wasb_default',
+        azure_fileshare_conn_id: str = 'azure_fileshare_default',
         gcp_conn_id: str = 'google_cloud_default',
         delegate_to: Optional[str] = None,
         replace: bool = False,
@@ -95,7 +95,7 @@ class AzureFileShareToGCSOperator(BaseOperator):
         self.share_name = share_name
         self.directory_name = directory_name
         self.prefix = prefix
-        self.wasb_conn_id = wasb_conn_id
+        self.azure_fileshare_conn_id = azure_fileshare_conn_id
         self.gcp_conn_id = gcp_conn_id
         self.dest_gcs = dest_gcs
         self.delegate_to = delegate_to
@@ -114,7 +114,7 @@ class AzureFileShareToGCSOperator(BaseOperator):
             )
 
     def execute(self, context):
-        azure_fileshare_hook = AzureFileShareHook(self.wasb_conn_id)
+        azure_fileshare_hook = AzureFileShareHook(self.azure_fileshare_conn_id)
         files = azure_fileshare_hook.list_files(
             share_name=self.share_name, directory_name=self.directory_name
         )

--- a/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -29,7 +29,8 @@ Breaking changes
 
 
 ``Azure Container Volume`` and ``Azure File Share`` have now dedicated connection types with editable
-UI fields. You should not use ``Wasb`` connection type any more for those connections.
+UI fields. You should not use ``Wasb`` connection type any more for those connections. Names of
+connection ids for those hooks/operators were changed to reflect that.
 
 Features
 ~~~~~~~~

--- a/airflow/providers/microsoft/azure/CHANGELOG.rst
+++ b/airflow/providers/microsoft/azure/CHANGELOG.rst
@@ -27,6 +27,10 @@ Breaking changes
 
 * ``Auto-apply apply_default decorator (#15667)``
 
+
+``Azure Container Volume`` and ``Azure File Share`` have now dedicated connection types with editable
+UI fields. You should not use ``Wasb`` connection type any more for those connections.
+
 Features
 ~~~~~~~~
 

--- a/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
@@ -16,7 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-from typing import List, Optional
+import warnings
+from typing import Any, Dict, List, Optional
 
 from azure.storage.file import File, FileService
 
@@ -27,24 +28,92 @@ class AzureFileShareHook(BaseHook):
     """
     Interacts with Azure FileShare Storage.
 
-    Additional options passed in the 'extra' field of the connection will be
-    passed to the `FileService()` constructor.
+    Additional options passed in the 'extra' field of the connection
+    ('sas_token', 'protocol', 'connection_string') will be
+    passed to the `FileService()` constructor after stripping `extra__azure_fileshare__` prefix
+    in order to support UI-editable fields.
 
-    :param wasb_conn_id: Reference to the :ref:`wasb connection <howto/connection:wasb>`.
-    :type wasb_conn_id: str
     """
 
-    def __init__(self, wasb_conn_id: str = 'wasb_default') -> None:
+    conn_name_attr = "azure_fileshare_conn_id"
+    default_conn_name = 'azure_fileshare_default'
+    conn_type = 'azure_fileshare'
+    hook_name = 'Azure FileShare'
+
+    def __init__(self, wasb_conn_id: str = 'azure_fileshare_default') -> None:
         super().__init__()
         self.conn_id = wasb_conn_id
         self._conn = None
 
+    @staticmethod
+    def get_connection_form_widgets() -> Dict[str, Any]:
+        """Returns connection widgets to add to connection form"""
+        from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
+        from flask_babel import lazy_gettext
+        from wtforms import PasswordField, StringField
+
+        return {
+            "extra__azure_fileshare__sas_token": PasswordField(
+                lazy_gettext('SAS Token (optional)'), widget=BS3PasswordFieldWidget()
+            ),
+            "extra__azure_fileshare__connection_string": StringField(
+                lazy_gettext('Connection String (optional)'), widget=BS3TextFieldWidget()
+            ),
+            "extra__azure_fileshare__protocol": StringField(
+                lazy_gettext('Account URL or token (optional)'), widget=BS3TextFieldWidget()
+            ),
+        }
+
+    @staticmethod
+    def get_ui_field_behaviour() -> Dict:
+        """Returns custom field behaviour"""
+        return {
+            "hidden_fields": ['schema', 'port', 'host', 'extra'],
+            "relabeling": {
+                'login': 'Blob Storage Login (optional)',
+                'password': 'Blob Storage Key (optional)',
+                'host': 'Account Name (Active Directory Auth)',
+            },
+            "placeholders": {
+                'login': 'account name',
+                'password': 'secret',
+                'host': 'account url',
+                'extra__azure_fileshare__sas_token': 'account url or token (optional)',
+                'extra__azure_fileshare__connection_string': 'account url or token (optional)',
+                'extra__azure_fileshare__protocol': 'account url or token (optional)',
+            },
+        }
+
     def get_conn(self) -> FileService:
         """Return the FileService object."""
-        if not self._conn:
-            conn = self.get_connection(self.conn_id)
-            service_options = conn.extra_dejson
-            self._conn = FileService(account_name=conn.login, account_key=conn.password, **service_options)
+        prefix = "extra__azure_fileshare__"
+        if self._conn:
+            return self._conn
+        conn = self.get_connection(self.conn_id)
+        service_options_with_prefix = conn.extra_dejson
+        service_options = {}
+        for key, value in service_options_with_prefix.items():
+            # in case dedicated FileShareHook is used, the connection will use the extras from UI.
+            # in case deprecated wasb hook is used, the old extras will work as well
+            if key.startswith(prefix):
+                if value != '':
+                    service_options[key[len(prefix) :]] = value
+                else:
+                    # warn if the deprecated wasb_connection is used
+                    warnings.warn(
+                        "You are using deprecated connection for AzureFileShareHook."
+                        " Please change it to `Azure FileShare`.",
+                        DeprecationWarning,
+                    )
+            else:
+                service_options[key] = value
+                # warn if the old non-prefixed value is used
+                warnings.warn(
+                    "You are using deprecated connection for AzureFileShareHook."
+                    " Please change it to `Azure FileShare`.",
+                    DeprecationWarning,
+                )
+        self._conn = FileService(account_name=conn.login, account_key=conn.password, **service_options)
         return self._conn
 
     def check_for_directory(self, share_name: str, directory_name: str, **kwargs) -> bool:

--- a/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_fileshare.py
@@ -28,10 +28,9 @@ class AzureFileShareHook(BaseHook):
     """
     Interacts with Azure FileShare Storage.
 
-    Additional options passed in the 'extra' field of the connection
-    ('sas_token', 'protocol', 'connection_string') will be
-    passed to the `FileService()` constructor after stripping `extra__azure_fileshare__` prefix
-    in order to support UI-editable fields.
+    :param azure_fileshare_conn_id: Reference to the
+        :ref:`Azure Container Volume connection id<howto/connection:azure_fileshare>`
+        of an Azure account of which container volumes should be used.
 
     """
 
@@ -40,9 +39,9 @@ class AzureFileShareHook(BaseHook):
     conn_type = 'azure_fileshare'
     hook_name = 'Azure FileShare'
 
-    def __init__(self, wasb_conn_id: str = 'azure_fileshare_default') -> None:
+    def __init__(self, azure_fileshare_conn_id: str = 'azure_fileshare_default') -> None:
         super().__init__()
-        self.conn_id = wasb_conn_id
+        self.conn_id = azure_fileshare_conn_id
         self._conn = None
 
     @staticmethod

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -119,7 +119,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                      "POSTGRES_PASSWORD": "{{ macros.connection('postgres_default').password }}",
                      "JOB_GUID": "{{ ti.xcom_pull(task_ids='task1', key='guid') }}" },
                     secured_variables = ['POSTGRES_PASSWORD'],
-                    volumes = [("azure_wasb_conn_id",
+                    volumes = [("azure_container_instance_conn_id",
                             "my_storage_container",
                             "my_fileshare",
                             "/input-data",

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -156,6 +156,7 @@ hook-class-names:
   - airflow.providers.microsoft.azure.hooks.azure_cosmos.AzureCosmosDBHook
   - airflow.providers.microsoft.azure.hooks.azure_data_lake.AzureDataLakeHook
   - airflow.providers.microsoft.azure.hooks.azure_fileshare.AzureFileShareHook
+  - airflow.providers.microsoft.azure.hooks.azure_container_volume.AzureContainerVolumeHook
   - airflow.providers.microsoft.azure.hooks.azure_container_instance.AzureContainerInstanceHook
   - airflow.providers.microsoft.azure.hooks.wasb.WasbHook
   - airflow.providers.microsoft.azure.hooks.azure_data_factory.AzureDataFactoryHook

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -155,6 +155,7 @@ hook-class-names:
   - airflow.providers.microsoft.azure.hooks.azure_batch.AzureBatchHook
   - airflow.providers.microsoft.azure.hooks.azure_cosmos.AzureCosmosDBHook
   - airflow.providers.microsoft.azure.hooks.azure_data_lake.AzureDataLakeHook
+  - airflow.providers.microsoft.azure.hooks.azure_fileshare.AzureFileShareHook
   - airflow.providers.microsoft.azure.hooks.azure_container_instance.AzureContainerInstanceHook
   - airflow.providers.microsoft.azure.hooks.wasb.WasbHook
   - airflow.providers.microsoft.azure.hooks.azure_data_factory.AzureDataFactoryHook

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_container_volume.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_container_volume.rst
@@ -17,30 +17,24 @@
 
 
 
-.. _howto/connection:wasb:
+.. _howto/connection:azure_container_volume:
 
-Microsoft Azure Blob Storage Connection
-=======================================
+Microsoft Azure Container Volume Connection
+===========================================
 
-The Microsoft Azure Blob Storage connection type enables the Azure Blob Storage Integrations.
+The Microsoft Azure Container Volume connection type enables the Azure Container Volume Integrations.
 
-Authenticating to Azure Blob Storage
-------------------------------------
+Authenticating to Azure Container Volume
+----------------------------------------
 
-There are four ways to connect to Azure Blob Storage using Airflow.
+There are four ways to connect to Azure Container Volume using Airflow.
 
 1. Use `token credentials
    <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
-   i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
-2. Use `Azure Shared Key Credential
-   <https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key>`_
-   i.e. add shared key credentials to ``extra__wasb__shared_access_key`` the Airflow connection.
-3. Use a `SAS Token
-   <https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas>`_
-   i.e. add a key config to ``extra__wasb__sas_token`` in the Airflow connection.
-4. Use a `Connection String
+   i.e. add specific credentials (client_id, secret) and subscription id to the Airflow connection.
+2. Use a `Connection String
    <https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/connection-strings/storage>`_
-   i.e. add connection string to ``extra__wasb__connection_string`` in the Airflow connection.
+   i.e. add connection string to ``extra__azure_container_volume__connection_string`` in the Airflow connection.
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.
@@ -48,7 +42,7 @@ configure multiple connections.
 Default Connection IDs
 ----------------------
 
-All hooks and operators related to Microsoft Azure Blob Storage use ``azure_container_volume_default`` by default.
+All hooks and operators related to Azure Container Volume use ``azure_container_volume_default`` by default.
 
 Configuring the Connection
 --------------------------
@@ -67,10 +61,7 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Azure connection.
     The following parameters are all optional:
 
-    * ``extra__wasb__tenant_id``: Specify the tenant to use. Needed for Active Directory (token) authentication.
-    * ``extra__wasb__shared_access_key``: Specify the shared access key. Needed for shared access key authentication.
-    * ``extra__wasb__connection_string``: Connection string for use with connection string authentication.
-    * ``extra__wasb__sas_token``: SAS Token for use with SAS Token authentication.
+    * ``extra__azure_container_volume__connection_string``: Connection string for use with connection string authentication.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -81,4 +72,4 @@ For example connect with token credentials:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_WASP_DEFAULT='wasb://blob%20username:blob%20password@myblob.com?tenant_id=tenant+id'
+   export AIRFLOW_CONN_WASP_DEFAULT='azure_container_volume://blob%20username:blob%20password@myblob.com'

--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_fileshare.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_fileshare.rst
@@ -17,30 +17,27 @@
 
 
 
-.. _howto/connection:wasb:
+.. _howto/connection:azure_fileshare:
 
-Microsoft Azure Blob Storage Connection
-=======================================
+Microsoft Azure File Share Connection
+=====================================
 
-The Microsoft Azure Blob Storage connection type enables the Azure Blob Storage Integrations.
+The Microsoft Azure File Share connection type enables the Azure File Share Integrations.
 
-Authenticating to Azure Blob Storage
-------------------------------------
+Authenticating to Azure File Share
+----------------------------------
 
-There are four ways to connect to Azure Blob Storage using Airflow.
+There are four ways to connect to Azure File Share using Airflow.
 
 1. Use `token credentials
    <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
-   i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
-2. Use `Azure Shared Key Credential
-   <https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key>`_
-   i.e. add shared key credentials to ``extra__wasb__shared_access_key`` the Airflow connection.
-3. Use a `SAS Token
+   i.e. add specific credentials (client_id, secret) and subscription id to the Airflow connection.
+2. Use a `SAS Token
    <https://docs.microsoft.com/en-us/rest/api/storageservices/create-account-sas>`_
-   i.e. add a key config to ``extra__wasb__sas_token`` in the Airflow connection.
-4. Use a `Connection String
+   i.e. add a key config to ``extra__azure_fileshare__sas_token`` in the Airflow connection.
+3. Use a `Connection String
    <https://docs.microsoft.com/en-us/azure/data-explorer/kusto/api/connection-strings/storage>`_
-   i.e. add connection string to ``extra__wasb__connection_string`` in the Airflow connection.
+   i.e. add connection string to ``extra__azure_fileshare__connection_string`` in the Airflow connection.
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.
@@ -48,7 +45,7 @@ configure multiple connections.
 Default Connection IDs
 ----------------------
 
-All hooks and operators related to Microsoft Azure Blob Storage use ``azure_container_volume_default`` by default.
+All hooks and operators related to Azure File Share use ``azure_fileshare_default`` by default.
 
 Configuring the Connection
 --------------------------
@@ -67,10 +64,9 @@ Extra (optional)
     Specify the extra parameters (as json dictionary) that can be used in Azure connection.
     The following parameters are all optional:
 
-    * ``extra__wasb__tenant_id``: Specify the tenant to use. Needed for Active Directory (token) authentication.
-    * ``extra__wasb__shared_access_key``: Specify the shared access key. Needed for shared access key authentication.
-    * ``extra__wasb__connection_string``: Connection string for use with connection string authentication.
-    * ``extra__wasb__sas_token``: SAS Token for use with SAS Token authentication.
+    * ``extra__azure_fileshare__connection_string``: Connection string for use with connection string authentication.
+    * ``extra__azure_fileshare__sas_token``: SAS Token for use with SAS Token authentication.
+    * ``extra__azure_fileshare__protocol``: Specify the protocol to use (default is ``https``).
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.
@@ -81,4 +77,4 @@ For example connect with token credentials:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_WASP_DEFAULT='wasb://blob%20username:blob%20password@myblob.com?tenant_id=tenant+id'
+   export AIRFLOW_CONN_WASP_DEFAULT='azure_fileshare://blob%20username@myblob.com?extra__azure_fileshare__sas_token=token'

--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -95,16 +95,12 @@ function discover_all_provider_packages() {
     # Columns is to force it wider, so it doesn't wrap at 80 characters
     COLUMNS=180 airflow providers list
 
-    local expected_number_of_providers=67
     local actual_number_of_providers
     actual_providers=$(airflow providers list --output yaml | grep package_name)
     actual_number_of_providers=$(wc -l <<<"$actual_providers")
-    if [[ ${actual_number_of_providers} != "${expected_number_of_providers}" ]]; then
+    if (( actual_number_of_providers < 67 )); then
         echo
-        echo  "${COLOR_RED}ERROR:Number of providers installed is wrong${COLOR_RESET}"
-        echo "Expected number was '${expected_number_of_providers}' and got '${actual_number_of_providers}'"
-        echo
-        echo "Either increase the number of providers if you added one or diagnose and fix the problem."
+        echo  "${COLOR_RED}ERROR:Number of providers installed is wrong: ${actual_number_of_providers}${COLOR_RESET}"
         echo
         echo "Providers were:"
         echo
@@ -117,16 +113,11 @@ function discover_all_provider_packages() {
 function discover_all_hooks() {
     group_start "Listing available hooks via 'airflow providers hooks'"
     COLUMNS=180 airflow providers hooks
-
-    local expected_number_of_hooks=70
     local actual_number_of_hooks
     actual_number_of_hooks=$(airflow providers hooks --output table | grep -c "| apache" | xargs)
-    if [[ ${actual_number_of_hooks} != "${expected_number_of_hooks}" ]]; then
+    if (( actual_number_of_hooks < 70 )); then
         echo
-        echo  "${COLOR_RED}ERROR: Number of hooks registered is wrong  ${COLOR_RESET}"
-        echo "Expected number was '${expected_number_of_hooks}' and got '${actual_number_of_hooks}'"
-        echo
-        echo "Either increase the number of hooks if you added one or diagnose and fix the problem."
+        echo  "${COLOR_RED}ERROR: Number of hooks registered is wrong: ${actual_number_of_hooks} ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -137,15 +128,11 @@ function discover_all_extra_links() {
     group_start "Listing available extra links via 'airflow providers links'"
     COLUMNS=180 airflow providers links
 
-    local expected_number_of_extra_links=6
     local actual_number_of_extra_links
     actual_number_of_extra_links=$(airflow providers links --output table | grep -c ^airflow.providers | xargs)
-    if [[ ${actual_number_of_extra_links} != "${expected_number_of_extra_links}" ]]; then
+    if (( actual_number_of_extra_links < 6 )); then
         echo
-        echo  "${COLOR_RED}ERROR: Number of links registered is wrong  ${COLOR_RESET}"
-        echo "Expected number was '${expected_number_of_extra_links}' and got '${actual_number_of_extra_links}'"
-        echo
-        echo "Either increase the number of links if you added one or diagnose and fix the problem."
+        echo  "${COLOR_RED}ERROR: Number of links registered is wrong: ${actual_number_of_extra_links}  ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -157,15 +144,11 @@ function discover_all_connection_form_widgets() {
 
     COLUMNS=180 airflow providers widgets
 
-    local expected_number_of_widgets=44
     local actual_number_of_widgets
     actual_number_of_widgets=$(airflow providers widgets --output table | grep -c ^extra)
-    if [[ ${actual_number_of_widgets} != "${expected_number_of_widgets}" ]]; then
+    if (( actual_number_of_widgets < 44 )); then
         echo
-        echo  "${COLOR_RED}ERROR: Number of connections with widgets registered is wrong  ${COLOR_RESET}"
-        echo "Expected number was '${expected_number_of_widgets}' and got '${actual_number_of_widgets}'"
-        echo
-        echo "Increase the number of connections with widgets if you added one or investigate"
+        echo  "${COLOR_RED}ERROR: Number of connections with widgets registered is wrong: ${actual_number_of_widgets}  ${COLOR_RESET}"
         echo
         exit 1
     fi
@@ -176,17 +159,12 @@ function discover_all_field_behaviours() {
     group_start "Listing connections with custom behaviours via 'airflow providers behaviours'"
     COLUMNS=180 airflow providers behaviours
 
-    local expected_number_of_connections_with_behaviours=21
     local actual_number_of_connections_with_behaviours
     actual_number_of_connections_with_behaviours=$(airflow providers behaviours --output table | grep -v "===" | \
         grep -v field_behaviours | grep -cv "^ " | xargs)
-    if [[ ${actual_number_of_connections_with_behaviours} != \
-            "${expected_number_of_connections_with_behaviours}" ]]; then
+    if (( actual_number_of_connections_with_behaviours < 21 )); then
         echo
-        echo  "${COLOR_RED}ERROR: Number of connections with customized behaviours is wrong  ${COLOR_RESET}"
-        echo "Expected number was '${expected_number_of_connections_with_behaviours}' and got '${actual_number_of_connections_with_behaviours}'"
-        echo
-        echo "Increase the number of connections if you added one or investigate."
+        echo  "${COLOR_RED}ERROR: Number of connections with customized behaviours is wrong: ${actual_number_of_connections_with_behaviours} ${COLOR_RESET}"
         echo
         exit 1
     fi

--- a/tests/core/test_providers_manager.py
+++ b/tests/core/test_providers_manager.py
@@ -20,229 +20,6 @@ import unittest
 
 from airflow.providers_manager import ProvidersManager
 
-ALL_PROVIDERS = [
-    'apache-airflow-providers-airbyte',
-    'apache-airflow-providers-amazon',
-    'apache-airflow-providers-apache-beam',
-    'apache-airflow-providers-apache-cassandra',
-    'apache-airflow-providers-apache-druid',
-    'apache-airflow-providers-apache-hdfs',
-    'apache-airflow-providers-apache-hive',
-    'apache-airflow-providers-apache-kylin',
-    'apache-airflow-providers-apache-livy',
-    'apache-airflow-providers-apache-pig',
-    'apache-airflow-providers-apache-pinot',
-    'apache-airflow-providers-apache-spark',
-    'apache-airflow-providers-apache-sqoop',
-    'apache-airflow-providers-asana',
-    'apache-airflow-providers-celery',
-    'apache-airflow-providers-cloudant',
-    'apache-airflow-providers-cncf-kubernetes',
-    'apache-airflow-providers-databricks',
-    'apache-airflow-providers-datadog',
-    'apache-airflow-providers-dingding',
-    'apache-airflow-providers-discord',
-    'apache-airflow-providers-docker',
-    'apache-airflow-providers-elasticsearch',
-    'apache-airflow-providers-exasol',
-    'apache-airflow-providers-facebook',
-    'apache-airflow-providers-ftp',
-    'apache-airflow-providers-google',
-    'apache-airflow-providers-grpc',
-    'apache-airflow-providers-hashicorp',
-    'apache-airflow-providers-http',
-    'apache-airflow-providers-imap',
-    'apache-airflow-providers-jdbc',
-    'apache-airflow-providers-jenkins',
-    'apache-airflow-providers-jira',
-    'apache-airflow-providers-microsoft-azure',
-    'apache-airflow-providers-microsoft-mssql',
-    'apache-airflow-providers-microsoft-winrm',
-    'apache-airflow-providers-mongo',
-    'apache-airflow-providers-mysql',
-    'apache-airflow-providers-neo4j',
-    'apache-airflow-providers-odbc',
-    'apache-airflow-providers-openfaas',
-    'apache-airflow-providers-opsgenie',
-    'apache-airflow-providers-oracle',
-    'apache-airflow-providers-pagerduty',
-    'apache-airflow-providers-papermill',
-    'apache-airflow-providers-plexus',
-    'apache-airflow-providers-postgres',
-    'apache-airflow-providers-presto',
-    'apache-airflow-providers-qubole',
-    'apache-airflow-providers-redis',
-    'apache-airflow-providers-salesforce',
-    'apache-airflow-providers-samba',
-    'apache-airflow-providers-segment',
-    'apache-airflow-providers-sendgrid',
-    'apache-airflow-providers-sftp',
-    'apache-airflow-providers-singularity',
-    'apache-airflow-providers-slack',
-    'apache-airflow-providers-snowflake',
-    'apache-airflow-providers-sqlite',
-    'apache-airflow-providers-ssh',
-    'apache-airflow-providers-tableau',
-    'apache-airflow-providers-telegram',
-    'apache-airflow-providers-trino',
-    'apache-airflow-providers-vertica',
-    'apache-airflow-providers-yandex',
-    'apache-airflow-providers-zendesk',
-]
-
-CONNECTIONS_LIST = [
-    'airbyte',
-    'asana',
-    'aws',
-    'azure',
-    'azure_batch',
-    'azure_container_registry',
-    'azure_cosmos',
-    'azure_data_explorer',
-    'azure_data_factory',
-    'azure_data_lake',
-    'cassandra',
-    'cloudant',
-    'databricks',
-    'dataprep',
-    'dingding',
-    'discord',
-    'docker',
-    'druid',
-    'elasticsearch',
-    'emr',
-    'exasol',
-    'facebook_social',
-    'ftp',
-    'gcpcloudsql',
-    'gcpcloudsqldb',
-    'gcpssh',
-    'google_cloud_platform',
-    'grpc',
-    'hdfs',
-    'hive_cli',
-    'hive_metastore',
-    'hiveserver2',
-    'http',
-    'imap',
-    'jdbc',
-    'jenkins',
-    'jira',
-    'kubernetes',
-    'leveldb',
-    'livy',
-    'mongo',
-    'mssql',
-    'mysql',
-    'neo4j',
-    'odbc',
-    'opsgenie',
-    'oracle',
-    'pig_cli',
-    'postgres',
-    'presto',
-    'qubole',
-    'redis',
-    's3',
-    'samba',
-    'segment',
-    'sftp',
-    'slackwebhook',
-    'snowflake',
-    'spark',
-    'spark_jdbc',
-    'spark_sql',
-    'sqlite',
-    'sqoop',
-    'ssh',
-    'tableau',
-    'trino',
-    'vault',
-    'vertica',
-    'wasb',
-    'yandexcloud',
-]
-
-CONNECTION_FORM_WIDGETS = [
-    'extra__asana__project',
-    'extra__asana__workspace',
-    'extra__azure__subscriptionId',
-    'extra__azure__tenantId',
-    'extra__azure_batch__account_url',
-    'extra__azure_cosmos__collection_name',
-    'extra__azure_cosmos__database_name',
-    'extra__azure_data_explorer__auth_method',
-    'extra__azure_data_explorer__certificate',
-    'extra__azure_data_explorer__tenant',
-    'extra__azure_data_explorer__thumbprint',
-    'extra__azure_data_factory__subscriptionId',
-    'extra__azure_data_factory__tenantId',
-    'extra__azure_data_lake__account_name',
-    'extra__azure_data_lake__tenant',
-    'extra__google_cloud_platform__key_path',
-    'extra__google_cloud_platform__keyfile_dict',
-    'extra__google_cloud_platform__num_retries',
-    'extra__google_cloud_platform__project',
-    'extra__google_cloud_platform__scope',
-    'extra__grpc__auth_type',
-    'extra__grpc__credential_pem_file',
-    'extra__grpc__scopes',
-    'extra__jdbc__drv_clsname',
-    'extra__jdbc__drv_path',
-    'extra__kubernetes__in_cluster',
-    'extra__kubernetes__kube_config',
-    'extra__kubernetes__kube_config_path',
-    'extra__kubernetes__namespace',
-    'extra__snowflake__account',
-    'extra__snowflake__aws_access_key_id',
-    'extra__snowflake__aws_secret_access_key',
-    'extra__snowflake__database',
-    'extra__snowflake__region',
-    'extra__snowflake__warehouse',
-    'extra__wasb__connection_string',
-    'extra__wasb__sas_token',
-    'extra__wasb__shared_access_key',
-    'extra__wasb__tenant_id',
-    'extra__yandexcloud__folder_id',
-    'extra__yandexcloud__oauth',
-    'extra__yandexcloud__public_ssh_key',
-    'extra__yandexcloud__service_account_json',
-    'extra__yandexcloud__service_account_json_path',
-]
-
-CONNECTIONS_WITH_FIELD_BEHAVIOURS = [
-    'asana',
-    'azure',
-    'azure_batch',
-    'azure_container_registry',
-    'azure_cosmos',
-    'azure_data_explorer',
-    'azure_data_factory',
-    'azure_data_lake',
-    'cloudant',
-    'docker',
-    'gcpssh',
-    'google_cloud_platform',
-    'jdbc',
-    'kubernetes',
-    'qubole',
-    'sftp',
-    'snowflake',
-    'spark',
-    'ssh',
-    'wasb',
-    'yandexcloud',
-]
-
-EXTRA_LINKS = [
-    'airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink',
-    'airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink',
-    'airflow.providers.google.cloud.operators.dataproc.DataprocClusterLink',
-    'airflow.providers.google.cloud.operators.dataproc.DataprocJobLink',
-    'airflow.providers.google.cloud.operators.mlengine.AIPlatformConsoleLink',
-    'airflow.providers.qubole.operators.qubole.QDSLink',
-]
-
 
 class TestProviderManager(unittest.TestCase):
     def test_providers_are_loaded(self):
@@ -254,24 +31,26 @@ class TestProviderManager(unittest.TestCase):
             version = provider_manager.providers[provider][0]
             assert re.search(r'[0-9]*\.[0-9]*\.[0-9]*.*', version)
             assert package_name == provider
-        assert ALL_PROVIDERS == provider_list
+        # just a sanity check - no exact number as otherwise we would have to update
+        # several tests if we add new connections/provider which is not ideal
+        assert len(provider_list) > 65
 
     def test_hooks(self):
         provider_manager = ProvidersManager()
         connections_list = list(provider_manager.hooks.keys())
-        assert CONNECTIONS_LIST == connections_list
+        assert len(connections_list) > 60
 
     def test_connection_form_widgets(self):
         provider_manager = ProvidersManager()
         connections_form_widgets = list(provider_manager.connection_form_widgets.keys())
-        assert CONNECTION_FORM_WIDGETS == connections_form_widgets
+        assert len(connections_form_widgets) > 29
 
     def test_field_behaviours(self):
         provider_manager = ProvidersManager()
         connections_with_field_behaviours = list(provider_manager.field_behaviours.keys())
-        assert CONNECTIONS_WITH_FIELD_BEHAVIOURS == connections_with_field_behaviours
+        assert len(connections_with_field_behaviours) > 16
 
     def test_extra_links(self):
         provider_manager = ProvidersManager()
         extra_link_class_names = list(provider_manager.extra_links_class_names)
-        assert EXTRA_LINKS == extra_link_class_names
+        assert len(extra_link_class_names) > 5

--- a/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs.py
@@ -25,7 +25,7 @@ AZURE_FILESHARE_SHARE = 'test-share'
 AZURE_FILESHARE_DIRECTORY_NAME = '/path/to/dir'
 GCS_PATH_PREFIX = 'gs://gcs-bucket/data/'
 MOCK_FILES = ["TEST1.csv", "TEST2.csv", "TEST3.csv"]
-WASB_CONN_ID = 'wasb_default'
+AZURE_FILESHARE_CONN_ID = 'azure_fileshare_default'
 GCS_CONN_ID = 'google_cloud_default'
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
@@ -38,7 +38,7 @@ class TestAzureFileShareToGCSOperator(unittest.TestCase):
             task_id=TASK_ID,
             share_name=AZURE_FILESHARE_SHARE,
             directory_name=AZURE_FILESHARE_DIRECTORY_NAME,
-            wasb_conn_id=WASB_CONN_ID,
+            azure_fileshare_conn_id=AZURE_FILESHARE_CONN_ID,
             gcp_conn_id=GCS_CONN_ID,
             dest_gcs=GCS_PATH_PREFIX,
             google_impersonation_chain=IMPERSONATION_CHAIN,
@@ -47,7 +47,7 @@ class TestAzureFileShareToGCSOperator(unittest.TestCase):
         assert operator.task_id == TASK_ID
         assert operator.share_name == AZURE_FILESHARE_SHARE
         assert operator.directory_name == AZURE_FILESHARE_DIRECTORY_NAME
-        assert operator.wasb_conn_id == WASB_CONN_ID
+        assert operator.azure_fileshare_conn_id == AZURE_FILESHARE_CONN_ID
         assert operator.gcp_conn_id == GCS_CONN_ID
         assert operator.dest_gcs == GCS_PATH_PREFIX
         assert operator.google_impersonation_chain == IMPERSONATION_CHAIN
@@ -61,7 +61,7 @@ class TestAzureFileShareToGCSOperator(unittest.TestCase):
             task_id=TASK_ID,
             share_name=AZURE_FILESHARE_SHARE,
             directory_name=AZURE_FILESHARE_DIRECTORY_NAME,
-            wasb_conn_id=WASB_CONN_ID,
+            azure_fileshare_conn_id=AZURE_FILESHARE_CONN_ID,
             gcp_conn_id=GCS_CONN_ID,
             dest_gcs=GCS_PATH_PREFIX,
             google_impersonation_chain=IMPERSONATION_CHAIN,
@@ -80,7 +80,7 @@ class TestAzureFileShareToGCSOperator(unittest.TestCase):
             any_order=True,
         )
 
-        azure_fileshare_mock_hook.assert_called_once_with(WASB_CONN_ID)
+        azure_fileshare_mock_hook.assert_called_once_with(AZURE_FILESHARE_CONN_ID)
 
         gcs_mock_hook.assert_called_once_with(
             gcp_conn_id=GCS_CONN_ID,
@@ -99,7 +99,7 @@ class TestAzureFileShareToGCSOperator(unittest.TestCase):
             task_id=TASK_ID,
             share_name=AZURE_FILESHARE_SHARE,
             directory_name=AZURE_FILESHARE_DIRECTORY_NAME,
-            wasb_conn_id=WASB_CONN_ID,
+            azure_fileshare_conn_id=AZURE_FILESHARE_CONN_ID,
             gcp_conn_id=GCS_CONN_ID,
             dest_gcs=GCS_PATH_PREFIX,
             google_impersonation_chain=IMPERSONATION_CHAIN,

--- a/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs_system.py
+++ b/tests/providers/google/cloud/transfers/test_azure_fileshare_to_gcs_system.py
@@ -45,17 +45,17 @@ AZURE_FILE_NAME = 'file.bin'
 @pytest.fixture
 def provide_azure_fileshare_with_directory():
     with create_session() as session:
-        wasb_conn_id = Connection(
+        azure_fileshare_conn_id = Connection(
             conn_id=CONN_ID,
             conn_type='https',
             login=AZURE_LOGIN,
             password=AZURE_KEY,
         )
-        session.add(wasb_conn_id)  # pylint: disable=expression-not-assigned
+        session.add(azure_fileshare_conn_id)  # pylint: disable=expression-not-assigned
 
     with provide_azure_fileshare(
         share_name=AZURE_SHARE_NAME,
-        wasb_conn_id=CONN_ID,
+        azure_fileshare_conn_id=CONN_ID,
         file_name=AZURE_FILE_NAME,
         directory=AZURE_DIRECTORY_NAME,
     ):

--- a/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_fileshare.py
@@ -29,6 +29,7 @@ import json
 import unittest
 from unittest import mock
 
+import pytest
 from azure.storage.file import Directory, File
 
 from airflow.models import Connection
@@ -38,36 +39,123 @@ from airflow.utils import db
 
 class TestAzureFileshareHook(unittest.TestCase):
     def setUp(self):
-        db.merge_conn(Connection(conn_id='wasb_test_key', conn_type='wasb', login='login', password='key'))
         db.merge_conn(
             Connection(
-                conn_id='wasb_test_sas_token',
-                conn_type='wasb',
+                conn_id='azure_fileshare_test_key',
+                conn_type='azure_file_share',
                 login='login',
-                extra=json.dumps({'sas_token': 'token'}),
+                password='key',
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id='azure_fileshare_extras',
+                conn_type='azure_fileshare',
+                login='login',
+                extra=json.dumps(
+                    {
+                        'extra__azure_fileshare__sas_token': 'token',
+                        'extra__azure_fileshare__protocol': 'http',
+                    }
+                ),
+            )
+        )
+        db.merge_conn(
+            # Neither password nor sas_token present
+            Connection(
+                conn_id='azure_fileshare_missing_credentials',
+                conn_type='azure_fileshare',
+                login='login',
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id='azure_fileshare_extras_deprecated',
+                conn_type='azure_fileshare',
+                login='login',
+                extra=json.dumps(
+                    {
+                        'sas_token': 'token',
+                    }
+                ),
+            )
+        )
+        db.merge_conn(
+            Connection(
+                conn_id='azure_fileshare_extras_deprecated_empty_wasb_extra',
+                conn_type='azure_fileshare',
+                login='login',
+                password='password',
+                extra=json.dumps(
+                    {
+                        'extra__azure_fileshare__shared_access_key': '',
+                    }
+                ),
+            )
+        )
+
+        db.merge_conn(
+            Connection(
+                conn_id='azure_fileshare_extras_wrong',
+                conn_type='azure_fileshare',
+                login='login',
+                extra=json.dumps(
+                    {
+                        'wrong_key': 'token',
+                    }
+                ),
             )
         )
 
     def test_key_and_connection(self):
         from azure.storage.file import FileService
 
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_key')
-        assert hook.conn_id == 'wasb_test_key'
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_test_key')
+        assert hook.conn_id == 'azure_fileshare_test_key'
         assert hook._conn is None
+        print(hook.get_conn())
         assert isinstance(hook.get_conn(), FileService)
 
     def test_sas_token(self):
         from azure.storage.file import FileService
 
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
-        assert hook.conn_id == 'wasb_test_sas_token'
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
+        assert hook.conn_id == 'azure_fileshare_extras'
         assert isinstance(hook.get_conn(), FileService)
+
+    def test_deprecated_sas_token(self):
+        from azure.storage.file import FileService
+
+        with pytest.warns(DeprecationWarning):
+            hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras_deprecated')
+            assert hook.conn_id == 'azure_fileshare_extras_deprecated'
+            assert isinstance(hook.get_conn(), FileService)
+
+    def test_deprecated_wasb_connection(self):
+        from azure.storage.file import FileService
+
+        with pytest.warns(DeprecationWarning):
+            hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras_deprecated_empty_wasb_extra')
+            assert hook.conn_id == 'azure_fileshare_extras_deprecated_empty_wasb_extra'
+            assert isinstance(hook.get_conn(), FileService)
+
+    def test_wrong_extras(self):
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras_wrong')
+        assert hook.conn_id == 'azure_fileshare_extras_wrong'
+        with pytest.raises(TypeError, match=".*wrong_key.*"):
+            hook.get_conn()
+
+    def test_missing_credentials(self):
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_missing_credentials')
+        assert hook.conn_id == 'azure_fileshare_missing_credentials'
+        with pytest.raises(ValueError, match=".*account_key or sas_token.*"):
+            hook.get_conn()
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_check_for_file(self, mock_service):
         mock_instance = mock_service.return_value
         mock_instance.exists.return_value = True
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         assert hook.check_for_file('share', 'directory', 'file', timeout=3)
         mock_instance.exists.assert_called_once_with('share', 'directory', 'file', timeout=3)
 
@@ -75,14 +163,14 @@ class TestAzureFileshareHook(unittest.TestCase):
     def test_check_for_directory(self, mock_service):
         mock_instance = mock_service.return_value
         mock_instance.exists.return_value = True
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         assert hook.check_for_directory('share', 'directory', timeout=3)
         mock_instance.exists.assert_called_once_with('share', 'directory', timeout=3)
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_load_file(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.load_file('path', 'share', 'directory', 'file', max_connections=1)
         mock_instance.create_file_from_path.assert_called_once_with(
             'share', 'directory', 'file', 'path', max_connections=1
@@ -91,7 +179,7 @@ class TestAzureFileshareHook(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_load_string(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.load_string('big string', 'share', 'directory', 'file', timeout=1)
         mock_instance.create_file_from_text.assert_called_once_with(
             'share', 'directory', 'file', 'big string', timeout=1
@@ -100,7 +188,7 @@ class TestAzureFileshareHook(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_load_stream(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.load_stream('stream', 'share', 'directory', 'file', 42, timeout=1)
         mock_instance.create_file_from_stream.assert_called_once_with(
             'share', 'directory', 'file', 'stream', 42, timeout=1
@@ -109,7 +197,7 @@ class TestAzureFileshareHook(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_list_directories_and_files(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.list_directories_and_files('share', 'directory', timeout=1)
         mock_instance.list_directories_and_files.assert_called_once_with('share', 'directory', timeout=1)
 
@@ -122,7 +210,7 @@ class TestAzureFileshareHook(unittest.TestCase):
             Directory("dir1"),
             Directory("dir2"),
         ]
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         files = hook.list_files('share', 'directory', timeout=1)
         assert files == ["file1", 'file2']
         mock_instance.list_directories_and_files.assert_called_once_with('share', 'directory', timeout=1)
@@ -130,14 +218,14 @@ class TestAzureFileshareHook(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_create_directory(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.create_directory('share', 'directory', timeout=1)
         mock_instance.create_directory.assert_called_once_with('share', 'directory', timeout=1)
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_get_file(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.get_file('path', 'share', 'directory', 'file', max_connections=1)
         mock_instance.get_file_to_path.assert_called_once_with(
             'share', 'directory', 'file', 'path', max_connections=1
@@ -146,7 +234,7 @@ class TestAzureFileshareHook(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_get_file_to_stream(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.get_file_to_stream('stream', 'share', 'directory', 'file', max_connections=1)
         mock_instance.get_file_to_stream.assert_called_once_with(
             'share', 'directory', 'file', 'stream', max_connections=1
@@ -155,13 +243,13 @@ class TestAzureFileshareHook(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_create_share(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.create_share('my_share')
         mock_instance.create_share.assert_called_once_with('my_share')
 
     @mock.patch('airflow.providers.microsoft.azure.hooks.azure_fileshare.FileService', autospec=True)
     def test_delete_share(self, mock_service):
         mock_instance = mock_service.return_value
-        hook = AzureFileShareHook(wasb_conn_id='wasb_test_sas_token')
+        hook = AzureFileShareHook(wasb_conn_id='azure_fileshare_extras')
         hook.delete_share('my_share')
         mock_instance.delete_share.assert_called_once_with('my_share')

--- a/tests/test_utils/azure_system_helpers.py
+++ b/tests/test_utils/azure_system_helpers.py
@@ -93,32 +93,32 @@ def provide_azure_data_lake_default_connection(key_file_path: str):
 
 
 @contextmanager
-def provide_azure_fileshare(share_name: str, wasb_conn_id: str, file_name: str, directory: str):
+def provide_azure_fileshare(share_name: str, azure_fileshare_conn_id: str, file_name: str, directory: str):
     AzureSystemTest.prepare_share(
         share_name=share_name,
-        wasb_conn_id=wasb_conn_id,
+        azure_fileshare_conn_id=azure_fileshare_conn_id,
         file_name=file_name,
         directory=directory,
     )
     yield
-    AzureSystemTest.delete_share(share_name=share_name, wasb_conn_id=wasb_conn_id)
+    AzureSystemTest.delete_share(share_name=share_name, azure_fileshare_conn_id=azure_fileshare_conn_id)
 
 
 @pytest.mark.system("azure")
 class AzureSystemTest(SystemTest):
     @classmethod
-    def create_share(cls, share_name: str, wasb_conn_id: str):
-        hook = AzureFileShareHook(wasb_conn_id=wasb_conn_id)
+    def create_share(cls, share_name: str, azure_fileshare_conn_id: str):
+        hook = AzureFileShareHook(azure_fileshare_conn_id=azure_fileshare_conn_id)
         hook.create_share(share_name)
 
     @classmethod
-    def delete_share(cls, share_name: str, wasb_conn_id: str):
-        hook = AzureFileShareHook(wasb_conn_id=wasb_conn_id)
+    def delete_share(cls, share_name: str, azure_fileshare_conn_id: str):
+        hook = AzureFileShareHook(azure_fileshare_conn_id=azure_fileshare_conn_id)
         hook.delete_share(share_name)
 
     @classmethod
-    def create_directory(cls, share_name: str, wasb_conn_id: str, directory: str):
-        hook = AzureFileShareHook(wasb_conn_id=wasb_conn_id)
+    def create_directory(cls, share_name: str, azure_fileshare_conn_id: str, directory: str):
+        hook = AzureFileShareHook(azure_fileshare_conn_id=azure_fileshare_conn_id)
         hook.create_directory(share_name=share_name, directory_name=directory)
 
     @classmethod
@@ -126,11 +126,11 @@ class AzureSystemTest(SystemTest):
         cls,
         string_data: str,
         share_name: str,
-        wasb_conn_id: str,
+        azure_fileshare_conn_id: str,
         file_name: str,
         directory: str,
     ):
-        hook = AzureFileShareHook(wasb_conn_id=wasb_conn_id)
+        hook = AzureFileShareHook(azure_fileshare_conn_id=azure_fileshare_conn_id)
         hook.load_string(
             string_data=string_data,
             share_name=share_name,
@@ -139,17 +139,19 @@ class AzureSystemTest(SystemTest):
         )
 
     @classmethod
-    def prepare_share(cls, share_name: str, wasb_conn_id: str, file_name: str, directory: str):
+    def prepare_share(cls, share_name: str, azure_fileshare_conn_id: str, file_name: str, directory: str):
         """
         Create share with a file in given directory. If directory is None, file is in root dir.
         """
-        cls.create_share(share_name=share_name, wasb_conn_id=wasb_conn_id)
-        cls.create_directory(share_name=share_name, wasb_conn_id=wasb_conn_id, directory=directory)
+        cls.create_share(share_name=share_name, azure_fileshare_conn_id=azure_fileshare_conn_id)
+        cls.create_directory(
+            share_name=share_name, azure_fileshare_conn_id=azure_fileshare_conn_id, directory=directory
+        )
         string_data = "".join(random.choice(string.ascii_letters) for _ in range(1024))
         cls.upload_file_from_string(
             string_data=string_data,
             share_name=share_name,
-            wasb_conn_id=wasb_conn_id,
+            azure_fileshare_conn_id=azure_fileshare_conn_id,
             file_name=file_name,
             directory=directory,
         )


### PR DESCRIPTION
The Azure File Share connection has not been creted in #15159 and it
caused an unexpected side effect as the default Azure Connection
passed service_options dictionary to FileService
with key that was unexpected.

This change fixes two things:

1) adds AzureFileShare connection that has separate conn_type
   and handles the extra_options specific for FileService Hook
   available in the Airflow UI.

2) handles the "deprecated" way of passing keys without UI prefix
   but raises a deprecation warning when such key is passed or
   when the Wasb connection is used with an empty extras rather
   than Azure File Share.

Fixes #16254

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
