### PR TITLE
Fix description on scheduler.livenessprobe.periodSeconds

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1144,7 +1144,7 @@
                             "default": 10
                         },
                         "periodSeconds": {
-                            "description": "Webserver Liveness probe period seconds.",
+                            "description": "Scheduler Liveness probe period seconds.",
                             "type": "integer",
                             "default": 30
                         }


### PR DESCRIPTION
Simply fix the description of `scheduler.livenessprobe.periodSeconds` so it is right in the params reference docs.