### PR TITLE
Add option to ignore host for misconfigured passive FTP servers

### DIFF
--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -49,11 +49,11 @@ class FTPHook(BaseHook):
         reference.
     :type ftp_conn_id: str
 
-    :param ignore_pasv_host: Ignore the host that is returned by the server and
+    :param ignore_passive_host: Ignore the host that is returned by the server and
         use the one from the connection. This is in case the FTP server is
         misconfigured and is replying to the PASV command with the internal
         IP address that was not accessible from the public internet.
-    :type ignore_pasv_host: bool
+    :type ignore_passive_host: bool
     """
 
     conn_name_attr = 'ftp_conn_id'
@@ -61,10 +61,10 @@ class FTPHook(BaseHook):
     conn_type = 'ftp'
     hook_name = 'FTP'
 
-    def __init__(self, ftp_conn_id: str = default_conn_name, ignore_pasv_host: bool = False) -> None:
+    def __init__(self, ftp_conn_id: str = default_conn_name, ignore_passive_host: bool = False) -> None:
         super().__init__()
         self.ftp_conn_id = ftp_conn_id
-        self.ignore_pasv_host = ignore_pasv_host
+        self.ignore_passive_host = ignore_passive_host
         self.conn: Optional[ftplib.FTP] = None
 
     def __enter__(self):
@@ -79,7 +79,7 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            ftp_cls = _FTPIgnoreHost if self.ignore_pasv_host else ftplib.FTP
+            ftp_cls = _FTPIgnoreHost if self.ignore_passive_host else ftplib.FTP
             self.conn = ftp_cls(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
 
@@ -302,7 +302,7 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            ftp_cls = _FTPSIgnoreHost if self.ignore_pasv_host else ftplib.FTP_TLS
+            ftp_cls = _FTPSIgnoreHost if self.ignore_passive_host else ftplib.FTP_TLS
 
             if params.port:
                 ftp_cls.port = params.port

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -25,13 +25,13 @@ from typing import Any, List, Optional
 from airflow.hooks.base import BaseHook
 
 
-class FTPIgnoreHost(ftplib.FTP):
+class _FTPIgnoreHost(ftplib.FTP):
     def makepasv(self):
         _, port = super().makepasv()
         return self.host, port
 
 
-class FTPSIgnoreHost(ftplib.FTP_TLS):
+class _FTPSIgnoreHost(ftplib.FTP_TLS):
     def makepasv(self):
         _, port = super().makepasv()
         return self.host, port
@@ -79,7 +79,7 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            ftp_cls = FTPIgnoreHost if self.ignore_pasv_host else ftplib.FTP
+            ftp_cls = _FTPIgnoreHost if self.ignore_pasv_host else ftplib.FTP
             self.conn = ftp_cls(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
 
@@ -302,7 +302,7 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            ftp_cls = FTPSIgnoreHost if self.ignore_pasv_host else ftplib.FTP_TLS
+            ftp_cls = _FTPSIgnoreHost if self.ignore_pasv_host else ftplib.FTP_TLS
 
             if params.port:
                 ftp_cls.port = params.port


### PR DESCRIPTION
Add option to ignore the host that is returned by the FTP server in
case the FTP server is misconfigured and is replying to the PASV
command with the internal IP address that was not accessible from the
public internet.

More info:

- https://stumbles.id.au/python-ftps-and-mis-configured-servers.html
- https://serverfault.com/questions/257573/ftp-server-timeouts-on-passive-i-can-only-use-active

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
