### PR TITLE
Removing/refactoring default_args pattern for Kubernetes example DAGs

### DIFF
--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -97,13 +97,8 @@ tolerations = [k8s.V1Toleration(key="key", operator="Equal", value="value")]
 # [END howto_operator_k8s_cluster_resources]
 
 
-default_args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='example_kubernetes_operator',
-    default_args=default_args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example'],

--- a/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes.py
@@ -38,24 +38,19 @@ from airflow.utils.dates import days_ago
 
 # [END import_module]
 
-# [START default_args]
-# These args will get passed on to each operator
-# You can override them on a per-task basis during operator initialization
-default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email': ['airflow@example.com'],
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'max_active_runs': 1,
-}
-# [END default_args]
 
 # [START instantiate_dag]
 
 dag = DAG(
     'spark_pi',
-    default_args=default_args,
+    default_args={
+        'owner': 'airflow',
+        'depends_on_past': False,
+        'email': ['airflow@example.com'],
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'max_active_runs': 1,
+    },
     description='submit spark-pi as sparkApplication on kubernetes',
     schedule_interval=timedelta(days=1),
     start_date=days_ago(1),


### PR DESCRIPTION
Related to #10285

- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)

>**Note:** There are several instances where the `xcom_pull()` call was not updated.  These instances involve accessing a specific value within the `XCom` or calling user-defined macros with an `XCom` value.  Reference #16618 for an open issue to enhance the `XComArg` functionality to provide similar behavior as the classic `xcom_pull()` method.

> **Note:** Not all DAGs were tested functionally (i.e. with hard integrations to source systems and executed), however each DAG was tested to compile and generate a DAG graph as expected locally.

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py | No | Yes | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update this occurrence:<br/>`"echo \"{{ task_instance.xcom_pull('write-xcom')[0] }}\""`. <br/><br/>Removed unneeded `default_args` pattern. |
| airflow/providers/cncf/kubernetes/example_dags/example_spark_kubernetes.py | No | Yes | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update this occurrence:<br/>`"{{ task_instance.xcom_pull(task_ids='spark_pi_submit')['metadata']['name'] }}"`. <br/><br/>Refactored `default_args` pattern. |
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
