### PR TITLE
Provide a function for REST_API calls to set task_instance to the given state

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -376,3 +376,29 @@ def set_dag_run_state_to_running(dag, execution_date, commit=False, session=None
 
     # To keep the return type consistent with the other similar functions.
     return res
+
+def mark_task_instance_state(dag, task_id, execution_date, upstream, downstream, future, past, state, dry_run):
+    """
+    Mark task as given state.
+    """
+    task = dag.get_task(task_id)
+    task.dag = dag
+
+    if not task:
+        error_message = f"Task ID {task_id} not found"
+        raise ValueError(error_message)
+
+    execution_date = timezone.parse(execution_date)
+
+    tis = set_state(tasks=[task],
+                    execution_date=execution_date,
+                    upstream=upstream,
+                    downstream=downstream,
+                    future=future,
+                    past=past,
+                    state=state,
+                    commit=not dry_run
+                    )
+    ti = tis.pop()
+    return {"dag_id": ti.dag_id, "task_id": ti.task_id,
+            "execution_date": ti.execution_date.strftime('%Y%m%d%H%M%S'), "state": ti.state}

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -100,15 +100,24 @@ class DagRun(Base, LoggingMixin):
 
         :param session: database session
         """
-        DR = DagRun
+        # DR = DagRun
 
-        exec_date = func.cast(self.execution_date, DateTime)
+        # exec_date = func.cast(self.execution_date, DateTime)
 
-        dr = session.query(DR).filter(
-            DR.dag_id == self.dag_id,
-            func.cast(DR.execution_date, DateTime) == exec_date,
-            DR.run_id == self.run_id
-        ).one()
+        # dr = session.query(DR).filter(
+        #     DR.dag_id == self.dag_id,
+        #     func.cast(DR.execution_date, DateTime) == exec_date,
+        #     DR.run_id == self.run_id
+        # ).one()
+
+        dr = DagRun.find(
+            dag_id=self.dag_id,
+            run_id=self.run_id,
+            execution_date=self.execution_date,
+            session=session
+        )
+
+        dr = dr[0]
 
         self.id = dr.id
         self.state = dr.state

--- a/airflow/sensors/external_task_sensor.py
+++ b/airflow/sensors/external_task_sensor.py
@@ -120,6 +120,17 @@ class ExternalTaskSensor(BaseSensorOperator):
         DM = DagModel
         TI = TaskInstance
         DR = DagRun
+
+        # if upstream dag paused, fail it immediately
+        dag_paused = session.query(DM).filter(
+            DM.dag_id == self.external_dag_id,
+            DM.is_paused == True
+        ).first()
+
+        if dag_paused:
+            raise AirflowException('The external DAG '
+                                   '{} paused.'.format(self.external_dag_id))
+
         if self.check_existence:
             dag_to_wait = session.query(DM).filter(
                 DM.dag_id == self.external_dag_id


### PR DESCRIPTION
We provide a method that allows the airflow rest_api calls to set the task_instance to the given state
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
