### PR TITLE
Updating Google Cloud example DAGs to use XComArgs

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py
@@ -67,7 +67,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output['dataset_id']
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -80,7 +80,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output['model_id']
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -96,4 +96,10 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_extraction.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_extraction.py
@@ -67,7 +67,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output['dataset_id']
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -80,7 +80,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output['model_id']
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -96,4 +96,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py
@@ -68,7 +68,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output['dataset_id']
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -81,7 +81,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output['model_id']
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -97,4 +97,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_translation.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_translation.py
@@ -74,7 +74,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output["dataset_id"]
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -87,7 +87,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output["model_id"]
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -103,4 +103,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py
@@ -71,7 +71,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output["dataset_id"]
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -84,7 +84,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output["model_id"]
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -100,4 +100,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py
@@ -72,7 +72,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output["dataset_id"]
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -85,7 +85,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output["model_id"]
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -101,4 +101,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_vision_classification.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_vision_classification.py
@@ -69,7 +69,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output["dataset_id"]
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -82,7 +82,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output["model_id"]
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -98,4 +98,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py
+++ b/airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py
@@ -71,7 +71,7 @@ with models.DAG(
         task_id="create_dataset_task", dataset=DATASET, location=GCP_AUTOML_LOCATION
     )
 
-    dataset_id = '{{ task_instance.xcom_pull("create_dataset_task", key="dataset_id") }}'
+    dataset_id = create_dataset_task.output["dataset_id"]
 
     import_dataset_task = AutoMLImportDataOperator(
         task_id="import_dataset_task",
@@ -84,7 +84,7 @@ with models.DAG(
 
     create_model = AutoMLTrainModelOperator(task_id="create_model", model=MODEL, location=GCP_AUTOML_LOCATION)
 
-    model_id = "{{ task_instance.xcom_pull('create_model', key='model_id') }}"
+    model_id = create_model.output["model_id"]
 
     delete_model_task = AutoMLDeleteModelOperator(
         task_id="delete_model_task",
@@ -100,4 +100,11 @@ with models.DAG(
         project_id=GCP_PROJECT_ID,
     )
 
-    create_dataset_task >> import_dataset_task >> create_model >> delete_model_task >> delete_datasets_task
+    import_dataset_task >> create_model
+    delete_model_task >> delete_datasets_task
+
+    # Task dependencies created via `XComArgs`:
+    #   create_dataset_task >> import_dataset_task
+    #   create_dataset_task >> create_model
+    #   create_model >> delete_model_task
+    #   create_dataset_task >> delete_datasets_task

--- a/airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.py
@@ -24,19 +24,18 @@ DEST_GCS_BUCKET = os.environ.get('GCP_GCS_BUCKET', 'gs://INVALID BUCKET NAME')
 AZURE_SHARE_NAME = os.environ.get('AZURE_SHARE_NAME', 'test-azure-share')
 AZURE_DIRECTORY_NAME = "test-azure-dir"
 
-default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email': ['airflow@example.com'],
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=5),
-}
 
 with DAG(
     dag_id='azure_fileshare_to_gcs_example',
-    default_args=default_args,
+    default_args={
+        'owner': 'airflow',
+        'depends_on_past': False,
+        'email': ['airflow@example.com'],
+        'email_on_failure': False,
+        'email_on_retry': False,
+        'retries': 1,
+        'retry_delay': timedelta(minutes=5),
+    },
     schedule_interval=None,
     start_date=datetime(2018, 11, 1),
     tags=['example'],

--- a/airflow/providers/google/cloud/example_dags/example_bigquery_queries.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_queries.py
@@ -160,7 +160,7 @@ for location in [None, LOCATION]:
 
         get_data_result = BashOperator(
             task_id="get_data_result",
-            bash_command="echo \"{{ task_instance.xcom_pull('get_data') }}\"",
+            bash_command=f"echo {get_data.output}",
         )
 
         # [START howto_operator_bigquery_check]
@@ -199,3 +199,5 @@ for location in [None, LOCATION]:
         execute_insert_query >> get_data >> get_data_result >> delete_dataset
         execute_insert_query >> execute_query_save >> bigquery_execute_multi_query >> delete_dataset
         execute_insert_query >> [check_count, check_value, check_interval] >> delete_dataset
+
+    globals()[dag_id] = dag_with_locations

--- a/airflow/providers/google/cloud/example_dags/example_cloud_memorystore.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_memorystore.py
@@ -96,7 +96,7 @@ with models.DAG(
     # [START howto_operator_create_instance_result]
     create_instance_result = BashOperator(
         task_id="create-instance-result",
-        bash_command="echo \"{{ task_instance.xcom_pull('create-instance') }}\"",
+        bash_command=f"echo {create_instance.output}",
     )
     # [END howto_operator_create_instance_result]
 
@@ -120,7 +120,7 @@ with models.DAG(
 
     # [START howto_operator_get_instance_result]
     get_instance_result = BashOperator(
-        task_id="get-instance-result", bash_command="echo \"{{ task_instance.xcom_pull('get-instance') }}\""
+        task_id="get-instance-result", bash_command=f"echo {get_instance.output}"
     )
     # [END howto_operator_get_instance_result]
 
@@ -142,7 +142,7 @@ with models.DAG(
 
     # [START howto_operator_list_instances_result]
     list_instances_result = BashOperator(
-        task_id="list-instances-result", bash_command="echo \"{{ task_instance.xcom_pull('get-instance') }}\""
+        task_id="list-instances-result", bash_command=f"echo {get_instance.output}"
     )
     # [END howto_operator_list_instances_result]
 
@@ -236,20 +236,22 @@ with models.DAG(
 
     create_instance >> get_instance >> get_instance_result
     create_instance >> update_instance
-    create_instance >> create_instance_result
     create_instance >> export_instance
     create_instance_2 >> import_instance
     create_instance >> list_instances >> list_instances_result
     list_instances >> delete_instance
     export_instance >> update_instance
     update_instance >> delete_instance
+    create_instance >> create_instance_result
     get_instance >> set_acl_permission >> export_instance
+    get_instance >> list_instances_result
     export_instance >> import_instance
     export_instance >> delete_instance
     failover_instance >> delete_instance_2
     import_instance >> failover_instance
 
     export_instance >> create_instance_and_import >> scale_instance >> export_and_delete_instance
+
 
 with models.DAG(
     "gcp_cloud_memorystore_memcached",

--- a/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py
+++ b/airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py
@@ -106,10 +106,6 @@ aws_to_gcs_transfer_body = {
 # [END howto_operator_gcp_transfer_create_job_body_aws]
 
 
-# [START howto_operator_gcp_transfer_default_args]
-default_args = {'owner': 'airflow'}
-# [END howto_operator_gcp_transfer_default_args]
-
 with models.DAG(
     'example_gcp_transfer_aws',
     schedule_interval=None,  # Override to match your needs

--- a/airflow/providers/google/cloud/example_dags/example_datacatalog.py
+++ b/airflow/providers/google/cloud/example_dags/example_datacatalog.py
@@ -72,14 +72,14 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_create_entry_group_result]
     create_entry_group_result = BashOperator(
         task_id="create_entry_group_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_entry_group', key='entry_group_id') }}\"",
+        bash_command=f"echo {create_entry_group.output['entry_group_id']}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_group_result]
 
     # [START howto_operator_gcp_datacatalog_create_entry_group_result2]
     create_entry_group_result2 = BashOperator(
         task_id="create_entry_group_result2",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_entry_group') }}\"",
+        bash_command=f"echo {create_entry_group.output}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_group_result2]
 
@@ -100,14 +100,14 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_create_entry_gcs_result]
     create_entry_gcs_result = BashOperator(
         task_id="create_entry_gcs_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_entry_gcs', key='entry_id') }}\"",
+        bash_command=f"echo {create_entry_gcs.output['entry_id']}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_gcs_result]
 
     # [START howto_operator_gcp_datacatalog_create_entry_gcs_result2]
     create_entry_gcs_result2 = BashOperator(
         task_id="create_entry_gcs_result2",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_entry_gcs') }}\"",
+        bash_command=f"echo {create_entry_gcs.output}",
     )
     # [END howto_operator_gcp_datacatalog_create_entry_gcs_result2]
 
@@ -125,14 +125,12 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_create_tag_result]
     create_tag_result = BashOperator(
         task_id="create_tag_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_tag', key='tag_id') }}\"",
+        bash_command=f"echo {create_tag.output['tag_id']}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_result]
 
     # [START howto_operator_gcp_datacatalog_create_tag_result2]
-    create_tag_result2 = BashOperator(
-        task_id="create_tag_result2", bash_command="echo \"{{ task_instance.xcom_pull('create_tag') }}\""
-    )
+    create_tag_result2 = BashOperator(task_id="create_tag_result2", bash_command=f"echo {create_tag.output}")
     # [END howto_operator_gcp_datacatalog_create_tag_result2]
 
     # [START howto_operator_gcp_datacatalog_create_tag_template]
@@ -154,14 +152,14 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_create_tag_template_result]
     create_tag_template_result = BashOperator(
         task_id="create_tag_template_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_tag_template', key='tag_template_id') }}\"",
+        bash_command=f"echo {create_tag_template.output['tag_template_id']}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_result]
 
     # [START howto_operator_gcp_datacatalog_create_tag_template_result2]
     create_tag_template_result2 = BashOperator(
         task_id="create_tag_template_result2",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_tag_template') }}\"",
+        bash_command=f"echo {create_tag_template.output}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_result2]
 
@@ -180,17 +178,14 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_create_tag_template_field_result]
     create_tag_template_field_result = BashOperator(
         task_id="create_tag_template_field_result",
-        bash_command=(
-            "echo \"{{ task_instance.xcom_pull('create_tag_template_field',"
-            + " key='tag_template_field_id') }}\""
-        ),
+        bash_command=f"echo {create_tag_template_field.output['tag_template_field_id']}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_field_result]
 
     # [START howto_operator_gcp_datacatalog_create_tag_template_field_result2]
     create_tag_template_field_result2 = BashOperator(
         task_id="create_tag_template_field_result2",
-        bash_command="echo \"{{ task_instance.xcom_pull('create_tag_template_field') }}\"",
+        bash_command=f"echo {create_tag_template_field.output}",
     )
     # [END howto_operator_gcp_datacatalog_create_tag_template_field_result2]
 
@@ -213,7 +208,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
         location=LOCATION,
         entry_group=ENTRY_GROUP_ID,
         entry=ENTRY_ID,
-        tag="{{ task_instance.xcom_pull('create_tag', key='tag_id') }}",
+        tag=create_tag.output["tag_id"],
     )
     # [END howto_operator_gcp_datacatalog_delete_tag]
 
@@ -246,7 +241,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_get_entry_group_result]
     get_entry_group_result = BashOperator(
         task_id="get_entry_group_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('get_entry_group') }}\"",
+        bash_command=f"echo {get_entry_group.output}",
     )
     # [END howto_operator_gcp_datacatalog_get_entry_group_result]
 
@@ -257,9 +252,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [END howto_operator_gcp_datacatalog_get_entry]
 
     # [START howto_operator_gcp_datacatalog_get_entry_result]
-    get_entry_result = BashOperator(
-        task_id="get_entry_result", bash_command="echo \"{{ task_instance.xcom_pull('get_entry') }}\""
-    )
+    get_entry_result = BashOperator(task_id="get_entry_result", bash_command=f"echo {get_entry.output}")
     # [END howto_operator_gcp_datacatalog_get_entry_result]
 
     # [START howto_operator_gcp_datacatalog_get_tag_template]
@@ -271,7 +264,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_get_tag_template_result]
     get_tag_template_result = BashOperator(
         task_id="get_tag_template_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('get_tag_template') }}\"",
+        bash_command=f"{get_tag_template.output}",
     )
     # [END howto_operator_gcp_datacatalog_get_tag_template_result]
 
@@ -283,9 +276,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [END howto_operator_gcp_datacatalog_list_tags]
 
     # [START howto_operator_gcp_datacatalog_list_tags_result]
-    list_tags_result = BashOperator(
-        task_id="list_tags_result", bash_command="echo \"{{ task_instance.xcom_pull('list_tags') }}\""
-    )
+    list_tags_result = BashOperator(task_id="list_tags_result", bash_command=f"echo {list_tags.output}")
     # [END howto_operator_gcp_datacatalog_list_tags_result]
 
     # Lookup
@@ -330,7 +321,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
     # [START howto_operator_gcp_datacatalog_search_catalog_result]
     search_catalog_result = BashOperator(
         task_id="search_catalog_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('search_catalog') }}\"",
+        bash_command=f"echo {search_catalog.output}",
     )
     # [END howto_operator_gcp_datacatalog_search_catalog_result]
 
@@ -354,7 +345,7 @@ with models.DAG("example_gcp_datacatalog", start_date=days_ago(1), schedule_inte
         location=LOCATION,
         entry_group=ENTRY_GROUP_ID,
         entry=ENTRY_ID,
-        tag_id="{{ task_instance.xcom_pull('create_tag', key='tag_id') }}",
+        tag_id=f"{create_tag.output['tag_id']}",
     )
     # [END howto_operator_gcp_datacatalog_update_tag]
 

--- a/airflow/providers/google/cloud/example_dags/example_functions.py
+++ b/airflow/providers/google/cloud/example_dags/example_functions.py
@@ -95,6 +95,7 @@ else:
 
 with models.DAG(
     'example_gcp_function',
+    default_args=default_args,
     schedule_interval=None,  # Override to match your needs
     start_date=dates.days_ago(1),
     tags=['example'],

--- a/airflow/providers/google/cloud/example_dags/example_gcs.py
+++ b/airflow/providers/google/cloud/example_dags/example_gcs.py
@@ -75,7 +75,7 @@ with models.DAG(
 
     list_buckets_result = BashOperator(
         task_id="list_buckets_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('list_buckets') }}\"",
+        bash_command=f"echo {list_buckets.output}",
     )
 
     upload_file = LocalFilesystemToGCSOperator(
@@ -155,6 +155,7 @@ with models.DAG(
     copy_file >> delete_bucket_1
     copy_file >> delete_bucket_2
     delete_files >> delete_bucket_1
+
 
 with models.DAG(
     "example_gcs_sensors",

--- a/airflow/providers/google/cloud/example_dags/example_natural_language.py
+++ b/airflow/providers/google/cloud/example_dags/example_natural_language.py
@@ -63,7 +63,7 @@ with models.DAG(
 
     # [START howto_operator_gcp_natural_language_analyze_entities_result]
     analyze_entities_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('analyze_entities') }}\"",
+        bash_command=f"echo {analyze_entities.output}",
         task_id="analyze_entities_result",
     )
     # [END howto_operator_gcp_natural_language_analyze_entities_result]
@@ -76,7 +76,7 @@ with models.DAG(
 
     # [START howto_operator_gcp_natural_language_analyze_entity_sentiment_result]
     analyze_entity_sentiment_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('analyze_entity_sentiment') }}\"",
+        bash_command=f"echo {analyze_entity_sentiment.output}",
         task_id="analyze_entity_sentiment_result",
     )
     # [END howto_operator_gcp_natural_language_analyze_entity_sentiment_result]
@@ -89,7 +89,7 @@ with models.DAG(
 
     # [START howto_operator_gcp_natural_language_analyze_sentiment_result]
     analyze_sentiment_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('analyze_sentiment') }}\"",
+        bash_command=f"echo {analyze_sentiment.output}",
         task_id="analyze_sentiment_result",
     )
     # [END howto_operator_gcp_natural_language_analyze_sentiment_result]
@@ -102,7 +102,7 @@ with models.DAG(
 
     # [START howto_operator_gcp_natural_language_analyze_classify_text_result]
     analyze_classify_text_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('analyze_classify_text') }}\"",
+        bash_command=f"echo {analyze_classify_text.output}",
         task_id="analyze_classify_text_result",
     )
     # [END howto_operator_gcp_natural_language_analyze_classify_text_result]

--- a/airflow/providers/google/cloud/example_dags/example_pubsub.py
+++ b/airflow/providers/google/cloud/example_dags/example_pubsub.py
@@ -65,7 +65,7 @@ with models.DAG(
     # [END howto_operator_gcp_pubsub_create_subscription]
 
     # [START howto_operator_gcp_pubsub_pull_message_with_sensor]
-    subscription = "{{ task_instance.xcom_pull('subscribe_task') }}"
+    subscription = subscribe_task.output
 
     pull_messages = PubSubPullSensor(
         task_id="pull_messages",
@@ -92,7 +92,7 @@ with models.DAG(
     unsubscribe_task = PubSubDeleteSubscriptionOperator(
         task_id="unsubscribe_task",
         project_id=GCP_PROJECT_ID,
-        subscription="{{ task_instance.xcom_pull('subscribe_task') }}",
+        subscription=subscription,
     )
     # [END howto_operator_gcp_pubsub_unsubscribe]
 
@@ -102,8 +102,12 @@ with models.DAG(
     )
     # [END howto_operator_gcp_pubsub_delete_topic]
 
-    create_topic >> subscribe_task >> [publish_task, pull_messages]
+    create_topic >> subscribe_task >> publish_task
     pull_messages >> pull_messages_result >> unsubscribe_task >> delete_topic
+
+    # Task dependencies created via `XComArgs`:
+    #   subscribe_task >> pull_messages
+    #   subscribe_task >> unsubscribe_task
 
 
 with models.DAG(
@@ -124,7 +128,7 @@ with models.DAG(
     # [END howto_operator_gcp_pubsub_create_subscription]
 
     # [START howto_operator_gcp_pubsub_pull_message_with_operator]
-    subscription = "{{ task_instance.xcom_pull('subscribe_task') }}"
+    subscription = subscribe_task.output
 
     pull_messages_operator = PubSubPullOperator(
         task_id="pull_messages",
@@ -151,7 +155,7 @@ with models.DAG(
     unsubscribe_task = PubSubDeleteSubscriptionOperator(
         task_id="unsubscribe_task",
         project_id=GCP_PROJECT_ID,
-        subscription="{{ task_instance.xcom_pull('subscribe_task') }}",
+        subscription=subscription,
     )
     # [END howto_operator_gcp_pubsub_unsubscribe]
 
@@ -170,3 +174,7 @@ with models.DAG(
         >> unsubscribe_task
         >> delete_topic
     )
+
+    # Task dependencies created via `XComArgs`:
+    #   subscribe_task >> pull_messages_operator
+    #   subscribe_task >> unsubscribe_task

--- a/airflow/providers/google/cloud/example_dags/example_tasks.py
+++ b/airflow/providers/google/cloud/example_dags/example_tasks.py
@@ -114,8 +114,9 @@ with models.DAG(
 
     get_queue_result = BashOperator(
         task_id="get_queue_result",
-        bash_command="echo \"{{ task_instance.xcom_pull('get_queue') }}\"",
+        bash_command=f"echo {get_queue.output}",
     )
+
     get_queue >> get_queue_result
 
     update_queue = CloudTasksQueueUpdateOperator(


### PR DESCRIPTION
Related to #10285

- Updated example DAG files such that `xcom_pull()` calls use an operator's `.output` property as well access of `TaskInstance` objects from context to use `get_current_context()` function
- Added comments to which task dependencies, if any, are handled and/or created via `XComArgs` for transparency
- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)
- Other miscellaneous updates based on `.output` refactoring

>**Note:** There are several instances where the `xcom_pull()` call was not updated.  These instances involve accessing a specific value within the `XCom` or calling user-defined macros with an `XCom` value.  Reference #16618 for an open issue to enhance the `XComArg` functionality to provide similar behavior as the classic `xcom_pull()` method.

> **Note:** Not all DAGs were tested functionally (i.e. with hard integrations to source systems and executed), however each DAG was tested to compile and generate a DAG graph as expected locally.

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/providers/google/cloud/example_dags/example_automl_nl_text_classification.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_nl_text_extraction.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_nl_text_sentiment.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_tables.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update the following occurrences: <br/>`"{{ extract_object_id(task_instance.xcom_pull('list_tables_spec_task')[0]) }}"`<br/>`'{{ task_instance.xcom_pull("create_dataset_task")["name"] }}'`</br>`"{{ get_target_column_spec(task_instance.xcom_pull('list_columns_spec_task'), target) }}"`<br/><br/>All other `xcom_pull()` calls have been updated. <br/><br/> Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_translation.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_classification.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_video_intelligence_tracking.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_vision_classification.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_automl_vision_object_detection.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_azure_fileshare_to_gcs.py | No | Yes | Refactored `default_args` pattern. |
| airflow/providers/google/cloud/example_dags/example_bigquery_dts.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_bigquery_operations.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_bigquery_queries.py | Yes | Yes | Added globals assignment so both example DAGs are exposed rather than only the last one in the loop. |
| airflow/providers/google/cloud/example_dags/example_cloud_build.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_cloud_memorystore.py | Yes ** | No | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update this occurrence: <br/>`"user-{{ task_instance.xcom_pull('get-instance')['persistence_iam_identity']"` <br/><br/>All other `xcom_pull()` calls have been updated. |
| airflow/providers/google/cloud/example_dags/example_datacatalog.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update this occurrence: </br>`"echo \"{{ task_instance.xcom_pull('lookup_entry')['display_name'] }}\""` <br/><br/>All other `xcom_pull()` calls have been updated. |
| airflow/providers/google/cloud/example_dags/example_cloud_sql.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. </br></br>Removed duplicate/redundant task. |
| airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_aws.py | No | Yes | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. </br></br>Removed unused `default_args` variable. |
| airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_gcp.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_cloud_storage_transfer_service_gcp.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update this occurrence: <br/>`"echo \"{{ task_instance.xcom_pull('lookup_entry')['display_name'] }}\""` </br></br>All other `xcom_pull()` calls have been updated. |
| airflow/providers/google/cloud/example_dags/example_dataflow.py| No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_dataproc.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_datastore.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update these occurrences: </br>` "{{task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[2] }}"` </br>`"{{ '/'.join(task_instance.xcom_pull('export_task')['response']['outputUrl'].split('/')[3:]) }}"` </br></br>All other `xcom_pull()` calls have been updated. </br></br>Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_functions.py | No | Yes | Added `default_args` to DAG as there was logic to populate the dict but not being applied. |
| airflow/providers/google/cloud/example_dags/example_dlp.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_gcs.py | Yes | No ||
| airflow/providers/google/cloud/example_dags/example_kubernetes_engine.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_mlengine.py | Yes | Yes | Removed unneeded `default_args` pattern. |
| airflow/providers/google/cloud/example_dags/example_natural_language.py | Yes | No ||
| airflow/providers/google/cloud/example_dags/example_pubsub.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update the following occurrence: <br/>`"""{% for m in task_instance.xcom_pull('pull_messages') %} echo "AckID: {{ m.get('ackId') }}, Base64-Encoded: {{ m.get('message') }}" {% endfor %}"""`<br/><br/>All other `xcom_pull()` calls have been updated. <br/><br/> Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_stackdriver.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_tasks.py | Yes | No ||
| airflow/providers/google/cloud/example_dags/example_translate.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_video_intelligence.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/cloud/example_dags/example_vision.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update the following occurrences: <br/>`"echo {{ task_instance.xcom_pull('annotate_image')['logoAnnotations'][0]['description'] }}"` </br>`"echo {{ task_instance.xcom_pull('detect_text')['textAnnotations'][0] }}"` </br>`"echo {{ task_instance.xcom_pull('document_detect_text')['textAnnotations'][0] }}"` </br>`"echo {{ task_instance.xcom_pull('detect_labels')['labelAnnotations'][0] }}"`<br/><br/>All other `xcom_pull()` calls have been updated. <br/><br/> Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/cloud/example_dags/example_workflows.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
