### PR TITLE
Add ability to specify XCom key for operators and task decorator

### DIFF
--- a/airflow/decorators/base.py
+++ b/airflow/decorators/base.py
@@ -226,7 +226,7 @@ def task_decorator_factory(
             )
             if f.__doc__:
                 op.doc_md = f.__doc__
-            return XComArg(op)
+            return XComArg(op, key=op.xcom_key)
 
         return cast(T, factory)
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -378,6 +378,9 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     :param do_xcom_push: if True, an XCom is pushed containing the Operator's
         result
     :type do_xcom_push: bool
+    :param xcom_key: Key used to push or pull XCom. If not specified XCOM_RETURN_KEY
+        will be used
+    :type xcom_key: str
     :param doc: Add documentation or notes to your Task objects that is visible in
         Task Instance details View in the Webserver
     :type doc: str
@@ -491,6 +494,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         task_concurrency: Optional[int] = None,
         executor_config: Optional[Dict] = None,
         do_xcom_push: bool = True,
+        xcom_key: str = XCOM_RETURN_KEY,
         inlets: Optional[Any] = None,
         outlets: Optional[Any] = None,
         task_group: Optional["TaskGroup"] = None,
@@ -616,6 +620,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         self.task_concurrency = task_concurrency
         self.executor_config = executor_config or {}
         self.do_xcom_push = do_xcom_push
+        self.xcom_key = xcom_key
 
         self.doc_md = doc_md
         self.doc_json = doc_json

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1313,7 +1313,7 @@ class TaskInstance(Base, LoggingMixin):
             result = task_copy.execute(context=context)
         # If the task returns a result, push an XCom containing it
         if task_copy.do_xcom_push and result is not None:
-            self.xcom_push(key=XCOM_RETURN_KEY, value=result)
+            self.xcom_push(key=task_copy.xcom_key, value=result)
         return result
 
     def _run_execute_callback(self, context: Context, task):

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -161,6 +161,7 @@
         "weight_rule": { "type": "string" },
         "executor_config": { "$ref": "#/definitions/dict" },
         "do_xcom_push": { "type": "boolean" },
+        "xcom_key": { "type": "string" },
         "ui_color": { "$ref": "#/definitions/color" },
         "ui_fgcolor": { "$ref": "#/definitions/color" },
         "template_fields": {

--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -400,6 +400,28 @@ class TestAirflowTaskDecorator(TestPythonBase):
         assert ti.xcom_pull(key='43') == 43
         assert ti.xcom_pull() == {'number': test_number + 1, '43': 43}
 
+    def test_xcom_key(self):
+        """Tests xcom_key argument on task"""
+
+        @task_decorator(xcom_key='mykey')
+        def return_val():
+            return {'number': 45}
+
+        with self.dag:
+            ret = return_val()
+
+        dr = self.dag.create_dagrun(
+            run_id=DagRunType.MANUAL,
+            start_date=timezone.utcnow(),
+            execution_date=DEFAULT_DATE,
+            state=State.RUNNING,
+        )
+
+        ret.operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+        ti = dr.get_task_instances()[0]
+        assert ti.xcom_pull(key='mykey') == {'number': 45}
+
     def test_default_args(self):
         """Test that default_args are captured when calling the function correctly"""
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1172,7 +1172,7 @@ class TestTaskInstance(unittest.TestCase):
         task_id = 'test_no_xcom_push'
         dag = models.DAG(dag_id='test_xcom')
 
-        # nothing saved to XCom
+        # XCom pushed with key=mykey
         task = PythonOperator(
             task_id=task_id,
             dag=dag,

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -916,6 +916,7 @@ class TestStringifiedDAGs(unittest.TestCase):
             'trigger_rule': 'all_success',
             'wait_for_downstream': False,
             'weight_rule': 'downstream',
+            'xcom_key': 'return_value',
         } == fields, """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 


### PR DESCRIPTION
Currently, we cannot specify a key for XCom using the task decorator
or any Operator except we explicitly use ti.xcom_push(key=key, value=value).
    
Whenever XCom is pushed, it implicitly use the key 'return_value' if we don't
explicitly push it and in the case of task decorator, we can't change this
value.
    
 This change adds an operator argument called `xcom_key` which helps us to change
 the xcom_key

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
