### PR TITLE
Clean Markdown with dedent to respect indents

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import json
+import textwrap
 import time
 from urllib.parse import urlencode
 
@@ -344,9 +345,7 @@ def wrapped_markdown(s, css_class='rich_doc'):
     """Convert a Markdown string to HTML."""
     if s is None:
         return None
-
-    s = '\n'.join(line.lstrip() for line in s.split('\n'))
-
+    s = textwrap.dedent(s)
     return Markup(f'<div class="{css_class}" >' + markdown.markdown(s, extensions=['tables']) + "</div>")
 
 

--- a/tests/www/test_utils.py
+++ b/tests/www/test_utils.py
@@ -218,3 +218,39 @@ class TestWrappedMarkdown(unittest.TestCase):
         )
 
         assert '<div class="rich_doc" ><h1>header</h1>\n<p>1st line\n2nd line</p></div>' == rendered
+
+    def test_wrapped_markdown_with_raw_code_block(self):
+        rendered = wrapped_markdown(
+            """\
+            # Markdown code block
+
+            Inline `code` works well.
+
+                Code block
+                does not
+                respect
+                newlines
+
+            """
+        )
+
+        assert (
+            '<div class="rich_doc" ><h1>Markdown code block</h1>\n'
+            '<p>Inline <code>code</code> works well.</p>\n'
+            '<pre><code>Code block\ndoes not\nrespect\nnewlines\n</code></pre></div>'
+        ) == rendered
+
+    def test_wrapped_markdown_with_nested_list(self):
+        rendered = wrapped_markdown(
+            """
+            ### Docstring with a code block
+
+            - And
+                - A nested list
+            """
+        )
+
+        assert (
+            '<div class="rich_doc" ><h3>Docstring with a code block</h3>\n'
+            '<ul>\n<li>And<ul>\n<li>A nested list</li>\n</ul>\n</li>\n</ul></div>'
+        ) == rendered


### PR DESCRIPTION
Close #16263, close #16138.

Note that the current Markdown engine does not support [fenced code blocks](https://python-markdown.github.io/extensions/fenced_code_blocks/), so it still won’t work after this change. Python-Markdown’s fenced code support is pretty spotty, and if we want to fix that for good IMO we should switch to another Markdown parser. [markdown-it-py](https://github.com/executablebooks/markdown-it-py) (the parser backing [MyST](https://myst-parser.readthedocs.io/en/latest/using/intro.html)) is a popular choice for [CommonMark](https://commonmark.org/) support, which is much closer to [GitHub-Flavored Markdown](https://github.github.com/gfm/) which almost everyone thinks is the standard Markdown (which is unfortunately because GFM is not standard, but that’s how the world works).