### PR TITLE
Adding task dependency for `example_kubernetes` DAG

### DIFF
--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -163,3 +163,5 @@ with DAG(
         task_id="pod_task_xcom_result",
     )
     # [END howto_operator_k8s_write_xcom]
+
+    write_xcom >> pod_task_xcom_result


### PR DESCRIPTION
Adding task dependency between tasks that involve generating an `XCom` in one task and consuming said `XCom` in the other.  The current DAG has these tasks executing in parallel.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
