### PR TITLE
Fix bug in mark TI success api

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1980,10 +1980,10 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         origin = get_safe_url(args.get('origin'))
         execution_date = args.get('execution_date')
 
-        upstream = to_boolean(args.get('failed_upstream'))
-        downstream = to_boolean(args.get('failed_downstream'))
-        future = to_boolean(args.get('failed_future'))
-        past = to_boolean(args.get('failed_past'))
+        upstream = to_boolean(args.get('success_upstream'))
+        downstream = to_boolean(args.get('success_downstream'))
+        future = to_boolean(args.get('success_future'))
+        past = to_boolean(args.get('success_past'))
 
         return self._mark_task_instance_state(
             dag_id,


### PR DESCRIPTION
Mistakenly checking for the wrong args in TI success API. Introduced in PR https://github.com/apache/airflow/pull/16233. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
