### PR TITLE
Avoid verification of images multiple times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,16 +286,16 @@ jobs:
           Wait for CI images
           ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
         id: wait-for-images
-        env:
-          CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING: >
-            ${{needs.build-info.outputs.pythonVersionsListAsString}}
         # We wait for the images to be available either from the build-ci-image step or from
         # "build-images-workflow-run.yml' run as pull_request_target.
         # We are utilising single job to wait for all images because this job merely waits
         # for the images to be available.
         # The test jobs wait for it to complete if WAIT_FOR_IMAGE is 'true'!
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_ci_images.sh
-
+        env:
+          CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING: >
+            ${{needs.build-info.outputs.pythonVersionsListAsString}}
+          VERIFY_IMAGE: "true"
 
   static-checks:
     timeout-minutes: 30
@@ -947,10 +947,11 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         # For the images to be available. The test jobs wait for it to complete!
         #
         id: wait-for-images
+        run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
         env:
           CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING: >
             ${{needs.build-info.outputs.pythonVersionsListAsString}}
-        run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
+          VERIFY_IMAGE: "true"
 
   tests-kubernetes:
     timeout-minutes: 50
@@ -989,6 +990,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Get all PROD images"
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
+        env:
+          VERIFY_IMAGE: "false"
       - name: "Cache virtualenv for kubernetes testing"
         uses: actions/cache@v2
         with:
@@ -1052,6 +1055,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         run: ./scripts/ci/tools/ci_free_space_on_ci.sh
       - name: "Get all PROD images"
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_prod_images.sh
+        env:
+          VERIFY_IMAGE: "false"
       - name: "Cache virtualenv for kubernetes testing"
         uses: actions/cache@v2
         with:
@@ -1226,6 +1231,8 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           Wait for CI images
           ${{ needs.build-info.outputs.pythonVersions }}:${{ env.GITHUB_REGISTRY_PULL_IMAGE_TAG }}
         run: ./scripts/ci/images/ci_wait_for_and_verify_all_ci_images.sh
+        env:
+          VERIFY_IMAGE: "false"
       - name: "Generate constraints with PyPI providers"
         run: ./scripts/ci/constraints/ci_generate_all_constraints.sh
         env:

--- a/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
@@ -45,14 +45,12 @@ start_end::group_end
 export AIRFLOW_CI_IMAGE_NAME="${BRANCH_NAME}-python${PYTHON_MAJOR_MINOR_VERSION}-ci"
 
 start_end::group_start "Waiting for ${AIRFLOW_CI_IMAGE_NAME} image to appear"
-
 push_pull_remove_images::wait_for_github_registry_image \
     "${AIRFLOW_CI_IMAGE_NAME}${GITHUB_REGISTRY_IMAGE_SUFFIX}" "${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
-
 build_images::prepare_ci_build
-
 pull_ci_image
-
-verify_image::verify_ci_image "${AIRFLOW_CI_IMAGE}"
-
 start_end::group_end
+
+if [[ ${VERIFY_IMAGE=} != "false" ]]; then
+    verify_image::verify_ci_image "${AIRFLOW_CI_IMAGE}"
+fi

--- a/scripts/ci/images/ci_wait_for_and_verify_prod_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_prod_image.sh
@@ -49,4 +49,6 @@ verbosity::print_info "Pulling the ${image_name_with_tag} image and tagging with
 push_pull_remove_images::pull_image_github_dockerhub "${AIRFLOW_PROD_IMAGE}" "${image_name_with_tag}"
 start_end::group_end
 
-verify_image::verify_prod_image "${AIRFLOW_PROD_IMAGE}"
+if [[ ${VERIFY_IMAGE=} != "false" ]]; then
+    verify_image::verify_prod_image "${AIRFLOW_PROD_IMAGE}"
+fi


### PR DESCRIPTION
The CI and PROD images are verified in CI build, and it takes
a minute or so, however they were verified multiple times.

Some time ago verification was added to be run then "wait for images"
job was run, but the same script has been run in every test. This is
not needed because this is the exact same image downloaded from
GitHub registry (identified by commit hash), so the extra
verificatoins are not needed. This will speed up the builds by
few percents.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
