### PR TITLE
Fix elasticsearch external log link with json_format

### DIFF
--- a/airflow/providers/elasticsearch/log/es_task_handler.py
+++ b/airflow/providers/elasticsearch/log/es_task_handler.py
@@ -335,14 +335,8 @@ class ElasticsearchTaskHandler(FileTaskHandler, ExternalLoggingMixin, LoggingMix
         :return: URL to the external log collection service
         :rtype: str
         """
-        log_id = self.log_id_template.format(
-            dag_id=task_instance.dag_id,
-            task_id=task_instance.task_id,
-            execution_date=task_instance.execution_date,
-            try_number=try_number,
-        )
-        url = 'https://' + self.frontend.format(log_id=quote(log_id))
-        return url
+        log_id = self._render_log_id(task_instance, try_number)
+        return 'https://' + self.frontend.format(log_id=quote(log_id))
 
     @property
     def supports_external_link(self) -> bool:

--- a/tests/providers/elasticsearch/log/test_es_task_handler.py
+++ b/tests/providers/elasticsearch/log/test_es_task_handler.py
@@ -408,20 +408,21 @@ class TestElasticsearchTaskHandler(unittest.TestCase):  # pylint: disable=too-ma
 
     @parameterized.expand(
         [
-            # Common case
-            ('localhost:5601/{log_id}', 'https://localhost:5601/' + quote(LOG_ID.replace('T', ' '))),
+            # Common cases
+            (True, 'localhost:5601/{log_id}', 'https://localhost:5601/' + quote(JSON_LOG_ID)),
+            (False, 'localhost:5601/{log_id}', 'https://localhost:5601/' + quote(LOG_ID)),
             # Ignore template if "{log_id}"" is missing in the URL
-            ('localhost:5601', 'https://localhost:5601'),
+            (False, 'localhost:5601', 'https://localhost:5601'),
         ]
     )
-    def test_get_external_log_url(self, es_frontend, expected_url):
+    def test_get_external_log_url(self, json_format, es_frontend, expected_url):
         es_task_handler = ElasticsearchTaskHandler(
             self.local_log_location,
             self.filename_template,
             self.log_id_template,
             self.end_of_log_mark,
             self.write_stdout,
-            self.json_format,
+            json_format,
             self.json_fields,
             self.host_field,
             self.offset_field,


### PR DESCRIPTION
When using json_format with elasticsearch remote logging the
execution date is sanitized, so we need to use the same
sanitized value when building the log_id for external links.