### PR TITLE
Change the logic of None comparison in model_list template

### DIFF
--- a/airflow/www/templates/airflow/model_list.html
+++ b/airflow/www/templates/airflow/model_list.html
@@ -77,7 +77,7 @@
         {% set formatter = formatters_columns.get(value) %}
         {% if formatter and formatter(item) %}
           <td>{{ formatter(item) }}</td>
-        {% elif item[value] != None %}
+        {% elif item[value] is not none %}
           <td>{{ item[value] }}</td>
         {% else %}
           <td></td>


### PR DESCRIPTION
This PR closes the #16836 and is related to #12315

**Why:**

There was an inconsistency in the UI where the presence of XCOM value was checked by `elif item[value] != None`. That caused a failure in XCOMs view when the user was trying to return not castable to bool XCOM objects (e.g. pandas data frames). Moreover, the method of comparison is not recommended by PEP8:

```Comparisons to singletons like None should always be done with is or is not, never the equality operators.```

The bug was uncovered by @turbaszek but was not fixed for some reason (probably due to the focus change).

**Changes:**

Change the comparison operator from `!=` to `is not`, which is recommended approach.