### PR TITLE
Fix TI success confirm page

### DIFF
--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -293,19 +293,19 @@
             <div class="row">
               <span class="btn-group col-xs-12 col-sm-9 task-instance-modal-column" data-toggle="buttons">
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="failed_past" autocomplete="off">
+                  <input type="checkbox" value="true" name="past" autocomplete="off">
                   Past
                 </label>
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="failed_future" autocomplete="off">
+                  <input type="checkbox" value="true" name="future" autocomplete="off">
                   Future
                 </label>
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="failed_upstream" autocomplete="off">
+                  <input type="checkbox" value="true" name="upstream" autocomplete="off">
                   Upstream
                 </label>
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="failed_downstream" autocomplete="off">
+                  <input type="checkbox" value="true" name="downstream" autocomplete="off">
                   Downstream
                 </label>
               </span>
@@ -326,19 +326,19 @@
             <div class="row">
               <span class="btn-group col-xs-12 col-sm-9 task-instance-modal-column" data-toggle="buttons">
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="success_past" autocomplete="off">
+                  <input type="checkbox" value="true" name="past" autocomplete="off">
                   Past
                 </label>
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="success_future" autocomplete="off">
+                  <input type="checkbox" value="true" name="future" autocomplete="off">
                   Future
                 </label>
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="success_upstream" autocomplete="off">
+                  <input type="checkbox" value="true" name="upstream" autocomplete="off">
                   Upstream
                 </label>
                 <label class="btn btn-default">
-                  <input type="checkbox" value="true" name="success_downstream" autocomplete="off">
+                  <input type="checkbox" value="true" name="downstream" autocomplete="off">
                   Downstream
                 </label>
               </span>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1879,10 +1879,10 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         execution_date = args.get('execution_date')
         state = args.get('state')
 
-        upstream = to_boolean(args.get('failed_upstream') or args.get('success_upstream'))
-        downstream = to_boolean(args.get('failed_downstream') or args.get('success_downstream'))
-        future = to_boolean(args.get('failed_future') or args.get('success_future'))
-        past = to_boolean(args.get('failed_past') or args.get('success_past'))
+        upstream = to_boolean(args.get('upstream'))
+        downstream = to_boolean(args.get('downstream'))
+        future = to_boolean(args.get('future'))
+        past = to_boolean(args.get('past'))
 
         try:
             dag = current_app.dag_bag.get_dag(dag_id)
@@ -1952,10 +1952,10 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         origin = get_safe_url(args.get('origin'))
         execution_date = args.get('execution_date')
 
-        upstream = to_boolean(args.get('failed_upstream'))
-        downstream = to_boolean(args.get('failed_downstream'))
-        future = to_boolean(args.get('failed_future'))
-        past = to_boolean(args.get('failed_past'))
+        upstream = to_boolean(args.get('upstream'))
+        downstream = to_boolean(args.get('downstream'))
+        future = to_boolean(args.get('future'))
+        past = to_boolean(args.get('past'))
 
         return self._mark_task_instance_state(
             dag_id,
@@ -1985,10 +1985,10 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         origin = get_safe_url(args.get('origin'))
         execution_date = args.get('execution_date')
 
-        upstream = to_boolean(args.get('success_upstream'))
-        downstream = to_boolean(args.get('success_downstream'))
-        future = to_boolean(args.get('success_future'))
-        past = to_boolean(args.get('success_past'))
+        upstream = to_boolean(args.get('upstream'))
+        downstream = to_boolean(args.get('downstream'))
+        future = to_boolean(args.get('future'))
+        past = to_boolean(args.get('past'))
 
         return self._mark_task_instance_state(
             dag_id,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1879,10 +1879,10 @@ class Airflow(AirflowBaseView):  # noqa: D101  pylint: disable=too-many-public-m
         execution_date = args.get('execution_date')
         state = args.get('state')
 
-        upstream = to_boolean(args.get('failed_upstream'))
-        downstream = to_boolean(args.get('failed_downstream'))
-        future = to_boolean(args.get('failed_future'))
-        past = to_boolean(args.get('failed_past'))
+        upstream = to_boolean(args.get('failed_upstream') or args.get('success_upstream'))
+        downstream = to_boolean(args.get('failed_downstream') or args.get('success_downstream'))
+        future = to_boolean(args.get('failed_future') or args.get('success_future'))
+        past = to_boolean(args.get('failed_past') or args.get('success_past'))
 
         try:
             dag = current_app.dag_bag.get_dag(dag_id)


### PR DESCRIPTION
On TI success/failed confirm page, we were considering only params for failed ones. This bug would cause wrong info being displayed on UI (for success) while upon hitting the submit button it would mark the correct number of TIs. 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
