### PR TITLE
Update Watchtower version to 1.0.6

### DIFF
--- a/docs/apache-airflow-providers-amazon/index.rst
+++ b/docs/apache-airflow-providers-amazon/index.rst
@@ -80,7 +80,7 @@ PIP requirements
 PIP package     Version required
 ==============  ====================
 ``boto3``       ``>=1.15.0,<1.18.0``
-``watchtower``  ``~=0.7.3``
+``watchtower``  ``~=1.0.6``
 ==============  ====================
 
 Cross provider package dependencies

--- a/setup.py
+++ b/setup.py
@@ -195,7 +195,7 @@ def get_sphinx_theme_version() -> str:
 # Start dependencies group
 amazon = [
     'boto3>=1.15.0,<1.18.0',
-    'watchtower~=0.7.3',
+    'watchtower~=1.0.6',
 ]
 apache_beam = [
     'apache-beam>=2.20.0',


### PR DESCRIPTION
Currently a pre 1.0 version of Watchtower is being used. There have been
many bug fixes and improvements since this version (the changelog can be found [here](https://github.com/kislyuk/watchtower/blob/develop/Changes.rst)).

This change updates Airflow's specified version in setup.py.

I have ran the following commands to test this locally:

`./breeze generate-constraints --generate-constraints-mode source-providers`

`./scripts/ci/testing/ci_run_airflow_testing.sh`

I believe this is the only line that needs to be changed for a dependency upgrade ([see discussion I started on the community slack](https://apache-airflow.slack.com/archives/CCPRP7943/p1621024646304600)) but please correct me if I'm wrong here.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
