### PR TITLE
Add num_runs query param for tree refresh

### DIFF
--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -28,6 +28,7 @@ import getMetaValue from './meta_value';
 // dagId comes from dag.html
 const dagId = getMetaValue('dag_id');
 const treeDataUrl = getMetaValue('tree_data');
+const numRuns = getMetaValue('num_runs');
 
 function toDateString(ts) {
   const dt = new Date(ts * 1000);
@@ -418,7 +419,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleRefresh() {
     $('#loading-dots').css('display', 'inline-block');
-    $.get(`${treeDataUrl}?dag_id=${dagId}`)
+    $.get(`${treeDataUrl}?dag_id=${dagId}&num_runs=${numRuns}`)
       .done(
         (runs) => {
           const newData = {

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -33,6 +33,11 @@
   </style>
 {% endblock %}
 
+{% block head_meta %}
+  {{ super() }}
+  <meta name="num_runs" content="{{ num_runs }}">
+{% endblock %}
+
 {% block content %}
   {{ super() }}
   <div class="row dag-view-tools">


### PR DESCRIPTION
Add `num_runs` as a meta field to add to the tree refresh request

Closes #16367 Where the refresh data was only using the default 25 runs even if the user changed the count via the UI.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
