### PR TITLE
AWS Hook - allow IDP HTTP retry (#12639)

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -236,7 +236,10 @@ class _SessionFactory(LoggingMixin):
             session.mount("https://", adapter)
             session.mount("http://", adapter)
 
-        idp_request_kwargs = saml_config["idp_request_kwargs"]
+        idp_request_kwargs = {}
+        if "idp_request_kwargs" in saml_config:
+            idp_request_kwargs = saml_config["idp_request_kwargs"]
+
         idp_response = session.get(idp_url, auth=auth, **idp_request_kwargs)
         idp_response.raise_for_status()
 

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -33,6 +33,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 import boto3
 import botocore
 import botocore.session
+import requests
 import tenacity
 from botocore.config import Config
 from botocore.credentials import ReadOnlyCredentials
@@ -41,6 +42,7 @@ try:
     from functools import cached_property
 except ImportError:
     from cached_property import cached_property
+
 from dateutil.tz import tzlocal
 
 from airflow.exceptions import AirflowException
@@ -214,18 +216,39 @@ class _SessionFactory(LoggingMixin):
             RoleArn=role_arn, PrincipalArn=principal_arn, SAMLAssertion=saml_assertion, **assume_role_kwargs
         )
 
-    def _fetch_saml_assertion_using_http_spegno_auth(self, saml_config: Dict[str, Any]) -> str:
-        import requests
+    def _get_idp_response(
+        self, saml_config: Dict[str, Any], auth: requests.auth.AuthBase
+    ) -> requests.models.Response:
+        idp_url = saml_config["idp_url"]
+        self.log.info("idp_url= %s", idp_url)
 
+        session = requests.Session()
+
+        # Configurable Retry when querying the IDP endpoint
+        if "idp_request_retry_kwargs" in saml_config:
+            idp_request_retry_kwargs = saml_config["idp_request_retry_kwargs"]
+            self.log.info("idp_request_retry_kwargs= %s", idp_request_retry_kwargs)
+            from requests.adapters import HTTPAdapter
+            from requests.packages.urllib3.util.retry import Retry
+
+            retry_strategy = Retry(**idp_request_retry_kwargs)
+            adapter = HTTPAdapter(max_retries=retry_strategy)
+            session.mount("https://", adapter)
+            session.mount("http://", adapter)
+
+        idp_request_kwargs = saml_config["idp_request_kwargs"]
+        idp_response = session.get(idp_url, auth=auth, **idp_request_kwargs)
+        idp_response.raise_for_status()
+
+        return idp_response
+
+    def _fetch_saml_assertion_using_http_spegno_auth(self, saml_config: Dict[str, Any]) -> str:
         # requests_gssapi will need paramiko > 2.6 since you'll need
         # 'gssapi' not 'python-gssapi' from PyPi.
         # https://github.com/paramiko/paramiko/pull/1311
         import requests_gssapi
         from lxml import etree
 
-        idp_url = saml_config["idp_url"]
-        self.log.info("idp_url= %s", idp_url)
-        idp_request_kwargs = saml_config["idp_request_kwargs"]
         auth = requests_gssapi.HTTPSPNEGOAuth()
         if 'mutual_authentication' in saml_config:
             mutual_auth = saml_config['mutual_authentication']
@@ -242,8 +265,7 @@ class _SessionFactory(LoggingMixin):
                     '(Exclude this setting will default to HTTPSPNEGOAuth() ).'
                 )
         # Query the IDP
-        idp_response = requests.get(idp_url, auth=auth, **idp_request_kwargs)
-        idp_response.raise_for_status()
+        idp_response = self._get_idp_response(saml_config, auth=auth)
         # Assist with debugging. Note: contains sensitive info!
         xpath = saml_config['saml_response_xpath']
         log_idp_response = 'log_idp_response' in saml_config and saml_config['log_idp_response']

--- a/docs/apache-airflow-providers-amazon/connections/aws.rst
+++ b/docs/apache-airflow-providers-amazon/connections/aws.rst
@@ -159,6 +159,12 @@ This assumes all other Connection fields eg **Login** are empty.
           "headers":{"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"},
           "verify":false
         },
+        "idp_request_retry_kwargs": {
+          "total": 10,
+          "backoff_factor":1,
+          "status":10,
+          "status_forcelist": [400, 429, 500, 502, 503, 504]
+        },
         "log_idp_response":false,
         "saml_response_xpath":"////INPUT[@NAME='SAMLResponse']/@VALUE",
       },
@@ -173,6 +179,7 @@ The following settings may be used within the ``assume_role_with_saml`` containe
     * ``idp_auth_method``: Specify "http_spegno_auth" to use the Python ``requests_gssapi`` library. This library is more up to date than ``requests_kerberos`` and is backward compatible. See ``requests_gssapi`` documentation on PyPI.
     * ``mutual_authentication``: Can be "REQUIRED", "OPTIONAL" or "DISABLED". See ``requests_gssapi`` documentation on PyPI.
     * ``idp_request_kwargs``: Additional ``kwargs`` passed to ``requests`` when requesting from the IDP (over HTTP/S).
+    * ``idp_request_retry_kwargs``: Additional ``kwargs`` to construct a ``urllib3.util.Retry`` used as a retry strategy when requesting from the IDP. See the ``urllib3`` documentation for more details.
     * ``log_idp_response``: Useful for debugging - if specified, print the IDP response content to the log. Note that a successful response will contain sensitive information!
     * ``saml_response_xpath``: How to query the IDP response using XML / HTML xpath.
     * ``assume_role_kwargs``: Additional ``kwargs`` passed to ``sts_client.assume_role_with_saml``.


### PR DESCRIPTION
When doing AssumeRoleWithSAML there is an HTTP request made to an IDP endpoint to obtain the SAML Assertion. This PR allows the IDP request to have a configurable Retry, which makes this authentication mechanism a bit more robust.

Tested with my own Airflow environment which uses this auth method, and it is working as intended.
It's working with and without the new configuration.

closes: 12639