### PR TITLE
Don't run tests for deprecated method on DAG class

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1129,7 +1129,7 @@ class DAG(LoggingMixin):
         warnings.warn(
             "This method is deprecated and will be removed in a future version.",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         dag_ids = dag_ids or [self.dag_id]
         query = session.query(DagRun).filter(DagRun.dag_id.in_(dag_ids))

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1224,20 +1224,6 @@ class TestDag(unittest.TestCase):
         assert dag.normalized_schedule_interval == expected_n_schedule_interval
         assert dag.schedule_interval == schedule_interval
 
-    def test_set_dag_runs_state(self):
-        clear_db_runs()
-        dag_id = "test_set_dag_runs_state"
-        dag = DAG(dag_id=dag_id)
-
-        for i in range(3):
-            dag.create_dagrun(run_id=f"test{i}", state=State.RUNNING)
-
-        dag.set_dag_runs_state(state=State.NONE)
-        drs = DagRun.find(dag_id=dag_id)
-
-        assert len(drs) == 3
-        assert all(dr.state == State.NONE for dr in drs)
-
     def test_create_dagrun_run_id_is_generated(self):
         dag = DAG(dag_id="run_id_is_generated")
         dr = dag.create_dagrun(run_type=DagRunType.MANUAL, execution_date=DEFAULT_DATE, state=State.NONE)


### PR DESCRIPTION
And since the deprecated method uses a decorator, we need stacklevel of three for the warning to show up in the right place.
