### PR TITLE
ensure task is skipped if missing sla

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -401,7 +401,10 @@ class DagFileProcessor(LoggingMixin):
         ts = timezone.utcnow()
         for ti in max_tis:
             task = dag.get_task(ti.task_id)
-            if task.sla and not isinstance(task.sla, timedelta):
+            if not task.sla:
+                continue
+  
+            if not isinstance(task.sla, timedelta):
                 raise TypeError(
                     f"SLA is expected to be timedelta object, got "
                     f"{type(task.sla)} in {task.dag_id}:{task.task_id}"

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -403,7 +403,7 @@ class DagFileProcessor(LoggingMixin):
             task = dag.get_task(ti.task_id)
             if not task.sla:
                 continue
-  
+
             if not isinstance(task.sla, timedelta):
                 raise TypeError(
                     f"SLA is expected to be timedelta object, got "


### PR DESCRIPTION
This protects against missing SLAs.

For instance, if a task does not have an SLA then it's possible this will result in an error like so:

```
TypeError: unsupported operand type(s) for +: 'DateTime' and 'NoneType'
  File "airflow/jobs/scheduler_job.py", line 565, in execute_callbacks
    self.manage_slas(dagbag.dags.get(request.dag_id))
  File "airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "airflow/jobs/scheduler_job.py", line 433, in manage_slas
    if following_schedule + task.sla < timezone.utcnow():
```

Here we simply skip tasks which do not have SLAs and avoid raising the exception in subsequent logic.

Co-authored-by: Travis Jefferson <travis@pathstream.com>