### PR TITLE
fix: change graph focus to top of view instead of center

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -541,7 +541,6 @@ function focusedGroupKey() {
 function focusGroup(nodeId) {
   if (nodeId != null && zoom != null) {
     const { x } = g.node(nodeId);
-    const { y } = g.node(nodeId);
     // This is the total canvas size.
     const { width, height } = svg.node().getBoundingClientRect();
 
@@ -560,7 +559,8 @@ function focusGroup(nodeId) {
       1.5, // cap zoom level to 1.5 so nodes are not too large
     ) * 0.9;
 
-    const [deltaX, deltaY] = [width / 2 - x * scale, height / 2 - y * scale];
+    // deltaY of 5 keeps the zoom at the top of the view but with a slight margin
+    const [deltaX, deltaY] = [width / 2 - x * scale, 5];
     zoom.translate([deltaX, deltaY]);
     zoom.scale(scale);
     zoom.event(innerSvg.transition().duration(duration));


### PR DESCRIPTION
When expanding/collapsing a group. We originally set the focus to the center of the graph view renderable area. But that isn't the center of the screen and often times the renderable area requires you to scroll down. This PR changes the focus to the top of the graph view so it appears clearly without the need to scroll.

Closes #16359

Before:
<img width="1168" alt="Screen Shot 2021-06-16 at 11 24 20 AM" src="https://user-images.githubusercontent.com/4600967/122257650-d5f53d00-ce95-11eb-88ae-f2ef75424c44.png">

After:
<img width="1166" alt="Screen Shot 2021-06-16 at 11 15 49 AM" src="https://user-images.githubusercontent.com/4600967/122257606-cb3aa800-ce95-11eb-85d0-d5d0f7304223.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
