### PR TITLE
Require can_edit on DAG privileges to modify TaskInstances and DagRuns

### DIFF
--- a/INTHEWILD.md
+++ b/INTHEWILD.md
@@ -33,6 +33,7 @@ Currently, **officially** using Airflow:
 1. [Accenture](https://www.accenture.com/au-en) [[@nijanthanvijayakumar](https://github.com/nijanthanvijayakumar)]
 1. [AdBOOST](https://www.adboost.sk) [[AdBOOST](https://github.com/AdBOOST)]
 1. [Adobe](https://www.adobe.com/) [[@mishikaSingh](https://github.com/mishikaSingh), [@ramandumcs](https://github.com/ramandumcs), [@vardancse](https://github.com/vardancse)]
+1. [Adyen](https://www.adyen.com/) [[@jorricks](https://github.com/jorricks)]
 1. [Agari](https://github.com/agaridata) [[@r39132](https://github.com/r39132)]
 1. [Agoda](https://agoda.com) [[@akki](https://github.com/akki)]
 1. [Airbnb](https://airbnb.io/) [[@mistercrunch](https://github.com/mistercrunch), [@artwr](https://github.com/artwr)]

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -40,7 +40,7 @@ from airflow.utils.types import DagRunType
 
 @security.requires_access(
     [
-        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+        (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
         (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG_RUN),
     ]
 )

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -227,7 +227,7 @@ def get_task_instances_batch(session=None):
 
 @security.requires_access(
     [
-        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+        (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
     ]
@@ -261,7 +261,7 @@ def post_clear_task_instances(dag_id: str, session=None):
 
 @security.requires_access(
     [
-        (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+        (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
     ]

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -533,17 +533,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         self._get_and_cache_perms()
         return (action_name, resource_name) in self.perms
 
-    def has_all_dags_edit_access(self):
-        """
-        Has all the dag access in any of the 3 cases:
-        1. Role needs to be in (Admin, Viewer, User, Op).
-        2. Has can_read action on dags resource.
-        3. Has can_edit action on dags resource.
-        """
-        return self._has_role(['Admin', 'Op', 'User']) or self._has_perm(
-            permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG
-        )
-
     def has_all_dags_access(self):
         """
         Has all the dag access in any of the 3 cases:

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -533,6 +533,17 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         self._get_and_cache_perms()
         return (action_name, resource_name) in self.perms
 
+    def has_all_dags_edit_access(self):
+        """
+        Has all the dag access in any of the 3 cases:
+        1. Role needs to be in (Admin, Viewer, User, Op).
+        2. Has can_read action on dags resource.
+        3. Has can_edit action on dags resource.
+        """
+        return self._has_role(['Admin', 'Op', 'User']) or self._has_perm(
+            permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG
+        )
+
     def has_all_dags_access(self):
         """
         Has all the dag access in any of the 3 cases:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3145,8 +3145,6 @@ class DagEditFilter(BaseFilter):
     """Filter using DagIDs"""
 
     def apply(self, query, func):  # pylint: disable=redefined-outer-name,unused-argument
-        if current_app.appbuilder.sm.has_all_dags_edit_access():
-            return query
         filter_dag_ids = current_app.appbuilder.sm.get_editable_dag_ids(g.user)
         return query.filter(self.model.dag_id.in_(filter_dag_ids))
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -27,9 +27,10 @@ import sys
 import traceback
 from collections import defaultdict
 from datetime import timedelta
+from functools import wraps
 from json import JSONDecodeError
 from operator import itemgetter
-from typing import Any, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Iterable, List, Optional, Set, Tuple, Union
 from urllib.parse import parse_qsl, unquote, urlencode, urlparse
 
 import lazy_object_proxy
@@ -1515,7 +1516,7 @@ class Airflow(AirflowBaseView):
     @expose('/run', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_TASK_INSTANCE),
         ]
     )
@@ -1793,7 +1794,7 @@ class Airflow(AirflowBaseView):
     @expose('/clear', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_TASK_INSTANCE),
         ]
     )
@@ -1837,7 +1838,7 @@ class Airflow(AirflowBaseView):
     @expose('/dagrun_clear', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_TASK_INSTANCE),
         ]
     )
@@ -1859,7 +1860,7 @@ class Airflow(AirflowBaseView):
     @expose('/blocked', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
         ]
     )
@@ -1966,7 +1967,7 @@ class Airflow(AirflowBaseView):
     @expose('/dagrun_failed', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG_RUN),
         ]
     )
@@ -1982,7 +1983,7 @@ class Airflow(AirflowBaseView):
     @expose('/dagrun_success', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG_RUN),
         ]
     )
@@ -2026,7 +2027,7 @@ class Airflow(AirflowBaseView):
     @expose('/confirm', methods=['GET'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
         ]
     )
@@ -2099,7 +2100,7 @@ class Airflow(AirflowBaseView):
     @expose('/failed', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
         ]
     )
@@ -2132,7 +2133,7 @@ class Airflow(AirflowBaseView):
     @expose('/success', methods=['POST'])
     @auth.has_access(
         [
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
         ]
     )
@@ -3140,6 +3141,16 @@ class DagFilter(BaseFilter):
         return query.filter(self.model.dag_id.in_(filter_dag_ids))
 
 
+class DagEditFilter(BaseFilter):
+    """Filter using DagIDs"""
+
+    def apply(self, query, func):  # pylint: disable=redefined-outer-name,unused-argument
+        if current_app.appbuilder.sm.has_all_dags_edit_access():
+            return query
+        filter_dag_ids = current_app.appbuilder.sm.get_editable_dag_ids(g.user)
+        return query.filter(self.model.dag_id.in_(filter_dag_ids))
+
+
 class AirflowModelView(ModelView):
     """Airflow Mode View."""
 
@@ -3147,6 +3158,71 @@ class AirflowModelView(ModelView):
     page_size = PAGE_SIZE
 
     CustomSQLAInterface = wwwutils.CustomSQLAInterface
+
+
+class AirflowPrivilegeVerifierModelView(AirflowModelView):
+    """
+    This ModelView prevents ability to pass primary keys of objects relating to DAGs you shouldn't be able to
+    edit. This only holds for the add, update and delete operations.
+    You will still need to use the `action_has_dag_edit_access()` for actions.
+    """
+
+    @staticmethod
+    def validate_dag_edit_access(item: Union[DagRun, TaskInstance]):
+        """Validates whether the user has 'can_edit' access for this specific DAG."""
+        if not current_app.appbuilder.sm.can_edit_dag(item.dag_id):
+            raise AirflowException(f"Access denied for dag_id {item.dag_id}")
+
+    def pre_add(self, item: Union[DagRun, TaskInstance]):
+        self.validate_dag_edit_access(item)
+
+    def pre_update(self, item: Union[DagRun, TaskInstance]):
+        self.validate_dag_edit_access(item)
+
+    def pre_delete(self, item: Union[DagRun, TaskInstance]):
+        self.validate_dag_edit_access(item)
+
+    def post_add_redirect(self):  # Required to prevent redirect loop
+        return redirect(self.get_default_url())
+
+    def post_edit_redirect(self):  # Required to prevent redirect loop
+        return redirect(self.get_default_url())
+
+    def post_delete_redirect(self):  # Required to prevent redirect loop
+        return redirect(self.get_default_url())
+
+
+def action_has_dag_edit_access(action_func: Callable) -> Callable:
+    """Decorator for actions which verifies you have DAG edit access on the given tis/drs."""
+
+    @wraps(action_func)
+    def check_dag_edit_acl_for_actions(
+        self,
+        items: Optional[Union[List[TaskInstance], List[DagRun], TaskInstance, DagRun]],
+        *args,
+        **kwargs,
+    ) -> None:
+        if items is None:
+            dag_ids: Set[str] = set()
+        elif isinstance(items, list):
+            dag_ids = {item.dag_id for item in items if item is not None}
+        elif isinstance(items, TaskInstance) or isinstance(items, DagRun):
+            dag_ids = {items.dag_id}
+        else:
+            raise ValueError(
+                "Was expecting the first argument of the action to be of type "
+                "Optional[Union[List[TaskInstance], List[DagRun], TaskInstance, DagRun]]."
+                f"Was of type: {type(items)}"
+            )
+
+        for dag_id in dag_ids:
+            if not current_app.appbuilder.sm.can_edit_dag(dag_id):
+                flash(f"Access denied for dag_id {dag_id}", "danger")
+                logging.warning("User %s tried to modify %s without having access.", g.user.username, dag_id)
+                return redirect(self.get_default_url())
+        return action_func(self, items, *args, **kwargs)
+
+    return check_dag_edit_acl_for_actions
 
 
 class SlaMissModelView(AirflowModelView):
@@ -3812,7 +3888,7 @@ class JobModelView(AirflowModelView):
     }
 
 
-class DagRunModelView(AirflowModelView):
+class DagRunModelView(AirflowPrivilegeVerifierModelView):
     """View to show records from DagRun table"""
 
     route_base = '/dagrun'
@@ -3861,7 +3937,7 @@ class DagRunModelView(AirflowModelView):
 
     base_order = ('execution_date', 'desc')
 
-    base_filters = [['dag_id', DagFilter, lambda: []]]
+    base_filters = [['dag_id', DagEditFilter, lambda: []]]
 
     edit_form = DagRunEditForm
 
@@ -3876,6 +3952,7 @@ class DagRunModelView(AirflowModelView):
     }
 
     @action('muldelete', "Delete", "Are you sure you want to delete selected records?", single=False)
+    @action_has_dag_edit_access
     @provide_session
     def action_muldelete(self, items, session=None):
         """Multiple delete."""
@@ -3884,6 +3961,7 @@ class DagRunModelView(AirflowModelView):
         return redirect(self.get_redirect())
 
     @action('set_running', "Set state to 'running'", '', single=False)
+    @action_has_dag_edit_access
     @provide_session
     def action_set_running(self, drs, session=None):
         """Set state to running."""
@@ -3906,6 +3984,7 @@ class DagRunModelView(AirflowModelView):
         "All running task instances would also be marked as failed, are you sure?",
         single=False,
     )
+    @action_has_dag_edit_access
     @provide_session
     def action_set_failed(self, drs, session=None):
         """Set state to failed."""
@@ -3932,6 +4011,7 @@ class DagRunModelView(AirflowModelView):
         "All task instances would also be marked as success, are you sure?",
         single=False,
     )
+    @action_has_dag_edit_access
     @provide_session
     def action_set_success(self, drs, session=None):
         """Set state to success."""
@@ -3953,6 +4033,7 @@ class DagRunModelView(AirflowModelView):
         return redirect(self.get_default_url())
 
     @action('clear', "Clear the state", "All task instances would be cleared, are you sure?", single=False)
+    @action_has_dag_edit_access
     @provide_session
     def action_clear(self, drs, session=None):
         """Clears the state."""
@@ -4114,7 +4195,7 @@ class TriggerModelView(AirflowModelView):
     }
 
 
-class TaskInstanceModelView(AirflowModelView):
+class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     """View to show records from TaskInstance table"""
 
     route_base = '/taskinstance'
@@ -4198,7 +4279,7 @@ class TaskInstanceModelView(AirflowModelView):
 
     base_order = ('job_id', 'asc')
 
-    base_filters = [['dag_id', DagFilter, lambda: []]]
+    base_filters = [['dag_id', DagEditFilter, lambda: []]]
 
     def log_url_formatter(self):
         """Formats log URL."""
@@ -4229,7 +4310,6 @@ class TaskInstanceModelView(AirflowModelView):
         'duration': duration_f,
     }
 
-    @provide_session
     @action(
         'clear',
         lazy_gettext('Clear'),
@@ -4239,6 +4319,8 @@ class TaskInstanceModelView(AirflowModelView):
         ),
         single=False,
     )
+    @action_has_dag_edit_access
+    @provide_session
     def action_clear(self, task_instances, session=None):
         """Clears the action."""
         try:
@@ -4271,11 +4353,7 @@ class TaskInstanceModelView(AirflowModelView):
             flash('Failed to set state', 'error')
 
     @action('set_running', "Set state to 'running'", '', single=False)
-    @auth.has_access(
-        [
-            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
-        ]
-    )
+    @action_has_dag_edit_access
     def action_set_running(self, tis):
         """Set state to 'running'"""
         self.set_task_instance_state(tis, State.RUNNING)
@@ -4283,11 +4361,7 @@ class TaskInstanceModelView(AirflowModelView):
         return redirect(self.get_redirect())
 
     @action('set_failed', "Set state to 'failed'", '', single=False)
-    @auth.has_access(
-        [
-            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
-        ]
-    )
+    @action_has_dag_edit_access
     def action_set_failed(self, tis):
         """Set state to 'failed'"""
         self.set_task_instance_state(tis, State.FAILED)
@@ -4295,11 +4369,7 @@ class TaskInstanceModelView(AirflowModelView):
         return redirect(self.get_redirect())
 
     @action('set_success', "Set state to 'success'", '', single=False)
-    @auth.has_access(
-        [
-            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
-        ]
-    )
+    @action_has_dag_edit_access
     def action_set_success(self, tis):
         """Set state to 'success'"""
         self.set_task_instance_state(tis, State.SUCCESS)
@@ -4307,11 +4377,7 @@ class TaskInstanceModelView(AirflowModelView):
         return redirect(self.get_redirect())
 
     @action('set_retry', "Set state to 'up_for_retry'", '', single=False)
-    @auth.has_access(
-        [
-            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
-        ]
-    )
+    @action_has_dag_edit_access
     def action_set_retry(self, tis):
         """Set state to 'up_for_retry'"""
         self.set_task_instance_state(tis, State.UP_FOR_RETRY)

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -697,7 +697,7 @@ def user_all_dags_edit_tis(acl_app):
         username="user_all_dags_edit_tis",
         role_name="role_all_dags_edit_tis",
         permissions=[
-            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
             (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
         ],

--- a/tests/www/views/test_views_dagrun.py
+++ b/tests/www/views/test_views_dagrun.py
@@ -16,11 +16,42 @@
 # specific language governing permissions and limitations
 # under the License.
 import pytest
+import werkzeug
 
 from airflow.models import DagBag, DagRun, TaskInstance
+from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session
-from tests.test_utils.www import check_content_in_response
+from airflow.www.views import DagRunModelView
+from tests.test_utils.api_connexion_utils import create_user, delete_roles, delete_user
+from tests.test_utils.www import check_content_in_response, client_with_login
+from tests.www.views.test_views_tasks import _get_appbuilder_pk_string
+
+
+@pytest.fixture(scope="module")
+def client_dr_without_dag_edit(app):
+    create_user(
+        app,
+        username="all_dr_permissions_except_dag_edit",
+        role_name="all_dr_permissions_except_dag_edit",
+        permissions=[
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG_RUN),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_DAG_RUN),
+        ],
+    )
+
+    yield client_with_login(
+        app,
+        username="all_dr_permissions_except_dag_edit",
+        password="all_dr_permissions_except_dag_edit",
+    )
+
+    delete_user(app, username="all_dr_permissions_except_dag_edit")  # type: ignore
+    delete_roles(app)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -42,6 +73,19 @@ def reset_dagrun():
         session.query(TaskInstance).delete()
 
 
+def test_create_dagrun_permission_denied(session, client_dr_without_dag_edit):
+    data = {
+        "state": "running",
+        "dag_id": "example_bash_operator",
+        "execution_date": "2018-07-06 05:06:03",
+        "run_id": "test_list_dagrun_includes_conf",
+        "conf": '{"include": "me"}',
+    }
+
+    with pytest.raises(werkzeug.test.ClientRedirectError):
+        client_dr_without_dag_edit.post('/dagrun/add', data=data, follow_redirects=True)
+
+
 @pytest.fixture()
 def running_dag_run(session):
     dag = DagBag().get_dag("example_bash_operator")
@@ -60,6 +104,22 @@ def running_dag_run(session):
     session.bulk_save_objects(tis)
     session.flush()
     return dr
+
+
+def test_delete_dagrun(session, admin_client, running_dag_run):
+    composite_key = _get_appbuilder_pk_string(DagRunModelView, running_dag_run)
+    assert session.query(DagRun).filter(DagRun.dag_id == running_dag_run.dag_id).count() == 1
+    admin_client.post(f"/dagrun/delete/{composite_key}", follow_redirects=True)
+    assert session.query(DagRun).filter(DagRun.dag_id == running_dag_run.dag_id).count() == 0
+
+
+def test_delete_dagrun_permission_denied(session, client_dr_without_dag_edit, running_dag_run):
+    composite_key = _get_appbuilder_pk_string(DagRunModelView, running_dag_run)
+
+    assert session.query(DagRun).filter(DagRun.dag_id == running_dag_run.dag_id).count() == 1
+    resp = client_dr_without_dag_edit.post(f"/dagrun/delete/{composite_key}", follow_redirects=True)
+    assert resp.status_code == 404  # If it doesn't fully succeed it gives a 404.
+    assert session.query(DagRun).filter(DagRun.dag_id == running_dag_run.dag_id).count() == 1
 
 
 @pytest.mark.parametrize(
@@ -134,3 +194,18 @@ def test_muldelete_dag_runs_action(session, admin_client, running_dag_run):
     assert resp.status_code == 200
     assert session.query(TaskInstance).count() == 0  # Deletes associated TIs.
     assert session.query(DagRun).filter(DagRun.id == dag_run_id).count() == 0
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["clear", "set_success", "set_failed", "set_running"],
+    ids=["clear", "success", "failed", "running"],
+)
+def test_set_dag_runs_action_permission_denied(client_dr_without_dag_edit, running_dag_run, action):
+    running_dag_id = running_dag_run.id
+    resp = client_dr_without_dag_edit.post(
+        "/dagrun/action_post",
+        data={"action": action, "rowid": [str(running_dag_id)]},
+        follow_redirects=True,
+    )
+    check_content_in_response(f"Access denied for dag_id {running_dag_run.dag_id}", resp)

--- a/tests/www/views/test_views_decorators.py
+++ b/tests/www/views/test_views_decorators.py
@@ -16,13 +16,17 @@
 # specific language governing permissions and limitations
 # under the License.
 import urllib.parse
+from typing import List
+from unittest import mock
 
 import pytest
 
-from airflow.models import DagBag, Log
+from airflow.models import DagBag, DagRun, Log, TaskInstance
 from airflow.utils import dates, timezone
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
+from airflow.www import app
+from airflow.www.views import action_has_dag_edit_access
 from tests.test_utils.db import clear_db_runs
 from tests.test_utils.www import check_content_in_response
 
@@ -76,6 +80,11 @@ def dagruns(bash_dag, sub_dag, xcom_dag):
     yield bash_dagrun, sub_dagrun, xcom_dagrun
 
     clear_db_runs()
+
+
+@action_has_dag_edit_access
+def some_view_action_which_requires_dag_edit_access(*args) -> bool:
+    return True
 
 
 def _check_last_log(session, dag_id, event, execution_date):
@@ -150,3 +159,48 @@ def test_calendar(admin_client, dagruns):
     datestr = bash_dagrun.execution_date.date().isoformat()
     expected = rf'{{\"date\":\"{datestr}\",\"state\":\"running\",\"count\":1}}'
     check_content_in_response(expected, resp)
+
+
+@pytest.mark.parametrize(
+    "class_type, no_instances, no_unique_dags",
+    [
+        (None, 0, 0),
+        (TaskInstance, 0, 0),
+        (TaskInstance, 1, 1),
+        (TaskInstance, 10, 1),
+        (TaskInstance, 10, 5),
+        (DagRun, 0, 0),
+        (DagRun, 1, 1),
+        (DagRun, 10, 1),
+        (DagRun, 10, 9),
+    ],
+)
+def test_action_has_dag_edit_access(create_task_instance, class_type, no_instances, no_unique_dags):
+    unique_dag_ids = [f"test_dag_id_{nr}" for nr in range(no_unique_dags)]
+    tis: List[TaskInstance] = [
+        create_task_instance(
+            task_id=f"test_task_instance_{nr}",
+            execution_date=timezone.datetime(2021, 1, 1 + nr),
+            dag_id=unique_dag_ids[nr % len(unique_dag_ids)],
+            run_id=f"test_run_id_{nr}",
+        )
+        for nr in range(no_instances)
+    ]
+    if class_type is None:
+        test_items = None
+    else:
+        test_items = tis if class_type == TaskInstance else [ti.get_dagrun() for ti in tis]
+        test_items = test_items[0] if len(test_items) == 1 else test_items
+
+    with app.create_app(testing=True).app_context():
+        with mock.patch("airflow.www.views.current_app.appbuilder.sm.can_edit_dag") as mocked_can_edit:
+            mocked_can_edit.return_value = True
+            assert not isinstance(test_items, list) or len(test_items) == no_instances
+            assert some_view_action_which_requires_dag_edit_access(None, test_items) is True
+            assert mocked_can_edit.call_count == no_unique_dags
+    clear_db_runs()
+
+
+def test_action_has_dag_edit_access_exception():
+    with pytest.raises(ValueError):
+        some_view_action_which_requires_dag_edit_access(None, "some_incorrect_value")

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -27,6 +27,7 @@ from airflow import settings
 from airflow.executors.celery_executor import CeleryExecutor
 from airflow.models import DagBag, DagModel, TaskInstance
 from airflow.models.dagcode import DagCode
+from airflow.security import permissions
 from airflow.ti_deps.dependencies_states import QUEUEABLE_STATES, RUNNABLE_STATES
 from airflow.utils import dates, timezone
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
@@ -34,9 +35,10 @@ from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from airflow.www.views import TaskInstanceModelView
+from tests.test_utils.api_connexion_utils import create_user, delete_roles, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_runs
-from tests.test_utils.www import check_content_in_response, check_content_not_in_response
+from tests.test_utils.www import check_content_in_response, check_content_not_in_response, client_with_login
 
 DEFAULT_DATE = dates.days_ago(2)
 
@@ -71,6 +73,32 @@ def init_dagruns(app, reset_dagruns):
     )
     yield
     clear_db_runs()
+
+
+@pytest.fixture(scope="module")
+def client_ti_without_dag_edit(app):
+    create_user(
+        app,
+        username="all_ti_permissions_except_dag_edit",
+        role_name="all_ti_permissions_except_dag_edit",
+        permissions=[
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_CREATE, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_TASK_INSTANCE),
+            (permissions.ACTION_CAN_ACCESS_MENU, permissions.RESOURCE_TASK_INSTANCE),
+        ],
+    )
+
+    yield client_with_login(
+        app,
+        username="all_ti_permissions_except_dag_edit",
+        password="all_ti_permissions_except_dag_edit",
+    )
+
+    delete_user(app, username="all_ti_permissions_except_dag_edit")  # type: ignore
+    delete_roles(app)
 
 
 @pytest.mark.parametrize(
@@ -594,6 +622,35 @@ def _get_appbuilder_pk_string(model_view_cls, instance) -> str:
     return model_view_cls._serialize_pk_if_composite(model_view_cls, pk_value)
 
 
+def test_task_instance_delete(session, admin_client, create_task_instance):
+    task_instance_to_delete = create_task_instance(
+        task_id="test_task_instance_delete",
+        execution_date=timezone.utcnow(),
+        state=State.DEFERRED,
+    )
+    composite_key = _get_appbuilder_pk_string(TaskInstanceModelView, task_instance_to_delete)
+    task_id = task_instance_to_delete.task_id
+
+    assert session.query(TaskInstance).filter(TaskInstance.task_id == task_id).count() == 1
+    admin_client.post(f"/taskinstance/delete/{composite_key}", follow_redirects=True)
+    assert session.query(TaskInstance).filter(TaskInstance.task_id == task_id).count() == 0
+
+
+def test_task_instance_delete_permission_denied(session, client_ti_without_dag_edit, create_task_instance):
+    task_instance_to_delete = create_task_instance(
+        task_id="test_task_instance_delete_permission_denied",
+        execution_date=timezone.utcnow(),
+        state=State.DEFERRED,
+    )
+    composite_key = _get_appbuilder_pk_string(TaskInstanceModelView, task_instance_to_delete)
+    task_id = task_instance_to_delete.task_id
+
+    assert session.query(TaskInstance).filter(TaskInstance.task_id == task_id).count() == 1
+    resp = client_ti_without_dag_edit.post(f"/taskinstance/delete/{composite_key}", follow_redirects=True)
+    assert resp.status_code == 404  # If it doesn't fully succeed it gives a 404.
+    assert session.query(TaskInstance).filter(TaskInstance.task_id == task_id).count() == 1
+
+
 def test_task_instance_clear(session, admin_client):
     task_id = "runme_0"
 
@@ -673,3 +730,27 @@ def test_task_instance_set_state_failure(admin_client, action):
     )
     assert resp.status_code == 200
     check_content_in_response("Failed to set state", resp)
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["clear", "set_success", "set_failed", "set_running"],
+    ids=["clear", "success", "failed", "running"],
+)
+def test_set_task_instance_action_permission_denied(session, client_ti_without_dag_edit, action):
+    task_id = "runme_0"
+
+    # Set the state to success for clearing.
+    ti_q = session.query(TaskInstance).filter(TaskInstance.task_id == task_id)
+    ti_q.update({"state": State.SUCCESS})
+    session.commit()
+
+    # Send a request to clear.
+    rowid = _get_appbuilder_pk_string(TaskInstanceModelView, ti_q.one())
+    expected_message = f"Access denied for dag_id {ti_q.one().dag_id}"
+    resp = client_ti_without_dag_edit.post(
+        "/taskinstance/action_post",
+        data={"action": action, "rowid": [rowid]},
+        follow_redirects=True,
+    )
+    check_content_in_response(expected_message, resp)


### PR DESCRIPTION
All permissions for modifying Task Instances or modifying Dag Runs as of today require `dag_read` permissions on the DAG and the corresponding action permission.
A full overview is shown [at the Access Control page of Airflow](https://airflow.apache.org/docs/apache-airflow/stable/security/access-control.html#dag-level-permissions)

It feels to me as in that case the whole `dag_edit` base_permission is undervalued in this case and the `dag_view` base_permission gives too much actual permissions.

Imagine the following setup:
- Everyone is able to see each others DAGs
- Some people should be able to modify their own DAGs
- They should not be able to modify their neighbours DAGs

This setup is currently not supported.
As a work around, on my work setup I currently implemented a SQLAlchemy listener to block update operations on  TaskInstances where a user doesn't have `can_edit` privilege on this specific DAG.
Therefore this PR changes the following items(copied from the link above) to require `DAGS.can_edit` where it currently says `DAGS.can_read` privileges.

**Currently:**
Action | Permissions | Minimum Role
-- | -- | --
Clear DAG | DAGs.can_read, Task Instances.can_delete | User
Clear DAG Run | DAGs.can_read, Task Instances.can_delete | User
Mark DAG as blocked | Dags.can_read, DAG Runs.can_read | User
Mark DAG Run as failed | Dags.can_read, DAG Runs.can_edit | User
Mark DAG Run as success | Dags.can_read, DAG Runs.can_edit | User
Clear Task Instance | DAGs.can_read, DAG Runs.can_read, Task Instances.can_edit | User
Triggers Task Instance | DAGs.can_read, Task Instances.can_create | User
Mark Task as failed | DAGs.can_read, Task Instances.can_edit | User
Mark Task as success | DAGs.can_read, Task Instances.can_edit | User

**Updated:**
Action | Permissions | Minimum Role
-- | -- | --
Clear DAG | DAGs.can_edit, Task Instances.can_delete | User
Clear DAG Run | DAGs.can_edit, Task Instances.can_delete | User
Mark DAG as blocked | Dags.can_edit, DAG Runs.can_read | User
Mark DAG Run as failed | Dags.can_edit, DAG Runs.can_edit | User
Mark DAG Run as success | Dags.can_edit, DAG Runs.can_edit | User
Clear Task Instance | DAGs.can_edit, Task Instances.can_edit | User
Triggers Task Instance | DAGs.can_edit, Task Instances.can_create | User
Mark Task as failed | DAGs.can_edit, Task Instances.can_edit | User
Mark Task as success | DAGs.can_edit, Task Instances.can_edit | User


If there is interest in merging this PR, I will also make a corresponding PR on the docs side to update the page.