### PR TITLE
BugFix: Using `json` string in template_field fails with K8s Operators

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -172,7 +172,7 @@ class KubernetesPodOperator(BaseOperator):
         'pod_template_file',
     )
 
-    template_ext = ('yaml', 'yml', 'json')
+    template_ext = ('.yaml', '.yml', '.json')
 
     # fmt: off
     def __init__(

--- a/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/operators/spark_kubernetes.py
@@ -43,7 +43,7 @@ class SparkKubernetesOperator(BaseOperator):
     """
 
     template_fields = ['application_file', 'namespace']
-    template_ext = ('yaml', 'yml', 'json')
+    template_ext = ('.yaml', '.yml', '.json')
     ui_color = '#f4a460'
 
     def __init__(


### PR DESCRIPTION

closes https://github.com/apache/airflow/issues/16922

Because we simply check if fields in template_field ends with `template_ext`,
this was causing issues if the str ends with json, in which case Airflow would
try to search for file instead of using the string

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
