### PR TITLE
Fix an issue that can't backfill at 00:00

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -100,15 +100,24 @@ class DagRun(Base, LoggingMixin):
 
         :param session: database session
         """
-        DR = DagRun
+        # DR = DagRun
 
-        exec_date = func.cast(self.execution_date, DateTime)
+        # exec_date = func.cast(self.execution_date, DateTime)
 
-        dr = session.query(DR).filter(
-            DR.dag_id == self.dag_id,
-            func.cast(DR.execution_date, DateTime) == exec_date,
-            DR.run_id == self.run_id
-        ).one()
+        # dr = session.query(DR).filter(
+        #     DR.dag_id == self.dag_id,
+        #     func.cast(DR.execution_date, DateTime) == exec_date,
+        #     DR.run_id == self.run_id
+        # ).one()
+
+        dr = DagRun.find(
+            dag_id=self.dag_id,
+            run_id=self.run_id,
+            execution_date=self.execution_date,
+            session=session
+        )
+
+        dr = dr[0]
 
         self.id = dr.id
         self.state = dr.state

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -120,6 +120,17 @@ class ExternalTaskSensor(BaseSensorOperator):
         DM = DagModel
         TI = TaskInstance
         DR = DagRun
+
+        # if upstream dag paused, fail it immediately
+        dag_paused = session.query(DM).filter(
+            DM.dag_id == self.external_dag_id,
+            DM.is_paused == True
+        ).first()
+
+        if dag_paused:
+            raise AirflowException('The external DAG '
+                                   '{} paused.'.format(self.external_dag_id))
+
         if self.check_existence:
             dag_to_wait = session.query(DM).filter(
                 DM.dag_id == self.external_dag_id


### PR DESCRIPTION

when we use backfill api we can see in `dag_run = self._get_dag_run(next_run_date, session=session)`  find dagrun by `run = DagRun.find(dag_id=self.dag.dag_id, execution_date=run_date, session=session)`，but next in `self._task_instances_for_dag_run(dag_run,session=session)` at `dag_run.refresh_from_db()` we use different method
 to find dagrun, this results in different results for the two queries, this unable to find 00:00 backfill_dagrun, when we use same way we can find it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
