### PR TITLE
Fix docker compose version to be the latest below 3, depends_on condition now works fine.

### DIFF
--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -41,7 +41,7 @@
 #
 # Feel free to modify this file to suit your needs.
 ---
-version: '3'
+version: '2.4'
 x-airflow-common:
   &airflow-common
   image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:|version|}


### PR DESCRIPTION
Fix docker compose version to handle ```depends_on``` feature called ```condition```. 
Versions above or equal 3 does not support this feature, it did not port healthcheck dependencies. 
Change version to to 2.4, the latest version below 3 that support that feature.