### PR TITLE
Fix wrong template_fields_renderers for AWS operators

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -144,7 +144,7 @@ class ECSOperator(BaseOperator):
 
     ui_color = '#f0ede4'
     template_fields = ('overrides',)
-    template_fields_renderers = {"overrides": "py"}
+    template_fields_renderers = {"overrides": "json"}
 
     def __init__(
         self,

--- a/airflow/providers/amazon/aws/operators/sagemaker_base.py
+++ b/airflow/providers/amazon/aws/operators/sagemaker_base.py
@@ -40,7 +40,7 @@ class SageMakerBaseOperator(BaseOperator):
 
     template_fields = ['config']
     template_ext = ()
-    template_fields_renderers = {"config": "py"}
+    template_fields_renderers = {"config": "json"}
     ui_color = '#ededed'
 
     integer_fields = []  # type: Iterable[Iterable[str]]


### PR DESCRIPTION
Related to #16808

Fixing wrong `template_fields_renderers` for Sagemaker and ECS operators. There might be other affected operators, but i'm fixing the ones i can test.