### PR TITLE
Fix/consistent get dag rest endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -34,14 +34,14 @@ from airflow.utils.session import provide_session
 
 
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
-@provide_session
-def get_dag(dag_id, session):
+def get_dag(dag_id):
     """Get basic information about a DAG."""
-    dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one_or_none()
-
+    try:
+        dag: DAG = current_app.dag_bag.get_dag(dag_id)
+    except SerializedDagNotFound:
+        raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
     if dag is None:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
-
     return dag_schema.dump(dag)
 
 

--- a/airflow/api_connexion/schemas/dag_schema.py
+++ b/airflow/api_connexion/schemas/dag_schema.py
@@ -56,7 +56,15 @@ class DAGSchema(SQLAlchemySchema):
     owners = fields.Method("get_owners", dump_only=True)
     description = auto_field(dump_only=True)
     schedule_interval = fields.Nested(ScheduleIntervalSchema)
-    tags = fields.List(fields.Nested(DagTagSchema), dump_only=True)
+    tags = fields.Method("get_tags", dump_only=True)
+
+    @staticmethod
+    def get_tags(obj: DAG):
+        """Dumps tags as objects"""
+        tags = obj.tags
+        if tags:
+            return [DagTagSchema().dump(dict(name=tag)) for tag in tags]
+        return []
 
     @staticmethod
     def get_owners(obj: DagModel):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/16839

I got a bit confused while updating the tests to the new behavior. Previously the tests were using the method `_create_dag_models` to generate test DAGs and when I changed to use the same DAGs from the tests on `TestGetDagDetails` the tests started failing because of tags for instance and then I noticed that tags are defined differently on `dag_schema` and `dag_detail_schema` and I felt like I needed to update `dag_schema` to use the same configuration. 

There is also the behavior that using DAGs from DagBag instead of directly inserting a DagModel on the database through the session the attributes `is_paused` and `is_active` come up as None instead of False/True.

Another thing that I noticed is that on TestGetDag there is a test related to the details endpoint [here](https://github.com/apache/airflow/blob/main/tests/api_connexion/endpoints/test_dag_endpoint.py#L204). Should we update this as well?

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
