### PR TITLE
generate go client with latest openapi generator template

### DIFF
--- a/clients/README.md
+++ b/clients/README.md
@@ -28,3 +28,11 @@ Supported languages:
 
 All client generation scripts use [pre-commit](https://pre-commit.com/#install)
 to prepend license header to generated code.
+
+## Usage
+
+To generate Go client, run:
+
+```
+bash ./gen/go.sh ../airflow/api_connexion/openapi/v1.yaml AIRFLOW_CLIENT_GO_REPO_PATH/airflow
+```

--- a/clients/gen/go.sh
+++ b/clients/gen/go.sh
@@ -25,7 +25,7 @@ readonly CLEANUP_DIRS
 # shellcheck source=./clients/gen/common.sh
 source "${CLIENTS_GEN_DIR}/common.sh"
 
-VERSION=1.1.0
+VERSION=2.0.0
 readonly VERSION
 
 go_config=(
@@ -35,6 +35,8 @@ go_config=(
 
 validate_input "$@"
 
+# additional-properties key value tuples need to be separated by comma, not space
+IFS=,
 gen_client go \
     --package-name airflow \
     --git-repo-id airflow-client-go/airflow \

--- a/clients/gen/go.sh
+++ b/clients/gen/go.sh
@@ -25,7 +25,7 @@ readonly CLEANUP_DIRS
 # shellcheck source=./clients/gen/common.sh
 source "${CLIENTS_GEN_DIR}/common.sh"
 
-VERSION=2.0.0
+VERSION=2.1.0
 readonly VERSION
 
 go_config=(


### PR DESCRIPTION
Fix go client generation for openapi-generator 5.x. After this the client repo is updated, I will start a discussion on the dev list to finalize go client's release procedure following @msumit 's python runbook.