### PR TITLE
Add selective permissions for GitHub Tokens

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -23,6 +23,9 @@ on:  # yamllint disable-line rule:truthy
   pull_request_target:
   push:
     branches: ['main', 'v1-10-test', 'v1-10-stable', 'v2-0-test']
+permissions:
+  # all other permissions are set to none
+  contents: read
 env:
   MOUNT_SELECTED_LOCAL_SOURCES: "false"
   FORCE_ANSWER_TO_QUESTIONS: "yes"
@@ -38,7 +41,7 @@ env:
   # Airflow one is going to be used
   CONSTRAINTS_GITHUB_REPOSITORY: >-
     ${{ secrets.CONSTRAINTS_GITHUB_REPOSITORY != '' &&
-        secrets.CONSTRAINTS_GITHUB_REPOSITORY || github.repository }}
+        secrets.CONSTRAINTS_GITHUB_REPOSITORY || 'apache/airflow' }}
   # This token is WRITE one - pull_request_target type of events always have the WRITE token
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # This token should not be empty in pull_request_target type of event.
@@ -130,6 +133,8 @@ jobs:
           BUILD_IMAGES_OVERRIDE: ${{ secrets.AIRFLOW_GITHUB_REGISTRY_WAIT_FOR_IMAGE }}
 
   build-ci-images:
+    permissions:
+      packages: write
     timeout-minutes: 80
     name: "Build CI images ${{matrix.python-version}}"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
@@ -204,6 +209,8 @@ jobs:
         run: ./scripts/ci/images/ci_push_ci_images.sh
 
   build-prod-images:
+    permissions:
+      packages: write
     timeout-minutes: 80
     name: "Build PROD images ${{matrix.python-version}}"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
@@ -282,6 +289,8 @@ jobs:
         run: ./scripts/ci/images/ci_push_production_images.sh
 
   cancel-on-ci-build:
+    permissions:
+      actions: write
     name: "Cancel 'CI Build' jobs on workflow failed/cancelled"
     runs-on: ${{ github.repository == 'apache/airflow' && 'self-hosted' || 'ubuntu-20.04' }}
     if: failure() || cancelled()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ on:  # yamllint disable-line rule:truthy
     branches: ['main', 'v[0-9]+-[0-9]+-test']
   pull_request:
     branches: ['main', 'v[0-9]+-[0-9]+-test', 'v[0-9]+-[0-9]+-stable']
-
+permissions:
+  # All other permissions are set to none
+  contents: read
 env:
   MOUNT_SELECTED_LOCAL_SOURCES: "false"
   FORCE_ANSWER_TO_QUESTIONS: "yes"
@@ -1098,6 +1100,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           retention-days: 7
 
   push-prod-images-to-github-registry:
+    permissions:
+      packages: write
     timeout-minutes: 10
     name: "Push PROD images as cache to GitHub Registry"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
@@ -1160,6 +1164,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           PUSH_PYTHON_BASE_IMAGE: ${{ steps.push-python-image.outputs.wanted}}
 
   push-ci-images-to-github-registry:
+    permissions:
+      packages: write
     timeout-minutes: 10
     name: "Push CI images as cache to GitHub Registry"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
@@ -1204,6 +1210,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         run: ./scripts/ci/images/ci_push_ci_images.sh
 
   constraints:
+    permissions:
+      contents: write
     timeout-minutes: 10
     name: "Constraints"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,8 @@ on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
 concurrency:
   group: codeql-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/label_when_reviewed.yml
+++ b/.github/workflows/label_when_reviewed.yml
@@ -18,7 +18,6 @@
 ---
 name: Label when reviewed
 on: pull_request_review  # yamllint disable-line rule:truthy
-
 jobs:
 
   label-when-reviewed:

--- a/.github/workflows/label_when_reviewed_workflow_run.yml
+++ b/.github/workflows/label_when_reviewed_workflow_run.yml
@@ -21,6 +21,10 @@ on:  # yamllint disable-line rule:truthy
   workflow_run:
     workflows: ["Label when reviewed"]
     types: ['requested']
+permissions:
+  # All other permissions are set to none
+  contents: read
+  pull-requests: write
 jobs:
 
   label-when-reviewed:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,10 @@ name: 'Close stale PRs & Issues'
 on:  # yamllint disable-line rule:truthy
   schedule:
     - cron: '0 0 * * *'
-
+permissions:
+  # All other permissions are set to none
+  pull-requests: write
+  issues: write
 jobs:
   stale:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
As of end of April we can set selective permissions for GitHub
tokens https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/

This allows us to use just a very small subset for workflows of ours
which is good idea for limiting vector of attacks for supply-chain
attacks.

For example that would render recent codecov hacking completely
useless even if someone grabs and uses the token immediately.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
