### PR TITLE
Fix templated default/example values in config ref docs

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -92,7 +92,7 @@ def _default_config_file_path(file_name: str):
     return os.path.join(templates_dir, file_name)
 
 
-def default_config_yaml() -> dict:
+def default_config_yaml() -> List[dict]:
     """
     Read Airflow configs from YAML file
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -349,8 +349,20 @@ if PACKAGE_NAME == 'apache-airflow':
     ) in AirflowConfigParser.deprecated_options.items():
         deprecated_options[deprecated_section][deprecated_key] = section, key, since_version
 
+    configs = default_config_yaml()
+
+    # We want the default/example we show in the docs to reflect the value _after_
+    # the config has been templated, not before
+    # e.g. {{dag_id}} in default_config.cfg -> {dag_id} in airflow.cfg, and what we want in docs
+    keys_to_format = ["default", "example"]
+    for conf_section in configs:
+        for option in conf_section["options"]:
+            for key in keys_to_format:
+                if option[key] and "{{" in option[key]:
+                    option[key] = option[key].replace("{{", "{").replace("}}", "}")
+
     jinja_contexts = {
-        'config_ctx': {"configs": default_config_yaml(), "deprecated_options": deprecated_options},
+        'config_ctx': {"configs": configs, "deprecated_options": deprecated_options},
         'quick_start_ctx': {
             'doc_root_url': f'https://airflow.apache.org/docs/apache-airflow/{PACKAGE_VERSION}/'
             if FOR_PRODUCTION


### PR DESCRIPTION
We should show the actual default/example value in the configuration
reference docs, not the templated values.

e.g. `{dag_id}` like you get in a generated airflow.cfg, not `{{dag_id}}`
like is stored in the airflow.cfg template.

Before:
<img width="526" alt="Screen Shot 2021-06-14 at 4 11 36 PM" src="https://user-images.githubusercontent.com/66968678/121966903-aa0a7800-cd2c-11eb-9ed9-58b682a2419f.png">

After:
<img width="458" alt="Screen Shot 2021-06-14 at 4 11 45 PM" src="https://user-images.githubusercontent.com/66968678/121966922-b1ca1c80-cd2c-11eb-8c9a-70a4936cf0e1.png">
