### PR TITLE
Unpause DAG on manual trigger

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -136,6 +136,7 @@
                 <form method="POST" action="{{ url_for('Airflow.trigger') }}">
                   <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                   <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
+                  <input type="hidden" name="unpause" value="True">
                   <input type="hidden" name="origin" value="{{ url_for('Airflow.' + dag.default_view, dag_id=dag.dag_id) }}">
                   <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                 </form>

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -188,6 +188,7 @@
                           <form method="POST" action="{{ url_for('Airflow.trigger') }}">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <input type="hidden" name="dag_id" value="{{ dag.dag_id }}">
+                            <input type="hidden" name="unpause" value="True">
                             <button type="submit" class="dropdown-form-btn">Trigger DAG</button>
                           </form>
                         </li>

--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -24,6 +24,7 @@
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('codemirror.css') }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('lint.css') }}">
+  <link rel="stylesheet" type="text/css" href="{{ url_for_asset('switch.css') }}">
 {% endblock %}
 
 {% block content %}
@@ -34,21 +35,26 @@
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
     <input type="hidden" name="dag_id" value="{{ dag_id }}">
     <input type="hidden" name="origin" value="{{ origin }}">
-
-    <div class="form-group">
+  <div class="form-group">
       <label class="sr-only" for="execution_date">Execution date</label>
       <div class="input-group">
         {{ form.execution_date(class_="form-control", disabled=False) }}
       </div>
     </div>
 
-    <div class="form-group">
-      <label for="conf">Configuration JSON (Optional, must be a dict object)</label>
+    <label for="conf">Configuration JSON (Optional, must be a dict object)</label>
       <textarea class="form-control" name="conf" id="json">{{ conf }}</textarea>
     </div>
     <p>
       To access configuration in your DAG use <code>{{ '{{ dag_run.conf }}' }}</code>.
     </p>
+    <div class="form-group">
+      <label class="switch-label">
+        <input class="switch-input" name="unpause" id="unpause" type="checkbox" checked>
+        <span class="switch" aria-hidden="true"></span>
+        Unpause DAG when triggered
+      </label>
+    </div>
     <button type="submit" class="btn btn-primary">Trigger</button>
     <button type="button" class="btn" onclick="location.href = '{{ origin }}'; return false">Cancel</button>
   </form>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1496,6 +1496,7 @@ class Airflow(AirflowBaseView):
         """Triggers DAG Run."""
         dag_id = request.values.get('dag_id')
         origin = get_safe_url(request.values.get('origin'))
+        unpause = request.values.get('unpause')
         request_conf = request.values.get('conf')
         request_execution_date = request.values.get('execution_date', default=timezone.utcnow().isoformat())
 
@@ -1560,6 +1561,10 @@ class Airflow(AirflowBaseView):
                 )
 
         dag = current_app.dag_bag.get_dag(dag_id)
+
+        if unpause and dag.is_paused:
+            models.DagModel.get_dagmodel(dag_id).set_is_paused(is_paused=False)
+
         dag.create_dagrun(
             run_type=DagRunType.MANUAL,
             execution_date=execution_date,


### PR DESCRIPTION
Problem: sometimes we forget to unpause a dag when we manually trigger a run and get frustrated when it doesn't run

Solution: By default, unpause a paused dag when manually triggering. It will be an extra field in "Trigger w/ config" that a user can opt out of


<img width="582" alt="Screen Shot 2021-06-21 at 10 57 04 AM" src="https://user-images.githubusercontent.com/4600967/122792068-6c06da00-d27f-11eb-89e9-e1edacebec52.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
