### PR TITLE
FIX Orphaned tasks stuck in executor as running

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -369,9 +369,7 @@ class CeleryExecutor(BaseExecutor):
                 "\n\t".join(repr(x) for x in timedout_keys),
             )
             for key in timedout_keys:
-                self.event_buffer[key] = (State.FAILED, None)
-                del self.tasks[key]
-                del self.adopted_task_timeouts[key]
+                self.change_state(key, State.FAILED)
 
     def debug_dump(self) -> None:
         """Called in response to SIGUSR2 by the scheduler"""

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -371,10 +371,12 @@ class TestCeleryExecutor(unittest.TestCase):
             key_1: queued_dttm + executor.task_adoption_timeout,
             key_2: queued_dttm + executor.task_adoption_timeout,
         }
+        executor.running = {key_1, key_2}
         executor.tasks = {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
         executor.sync()
         assert executor.event_buffer == {key_1: (State.FAILED, None), key_2: (State.FAILED, None)}
         assert executor.tasks == {}
+        assert executor.running == set()
         assert executor.adopted_task_timeouts == {}
 
 


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/13542

The issue discussed here was caused by multiple things.
One of the issues is that when the scheduler picks up 'assumed to be' `orphaned` tasks, these tasks might have never made it to celery.
When the tasks execution never happens, it is automatically cleaned up but only partially.
Then once the scheduler retries to queue the task again, it won't be able to, because there is still a reference of the task in the set of the `running` variable.
This PR should fix the described issue.