### PR TITLE
Fix false positive when inheriting class that inherits ``DbApiHook``

### DIFF
--- a/airflow/upgrade/rules/db_api_functions.py
+++ b/airflow/upgrade/rules/db_api_functions.py
@@ -63,8 +63,9 @@ def get_all_non_dbapi_children():
         next_generation = []
         for child in basehook_children:
             subclasses = child.__subclasses__()
-            if subclasses:
-                next_generation.extend(subclasses)
+            for subclass in subclasses:
+                if all(base_class.__name__ != 'DbApiHook' for base_class in subclass.__bases__):
+                    next_generation.append(subclass)
         res.extend(next_generation)
         basehook_children = next_generation
     return res

--- a/tests/upgrade/rules/test_db_api_functions.py
+++ b/tests/upgrade/rules/test_db_api_functions.py
@@ -18,6 +18,7 @@ from unittest import TestCase
 
 from airflow.hooks.base_hook import BaseHook
 from airflow.hooks.dbapi_hook import DbApiHook
+from airflow.contrib.hooks.bigquery_hook import BigQueryHook
 from airflow.upgrade.rules.db_api_functions import DbApiRule
 
 
@@ -41,7 +42,7 @@ class GrandChildHook(MyHook):
         pass
 
 
-class ProperDbApiHook(DbApiHook):
+class ProperDbApiHook(DbApiHook, BigQueryHook):
     def bulk_dump(self, table, tmp_file):
         pass
 


### PR DESCRIPTION
closes apache#14541

This PR/commit fixes the issue described in https://github.com/apache/airflow/issues/14541 when there were false positives when the Hook was inherited from a class other than ``DbApiHook``.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
