### PR TITLE
Adjust sizes of CI sponsor logos to look more similar

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,5 +332,5 @@ The CI infrastructure for Apache Airflow has been sponsored by:
 
 <!-- Orderd by most recently "funded" -->
 
-<a href="https://astronomer.io"><img src="https://assets2.astronomer.io/logos/logoForLIGHTbackground.png" alt="astronomer.io" width="200px"></a>
-<a href="https://aws.amazon.com/opensource/"><img src="docs/integration-logos/aws/AWS-Cloud-alt_light-bg@4x.png" alt="AWS OpenSource" width="200px"></a>
+<a href="https://astronomer.io"><img src="https://assets2.astronomer.io/logos/logoForLIGHTbackground.png" alt="astronomer.io" width="250px"></a>
+<a href="https://aws.amazon.com/opensource/"><img src="docs/integration-logos/aws/AWS-Cloud-alt_light-bg@4x.png" alt="AWS OpenSource" width="130px"></a>


### PR DESCRIPTION
They have different aspect ratios and different "percived" sizes, so
setting height didn't really work -- these manually chosen widths look
"about equal to me".

Before:

![image](https://user-images.githubusercontent.com/34150/123804916-8d05a580-d8e5-11eb-94da-d8061d9e4b12.png)

After:

![image](https://user-images.githubusercontent.com/34150/123805229-cf2ee700-d8e5-11eb-8432-967780b56cb5.png)


