### PR TITLE
Secrets backend failover

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -88,7 +88,7 @@ def _get_config_value_from_secret_backend(config_key):
         return secrets_client.get_config(config_key)
     except Exception as e:  # pylint: disable=broad-except
         raise AirflowConfigException(
-            'Cannot retrieve config from Alternative Secrets Backend. '
+            'Cannot retrieve config from alternative secrets git backend. '
             'Make sure it is configured properly and that the Backend '
             'is accessible.\n'
             f'{e}'

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -81,10 +81,18 @@ def run_command(command):
 
 def _get_config_value_from_secret_backend(config_key):
     """Get Config option values from Secret Backend"""
-    secrets_client = get_custom_secret_backend()
-    if not secrets_client:
-        return None
-    return secrets_client.get_config(config_key)
+    try:
+        secrets_client = get_custom_secret_backend()
+        if not secrets_client:
+            return None
+        return secrets_client.get_config(config_key)
+    except Exception as e:  # pylint: disable=broad-except
+        raise AirflowConfigException(
+            'Cannot retrieve config from Alternative Secrets Backend. '
+            'Make sure it is configured properly and that the Backend '
+            'is accessible.\n'
+            f'{e}'
+        )
 
 
 def _default_config_file_path(file_name: str):

--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -88,7 +88,7 @@ def _get_config_value_from_secret_backend(config_key):
         return secrets_client.get_config(config_key)
     except Exception as e:  # pylint: disable=broad-except
         raise AirflowConfigException(
-            'Cannot retrieve config from alternative secrets git backend. '
+            'Cannot retrieve config from alternative secrets backend. '
             'Make sure it is configured properly and that the Backend '
             'is accessible.\n'
             f'{e}'

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -398,8 +398,9 @@ class Connection(Base, LoggingMixin):
                     return conn
             except Exception:  # pylint: disable=broad-except
                 log.exception(
-                    'Unable to retrieve connection from alternative secrets backend. '
-                    'Checking default secrets backends.'
+                    'Unable to retrieve connection from secrets backend (%s). '
+                    'Checking subsequent secrets backend.',
+                    type(secrets_backend).__name__,
                 )
 
         raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -36,7 +36,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
 from airflow.utils.module_loading import import_string
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 def parse_netloc_to_hostname(*args, **kwargs):
@@ -398,7 +398,7 @@ class Connection(Base, LoggingMixin):
                     return conn
             except Exception:  # pylint: disable=broad-except
                 log.exception(
-                    'Unable to retrieve connection from Alternative Secrets Backend. '
+                    'Unable to retrieve connection from alternative secrets backend. '
                     'Checking default secrets backends.'
                 )
 

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -17,8 +17,8 @@
 # under the License.
 
 import json
-import warnings
 import logging
+import warnings
 from json import JSONDecodeError
 from typing import Dict, Optional, Union
 from urllib.parse import parse_qsl, quote, unquote, urlencode, urlparse
@@ -396,10 +396,10 @@ class Connection(Base, LoggingMixin):
                 conn = secrets_backend.get_connection(conn_id=conn_id)
                 if conn:
                     return conn
-            except Exception as e:
-                log.warning('Unable to retrieve connection from alternative secret backend:'
-                            f'\n{e}\n'
-                            'Checking default secrets backends'
-                            )
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    'Unable to retrieve connection from Alternative Secrets Backend. '
+                    'Checking default secrets backends.'
+                )
 
         raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -205,9 +205,9 @@ class Variable(Base, LoggingMixin):
                 var_val = secrets_backend.get_variable(key=key)
                 if var_val is not None:
                     return var_val
-            except Exception as e:
-                log.warning('Unable to retrieve variable from alternative secret backend:'
-                            f'\n{e}\n'
-                            'Checking default secrets backends'
-                            )
+            except Exception:  # pylint: disable=broad-except
+                log.exception(
+                    'Unable to retrieve variable from Alternative Secrets Backend. '
+                    'Checking default secrets backends.'
+                )
         return None

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -33,7 +33,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
 from airflow.utils.session import provide_session
 
-log = logging.getLogger()
+log = logging.getLogger(__name__)
 
 
 class Variable(Base, LoggingMixin):
@@ -207,7 +207,7 @@ class Variable(Base, LoggingMixin):
                     return var_val
             except Exception:  # pylint: disable=broad-except
                 log.exception(
-                    'Unable to retrieve variable from Alternative Secrets Backend. '
+                    'Unable to retrieve variable from alternative secrets backend. '
                     'Checking default secrets backends.'
                 )
         return None

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -201,7 +201,13 @@ class Variable(Base, LoggingMixin):
         :return: Variable Value
         """
         for secrets_backend in ensure_secrets_loaded():
-            var_val = secrets_backend.get_variable(key=key)
-            if var_val is not None:
-                return var_val
+            try:
+                var_val = secrets_backend.get_variable(key=key)
+                if var_val is not None:
+                    return var_val
+            except Exception as e:
+                log.warning('Unable to retrieve variable from alternative secret backend:'
+                            f'\n{e}\n'
+                            'Checking default secrets backends'
+                            )
         return None

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -207,7 +207,8 @@ class Variable(Base, LoggingMixin):
                     return var_val
             except Exception:  # pylint: disable=broad-except
                 log.exception(
-                    'Unable to retrieve variable from alternative secrets backend. '
-                    'Checking default secrets backends.'
+                    'Unable to retrieve variable from secrets backend (%s). '
+                    'Checking subsequent secrets backend.',
+                    type(secrets_backend).__name__,
                 )
         return None

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -281,7 +281,7 @@ sql_alchemy_conn = airflow
         with pytest.raises(
             AirflowConfigException,
             match=re.escape(
-                'Cannot retrieve config from Alternative Secrets Backend. '
+                'Cannot retrieve config from alternative secrets backend. '
                 'Make sure it is configured properly and that the Backend '
                 'is accessible.'
             ),

--- a/tests/core/test_configuration.py
+++ b/tests/core/test_configuration.py
@@ -251,6 +251,43 @@ sql_alchemy_conn = airflow
 
         assert 'sqlite:////Users/airflow/airflow/airflow.db' == test_conf.get('test', 'sql_alchemy_conn')
 
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    @conf_vars(
+        {
+            ("secrets", "backend"): "airflow.providers.hashicorp.secrets.vault.VaultBackend",
+            ("secrets", "backend_kwargs"): '{"url": "http://127.0.0.1:8200", "token": "token"}',
+        }
+    )
+    def test_config_raise_exception_from_secret_backend_connection_error(self, mock_hvac):
+        """Get Config Value from a Secret Backend"""
+
+        mock_client = mock.MagicMock()
+        # mock_client.side_effect = AirflowConfigException
+        mock_hvac.Client.return_value = mock_client
+        mock_client.secrets.kv.v2.read_secret_version.return_value = Exception
+
+        test_config = '''[test]
+sql_alchemy_conn_secret = sql_alchemy_conn
+'''
+        test_config_default = '''[test]
+sql_alchemy_conn = airflow
+'''
+        test_conf = AirflowConfigParser(default_config=parameterized_config(test_config_default))
+        test_conf.read_string(test_config)
+        test_conf.sensitive_config_values = test_conf.sensitive_config_values | {
+            ('test', 'sql_alchemy_conn'),
+        }
+
+        with pytest.raises(
+            AirflowConfigException,
+            match=re.escape(
+                'Cannot retrieve config from Alternative Secrets Backend. '
+                'Make sure it is configured properly and that the Backend '
+                'is accessible.'
+            ),
+        ):
+            test_conf.get('test', 'sql_alchemy_conn')
+
     def test_getboolean(self):
         """Test AirflowConfigParser.getboolean"""
         test_config = """


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

1. Currently Airflow does not check the default secrets backends (`env` and `metastore db`) if there is any sort of connection related error to an Alternative Backend, causing related tasks to fail. The change proposed here allows it to fail over to checking the default backends when this happens.

2. Additionally GCP Secrets Manager causes the Airflow Webserver to crash at startup if credentials for the backend cannot be found. This behavior seems to be unique to GCP Secret Manager and this PR addresses that for parity in behavior regarding missing credentials across all backends.

closes: #14592 


@kaxil 
