### PR TITLE
We don't need to build against Python 2.7 or 3.5 anymore

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -158,7 +158,6 @@ jobs:
         # We cannot "source" the script here because that would be a security problem (we cannot run
         # any code that comes from the sources coming from the PR. Therefore we extract the
         # DEFAULT_BRANCH and DEFAULT_CONSTRAINTS_BRANCH via custom grep/awk/sed commands
-        # Also 2.7 and 3.5 versions are not allowed to proceed on main
         id: defaults
         run: |
           DEFAULT_BRANCH=$(grep "export DEFAULT_BRANCH" scripts/ci/libraries/_initialization.sh | \
@@ -168,13 +167,6 @@ jobs:
             scripts/ci/libraries/_initialization.sh | \
             awk 'BEGIN{FS="="} {print $3}' | sed s'/["}]//g')
           echo "DEFAULT_CONSTRAINTS_BRANCH=${DEFAULT_CONSTRAINTS_BRANCH}" >> $GITHUB_ENV
-          if [[ ${DEFAULT_BRANCH} != "v1-10-test" && \
-            ( ${PYTHON_MAJOR_MINOR_VERSION} == "2.7" || ${PYTHON_MAJOR_MINOR_VERSION} == "3.5" ) \
-          ]]; then
-              echo "::set-output name=proceed::false"
-          else
-              echo "::set-output name=proceed::true"
-          fi
       - name: >
           Checkout "${{ needs.build-info.outputs.targetBranch }}" branch to 'main-airflow' folder
           to use ci/scripts from there.
@@ -184,12 +176,10 @@ jobs:
           ref: "${{ needs.build-info.outputs.targetBranch }}"
           persist-credentials: false
           submodules: recursive
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
-        if: steps.defaults.outputs.proceed == 'true'
       - name: >
           Override "scripts/ci" with the "${{ needs.build-info.outputs.targetBranch }}" branch
           so that the PR does not override it
@@ -199,16 +189,12 @@ jobs:
         run: |
           rm -rf "scripts/ci"
           mv "main-airflow/scripts/ci" "scripts"
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.TARGET_COMMIT_SHA }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Push CI images ${{ matrix.python-version }}:${{ env.TARGET_COMMIT_SHA }}"
         run: ./scripts/ci/images/ci_push_ci_images.sh
-        if: steps.defaults.outputs.proceed == 'true'
 
   build-prod-images:
     timeout-minutes: 80
@@ -245,7 +231,6 @@ jobs:
         # We cannot "source" the script here because that would be a security problem (we cannot run
         # any code that comes from the sources coming from the PR. Therefore we extract the
         # DEFAULT_BRANCH and DEFAULT_CONSTRAINTS_BRANCH via custom grep/awk/sed commands
-        # Also 2.7 and 3.5 versions are not allowed to proceed on main
         id: defaults
         run: |
           DEFAULT_BRANCH=$(grep "export DEFAULT_BRANCH" scripts/ci/libraries/_initialization.sh | \
@@ -256,12 +241,6 @@ jobs:
             awk 'BEGIN{FS="="} {print $3}' | sed s'/["}]//g')
           echo "DEFAULT_CONSTRAINTS_BRANCH=${DEFAULT_CONSTRAINTS_BRANCH}" >> $GITHUB_ENV
           if [[ ${DEFAULT_BRANCH} != "v1-10-test" && \
-            ( ${PYTHON_MAJOR_MINOR_VERSION} == "2.7" || ${PYTHON_MAJOR_MINOR_VERSION} == "3.5" ) \
-          ]]; then
-              echo "::set-output name=proceed::false"
-          else
-              echo "::set-output name=proceed::true"
-          fi
       - name: >
           Checkout "${{ needs.build-info.outputs.targetBranch }}" branch to 'main-airflow' folder
           to use ci/scripts from there.
@@ -271,12 +250,10 @@ jobs:
           ref: "${{ needs.build-info.outputs.targetBranch }}"
           persist-credentials: false
           submodules: recursive
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Setup python"
         uses: actions/setup-python@v2
         with:
           python-version: ${{ needs.build-info.outputs.defaultPythonVersion }}
-        if: steps.defaults.outputs.proceed == 'true'
       - name: >
           Override "scripts/ci" with the "${{ needs.build-info.outputs.targetBranch }}" branch
           so that the PR does not override it
@@ -286,22 +263,17 @@ jobs:
         run: |
           rm -rf "scripts/ci"
           mv "main-airflow/scripts/ci" "scripts"
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Free space"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Build CI images ${{ matrix.python-version }}:${{ env.TARGET_COMMIT_SHA }}"
         run: ./scripts/ci/images/ci_prepare_ci_image_on_ci.sh
         # Pull images built in the previous step
-        if: steps.defaults.outputs.proceed == 'true'
         env:
           GITHUB_REGISTRY_WAIT_FOR_IMAGE: "true"
       - name: "Build PROD images ${{ matrix.python-version }}:${{ env.TARGET_COMMIT_SHA }}"
         run: ./scripts/ci/images/ci_prepare_prod_image_on_ci.sh
-        if: steps.defaults.outputs.proceed == 'true'
       - name: "Push PROD images ${{ matrix.python-version }}:${{ env.TARGET_COMMIT_SHA }}"
         run: ./scripts/ci/images/ci_push_production_images.sh
-        if: steps.defaults.outputs.proceed == 'true'
 
   cancel-on-ci-build:
     name: "Cancel 'CI Build' jobs on workflow failed/cancelled"

--- a/CI.rst
+++ b/CI.rst
@@ -808,8 +808,7 @@ The image names follow the patterns:
 +--------------+----------------------------+--------------------------------+--------------------------------------------------------------------------------------------+
 
 * <BRANCH> might be either "main" or "v1-10-test" or "v2-*-test"
-* <X.Y> - Python version (Major + Minor). For "main" and "v2-*-test" should be in ["3.6", "3.7", "3.8"]. For
-  v1-10-test it should be in ["2.7", "3.5", "3.6". "3.7", "3.8"].
+* <X.Y> - Python version (Major + Minor). For "main" and "v2-*-test" should be in ["3.6", "3.7", "3.8"].
 * <COMMIT_SHA> - for images that get merged to "main", "v2-*-test" of "v1-10-test", or built as part of a
   pull request the images are tagged with the (full length) commit SHA of that particular branch. For pull
   requests the SHA used is the tip of the pull request branch.

--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ We **highly** recommend upgrading to the latest Airflow major release at the ear
 
 Apache Airflow is tested with:
 
-|                      | Main version (dev)        | Stable version (2.0.2)   | Previous version (1.10.15) |
-| -------------------- | ------------------------- | ------------------------ | -------------------------  |
-| Python               | 3.6, 3.7, 3.8             | 3.6, 3.7, 3.8            | 2.7, 3.5, 3.6, 3.7, 3.8    |
-| Kubernetes           | 1.20, 1.19, 1.18          | 1.20, 1.19, 1.18         | 1.18, 1.17, 1.16           |
-| PostgreSQL           | 9.6, 10, 11, 12, 13       | 9.6, 10, 11, 12, 13      | 9.6, 10, 11, 12, 13        |
-| MySQL                | 5.7, 8                    | 5.7, 8                   | 5.6, 5.7                   |
-| SQLite               | 3.15.0+                   | 3.15.0+                  | 3.15.0+                    |
-| MSSQL(Experimental)  | 2017,2019                 |                          |                            |
+|                      | Main version (dev)        | Stable version (2.0.2)   |
+| -------------------- | ------------------------- | ------------------------ |
+| Python               | 3.6, 3.7, 3.8             | 3.6, 3.7, 3.8            |
+| Kubernetes           | 1.20, 1.19, 1.18          | 1.20, 1.19, 1.18         |
+| PostgreSQL           | 9.6, 10, 11, 12, 13       | 9.6, 10, 11, 12, 13      |
+| MySQL                | 5.7, 8                    | 5.7, 8                   |
+| SQLite               | 3.15.0+                   | 3.15.0+                  |
+| MSSQL(Experimental)  | 2017,2019                 |                          |
 
 **Note:** MySQL 5.x versions are unable to or have limitations with
 running multiple schedulers -- please see the [Scheduler docs](https://airflow.apache.org/docs/apache-airflow/stable/scheduler.html).

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -102,7 +102,7 @@ function initialization::initialize_base_variables() {
     export PRODUCTION_IMAGE="false"
 
     # All supported major/minor versions of python in all versions of Airflow
-    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("2.7" "3.5" "3.6" "3.7" "3.8")
+    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.6" "3.7" "3.8")
     export ALL_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported major/minor versions of python


### PR DESCRIPTION
Airflow 1.10 has reached end of life on June 17th 2021, so we can tidy up our build scripts and not have to build these versions anymore

Do not merge before June 17th 2021