### PR TITLE
Fix unchecked indexing in _build_metrics

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -115,7 +115,8 @@ def _build_metrics(func_name, namespace):
     sub_commands_to_check = {'users', 'connections'}
     sensitive_fields = {'-p', '--password', '--conn-password'}
     full_command = list(sys.argv)
-    if full_command[1] in sub_commands_to_check:
+    sub_command = full_command[1] if len(full_command) > 1 else None
+    if sub_command in sub_commands_to_check:
         for idx, command in enumerate(full_command):
             if command in sensitive_fields:
                 # For cases when password is passed as "--password xyz" (with space between key and value)


### PR DESCRIPTION
I am not sure if this can happened during regular use of the cli, but when
running test cases `sys.argv` can be that args passed to the pytest. When this
is the case it is possible for argv to only contain a single element.

For the test case I was adding the resulting `IndexError` was caught and
ignored here:
https://github.com/apache/airflow/blob/main/airflow/task/task_runner/standard_task_runner.py#L87
meaning it was very hard to uncover the cause of the exception.
