### PR TITLE
Tree View UI for larger DAGs & more consistent spacing in Tree View

### DIFF
--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -72,7 +72,6 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   treeDepth += 1;
 
-  const innerWidth = window.innerWidth > 1200 ? 1200 : window.innerWidth;
   const squareX = (treeDepth * 25) + 200;
 
   const squareSpacing = 2;

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -73,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
   treeDepth += 1;
 
   const innerWidth = window.innerWidth > 1200 ? 1200 : window.innerWidth;
-  const squareX = innerWidth - (data.instances.length * squareSize) - (treeDepth * 50);
+  const squareX = (treeDepth * 25) + 200;
 
   const squareSpacing = 2;
   const margin = {


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #16238

Currently, the space available for the tree and operator names in the tree view is calculated by substracting a quite a few things from the screen width. This does not really make sense. It would be better to calculate the required width of the tree and add some more for operator names.

This PR makes a suggestion accordingly. 

Note: It might be even better to calculate the required width for operator names dynamically. 