### PR TITLE
Add back-compat layer to clear_task_instances

### DIFF
--- a/airflow/typing_compat.py
+++ b/airflow/typing_compat.py
@@ -26,12 +26,13 @@ try:
     # python 3.8 we can safely remove this shim import after Airflow drops
     # support for <3.8
     from typing import (  # type: ignore # noqa # pylint: disable=unused-import
+        Literal,
         Protocol,
         TypedDict,
         runtime_checkable,
     )
 except ImportError:
-    from typing_extensions import Protocol, TypedDict, runtime_checkable  # type: ignore # noqa
+    from typing_extensions import Literal, Protocol, TypedDict, runtime_checkable  # type: ignore # noqa
 
 
 # Before Py 3.7, there is no re.Pattern class


### PR DESCRIPTION
In preparing 2.1.1 I noticed that we have a possible breaking change that we can easily make not breaking.

It is unlikely that anyone is using this function directly, but it is
easy for us to maintain compatibility, so we should
