### PR TITLE
Use Serialization to support more objects in XCom

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -196,7 +196,7 @@ class BaseSerialization:
         return serialized_object
 
     @classmethod
-    def _serialize(cls, var: Any) -> Any:  # Unfortunately there is no support for recursive types in mypy
+    def _serialize(cls, var: Any, fail_on_error: bool = False) -> Any:
         """Helper function of depth first search for serialization.
 
         The serialization protocol is:
@@ -251,6 +251,8 @@ class BaseSerialization:
         elif isinstance(var, TaskGroup):
             return SerializedTaskGroup.serialize_task_group(var)
         else:
+            if fail_on_error:
+                raise TypeError(f"Can't serialize {var} - invalid type - {type(var)} ")
             log.debug('Cast type %s to str in serialization.', type(var))
             return str(var)
 


### PR DESCRIPTION
closes https://github.com/apache/airflow/issues/8703

This way we will support Set, Tuple (and others like DAG,
BaseOperator, relativedelta, datetime) in XCom in serialization and
de-serialization.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
