### PR TITLE
Fix release date for 2.1.1

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,9 +1,8 @@
-Airflow 2.1.1, 2021-06-29
+Airflow 2.1.1, 2021-07-02
 -------------------------
 
 Bug Fixes
 """""""""
-
 
 - Don't crash attempting to mask secrets in dict with non-string keys (#16601)
 - Always install sphinx_airflow_theme from ``PyPI`` (#16594)


### PR DESCRIPTION
Airflow 2.1.1 was released a bit later than we expected, it was released on 2021-07-02

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
