### PR TITLE
Change timezone serialization logic

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -243,7 +243,7 @@ class BaseSerialization:
         elif isinstance(var, datetime.timedelta):
             return cls._encode(var.total_seconds(), type_=DAT.TIMEDELTA)
         elif isinstance(var, Timezone):
-            return SerializedDAG.serialize_timezone(var)
+            return cls.serialize_timezone(var)
         elif isinstance(var, relativedelta.relativedelta):
             encoded = {k: v for k, v in var.__dict__.items() if not k.startswith("_") and v}
             if var.weekday and var.weekday.n:

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -199,18 +199,13 @@ class BaseSerialization:
     @classmethod
     def serialize_timezone(cls, var: datetime.tzinfo) -> Any:
         """Serializes a timezone to json"""
-        tz_name = None
-        try:
-            tz_name = var.name
-        except AttributeError:
-            pass
+        tz_name = getattr(var, 'name', None)
         if not tz_name:
             try:
                 tz_name = var.tzname(datetime.datetime.utcnow())
             except InvalidTimezone:
-                pass
-        if not tz_name:
-            raise TypeError(f"the timezone {var} can't be serialized")
+                raise TypeError(f"the timezone {var} can't be serialized")
+
 
         return cls._encode(str(tz_name), type_=DAT.TIMEZONE)
 

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -203,9 +203,11 @@ class BaseSerialization:
         if not tz_name:
             try:
                 tz_name = var.tzname(datetime.datetime.utcnow())
-            except InvalidTimezone:
-                raise TypeError(f"the timezone {var} can't be serialized")
+            except:
+                pass
 
+        if not tz_name:
+            raise TypeError(f"the timezone {var} can't be serialized")
 
         return cls._encode(str(tz_name), type_=DAT.TIMEZONE)
 
@@ -325,7 +327,7 @@ class BaseSerialization:
             return pendulum.parse("2021-01-01T12:00:00" + tz_name).tzinfo
         except ValueError:
             pass
-        raise ValueError("{tz_name} can't be converted to pendulum.tz.timezone.Timezone")
+        raise ValueError(f"{tz_name} can't be converted to pendulum.tz.timezone.Timezone")
 
     @classmethod
     def _deserialize_timedelta(cls, seconds: int) -> datetime.timedelta:

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -32,6 +32,7 @@ import pytest
 from dateutil.relativedelta import FR, relativedelta
 from kubernetes.client import models as k8s
 from parameterized import parameterized
+from pendulum.tz.timezone import FixedTimezone
 
 from airflow.hooks.base import BaseHook
 from airflow.kubernetes.pod_generator import PodGenerator
@@ -446,6 +447,26 @@ class TestStringifiedDAGs(unittest.TestCase):
                 datetime(2019, 8, 1, tzinfo=timezone.utc),
             ),
             (pendulum.datetime(2019, 8, 1, tz='UTC'), None, pendulum.datetime(2019, 8, 1, tz='UTC')),
+            (
+                pendulum.parse("2019-08-01T00:00:00.000+00:00"),
+                None,
+                pendulum.parse("2019-08-01T00:00:00.000+00:00"),
+            ),
+            (
+                pendulum.parse("2019-08-01T00:00:00.000+01:30"),
+                None,
+                pendulum.parse("2019-08-01T00:00:00.000+01:30"),
+            ),
+            (
+                pendulum.datetime(2019, 8, 1, tz='Europe/Stockholm'),
+                None,
+                pendulum.datetime(2019, 8, 1, tz='Europe/Stockholm'),
+            ),
+            (
+                pendulum.datetime(2019, 8, 1, tz=FixedTimezone(3600)),
+                None,
+                pendulum.datetime(2019, 8, 1, tz=FixedTimezone(3600)),
+            ),
         ]
     )
     def test_deserialization_start_date(self, dag_start_date, task_start_date, expected_task_start_date):
@@ -463,6 +484,9 @@ class TestStringifiedDAGs(unittest.TestCase):
         dag = SerializedDAG.from_dict(serialized_dag)
         simple_task = dag.task_dict["simple_task"]
         assert simple_task.start_date == expected_task_start_date
+        # timezone may have been converted but the offset and name should be the same
+        assert dag.timezone.utcoffset(dag_start_date) == dag_start_date.tzinfo.utcoffset(dag_start_date)
+        assert dag.timezone.tzname(dag_start_date) == dag_start_date.tzinfo.tzname(dag_start_date)
 
     def test_deserialization_with_dag_context(self):
         with DAG(dag_id='simple_dag', start_date=datetime(2019, 8, 1, tzinfo=timezone.utc)) as dag:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Closes #16613

Current dag serialization logic assumes the the `dag.timezone` is a `pendulum.Timezone` and more specifically a "named" timezone (`FixedTimezone` will fail to serialize for example) and not just a `datetime.tzinfo`. 

The proposed change will work with named timezones `pendulum.tz.timezone.Timezone`, fixed offset timezones `pendulum.tz.timezone.FixedTimezone` and "regular" `datetime.tzinfo` implementations. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
