### PR TITLE
When a task instance fails with exception, log it

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1451,7 +1451,7 @@ class TaskInstance(Base, LoggingMixin):
 
         if error:
             if isinstance(error, Exception):
-                self.log.exception("Task failed with exception")
+                self.log.error("Task failed with exception", exc_info=error)
             else:
                 self.log.error("%s", error)
             # external monitoring process provides pickle file so _run_raw_task


### PR DESCRIPTION
The previous `exception()` call looks at `sys.exc_info()` for the active exception, but since the failure handler is not in a Python exception handling context, it fails to actually log the exception. This is 
amended by passing in the exception instance explicitly, which is a valid argument type according to logging's documentation.

Fix #16564.