### PR TITLE
Replace execution_date with run_id in airflow tasks run command

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -63,7 +63,7 @@ def _get_ti(task, exec_date_or_run_id):
         except (ParserError, TypeError):
             raise AirflowException(f"DagRun with run_id: {exec_date_or_run_id} not found")
     ti = dag_run.get_task_instance(task.task_id)
-    ti.task = task
+    ti.refresh_from_task(task)
     return ti
 
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -393,7 +393,6 @@ class TaskInstance(Base, LoggingMixin):
         super().__init__()
         self.dag_id = task.dag_id
         self.task_id = task.task_id
-        self.task = task
         self.refresh_from_task(task)
         self._log = logging.getLogger("airflow.task")
 
@@ -759,6 +758,7 @@ class TaskInstance(Base, LoggingMixin):
         :param pool_override: Use the pool_override instead of task's pool
         :type pool_override: str
         """
+        self.task = task
         self.queue = task.queue
         self.pool = pool_override or task.pool
         self.pool_slots = task.pool_slots

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -562,6 +562,7 @@ class TestLocalTaskJob:
                 python_callable=task_function,
                 on_failure_callback=failure_callback,
             )
+        dag_maker.create_dagrun()
 
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
@@ -599,6 +600,7 @@ class TestLocalTaskJob:
                 on_failure_callback=failure_callback,
             )
         dag_maker.create_dagrun()
+
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1790,8 +1790,8 @@ class TestTaskInstance:
     def test_generate_command_default_param(self):
         dag_id = 'test_generate_command_default_param'
         task_id = 'task'
-        assert_command = ['airflow', 'tasks', 'run', dag_id, task_id, DEFAULT_DATE.isoformat()]
-        generate_command = TI.generate_command(dag_id=dag_id, task_id=task_id, execution_date=DEFAULT_DATE)
+        assert_command = ['airflow', 'tasks', 'run', dag_id, task_id, 'run_1']
+        generate_command = TI.generate_command(dag_id=dag_id, task_id=task_id, run_id='run_1')
         assert assert_command == generate_command
 
     def test_generate_command_specific_param(self):
@@ -1803,11 +1803,11 @@ class TestTaskInstance:
             'run',
             dag_id,
             task_id,
-            DEFAULT_DATE.isoformat(),
+            'run_1',
             '--mark-success',
         ]
         generate_command = TI.generate_command(
-            dag_id=dag_id, task_id=task_id, execution_date=DEFAULT_DATE, mark_success=True
+            dag_id=dag_id, task_id=task_id, run_id='run_1', mark_success=True
         )
         assert assert_command == generate_command
 
@@ -1871,7 +1871,7 @@ class TestTaskInstance:
                             'run',
                             'test_get_rendered_k8s_spec',
                             'op1',
-                            '2016-01-01T00:00:00+00:00',
+                            'scheduled__2016-01-01T00:00:00+00:00',
                             '--subdir',
                             __file__,
                         ],

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1839,8 +1839,9 @@ class TestTaskInstance:
     def test_render_k8s_pod_yaml(self, pod_mutation_hook, dag_maker):
         with dag_maker('test_get_rendered_k8s_spec'):
             task = BashOperator(task_id='op1', bash_command="{{ task.task_id }}")
-        dag_maker.create_dagrun()
-        ti = TI(task=task, execution_date=DEFAULT_DATE)
+        dr = dag_maker.create_dagrun(run_id='test_run_id')
+        ti = dr.get_task_instance(task.task_id)
+        ti.task = task
 
         expected_pod_spec = {
             'metadata': {
@@ -1871,7 +1872,7 @@ class TestTaskInstance:
                             'run',
                             'test_get_rendered_k8s_spec',
                             'op1',
-                            'scheduled__2016-01-01T00:00:00+00:00',
+                            'test_run_id',
                             '--subdir',
                             __file__,
                         ],


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: https://github.com/apache/airflow/issues/16303

Swaps the `execution_date` with `run_id` when generating `airflow tasks run` commands to send to executors. 

I had to add a `run_id` property to the TaskInstance class, this can be removed when https://github.com/apache/airflow/issues/16302 is completed. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
