### PR TITLE
Removes coverage from kubernetes tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1036,15 +1036,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: failure()
         with:
           name: >
-            kind-logs-
+            kind-logs-${{matrix.executor}}
           path: /tmp/kind_logs_*
-          retention-days: 7
-      - name: "Upload artifact for coverage"
-        uses: actions/upload-artifact@v2
-        with:
-          name: >
-            coverage-k8s-
-          path: "./files/coverage*.xml"
           retention-days: 7
 
   tests-helm-executor-upgrade:
@@ -1107,15 +1100,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         if: failure()
         with:
           name: >
-            kind-logs-
+            kind-logs-KubernetesExecutor
           path: /tmp/kind_logs_*
-          retention-days: 7
-      - name: "Upload artifact for coverage"
-        uses: actions/upload-artifact@v2
-        with:
-          name: >
-            coverage-k8s-
-          path: "./files/coverage*.xml"
           retention-days: 7
 
   push-prod-images-to-github-registry:

--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -62,9 +62,6 @@ function parse_tests_to_run() {
             "--verbosity=1"
             "--strict-markers"
             "--durations=100"
-            "--cov=airflow/"
-            "--cov-config=.coveragerc"
-            "--cov-report=xml:files/coverage-${KIND_CLUSTER_NAME}-${HOST_PYTHON_VERSION}-${EXECUTOR}.xml"
             "--color=yes"
             "--maxfail=50"
             "--pythonwarnings=ignore::DeprecationWarning"
@@ -92,7 +89,7 @@ function create_virtualenv() {
 
     pip install --upgrade "pip==${AIRFLOW_PIP_VERSION}" "wheel==${WHEEL_VERSION}"
 
-    pip install pytest freezegun pytest-cov \
+    pip install pytest freezegun \
       --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${HOST_PYTHON_VERSION}.txt"
 
     pip install -e ".[cncf.kubernetes,postgres]" \


### PR DESCRIPTION
The coverage generated by parallel runs of K8S tests cause often
failures of tests because temporary .coverage files were generated
in airflow sources. However the coverage of those tests was actually
wrong - it did not check the coverage of Airflow code (it is
running inside K8S in scheduler/workers/webserver pods).

This is quite a bit complex task captured in #16793 but for now we
should simply disable the coverage for those tests.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
