### PR TITLE
Disable Pylint member check for ``tests/decorators/test_python.py``

### DIFF
--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -454,9 +454,11 @@ class TestAirflowTaskDecorator(TestPythonBase):
         bigger_number.operator.run(  # pylint: disable=maybe-no-member
             start_date=DEFAULT_DATE, end_date=DEFAULT_DATE
         )
-        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)  # pylint: disable=maybe-no-member
+        # pylint: disable=no-member, maybe-no-member
+        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
         ti_add_num = [ti for ti in dr.get_task_instances() if ti.task_id == 'add_num'][0]
-        assert ti_add_num.xcom_pull(key=ret.key) == (test_number + 2) * 2  # pylint: disable=maybe-no-member
+        assert ti_add_num.xcom_pull(key=ret.key) == (test_number + 2) * 2
+        # pylint: enable=no-member, maybe-no-member
 
     def test_dag_task(self):
         """Tests dag.task property to generate task"""


### PR DESCRIPTION
Some PRs are failing this check:

https://github.com/apache/airflow/pull/16408/checks?check_run_id=2823934948#step:9:54
https://github.com/apache/airflow/pull/16393/checks?check_run_id=2813095540#step:9:54

However those PRs have not changed that file.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
