### PR TITLE
Remove duplicated/overlapping tests around render_k8s_pod_yaml

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1693,11 +1693,12 @@ class TaskInstance(Base, LoggingMixin):  # pylint: disable=R0902,R0904
                     "rendering of template_fields."
                 ) from e
 
-    def get_rendered_k8s_spec(self):
+    @provide_session
+    def get_rendered_k8s_spec(self, session=None):
         """Fetch rendered template fields from DB"""
         from airflow.models.renderedtifields import RenderedTaskInstanceFields
 
-        rendered_k8s_spec = RenderedTaskInstanceFields.get_k8s_pod_yaml(self)
+        rendered_k8s_spec = RenderedTaskInstanceFields.get_k8s_pod_yaml(self, session=session)
         if not rendered_k8s_spec:
             try:
                 rendered_k8s_spec = self.render_k8s_pod_yaml()


### PR DESCRIPTION
When making another change here, I noticed that we were basically
testing the same thing twice in test_taskinstance and
test_renderedtifields, which does no one any good.

I have updated the tests to use mocking to avoid duplication, and
exercised a few more of the branches in the functions under test


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).