### PR TITLE
Updating Apache example DAGs to use XComArgs

### DIFF
--- a/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
+++ b/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
@@ -25,13 +25,8 @@ from airflow.providers.apache.cassandra.sensors.record import CassandraRecordSen
 from airflow.providers.apache.cassandra.sensors.table import CassandraTableSensor
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'Airflow',
-}
-
 with DAG(
     dag_id='example_cassandra_operator',
-    default_args=args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example'],

--- a/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
+++ b/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
@@ -66,27 +66,17 @@ def transfertodb():
     """
 
 
-# --------------------------------------------------------------------------------
-# set default arguments
-# --------------------------------------------------------------------------------
-
-default_args = {
-    'owner': 'Ekhtiar',
-    'depends_on_past': False,
-    'email': ['airflow@example.com'],
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=5),
-    # 'queue': 'bash_queue',
-    # 'pool': 'backfill',
-    # 'priority_weight': 10,
-    # 'end_date': datetime(2016, 1, 1),
-}
-
 with DAG(
     dag_id='example_twitter_dag',
-    default_args=default_args,
+    default_args={
+        'owner': 'Ekhtiar',
+        'depends_on_past': False,
+        'email': ['airflow@example.com'],
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'retries': 1,
+        'retry_delay': timedelta(minutes=5),
+    },
     schedule_interval="@daily",
     start_date=days_ago(5),
     tags=['example'],

--- a/airflow/providers/apache/pig/example_dags/example_pig.py
+++ b/airflow/providers/apache/pig/example_dags/example_pig.py
@@ -22,13 +22,8 @@ from airflow import DAG
 from airflow.providers.apache.pig.operators.pig import PigOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'airflow',
-}
-
 dag = DAG(
     dag_id='example_pig_operator',
-    default_args=args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example'],

--- a/airflow/providers/apache/spark/example_dags/example_spark_dag.py
+++ b/airflow/providers/apache/spark/example_dags/example_spark_dag.py
@@ -26,13 +26,8 @@ from airflow.providers.apache.spark.operators.spark_sql import SparkSqlOperator
 from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'Airflow',
-}
-
 with DAG(
     dag_id='example_spark_operator',
-    default_args=args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example'],


### PR DESCRIPTION
Related to #10285

- Updated example DAG files such that `xcom_pull()` calls use an operator's `.output` property
- Added comments to which task dependencies, if any, are handled and/or created via `XComArgs` for transparency
- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)

>**Note:** There are several instances where the `xcom_pull()` call was not updated.  These instances involve accessing a specific value within the `XCom` or calling user-defined macros with an `XCom` value.  Reference #16618 for an open issue to enhance the `XComArg` functionality to provide similar behavior as the classic `xcom_pull()` method.

> **Note:** Not all DAGs were tested functionally (i.e. with hard integrations to source systems and executed), however each DAG was tested to compile and generate a DAG graph as expected locally.

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/providers/apache/beam/example_dags/example_beam.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly.  Could not update any occurrences in this DAG. |
| airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/providers/apache/hive/example_dags/example_twitter_dag.py | No | Yes | Refactored `default_args` pattern. |
| airflow/providers/apache/kylin/example_dags/example_kylin_dag.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. <br/><br/>Removed unneeded `default_args` pattern. |
| airflow/providers/apache/pig/example_dags/example_pig.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/providers/apache/spark/example_dags/example_spark_dag.py | No | Yes | Removed unneeded `default_args` pattern. |
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
