### PR TITLE
Fix wait-for-images CI step

### DIFF
--- a/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
@@ -42,7 +42,7 @@ start_end::group_start "Configure Docker Registry"
 build_images::configure_docker_registry
 start_end::group_end
 
-export AIRFLOW_CI_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}-ci"
+export AIRFLOW_CI_IMAGE_NAME="${GITHUB_REGISTRY_AIRFLOW_CI_IMAGE}"
 
 start_end::group_start "Waiting for ${AIRFLOW_CI_IMAGE_NAME} image to appear"
 

--- a/scripts/ci/images/ci_wait_for_and_verify_prod_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_prod_image.sh
@@ -34,7 +34,7 @@ start_end::group_start "Configure Docker Registry"
 build_images::configure_docker_registry
 start_end::group_end
 
-export AIRFLOW_PROD_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}"
+export AIRFLOW_PROD_IMAGE_NAME="${GITHUB_REGISTRY_AIRFLOW_PROD_IMAGE}"
 
 start_end::group_start "Waiting for ${AIRFLOW_PROD_IMAGE_NAME} image to appear"
 


### PR DESCRIPTION
(This might be the fix, giving it a shot)

wait-for-images is looking for:

`main-python3.6-ci-v2:{tag}`

But the image was built as:

`ghcr.io/apache/airflow-main-python3.6-v2:{tag}`