### PR TITLE
Remove default_args pattern + added get_current_context() use for Core Airflow example DAGs

### DIFF
--- a/airflow/example_dags/example_bash_operator.py
+++ b/airflow/example_dags/example_bash_operator.py
@@ -25,13 +25,8 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='example_bash_operator',
-    default_args=args,
     schedule_interval='0 0 * * *',
     start_date=days_ago(2),
     dagrun_timeout=timedelta(minutes=60),

--- a/airflow/example_dags/example_branch_datetime_operator.py
+++ b/airflow/example_dags/example_branch_datetime_operator.py
@@ -27,14 +27,9 @@ from airflow.operators.datetime import BranchDateTimeOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    "owner": "airflow",
-}
-
 dag = DAG(
     dag_id="example_branch_datetime_operator",
     start_date=days_ago(2),
-    default_args=args,
     tags=["example"],
     schedule_interval="@daily",
 )
@@ -60,7 +55,6 @@ cond1 >> [dummy_task_1, dummy_task_2]
 dag = DAG(
     dag_id="example_branch_datetime_operator_2",
     start_date=days_ago(2),
-    default_args=args,
     tags=["example"],
     schedule_interval="@daily",
 )

--- a/airflow/example_dags/example_branch_day_of_week_operator.py
+++ b/airflow/example_dags/example_branch_day_of_week_operator.py
@@ -25,14 +25,9 @@ from airflow.operators.dummy import DummyOperator
 from airflow.operators.weekday import BranchDayOfWeekOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    "owner": "airflow",
-}
-
 with DAG(
     dag_id="example_weekday_branch_operator",
     start_date=days_ago(2),
-    default_args=args,
     tags=["example"],
     schedule_interval="@daily",
 ) as dag:

--- a/airflow/example_dags/example_branch_operator.py
+++ b/airflow/example_dags/example_branch_operator.py
@@ -26,13 +26,8 @@ from airflow.operators.python import BranchPythonOperator
 from airflow.utils.dates import days_ago
 from airflow.utils.edgemodifier import Label
 
-args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='example_branch_operator',
-    default_args=args,
     start_date=days_ago(2),
     schedule_interval="@daily",
     tags=['example', 'example2'],

--- a/airflow/example_dags/example_branch_python_dop_operator_3.py
+++ b/airflow/example_dags/example_branch_python_dop_operator_3.py
@@ -26,11 +26,6 @@ from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import BranchPythonOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'airflow',
-    'depends_on_past': True,
-}
-
 
 def should_run(**kwargs):
     """
@@ -55,7 +50,7 @@ with DAG(
     dag_id='example_branch_dop_operator_v3',
     schedule_interval='*/1 * * * *',
     start_date=days_ago(2),
-    default_args=args,
+    default_args={'depends_on_past': True},
     tags=['example'],
 ) as dag:
 

--- a/airflow/example_dags/example_dag_decorator.py
+++ b/airflow/example_dags/example_dag_decorator.py
@@ -25,8 +25,6 @@ from airflow.models.baseoperator import BaseOperator
 from airflow.operators.email import EmailOperator
 from airflow.utils.dates import days_ago
 
-DEFAULT_ARGS = {"owner": "airflow"}
-
 
 class GetRequestOperator(BaseOperator):
     """Custom operator to sand GET request to provided url"""
@@ -40,7 +38,7 @@ class GetRequestOperator(BaseOperator):
 
 
 # [START dag_decorator_usage]
-@dag(default_args=DEFAULT_ARGS, schedule_interval=None, start_date=days_ago(2), tags=['example'])
+@dag(schedule_interval=None, start_date=days_ago(2), tags=['example'])
 def example_dag_decorator(email: str = 'example@example.com'):
     """
     DAG to send server IP to email.

--- a/airflow/example_dags/example_kubernetes_executor.py
+++ b/airflow/example_dags/example_kubernetes_executor.py
@@ -25,13 +25,8 @@ from airflow.example_dags.libs.helper import print_stuff
 from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='example_kubernetes_executor',
-    default_args=args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example', 'example2'],

--- a/airflow/example_dags/example_kubernetes_executor_config.py
+++ b/airflow/example_dags/example_kubernetes_executor_config.py
@@ -27,10 +27,6 @@ from airflow.operators.python import PythonOperator
 from airflow.settings import AIRFLOW_HOME
 from airflow.utils.dates import days_ago
 
-default_args = {
-    'owner': 'airflow',
-}
-
 log = logging.getLogger(__name__)
 
 try:
@@ -38,7 +34,6 @@ try:
 
     with DAG(
         dag_id='example_kubernetes_executor_config',
-        default_args=default_args,
         schedule_interval=None,
         start_date=days_ago(2),
         tags=['example3'],

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -59,9 +59,6 @@ def print_env_vars(test_mode):
 
 with DAG(
     "example_passing_params_via_test_command",
-    default_args={
-        "owner": "airflow",
-    },
     schedule_interval='*/1 * * * *',
     start_date=days_ago(1),
     dagrun_timeout=timedelta(minutes=4),

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -81,7 +81,7 @@ with DAG(
     also_run_this = BashOperator(
         task_id='also_run_this',
         bash_command=my_templated_command,
-        params={"miff": "agg", "foo": "bar"},
+        params={"miff": "agg"},
     )
 
     env_var_test_task = PythonOperator(task_id='env_var_test_task', python_callable=print_env_vars)

--- a/airflow/example_dags/example_passing_params_via_test_command.py
+++ b/airflow/example_dags/example_passing_params_via_test_command.py
@@ -81,7 +81,7 @@ with DAG(
     also_run_this = BashOperator(
         task_id='also_run_this',
         bash_command=my_templated_command,
-        params={"miff": "agg"},
+        params={"miff": "agg", "foo": "bar"},
     )
 
     env_var_test_task = PythonOperator(task_id='env_var_test_task', python_callable=print_env_vars)

--- a/airflow/example_dags/example_python_operator.py
+++ b/airflow/example_dags/example_python_operator.py
@@ -24,13 +24,8 @@ from airflow import DAG
 from airflow.operators.python import PythonOperator, PythonVirtualenvOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='example_python_operator',
-    default_args=args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example'],

--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -23,13 +23,8 @@ from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.utils import dates
 
-args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='example_short_circuit_operator',
-    default_args=args,
     start_date=dates.days_ago(2),
     tags=['example'],
 ) as dag:

--- a/airflow/example_dags/example_skip_dag.py
+++ b/airflow/example_dags/example_skip_dag.py
@@ -23,10 +23,6 @@ from airflow.exceptions import AirflowSkipException
 from airflow.operators.dummy import DummyOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'airflow',
-}
-
 
 # Create some placeholder operators
 class DummySkipOperator(DummyOperator):
@@ -56,6 +52,6 @@ def create_test_pipeline(suffix, trigger_rule, dag_):
     join >> final
 
 
-with DAG(dag_id='example_skip_dag', default_args=args, start_date=days_ago(2), tags=['example']) as dag:
+with DAG(dag_id='example_skip_dag', start_date=days_ago(2), tags=['example']) as dag:
     create_test_pipeline('1', 'all_success', dag)
     create_test_pipeline('2', 'one_success', dag)

--- a/airflow/example_dags/example_trigger_controller_dag.py
+++ b/airflow/example_dags/example_trigger_controller_dag.py
@@ -27,7 +27,6 @@ from airflow.utils.dates import days_ago
 
 with DAG(
     dag_id="example_trigger_controller_dag",
-    default_args={"owner": "airflow"},
     start_date=days_ago(2),
     schedule_interval="@once",
     tags=['example'],

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -24,7 +24,7 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator, get_current_context
+from airflow.operators.python import PythonOperator
 from airflow.utils.dates import days_ago
 
 
@@ -35,7 +35,6 @@ def run_this_func(dag_run):
     :param dag_run: The DagRun object
     :type dag_run: dict
     """
-    context = get_current_context()
     print(f"Remotely received value of {dag_run.conf['message']} for key=message")
 
 

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -28,15 +28,15 @@ from airflow.operators.python import PythonOperator, get_current_context
 from airflow.utils.dates import days_ago
 
 
-def run_this_func():
+def run_this_func(dag_run):
     """
     Print the payload "message" passed to the DagRun conf attribute.
 
-    :param context: The execution context
-    :type context: dict
+    :param dag_run: The DagRun object
+    :type dag_run: dict
     """
     context = get_current_context()
-    print(f"Remotely received value of {context['dag_run'].conf['message']} for key=message")
+    print(f"Remotely received value of {dag_run.conf['message']} for key=message")
 
 
 with DAG(

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -33,7 +33,7 @@ def run_this_func(dag_run):
     Print the payload "message" passed to the DagRun conf attribute.
 
     :param dag_run: The DagRun object
-    :type dag_run: dict
+    :type dag_run: DagRun
     """
     print(f"Remotely received value of {dag_run.conf['message']} for key=message")
 

--- a/airflow/example_dags/example_trigger_target_dag.py
+++ b/airflow/example_dags/example_trigger_target_dag.py
@@ -24,23 +24,23 @@ Example usage of the TriggerDagRunOperator. This example holds 2 DAGs:
 
 from airflow import DAG
 from airflow.operators.bash import BashOperator
-from airflow.operators.python import PythonOperator
+from airflow.operators.python import PythonOperator, get_current_context
 from airflow.utils.dates import days_ago
 
 
-def run_this_func(**context):
+def run_this_func():
     """
     Print the payload "message" passed to the DagRun conf attribute.
 
     :param context: The execution context
     :type context: dict
     """
+    context = get_current_context()
     print(f"Remotely received value of {context['dag_run'].conf['message']} for key=message")
 
 
 with DAG(
     dag_id="example_trigger_target_dag",
-    default_args={"owner": "airflow"},
     start_date=days_ago(2),
     schedule_interval=None,
     tags=['example'],

--- a/airflow/example_dags/example_xcom.py
+++ b/airflow/example_dags/example_xcom.py
@@ -36,26 +36,17 @@ def push_by_returning(**kwargs):
     return value_2
 
 
-def puller(**kwargs):
+def _compare_values(pulled_value, check_value):
+    if pulled_value != check_value:
+        raise ValueError(f'The two values differ {pulled_value} and {check_value}')
+
+
+def puller(pulled_value_1, pulled_value_2, **kwargs):
     """Pull all previously pushed XComs and check if the pushed values match the pulled values."""
-    ti = kwargs['ti']
 
-    # get value_1
-    pulled_value_1 = ti.xcom_pull(key=None, task_ids='push')
-    if pulled_value_1 != value_1:
-        raise ValueError(f'The two values differ {pulled_value_1} and {value_1}')
-
-    # get value_2
-    pulled_value_2 = ti.xcom_pull(task_ids='push_by_returning')
-    if pulled_value_2 != value_2:
-        raise ValueError(f'The two values differ {pulled_value_2} and {value_2}')
-
-    # get both value_1 and value_2
-    pulled_value_1, pulled_value_2 = ti.xcom_pull(key=None, task_ids=['push', 'push_by_returning'])
-    if pulled_value_1 != value_1:
-        raise ValueError(f'The two values differ {pulled_value_1} and {value_1}')
-    if pulled_value_2 != value_2:
-        raise ValueError(f'The two values differ {pulled_value_2} and {value_2}')
+    # Check pulled values from function args
+    _compare_values(pulled_value_1, value_1)
+    _compare_values(pulled_value_2, value_2)
 
 
 def pull_value_from_bash_push(**kwargs):
@@ -70,7 +61,6 @@ with DAG(
     'example_xcom',
     schedule_interval="@once",
     start_date=days_ago(2),
-    default_args={'owner': 'airflow'},
     tags=['example'],
 ) as dag:
 
@@ -87,9 +77,11 @@ with DAG(
     pull = PythonOperator(
         task_id='puller',
         python_callable=puller,
+        op_kwargs={
+            'pulled_value_1': push1.output['value from pusher 1'],
+            'pulled_value_2': push2.output,
+        },
     )
-
-    pull << [push1, push2]
 
     bash_push = BashOperator(
         task_id='bash_push',
@@ -98,13 +90,12 @@ with DAG(
         '{{ ti.xcom_push(key="manually_pushed_value", value="manually_pushed_value") }}" && '
         'echo "value_by_return"',
     )
+
     bash_pull = BashOperator(
         task_id='bash_pull',
         bash_command='echo "bash pull demo" && '
-        'echo "The xcom pushed manually is '
-        '"{{ ti.xcom_pull(task_ids="bash_push", key="manually_pushed_value") }}" && '
-        'echo "The returned_value xcom is '
-        '"{{ ti.xcom_pull(task_ids="bash_push", key="return_value") }}" && '
+        f'echo "The xcom pushed manually is {bash_push.output["manually_pushed_value"]}" && '
+        f'echo "The returned_value xcom is {bash_push.output}" && '
         'echo "finished"',
         do_xcom_push=False,
     )
@@ -115,3 +106,7 @@ with DAG(
     )
 
     [bash_pull, python_pull_from_bash] << bash_push
+
+    # Task dependencies created via `XComArgs`:
+    #   push1 >> pull
+    #   push2 >> pull

--- a/airflow/example_dags/example_xcomargs.py
+++ b/airflow/example_dags/example_xcomargs.py
@@ -42,7 +42,6 @@ def print_value(value):
 
 with DAG(
     dag_id='example_xcom_args',
-    default_args={'owner': 'airflow'},
     start_date=days_ago(2),
     schedule_interval=None,
     tags=['example'],
@@ -57,7 +56,6 @@ with DAG(
 
 with DAG(
     "example_xcom_args_with_operators",
-    default_args={'owner': 'airflow'},
     start_date=days_ago(2),
     schedule_interval=None,
     tags=['example'],

--- a/airflow/example_dags/tutorial_taskflow_api_etl.py
+++ b/airflow/example_dags/tutorial_taskflow_api_etl.py
@@ -26,17 +26,9 @@ from airflow.utils.dates import days_ago
 
 # [END import_module]
 
-# [START default_args]
-# These args will get passed on to each operator
-# You can override them on a per-task basis during operator initialization
-default_args = {
-    'owner': 'airflow',
-}
-# [END default_args]
-
 
 # [START instantiate_dag]
-@dag(default_args=default_args, schedule_interval=None, start_date=days_ago(2), tags=['example'])
+@dag(schedule_interval=None, start_date=days_ago(2), tags=['example'])
 def tutorial_taskflow_api_etl():
     """
     ### TaskFlow API Tutorial Documentation

--- a/airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.py
+++ b/airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.py
@@ -26,17 +26,9 @@ from airflow.utils.dates import days_ago
 
 # [END import_module]
 
-# [START default_args]
-# These args will get passed on to each operator
-# You can override them on a per-task basis during operator initialization
-default_args = {
-    'owner': 'airflow',
-}
-# [END default_args]
-
 
 # [START instantiate_dag]
-@dag(default_args=default_args, schedule_interval=None, start_date=days_ago(2), tags=['example'])
+@dag(schedule_interval=None, start_date=days_ago(2), tags=['example'])
 def tutorial_taskflow_api_etl_virtualenv():
     """
     ### TaskFlow API Tutorial Documentation

--- a/airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.py
+++ b/airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.py
@@ -19,8 +19,6 @@
 
 # [START tutorial]
 # [START import_module]
-import json
-
 from airflow.decorators import dag, task
 from airflow.utils.dates import days_ago
 
@@ -53,6 +51,8 @@ def tutorial_taskflow_api_etl_virtualenv():
         pipeline. In this case, getting data is simulated by reading from a
         hardcoded JSON string.
         """
+        import json
+
         data_string = '{"1001": 301.27, "1002": 433.21, "1003": 502.22}'
 
         order_data_dict = json.loads(data_string)


### PR DESCRIPTION
Related to #10285

- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)
- Updated example DAG files such that `xcom_pull()` calls use an operator's `.output` property as well access of `TaskInstance` objects from context to use `get_current_context()` function
- Added comments to which task dependencies, if any, are handled and/or created via `XComArgs` for transparency

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/example_dags/example_bash_operator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_branch_datetime_operator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_branch_day_of_week_operator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_branch_operator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_branch_python_dop_operator_3.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_dag_decorator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_kubernetes_executor_config.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_kubernetes_executor.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_passing_params_via_test_command.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_python_operator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_short_circuit_operator.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_skip_dag.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_trigger_controller_dag.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_trigger_target_dag.py | No | Yes | Removed unneeded `default_args` pattern. </br></br>Updated to use `get_current_context()`.|
| airflow/example_dags/example_xcom.py | Yes | Yes | Included examples for context retrieval using `get_current_context()` based on previous PR comments to show new and old means of `XCom` access.<br/><br/>Removed explicit task dependencies that are created via `XComArgs`. <br/><br/>Removed unneeded `default_args` pattern. |
| airflow/example_dags/example_xcomargs.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/example_dags/tutorial_etl_dag.py | No | No | Not updated based on earlier comment to keep this file unchanged during initial PR. |
| airflow/example_dags/tutorial_taskflow_api_etl_virtualenv.py | No | Yes | Removed unneeded `default_args` pattern. </br></br> Moved `import json` statement to inside `extract()` function to prevent failures.  |
| airflow/example_dags/tutorial_taskflow_api_etl.py | No | Yes | Removed unneeded `default_args` pattern. |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
