### PR TITLE
Add more filter options to list_keys of S3Hook

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -63,12 +63,9 @@ class ResponseFilter:
 
     def filter(self, object_filter: Optional[dict] = None) -> list:
         """
-        object_filter = {
-            'key': 'Sample',
-            'LastModified__gt': datetime.now()
-        }
+        object_filter = {'key': 'Sample','LastModified__gt': datetime.now()}
+        if object_filter is None return all the Keys.
         """
-        # if object_filter is None return all the Keys.
         if object_filter is None:
             result = []
             if "Contents" in self.data:
@@ -84,8 +81,10 @@ class ResponseFilter:
         def parse_filter(item) -> operation:
             """
             The item is expected to be a tuple with exactly two elements
-            >>> parse_filter(('LastModified__gt', datetime.strptime('2018-11-25T09:55:48+0000','%Y-%m-%dT%H:%M:%S%z')))
-            Q(op=<built-in function gt>, key='LastModified__gt', value=datetime.strptime('2018-11-25T09:55:48+0000','%Y-%m-%dT%H:%M:%S%z'))
+            >>> parse_filter(('LastModified__gt',
+             datetime.strptime('2018-11-25T09:55:48+0000','%Y-%m-%dT%H:%M:%S%z')))
+            Q(op=<built-in function gt>, key='LastModified__gt',
+             value=datetime.strptime('2018-11-25T09:55:48+0000','%Y-%m-%dT%H:%M:%S%z'))
             >>> parse_filter(('Key', 'Sample'))
             Q(op=<built-in function eq>, key='Key', value='Sample')
             >>> parse_filter(('LastModified__bad', 'red'))

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -23,6 +23,7 @@ import gzip as gz
 import io
 import re
 import shutil
+from datetime import datetime
 from functools import wraps
 from inspect import signature
 from io import BytesIO
@@ -269,6 +270,9 @@ class S3Hook(AwsBaseHook):
         delimiter: Optional[str] = None,
         page_size: Optional[int] = None,
         max_items: Optional[int] = None,
+        start_after_key: Optional[str] = '',
+        start_after_datetime: Optional[datetime] = None,
+        to_datetime: Optional[datetime] = None,
     ) -> list:
         """
         Lists keys in a bucket under prefix and not containing delimiter
@@ -283,6 +287,12 @@ class S3Hook(AwsBaseHook):
         :type page_size: int
         :param max_items: maximum items to return
         :type max_items: int
+        :param start_after_key: returns keys after this specified key in the bucket.
+        :type start_after_key: str
+        :param start_after_datetime: returns keys with last modified datetime greater than the specified datetime.
+        :type start_after_datetime: datetime , ISO8601: '%Y-%m-%dT%H:%M:%S%z', e.g. 2021-02-20T05:20:20+0000
+        :param to_datetime: returns keys with last modified datetime less than the specified datetime.
+        :type to_datetime: datetime , ISO8601: '%Y-%m-%dT%H:%M:%S%z', e.g. 2021-02-20T05:20:20+0000
         :return: a list of matched keys
         :rtype: list
         """
@@ -292,18 +302,24 @@ class S3Hook(AwsBaseHook):
             'PageSize': page_size,
             'MaxItems': max_items,
         }
-
         paginator = self.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(
-            Bucket=bucket_name, Prefix=prefix, Delimiter=delimiter, PaginationConfig=config
+            Bucket=bucket_name,
+            Prefix=prefix,
+            Delimiter=delimiter,
+            PaginationConfig=config,
+            StartAfter=start_after_key,
         )
-
+        # JMESPath to query directly on paginated results
+        filtered_response = response.search(
+            "Contents[?to_string("
+            "LastModified)<='\"{}\"' && "
+            "to_string(LastModified)>='\"{"
+            "}\"'].Key".format(to_datetime, start_after_datetime)
+        )
         keys = []
-        for page in response:
-            if 'Contents' in page:
-                for k in page['Contents']:
-                    keys.append(k['Key'])
-
+        for key in filtered_response:
+            keys.append(key)
         return keys
 
     @provide_bucket_name

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -21,8 +21,10 @@
 import fnmatch
 import gzip as gz
 import io
+import operator
 import re
 import shutil
+from collections import namedtuple
 from datetime import datetime
 from functools import wraps
 from inspect import signature
@@ -40,6 +42,81 @@ from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 from airflow.utils.helpers import chunks
 
 T = TypeVar("T", bound=Callable)
+
+
+class ResponseFilter:
+    """
+    ResponseFilter class filters the S3 boto3 response based on various operations
+    defined by user. This class can be extended as per required for parsing and filtering the
+    response based on different object filter
+    """
+
+    allowed_operations = {
+        "lte": operator.le,
+        "gte": operator.ge,
+        "gt": operator.gt,
+        "lt": operator.lt,
+        "eq": operator.eq,
+    }
+
+    def __init__(self, data):
+        self.data = data
+
+    def filter(self, object_filter: Optional[dict] = None) -> list:
+        """
+        object_filter = {
+            'key': 'Sample',
+            'LastModified__gt': datetime.now()
+        }
+        """
+        # if object_filter is None return all the Keys.
+        if object_filter is None:
+            result = []
+            if "Contents" in self.data:
+                contents = self.data["Contents"]
+                for content in contents:
+                    result.append(content.get("Key"))
+                return result
+
+        # object_filter is expected to be list of tuple with exactly two elements.
+        object_filter = [(k, v) for k, v in object_filter.items()]
+        operation = namedtuple("Q", "op key value")
+
+        def parse_filter(item) -> operation:
+            """
+            The item is expected to be a tuple with exactly two elements
+            >>> parse_filter(('LastModified__gt', datetime.strptime('2018-11-25T09:55:48+0000','%Y-%m-%dT%H:%M:%S%z')))
+            Q(op=<built-in function gt>, key='LastModified__gt', value=datetime.strptime('2018-11-25T09:55:48+0000','%Y-%m-%dT%H:%M:%S%z'))
+            >>> parse_filter(('Key', 'Sample'))
+            Q(op=<built-in function eq>, key='Key', value='Sample')
+            >>> parse_filter(('LastModified__bad', 'red'))
+            Traceback (most recent call last):
+             ...
+            AssertionError: 'bad' operation is not allowed
+            >>> parse_filter(('Name', 'red'))
+            Traceback (most recent call last):
+             ...
+            AssertionError: Key Name not found
+            """
+            key, *op = item[0].split("__")
+            # no value after __ means exact value query, e.g. key='Sample'
+            op = "".join(op).strip() or "eq"
+            assert op in self.allowed_operations, f"{repr(op)} operation is not allowed"
+            return operation(self.allowed_operations[op], key, item[1])
+
+        if "Contents" in self.data:
+            contents = self.data["Contents"]
+            results = {i["Key"] for i in contents}
+            for item in map(parse_filter, object_filter):
+                if "Contents" in self.data:
+                    for content in contents:
+                        if item.op == operator.contains and all(
+                            item.op(content[item.key], v) for v in item.value
+                        ):
+                            results.add(content.get("Key"))
+                        elif not item.op(content[item.key], item.value):
+                            results.discard(content.get("Key"))
+        return results
 
 
 def provide_bucket_name(func: T) -> T:
@@ -270,9 +347,8 @@ class S3Hook(AwsBaseHook):
         delimiter: Optional[str] = None,
         page_size: Optional[int] = None,
         max_items: Optional[int] = None,
-        start_after_key: Optional[str] = '',
-        start_after_datetime: Optional[datetime] = None,
-        to_datetime: Optional[datetime] = None,
+        start_after_key: Optional[str] = None,
+        object_filter: Optional[dict] = None,
     ) -> list:
         """
         Lists keys in a bucket under prefix and not containing delimiter
@@ -289,10 +365,10 @@ class S3Hook(AwsBaseHook):
         :type max_items: int
         :param start_after_key: returns keys after this specified key in the bucket.
         :type start_after_key: str
-        :param start_after_datetime: returns keys with last modified datetime greater than the specified datetime.
-        :type start_after_datetime: datetime , ISO8601: '%Y-%m-%dT%H:%M:%S%z', e.g. 2021-02-20T05:20:20+0000
-        :param to_datetime: returns keys with last modified datetime less than the specified datetime.
-        :type to_datetime: datetime , ISO8601: '%Y-%m-%dT%H:%M:%S%z', e.g. 2021-02-20T05:20:20+0000
+        :param object_filter: returns keys based on object filter dict
+        :type object_filter: dict, for example: object_filter = {
+                "LastModified__lt": datetime.now(),
+            }
         :return: a list of matched keys
         :rtype: list
         """
@@ -303,23 +379,22 @@ class S3Hook(AwsBaseHook):
             'MaxItems': max_items,
         }
         paginator = self.get_conn().get_paginator('list_objects_v2')
-        response = paginator.paginate(
-            Bucket=bucket_name,
-            Prefix=prefix,
-            Delimiter=delimiter,
-            PaginationConfig=config,
-            StartAfter=start_after_key,
-        )
-        # JMESPath to query directly on paginated results
-        filtered_response = response.search(
-            "Contents[?to_string("
-            "LastModified)<='\"{}\"' && "
-            "to_string(LastModified)>='\"{"
-            "}\"'].Key".format(to_datetime, start_after_datetime)
-        )
+        operation_parameters = {
+            "Bucket": bucket_name,
+            "Prefix": prefix,
+            "Delimiter": delimiter,
+            "PaginationConfig": config,
+        }
+
+        if start_after_key:
+            operation_parameters["StartAfter"] = start_after_key
+
+        response = paginator.paginate(**operation_parameters)
         keys = []
-        for key in filtered_response:
-            keys.append(key)
+        for page in response:
+            page_response = ResponseFilter(page)
+            keys.extend(page_response.filter(object_filter=object_filter))
+
         return keys
 
     @provide_bucket_name

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -25,7 +25,6 @@ import operator
 import re
 import shutil
 from collections import namedtuple
-from datetime import datetime
 from functools import wraps
 from inspect import signature
 from io import BytesIO
@@ -76,7 +75,7 @@ class ResponseFilter:
                 contents = self.data["Contents"]
                 for content in contents:
                     result.append(content.get("Key"))
-                return result
+            return result
 
         # object_filter is expected to be list of tuple with exactly two elements.
         object_filter = [(k, v) for k, v in object_filter.items()]
@@ -366,9 +365,7 @@ class S3Hook(AwsBaseHook):
         :param start_after_key: returns keys after this specified key in the bucket.
         :type start_after_key: str
         :param object_filter: returns keys based on object filter dict
-        :type object_filter: dict, for example: object_filter = {
-                "LastModified__lt": datetime.now(),
-            }
+        :type object_filter: dict, for example: object_filter = {"LastModified__lt": datetime.now(),}
         :return: a list of matched keys
         :rtype: list
         """
@@ -378,6 +375,7 @@ class S3Hook(AwsBaseHook):
             'PageSize': page_size,
             'MaxItems': max_items,
         }
+
         paginator = self.get_conn().get_paginator('list_objects_v2')
         operation_parameters = {
             "Bucket": bucket_name,

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -22,6 +22,7 @@ import tempfile
 from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock
+from datetime import datetime
 
 import boto3
 import pytest

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -19,6 +19,7 @@
 import gzip as gz
 import os
 import tempfile
+from datetime import datetime
 from unittest import mock
 from unittest.mock import Mock
 
@@ -149,10 +150,15 @@ class TestAwsS3Hook:
         bucket.put_object(Key='a', Body=b'a')
         bucket.put_object(Key='dir/b', Body=b'b')
 
+        start_datetime = datetime.strptime('1900-08-19T09:55:48+0000', '%Y-%m-%dT%H:%M:%S%z')
+        to_datetime = datetime.strptime('1901-08-19T09:55:48+0000', '%Y-%m-%dT%H:%M:%S%z')
+
         assert [] == hook.list_keys(s3_bucket, prefix='non-existent/')
         assert ['a', 'dir/b'] == hook.list_keys(s3_bucket)
         assert ['a'] == hook.list_keys(s3_bucket, delimiter='/')
         assert ['dir/b'] == hook.list_keys(s3_bucket, prefix='dir/')
+        assert ['dir/b'] == hook.list_keys(s3_bucket, start_after_key='a')
+        assert [] == hook.list_keys(s3_bucket, start_after_datetime=start_datetime, to_datetime=to_datetime)
 
     def test_list_keys_paged(self, s3_bucket):
         hook = S3Hook()

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -150,15 +150,19 @@ class TestAwsS3Hook:
         bucket.put_object(Key='a', Body=b'a')
         bucket.put_object(Key='dir/b', Body=b'b')
 
-        start_datetime = datetime.strptime('1900-08-19T09:55:48+0000', '%Y-%m-%dT%H:%M:%S%z')
-        to_datetime = datetime.strptime('1901-08-19T09:55:48+0000', '%Y-%m-%dT%H:%M:%S%z')
+        LastModified__gte = datetime.strptime('1900-08-19T09:55:48+0000', '%Y-%m-%dT%H:%M:%S%z')
+        LastModified__lt = datetime.strptime('1901-08-19T09:55:48+0000', '%Y-%m-%dT%H:%M:%S%z')
+        object_filter = {
+            "LastModified__gte": LastModified__gte,
+            "LastModified__lt": LastModified__lt,
+        }
 
         assert [] == hook.list_keys(s3_bucket, prefix='non-existent/')
         assert ['a', 'dir/b'] == hook.list_keys(s3_bucket)
         assert ['a'] == hook.list_keys(s3_bucket, delimiter='/')
         assert ['dir/b'] == hook.list_keys(s3_bucket, prefix='dir/')
         assert ['dir/b'] == hook.list_keys(s3_bucket, start_after_key='a')
-        assert [] == hook.list_keys(s3_bucket, start_after_datetime=start_datetime, to_datetime=to_datetime)
+        assert [] == hook.list_keys(s3_bucket, object_filter=object_filter)
 
     def test_list_keys_paged(self, s3_bucket):
         hook = S3Hook()


### PR DESCRIPTION
Add more filter options to list_keys of S3Hook
    
This commit adds following filters to list the keys in list_keys of S3Hook:
    - `start_after_key` filters the any keys after the specified key. start_after_key can be any key in the bucket.
    - `start_after_datetime` filters all the keys with last modified date-time greater than or equal to the start_after_datetime.
    - `to_datetime` filters all the keys with last modified date-time less than or equal to the to_datetime
   
closes: #16627  

This change wouldn't affect dependencies for other operators like S3DeleteObjectsOperator, S3ListOperator, S3Hook methods:get_wildcard_key, delete_bucket and S3KeysUnchangedSensor.

Corresponding unittest has been added to test_s3.py.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #16627

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
