### PR TITLE
Prevent Redis access directly from host

### DIFF
--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -85,7 +85,7 @@ services:
 
   redis:
     image: redis:latest
-    ports:
+    expose:
       - 6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]

--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
   redis:
     image: redis:latest
     ports:
-      - 6379:6379
+      - 6379
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s


### PR DESCRIPTION
The default `docker-compose.yaml` file exposes Redis to the host by specifying port mapping of `6379:6379`.

Since Redis is unauthenticated by default and runs as root, this poses a risk and will likely be overlooked by users deploying Airflow using docker compose in VPSes or other instances that are publicly facing, even though it's not meant for production use.

I could not find a reason to have Redis be accessible through the host, so I'm proposing to restrict this port from being accessible via the hypervisor.

Redis can be made to write files into the file system using techniques such as [CONFIG SET](https://redis.io/commands/config-set), on a VPS, this will result in a system compromise by a bot within a few hours if not minutes. Here is an [example how Malware abuses Redis instances to execute code.](https://www.trendmicro.com/en_ca/research/20/d/exposed-redis-instances-abused-for-remote-code-execution-cryptocurrency-mining.html)

