### PR TITLE
 gitpodify Apache Airflow - online development workspace

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,8 @@
 tasks:
   - init: ./breeze
     
+  - openMode: split-right
+    command: echo for running integration test with breeze
 # Ports to expose on workspace startup
 ports:
   - port: 8000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,7 @@
 # Docs: https://www.gitpod.io/docs/config-gitpod-file/
 
 tasks:
-  - init: ./breeze
+  - init: ./breeze -y
     
   - openMode: split-right
     command: echo for running integration test with breeze

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+# Reference: https://www.gitpod.io/docs/references/gitpod-yml
+# Docs: https://www.gitpod.io/docs/config-gitpod-file/
+
+tasks:
+  - init: ./breeze
+    
+# Ports to expose on workspace startup
+ports:
+  - port: 8000
+    onOpen: open-preview


### PR DESCRIPTION
At present, configuration startups up the ide
with `./breeze -y` for setting up breeze environment.

**How to test?**

Visiting the link
[https://gitpod.io/#https://github.com/`apache/airflow/pull/16498`](https://gitpod.io/#https://github.com/apache/airflow/pull/16498) would fire up the online ready to code workspace.


**Terminals:**

![image](https://user-images.githubusercontent.com/53068787/122351597-e7107d80-cf6b-11eb-9850-20df163fdd0f.png)

**Testing:**

  <details>
  <summary><code> pytest tests/core/test_core.py::TestCore::test_check_operators</code></summary>

```console
root@d143c0ff1e51:/opt/airflow# pytest tests/core/test_core.py::TestCore::test_check_operators
================================= test session starts ==================================
platform linux -- Python 3.6.13, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /opt/airflow, configfile: pytest.ini
plugins: httpx-0.12.0, cov-2.12.0, requests-mock-1.9.3, celery-4.4.7, forked-1.3.0, instafail-0.4.2, xdist-2.2.1, rerunfailures-9.1.1, flaky-3.7.0, timeouts-1.2.1
setup timeout: 0.0s, execution timeout: 0.0s, teardown timeout: 0.0s
collected 1 item                                                                       

tests/core/test_core.py::TestCore::test_check_operators 
PASSED                   [100%]

=================================== warnings summary ===================================
tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/importlib/__init__.py:126: DeprecationWarning: This module is deprecated. Please use `airflow.providers.tableau.hooks.tableau`.
    return _bootstrap._gcd_import(name[level:], package, level)

tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
    return f(*args, **kwds)

tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/site-packages/boto/plugin.py:40: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/site-packages/dns/hash.py:25: DeprecationWarning: dns.hash module will be removed in future versions. Please use hashlib instead.
    DeprecationWarning)

tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/site-packages/eventlet/green/OpenSSL/__init__.py:6: DeprecationWarning: OpenSSL.tsafe is deprecated and will be removed
    from . import tsafe

tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/site-packages/alembic/ddl/sqlite.py:44: UserWarning: Skipping unsupported ALTER for creation of implicit constraintPlease refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy.
    "Skipping unsupported ALTER for "

tests/core/test_core.py::TestCore::test_check_operators
tests/core/test_core.py::TestCore::test_check_operators
tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/site-packages/flask_caching/__init__.py:241: DeprecationWarning: Using the initialization functions in flask_caching.backend is deprecated.  Use the a full path to backend classes directly.
    category=DeprecationWarning,

tests/core/test_core.py::TestCore::test_check_operators
tests/core/test_core.py::TestCore::test_check_operators
tests/core/test_core.py::TestCore::test_check_operators
tests/core/test_core.py::TestCore::test_check_operators
  /usr/local/lib/python3.6/site-packages/marshmallow/fields.py:201: RemovedInMarshmallow4Warning: Passing field metadata as a keyword arg is deprecated. Use the explicit `metadata=...` argument instead.
    RemovedInMarshmallow4Warning,

tests/core/test_core.py::TestCore::test_check_operators
  /opt/airflow/tests/core/test_core.py:102: DeprecationWarning: This class is deprecated.
              Please use `airflow.operators.sql.SQLCheckOperator`.
    task_id='check', sql="select count(*) from operator_test_table", conn_id=conn_id, dag=self.dag

tests/core/test_core.py::TestCore::test_check_operators
  /opt/airflow/tests/core/test_core.py:113: DeprecationWarning: This class is deprecated.
              Please use `airflow.operators.sql.SQLValueCheckOperator`.
    dag=self.dag,

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================== 1 passed, 15 warnings in 37.48s ============================
```

</details>

**Problems encountered:**

1. "Error response from daemon: driver failed programming external connectivity on endpoint" while running `./breeze --integration mongo`

2. Which ports should be open to public/private ? (suggestions please.)
![image](https://user-images.githubusercontent.com/53068787/122359407-25f60180-cf73-11eb-9bf6-027858a69440.png)


Related: #16480 
