### PR TITLE
Updating the DAG docstring to include `render_template_as_native_obj`

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -216,6 +216,10 @@ class DAG(LoggingMixin):
         <https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment>`_
 
     :type jinja_environment_kwargs: dict
+    :param render_template_as_native_obj: If True, uses a Jinja ```NativeEnvironment``
+        to render templates as native Python types. If False, a Jinja
+        ``Environment`` is used to render templates as string values.
+    :type render_template_as_native_obj: bool
     :param tags: List of tags to help filtering DAGS in the UI.
     :type tags: List[str]
     """


### PR DESCRIPTION
The current docstring for the `airflow.models.dag.DAG` class is missing the `render_template_as_native_obj` parameter and therefore missing in the public documentation as well.  This PR updates the docstring accordingly.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
