### PR TITLE
Deprecate Tableau personal token authentication

### DIFF
--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -108,7 +108,7 @@ class TableauHook(BaseHook):
         warnings.warn(
             "Authentication via personal access token is deprecated. "
             "Please, use the password authentication to avoid inconsistencies.",
-            DeprecationWarning
+            DeprecationWarning,
         )
         tableau_auth = PersonalAccessTokenAuth(
             token_name=self.conn.extra_dejson['token_name'],

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import warnings
 from distutils.util import strtobool
 from enum import Enum
 from typing import Any, Optional
@@ -39,7 +40,11 @@ class TableauJobFinishCode(Enum):
 class TableauHook(BaseHook):
     """
     Connects to the Tableau Server Instance and allows to communicate with it.
-    .. see also:: https://tableau.github.io/server-client-python/docs/
+
+    Can be used as a context manager: automatically authenticates the connection
+    when opened and signs out when closed.
+
+    .. seealso:: https://tableau.github.io/server-client-python/docs/
 
     :param site_id: The id of the site where the workbook belongs to.
         It will connect to the default site if you don't provide an id.
@@ -81,7 +86,8 @@ class TableauHook(BaseHook):
 
     def get_conn(self) -> Auth.contextmgr:
         """
-        Signs in to the Tableau Server and automatically signs out if used as ContextManager.
+        Sign in to the Tableau Server.
+
         :return: an authorized Tableau Server Context Manager object.
         :rtype: tableauserverclient.server.Auth.contextmgr
         """
@@ -98,6 +104,12 @@ class TableauHook(BaseHook):
         return self.server.auth.sign_in(tableau_auth)
 
     def _auth_via_token(self) -> Auth.contextmgr:
+        """The method is deprecated. Please, use the authentication via password instead."""
+        warnings.warn(
+            "Authentication via personal access token is deprecated. "
+            "Please, use the password authentication to avoid inconsistencies.",
+            DeprecationWarning
+        )
         tableau_auth = PersonalAccessTokenAuth(
             token_name=self.conn.extra_dejson['token_name'],
             personal_access_token=self.conn.extra_dejson['personal_access_token'],
@@ -111,10 +123,13 @@ class TableauHook(BaseHook):
         .. see also:: https://tableau.github.io/server-client-python/docs/page-through-results
 
         :param resource_name: The name of the resource to paginate.
-            For example: jobs or workbooks
+            For example: jobs or workbooks.
         :type resource_name: str
         :return: all items by returning a Pager.
         :rtype: tableauserverclient.Pager
         """
-        resource = getattr(self.server, resource_name)
+        try:
+            resource = getattr(self.server, resource_name)
+        except AttributeError:
+            raise ValueError(f"Resource name {resource_name} is not found.")
         return Pager(resource.get)

--- a/airflow/providers/tableau/sensors/tableau_job_status.py
+++ b/airflow/providers/tableau/sensors/tableau_job_status.py
@@ -31,7 +31,7 @@ class TableauJobStatusSensor(BaseSensorOperator):
 
     .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
 
-    :param job_id: The job to watch.
+    :param job_id: Id of the job to watch.
     :type job_id: str
     :param site_id: The id of the site where the workbook belongs to.
     :type site_id: Optional[str]
@@ -69,6 +69,6 @@ class TableauJobStatusSensor(BaseSensorOperator):
                 int(tableau_hook.server.jobs.get_by_id(self.job_id).finish_code)
             )
             self.log.info('Current finishCode is %s (%s)', finish_code.name, finish_code.value)
-            if finish_code in [TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED]:
+            if finish_code in (TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED):
                 raise TableauJobFailedException('The Tableau Refresh Workbook Job failed!')
             return finish_code == TableauJobFinishCode.SUCCESS

--- a/docs/apache-airflow-providers-tableau/connections/tableau.rst
+++ b/docs/apache-airflow-providers-tableau/connections/tableau.rst
@@ -40,7 +40,7 @@ Authentication by personal token was deprecated as Tableau automatically invalid
 personal token connection if one or more parallel connections with the same token are opened.
 So, in the environments with multiple parallel tasks this authentication method can lead to numerous bugs
 and all the jobs will not run as they intended. Therefore, personal token auth option
-is considered harmful and has been deprecated.
+is considered harmful until the logic of Tableau server client changes.
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.

--- a/docs/apache-airflow-providers-tableau/connections/tableau.rst
+++ b/docs/apache-airflow-providers-tableau/connections/tableau.rst
@@ -34,7 +34,13 @@ There are two ways to connect to Tableau using Airflow.
    i.e. add a ``password`` and ``login`` to the Airflow connection.
 2. Use a `Token Authentication
    <https://tableau.github.io/server-client-python/docs/api-ref#personalaccesstokenauth-class>`_
-   i.e. add a ``token_name`` and ``personal_access_token`` to the Airflow connection.
+   i.e. add a ``token_name`` and ``personal_access_token`` to the Airflow connection (deprecated).
+
+Authentication by personal token was deprecated as Tableau automatically invalidates opened
+personal token connection if one or more parallel connections with the same token are opened.
+So, in the environments with multiple parallel tasks this authentication method can lead to numerous bugs
+and all the jobs will not run as they intended. Therefore, personal token auth option
+is considered harmful and has been deprecated.
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.


### PR DESCRIPTION
This PR closes #16669.

**Why:**

Authentication by personal token was not working properly since the Tableau provider's creation due to how the Tableau server client works (it invalidates previous personal token connection if one or more parallel are opened). Therefore, we decided to deprecate it.

*Changes:*

1. Remove `_auth_via_token` method from the `TableauHook` and make the documentation notes about the deprecation.
2. Fix `get_all` method of `TableauHook` to raise a  verbose error when there is wrong object type was supplied.
3. Deprecate the usage of `TableauJobStatusSensor` in case of blocking `TableauRefreshWorkbookOperator` execution to remove the creation of duplicated connection (which is done by a sensor) and to improve the conformity of the class to SRP. Also fix some small documentation issues.
4. Deprecate testing of the personal token authentication and add change the logic of "blocked" task test.