### PR TITLE
Chart: Support for overriding webserver and flower service ports

### DIFF
--- a/chart/templates/flower/flower-service.yaml
+++ b/chart/templates/flower/flower-service.yaml
@@ -44,9 +44,12 @@ spec:
     component: flower
     release: {{ .Release.Name }}
   ports:
-    - name: flower-ui
-      protocol: TCP
-      port: {{ .Values.ports.flowerUI }}
+  {{ range .Values.flower.service.ports }}
+    -
+      {{- range $key, $val := . }}
+      {{ $key }}: {{ tpl (toString $val) $ }}
+      {{- end }}
+  {{- end }}
   {{- if .Values.flower.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.flower.service.loadBalancerIP }}
   {{- end }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -155,7 +155,7 @@ spec:
 {{ toYaml .Values.webserver.extraVolumeMounts | indent 12 }}
 {{- end }}
           ports:
-            - name: webserver-ui
+            - name: airflow-ui
               containerPort: {{ .Values.ports.airflowUI }}
           livenessProbe:
             httpGet:

--- a/chart/templates/webserver/webserver-service.yaml
+++ b/chart/templates/webserver/webserver-service.yaml
@@ -42,9 +42,12 @@ spec:
     component: webserver
     release: {{ .Release.Name }}
   ports:
-    - name: airflow-ui
-      protocol: TCP
-      port: {{ .Values.ports.airflowUI }}
+  {{ range .Values.webserver.service.ports }}
+    -
+      {{- range $key, $val := . }}
+      {{ $key }}: {{ tpl (toString $val) $ }}
+      {{- end }}
+  {{- end }}
   {{- if .Values.webserver.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.webserver.service.loadBalancerIP }}
   {{- end }}

--- a/chart/tests/test_flower.py
+++ b/chart/tests/test_flower.py
@@ -269,9 +269,7 @@ class TestFlowerService:
             "spec.selector", docs[0]
         )
         assert "ClusterIP" == jmespath.search("spec.type", docs[0])
-        assert {"name": "flower-ui", "protocol": "TCP", "port": 5555} in jmespath.search(
-            "spec.ports", docs[0]
-        )
+        assert {"name": "flower-ui", "port": 5555} in jmespath.search("spec.ports", docs[0])
 
     def test_overrides(self):
         docs = render_chart(
@@ -290,7 +288,36 @@ class TestFlowerService:
 
         assert {"foo": "bar"} == jmespath.search("metadata.annotations", docs[0])
         assert "LoadBalancer" == jmespath.search("spec.type", docs[0])
-        assert {"name": "flower-ui", "protocol": "TCP", "port": 9000} in jmespath.search(
-            "spec.ports", docs[0]
-        )
+        assert {"name": "flower-ui", "port": 9000} in jmespath.search("spec.ports", docs[0])
         assert "127.0.0.1" == jmespath.search("spec.loadBalancerIP", docs[0])
+
+    @pytest.mark.parametrize(
+        "ports, expected_ports",
+        [
+            ([{"port": 8888}], [{"port": 8888}]),  # name is optional with a single port
+            (
+                [{"name": "{{ .Release.Name }}", "protocol": "UDP", "port": "{{ .Values.ports.flowerUI }}"}],
+                [{"name": "RELEASE-NAME", "protocol": "UDP", "port": 5555}],
+            ),
+            ([{"name": "only_sidecar", "port": "{{ int 9000 }}"}], [{"name": "only_sidecar", "port": 9000}]),
+            (
+                [
+                    {"name": "flower-ui", "port": "{{ .Values.ports.flowerUI }}"},
+                    {"name": "sidecar", "port": 80, "targetPort": "sidecar"},
+                ],
+                [
+                    {"name": "flower-ui", "port": 5555},
+                    {"name": "sidecar", "port": 80, "targetPort": "sidecar"},
+                ],
+            ),
+        ],
+    )
+    def test_ports_overrides(self, ports, expected_ports):
+        docs = render_chart(
+            values={
+                "flower": {"service": {"ports": ports}},
+            },
+            show_only=["templates/flower/flower-service.yaml"],
+        )
+
+        assert expected_ports == jmespath.search("spec.ports", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1737,6 +1737,28 @@
                             "type": "object",
                             "default": {}
                         },
+                        "ports": {
+                            "description": "Ports for the webserver Service.",
+                            "type": "array",
+                            "default": [
+                                {
+                                    "name": "airflow-ui",
+                                    "port": "{{ .Values.ports.airflowUI }}"
+                                }
+                            ],
+                            "examples": [
+                                {
+                                    "name": "airflow-ui",
+                                    "port": 80,
+                                    "targetPort": "airflow-ui"
+                                },
+                                {
+                                    "name": "only_sidecar",
+                                    "port": 80,
+                                    "targetPort": 8888
+                                }
+                            ]
+                        },
                         "loadBalancerIP": {
                             "description": "Webserver Service loadBalancerIP.",
                             "type": [
@@ -1864,6 +1886,23 @@
                             "description": "Annotations for the flower Service.",
                             "type": "object",
                             "default": {}
+                        },
+                        "ports": {
+                            "description": "Ports for the flower Service.",
+                            "type": "array",
+                            "default": [
+                                {
+                                    "name": "flower-ui",
+                                    "port": "{{ .Values.ports.flowerUI }}"
+                                }
+                            ],
+                            "examples": [
+                                {
+                                    "name": "flower-ui",
+                                    "port": 8080,
+                                    "targetPort": "flower-ui"
+                                }
+                            ]
                         },
                         "loadBalancerIP": {
                             "description": "Flower Service loadBalancerIP.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -675,6 +675,19 @@ webserver:
     type: ClusterIP
     ## service annotations
     annotations: {}
+    ports:
+      - name: airflow-ui
+        port: "{{ .Values.ports.airflowUI }}"
+    # To change the port used to access the webserver:
+    # ports:
+    #   - name: airflow-ui
+    #     port: 80
+    #     targetPort: airflow-ui
+    # To only expose a sidecar, not the webserver directly:
+    # ports:
+    #   - name: only_sidecar
+    #     port: 80
+    #     targetPort: 8888
     loadBalancerIP: ~
 
   # Select certain nodes for airflow webserver pods.
@@ -739,6 +752,14 @@ flower:
     type: ClusterIP
     ## service annotations
     annotations: {}
+    ports:
+      - name: flower-ui
+        port: "{{ .Values.ports.flowerUI }}"
+    # To change the port used to access flower:
+    # ports:
+    #   - name: flower-ui
+    #     port: 8080
+    #     targetPort: flower-ui
     loadBalancerIP: ~
 
   # Launch additional containers into the flower pods.


### PR DESCRIPTION
(Alternate approach of #16517)

This allows services to expose sidecars with webservers in them, or even to only expose a sidecar (say enforcing inbound traffic to go through a proxy).

If we are okay with the general approach, both NetworkPolicy and Ingress need similar changes so there is broad support for these types of sidecars.

Closes #16039