### PR TITLE
Updating Amazon-AWS example DAGs to use XComArgs

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.py
+++ b/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.py
@@ -28,17 +28,15 @@ import os
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import ECSOperator
 
-DEFAULT_ARGS = {
-    "owner": "airflow",
-    "depends_on_past": False,
-    "email": ["airflow@example.com"],
-    "email_on_failure": False,
-    "email_on_retry": False,
-}
-
 dag = DAG(
     dag_id="ecs_fargate_dag",
-    default_args=DEFAULT_ARGS,
+    default_args={
+        "owner": "airflow",
+        "depends_on_past": False,
+        "email": ["airflow@example.com"],
+        "email_on_failure": False,
+        "email_on_retry": False,
+    },
     default_view="graph",
     schedule_interval=None,
     start_date=datetime.datetime(2020, 1, 1),

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
@@ -37,7 +37,7 @@ from os import getenv
 
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
-from airflow.operators.python import BranchPythonOperator
+from airflow.operators.python import BranchPythonOperator, get_current_context
 from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
 from airflow.utils.dates import days_ago
 
@@ -53,12 +53,13 @@ YOUTUBE_VIDEO_FIELDS = getenv("YOUTUBE_VIDEO_FIELDS", "items(id,snippet(descript
 
 
 # [START howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
-def _check_and_transform_video_ids(xcom_key, task_ids, task_instance, **kwargs):
-    video_ids_response = task_instance.xcom_pull(task_ids=task_ids, key=xcom_key)
+def _check_and_transform_video_ids(xcom_key, task_output):
+    video_ids_response = task_output[xcom_key]
     video_ids = [item['id']['videoId'] for item in video_ids_response['items']]
 
     if video_ids:
-        task_instance.xcom_push(key='video_ids', value={'id': ','.join(video_ids)})
+        context = get_current_context()
+        context["task_instance"].xcom_push(key='video_ids', value={'id': ','.join(video_ids)})
         return 'video_data_to_s3'
     return 'no_video_ids'
 
@@ -98,7 +99,7 @@ with DAG(
     # [START howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
     task_check_and_transform_video_ids = BranchPythonOperator(
         python_callable=_check_and_transform_video_ids,
-        op_args=[task_video_ids_to_s3.google_api_response_via_xcom, task_video_ids_to_s3.task_id],
+        op_args=[task_video_ids_to_s3.google_api_response_via_xcom, task_video_ids_to_s3.output],
         task_id='check_and_transform_video_ids',
     )
     # [END howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
@@ -121,4 +122,7 @@ with DAG(
     # [START howto_operator_google_api_to_s3_transfer_advanced_task_2_1]
     task_no_video_ids = DummyOperator(task_id='no_video_ids')
     # [END howto_operator_google_api_to_s3_transfer_advanced_task_2_1]
-    task_video_ids_to_s3 >> task_check_and_transform_video_ids >> [task_video_data_to_s3, task_no_video_ids]
+    task_check_and_transform_video_ids >> [task_video_data_to_s3, task_no_video_ids]
+
+    # Task dependency created via `XComArgs`:
+    #   task_video_ids_to_s3 >> task_check_and_transform_video_ids

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
@@ -53,8 +53,8 @@ YOUTUBE_VIDEO_FIELDS = getenv("YOUTUBE_VIDEO_FIELDS", "items(id,snippet(descript
 
 
 # [START howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
-def _check_and_transform_video_ids(xcom_key, task_output):
-    video_ids_response = task_output[xcom_key]
+def _check_and_transform_video_ids(task_output):
+    video_ids_response = task_output
     video_ids = [item['id']['videoId'] for item in video_ids_response['items']]
 
     if video_ids:
@@ -99,7 +99,7 @@ with DAG(
     # [START howto_operator_google_api_to_s3_transfer_advanced_task_1_1]
     task_check_and_transform_video_ids = BranchPythonOperator(
         python_callable=_check_and_transform_video_ids,
-        op_args=[task_video_ids_to_s3.google_api_response_via_xcom, task_video_ids_to_s3.output],
+        op_args=[task_video_ids_to_s3.output[task_video_ids_to_s3.google_api_response_via_xcom]],
         task_id='check_and_transform_video_ids',
     )
     # [END howto_operator_google_api_to_s3_transfer_advanced_task_1_1]


### PR DESCRIPTION
Related to #10285

- Updated example DAG files such that `xcom_pull()` calls use an operator's `.output` property as well access of `TaskInstance` objects from context to use `get_current_context()` function
- Added comments to which task dependencies, if any, are handled and/or created via `XComArgs` for transparency
- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)

>**Note:** There are several instances where the `xcom_pull()` call was not updated.  These instances involve accessing a specific value within the `XCom` or calling user-defined macros with an `XCom` value.  Reference #16618 for an open issue to enhance the `XComArg` functionality to provide similar behavior as the classic `xcom_pull()` method.

> **Note:** Not all DAGs were tested functionally (i.e. with hard integrations to source systems and executed), however each DAG was tested to compile and generate a DAG graph as expected locally.

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`.</br></br>Refactored  `default_args` pattern. |
| airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.py | No | Yes | Refactored  `default_args` pattern. |
| airflow/providers/amazon/aws/example_dags/example_emr_job_flow_automatic_steps.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. </br></br>Refactored  `default_args` pattern. |
airflow/providers/amazon/aws/example_dags/example_emr_job_flow_manual_steps.py |  Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update this occurrence: <br/>`"{{ task_instance.xcom_pull(task_ids='add_steps', key='return_value')[0] }}"`. <br/><br/> All other `xcom_pull()` calls have been updated.<br/><br/>Removed explicit task dependencies that are created via `XComArgs`. </br></br>Refactored  `default_args` pattern. |
| airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value.  Could not update any occurrences in this DAG. |
| airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. </br></br>Updated to use `get_current_context()`. |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
