### PR TITLE
Clear without retry

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -872,6 +872,7 @@ def clear(args):
         confirm_prompt=not args.no_confirm,
         include_subdags=not args.exclude_subdags,
         include_parentdag=not args.exclude_parentdag,
+        donot_allow_retry=args.donot_allow_retry,
     )
 
 
@@ -3500,6 +3501,11 @@ class CLIFactory(object):
             ('-u', '--username',),
             help='Username of the user',
             type=str),
+        'donot_allow_retry': Arg(
+            ("--donot_allow_retry",),
+            (
+                "if set, clear task failed without retry"),
+            "store_true"),
 
         # list_dag_runs
         'no_backfill': Arg(
@@ -4028,7 +4034,7 @@ class CLIFactory(object):
             'help': "Clear a set of task instance, as if they never ran",
             'args': (
                 'dag_id', 'task_regex', 'start_date', 'end_date', 'subdir',
-                'upstream', 'downstream', 'no_confirm', 'only_failed', 'yes',
+                'upstream', 'downstream', 'no_confirm', 'only_failed', 'yes', 'donot_allow_retry',
                 'only_running', 'exclude_subdags', 'exclude_parentdag', 'dag_regex'),
         }, {
             'func': pause,

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -954,6 +954,7 @@ class DAG(BaseDag, LoggingMixin):
             only_failed=False,
             only_running=False,
             confirm_prompt=False,
+            donot_allow_retry=False,
             include_subdags=True,
             include_parentdag=True,
             reset_dag_runs=True,
@@ -978,6 +979,8 @@ class DAG(BaseDag, LoggingMixin):
         :type only_running: bool
         :param confirm_prompt: Ask for confirmation
         :type confirm_prompt: bool
+        :param donot_allow_retry: task failed without retry.
+        :type donot_allow_retry: bool
         :param include_subdags: Clear tasks in subdags and clear external tasks
             indicated by ExternalTaskMarker
         :type include_subdags: bool
@@ -1026,6 +1029,7 @@ class DAG(BaseDag, LoggingMixin):
                 start_date=start_date, end_date=end_date,
                 only_failed=only_failed,
                 only_running=only_running,
+                donot_allow_retry=donot_allow_retry,
                 confirm_prompt=confirm_prompt,
                 include_subdags=include_subdags,
                 include_parentdag=False,
@@ -1090,6 +1094,7 @@ class DAG(BaseDag, LoggingMixin):
                                                          end_date=tii.execution_date,
                                                          only_failed=only_failed,
                                                          only_running=only_running,
+                                                         donot_allow_retry=donot_allow_retry,
                                                          confirm_prompt=confirm_prompt,
                                                          include_subdags=include_subdags,
                                                          include_parentdag=False,
@@ -1127,6 +1132,7 @@ class DAG(BaseDag, LoggingMixin):
             clear_task_instances(tis,
                                  session,
                                  dag=self,
+                                 donot_allow_retry=donot_allow_retry,
                                  )
             if reset_dag_runs:
                 self.set_dag_runs_state(session=session,
@@ -1150,6 +1156,7 @@ class DAG(BaseDag, LoggingMixin):
             confirm_prompt=False,
             include_subdags=True,
             include_parentdag=False,
+            donot_allow_retry=False,
             reset_dag_runs=True,
             dry_run=False,
     ):
@@ -1163,6 +1170,7 @@ class DAG(BaseDag, LoggingMixin):
                 confirm_prompt=False,
                 include_subdags=include_subdags,
                 include_parentdag=include_parentdag,
+                donot_allow_retry=donot_allow_retry,
                 reset_dag_runs=reset_dag_runs,
                 dry_run=True)
             all_tis.extend(tis)
@@ -1192,6 +1200,7 @@ class DAG(BaseDag, LoggingMixin):
                           confirm_prompt=False,
                           include_subdags=include_subdags,
                           reset_dag_runs=reset_dag_runs,
+                          donot_allow_retry=donot_allow_retry,
                           dry_run=False,
                           )
         else:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -100,15 +100,24 @@ class DagRun(Base, LoggingMixin):
 
         :param session: database session
         """
-        DR = DagRun
+        # DR = DagRun
 
-        exec_date = func.cast(self.execution_date, DateTime)
+        # exec_date = func.cast(self.execution_date, DateTime)
 
-        dr = session.query(DR).filter(
-            DR.dag_id == self.dag_id,
-            func.cast(DR.execution_date, DateTime) == exec_date,
-            DR.run_id == self.run_id
-        ).one()
+        # dr = session.query(DR).filter(
+        #     DR.dag_id == self.dag_id,
+        #     func.cast(DR.execution_date, DateTime) == exec_date,
+        #     DR.run_id == self.run_id
+        # ).one()
+
+        dr = DagRun.find(
+            dag_id=self.dag_id,
+            run_id=self.run_id,
+            execution_date=self.execution_date,
+            session=session
+        )
+
+        dr = dr[0]
 
         self.id = dr.id
         self.state = dr.state

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -72,6 +72,7 @@ def clear_task_instances(tis,
                          session,
                          activate_dag_runs=True,
                          dag=None,
+                         donot_allow_retry=False,
                          ):
     """
     Clears a set of task instances, but makes sure the running ones
@@ -81,6 +82,7 @@ def clear_task_instances(tis,
     :param session: current session
     :param activate_dag_runs: flag to check for active dag run
     :param dag: DAG object
+    :param donot_allow_retry: task do not allow retry
     """
     job_ids = []
     for ti in tis:
@@ -102,6 +104,8 @@ def clear_task_instances(tis,
                 # original max_tries or the last attempted try number.
                 ti.max_tries = max(ti.max_tries, ti.prev_attempted_tries)
             ti.state = State.NONE
+            if donot_allow_retry:
+                ti.max_tries = 0
             session.merge(ti)
         # Clear all reschedules related to the ti to clear
         TR = TaskReschedule

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -120,6 +120,17 @@ class ExternalTaskSensor(BaseSensorOperator):
         DM = DagModel
         TI = TaskInstance
         DR = DagRun
+
+        # if upstream dag paused, fail it immediately
+        dag_paused = session.query(DM).filter(
+            DM.dag_id == self.external_dag_id,
+            DM.is_paused == True
+        ).first()
+
+        if dag_paused:
+            raise AirflowException('The external DAG '
+                                   '{} paused.'.format(self.external_dag_id))
+
         if self.check_existence:
             dag_to_wait = session.query(DM).filter(
                 DM.dag_id == self.external_dag_id


### PR DESCRIPTION
related: #16458

In my application, we use clear api to rerun the task, but we thought of the rerun as a one-time thing and didn't want to try again if the task failed. So we add a parameter in Clear API to control whether the task can be retried after failed
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
