### PR TITLE
Update permission migrations to use new naming scheme.

### DIFF
--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -285,26 +285,26 @@ mapping = {
 
 
 def remap_permissions():
-    """Apply Map Airflow view permissions."""
+    """Apply Map Airflow permissions."""
     appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
     for old, new in mapping.items():
-        (old_view_name, old_perm_name) = old
-        old_pvm = appbuilder.sm.get_permission(old_perm_name, old_view_name)
-        if not old_pvm:
+        (old_resource_name, old_action_name) = old
+        old_permission = appbuilder.sm.get_permission(old_action_name, old_resource_name)
+        if not old_permission:
             continue
-        for new_perm_name, new_view_name in new:
-            new_pvm = appbuilder.sm.add_permission_view_menu(new_perm_name, new_view_name)
+        for new_action_name, new_resource_name in new:
+            new_permission = appbuilder.sm.create_permission(new_action_name, new_resource_name)
             for role in appbuilder.sm.get_all_roles():
-                if appbuilder.sm.exist_permission_on_roles(old_view_name, old_perm_name, [role.id]):
-                    appbuilder.sm.add_permission_role(role, new_pvm)
-                    appbuilder.sm.del_permission_role(role, old_pvm)
-        appbuilder.sm.del_permission_view_menu(old_perm_name, old_view_name)
+                if appbuilder.sm.exist_permission_on_roles(old_resource_name, old_action_name, [role.id]):
+                    appbuilder.sm.add_permission_to_role(role, new_permission)
+                    appbuilder.sm.remove_permission_from_role(role, old_permission)
+        appbuilder.sm.delete_permission(old_action_name, old_resource_name)
 
-        if not appbuilder.sm.find_permission(old_perm_name):
+        if not appbuilder.sm.get_action(old_action_name):
             continue
-        view_menus = appbuilder.sm.get_all_view_menu()
-        if not any(appbuilder.sm.get_permission(old_perm_name, view.name) for view in view_menus):
-            appbuilder.sm.del_permission(old_perm_name)
+        resources = appbuilder.sm.get_all_resources()
+        if not any(appbuilder.sm.get_permission(old_action_name, resource.name) for resource in resources):
+            appbuilder.sm.delete_action(old_action_name)
 
 
 def upgrade():

--- a/airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py
+++ b/airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py
@@ -36,7 +36,7 @@ depends_on = None
 
 
 def upgrade():
-    """Remove can_read permission on config resource for User and Viewer role"""
+    """Remove can_read action from config resource for User and Viewer role"""
     log = logging.getLogger()
     handlers = log.handlers[:]
 
@@ -50,13 +50,13 @@ def upgrade():
         if appbuilder.sm.exist_permission_on_roles(
             permissions.RESOURCE_CONFIG, permissions.ACTION_CAN_READ, [role.id]
         ):
-            appbuilder.sm.del_permission_role(role, can_read_on_config_perm)
+            appbuilder.sm.remove_permission_from_role(role, can_read_on_config_perm)
 
     log.handlers = handlers
 
 
 def downgrade():
-    """Add can_read permission on config resource for User and Viewer role"""
+    """Add can_read action on config resource for User and Viewer role"""
     appbuilder = create_app(config={'FAB_UPDATE_PERMS': False}).appbuilder
     roles_to_modify = [role for role in appbuilder.sm.get_all_roles() if role.name in ["User", "Viewer"]]
     can_read_on_config_perm = appbuilder.sm.get_permission(
@@ -67,4 +67,4 @@ def downgrade():
         if not appbuilder.sm.exist_permission_on_roles(
             permissions.RESOURCE_CONFIG, permissions.ACTION_CAN_READ, [role.id]
         ):
-            appbuilder.sm.add_permission_role(role, can_read_on_config_perm)
+            appbuilder.sm.add_permission_to_role(role, can_read_on_config_perm)


### PR DESCRIPTION
Part of the Resource/Action FAB Name epic.

Updates the following migrations to use the new naming scheme. Should not change any behaviors, as it just updates variable names and method call names.

airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py