### PR TITLE
Use resource and action names in test_security.py.

### DIFF
--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -45,7 +45,7 @@ def create_role(app, name, permissions=None):
         permissions = []
     for permission in permissions:
         perm_object = appbuilder.sm.get_permission(*permission)
-        appbuilder.sm.add_permission_role(role, perm_object)
+        appbuilder.sm.add_permission_to_role(role, perm_object)
     return role
 
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -88,7 +88,6 @@ class TestSecurity(unittest.TestCase):
         cls.app.config['WTF_CSRF_ENABLED'] = False
         cls.delete_roles()
         cls.security_manager = cls.appbuilder.sm
-        cls.security_manager.reset_all_permissions()
 
     def setUp(self):
         clear_db_runs()

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -196,8 +196,8 @@ def user_edit_one_dag(acl_app):
 
 @pytest.mark.usefixtures("user_edit_one_dag")
 def test_permission_exist(acl_app):
-    perms_views = acl_app.appbuilder.sm.find_permissions_view_menu(
-        acl_app.appbuilder.sm.find_view_menu('DAG:example_bash_operator'),
+    perms_views = acl_app.appbuilder.sm.get_resource_permissions(
+        acl_app.appbuilder.sm.get_resource('DAG:example_bash_operator')
     )
     assert len(perms_views) == 2
 


### PR DESCRIPTION
Part of the Resource/Action FAB Name epic.

Updates the following test files to use the new naming scheme. Should not change any behaviors, as it just updates variable names and method call names.

tests/test_utils/api_connexion_utils.py
tests/www/test_security.py