### PR TITLE
Fix incorrect direct use of cached_property module.

### DIFF
--- a/airflow/timetables/schedules.py
+++ b/airflow/timetables/schedules.py
@@ -18,11 +18,11 @@
 import datetime
 import typing
 
-from cached_property import cached_property
 from croniter import CroniterBadCronError, CroniterBadDateError, croniter
 from dateutil.relativedelta import relativedelta
 from pendulum import DateTime
 
+from airflow.compat.functools import cached_property
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.typing_compat import Protocol
 from airflow.utils.dates import cron_presets


### PR DESCRIPTION
On Python 3.8 and 3.9 we use the built in functools decorator for this.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
