### PR TITLE
Remove support jinja templated log_id in elasticsearch

### DIFF
--- a/airflow/providers/elasticsearch/CHANGELOG.rst
+++ b/airflow/providers/elasticsearch/CHANGELOG.rst
@@ -26,6 +26,14 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 * ``Auto-apply apply_default decorator (#15667)``
+* ``Remove support Jinja templated log_id in Elasticsearch (TBD)``
+
+  While undocumented, previously ``[elasticsearch] log_id`` supported a Jinja templated string.
+  Support for Jinja templates has now been removed. ``log_id`` should be a template string instead,
+  for example: ``{dag_id}-{task_id}-{execution_date}-{try_number}``.
+
+  If you used a Jinja template previously, the ``execution_date`` on your Elasticsearch documents will need
+  to be updated to the new format.
 
 .. warning:: Due to apply_default decorator removal, this version of the provider requires Airflow 2.1.0+.
    If your Airflow version is < 2.1.0, and you want to install this provider version, first upgrade

--- a/airflow/providers/elasticsearch/CHANGELOG.rst
+++ b/airflow/providers/elasticsearch/CHANGELOG.rst
@@ -26,7 +26,7 @@ Breaking changes
 ~~~~~~~~~~~~~~~~
 
 * ``Auto-apply apply_default decorator (#15667)``
-* ``Remove support Jinja templated log_id in Elasticsearch (TBD)``
+* ``Remove support Jinja templated log_id in Elasticsearch (16465)``
 
   While undocumented, previously ``[elasticsearch] log_id`` supported a Jinja templated string.
   Support for Jinja templates has now been removed. ``log_id`` should be a template string instead,
@@ -45,10 +45,16 @@ Features
 
 * ``Support remote logging in elasticsearch with filebeat 7 (#14625)``
 
+Bug fixes
+~~~~~~~~~
+
+* ``Fix external elasticsearch logs link (#16357)``
+
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
    * ``Bump pyupgrade v2.13.0 to v2.18.1 (#15991)``
    * ``Updated documentation for June 2021 provider release (#16294)``
+   * ``More documentation update for June providers release (#16405)``
    * ``Docs: Fix url for ''Elasticsearch'' (#16275)``
    * ``Add ElasticSearch Connection Doc (#16436)``
    * ``More documentation update for June providers release (#16405)``

--- a/airflow/providers/elasticsearch/CHANGELOG.rst
+++ b/airflow/providers/elasticsearch/CHANGELOG.rst
@@ -19,7 +19,7 @@
 Changelog
 ---------
 
-2.0.0
+2.0.1
 .....
 
 Breaking changes

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -22,7 +22,7 @@ description: |
     `Elasticsearch <https://www.elastic.co/elasticsearch>`__
 
 versions:
-  - 2.0.0
+  - 2.0.1
   - 1.0.4
   - 1.0.3
   - 1.0.2

--- a/docs/apache-airflow-providers-elasticsearch/index.rst
+++ b/docs/apache-airflow-providers-elasticsearch/index.rst
@@ -57,7 +57,7 @@ Package apache-airflow-providers-elasticsearch
 `Elasticsearch <https://www.elastic.co/elasticsearch>`__
 
 
-Release: 2.0.0
+Release: 2.0.1
 
 Provider package
 ----------------

--- a/docs/apache-airflow-providers-elasticsearch/logging.rst
+++ b/docs/apache-airflow-providers-elasticsearch/logging.rst
@@ -38,7 +38,7 @@ First, to use the handler, ``airflow.cfg`` must be configured as follows:
 
     [elasticsearch]
     host = <host>:<port>
-    log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+    log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
     end_of_log_mark = end_of_log
     write_stdout =
     json_fields =
@@ -56,7 +56,7 @@ To output task logs to stdout in JSON format, the following config could be used
 
     [elasticsearch]
     host = <host>:<port>
-    log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+    log_id_template = {dag_id}-{task_id}-{execution_date}-{try_number}
     end_of_log_mark = end_of_log
     write_stdout = True
     json_format = True

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -43,6 +43,7 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
     TASK_ID = 'task_for_testing_file_log_handler'
     EXECUTION_DATE = datetime(2016, 1, 1)
     LOG_ID = f'{DAG_ID}-{TASK_ID}-2016-01-01T00:00:00+00:00-1'
+    JSON_LOG_ID = f'{DAG_ID}-{TASK_ID}-{ElasticsearchTaskHandler._clean_execution_date(EXECUTION_DATE)}-1'
 
     @elasticmock
     def setUp(self):
@@ -396,27 +397,10 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
         assert self.es_task_handler.closed
 
     def test_render_log_id(self):
-        expected_log_id = (
-            'dag_for_testing_file_task_handler-'
-            'task_for_testing_file_log_handler-2016-01-01T00:00:00+00:00-1'
-        )
-        log_id = self.es_task_handler._render_log_id(self.ti, 1)
-        assert expected_log_id == log_id
+        assert self.LOG_ID == self.es_task_handler._render_log_id(self.ti, 1)
 
-        # Switch to use jinja template.
-        self.es_task_handler = ElasticsearchTaskHandler(
-            self.local_log_location,
-            self.filename_template,
-            '{{ ti.dag_id }}-{{ ti.task_id }}-{{ ts }}-{{ try_number }}',
-            self.end_of_log_mark,
-            self.write_stdout,
-            self.json_format,
-            self.json_fields,
-            self.host_field,
-            self.offset_field,
-        )
-        log_id = self.es_task_handler._render_log_id(self.ti, 1)
-        assert expected_log_id == log_id
+        self.es_task_handler.json_format = True
+        assert self.JSON_LOG_ID == self.es_task_handler._render_log_id(self.ti, 1)
 
     def test_clean_execution_date(self):
         clean_execution_date = self.es_task_handler._clean_execution_date(datetime(2016, 7, 8, 9, 10, 11, 12))


### PR DESCRIPTION
This simplifies the handling of log_id in elasticsearch remote logging.
Support for a jinja templated log_id was never explicitly documented, and
where it was included in examples it was actually broken.

If someone fixed the broken jinja examples and used it, differing formats for
execution_date may be problematic and updating documents in Elasticsearch
may be required.