### PR TITLE
Chart: fix labels on cleanup serviceaccount

### DIFF
--- a/chart/templates/cleanup/cleanup-serviceaccount.yaml
+++ b/chart/templates/cleanup/cleanup-serviceaccount.yaml
@@ -29,7 +29,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
-    {{ toYaml . | indent 4 }}
+    {{ toYaml . | nindent 4 }}
     {{- end }}
   {{- with .Values.cleanup.serviceAccount.annotations }}
   annotations:

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -134,6 +134,7 @@ class TestBaseChartTest(unittest.TestCase):
                 "pgbouncer": {"enabled": True},
                 "redis": {"enabled": True},
                 "networkPolicies": {"enabled": True},
+                "cleanup": {"enabled": True},
                 "postgresql": {"enabled": False},  # We won't check the objects created by the postgres chart
             },
         )
@@ -143,6 +144,7 @@ class TestBaseChartTest(unittest.TestCase):
         }
 
         kind_names_tuples = [
+            (f"{release_name}-airflow-cleanup", "ServiceAccount", None),
             (f"{release_name}-airflow-config", "ConfigMap", "config"),
             (f"{release_name}-airflow-create-user-job", "ServiceAccount", "create-user-job"),
             (f"{release_name}-airflow-flower", "ServiceAccount", "flower"),
@@ -156,6 +158,9 @@ class TestBaseChartTest(unittest.TestCase):
             (f"{release_name}-airflow-webserver", "ServiceAccount", "webserver"),
             (f"{release_name}-airflow-worker", "ServiceAccount", "worker"),
             (f"{release_name}-broker-url", "Secret", "redis"),
+            (f"{release_name}-cleanup", "CronJob", "airflow-cleanup-pods"),
+            (f"{release_name}-cleanup-role", "Role", None),
+            (f"{release_name}-cleanup-rolebinding", "RoleBinding", None),
             (f"{release_name}-create-user", "Job", "create-user-job"),
             (f"{release_name}-fernet-key", "Secret", None),
             (f"{release_name}-flower", "Deployment", "flower"),


### PR DESCRIPTION
This PR allows both `labels` and `cleanup.enabled` to be used at the same time. Previously, the labels were incorrectly indented leading to invalid yaml.