### PR TITLE
Update DBApi with backwards compatibility note

### DIFF
--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -42,6 +42,14 @@ class ConnectorProtocol(Protocol):
         """
 
 
+#########################################################################################
+#                                                                                       #
+#  Note! Be extra careful when changing this file. This hook is used as a base for      #
+#  a number of DBApi-related hooks and providers depend on the methods implemented      #
+#  here. Whatever you add here, has to backwards compatible unless                      #
+#  `>=<Airflow version>` is added to providers' requirements using the new feature      #
+#                                                                                       #
+#########################################################################################
 class DbApiHook(BaseHook):
     """Abstract base class for sql hooks."""
 


### PR DESCRIPTION
DBApi should not be changed too often and it should be
changed in a backwards-compatible manner.

This PR adds a note about it as well as adds information in
Postgres Hook about the schema override only working with
Airflow 2.2+

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
