### PR TITLE
Revert "Exclude Yarn.lock to be built into python wheel (#16494)"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,7 +29,6 @@ graft scripts/upstart
 graft airflow/config_templates
 recursive-exclude airflow/www/node_modules *
 global-exclude __pycache__  *.pyc
-exclude airflow/www/yarn.lock
 include airflow/alembic.ini
 include airflow/api_connexion/openapi/v1.yaml
 include airflow/git_version


### PR DESCRIPTION
This reverts commit a76a67cb8bb3dc55b1b0ffd05084919924b5b8d3.

e.g.
https://github.com/apache/airflow/runs/2853673927
https://github.com/apache/airflow/pull/16517/checks?check_run_id=2853852004

This is breaking main, build prod image:

```
+ find package.json yarn.lock static/css static/js -type f
+ sort
+ xargs md5sum
find: ‘yarn.lock’: No such file or directory
```