### PR TITLE
Clean up Mssql data directories at the end of each CI run

### DIFF
--- a/scripts/ci/libraries/_traps.sh
+++ b/scripts/ci/libraries/_traps.sh
@@ -31,8 +31,17 @@ function traps::add_trap() {
     do
         # adding trap to exiting trap
         local handlers
-        handlers="$( trap -p "${signal}" | cut -f2 -d \' )"
+        # shellcheck disable=SC2046
+        handlers="$(_parse_current_traps "${signal}")"
         # shellcheck disable=SC2064
         trap "${trap};${handlers}" "${signal}"
     done
+}
+
+function _parse_current_traps() {
+  local signal="$1"
+  # Yes, eval is evil, but this is the only way I was able to "parse" the output of trap which is "already" quoted
+  eval "set -- $(trap -p "$signal")"
+  # Output format is `trap -- 'command' <signal>`
+  echo "${3-}"
 }

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -103,7 +103,7 @@ function run_airflow_testing_in_docker() {
 
             # Runner user doesn't have blanket sudo access, but we can run docker as root. Go figure
             traps::add_trap "rm -vrf -- '${MSSQL_DATA_VOLUME}' || true" EXIT
-            traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rvf -- /mssql/*'" EXIT
+            traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rvf -- /mssql/*' || true" EXIT
 
             # Clean up at start too, in case a previous runer left it messy
             docker run --rm -u 0 -v "${MSSQL_DATA_VOLUME}":/mssql alpine sh -c 'rm -rfv -- /mssql/*'  || true

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -102,7 +102,7 @@ function run_airflow_testing_in_docker() {
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-bind-volume.yml")
 
             # Runner user doesn't have blanket sudo access, but we can run docker as root. Go figure
-            traps::add_trap "rm -vrf -- '${MSSQL_DATA_VOLUME}'" EXIT
+            traps::add_trap "rm -vrf -- '${MSSQL_DATA_VOLUME}' || true" EXIT
             traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rvf -- /mssql/*'" EXIT
 
             # Clean up at start too, in case a previous runer left it messy

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -102,12 +102,12 @@ function run_airflow_testing_in_docker() {
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-bind-volume.yml")
 
             # Runner user doesn't have blanket sudo access, but we can run docker as root. Go figure
-            traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rf -- /mssql/*' 2>/dev/null" EXIT
-            traps::add_trap "rm -rf -- '${MSSQL_DATA_VOLUME}'" EXIT
+            traps::add_trap "rm -vrf -- '${MSSQL_DATA_VOLUME}'" EXIT
+            traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rvf -- /mssql/*'" EXIT
 
             # Clean up at start too, in case a previous runer left it messy
-            docker run --rm -u 0 -v "${MSSQL_DATA_VOLUME}":/mssql alpine sh -c 'rm -rf -- /mssql/*' 2>/dev/null || true
-            rm -rf -- "${MSSQL_DATA_VOLUME}" || true
+            docker run --rm -u 0 -v "${MSSQL_DATA_VOLUME}":/mssql alpine sh -c 'rm -rfv -- /mssql/*'  || true
+            rm -rvf -- "${MSSQL_DATA_VOLUME}" || true
         else
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-docker-volume.yml")
         fi

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -100,6 +100,14 @@ function run_airflow_testing_in_docker() {
             # to be set to "root" (GID=0) for the volume to work and this cannot be accomplished without sudo
             chmod a+rwx "${MSSQL_DATA_VOLUME}"
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-bind-volume.yml")
+
+            # Runner user doesn't have blanket sudo access, but we can run docker as root. Go figure
+            traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rf -- /mssql/*' 2>/dev/null" EXIT
+            traps::add_trap "rm -rf -- '${MSSQL_DATA_VOLUME}'" EXIT
+
+            # Clean up at start too, in case a previous runer left it messy
+            docker run --rm -u 0 -v "${MSSQL_DATA_VOLUME}":/mssql alpine sh -c 'rm -rf -- /mssql/*' 2>/dev/null || true
+            rm -rf -- "${MSSQL_DATA_VOLUME}" || true
         else
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-docker-volume.yml")
         fi

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -102,12 +102,10 @@ function run_airflow_testing_in_docker() {
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-bind-volume.yml")
 
             # Runner user doesn't have blanket sudo access, but we can run docker as root. Go figure
-            traps::add_trap "rm -vrf -- '${MSSQL_DATA_VOLUME}' || true" EXIT
             traps::add_trap "docker run -u 0 --rm -v ${MSSQL_DATA_VOLUME}:/mssql alpine sh -c 'rm -rvf -- /mssql/*' || true" EXIT
 
             # Clean up at start too, in case a previous runer left it messy
             docker run --rm -u 0 -v "${MSSQL_DATA_VOLUME}":/mssql alpine sh -c 'rm -rfv -- /mssql/*'  || true
-            rm -rvf -- "${MSSQL_DATA_VOLUME}" || true
         else
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-docker-volume.yml")
         fi


### PR DESCRIPTION
On self hosted runners (where we have the tmpfs docker data dir for speed) we need to remove the files between runs, else mssql 2019 and 2017 will fight over the data dirs
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).