### PR TITLE
Add recursive flag to glob in filesystem sensor

### DIFF
--- a/airflow/sensors/filesystem.py
+++ b/airflow/sensors/filesystem.py
@@ -38,6 +38,9 @@ class FileSensor(BaseSensorOperator):
     :param filepath: File or folder name (relative to
         the base path set within the connection), can be a glob.
     :type filepath: str
+    :param recursive: when set True, enables recursive directory matching behavior of
+        `**` in glob filepath parameter. Defaults to False.
+    :type recursive: bool
     """
 
     template_fields = ('filepath',)

--- a/airflow/sensors/filesystem.py
+++ b/airflow/sensors/filesystem.py
@@ -43,10 +43,11 @@ class FileSensor(BaseSensorOperator):
     template_fields = ('filepath',)
     ui_color = '#91818a'
 
-    def __init__(self, *, filepath, fs_conn_id='fs_default', **kwargs):
+    def __init__(self, *, filepath, fs_conn_id='fs_default', recursive=False, **kwargs):
         super().__init__(**kwargs)
         self.filepath = filepath
         self.fs_conn_id = fs_conn_id
+        self.recursive = recursive
 
     def poke(self, context):
         hook = FSHook(self.fs_conn_id)
@@ -54,7 +55,7 @@ class FileSensor(BaseSensorOperator):
         full_path = os.path.join(basepath, self.filepath)
         self.log.info('Poking for file %s', full_path)
 
-        for path in glob(full_path, recursive=True):
+        for path in glob(full_path, recursive=self.recursive):
             if os.path.isfile(path):
                 mod_time = os.path.getmtime(path)
                 mod_time = datetime.datetime.fromtimestamp(mod_time).strftime('%Y%m%d%H%M%S')

--- a/airflow/sensors/filesystem.py
+++ b/airflow/sensors/filesystem.py
@@ -38,8 +38,8 @@ class FileSensor(BaseSensorOperator):
     :param filepath: File or folder name (relative to
         the base path set within the connection), can be a glob.
     :type filepath: str
-    :param recursive: when set True, enables recursive directory matching behavior of
-        `**` in glob filepath parameter. Defaults to False.
+    :param recursive: when set to ``True``, enables recursive directory matching behavior of
+        ``**`` in glob filepath parameter. Defaults to ``False``.
     :type recursive: bool
     """
 

--- a/airflow/sensors/filesystem.py
+++ b/airflow/sensors/filesystem.py
@@ -54,7 +54,7 @@ class FileSensor(BaseSensorOperator):
         full_path = os.path.join(basepath, self.filepath)
         self.log.info('Poking for file %s', full_path)
 
-        for path in glob(full_path):
+        for path in glob(full_path, recursive=True):
             if os.path.isfile(path):
                 mod_time = os.path.getmtime(path)
                 mod_time = datetime.datetime.fromtimestamp(mod_time).strftime('%Y%m%d%H%M%S')

--- a/tests/sensors/test_filesystem.py
+++ b/tests/sensors/test_filesystem.py
@@ -131,6 +131,26 @@ class TestFileSensor(unittest.TestCase):
             task._hook = self.hook
             task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
 
+    def test_wildcared_directory(self):
+        temp_dir = tempfile.mkdtemp()
+        subdir = tempfile.mkdtemp(dir=temp_dir)
+        task = FileSensor(
+            task_id='test',
+            filepath=temp_dir + "/**",
+            fs_conn_id='fs_default',
+            dag=self.dag,
+            timeout=0,
+            poke_interval=1,
+        )
+        task._hook = self.hook
+
+        try:
+            # `touch` the dir
+            open(subdir + "/file", "a").close()
+            task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        finally:
+            shutil.rmtree(temp_dir)
+
     def test_subdirectory_not_empty(self):
         suffix = '.txt'
         temp_dir = tempfile.mkdtemp()

--- a/tests/sensors/test_filesystem.py
+++ b/tests/sensors/test_filesystem.py
@@ -141,6 +141,7 @@ class TestFileSensor(unittest.TestCase):
             dag=self.dag,
             timeout=0,
             poke_interval=1,
+            recursive=True,
         )
         task._hook = self.hook
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR aims to fix #16725 by adding the `recursive` flag to `glob` in the filesystem sensor.

closes: #16725 
---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
