### PR TITLE
Adding: Snowflake Role in snowflake provider hook

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -99,6 +99,8 @@ class SnowflakeHook(DbApiHook):
             "extra__snowflake__aws_secret_access_key": PasswordField(
                 lazy_gettext('AWS Secret Key'), widget=BS3PasswordFieldWidget()
             ),
+            "extra__snowflake__role": StringField(lazy_gettext('Role'), widget=BS3TextFieldWidget()
+                                                  ),
         }
 
     @staticmethod
@@ -112,7 +114,6 @@ class SnowflakeHook(DbApiHook):
             "placeholders": {
                 'extra': json.dumps(
                     {
-                        "role": "snowflake role",
                         "authenticator": "snowflake oauth",
                         "private_key_file": "private key",
                         "session_parameters": "session parameters",
@@ -129,6 +130,7 @@ class SnowflakeHook(DbApiHook):
                 'extra__snowflake__region': 'snowflake hosted region',
                 'extra__snowflake__aws_access_key_id': 'aws access key id (S3ToSnowflakeOperator)',
                 'extra__snowflake__aws_secret_access_key': 'aws secret access key (S3ToSnowflakeOperator)',
+                'extra__snowflake__role': 'snowflake role',
             },
         }
 
@@ -160,7 +162,7 @@ class SnowflakeHook(DbApiHook):
             'database', ''
         )
         region = conn.extra_dejson.get('extra__snowflake__region', '') or conn.extra_dejson.get('region', '')
-        role = conn.extra_dejson.get('role', '')
+        role = conn.extra_dejson.get('extra__snowflake__role', '') or conn.extra_dejson.get('role', '')
         schema = conn.schema or ''
         authenticator = conn.extra_dejson.get('authenticator', 'snowflake')
         session_parameters = conn.extra_dejson.get('session_parameters')

--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -99,8 +99,7 @@ class SnowflakeHook(DbApiHook):
             "extra__snowflake__aws_secret_access_key": PasswordField(
                 lazy_gettext('AWS Secret Key'), widget=BS3PasswordFieldWidget()
             ),
-            "extra__snowflake__role": StringField(lazy_gettext('Role'), widget=BS3TextFieldWidget()
-                                                  ),
+            "extra__snowflake__role": StringField(lazy_gettext('Role'), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -178,3 +178,158 @@ class TestSnowflakeHook(unittest.TestCase):
         self.conn.password = None
         params = self.db_hook._get_conn_params()
         assert 'private_key' in params
+
+
+"""
+    Testing hooks with assigning`extra_` parameters
+"""
+
+
+class TestSnowflakeHookExtra(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+
+        self.conn = conn = mock.MagicMock()
+
+        self.conn.login = 'user'
+        self.conn.password = 'pw'
+        self.conn.schema = 'public'
+        self.conn.extra_dejson = {
+            'extra__snowflake__database': 'db',
+            'extra__snowflake__account': 'airflow',
+            'extra__snowflake__warehouse': 'af_wh',
+            'extra__snowflake__region': 'af_region',
+            'extra__snowflake__role': 'af_role',
+        }
+
+        class UnitTestSnowflakeHookExtra(SnowflakeHook):
+            conn_name_attr = 'snowflake_conn_id'
+
+            def get_conn(self):
+                return conn
+
+            def get_connection(self, _):
+                return conn
+
+        self.db_hook_extra = UnitTestSnowflakeHookExtra(session_parameters={"QUERY_TAG": "This is a test hook"})
+
+        self.non_encrypted_private_key = "/tmp/test_key.pem"
+        self.encrypted_private_key = "/tmp/test_key.p8"
+
+        # Write some temporary private keys. First is not encrypted, second is with a passphrase.
+        key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+        private_key = key.private_bytes(
+            serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8, serialization.NoEncryption()
+        )
+
+        with open(self.non_encrypted_private_key, "wb") as file:
+            file.write(private_key)
+
+        key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=2048)
+        private_key = key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.BestAvailableEncryption(self.conn.password.encode()),
+        )
+
+        with open(self.encrypted_private_key, "wb") as file:
+            file.write(private_key)
+
+    def tearDownExtra(self):
+        os.remove(self.encrypted_private_key)
+        os.remove(self.non_encrypted_private_key)
+
+    def test_get_uri_extra(self):
+        uri_shouldbe = (
+            'snowflake://user:pw@airflow/db/public?warehouse=af_wh&role=af_role&authenticator=snowflake'
+        )
+        assert uri_shouldbe == self.db_hook_extra.get_uri()
+
+    @parameterized.expand(
+        [
+            ('select * from table', ['uuid', 'uuid']),
+            ('select * from table;select * from table2', ['uuid', 'uuid', 'uuid2', 'uuid2']),
+            (['select * from table;'], ['uuid', 'uuid']),
+            (['select * from table;', 'select * from table2;'], ['uuid', 'uuid', 'uuid2', 'uuid2']),
+        ],
+    )
+    def test_run_storing_query_ids_extra(self, sql, query_ids):
+        cur = mock.MagicMock(rowcount=0)
+        self.conn.cursor.return_value = cur
+        type(cur).sfqid = mock.PropertyMock(side_effect=query_ids)
+        mock_params = {"mock_param": "mock_param"}
+        self.db_hook_extra.run(sql, parameters=mock_params)
+
+        sql_list = sql if isinstance(sql, list) else re.findall(".*?[;]", sql)
+        cur.execute.assert_has_calls([mock.call(query, mock_params) for query in sql_list])
+        assert self.db_hook_extra.query_ids == query_ids[::2]
+        cur.close.assert_called()
+
+    def test_get_conn_params_extra(self):
+        conn_params_shouldbe = {
+            'user': 'user',
+            'password': 'pw',
+            'schema': 'public',
+            'database': 'db',
+            'account': 'airflow',
+            'warehouse': 'af_wh',
+            'region': 'af_region',
+            'role': 'af_role',
+            'authenticator': 'snowflake',
+            'session_parameters': {"QUERY_TAG": "This is a test hook"},
+            "application": "AIRFLOW",
+        }
+        assert self.db_hook_extra.snowflake_conn_id == 'snowflake_default'
+        assert conn_params_shouldbe == self.db_hook_extra._get_conn_params()
+
+    def test_get_conn_params_env_variable_extra(self):
+        conn_params_shouldbe = {
+            'user': 'user',
+            'password': 'pw',
+            'schema': 'public',
+            'database': 'db',
+            'account': 'airflow',
+            'warehouse': 'af_wh',
+            'region': 'af_region',
+            'role': 'af_role',
+            'authenticator': 'snowflake',
+            'session_parameters': {"QUERY_TAG": "This is a test hook"},
+            "application": "AIRFLOW_TEST",
+        }
+        with patch_environ({"AIRFLOW_SNOWFLAKE_PARTNER": 'AIRFLOW_TEST'}):
+            assert self.db_hook_extra.snowflake_conn_id == 'snowflake_default'
+            assert conn_params_shouldbe == self.db_hook_extra._get_conn_params()
+
+    def test_get_conn_extra(self):
+        assert self.db_hook_extra.get_conn() == self.conn
+
+    def test_key_pair_auth_encrypted_extra(self):
+        self.conn.extra_dejson = {
+            'database': 'db',
+            'account': 'airflow',
+            'warehouse': 'af_wh',
+            'region': 'af_region',
+            'role': 'af_role',
+            'private_key_file': self.encrypted_private_key,
+        }
+
+        params = self.db_hook_extra._get_conn_params()
+        assert 'private_key' in params
+
+    def test_key_pair_auth_not_encrypted_extra(self):
+        self.conn.extra_dejson = {
+            'database': 'db',
+            'account': 'airflow',
+            'warehouse': 'af_wh',
+            'region': 'af_region',
+            'role': 'af_role',
+            'private_key_file': self.non_encrypted_private_key,
+        }
+
+        self.conn.password = ''
+        params = self.db_hook_extra._get_conn_params()
+        assert 'private_key' in params
+
+        self.conn.password = None
+        params = self.db_hook_extra._get_conn_params()
+        assert 'private_key' in params

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -211,7 +211,9 @@ class TestSnowflakeHookExtra(unittest.TestCase):
             def get_connection(self, _):
                 return conn
 
-        self.db_hook_extra = UnitTestSnowflakeHookExtra(session_parameters={"QUERY_TAG": "This is a test hook"})
+        self.db_hook_extra = UnitTestSnowflakeHookExtra(
+            session_parameters={"QUERY_TAG": "This is a test hook"}
+        )
 
         self.non_encrypted_private_key = "/tmp/test_key.pem"
         self.encrypted_private_key = "/tmp/test_key.p8"


### PR DESCRIPTION
Changes made with respect to the issue https://github.com/apache/airflow/issues/16717 
Adding:

> 1. 'extra__snowflake__role' to get_connection_form_widgets() to enable snowflake role capture.
> 2. 'extra__snowflake__role' to get_ui_field_behaviour() to placeholders to return snowflake role to the UI. 

Updated 

> 1._get_conn_params() to capture snowflake role from 'extra__snowflake__role'.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
