### PR TITLE
Remove SQLAlchemy <1.4 constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -149,8 +149,7 @@ install_requires =
     pyyaml>=5.1
     rich>=9.2.0
     setproctitle>=1.1.8, <2
-    # SQLAlchemy 1.4 breaks sqlalchemy-utils https://github.com/kvesteri/sqlalchemy-utils/issues/505
-    sqlalchemy>=1.3.18, <1.4
+    sqlalchemy>=1.3.18
     sqlalchemy_jsonfield~=1.0
     # Required by vendored-in connexion
     swagger-ui-bundle>=0.0.2


### PR DESCRIPTION
This was added due to flask-sqlalchemy and sqlalchemy-utils not declaring the upper bounds. They have since released sqlalchemy 1.4-compatible versions, so we can remove that hack.

Note that this does *not* actually make us run on sqlalchemy 1.4 since flask-appbuilder still has a <1.4 pin. But that's for flask-appbuilder to worry about—code in Airflow is compatible, so we can remove the constraint now, and get sqlalchemy 1.4 as soon as flask-appbuilder allows us to.