### PR TITLE
Don't fail the build if we cant run `apt clean`

### DIFF
--- a/scripts/ci/tools/ci_free_space_on_ci.sh
+++ b/scripts/ci/tools/ci_free_space_on_ci.sh
@@ -23,7 +23,7 @@ sudo swapoff -a
 sudo rm -f /swapfile
 
 echo "${COLOR_BLUE}Cleaning apt${COLOR_RESET}"
-sudo apt clean
+sudo apt clean || true
 
 echo "${COLOR_BLUE}Pruning docker${COLOR_RESET}"
 docker_v system prune --all --force --volumes


### PR DESCRIPTION
I just had a build fail with this:

```
E: Could not get lock /var/cache/apt/archives/lock. It is held by
process 53088 (unattended-upgr)
E: Unable to lock directory /var/cache/apt/archives/
```

That is not a fatal error, and we should just continue


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).