### PR TITLE
Quarantine test_process_kill_calls_on_failure_callback

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -519,6 +519,7 @@ class TestLocalTaskJob(unittest.TestCase):
             (signal.SIGKILL,),
         ]
     )
+    @pytest.mark.quarantined
     def test_process_kill_calls_on_failure_callback(self, signal_type):
         """
         Test that ensures that when a task is killed with sigterm or sigkill


### PR DESCRIPTION
test_process_kill_calls_on_failure_callback seems to be flaky in the CI suite and occasionally fails without reason. Until it's fixed, it should be quarantined with other flaky tests.
