### PR TITLE
Remove limitation for elasticsearch library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,7 @@ druid = [
 ]
 elasticsearch = [
     'elasticsearch>7',
-    'elasticsearch-dbapi==0.1.0',
+    'elasticsearch-dbapi',
     'elasticsearch-dsl>=5.0.0',
 ]
 exasol = [

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ druid = [
     'pydruid>=0.4.1',
 ]
 elasticsearch = [
-    'elasticsearch>7, <7.6.0',
+    'elasticsearch>7',
     'elasticsearch-dbapi==0.1.0',
     'elasticsearch-dsl>=5.0.0',
 ]

--- a/tests/providers/elasticsearch/log/elasticmock/fake_elasticsearch.py
+++ b/tests/providers/elasticsearch/log/elasticmock/fake_elasticsearch.py
@@ -88,7 +88,7 @@ class FakeElasticsearch(Elasticsearch):
         'version',
         'version_type',
     )
-    def index(self, index, doc_type, body, id=None, params=None):
+    def index(self, index, doc_type, body, id=None, params=None, headers=None):
         if index not in self.__documents_dict:
             self.__documents_dict[index] = []
 
@@ -98,10 +98,24 @@ class FakeElasticsearch(Elasticsearch):
         version = 1
 
         self.__documents_dict[index].append(
-            {'_type': doc_type, '_id': id, '_source': body, '_index': index, '_version': version}
+            {
+                '_type': doc_type,
+                '_id': id,
+                '_source': body,
+                '_index': index,
+                '_version': version,
+                '_headers': headers,
+            }
         )
 
-        return {'_type': doc_type, '_id': id, 'created': True, '_version': version, '_index': index}
+        return {
+            '_type': doc_type,
+            '_id': id,
+            'created': True,
+            '_version': version,
+            '_index': index,
+            '_headers': headers,
+        }
 
     @query_params('parent', 'preference', 'realtime', 'refresh', 'routing')
     def exists(self, index, doc_type, id, params=None):
@@ -198,7 +212,7 @@ class FakeElasticsearch(Elasticsearch):
         'track_scores',
         'version',
     )
-    def count(self, index=None, doc_type=None, body=None, params=None):
+    def count(self, index=None, doc_type=None, body=None, params=None, headers=None):
         searchable_indexes = self._normalize_index_to_list(index)
         searchable_doc_types = self._normalize_doc_type_to_list(doc_type)
 
@@ -247,7 +261,7 @@ class FakeElasticsearch(Elasticsearch):
         'track_scores',
         'version',
     )
-    def search(self, index=None, doc_type=None, body=None, params=None):
+    def search(self, index=None, doc_type=None, body=None, params=None, headers=None):
         searchable_indexes = self._normalize_index_to_list(index)
 
         matches = self._find_match(index, doc_type, body)
@@ -275,7 +289,7 @@ class FakeElasticsearch(Elasticsearch):
     @query_params(
         'consistency', 'parent', 'refresh', 'replication', 'routing', 'timeout', 'version', 'version_type'
     )
-    def delete(self, index, doc_type, id, params=None):
+    def delete(self, index, doc_type, id, params=None, headers=None):
 
         found = False
 


### PR DESCRIPTION
Elasticsearch <7.6.0 does not work with Python 3.9 (import
errors on deprecated base64 functionality that have been removed
in Python 3.9) see:

ihttps://bugzilla.redhat.com/show_bug.cgi?id=1894188

This PR bumps elasticsearch library version to latest available
(7.13.1 as of this writing) in order to get it Python 3.9
compatible.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
