### PR TITLE
[#16460]: Fixed typos in task regex param

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -80,7 +80,7 @@ def dag_backfill(args, dag=None):
         )
         if not dag.task_dict:
             raise AirflowException(
-                f"There is no any task that match '{args.task_regex}' regex. Nothing to run, exiting..."
+                f"There are no tasks that match '{args.task_regex}' regex. Nothing to run, exiting..."
             )
 
     run_conf = None

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -78,6 +78,10 @@ def dag_backfill(args, dag=None):
         dag = dag.partial_subset(
             task_ids_or_regex=args.task_regex, include_upstream=not args.ignore_dependencies
         )
+        if not dag.task_dict:
+            err_message = f"There is no any task that match '{args.task_regex}' regex. "
+                          "Nothing to run, exiting..."
+            raise AirflowException(err_message)
 
     run_conf = None
     if args.conf:

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -79,9 +79,10 @@ def dag_backfill(args, dag=None):
             task_ids_or_regex=args.task_regex, include_upstream=not args.ignore_dependencies
         )
         if not dag.task_dict:
-            err_message = f"There is no any task that match '{args.task_regex}' regex. "
-                          "Nothing to run, exiting..."
-            raise AirflowException(err_message)
+            raise AirflowException(
+                f"There is no any task that match '{args.task_regex}' regex. "
+                "Nothing to run, exiting..."
+            )
 
     run_conf = None
     if args.conf:

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -80,8 +80,7 @@ def dag_backfill(args, dag=None):
         )
         if not dag.task_dict:
             raise AirflowException(
-                f"There is no any task that match '{args.task_regex}' regex. "
-                "Nothing to run, exiting..."
+                f"There is no any task that match '{args.task_regex}' regex. Nothing to run, exiting..."
             )
 
     run_conf = None


### PR DESCRIPTION
Backfill should not create a DagRun in case there is no any task that matches the regex.

closes: #16460
