### PR TITLE
Support DAGS folder being in different location on scheduler and runners

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -496,18 +496,8 @@ class SchedulerJob(BaseJob):
         """
         # actually enqueue them
         for ti in task_instances:
-            command = TI.generate_command(
-                ti.dag_id,
-                ti.task_id,
-                ti.execution_date,
+            command = ti.command_as_list(
                 local=True,
-                mark_success=False,
-                ignore_all_deps=False,
-                ignore_depends_on_past=False,
-                ignore_task_deps=False,
-                ignore_ti_state=False,
-                pool=ti.pool,
-                file_path=ti.dag_model.fileloc,
                 pickle_id=ti.dag_model.pickle_id,
             )
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -20,6 +20,7 @@ import copy
 import functools
 import logging
 import os
+import pathlib
 import pickle
 import re
 import sys
@@ -236,12 +237,20 @@ class DAG(LoggingMixin):
         'parent_dag',
         'start_date',
         'schedule_interval',
-        'full_filepath',
+        'fileloc',
         'template_searchpath',
         'last_loaded',
     }
 
     __serialized_fields: Optional[FrozenSet[str]] = None
+
+    fileloc: str
+    """
+    File path that needs to be imported to load this DAG or subdag.
+
+    This may not be an actual file on disk in the case when this DAG is loaded
+    from a ZIP file or other DAG distribution format.
+    """
 
     def __init__(
         self,
@@ -286,10 +295,16 @@ class DAG(LoggingMixin):
             self.params.update(self.default_args['params'])
             del self.default_args['params']
 
+        if full_filepath:
+            warnings.warn(
+                "Passing full_filepath to DAG() is deprecated and has no effect",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         validate_key(dag_id)
 
         self._dag_id = dag_id
-        self._full_filepath = full_filepath if full_filepath else ''
         if concurrency and not max_active_tasks:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
@@ -655,11 +670,22 @@ class DAG(LoggingMixin):
 
     @property
     def full_filepath(self) -> str:
-        return self._full_filepath
+        """:meta private:"""
+        warnings.warn(
+            "DAG.full_filepath is deprecated in favour of fileloc",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.fileloc
 
     @full_filepath.setter
     def full_filepath(self, value) -> None:
-        self._full_filepath = value
+        warnings.warn(
+            "DAG.full_filepath is deprecated in favour of fileloc",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.fileloc = value
 
     @property
     def concurrency(self) -> int:
@@ -735,15 +761,26 @@ class DAG(LoggingMixin):
 
     @property
     def filepath(self) -> str:
-        """File location of where the dag object is instantiated"""
-        fn = self.full_filepath.replace(settings.DAGS_FOLDER + '/', '')
-        fn = fn.replace(os.path.dirname(__file__) + '/', '')
-        return fn
+        """:meta private:"""
+        warnings.warn(
+            "filepath is deprecated, use relative_fileloc instead", DeprecationWarning, stacklevel=2
+        )
+        return str(self.relative_fileloc)
+
+    @property
+    def relative_fileloc(self) -> pathlib.Path:
+        """File location of the importable dag 'file' relative to the configured DAGs folder."""
+        path = pathlib.Path(self.fileloc)
+        try:
+            return path.relative_to(settings.DAGS_FOLDER)
+        except ValueError:
+            # Not relative to DAGS_FOLDER.
+            return path
 
     @property
     def folder(self) -> str:
         """Folder location of where the DAG object is instantiated."""
-        return os.path.dirname(self.full_filepath)
+        return os.path.dirname(self.fileloc)
 
     @property
     def owner(self) -> str:
@@ -2118,9 +2155,11 @@ class DAG(LoggingMixin):
             .group_by(DagRun.dag_id)
             .all()
         )
+        filelocs = []
 
         for orm_dag in sorted(orm_dags, key=lambda d: d.dag_id):
             dag = dag_by_ids[orm_dag.dag_id]
+            filelocs.append(dag.fileloc)
             if dag.is_subdag:
                 orm_dag.is_subdag = True
                 orm_dag.fileloc = dag.parent_dag.fileloc  # type: ignore
@@ -2157,7 +2196,7 @@ class DAG(LoggingMixin):
                         session.add(dag_tag_orm)
 
         if settings.STORE_DAG_CODE:
-            DagCode.bulk_sync_to_db([dag.fileloc for dag in orm_dags])
+            DagCode.bulk_sync_to_db(filelocs)
 
         # Issue SQL/finish "Unit of Work", but let @provide_session commit (or if passed a session, let caller
         # decide when to commit
@@ -2274,7 +2313,6 @@ class DAG(LoggingMixin):
                 '_old_context_manager_dags',
                 'safe_dag_id',
                 'last_loaded',
-                '_full_filepath',
                 'user_defined_filters',
                 'user_defined_macros',
                 'partial',
@@ -2332,7 +2370,7 @@ class DagModel(Base):
     These items are stored in the database for state related information
     """
     dag_id = Column(String(ID_LEN), primary_key=True)
-    root_dag_id = Column(String(ID_LEN))
+    root_dag_id = Column(String(ID_LEN), ForeignKey("dag.dag_id"))
     # A DAG can be paused from the UI / DB
     # Set this default value of is_paused based on a configuration value!
     is_paused_at_creation = conf.getboolean('core', 'dags_are_paused_at_creation')
@@ -2382,6 +2420,8 @@ class DagModel(Base):
         Index('idx_next_dagrun_create_after', next_dagrun_create_after, unique=False),
     )
 
+    parent_dag = relationship("DagModel", remote_side=[dag_id])
+
     NUM_DAGS_PER_DAGRUN_QUERY = conf.getint('scheduler', 'max_dagruns_to_create_per_loop', fallback=10)
 
     def __init__(self, concurrency=None, **kwargs):
@@ -2410,7 +2450,7 @@ class DagModel(Base):
     @staticmethod
     @provide_session
     def get_dagmodel(dag_id, session=None):
-        return session.query(DagModel).filter(DagModel.dag_id == dag_id).first()
+        return session.query(DagModel).options(joinedload(DagModel.parent_dag)).get(dag_id)
 
     @classmethod
     @provide_session
@@ -2454,6 +2494,18 @@ class DagModel(Base):
     @property
     def safe_dag_id(self):
         return self.dag_id.replace('.', '__dot__')
+
+    @property
+    def relative_fileloc(self) -> Optional[pathlib.Path]:
+        """File location of the importable dag 'file' relative to the configured DAGs folder."""
+        if self.fileloc is None:
+            return None
+        path = pathlib.Path(self.fileloc)
+        try:
+            return path.relative_to(settings.DAGS_FOLDER)
+        except ValueError:
+            # Not relative to DAGS_FOLDER.
+            return path
 
     @provide_session
     def set_is_paused(self, is_paused: bool, including_subdags: bool = True, session=None) -> None:

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2370,7 +2370,7 @@ class DagModel(Base):
     These items are stored in the database for state related information
     """
     dag_id = Column(String(ID_LEN), primary_key=True)
-    root_dag_id = Column(String(ID_LEN), ForeignKey("dag.dag_id"))
+    root_dag_id = Column(String(ID_LEN))
     # A DAG can be paused from the UI / DB
     # Set this default value of is_paused based on a configuration value!
     is_paused_at_creation = conf.getboolean('core', 'dags_are_paused_at_creation')
@@ -2420,7 +2420,9 @@ class DagModel(Base):
         Index('idx_next_dagrun_create_after', next_dagrun_create_after, unique=False),
     )
 
-    parent_dag = relationship("DagModel", remote_side=[dag_id])
+    parent_dag = relationship(
+        "DagModel", remote_side=[dag_id], primaryjoin=root_dag_id == dag_id, foreign_keys=[root_dag_id]
+    )
 
     NUM_DAGS_PER_DAGRUN_QUERY = conf.getint('scheduler', 'max_dagruns_to_create_per_loop', fallback=10)
 

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -90,7 +90,7 @@ class SerializedDagModel(Base):
 
     def __init__(self, dag: DAG):
         self.dag_id = dag.dag_id
-        self.fileloc = dag.full_filepath
+        self.fileloc = dag.fileloc
         self.fileloc_hash = DagCode.dag_fileloc_hash(self.fileloc)
         self.data = SerializedDAG.to_dict(dag)
         self.last_updated = timezone.utcnow()

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -752,7 +752,6 @@ class SerializedDAG(DAG, BaseSerialization):
         for k in keys_to_set_none:
             setattr(dag, k, None)
 
-        setattr(dag, 'full_filepath', dag.fileloc)
         for task in dag.task_dict.values():
             task.dag = dag
             serializable_task: BaseOperator = task

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -88,8 +88,8 @@
       <td>{{ dag.task_ids }}</td>
     </tr>
     <tr>
-      <th>Filepath</th>
-      <td>{{ dag.filepath }}</td>
+      <th>Relative file location</th>
+      <td>{{ dag.relative_fileloc }}</td>
     </tr>
     <tr>
       <th>Owner</th>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1388,9 +1388,8 @@ class Airflow(AirflowBaseView):
         dttm = timezone.parse(execution_date)
         form = DateTimeForm(data={'execution_date': dttm})
         root = request.args.get('root', '')
-        dm_db = models.DagModel
         ti_db = models.TaskInstance
-        dag = session.query(dm_db).filter(dm_db.dag_id == dag_id).first()
+        dag = DagModel.get_dagmodel(dag_id)
         ti = session.query(ti_db).filter(and_(ti_db.dag_id == dag_id, ti_db.task_id == task_id)).first()
 
         if not ti:

--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -52,7 +52,7 @@ def _check_task_rules(current_task: BaseOperator):
     if notices:
         notices_list = " * " + "\n * ".join(notices)
         raise AirflowClusterPolicyViolation(
-            f"DAG policy violation (DAG ID: {current_task.dag_id}, Path: {current_task.dag.filepath}):\n"
+            f"DAG policy violation (DAG ID: {current_task.dag_id}, Path: {current_task.dag.fileloc}):\n"
             f"Notices:\n"
             f"{notices_list}"
         )
@@ -70,7 +70,7 @@ def dag_policy(dag: DAG):
     """Ensure that DAG has at least one tag"""
     if not dag.tags:
         raise AirflowClusterPolicyViolation(
-            f"DAG {dag.dag_id} has no tags. At least one tag required. File path: {dag.filepath}"
+            f"DAG {dag.dag_id} has no tags. At least one tag required. File path: {dag.fileloc}"
         )
 
 

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -407,9 +407,9 @@ class TestDagFileProcessorManager(unittest.TestCase):
                 seconds=manager._zombie_threshold_secs + 1
             )
             manager._find_zombies()
-            requests = manager._callback_to_execute[dag.full_filepath]
+            requests = manager._callback_to_execute[dag.fileloc]
             assert 1 == len(requests)
-            assert requests[0].full_filepath == dag.full_filepath
+            assert requests[0].full_filepath == dag.fileloc
             assert requests[0].msg == "Detected as zombie"
             assert requests[0].is_failure_callback is True
             assert isinstance(requests[0].simple_task_instance, SimpleTaskInstance)
@@ -451,7 +451,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
 
                 expected_failure_callback_requests = [
                     TaskCallbackRequest(
-                        full_filepath=dag.full_filepath,
+                        full_filepath=dag.fileloc,
                         simple_task_instance=SimpleTaskInstance(ti),
                         msg="Message",
                     )

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -685,7 +685,7 @@ class TestDagFileProcessor(unittest.TestCase):
 
             requests = [
                 TaskCallbackRequest(
-                    full_filepath=dag.full_filepath,
+                    full_filepath=dag.fileloc,
                     simple_task_instance=SimpleTaskInstance(ti),
                     msg="Message",
                 )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -200,8 +200,8 @@ class TestSchedulerJob:
         dag_id2 = "test_process_executor_events_2"
         task_id_1 = 'dummy_task'
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, full_filepath="/test_path1/")
-        dag2 = DAG(dag_id=dag_id2, start_date=DEFAULT_DATE, full_filepath="/test_path1/")
+        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
+        dag2 = DAG(dag_id=dag_id2, start_date=DEFAULT_DATE)
         task1 = DummyOperator(dag=dag, task_id=task_id_1)
         DummyOperator(dag=dag2, task_id=task_id_1)
         dag.fileloc = "/test_path1/"

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -21,4 +21,4 @@ import os
 from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
-TEST_DAGS_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../dags')
+TEST_DAGS_FOLDER = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'dags'))

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -25,6 +25,7 @@ import re
 import unittest
 from contextlib import redirect_stdout
 from datetime import timedelta
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Optional
 from unittest import mock
@@ -1769,6 +1770,19 @@ class TestDagModel:
 
         session.rollback()
         session.close()
+
+    @pytest.mark.parametrize(
+        ('fileloc', 'expected_relative'),
+        [
+            (os.path.join(settings.DAGS_FOLDER, 'a.py'), Path('a.py')),
+            ('/tmp/foo.py', Path('/tmp/foo.py')),
+        ],
+    )
+    def test_relative_fileloc(self, fileloc, expected_relative):
+        dag = DAG(dag_id='test')
+        dag.fileloc = fileloc
+
+        assert dag.relative_fileloc == expected_relative
 
 
 class TestQueries(unittest.TestCase):

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -246,7 +246,7 @@ class TestDagBag(unittest.TestCase):
         expected = {
             'example_bash_operator': 'airflow/example_dags/example_bash_operator.py',
             'example_subdag_operator': 'airflow/example_dags/example_subdag_operator.py',
-            'example_subdag_operator.section-1': 'airflow/example_dags/subdags/subdag.py',
+            'example_subdag_operator.section-1': 'airflow/example_dags/example_subdag_operator.py',
             'test_zip_dag': 'dags/test_zip.zip/test_zip.py',
         }
 
@@ -507,11 +507,14 @@ class TestDagBag(unittest.TestCase):
         assert len(test_dag.subdags) == 6
 
         # Perform processing dag
-        dagbag, found_dags, _ = self.process_dag(nested_subdags)
+        dagbag, found_dags, filename = self.process_dag(nested_subdags)
 
         # Validate correctness
         # all dags from test_dag should be listed
         self.validate_dags(test_dag, found_dags, dagbag)
+
+        for dag in dagbag.dags.values():
+            assert dag.fileloc == filename
 
     def test_skip_cycle_dags(self):
         """

--- a/tests/models/test_renderedtifields.py
+++ b/tests/models/test_renderedtifields.py
@@ -26,6 +26,7 @@ from unittest import mock
 from parameterized import parameterized
 
 from airflow import settings
+from airflow.configuration import TEST_DAGS_FOLDER
 from airflow.models import Variable
 from airflow.models.dag import DAG
 from airflow.models.renderedtifields import RenderedTaskInstanceFields as RTIF
@@ -244,6 +245,7 @@ class TestRenderedTaskInstanceFields(unittest.TestCase):
         dag = DAG("test_get_k8s_pod_yaml", start_date=START_DATE)
         with dag:
             task = BashOperator(task_id="test", bash_command="echo hi")
+        dag.fileloc = TEST_DAGS_FOLDER + '/test_get_k8s_pod_yaml.py'
 
         ti = TI(task=task, execution_date=EXECUTION_DATE)
 

--- a/tests/models/test_serialized_dag.py
+++ b/tests/models/test_serialized_dag.py
@@ -71,7 +71,7 @@ class SerializedDagModelTest(unittest.TestCase):
                 assert SDM.has_dag(dag.dag_id)
                 result = session.query(SDM.fileloc, SDM.data).filter(SDM.dag_id == dag.dag_id).one()
 
-                assert result.fileloc == dag.full_filepath
+                assert result.fileloc == dag.fileloc
                 # Verifies JSON schema.
                 SerializedDAG.validate_schema(result.data)
 
@@ -138,8 +138,8 @@ class SerializedDagModelTest(unittest.TestCase):
         # Tests removing by file path.
         dag_removed_by_file = filtered_example_dags_list[0]
         # remove repeated files for those DAGs that define multiple dags in the same file (set comprehension)
-        example_dag_files = list({dag.full_filepath for dag in filtered_example_dags_list})
-        example_dag_files.remove(dag_removed_by_file.full_filepath)
+        example_dag_files = list({dag.fileloc for dag in filtered_example_dags_list})
+        example_dag_files.remove(dag_removed_by_file.fileloc)
         SDM.remove_deleted_dags(example_dag_files)
         assert not SDM.has_dag(dag_removed_by_file.dag_id)
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -68,7 +68,7 @@ from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 from airflow.version import version
-from tests.models import DEFAULT_DATE
+from tests.models import DEFAULT_DATE, TEST_DAGS_FOLDER
 from tests.test_utils import db
 from tests.test_utils.asserts import assert_queries_count
 from tests.test_utils.config import conf_vars
@@ -1899,6 +1899,26 @@ class TestTaskInstance(unittest.TestCase):
         assert call(f'ti.start.{dag.dag_id}.{op.task_id}') in stats_mock.mock_calls
         assert stats_mock.call_count == 5
 
+    def test_command_as_list(self):
+        dag = DAG(
+            'test_dag',
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+        )
+        dag.fileloc = os.path.join(TEST_DAGS_FOLDER, 'x.py')
+        op = DummyOperator(task_id='dummy_op', dag=dag)
+        ti = TI(task=op, execution_date=DEFAULT_DATE)
+        assert ti.command_as_list() == [
+            'airflow',
+            'tasks',
+            'run',
+            dag.dag_id,
+            op.task_id,
+            DEFAULT_DATE.isoformat(),
+            '--subdir',
+            'DAGS_FOLDER/x.py',
+        ]
+
     def test_generate_command_default_param(self):
         dag_id = 'test_generate_command_default_param'
         task_id = 'task'
@@ -1925,8 +1945,9 @@ class TestTaskInstance(unittest.TestCase):
 
     def test_get_rendered_template_fields(self):
 
-        with DAG('test-dag', start_date=DEFAULT_DATE):
+        with DAG('test-dag', start_date=DEFAULT_DATE) as dag:
             task = BashOperator(task_id='op1', bash_command="{{ task.task_id }}")
+        dag.fileloc = TEST_DAGS_FOLDER + '/test_get_k8s_pod_yaml.py'
 
         ti = TI(task=task, execution_date=DEFAULT_DATE)
 
@@ -1984,6 +2005,8 @@ class TestTaskInstance(unittest.TestCase):
                             'test_get_rendered_k8s_spec',
                             'op1',
                             '2016-01-01T00:00:00+00:00',
+                            '--subdir',
+                            __file__,
                         ],
                         'image': ':',
                         'name': 'base',

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -380,10 +380,6 @@ class TestStringifiedDAGs(unittest.TestCase):
         for task_id in dag.task_ids:
             self.validate_deserialized_task(serialized_dag.get_task(task_id), dag.get_task(task_id))
 
-        # Verify that the DAG object has 'full_filepath' attribute
-        # and is equal to fileloc
-        assert serialized_dag.full_filepath == dag.fileloc
-
     def validate_deserialized_task(
         self,
         serialized_task,


### PR DESCRIPTION
There has been some vestigial support for this concept in Airflow for a
while (all the CLI command already turn the literal `DAGS_FOLDER` in to
the real value of the DAGS folder when loading dags), but sometime
around 1.10.1-1.10.3 it got fully broken and the scheduler only ever
passed full paths to DAG files.

This PR brings back this behaviour

Closes #8061


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).