### PR TITLE
fix: instance name env var in docs for customizing site title

### DIFF
--- a/docs/apache-airflow/howto/customize-dag-ui-page-instance-name.rst
+++ b/docs/apache-airflow/howto/customize-dag-ui-page-instance-name.rst
@@ -38,7 +38,7 @@ To make this change, simply:
 
 .. code-block::
 
-  AIRFLOW__WEBSERVER__SITE_TITLE = "DevEnv"
+  AIRFLOW__WEBSERVER__INSTANCE_NAME = "DevEnv"
 
 
 Screenshots


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixed the instance name env var in the docs used to customize the DAG UI Page. Tested with Airflow 2.1.0.

This change also makes docs consistent with the information [here](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#instance-name).

Env vars take the format `AIRFLOW__{SECTION}__{KEY}`. The `section` for this env var is `CORE` and the `key` is `INSTANCE_NAME`. References https://github.com/apache/airflow/issues/9538

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
