### PR TITLE
Fix label_when_reviewed_workflow_run permissions

### DIFF
--- a/.github/workflows/label_when_reviewed_workflow_run.yml
+++ b/.github/workflows/label_when_reviewed_workflow_run.yml
@@ -23,7 +23,7 @@ on:  # yamllint disable-line rule:truthy
     types: ['requested']
 permissions:
   # All other permissions are set to none
-  chekcs: write
+  checks: write
   contents: read
   pull-requests: write
 jobs:

--- a/.github/workflows/label_when_reviewed_workflow_run.yml
+++ b/.github/workflows/label_when_reviewed_workflow_run.yml
@@ -23,6 +23,7 @@ on:  # yamllint disable-line rule:truthy
     types: ['requested']
 permissions:
   # All other permissions are set to none
+  chekcs: write
   contents: read
   pull-requests: write
 jobs:


### PR DESCRIPTION
This workflow run is currently failing with:

```
Run ./.github/actions/checks-action
  with:
    token: ***
    name: Selective build check
    status: in_progress
    sha: 2cf8c7f268c1db73d840f029aa5180941519c492
    details_url: https://github.com/apache/airflow/actions/runs/960898933
    output: {"summary": "Checking selective status of the build in [the run](https://github.com/apache/airflow/actions/runs/960898933) "}

Error: Resource not accessible by integration
```

so I _think_ this will help


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).