### PR TITLE
Add Pytest fixture to create dag and dagrun and use it on local task job tests

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -20,7 +20,6 @@ import multiprocessing
 import os
 import signal
 import time
-import unittest
 import uuid
 from multiprocessing import Lock, Value
 from unittest import mock
@@ -55,21 +54,15 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 TEST_DAG_FOLDER = os.environ['AIRFLOW__CORE__DAGS_FOLDER']
 
 
-class TestLocalTaskJob(unittest.TestCase):
-    def setUp(self):
+class TestLocalTaskJob:
+    @pytest.fixture(autouse=True)
+    def clean_db_and_set_instance_attrs(self):
         db.clear_db_dags()
         db.clear_db_jobs()
         db.clear_db_runs()
         db.clear_db_task_fail()
-        patcher = patch('airflow.jobs.base_job.sleep')
-        self.addCleanup(patcher.stop)
-        self.mock_base_job_sleep = patcher.start()
-
-    def tearDown(self) -> None:
-        db.clear_db_dags()
-        db.clear_db_jobs()
-        db.clear_db_runs()
-        db.clear_db_task_fail()
+        with patch('airflow.jobs.base_job.sleep') as self.mock_base_job_sleep:
+            yield
 
     def validate_ti_states(self, dag_run, ti_state_mapping, error_message):
         for task_id, expected_state in ti_state_mapping.items():
@@ -77,23 +70,19 @@ class TestLocalTaskJob(unittest.TestCase):
             task_instance.refresh_from_db()
             assert task_instance.state == expected_state, error_message
 
-    def test_localtaskjob_essential_attr(self):
+    def test_localtaskjob_essential_attr(self, dag_maker):
         """
         Check whether essential attributes
         of LocalTaskJob can be assigned with
         proper values without intervention
         """
-        dag = DAG(
+        with dag_maker(
             'test_localtaskjob_essential_attr', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'}
-        )
-
-        with dag:
+        ):
             op1 = DummyOperator(task_id='op1')
 
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_id="test", state=State.SUCCESS, execution_date=DEFAULT_DATE, start_date=DEFAULT_DATE
-        )
+        dr = dag_maker.dag_run
+
         ti = dr.get_task_instance(task_id=op1.task_id)
 
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())
@@ -106,21 +95,12 @@ class TestLocalTaskJob(unittest.TestCase):
         check_result_2 = [getattr(job1, attr) is not None for attr in essential_attr]
         assert all(check_result_2)
 
-    def test_localtaskjob_heartbeat(self):
+    def test_localtaskjob_heartbeat(self, dag_maker):
         session = settings.Session()
-        dag = DAG('test_localtaskjob_heartbeat', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
-        with dag:
+        with dag_maker('test_localtaskjob_heartbeat'):
             op1 = DummyOperator(task_id='op1')
 
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_id="test",
-            state=State.SUCCESS,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
+        dr = dag_maker.dag_run
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         ti.state = State.RUNNING
         ti.hostname = "blablabla"
@@ -148,22 +128,11 @@ class TestLocalTaskJob(unittest.TestCase):
             job1.heartbeat_callback()
 
     @mock.patch('airflow.jobs.local_task_job.psutil')
-    def test_localtaskjob_heartbeat_with_run_as_user(self, psutil_mock):
+    def test_localtaskjob_heartbeat_with_run_as_user(self, psutil_mock, dag_maker):
         session = settings.Session()
-        dag = DAG('test_localtaskjob_heartbeat', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
-        with dag:
+        with dag_maker('test_localtaskjob_heartbeat'):
             op1 = DummyOperator(task_id='op1', run_as_user='myuser')
-
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_id="test",
-            state=State.SUCCESS,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
-
+        dr = dag_maker.dag_run
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         ti.state = State.RUNNING
         ti.pid = 2
@@ -204,7 +173,8 @@ class TestLocalTaskJob(unittest.TestCase):
         Test that task heartbeat will sleep when it fails fast
         """
         self.mock_base_job_sleep.side_effect = time.sleep
-
+        dag_id = 'test_heartbeat_failed_fast'
+        task_id = 'test_heartbeat_failed_fast_op'
         with create_session() as session:
             dagbag = DagBag(
                 dag_folder=TEST_DAG_FOLDER,
@@ -222,6 +192,7 @@ class TestLocalTaskJob(unittest.TestCase):
                 start_date=DEFAULT_DATE,
                 session=session,
             )
+
             ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
             ti.refresh_from_db()
             ti.state = State.RUNNING
@@ -287,6 +258,7 @@ class TestLocalTaskJob(unittest.TestCase):
         assert State.SUCCESS == ti.state
 
     def test_localtaskjob_double_trigger(self):
+
         dagbag = DagBag(
             dag_folder=TEST_DAG_FOLDER,
             include_examples=False,
@@ -304,6 +276,7 @@ class TestLocalTaskJob(unittest.TestCase):
             start_date=DEFAULT_DATE,
             session=session,
         )
+
         ti = dr.get_task_instance(task_id=task.task_id, session=session)
         ti.state = State.RUNNING
         ti.hostname = get_hostname()
@@ -374,7 +347,7 @@ class TestLocalTaskJob(unittest.TestCase):
         assert time_end - time_start < job1.heartrate
         session.close()
 
-    def test_mark_failure_on_failure_callback(self):
+    def test_mark_failure_on_failure_callback(self, dag_maker):
         """
         Test that ensures that mark_failure in the UI fails
         the task, and executes on_failure_callback
@@ -403,21 +376,11 @@ class TestLocalTaskJob(unittest.TestCase):
             with task_terminated_externally.get_lock():
                 task_terminated_externally.value = 0
 
-        with DAG(dag_id='test_mark_failure', start_date=DEFAULT_DATE) as dag:
+        with dag_maker("test_mark_failure", start_date=DEFAULT_DATE):
             task = PythonOperator(
                 task_id='test_state_succeeded1',
                 python_callable=task_function,
                 on_failure_callback=check_failure,
-            )
-
-        dag.clear()
-        with create_session() as session:
-            dag.create_dagrun(
-                run_id="test",
-                state=State.RUNNING,
-                execution_date=DEFAULT_DATE,
-                start_date=DEFAULT_DATE,
-                session=session,
             )
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
@@ -435,7 +398,7 @@ class TestLocalTaskJob(unittest.TestCase):
 
     @patch('airflow.utils.process_utils.subprocess.check_call')
     @patch.object(StandardTaskRunner, 'return_code')
-    def test_failure_callback_only_called_once(self, mock_return_code, _check_call):
+    def test_failure_callback_only_called_once(self, mock_return_code, _check_call, dag_maker):
         """
         Test that ensures that when a task exits with failure by itself,
         failure callback is only called once
@@ -454,22 +417,11 @@ class TestLocalTaskJob(unittest.TestCase):
         def task_function(ti):
             raise AirflowFailException()
 
-        dag = DAG(dag_id='test_failure_callback_race', start_date=DEFAULT_DATE)
-        task = PythonOperator(
-            task_id='test_exit_on_failure',
-            python_callable=task_function,
-            on_failure_callback=failure_callback,
-            dag=dag,
-        )
-
-        dag.clear()
-        with create_session() as session:
-            dag.create_dagrun(
-                run_id="test",
-                state=State.RUNNING,
-                execution_date=DEFAULT_DATE,
-                start_date=DEFAULT_DATE,
-                session=session,
+        with dag_maker("test_failure_callback_race"):
+            task = PythonOperator(
+                task_id='test_exit_on_failure',
+                python_callable=task_function,
+                on_failure_callback=failure_callback,
             )
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
@@ -500,7 +452,7 @@ class TestLocalTaskJob(unittest.TestCase):
         assert failure_callback_called.value == 1
 
     @pytest.mark.quarantined
-    def test_mark_success_on_success_callback(self):
+    def test_mark_success_on_success_callback(self, dag_maker):
         """
         Test that ensures that where a task is marked success in the UI
         on_success_callback gets executed
@@ -516,8 +468,6 @@ class TestLocalTaskJob(unittest.TestCase):
                 success_callback_called.value += 1
             assert context['dag_run'].dag_id == 'test_mark_success'
 
-        dag = DAG(dag_id='test_mark_success', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
         def task_function(ti):
 
             time.sleep(60)
@@ -525,23 +475,15 @@ class TestLocalTaskJob(unittest.TestCase):
             with shared_mem_lock:
                 task_terminated_externally.value = 0
 
-        task = PythonOperator(
-            task_id='test_state_succeeded1',
-            python_callable=task_function,
-            on_success_callback=success_callback,
-            dag=dag,
-        )
+        with dag_maker(dag_id='test_mark_success', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'}):
+            task = PythonOperator(
+                task_id='test_state_succeeded1',
+                python_callable=task_function,
+                on_success_callback=success_callback,
+            )
 
         session = settings.Session()
 
-        dag.clear()
-        dag.create_dagrun(
-            run_id="test",
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())
@@ -573,7 +515,7 @@ class TestLocalTaskJob(unittest.TestCase):
         ]
     )
     @pytest.mark.quarantined
-    def test_process_kill_calls_on_failure_callback(self, signal_type):
+    def test_process_kill_calls_on_failure_callback(self, signal_type, dag_maker):
         """
         Test that ensures that when a task is killed with sigterm or sigkill
         on_failure_callback gets executed
@@ -589,8 +531,6 @@ class TestLocalTaskJob(unittest.TestCase):
                 failure_callback_called.value += 1
             assert context['dag_run'].dag_id == 'test_mark_failure'
 
-        dag = DAG(dag_id='test_mark_failure', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
         def task_function(ti):
 
             time.sleep(60)
@@ -598,23 +538,12 @@ class TestLocalTaskJob(unittest.TestCase):
             with shared_mem_lock:
                 task_terminated_externally.value = 0
 
-        task = PythonOperator(
-            task_id='test_on_failure',
-            python_callable=task_function,
-            on_failure_callback=failure_callback,
-            dag=dag,
-        )
-
-        session = settings.Session()
-
-        dag.clear()
-        dag.create_dagrun(
-            run_id="test",
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
+        with dag_maker(dag_id='test_mark_failure', start_date=DEFAULT_DATE, default_args={'owner': 'owner1'}):
+            task = PythonOperator(
+                task_id='test_on_failure',
+                python_callable=task_function,
+                on_failure_callback=failure_callback,
+            )
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())
@@ -739,7 +668,7 @@ class TestLocalTaskJob(unittest.TestCase):
             if scheduler_job.processor_agent:
                 scheduler_job.processor_agent.end()
 
-    def test_task_exit_should_update_state_of_finished_dagruns_with_dag_paused(self):
+    def test_task_exit_should_update_state_of_finished_dagruns_with_dag_paused(self, dag_maker):
         """Test that with DAG paused, DagRun state will update when the tasks finishes the run"""
         dag = DAG(dag_id='test_dags', start_date=DEFAULT_DATE)
         op1 = PythonOperator(task_id='dummy', dag=dag, owner='airflow', python_callable=lambda: True)
@@ -767,6 +696,7 @@ class TestLocalTaskJob(unittest.TestCase):
             start_date=DEFAULT_DATE,
             session=session,
         )
+
         assert dr.state == State.RUNNING
         ti = TaskInstance(op1, dr.execution_date)
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True, executor=SequentialExecutor())

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -54,13 +54,19 @@ DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 TEST_DAG_FOLDER = os.environ['AIRFLOW__CORE__DAGS_FOLDER']
 
 
+@pytest.fixture
+def clear_db():
+    db.clear_db_dags()
+    db.clear_db_jobs()
+    db.clear_db_runs()
+    db.clear_db_task_fail()
+    yield
+
+
+@pytest.mark.usefixtures('clear_db')
 class TestLocalTaskJob:
     @pytest.fixture(autouse=True)
-    def clean_db_and_set_instance_attrs(self):
-        db.clear_db_dags()
-        db.clear_db_jobs()
-        db.clear_db_runs()
-        db.clear_db_task_fail()
+    def set_instance_attrs(self):
         with patch('airflow.jobs.base_job.sleep') as self.mock_base_job_sleep:
             yield
 

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -63,6 +63,16 @@ def clear_db():
     yield
 
 
+@pytest.fixture(scope='class')
+def clear_db_class():
+    yield
+    db.clear_db_dags()
+    db.clear_db_jobs()
+    db.clear_db_runs()
+    db.clear_db_task_fail()
+
+
+@pytest.mark.usefixtures('clear_db_class')
 @pytest.mark.usefixtures('clear_db')
 class TestLocalTaskJob:
     @pytest.fixture(autouse=True)

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -72,8 +72,7 @@ def clear_db_class():
     db.clear_db_task_fail()
 
 
-@pytest.mark.usefixtures('clear_db_class')
-@pytest.mark.usefixtures('clear_db')
+@pytest.mark.usefixtures('clear_db_class', 'clear_db')
 class TestLocalTaskJob:
     @pytest.fixture(autouse=True)
     def set_instance_attrs(self):


### PR DESCRIPTION
This change adds pytest fixture to use in creating dag and dagruns

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
