### PR TITLE
Chart: allow using krb5.conf with CeleryExecutor

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -63,8 +63,8 @@ data:
 {{ tpl (.Files.Get "files/pod-template-file.kubernetes-helm-yaml") . | nindent 4 }}
 {{- end }}
 {{- end }}
+{{- end }}
 {{- if .Values.kerberos.enabled }}
   krb5.conf: |
     {{ tpl .Values.kerberos.config . | nindent 4 }}
-{{- end }}
 {{- end }}

--- a/chart/tests/test_configmap.py
+++ b/chart/tests/test_configmap.py
@@ -63,3 +63,14 @@ class ConfigmapTest(unittest.TestCase):
             "# Well hello RELEASE-NAME!"
             == jmespath.search('data."airflow_local_settings.py"', docs[0]).strip()
         )
+
+    def test_kerberos_config_available_with_celery_executor(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+                "kerberos": {"enabled": True, "config": "krb5content"},
+            },
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        assert jmespath.search('data."krb5.conf"', docs[0]) == "\nkrb5content\n"


### PR DESCRIPTION
For some reason kerberos can be used only when setting `executor: KubernetesExecutor` or `CeleryKubernetesExecutor`  in helm chart - see https://github.com/apache/airflow/blob/main/chart/templates/configmaps/configmap.yaml#L57 .

This PR allows to use kerberos when setting `executor: CeleryExecutor`.  