### PR TITLE
Chart: Apply worker's node assigning settings to Pod Template File

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+{{- $nodeSelector := or .Values.nodeSelector .Values.workers.nodeSelector }}
+{{- $affinity := or .Values.affinity .Values.workers.affinity }}
+{{- $tolerations := or .Values.tolerations .Values.workers.tolerations }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -84,9 +87,9 @@ spec:
   securityContext:
     runAsUser: {{ .Values.uid }}
     fsGroup: {{ .Values.gid }}
-  nodeSelector: {{ toYaml .Values.nodeSelector | nindent 4 }}
-  affinity: {{ toYaml .Values.affinity | nindent 4 }}
-  tolerations: {{ toYaml .Values.tolerations | nindent 4 }}
+  nodeSelector: {{ toYaml $nodeSelector | nindent 4 }}
+  affinity: {{ toYaml $affinity | nindent 4 }}
+  tolerations: {{ toYaml $tolerations | nindent 4 }}
   serviceAccountName: {{ include "worker.serviceAccountName" . }}
   volumes:
   {{- if .Values.dags.persistence.enabled }}

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -486,3 +486,49 @@ class PodTemplateFileTest(unittest.TestCase):
             chart_dir=self.temp_chart_dir,
         )
         assert {} == jmespath.search("spec.containers[0].resources", docs[0])
+
+    def test_should_create_valid_affinity_tolerations_and_node_selector(self):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                "workers": {
+                    "affinity": {
+                        "nodeAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "nodeSelectorTerms": [
+                                    {
+                                        "matchExpressions": [
+                                            {"key": "foo", "operator": "In", "values": ["true"]},
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "tolerations": [
+                        {"key": "dynamic-pods", "operator": "Equal", "value": "true", "effect": "NoSchedule"}
+                    ],
+                    "nodeSelector": {"diskType": "ssd"},
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert "Pod" == jmespath.search("kind", docs[0])
+        assert "foo" == jmespath.search(
+            "spec.affinity.nodeAffinity."
+            "requiredDuringSchedulingIgnoredDuringExecution."
+            "nodeSelectorTerms[0]."
+            "matchExpressions[0]."
+            "key",
+            docs[0],
+        )
+        assert "ssd" == jmespath.search(
+            "spec.nodeSelector.diskType",
+            docs[0],
+        )
+        assert "dynamic-pods" == jmespath.search(
+            "spec.tolerations[0].key",
+            docs[0],
+        )


### PR DESCRIPTION
Since we treat Kubernetes Task Pod as worker when using KubernetesExecutor or CeleryKubernetesExecutor, we should allow overriding `.Values.nodeSelector` by `.Values.workers.nodeSelector` for Pod template file too.

This is consistent with how we assign `serviceAccountName`, `VolumeMounts` etc

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
