### PR TITLE
Fix spellcheck failure

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -77,6 +77,7 @@ Configs
 ContainerPort
 Cron
 Ctrl
+DBs
 Daemonize
 DagFileProcessorManager
 DagRun


### PR DESCRIPTION
Locally, building the `apache-airflow` docs results in a spellcheck failure:

```                        
migrations-ref.rst:151: (DBs)  Increase text size for MySQL (not relevant for other DBs’ text types)         
                                                                                                             
File path: apache-airflow/migrations-ref.rst                                                                 
Incorrect Spelling: 'DBs'                                                                                    
Line with Error: 'Increase text size for MySQL (not relevant for other DBs’ text types)'                     
Line Number: 151
```

I'm not exactly sure why CI passes, but this is certainly annoying to have happen locally regardless.