### PR TITLE
Have UI and POST /task_instances_state API endpoint have same behaviour

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -20,7 +20,6 @@ from flask import current_app, request
 from marshmallow import ValidationError
 from sqlalchemy import and_, func
 
-from airflow.api.common.experimental.mark_tasks import set_state
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound
 from airflow.api_connexion.parameters import format_datetime, format_parameters
@@ -295,14 +294,14 @@ def post_set_task_instances_state(dag_id, session):
         error_message = f"Task ID {task_id} not found"
         raise NotFound(error_message)
 
-    tis = set_state(
-        tasks=[task],
+    tis = dag.set_task_instance_state(
+        task_id=task_id,
         execution_date=data["execution_date"],
+        state=data["new_state"],
         upstream=data["include_upstream"],
         downstream=data["include_downstream"],
         future=data["include_future"],
         past=data["include_past"],
-        state=data["new_state"],
         commit=not data["dry_run"],
     )
     execution_dates = {ti.execution_date for ti in tis}

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1304,6 +1304,79 @@ class DAG(LoggingMixin):
 
         return tis
 
+    @provide_session
+    def set_task_instance_state(
+        self,
+        task_id: str,
+        execution_date: datetime,
+        state: State,
+        upstream: Optional[bool] = False,
+        downstream: Optional[bool] = False,
+        future: Optional[bool] = False,
+        past: Optional[bool] = False,
+        session=None,
+    ) -> List[TaskInstance]:
+        """
+        Set the state of a TaskInstance to the given state, and clear its downstream tasks that are
+        in failed or upstream_failed state.
+
+        :param task_id: Task ID of the TaskInstance
+        :type task_id str
+        :param execution_date: execution_date of the TaskInstance
+        :type execution_date: datetime
+        :param state: State to set the TaskInstance to
+        :type state: State
+        :param upstream: Include all upstream tasks of the given task_id
+        :type upstream: bool
+        :param downstream: Include all downstream tasks of the given task_id
+        :type downstream: bool
+        :param future: Include all future TaskInstances of the given task_id
+        :type future: bool
+        :param past: Include all past TaskInstances of the given task_id
+        :type past: bool
+        """
+        from airflow.api.common.experimental.mark_tasks import set_state
+
+        task = self.get_task(task_id)
+        task.dag = self
+
+        altered = set_state(
+            tasks=[task],
+            execution_date=execution_date,
+            upstream=upstream,
+            downstream=downstream,
+            future=future,
+            past=past,
+            state=state,
+            commit=True,
+            session=session,
+        )
+
+        # Clear downstream tasks that are in failed/upstream_failed state to resume them.
+        # Flush the session so that the tasks marked success are reflected in the db.
+        session.flush()
+        subdag = self.partial_subset(
+            task_ids_or_regex={task_id},
+            include_downstream=True,
+            include_upstream=False,
+        )
+
+        end_date = execution_date if not future else None
+        start_date = execution_date if not past else None
+
+        subdag.clear(
+            start_date=start_date,
+            end_date=end_date,
+            include_subdags=True,
+            include_parentdag=True,
+            only_failed=True,
+            session=session,
+            # Exclude the task itself from being cleared
+            exclude_task_ids={task_id},
+        )
+
+        return altered
+
     @property
     def roots(self) -> List[BaseOperator]:
         """Return nodes with no parents. These are first to execute and are called roots or root nodes."""

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1322,7 +1322,7 @@ class DAG(LoggingMixin):
         in failed or upstream_failed state.
 
         :param task_id: Task ID of the TaskInstance
-        :type task_id str
+        :type task_id: str
         :param execution_date: execution_date of the TaskInstance
         :type execution_date: datetime
         :param state: State to set the TaskInstance to

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1314,6 +1314,7 @@ class DAG(LoggingMixin):
         downstream: Optional[bool] = False,
         future: Optional[bool] = False,
         past: Optional[bool] = False,
+        commit: Optional[bool] = True,
         session=None,
     ) -> List[TaskInstance]:
         """
@@ -1332,6 +1333,8 @@ class DAG(LoggingMixin):
         :type downstream: bool
         :param future: Include all future TaskInstances of the given task_id
         :type future: bool
+        :param commit: Commit changes
+        :type commit: bool
         :param past: Include all past TaskInstances of the given task_id
         :type past: bool
         """
@@ -1348,9 +1351,12 @@ class DAG(LoggingMixin):
             future=future,
             past=past,
             state=state,
-            commit=True,
+            commit=commit,
             session=session,
         )
+
+        if not commit:
+            return altered
 
         # Clear downstream tasks that are in failed/upstream_failed state to resume them.
         # Flush the session so that the tasks marked success are reflected in the db.

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -1033,10 +1033,10 @@ class TestPostClearTaskInstances(TestTaskInstanceEndpoint):
 
 
 class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
-    @mock.patch('airflow.api_connexion.endpoints.task_instance_endpoint.set_state')
-    def test_should_assert_call_mocked_api(self, mock_set_state, session):
+    @mock.patch('airflow.models.dag.DAG.set_task_instance_state')
+    def test_should_assert_call_mocked_api(self, mock_set_task_instance_state, session):
         self.create_task_instances(session)
-        mock_set_state.return_value = (
+        mock_set_task_instance_state.return_value = (
             session.query(TaskInstance).filter(TaskInstance.task_id == "print_the_context").all()
         )
         response = self.client.post(
@@ -1065,16 +1065,14 @@ class TestPostSetTaskInstanceState(TestTaskInstanceEndpoint):
             ]
         }
 
-        dag = self.app.dag_bag.dags['example_python_operator']
-        task = dag.task_dict['print_the_context']
-        mock_set_state.assert_called_once_with(
+        mock_set_task_instance_state.assert_called_once_with(
             commit=False,
             downstream=True,
             execution_date=DEFAULT_DATETIME_1,
             future=True,
             past=True,
             state='failed',
-            tasks=[task],
+            task_id='print_the_context',
             upstream=True,
         )
 


### PR DESCRIPTION
Keep the behavior of `post_set_task_instances_state` in the api the same as that of Mark Success/Failed in the UI after #13037.
Marking Success/Failed in the UI also clears downstream tasks that are in failed/upstream_failed state. This PR makes the corresponding feature in the api `post_set_task_instances_state` do the same. See comments from @ashb [here](https://github.com/apache/airflow/pull/13037#pullrequestreview-673022834).