### PR TITLE
fix example_jenkins_job_trigger.py

### DIFF
--- a/airflow/providers/jenkins/example_dags/example_jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/example_dags/example_jenkins_job_trigger.py
@@ -17,7 +17,7 @@
 # under the License.
 from datetime import datetime, timedelta
 
-from six.moves.urllib.request import Request
+from requests import Request
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
@@ -58,7 +58,7 @@ with DAG(
         # You can then use it to access things or to get the job number
         # This url looks like : http://jenkins_url/job/job_name/job_number/
         url += "artifact/myartifact.xml"  # Or any other artifact name
-        request = Request(url)
+        request = Request(method='GET', url=url)
         response = jenkins_server.jenkins_open(request)
         return response  # We store the artifact content in a xcom variable for later use
 


### PR DESCRIPTION
fix initialization of Request which used by `jenkins.Jenkins.jenkins_open` in DAG demo.
The demo will failed because `urllib.request.Request` does not have an attribute named `cookies`, while `requests.sessions.Session.prepare_request` using it.

```
[xxxx] {taskinstance.py:1481} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/airflow/models/taskinstance.py", line 1137, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/usr/local/lib/python3.6/site-packages/airflow/models/taskinstance.py", line 1311, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/usr/local/lib/python3.6/site-packages/airflow/models/taskinstance.py", line 1341, in _execute_task
    result = task_copy.execute(context=context)
  File "/usr/local/lib/python3.6/site-packages/airflow/operators/python.py", line 150, in execute
    return_value = self.execute_callable()
  File "/usr/local/lib/python3.6/site-packages/airflow/operators/python.py", line 161, in execute_callable
    return self.python_callable(*self.op_args, **self.op_kwargs)
  File "/xxx/dags/test_jenkins.py", line 49, in grab_artifact_from_jenkins
    response = jenkins_server.jenkins_open(request)
  File "/usr/local/lib/python3.6/site-packages/jenkins/__init__.py", line 557, in jenkins_open
    return self.jenkins_request(req, add_crumb, resolve_auth).text
  File "/usr/local/lib/python3.6/site-packages/jenkins/__init__.py", line 576, in jenkins_request
    self._request(req))
  File "/usr/local/lib/python3.6/site-packages/jenkins/__init__.py", line 544, in _request
    r = self._session.prepare_request(req)
  File "/usr/local/lib/python3.6/site-packages/requests/sessions.py", line 440, in prepare_request
    cookies = request.cookies or {}
AttributeError: 'Request' object has no attribute 'cookies'
```

```
    def jenkins_open(self, req, add_crumb=True, resolve_auth=True):
        '''Return the HTTP response body from a ``requests.Request``.

        :returns: ``str``
        '''
        return self.jenkins_request(req, add_crumb, resolve_auth).text
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
