### PR TITLE
Support for overriding webserver and flower service ports

### DIFF
--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -44,9 +44,12 @@ spec:
     component: flower
     release: {{ .Release.Name }}
   ports:
+    {{- if .Values.flower.service.portsOverride }}
+    {{- toYaml .Values.flower.service.portsOverride | nindent 4 }}
+    {{- else }}
     - name: flower-ui
-      protocol: TCP
       port: {{ .Values.ports.flowerUI }}
+    {{- end }}
   {{- if .Values.flower.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.flower.service.loadBalancerIP }}
   {{- end }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -155,7 +155,7 @@ spec:
 {{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}
 {{- end }}
           ports:
-            - name: webserver-ui
+            - name: airflow-ui
               containerPort: {{ .Values.ports.airflowUI }}
           livenessProbe:
             httpGet:

--- a/chart/templates/webserver/webserver-service.yaml
+++ b/chart/templates/webserver/webserver-service.yaml
@@ -42,9 +42,12 @@ spec:
     component: webserver
     release: {{ .Release.Name }}
   ports:
+    {{- if .Values.webserver.service.portsOverride }}
+    {{- toYaml .Values.webserver.service.portsOverride | nindent 4 }}
+    {{- else }}
     - name: airflow-ui
-      protocol: TCP
       port: {{ .Values.ports.airflowUI }}
+    {{- end }}
   {{- if .Values.webserver.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.webserver.service.loadBalancerIP }}
   {{- end }}

--- a/chart/tests/test_flower.py
+++ b/chart/tests/test_flower.py
@@ -269,9 +269,7 @@ class TestFlowerService:
             "spec.selector", docs[0]
         )
         assert "ClusterIP" == jmespath.search("spec.type", docs[0])
-        assert {"name": "flower-ui", "protocol": "TCP", "port": 5555} in jmespath.search(
-            "spec.ports", docs[0]
-        )
+        assert {"name": "flower-ui", "port": 5555} in jmespath.search("spec.ports", docs[0])
 
     def test_overrides(self):
         docs = render_chart(
@@ -290,7 +288,15 @@ class TestFlowerService:
 
         assert {"foo": "bar"} == jmespath.search("metadata.annotations", docs[0])
         assert "LoadBalancer" == jmespath.search("spec.type", docs[0])
-        assert {"name": "flower-ui", "protocol": "TCP", "port": 9000} in jmespath.search(
-            "spec.ports", docs[0]
-        )
+        assert {"name": "flower-ui", "port": 9000} in jmespath.search("spec.ports", docs[0])
         assert "127.0.0.1" == jmespath.search("spec.loadBalancerIP", docs[0])
+
+    def test_port_overrides(self):
+        docs = render_chart(
+            values={
+                "flower": {"service": {"portsOverride": [{"name": "foo", "protocol": "UDP", "port": 1000}]}},
+            },
+            show_only=["templates/flower/flower-service.yaml"],
+        )
+
+        assert {"name": "foo", "protocol": "UDP", "port": 1000} in jmespath.search("spec.ports", docs[0])

--- a/chart/tests/test_webserver.py
+++ b/chart/tests/test_webserver.py
@@ -441,9 +441,7 @@ class WebserverServiceTest(unittest.TestCase):
             "spec.selector", docs[0]
         )
         assert "ClusterIP" == jmespath.search("spec.type", docs[0])
-        assert {"name": "airflow-ui", "protocol": "TCP", "port": 8080} in jmespath.search(
-            "spec.ports", docs[0]
-        )
+        assert {"name": "airflow-ui", "port": 8080} in jmespath.search("spec.ports", docs[0])
 
     def test_overrides(self):
         docs = render_chart(
@@ -462,10 +460,20 @@ class WebserverServiceTest(unittest.TestCase):
 
         assert {"foo": "bar"} == jmespath.search("metadata.annotations", docs[0])
         assert "LoadBalancer" == jmespath.search("spec.type", docs[0])
-        assert {"name": "airflow-ui", "protocol": "TCP", "port": 9000} in jmespath.search(
-            "spec.ports", docs[0]
-        )
+        assert {"name": "airflow-ui", "port": 9000} in jmespath.search("spec.ports", docs[0])
         assert "127.0.0.1" == jmespath.search("spec.loadBalancerIP", docs[0])
+
+    def test_port_overrides(self):
+        docs = render_chart(
+            values={
+                "webserver": {
+                    "service": {"portsOverride": [{"name": "foo", "protocol": "UDP", "port": 1000}]}
+                },
+            },
+            show_only=["templates/webserver/webserver-service.yaml"],
+        )
+
+        assert {"name": "foo", "protocol": "UDP", "port": 1000} in jmespath.search("spec.ports", docs[0])
 
 
 class WebserverConfigmapTest(unittest.TestCase):

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1737,6 +1737,23 @@
                             "type": "object",
                             "default": {}
                         },
+                        "portsOverride": {
+                            "description": "Override ports for the webserver Service.",
+                            "type": "array",
+                            "default": [],
+                            "examples": [
+                                {
+                                    "name": "airflow-ui",
+                                    "port": 80,
+                                    "targetPort": "airflow-ui"
+                                },
+                                {
+                                    "name": "only_sidecar",
+                                    "port": 80,
+                                    "targetPort": 8888
+                                }
+                            ]
+                        },
                         "loadBalancerIP": {
                             "description": "Webserver Service loadBalancerIP.",
                             "type": [
@@ -1864,6 +1881,18 @@
                             "description": "Annotations for the flower Service.",
                             "type": "object",
                             "default": {}
+                        },
+                        "portsOverride": {
+                            "description": "Override ports for the flower Service.",
+                            "type": "array",
+                            "default": [],
+                            "examples": [
+                                {
+                                    "name": "flower-ui",
+                                    "port": 8080,
+                                    "targetPort": "flower-ui"
+                                }
+                            ]
                         },
                         "loadBalancerIP": {
                             "description": "Flower Service loadBalancerIP.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -676,6 +676,16 @@ webserver:
     ## service annotations
     annotations: {}
     portsOverride: []
+    # To change the port used to access the webserver:
+    # portsOverride:
+    # - name: airflow-ui
+    #   port: 80
+    #   targetPort: airflow-ui
+    # To only expose a sidecar, not the webserver directly:
+    # portsOverride:
+    # - name: only_sidecar
+    #   port: 80
+    #   targetPort: 8888
     loadBalancerIP: ~
 
   # Select certain nodes for airflow webserver pods.
@@ -741,6 +751,11 @@ flower:
     ## service annotations
     annotations: {}
     portsOverride: []
+    # To change the port used to access flower:
+    # portsOverride:
+    # - name: flower-ui
+    #   port: 8080
+    #   targetPort: flower-ui
     loadBalancerIP: ~
 
   # Launch additional containers into the flower pods.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -675,6 +675,7 @@ webserver:
     type: ClusterIP
     ## service annotations
     annotations: {}
+    portsOverride: []
     loadBalancerIP: ~
 
   # Select certain nodes for airflow webserver pods.
@@ -739,6 +740,7 @@ flower:
     type: ClusterIP
     ## service annotations
     annotations: {}
+    portsOverride: []
     loadBalancerIP: ~
 
   # Launch additional containers into the flower pods.


### PR DESCRIPTION
This allows services to expose sidecars with webservers in them, or even to only expose a sidecar (say enforcing inbound traffic to go through a proxy).

If we are okay with the general approach, both NetworkPolicy and Ingress need similar changes so there is broad support for these types of sidecars.

Closes #16039