### PR TITLE
Bugfix: Add missing application item to conn params in snowflake test

### DIFF
--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -121,6 +121,7 @@ class TestSnowflakeHook(unittest.TestCase):
             'role': 'af_role',
             'authenticator': 'snowflake',
             'session_parameters': {"QUERY_TAG": "This is a test hook"},
+            "application": os.environ.get("AIRFLOW_SNOWFLAKE_PARTNER", "AIRFLOW"),
         }
         assert self.db_hook.snowflake_conn_id == 'snowflake_default'  # pylint: disable=no-member
         assert conn_params_shouldbe == self.db_hook._get_conn_params()

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -109,7 +109,9 @@ class TestSnowflakeHook(unittest.TestCase):
         assert self.db_hook.query_ids == query_ids[::2]
         cur.close.assert_called()
 
-    def test_get_conn_params(self):
+    @mock.patch("airflow.providers.snowflake.hooks.snowflake.os.environ")
+    def test_get_conn_params(self, mock_env):
+        mock_env.get.return_value = 'test_partner'
         conn_params_shouldbe = {
             'user': 'user',
             'password': 'pw',
@@ -121,7 +123,7 @@ class TestSnowflakeHook(unittest.TestCase):
             'role': 'af_role',
             'authenticator': 'snowflake',
             'session_parameters': {"QUERY_TAG": "This is a test hook"},
-            "application": os.environ.get("AIRFLOW_SNOWFLAKE_PARTNER", "AIRFLOW"),
+            "application": 'test_partner',
         }
         assert self.db_hook.snowflake_conn_id == 'snowflake_default'  # pylint: disable=no-member
         assert conn_params_shouldbe == self.db_hook._get_conn_params()

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -109,9 +109,8 @@ class TestSnowflakeHook(unittest.TestCase):
         assert self.db_hook.query_ids == query_ids[::2]
         cur.close.assert_called()
 
-    @mock.patch("airflow.providers.snowflake.hooks.snowflake.os.environ")
-    def test_get_conn_params(self, mock_env):
-        mock_env.get.return_value = 'test_partner'
+    @mock.patch.dict(os.environ, AIRFLOW_SNOWFLAKE_PARTNER='test_partner')
+    def test_get_conn_params(self):
         conn_params_shouldbe = {
             'user': 'user',
             'password': 'pw',


### PR DESCRIPTION
The application item is missing in snowflake hook test

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
