### PR TITLE
Update Year in Providers NOTICE file and fix branch name

### DIFF
--- a/provider_packages/INSTALL
+++ b/provider_packages/INSTALL
@@ -2,7 +2,7 @@
 
 NOTE! Those sources are only intended to be used to build Apache Airflow Provider packages,
 not the Apache Airflow. They have been generated using the unreleased version of Apache Airflow.
-(from master)
+(from main)
 
 The .tar.gz sdist package contains setup.py file that can be use to build the provider package using:
 

--- a/provider_packages/NOTICE
+++ b/provider_packages/NOTICE
@@ -1,5 +1,5 @@
 Apache Airflow
-Copyright 2016-2020 The Apache Software Foundation
+Copyright 2016-2021 The Apache Software Foundation
 
 This product includes software developed at The Apache Software
 Foundation (http://www.apache.org/).


### PR DESCRIPTION
This PR/commit updates the year for the license to 2021 from 2020 and fixes the branch name to main instead of master

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
