### PR TITLE
Use safe get with AWS DMS describe replication tasks

### DIFF
--- a/airflow/providers/amazon/aws/hooks/dms.py
+++ b/airflow/providers/amazon/aws/hooks/dms.py
@@ -47,12 +47,12 @@ class DmsHook(AwsBaseHook):
         Describe replication tasks
 
         :return: Marker and list of replication tasks
-        :rtype: (str, list)
+        :rtype: (Optional[str], list)
         """
         dms_client = self.get_conn()
         response = dms_client.describe_replication_tasks(**kwargs)
 
-        return response['Marker'], response['ReplicationTasks']
+        return response.get('Marker'), response.get('ReplicationTasks', [])
 
     def find_replication_tasks_by_arn(
         self, replication_task_arn: str, without_settings: Optional[bool] = False
@@ -66,8 +66,7 @@ class DmsHook(AwsBaseHook):
 
         :return: list of replication tasks that match the ARN
         """
-        dms_client = self.get_conn()
-        response = dms_client.describe_replication_tasks(
+        _, tasks = self.describe_replication_tasks(
             Filters=[
                 {
                     'Name': 'replication-task-arn',
@@ -77,7 +76,7 @@ class DmsHook(AwsBaseHook):
             WithoutSettings=without_settings,
         )
 
-        return response['ReplicationTasks']
+        return tasks
 
     def get_task_status(self, replication_task_arn: str) -> Optional[str]:
         """

--- a/airflow/providers/amazon/aws/operators/dms_describe_tasks.py
+++ b/airflow/providers/amazon/aws/operators/dms_describe_tasks.py
@@ -58,7 +58,7 @@ class DmsDescribeTasksOperator(BaseOperator):
         Describes AWS DMS replication tasks from Airflow
 
         :return: Marker and list of replication tasks
-        :rtype: (str, list)
+        :rtype: (Optional[str], list)
         """
         dms_hook = DmsHook(aws_conn_id=self.aws_conn_id)
         return dms_hook.describe_replication_tasks(**self.describe_tasks_kwargs)


### PR DESCRIPTION
AWS DMS boto3 `describe_replication_tasks` omits `Marker` property in
the response if no more tasks is available, it also omits
`ReplicationTasks` property if no tasks is found.

In this case `describe_replication_tasks` function in DmsHook will fail, so it's better to use safe get.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
