### PR TITLE
Mask value if the key is ``token``

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 DEFAULT_SENSITIVE_FIELDS = frozenset(
     {
         'access_token',
+        'token',
         'api_key',
         'apikey',
         'authorization',

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -34,7 +34,6 @@ log = logging.getLogger(__name__)
 DEFAULT_SENSITIVE_FIELDS = frozenset(
     {
         'access_token',
-        'token',
         'api_key',
         'apikey',
         'authorization',
@@ -43,6 +42,7 @@ DEFAULT_SENSITIVE_FIELDS = frozenset(
         'password',
         'private_key',
         'secret',
+        'token',
     }
 )
 """Names of fields (Connection extra, Variable key name etc.) that are deemed sensitive"""


### PR DESCRIPTION
Some connections (including the databricks connection) use the key 'token' in the 'extra' field (this has always been the case). Including it here so that these sensitive tokens are also masked by default.

The prior implementation just masked all of the 'extra' json: "XXXXXXXX" if conn.extra_dejson else None https://github.com/apache/airflow/blob/88199eefccb4c805f8d6527bab5bf600b397c35e/airflow/hooks/base.py#L78

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
