### PR TITLE
Customizable xcom_sidecar_container

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -160,6 +160,13 @@ class KubernetesPodOperator(BaseOperator):
     :param termination_grace_period: Termination grace period if task killed in UI,
         defaults to kubernetes default
     :type termination_grace_period: int
+    :param xcom_sidecar_container: Definition of custom sidecar container. Useful when
+        you need to customize some parts of a default one (like container image poitning
+        to private repository). It is a good idea to define this as a modification of
+        airflow.providers.cncf.kubernetes.utils.xcom_sidecar.PodDefaults.SIDECAR_CONTAINER.
+        If no xcom-sidecar_container is provided then PodDefaults.SIDECAR_CONTAINER will
+        be used.
+        defaults to None
     """
 
     template_fields: Iterable[str] = (

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -21,8 +21,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple
 
 from kubernetes.client import CoreV1Api, models as k8s
 
-from airflow.airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
-
 try:
     import airflow.utils.yaml as yaml
 except ImportError:
@@ -492,7 +490,9 @@ class KubernetesPodOperator(BaseOperator):
             pod = secret.attach_to_pod(pod)
         if self.do_xcom_push:
             self.log.debug("Adding xcom sidecar to task %s", self.task_id)
-            pod = xcom_sidecar.add_xcom_sidecar(pod, self.xcom_sidecar_container or PodDefaults.SIDECAR_CONTAINER)
+            pod = xcom_sidecar.add_xcom_sidecar(pod,
+                                                self.xcom_sidecar_container
+                                                or xcom_sidecar.PodDefaults.SIDECAR_CONTAINER)
         return pod
 
     def create_new_pod_for_operator(self, labels, launcher) -> Tuple[State, k8s.V1Pod, Optional[str]]:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -167,6 +167,7 @@ class KubernetesPodOperator(BaseOperator):
         If no xcom-sidecar_container is provided then PodDefaults.SIDECAR_CONTAINER will
         be used.
         defaults to None
+    :type xcom_sidecar_container: Optional[k8s.V1Container]
     """
 
     template_fields: Iterable[str] = (

--- a/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py
+++ b/airflow/providers/cncf/kubernetes/utils/xcom_sidecar.py
@@ -32,6 +32,7 @@ class PodDefaults:
     XCOM_CMD = 'trap "exit 0" INT; while true; do sleep 1; done;'
     VOLUME_MOUNT = k8s.V1VolumeMount(name='xcom', mount_path=XCOM_MOUNT_PATH)
     VOLUME = k8s.V1Volume(name='xcom', empty_dir=k8s.V1EmptyDirVolumeSource())
+
     SIDECAR_CONTAINER = k8s.V1Container(
         name=SIDECAR_CONTAINER_NAME,
         command=['sh', '-c', XCOM_CMD],
@@ -45,13 +46,14 @@ class PodDefaults:
     )
 
 
-def add_xcom_sidecar(pod: k8s.V1Pod) -> k8s.V1Pod:
+def add_xcom_sidecar(pod: k8s.V1Pod, container_spec: k8s.V1Container) -> k8s.V1Pod:
     """Adds sidecar"""
     pod_cp = copy.deepcopy(pod)
     pod_cp.spec.volumes = pod.spec.volumes or []
     pod_cp.spec.volumes.insert(0, PodDefaults.VOLUME)
     pod_cp.spec.containers[0].volume_mounts = pod_cp.spec.containers[0].volume_mounts or []
     pod_cp.spec.containers[0].volume_mounts.insert(0, PodDefaults.VOLUME_MOUNT)
-    pod_cp.spec.containers.append(PodDefaults.SIDECAR_CONTAINER)
+
+    pod_cp.spec.containers.append(container_spec)
 
     return pod_cp


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/10605

This PR introduces additional keyword argument to KubernetesPodOperator enabling overriding container spec for xcom sidecar container.

The assumption is we can provide our own, custom V1Container specification to the operator which would override PodDefaults.SIDECAR_CONTAINER definition. The implementation is written in such fashion so the default spec is the same as before (backwards compatibility).

The need for such functionality was voiced in several issues:
https://github.com/apache/airflow/issues/10605
https://github.com/apache/airflow/issues/14926
https://github.com/apache/airflow/issues/16850
