### PR TITLE
Updating miscellaneous Google example DAGs to use XComArgs

### DIFF
--- a/airflow/providers/google/leveldb/example_dags/example_leveldb.py
+++ b/airflow/providers/google/leveldb/example_dags/example_leveldb.py
@@ -23,13 +23,8 @@ from airflow import models
 from airflow.providers.google.leveldb.operators.leveldb import LevelDBOperator
 from airflow.utils.dates import days_ago
 
-default_args = {
-    'owner': 'airflow',
-}
-
 with models.DAG(
     'example_leveldb',
-    default_args=default_args,
     start_date=days_ago(2),
     schedule_interval=None,
     tags=['example'],

--- a/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
@@ -89,7 +89,7 @@ with models.DAG(
 ) as dag1:
     # [START howto_google_display_video_createquery_report_operator]
     create_report = GoogleDisplayVideo360CreateReportOperator(body=REPORT, task_id="create_report")
-    report_id = "{{ task_instance.xcom_pull('create_report', key='report_id') }}"
+    report_id = create_report.output["report_id"]
     # [END howto_google_display_video_createquery_report_operator]
 
     # [START howto_google_display_video_runquery_report_operator]
@@ -115,7 +115,14 @@ with models.DAG(
     delete_report = GoogleDisplayVideo360DeleteReportOperator(report_id=report_id, task_id="delete_report")
     # [END howto_google_display_video_deletequery_report_operator]
 
-    create_report >> run_report >> wait_for_report >> get_report >> delete_report
+    run_report >> wait_for_report >> get_report >> delete_report
+
+    # Task dependencies created via `XComArgs`:
+    #   create_report >> run_report
+    #   create_report >> wait_for_report
+    #   create_report >> get_report
+    #   create_report >> delete_report
+
 
 with models.DAG(
     "example_display_video_misc",
@@ -183,7 +190,7 @@ with models.DAG(
     upload_sdf_to_big_query = GCSToBigQueryOperator(
         task_id="upload_sdf_to_big_query",
         bucket=BUCKET,
-        source_objects=['{{ task_instance.xcom_pull("upload_sdf_to_bigquery")}}'],
+        source_objects=[save_sdf_in_gcs.output],
         destination_project_dataset_table=f"{BQ_DATA_SET}.gcs_to_bq_table",
         schema_fields=[
             {"name": "name", "type": "STRING", "mode": "NULLABLE"},
@@ -193,4 +200,7 @@ with models.DAG(
     )
     # [END howto_google_display_video_gcs_to_big_query_operator]
 
-    create_sdf_download_task >> wait_for_operation >> save_sdf_in_gcs >> upload_sdf_to_big_query
+    create_sdf_download_task >> wait_for_operation >> save_sdf_in_gcs
+
+    # Task dependency created via `XComArgs`:
+    #   save_sdf_in_gcs >> upload_sdf_to_big_query

--- a/airflow/providers/google/marketing_platform/example_dags/example_search_ads.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_search_ads.py
@@ -54,7 +54,7 @@ with models.DAG(
     # [END howto_search_ads_generate_report_operator]
 
     # [START howto_search_ads_get_report_id]
-    report_id = "{{ task_instance.xcom_pull('generate_report', key='report_id') }}"
+    report_id = generate_report.output["report_id"]
     # [END howto_search_ads_get_report_id]
 
     # [START howto_search_ads_get_report_operator]
@@ -67,4 +67,8 @@ with models.DAG(
     )
     # [END howto_search_ads_getfile_report_operator]
 
-    generate_report >> wait_for_report >> download_report
+    wait_for_report >> download_report
+
+    # Task dependencies created via `XComArgs`:
+    #   generate_report >> wait_for_report
+    #   generate_report >> download_report

--- a/airflow/providers/google/suite/example_dags/example_sheets.py
+++ b/airflow/providers/google/suite/example_dags/example_sheets.py
@@ -57,7 +57,7 @@ with models.DAG(
     # [START print_spreadsheet_url]
     print_spreadsheet_url = BashOperator(
         task_id="print_spreadsheet_url",
-        bash_command="echo {{ task_instance.xcom_pull('create_spreadsheet', key='spreadsheet_url') }}",
+        bash_command=f"echo {create_spreadsheet.output['spreadsheet_url']}",
     )
     # [END print_spreadsheet_url]
 


### PR DESCRIPTION
Related to #10285

- Updated example DAG files such that `xcom_pull()` calls use an operator's `.output` property
- Added comments to which task dependencies, if any, are handled and/or created via `XComArgs` for transparency
- Removed or refactored the `default_args` pattern where necessary as requested by @ashb (i.e. removed a separated `default_args` declaration for deference for declaration as part of the `DAG` object)
- Other miscellaneous updates based on `.output` refactoring

>**Note:** There are several instances where the `xcom_pull()` call was not updated.  These instances involve accessing a specific value within the `XCom` or calling user-defined macros with an `XCom` value.  Reference #16618 for an open issue to enhance the `XComArg` functionality to provide similar behavior as the classic `xcom_pull()` method.

> **Note:** Not all DAGs were tested functionally (i.e. with hard integrations to source systems and executed), however each DAG was tested to compile and generate a DAG graph as expected locally.

An detailed summary of all changes made as part of this PR can be found below:
| DAG File | Converted `xcom_pull()`? | Other Updates? | Comments |
| ---------| ------------------------ | -------------- | -------- |
| airflow/providers/google/leveldb/example_dags/example_leveldb.py | No | Yes | Removed unneeded `default_args` pattern. |
| airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/marketing_platform/example_dags/example_display_video.py | Yes ** | Yes | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update the following occurrence: <br/>`'{{ task_instance.xcom_pull("create_sdf_download_task")["name"] }}'`<br/><br/>All other `xcom_pull()` calls have been updated. <br/><br/> Removed explicit task dependencies that are created via `XComArgs`. </br></br>Updated this instance to reference the correct task rather than an non-existant one:</br>`'{{ task_instance.xcom_pull("upload_sdf_to_bigquery")}}'`|
| airflow/providers/google/marketing_platform/example_dags/example_search_ads.py | Yes | Yes | Removed explicit task dependencies that are created via `XComArgs`. |
| airflow/providers/google/suite/example_dags/example_gcs_to_sheets.py | No | No | Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update any occurrences in this DAG. |
| airflow/providers/google/suite/example_dags/example_sheets.py | Yes ** | No | ** Current `XComArg` object does not support accessing specific values of an iterable `XCom` value elegantly. Did not update the following occurrences: <br/>`"{{ task_instance.xcom_pull('upload_sheet_to_gcs')[0] }}"`<br/><br/>All other `xcom_pull()` calls have been updated. |

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
