### PR TITLE
Redact conn secrets in webserver logs

### DIFF
--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -22,6 +22,8 @@ from typing import TYPE_CHECKING, Any, Dict, List
 
 from airflow.typing_compat import Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
+from airflow.utils.log.secrets_masker import redact
+
 
 if TYPE_CHECKING:
     from airflow.models.connection import Connection  # Avoid circular imports.
@@ -74,8 +76,8 @@ class BaseHook(LoggingMixin):
                 conn.port,
                 conn.schema,
                 conn.login,
-                conn.password,
-                conn.extra_dejson,
+                redact(conn.password),
+                redact(conn.extra_dejson),
             )
         return conn
 

--- a/airflow/hooks/base.py
+++ b/airflow/hooks/base.py
@@ -24,7 +24,6 @@ from airflow.typing_compat import Protocol
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import redact
 
-
 if TYPE_CHECKING:
     from airflow.models.connection import Connection  # Avoid circular imports.
 


### PR DESCRIPTION
Found sensitive connection attributes in webserver logs while testing a connection from UI. 

Before:
```
[2021-06-22 12:00:32,341] {base.py:80} INFO - Using connection to: id: VmAyCbqf. Host: https://www.httpbin.org/, Port: None, Schema: , Login: admin, Password: admin, extra: {'access_token': '123456', 'foo': 'bar'}
```

After:
```
[2021-06-22 12:04:14,162] {base.py:80} INFO - Using connection to: id: 4P0GvhP3. Host: https://www.httpbin.org/, Port: None, Schema: , Login: admin, Password: ***, extra: {'access_token': '***', 'foo': 'bar'}
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
