### PR TITLE
Adding missing word to welcome message

### DIFF
--- a/scripts/in_container/run_tmux_welcome.sh
+++ b/scripts/in_container/run_tmux_welcome.sh
@@ -19,5 +19,5 @@ cd /opt/airflow/ || exit
 clear
 echo "Welcome to your tmux based running Airflow environment (courtesy of Breeze)."
 echo
-echo "     To stop Airflow and exit tmux just 'stop_airflow'."
+echo "     To stop Airflow and exit tmux just type 'stop_airflow'."
 echo


### PR DESCRIPTION
Adding a missing word to the welcome message statement when starting Airflow with Breeze.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
