### PR TITLE
Remove class references in changelogs

### DIFF
--- a/airflow/providers/docker/CHANGELOG.rst
+++ b/airflow/providers/docker/CHANGELOG.rst
@@ -35,14 +35,15 @@ Breaking changes
 * ``Replace DockerOperator's 'volumes' arg for 'mounts' (#15843)``
 
 The ``volumes`` parameter in
-:class:`~airflow.providers.docker.operators.docker.DockerOperator` and
-:class:`~airflow.providers.docker.operators.docker_swarm.DockerSwarmOperator`
+``airflow.providers.docker.operators.docker.DockerOperator`` and
+``airflow.providers.docker.operators.docker_swarm.DockerSwarmOperator``
 was replaced by the ``mounts`` parameter, which uses the newer
 `mount syntax <https://docs.docker.com/storage/>`__ instead of ``--bind``.
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
    * ``Updated documentation for June 2021 provider release (#16294)``
+   * ``More documentation update for June providers release (#16405)``
 
 1.2.0
 .....

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -66,7 +66,7 @@ Bug Fixes
    * ``Updated documentation for June 2021 provider release (#16294)``
    * ``Fix spelling (#15699)``
    * ``Add short description to BaseSQLToGCSOperator docstring (#15728)``
-
+   * ``More documentation update for June providers release (#16405)``
 
 3.0.0
 .....
@@ -77,7 +77,7 @@ Breaking changes
 Change in ``AutoMLPredictOperator``
 ```````````````````````````````````
 
-The ``params`` parameter in :class:`~airflow.providers.google.cloud.operators.automl.AutoMLPredictOperator` class
+The ``params`` parameter in ``airflow.providers.google.cloud.operators.automl.AutoMLPredictOperator`` class
 was renamed ``operation_params`` because it conflicted with a ``param`` parameter in the ``BaseOperator`` class.
 
 Integration with the ``apache.beam`` provider


### PR DESCRIPTION
PyPI does not handle class references in changelogs.
Since we want changelogs to be part of PyPI readmes,
we need to remove those.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
