### PR TITLE
Add extra_headers argument to LivyHook and LivyOperator

### DIFF
--- a/airflow/providers/apache/livy/hooks/livy.py
+++ b/airflow/providers/apache/livy/hooks/livy.py
@@ -70,9 +70,13 @@ class LivyHook(HttpHook, LoggingMixin):
     hook_name = 'Apache Livy'
 
     def __init__(
-        self, livy_conn_id: str = default_conn_name, extra_options: Optional[Dict[str, Any]] = None
+        self,
+        livy_conn_id: str = default_conn_name,
+        extra_options: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, Any]] = None,
     ) -> None:
         super().__init__(http_conn_id=livy_conn_id)
+        self.extra_headers = extra_headers or {}
         self.extra_options = extra_options or {}
 
     def get_conn(self, headers: Optional[Dict[str, Any]] = None) -> Any:
@@ -137,7 +141,9 @@ class LivyHook(HttpHook, LoggingMixin):
             self.get_conn()
         self.log.info("Submitting job %s to %s", batch_submit_body, self.base_url)
 
-        response = self.run_method(method='POST', endpoint='/batches', data=batch_submit_body)
+        response = self.run_method(
+            method='POST', endpoint='/batches', data=batch_submit_body, headers=self.extra_headers
+        )
         self.log.debug("Got response: %s", response.text)
 
         try:

--- a/airflow/providers/apache/livy/operators/livy.py
+++ b/airflow/providers/apache/livy/operators/livy.py
@@ -93,6 +93,7 @@ class LivyOperator(BaseOperator):
         livy_conn_id: str = 'livy_default',
         polling_interval: int = 0,
         extra_options: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
         # pylint: disable-msg=too-many-arguments
@@ -121,6 +122,7 @@ class LivyOperator(BaseOperator):
         self._livy_conn_id = livy_conn_id
         self._polling_interval = polling_interval
         self._extra_options = extra_options or {}
+        self._extra_headers = extra_headers or {}
 
         self._livy_hook: Optional[LivyHook] = None
         self._batch_id: Union[int, str]
@@ -133,7 +135,11 @@ class LivyOperator(BaseOperator):
         :rtype: LivyHook
         """
         if self._livy_hook is None or not isinstance(self._livy_hook, LivyHook):
-            self._livy_hook = LivyHook(livy_conn_id=self._livy_conn_id, extra_options=self._extra_options)
+            self._livy_hook = LivyHook(
+                livy_conn_id=self._livy_conn_id,
+                extra_headers=self._extra_headers,
+                extra_options=self._extra_options,
+            )
         return self._livy_hook
 
     def execute(self, context: Dict[Any, Any]) -> Any:

--- a/tests/providers/apache/livy/hooks/test_livy.py
+++ b/tests/providers/apache/livy/hooks/test_livy.py
@@ -255,7 +255,7 @@ class TestLivyHook(unittest.TestCase):
         resp = hook.post_batch(file='sparkapp')
 
         mock_request.assert_called_once_with(
-            method='POST', endpoint='/batches', data=json.dumps({'file': 'sparkapp'})
+            method='POST', endpoint='/batches', data=json.dumps({'file': 'sparkapp'}), headers={}
         )
 
         request_args = mock_request.call_args[1]
@@ -446,3 +446,16 @@ class TestLivyHook(unittest.TestCase):
         with self.subTest('random string'):
             with pytest.raises(TypeError):
                 LivyHook._validate_session_id('asd')
+
+    @requests_mock.mock()
+    def test_extra_headers(self, mock):
+        mock.register_uri(
+            'POST',
+            '//livy:8998/batches',
+            json={'id': BATCH_ID, 'state': BatchState.STARTING.value, 'log': []},
+            status_code=201,
+            request_headers={'X-Requested-By': 'user'},
+        )
+
+        hook = LivyHook(extra_headers={'X-Requested-By': 'user'})
+        hook.post_batch(file='sparkapp')


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Adds an `extra_headers` option to `LivyHook` and `LivyOperator`. This allows passing extra header options to requests before sending a request to Livy. This is required for instance when CSRF protection is enabled (i.e. on HDinsights): https://github.com/MicrosoftDocs/azure-docs/issues/10457.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
