### PR TITLE
Remove/refactor default_args pattern for Microsoft example DAGs

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
@@ -25,19 +25,17 @@ from airflow.providers.microsoft.azure.operators.azure_container_instances impor
     AzureContainerInstancesOperator,
 )
 
-default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email': ['airflow@example.com'],
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=5),
-}
-
 with DAG(
     dag_id='aci_example',
-    default_args=default_args,
+    default_args={
+        'owner': 'airflow',
+        'depends_on_past': False,
+        'email': ['airflow@example.com'],
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'retries': 1,
+        'retry_delay': timedelta(minutes=5),
+    },
     schedule_interval=timedelta(1),
     start_date=datetime(2018, 11, 1),
     tags=['example'],

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
@@ -31,17 +31,15 @@ from airflow.providers.microsoft.azure.operators.azure_cosmos import AzureCosmos
 from airflow.providers.microsoft.azure.sensors.azure_cosmos import AzureCosmosDocumentSensor
 from airflow.utils import dates
 
-default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email': ['airflow@example.com'],
-    'email_on_failure': False,
-    'email_on_retry': False,
-}
-
 with DAG(
     dag_id='example_azure_cosmosdb_sensor',
-    default_args=default_args,
+    default_args={
+        'owner': 'airflow',
+        'depends_on_past': False,
+        'email': ['airflow@example.com'],
+        'email_on_failure': False,
+        'email_on_retry': False,
+    },
     start_date=dates.days_ago(2),
     doc_md=__doc__,
     tags=['example'],

--- a/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
+++ b/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
@@ -36,13 +36,8 @@ from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
 from airflow.utils.dates import days_ago
 
-default_args = {
-    'owner': 'airflow',
-}
-
 with DAG(
     dag_id='POC_winrm_parallel',
-    default_args=default_args,
     schedule_interval='0 0 * * *',
     start_date=days_ago(2),
     dagrun_timeout=timedelta(minutes=60),


### PR DESCRIPTION
- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py | No | Yes | Refactored `default_args` pattern. |
| airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py | No | Yes | Refactored `default_args` pattern. |
| airflow/providers/microsoft/winrm/example_dags/example_winrm.py | No | Yes | Removed `default_args` pattern. |
---

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
