### PR TITLE
Better description for `pod_template_file`

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2039,11 +2039,12 @@
   options:
     - name: pod_template_file
       description: |
-        Path to the YAML pod file. If set, all other kubernetes-related fields are ignored.
+        Path to the YAML pod file that forms the basis for KubernetesExecutor workers.
       version_added: 1.10.11
       type: string
       example: ~
       default: ""
+      see_also: ":ref:`concepts:pod_template_file`"
     - name: worker_container_repository
       description: |
         The repository of the Kubernetes Image for the Worker to Run

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1009,7 +1009,7 @@ use_ssl = False
 verify_certs = True
 
 [kubernetes]
-# Path to the YAML pod file. If set, all other kubernetes-related fields are ignored.
+# Path to the YAML pod file that forms the basis for KubernetesExecutor workers.
 pod_template_file =
 
 # The repository of the Kubernetes Image for the Worker to Run


### PR DESCRIPTION
In Airflow 2+, `pod_template_file` is the only way to configure workers,
so we can remove the "other fields" language.

Also drop a link to the `pod_template_file` section for KubernetesExecutor via `see_also`.

Related: #16833 