### PR TITLE
Allow configuration of pod resources in helm chart

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -54,6 +54,8 @@ spec:
       imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
       name: base
       ports: []
+      resources:
+{{ toYaml .Values.workers.resources | indent 8 }}
       volumeMounts:
         - mountPath: {{ template "airflow_logs" . }}
           name: logs

--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -126,6 +126,8 @@ spec:
                 # Allow existing queries clients to complete within 120 seconds
                 command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
         - name: metrics-exporter
+          resources:
+{{ toYaml .Values.pgbouncer.metricsExporterSidecar.resources | indent 12 }}
           image: {{ template "pgbouncer_exporter_image" . }}
           imagePullPolicy: {{ .Values.images.pgbouncerExporter.pullPolicy }}
           env:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -104,6 +104,8 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-airflow-migrations
+          resources:
+{{ toYaml .Values.scheduler.resources | indent 12 }}
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
@@ -198,6 +200,8 @@ spec:
 {{- end }}
         {{- if .Values.scheduler.logGroomerSidecar.enabled }}
         - name: scheduler-log-groomer
+          resources:
+{{ toYaml .Values.scheduler.logGroomerSidecar.resources | indent 12 }}
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           {{- if .Values.scheduler.logGroomerSidecar.command }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -98,6 +98,8 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-airflow-migrations
+          resources:
+{{ toYaml .Values.webserver.resources | indent 12 }}
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -100,6 +100,8 @@ spec:
       initContainers:
       {{- if and $persistence .Values.workers.persistence.fixPermissions }}
         - name: volume-permissions
+          resources:
+{{ toYaml .Values.workers.resources | indent 12 }}
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           command:
@@ -114,6 +116,8 @@ spec:
               mountPath: {{ template "airflow_logs" . }}
       {{- end }}
         - name: wait-for-airflow-migrations
+          resources:
+{{ toYaml .Values.workers.resources | indent 12 }}
           image: {{ template "airflow_image" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
@@ -196,6 +200,8 @@ spec:
           {{- if .Values.workers.logGroomerSidecar.args }}
           args: {{ tpl (toYaml .Values.workers.logGroomerSidecar.args) . | nindent 12 }}
           {{- end }}
+          resources:
+{{ toYaml .Values.workers.logGroomerSidecar.resources | indent 12 }}
           volumeMounts:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -196,6 +196,33 @@ class PgbouncerTest(unittest.TestCase):
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
 
+    def test_metrics_exporter_resources(self):
+        docs = render_chart(
+            values={
+                "pgbouncer": {
+                    "enabled": True,
+                    "metricsExporterSidecar": {
+                        "resources": {
+                            "requests": {"memory": "2Gi", "cpu": "1"},
+                            "limits": {"memory": "3Gi", "cpu": "2"},
+                        }
+                    },
+                }
+            },
+            show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
+        )
+
+        assert {
+            "limits": {
+                "cpu": "2",
+                "memory": "3Gi",
+            },
+            "requests": {
+                "cpu": "1",
+                "memory": "2Gi",
+            },
+        } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])
+
 
 class PgbouncerConfigTest(unittest.TestCase):
     def test_config_not_created_by_default(self):

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -453,3 +453,36 @@ class PodTemplateFileTest(unittest.TestCase):
             "component": "worker",
             "tier": "airflow",
         } == jmespath.search("metadata.labels", docs[0])
+
+    def test_should_add_resources(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "resources": {
+                        "requests": {"memory": "2Gi", "cpu": "1"},
+                        "limits": {"memory": "3Gi", "cpu": "2"},
+                    }
+                }
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert {
+            "limits": {
+                "cpu": "2",
+                "memory": "3Gi",
+            },
+            "requests": {
+                "cpu": "1",
+                "memory": "2Gi",
+            },
+        } == jmespath.search("spec.containers[0].resources", docs[0])
+
+    def test_empty_resources(self):
+        docs = render_chart(
+            values={},
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+        assert {} == jmespath.search("spec.containers[0].resources", docs[0])

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -214,10 +214,22 @@ class SchedulerTest(unittest.TestCase):
             show_only=["templates/scheduler/scheduler-deployment.yaml"],
         )
         assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "200m" == jmespath.search("spec.template.spec.containers[0].resources.limits.cpu", docs[0])
         assert "169Mi" == jmespath.search(
             "spec.template.spec.containers[0].resources.requests.memory", docs[0]
         )
         assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+        assert "128Mi" == jmespath.search(
+            "spec.template.spec.initContainers[0].resources.limits.memory", docs[0]
+        )
+        assert "200m" == jmespath.search("spec.template.spec.initContainers[0].resources.limits.cpu", docs[0])
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.initContainers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search(
+            "spec.template.spec.initContainers[0].resources.requests.cpu", docs[0]
+        )
 
     def test_scheduler_resources_are_not_added_by_default(self):
         docs = render_chart(
@@ -391,3 +403,29 @@ class SchedulerTest(unittest.TestCase):
         assert "git-sync-init" in [
             c["name"] for c in jmespath.search("spec.template.spec.initContainers", docs[0])
         ]
+
+    def test_log_groomer_resources(self):
+        docs = render_chart(
+            values={
+                "scheduler": {
+                    "logGroomerSidecar": {
+                        "resources": {
+                            "requests": {"memory": "2Gi", "cpu": "1"},
+                            "limits": {"memory": "3Gi", "cpu": "2"},
+                        }
+                    }
+                }
+            },
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        assert {
+            "limits": {
+                "cpu": "2",
+                "memory": "3Gi",
+            },
+            "requests": {
+                "cpu": "1",
+                "memory": "2Gi",
+            },
+        } == jmespath.search("spec.template.spec.containers[1].resources", docs[0])

--- a/chart/tests/test_webserver.py
+++ b/chart/tests/test_webserver.py
@@ -249,16 +249,32 @@ class WebserverDeploymentTest(unittest.TestCase):
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )
         assert "128Mi" == jmespath.search("spec.template.spec.containers[0].resources.limits.memory", docs[0])
+        assert "200m" == jmespath.search("spec.template.spec.containers[0].resources.limits.cpu", docs[0])
+
         assert "169Mi" == jmespath.search(
             "spec.template.spec.containers[0].resources.requests.memory", docs[0]
         )
         assert "300m" == jmespath.search("spec.template.spec.containers[0].resources.requests.cpu", docs[0])
+
+        # initContainer wait-for-airflow-migrations
+        assert "128Mi" == jmespath.search(
+            "spec.template.spec.initContainers[0].resources.limits.memory", docs[0]
+        )
+        assert "200m" == jmespath.search("spec.template.spec.initContainers[0].resources.limits.cpu", docs[0])
+
+        assert "169Mi" == jmespath.search(
+            "spec.template.spec.initContainers[0].resources.requests.memory", docs[0]
+        )
+        assert "300m" == jmespath.search(
+            "spec.template.spec.initContainers[0].resources.requests.cpu", docs[0]
+        )
 
     def test_webserver_resources_are_not_added_by_default(self):
         docs = render_chart(
             show_only=["templates/webserver/webserver-deployment.yaml"],
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
+        assert jmespath.search("spec.template.spec.initContainers[0].resources", docs[0]) == {}
 
     @parameterized.expand(
         [

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1112,6 +1112,23 @@
                                 "bash",
                                 "/clean-logs"
                             ]
+                        },
+                        "resources": {
+                            "description": "Resources for Airflow workers log groomer sidecar.",
+                            "type": "object",
+                            "default": {},
+                            "examples": [
+                                {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    }
+                                }
+                            ]
                         }
                     }
                 }
@@ -1337,6 +1354,23 @@
                             "default": [
                                 "bash",
                                 "/clean-logs"
+                            ]
+                        },
+                        "resources": {
+                            "description": "Resources for log groomer sidecar.",
+                            "type": "object",
+                            "default": {},
+                            "examples": [
+                                {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    }
+                                }
                             ]
                         }
                     }
@@ -2210,6 +2244,31 @@
                     "description": "PgBouncer run as user parameter.",
                     "type": "integer",
                     "default": 65534
+                },
+                "metricsExporterSidecar": {
+                    "description": "PgBouncer - metrics exporter settings.",
+                    "type": "object",
+                    "x-docsSection": "PgBouncer",
+                    "additionalProperties": false,
+                    "properties": {
+                        "resources": {
+                            "description": "Resources for the PgBouncer metric exporter.",
+                            "type": "object",
+                            "default": {},
+                            "examples": [
+                                {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "128Mi"
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -447,6 +447,13 @@ workers:
     command: ~
     # Args to use when running the Airflow scheduler log groomer sidecar (templated).
     args: ["bash", "/clean-logs"]
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 # Airflow scheduler settings
 scheduler:
@@ -533,7 +540,13 @@ scheduler:
     command: ~
     # Args to use when running the Airflow scheduler log groomer sidecar (templated).
     args: ["bash", "/clean-logs"]
-
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 # Airflow create user job settings
 createUserJob:
   # Annotations on the create user job pod
@@ -640,6 +653,7 @@ webserver:
   extraContainers: []
   # Add additional init containers into webserver.
   extraInitContainers: []
+
 
   # Mount additional volumes into webserver.
   extraVolumes: []
@@ -864,6 +878,16 @@ pgbouncer:
   tolerations: []
 
   uid: 65534
+
+  metricsExporterSidecar:
+    resources: {}
+    #  limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    #  requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
 
 # Configuration for the redis provisioned by the chart
 redis:


### PR DESCRIPTION
Currently it's possible to configure some of the pod resources via the helm chart values like for example the scheduler pod main container but it's not possible for the `scheduler-log-groomer` container. 

In deployments with `ResourceQuotas` it's desirable to be able to control the `limits` of each container specifically to avoid pods reserve way too much cpu and memory  and eat up the quota unnecessarily. Even though the current helm chart allows to add a `LimitRange` that defines the default `limits` that is not enough. 

This introduces the ability to provide a specific resource blocks for 

* `pod_template_file`: for the pods started by the `KubernetesPodOperator` itself . ([pod_template_file doc](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html#pod-template-file))
* pgbouncer's `metrics-exporter`
* scheduler's  `scheduler-log-groomer`
* webserver's initContainer `wait-for-airflow-migrations`
* worker's `worker-log-groomer`