### PR TITLE
Update release documentation for elasticsearch

### DIFF
--- a/airflow/providers/elasticsearch/CHANGELOG.rst
+++ b/airflow/providers/elasticsearch/CHANGELOG.rst
@@ -19,6 +19,17 @@
 Changelog
 ---------
 
+2.0.2
+.....
+
+Bug Fixes
+~~~~~~~~~
+
+* Updated dependencies to allow Python 3.9 support
+
+.. Below changes are excluded from the changelog. Move them to
+   appropriate section above if needed. Do not delete the lines(!):
+
 2.0.1
 .....
 

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -22,6 +22,7 @@ description: |
     `Elasticsearch <https://www.elastic.co/elasticsearch>`__
 
 versions:
+  - 2.0.2
   - 2.0.1
   - 1.0.4
   - 1.0.3

--- a/docs/apache-airflow-providers-elasticsearch/commits.rst
+++ b/docs/apache-airflow-providers-elasticsearch/commits.rst
@@ -31,11 +31,12 @@ For high-level changelog, see :doc:`package information including changelog <ind
 2.0.1
 .....
 
-Latest change: 2021-06-16
+Latest change: 2021-06-18
 
 ================================================================================================  ===========  =====================================================================
 Commit                                                                                            Committed    Subject
 ================================================================================================  ===========  =====================================================================
+`bbc627a3d <https://github.com/apache/airflow/commit/bbc627a3dab17ba4cf920dd1a26dbed6f5cebfd1>`_  2021-06-18   ``Prepares documentation for rc2 release of Providers (#16501)``
 `3cf67be38 <https://github.com/apache/airflow/commit/3cf67be3875fa0b91408ed0433779970e4f6acf5>`_  2021-06-16   ``Support non-https elasticsearch external links (#16489)``
 `247ba3187 <https://github.com/apache/airflow/commit/247ba31872aa5a8a9e92f781a6beba75945ece1b>`_  2021-06-16   ``Fix Elasticsearch external log link with ''json_format'' (#16467)``
 `5e12b3de3 <https://github.com/apache/airflow/commit/5e12b3de31dd1cf3d6e5088edbf497f91dcae4d8>`_  2021-06-16   ``Remove support jinja templated log_id in elasticsearch (#16465)``

--- a/docs/apache-airflow-providers-elasticsearch/index.rst
+++ b/docs/apache-airflow-providers-elasticsearch/index.rst
@@ -57,7 +57,7 @@ Package apache-airflow-providers-elasticsearch
 `Elasticsearch <https://www.elastic.co/elasticsearch>`__
 
 
-Release: 2.0.1
+Release: 2.0.2
 
 Provider package
 ----------------
@@ -78,9 +78,9 @@ PIP requirements
 PIP package              Version required
 =======================  ==================
 ``apache-airflow``       ``>=2.1.0``
-``elasticsearch-dbapi``  ``==0.1.0``
+``elasticsearch-dbapi``
 ``elasticsearch-dsl``    ``>=5.0.0``
-``elasticsearch``        ``>7, <7.6.0``
+``elasticsearch``        ``>7``
 =======================  ==================
 
 .. include:: ../../airflow/providers/elasticsearch/CHANGELOG.rst


### PR DESCRIPTION
After adding Python 3.9 we need to release an out-of-band
Python 3.9 compliant elasticsearch release. The only difference
for the provider are changed dependencies to make them work
for Python 3.9. Without it we will not be able to generate
constraints when we release next airflow version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
