### PR TITLE
fix(wait_for_airflow_db:prod): you can run this command only if it exists

### DIFF
--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -194,7 +194,7 @@ function set_pythonpath_for_root_user() {
 
 function wait_for_airflow_db() {
     # Check if Airflow has a command to check the connection to the database.
-    if ! airflow db check --help >/dev/null 2>&1; then
+    if airflow db check --help >/dev/null 2>&1; then
         run_check_with_retries "airflow db check"
     else
         # Verify connections to the Airflow DB by guessing the database address based on environment variables,


### PR DESCRIPTION
If you are below the 2.X version of airflow, the check fails, the condition must be inverted

Reference: https://github.com/apache/airflow/blob/main/UPDATING.md