### PR TITLE
Serialize dag timezone to a tzname or offset

### DIFF
--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -48,7 +48,10 @@
       }
     },
     "timezone": {
-      "type": "string"
+      "anyOf": [
+          { "type": "string" },
+          { "type": "integer"}
+      ]
     },
     "dict": {
       "description": "A python dictionary containing values of any type",

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -27,6 +27,8 @@ import cattr
 import pendulum
 from dateutil import relativedelta
 
+from airflow.utils.timezone import _get_tzname_or_offset
+
 try:
     from functools import cache
 except ImportError:
@@ -228,7 +230,7 @@ class BaseSerialization:
         elif isinstance(var, datetime.timedelta):
             return cls._encode(var.total_seconds(), type_=DAT.TIMEDELTA)
         elif isinstance(var, Timezone):
-            return cls._encode(str(var.name), type_=DAT.TIMEZONE)
+            return cls._encode(_get_tzname_or_offset(var), type_=DAT.TIMEZONE)
         elif isinstance(var, relativedelta.relativedelta):
             encoded = {k: v for k, v in var.__dict__.items() if not k.startswith("_") and v}
             if var.weekday and var.weekday.n:
@@ -284,7 +286,7 @@ class BaseSerialization:
         elif type_ == DAT.TIMEDELTA:
             return datetime.timedelta(seconds=var)
         elif type_ == DAT.TIMEZONE:
-            return Timezone(var)
+            return pendulum.timezone(var)
         elif type_ == DAT.RELATIVEDELTA:
             if 'weekday' in var:
                 var['weekday'] = relativedelta.weekday(*var['weekday'])  # type: ignore

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -27,7 +27,7 @@ import cattr
 import pendulum
 from dateutil import relativedelta
 
-from airflow.utils.timezone import _get_tzname_or_offset
+from airflow.utils.timezone import get_tzname_or_offset
 
 try:
     from functools import cache

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -230,7 +230,7 @@ class BaseSerialization:
         elif isinstance(var, datetime.timedelta):
             return cls._encode(var.total_seconds(), type_=DAT.TIMEDELTA)
         elif isinstance(var, Timezone):
-            return cls._encode(_get_tzname_or_offset(var), type_=DAT.TIMEZONE)
+            return cls._encode(get_tzname_or_offset(var), type_=DAT.TIMEZONE)
         elif isinstance(var, relativedelta.relativedelta):
             encoded = {k: v for k, v in var.__dict__.items() if not k.startswith("_") and v}
             if var.weekday and var.weekday.n:

--- a/docs/apache-airflow/timezone.rst
+++ b/docs/apache-airflow/timezone.rst
@@ -1,3 +1,5 @@
+
+
  .. Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
     distributed with this work for additional information
@@ -126,7 +128,7 @@ Time zone aware DAGs
 --------------------
 
 Creating a time zone aware DAG is quite simple. Just make sure to supply a time zone aware ``start_date``
-using ``pendulum``.
+using ``pendulum``. Don't use other ``datetime.tzinfo`` implementations.
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #16613
related: #16631


Tries to serialize the `dag.timezone` in a slightly more robust way, using
* use `start_date.tzinfo.name`  if exist and it's recognized by pendulum as valid timezone identifier
* use `start_date.tzinfo.tzname(...)` if it's recognized by pendulum as valid timezone identifier
* use the `start_date.tzinfo.utcoffset(...)`  as last resort.

This allows to use `DAG(....,start_date=pendulum.parse("2021-06-01T12:00:00+01:00"))` which was not possible before because the timezone was serialized as `+01:00` and it raised an `InvalidTimezone` exception at deserialization time when tried to execute `pendulum.timezone('+01:00')`



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
