### PR TITLE
Allow attaching to previously launched task in ECSOperator

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -530,7 +530,7 @@ class AwsBaseHook(BaseHook):
             def decorator_f(self, *args, **kwargs):
                 retry_args = getattr(self, 'retry_args', None)
                 if retry_args is None:
-                    return fun(self)
+                    return fun(self, *args, **kwargs)
                 multiplier = retry_args.get('multiplier', 1)
                 min_limit = retry_args.get('min', 1)
                 max_limit = retry_args.get('max', 1)
@@ -543,7 +543,7 @@ class AwsBaseHook(BaseHook):
                     'before': tenacity_logger,
                     'after': tenacity_logger,
                 }
-                return tenacity.retry(**default_kwargs)(fun)(self)
+                return tenacity.retry(**default_kwargs)(fun)(self, *args, **kwargs)
 
             return decorator_f
 

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -137,9 +137,9 @@ class ECSOperator(BaseOperator):
         finished.
     :type awslogs_stream_prefix: str
     :param reattach: If set to True, will check if the task previously launched by the task_instance
-    is already running. If so, the operator will attach to it instead of starting a new task.
-    This is to avoid relaunching a new task when the connection drops between Airflow and ECS while the task
-    is running (when the Airflow worker is restarted for example).
+        is already running. If so, the operator will attach to it instead of starting a new task.
+        This is to avoid relaunching a new task when the connection drops between Airflow and ECS while
+        the task is running (when the Airflow worker is restarted for example).
     :type reattach: bool
     :param quota_retry: Config if and how to retry _start_task() for transient errors.
     :type quota_retry: dict

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -24,11 +24,12 @@ from typing import Dict, Generator, Optional
 from botocore.waiter import Waiter
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
+from airflow.models import BaseOperator, XCom
 from airflow.providers.amazon.aws.exceptions import ECSOperatorError
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
 from airflow.typing_compat import Protocol, runtime_checkable
+from airflow.utils.session import provide_session
 
 
 def should_retry(exception: Exception):
@@ -138,6 +139,12 @@ class ECSOperator(BaseOperator):
     :param reattach: If set to True, will check if a task from the same family is already running.
         If so, the operator will attach to it instead of starting a new task.
     :type reattach: bool
+    :param reattach_prev_task: If set to True, will check if the task previously launched by the task_instance
+    is already running. If so, the operator will attach to it instead of starting a new task.
+    This is to avoid relaunching a new task when the connection drops between Airflow and ECS while the task
+    is running.
+    reattach and reattach_prev_task cannot be both True.
+    :type reattach_prev_task: bool
     :param quota_retry: Config if and how to retry _start_task() for transient errors.
     :type quota_retry: dict
     """
@@ -168,6 +175,7 @@ class ECSOperator(BaseOperator):
         propagate_tags: Optional[str] = None,
         quota_retry: Optional[dict] = None,
         reattach: bool = False,
+        reattach_prev_task: bool = False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -191,6 +199,12 @@ class ECSOperator(BaseOperator):
         self.awslogs_region = awslogs_region
         self.propagate_tags = propagate_tags
         self.reattach = reattach
+        self.reattach_prev_task = reattach_prev_task
+
+        if self.reattach_prev_task and self.reattach:
+            raise AirflowException(
+                "reattach_prev_task and reattach cannot be both True"
+            )
 
         if self.awslogs_region is None:
             self.awslogs_region = region_name
@@ -200,7 +214,8 @@ class ECSOperator(BaseOperator):
         self.arn: Optional[str] = None
         self.retry_args = quota_retry
 
-    def execute(self, context):
+    @provide_session
+    def execute(self, context, session=None):
         self.log.info(
             'Running ECS Task - Task definition: %s - on cluster %s', self.task_definition, self.cluster
         )
@@ -208,11 +223,11 @@ class ECSOperator(BaseOperator):
 
         self.client = self.get_hook().get_conn()
 
-        if self.reattach:
+        if self.reattach or self.reattach_prev_task:
             self._try_reattach_task()
 
         if not self.arn:
-            self._start_task()
+            self._start_task(context)
 
         self._wait_for_task_ended()
 
@@ -220,12 +235,19 @@ class ECSOperator(BaseOperator):
 
         self.log.info('ECS Task has been successfully executed')
 
+        if self.reattach_prev_task:
+            # Clear the XCom value storing the ECS task ARN if the task has completed (we can't reattach it anymore)
+            self._xcom_del(session, f"{self.task_id}_task_arn")
+
         if self.do_xcom_push:
             return self._last_log_message()
 
         return None
 
-    def _start_task(self):
+    def _xcom_del(self, session, task_id):
+        session.query(XCom).filter(XCom.dag_id == self.dag_id, XCom.task_id == task_id).delete()
+
+    def _start_task(self, context):
         run_opts = {
             'cluster': self.cluster,
             'taskDefinition': self.task_definition,
@@ -261,6 +283,26 @@ class ECSOperator(BaseOperator):
         self.log.info('ECS Task started: %s', response)
 
         self.arn = response['tasks'][0]['taskArn']
+        ecs_task_id = self.arn.split("/")[-1]
+        self.log.info(f"ECS task ID is: {ecs_task_id}")
+
+        if self.reattach_prev_task:
+            # Save the task ARN in XCom to be able to reattach it if needed
+            self._xcom_set(
+                context,
+                key="ecs_task_arn",
+                value=self.arn,
+                task_id=f"{self.task_id}_task_arn"
+            )
+
+    def _xcom_set(self, context, key, value, task_id):
+        XCom.set(
+            key=key,
+            value=value,
+            task_id=task_id,
+            dag_id=self.dag_id,
+            execution_date=context["ti"].execution_date,
+        )
 
     def _try_reattach_task(self):
         task_def_resp = self.client.describe_task_definition(taskDefinition=self.task_definition)
@@ -271,15 +313,30 @@ class ECSOperator(BaseOperator):
         )
         running_tasks = list_tasks_resp['taskArns']
 
-        running_tasks_count = len(running_tasks)
-        if running_tasks_count > 1:
-            self.arn = running_tasks[0]
-            self.log.warning('More than 1 ECS Task found. Reattaching to %s', self.arn)
-        elif running_tasks_count == 1:
-            self.arn = running_tasks[0]
-            self.log.info('Reattaching task: %s', self.arn)
-        else:
-            self.log.info('No active tasks found to reattach')
+        # Check if the ECS task previously launched is already running
+        if self.reattach_prev_task:
+            previous_task_arn = self.xcom_pull(
+                task_ids=f"{self.task_id}_task_arn", key="ecs_task_arn"
+            )
+            self.log.info(f"Previously launched task = {previous_task_arn}")
+            if previous_task_arn in running_tasks:
+                self.arn = previous_task_arn
+                self.log.info("Reattaching previously launched task: %s", self.arn)
+            else:
+                self.log.info("No active previously launched task found to reattach")
+        # Check if an ECS task of the same family is already running
+        elif self.reattach:
+            running_tasks_count = len(running_tasks)
+            if running_tasks_count > 1:
+                self.arn = running_tasks[0]
+                self.log.warning(
+                    "More than 1 ECS Task found. Reattaching to %s", self.arn
+                )
+            elif running_tasks_count == 1:
+                self.arn = running_tasks[0]
+                self.log.info("Reattaching task from same family: %s", self.arn)
+            else:
+                self.log.info("No active tasks found to reattach")
 
     def _wait_for_task_ended(self) -> None:
         if not self.client or not self.arn:

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -229,7 +229,7 @@ class ECSOperator(BaseOperator):
         if self.reattach:
             # Clear the XCom value storing the ECS task ARN if the task has completed
             # as we can't reattach it anymore
-            self._xcom_del(session, f"{self.task_id}_task_arn")
+            self._xcom_del(session, self.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.task_id))
 
         if self.do_xcom_push:
             return self._last_log_message()
@@ -306,7 +306,10 @@ class ECSOperator(BaseOperator):
         running_tasks = list_tasks_resp['taskArns']
 
         # Check if the ECS task previously launched is already running
-        previous_task_arn = self.xcom_pull(task_ids=f"{self.task_id}_task_arn", key="ecs_task_arn")
+        previous_task_arn = self.xcom_pull(
+            task_ids=self.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.task_id),
+            key=self.REATTACH_XCOM_KEY,
+        )
         if previous_task_arn in running_tasks:
             self.arn = previous_task_arn
             self.log.info("Reattaching previously launched task: %s", self.arn)

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -225,7 +225,8 @@ class ECSOperator(BaseOperator):
         self.log.info('ECS Task has been successfully executed')
 
         if self.reattach:
-            # Clear the XCom value storing the ECS task ARN if the task has completed (we can't reattach it anymore)
+            # Clear the XCom value storing the ECS task ARN if the task has completed
+            # as we can't reattach it anymore
             self._xcom_del(session, f"{self.task_id}_task_arn")
 
         if self.do_xcom_push:

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -202,9 +202,7 @@ class ECSOperator(BaseOperator):
         self.reattach_prev_task = reattach_prev_task
 
         if self.reattach_prev_task and self.reattach:
-            raise AirflowException(
-                "reattach_prev_task and reattach cannot be both True"
-            )
+            raise AirflowException("reattach_prev_task and reattach cannot be both True")
 
         if self.awslogs_region is None:
             self.awslogs_region = region_name
@@ -288,12 +286,7 @@ class ECSOperator(BaseOperator):
 
         if self.reattach_prev_task:
             # Save the task ARN in XCom to be able to reattach it if needed
-            self._xcom_set(
-                context,
-                key="ecs_task_arn",
-                value=self.arn,
-                task_id=f"{self.task_id}_task_arn"
-            )
+            self._xcom_set(context, key="ecs_task_arn", value=self.arn, task_id=f"{self.task_id}_task_arn")
 
     def _xcom_set(self, context, key, value, task_id):
         XCom.set(
@@ -315,9 +308,7 @@ class ECSOperator(BaseOperator):
 
         # Check if the ECS task previously launched is already running
         if self.reattach_prev_task:
-            previous_task_arn = self.xcom_pull(
-                task_ids=f"{self.task_id}_task_arn", key="ecs_task_arn"
-            )
+            previous_task_arn = self.xcom_pull(task_ids=f"{self.task_id}_task_arn", key="ecs_task_arn")
             self.log.info(f"Previously launched task = {previous_task_arn}")
             if previous_task_arn in running_tasks:
                 self.arn = previous_task_arn
@@ -329,9 +320,7 @@ class ECSOperator(BaseOperator):
             running_tasks_count = len(running_tasks)
             if running_tasks_count > 1:
                 self.arn = running_tasks[0]
-                self.log.warning(
-                    "More than 1 ECS Task found. Reattaching to %s", self.arn
-                )
+                self.log.warning("More than 1 ECS Task found. Reattaching to %s", self.arn)
             elif running_tasks_count == 1:
                 self.arn = running_tasks[0]
                 self.log.info("Reattaching task from same family: %s", self.arn)

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -357,13 +357,17 @@ class TestECSOperator(unittest.TestCase):
             ['', {'testTagKey': 'testTagValue'}],
         ]
     )
-    @mock.patch.object(ECSOperator,
-                       "xcom_pull",
-                       return_value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55")
+    @mock.patch.object(
+        ECSOperator,
+        "xcom_pull",
+        return_value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55",
+    )
     @mock.patch.object(ECSOperator, '_wait_for_task_ended')
     @mock.patch.object(ECSOperator, '_check_success_task')
     @mock.patch.object(ECSOperator, '_start_task')
-    def test_reattach_prev_task_successful(self, launch_type, tags, start_mock, check_mock, wait_mock, xcom_mock):
+    def test_reattach_prev_task_successful(
+        self, launch_type, tags, start_mock, check_mock, wait_mock, xcom_mock
+    ):
 
         self.set_up_operator(launch_type=launch_type, tags=tags)  # pylint: disable=no-value-for-parameter
         client_mock = self.aws_hook_mock.return_value.get_conn.return_value
@@ -371,7 +375,7 @@ class TestECSOperator(unittest.TestCase):
         client_mock.list_tasks.return_value = {
             'taskArns': [
                 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b54',
-                'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+                'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55',
             ]
         }
 
@@ -410,14 +414,14 @@ class TestECSOperator(unittest.TestCase):
     @mock.patch.object(ECSOperator, '_try_reattach_task')
     @mock.patch.object(ECSOperator, '_wait_for_task_ended')
     @mock.patch.object(ECSOperator, '_check_success_task')
-    def test_reattach_prev_task_first_try(self, launch_type, tags, check_mock, wait_mock, reattach_mock, xcom_set_mock, xcom_del_mock):
+    def test_reattach_prev_task_first_try(
+        self, launch_type, tags, check_mock, wait_mock, reattach_mock, xcom_set_mock, xcom_del_mock
+    ):
 
         self.set_up_operator(launch_type=launch_type, tags=tags)  # pylint: disable=no-value-for-parameter
         client_mock = self.aws_hook_mock.return_value.get_conn.return_value
         client_mock.describe_task_definition.return_value = {'taskDefinition': {'family': 'f'}}
-        client_mock.list_tasks.return_value = {
-            'taskArns': []
-        }
+        client_mock.list_tasks.return_value = {'taskArns': []}
         client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
 
         self.ecs.reattach_prev_task = True

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -349,6 +349,102 @@ class TestECSOperator(unittest.TestCase):
         check_mock.assert_called_once_with()
         assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
 
+    @parameterized.expand(
+        [
+            ['EC2', None],
+            ['FARGATE', None],
+            ['EC2', {'testTagKey': 'testTagValue'}],
+            ['', {'testTagKey': 'testTagValue'}],
+        ]
+    )
+    @mock.patch.object(ECSOperator,
+                       "xcom_pull",
+                       return_value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55")
+    @mock.patch.object(ECSOperator, '_wait_for_task_ended')
+    @mock.patch.object(ECSOperator, '_check_success_task')
+    @mock.patch.object(ECSOperator, '_start_task')
+    def test_reattach_prev_task_successful(self, launch_type, tags, start_mock, check_mock, wait_mock, xcom_mock):
+
+        self.set_up_operator(launch_type=launch_type, tags=tags)  # pylint: disable=no-value-for-parameter
+        client_mock = self.aws_hook_mock.return_value.get_conn.return_value
+        client_mock.describe_task_definition.return_value = {'taskDefinition': {'family': 'f'}}
+        client_mock.list_tasks.return_value = {
+            'taskArns': [
+                'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b54',
+                'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+            ]
+        }
+
+        self.ecs.reattach_prev_task = True
+        self.ecs.execute(None)
+
+        self.aws_hook_mock.return_value.get_conn.assert_called_once()
+        extend_args = {}
+        if launch_type:
+            extend_args['launchType'] = launch_type
+        if launch_type == 'FARGATE':
+            extend_args['platformVersion'] = 'LATEST'
+        if tags:
+            extend_args['tags'] = [{'key': k, 'value': v} for (k, v) in tags.items()]
+
+        client_mock.describe_task_definition.assert_called_once_with(taskDefinition='t')
+
+        client_mock.list_tasks.assert_called_once_with(cluster='c', desiredStatus='RUNNING', family='f')
+
+        start_mock.assert_not_called()
+        xcom_mock.assert_called_once_with(key='ecs_task_arn', task_ids='task_task_arn')
+        wait_mock.assert_called_once_with()
+        check_mock.assert_called_once_with()
+        assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+
+    @parameterized.expand(
+        [
+            ['EC2', None],
+            ['FARGATE', None],
+            ['EC2', {'testTagKey': 'testTagValue'}],
+            ['', {'testTagKey': 'testTagValue'}],
+        ]
+    )
+    @mock.patch.object(ECSOperator, '_xcom_del')
+    @mock.patch.object(ECSOperator, '_xcom_set')
+    @mock.patch.object(ECSOperator, '_try_reattach_task')
+    @mock.patch.object(ECSOperator, '_wait_for_task_ended')
+    @mock.patch.object(ECSOperator, '_check_success_task')
+    def test_reattach_prev_task_first_try(self, launch_type, tags, check_mock, wait_mock, reattach_mock, xcom_set_mock, xcom_del_mock):
+
+        self.set_up_operator(launch_type=launch_type, tags=tags)  # pylint: disable=no-value-for-parameter
+        client_mock = self.aws_hook_mock.return_value.get_conn.return_value
+        client_mock.describe_task_definition.return_value = {'taskDefinition': {'family': 'f'}}
+        client_mock.list_tasks.return_value = {
+            'taskArns': []
+        }
+        client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
+
+        self.ecs.reattach_prev_task = True
+        self.ecs.execute(None)
+
+        self.aws_hook_mock.return_value.get_conn.assert_called_once()
+        extend_args = {}
+        if launch_type:
+            extend_args['launchType'] = launch_type
+        if launch_type == 'FARGATE':
+            extend_args['platformVersion'] = 'LATEST'
+        if tags:
+            extend_args['tags'] = [{'key': k, 'value': v} for (k, v) in tags.items()]
+
+        reattach_mock.called_once()
+        xcom_set_mock.assert_called_once_with(
+            None,
+            key="ecs_task_arn",
+            task_id="task_task_arn",
+            value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55",
+        )
+        client_mock.run_task.assert_called_once()
+        wait_mock.assert_called_once_with()
+        check_mock.assert_called_once_with()
+        xcom_del_mock.assert_called_once()
+        assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
+
     @mock.patch.object(ECSOperator, '_last_log_message', return_value="Log output")
     def test_execute_xcom_with_log(self, mock_cloudwatch_log_message):
         self.ecs.do_xcom_push = True

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -316,7 +316,6 @@ class TestECSOperator(unittest.TestCase):
             ['', {'testTagKey': 'testTagValue'}],
         ]
     )
-<<<<<<< HEAD
     @mock.patch.object(ECSOperator, '_wait_for_task_ended')
     @mock.patch.object(ECSOperator, '_check_success_task')
     @mock.patch.object(ECSOperator, '_start_task')

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -359,6 +359,10 @@ class TestECSOperator(unittest.TestCase):
     )
     @mock.patch.object(
         ECSOperator,
+        "_xcom_del"
+    )
+    @mock.patch.object(
+        ECSOperator,
         "xcom_pull",
         return_value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55",
     )
@@ -398,7 +402,7 @@ class TestECSOperator(unittest.TestCase):
         start_mock.assert_not_called()
         xcom_pull_mock.assert_called_once_with(
             key=self.ecs.REATTACH_XCOM_KEY,
-            task_ids=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id)
+            task_ids=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id),
         )
         wait_mock.assert_called_once_with()
         check_mock.assert_called_once_with()

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -357,10 +357,7 @@ class TestECSOperator(unittest.TestCase):
             ['', {'testTagKey': 'testTagValue'}],
         ]
     )
-    @mock.patch.object(
-        ECSOperator,
-        "_xcom_del"
-    )
+    @mock.patch.object(ECSOperator, "_xcom_del")
     @mock.patch.object(
         ECSOperator,
         "xcom_pull",

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -397,7 +397,10 @@ class TestECSOperator(unittest.TestCase):
         client_mock.list_tasks.assert_called_once_with(cluster='c', desiredStatus='RUNNING', family='f')
 
         start_mock.assert_not_called()
-        xcom_pull_mock.assert_called_once_with(key='ecs_task_arn', task_ids='task_task_arn')
+        xcom_pull_mock.assert_called_once_with(
+            key=self.ecs.REATTACH_XCOM_KEY,
+            task_ids=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id)
+        )
         wait_mock.assert_called_once_with()
         check_mock.assert_called_once_with()
         xcom_del_mock.assert_called_once()
@@ -442,8 +445,8 @@ class TestECSOperator(unittest.TestCase):
         client_mock.run_task.assert_called_once()
         xcom_set_mock.assert_called_once_with(
             None,
-            key="ecs_task_arn",
-            task_id="task_task_arn",
+            key=self.ecs.REATTACH_XCOM_KEY,
+            task_id=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id),
             value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55",
         )
         wait_mock.assert_called_once_with()


### PR DESCRIPTION
FYI @darwinyip 

This PR adds a parameter reattach_prev_task to ECSOperator.

**Before:**
Until now we could use 'reattach' which was reattaching a running ECS Task (if there was one running) of the same 'family' instead of creating a new one. The problem was that if we had workflows using the same ECS Task Definition in several tasks, it didn't know which one to reattach and we could only use `concurrency=1` in some pipelines for example (when we launch the same ECS task in parallel from Airflow with different configurations).

**Now:**
Now with reattach_prev_task instead, when we launch a new ECS task, it will store temporarily the ECS Task ARN in XCOM. If there is an issue during the run (typically connection problem between Airflow and ECS for long-running tasks or Airflow worker restarting which was then still running those tasks in the background without Airflow being aware of it):
- self._start_task will store the ECS task ARN in XCOM (in a 'fake' task_id equal to f"{self.task_id}_task_arn"
- in the next execution, it will check if this task ARN is still running and if so it will reattach it to the operator, otherwise it will create a new one
- when the operator runs succesfully it will delete the XCOM value


I didn't change the logic of 'reattach' to do that directly because I didn't know if it had been designed for other use cases

**Update 2021-07-01:**
After discussing with @darwinyip  I made the change to 'reattach' directly instead of creating a new flag