### PR TITLE
New Tableau operator: TableauRefreshDatasourceOperator

### DIFF
--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -126,12 +126,26 @@ class TableauHook(BaseHook):
 
     def get_job_status(self, job_id: str) -> Enum:
         """
-           Get the current state of a defined Tableau Job.
-           .. see also:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
+        Get the current state of a defined Tableau Job.
+        .. see also:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
 
-           :param job_id: The id of the job to check.
-           :type job_id: str
-           :rtype: Enum
-           """
-        return TableauJobFinishCode(
-                int(self.server.jobs.get_by_id(job_id).finish_code))
+        :param job_id: The id of the job to check.
+        :type job_id: str
+        :rtype: Enum
+        """
+        return TableauJobFinishCode(int(self.server.jobs.get_by_id(job_id).finish_code))
+
+    def waiting_until_succeeded(self, job_id: str) -> bool:
+        """
+        Wait until the current state of a defined Tableau Job is not PENDING.
+
+        :param job_id: The id of the job to check.
+        :type job_id: str
+        :return: return True if the job has SUCCESS status, False otherwise.
+        :rtype: bool
+        """
+        finish_code = TableauJobFinishCode.PENDING
+        while finish_code == TableauJobFinishCode.PENDING:
+            finish_code = self.get_job_status(job_id=job_id)
+
+        return finish_code == TableauJobFinishCode.SUCCESS

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -21,7 +21,12 @@ from typing import Any, Optional
 from tableauserverclient import Pager, PersonalAccessTokenAuth, Server, TableauAuth
 from tableauserverclient.server import Auth
 
+from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
+
+
+class TableauJobFailedException(AirflowException):
+    """An exception that indicates that a Job failed to complete."""
 
 
 class TableauJobFinishCode(Enum):
@@ -118,3 +123,15 @@ class TableauHook(BaseHook):
         """
         resource = getattr(self.server, resource_name)
         return Pager(resource.get)
+
+    def get_job_status(self, job_id: str) -> Enum:
+        """
+           Get the current state of a defined Tableau Job.
+           .. see also:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
+
+           :param job_id: The id of the job to check.
+           :type job_id: str
+           :rtype: Enum
+           """
+        return TableauJobFinishCode(
+                int(self.server.jobs.get_by_id(job_id).finish_code))

--- a/airflow/providers/tableau/operators/tableau_refresh_datasource.py
+++ b/airflow/providers/tableau/operators/tableau_refresh_datasource.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Optional
+
+from tableauserverclient import DatasourceItem
+
+from airflow.exceptions import AirflowException
+from airflow.models import BaseOperator
+from airflow.providers.tableau.hooks.tableau import TableauHook
+
+
+class TableauRefreshDatasourceOperator(BaseOperator):
+    """
+    Refreshes a Tableau Datasource
+
+    .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#data-sources
+
+    :param datasource_name: The name of the datasource to refresh.
+    :type datasource_name: str
+    :param site_id: The id of the site where the datasource belongs to.
+    :type site_id: Optional[str]
+    :param blocking: By default the extract refresh will be blocking means it will wait until it has finished.
+    :type blocking: bool
+    :param tableau_conn_id: The Tableau Connection id containing the credentials
+        to authenticate to the Tableau Server.
+    :type tableau_conn_id: str
+    """
+
+    def __init__(
+        self,
+        *,
+        datasource_name: str,
+        site_id: Optional[str] = None,
+        blocking: bool = True,
+        tableau_conn_id: str = 'tableau_default',
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.datasource_name = datasource_name
+        self.site_id = site_id
+        self.blocking = blocking
+        self.tableau_conn_id = tableau_conn_id
+
+    def execute(self, context: dict) -> str:
+        """
+        Executes the Tableau Extract Refresh and pushes the job id to xcom.
+
+        :param context: The task context during execution.
+        :type context: dict
+        :return: the id of the job that executes the extract refresh
+        :rtype: str
+        """
+        with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
+            datasource = self._get_datasource_by_name(tableau_hook)
+
+            job_id = self._refresh_datasource(tableau_hook, datasource.id)
+            if self.blocking:
+                from airflow.providers.tableau.sensors.tableau_job_status import TableauJobStatusSensor
+
+                TableauJobStatusSensor(
+                    job_id=job_id,
+                    site_id=self.site_id,
+                    tableau_conn_id=self.tableau_conn_id,
+                    task_id='wait_until_succeeded',
+                    dag=None,
+                ).execute(context={})
+                self.log.info('Datasource %s has been successfully refreshed.', self.datasource_name)
+            return job_id
+
+    def _get_datasource_by_name(self, tableau_hook: TableauHook) -> DatasourceItem:
+        for datasource in tableau_hook.get_all(resource_name='datasources'):
+            if datasource.name == self.datasource_name:
+                self.log.info('Found matching datasource with id %s', datasource.id)
+                return datasource
+
+        raise AirflowException(f'Datasource {self.datasource_name} not found!')
+
+    def _refresh_datasource(self, tableau_hook: TableauHook, datasource_id: str) -> str:
+        job = tableau_hook.server.datasources.refresh(datasource_id)
+        self.log.info('Refreshing Datasource %s...', self.datasource_name)
+        return job.id

--- a/airflow/providers/tableau/provider.yaml
+++ b/airflow/providers/tableau/provider.yaml
@@ -38,6 +38,7 @@ operators:
   - integration-name: Tableau
     python-modules:
       - airflow.providers.tableau.operators.tableau_refresh_workbook
+      - airflow.providers.tableau.operators.tableau_refresh_datasource
 
 sensors:
   - integration-name: Tableau

--- a/airflow/providers/tableau/sensors/tableau_job_status.py
+++ b/airflow/providers/tableau/sensors/tableau_job_status.py
@@ -16,13 +16,8 @@
 # under the License.
 from typing import Optional
 
-from airflow.exceptions import AirflowException
-from airflow.providers.tableau.hooks.tableau import TableauHook, TableauJobFinishCode
+from airflow.providers.tableau.hooks.tableau import TableauHook, TableauJobFinishCode, TableauJobFailedException
 from airflow.sensors.base import BaseSensorOperator
-
-
-class TableauJobFailedException(AirflowException):
-    """An exception that indicates that a Job failed to complete."""
 
 
 class TableauJobStatusSensor(BaseSensorOperator):
@@ -65,10 +60,8 @@ class TableauJobStatusSensor(BaseSensorOperator):
         :rtype: bool
         """
         with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
-            finish_code = TableauJobFinishCode(
-                int(tableau_hook.server.jobs.get_by_id(self.job_id).finish_code)
-            )
+            finish_code = tableau_hook.get_job_status(job_id=self.job_id)
             self.log.info('Current finishCode is %s (%s)', finish_code.name, finish_code.value)
             if finish_code in [TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED]:
-                raise TableauJobFailedException('The Tableau Refresh Workbook Job failed!')
+                raise TableauJobFailedException('The Tableau Refresh Job failed!')
             return finish_code == TableauJobFinishCode.SUCCESS

--- a/airflow/providers/tableau/sensors/tableau_job_status.py
+++ b/airflow/providers/tableau/sensors/tableau_job_status.py
@@ -16,7 +16,11 @@
 # under the License.
 from typing import Optional
 
-from airflow.providers.tableau.hooks.tableau import TableauHook, TableauJobFinishCode, TableauJobFailedException
+from airflow.providers.tableau.hooks.tableau import (
+    TableauHook,
+    TableauJobFailedException,
+    TableauJobFinishCode,
+)
 from airflow.sensors.base import BaseSensorOperator
 
 

--- a/tests/providers/tableau/operators/test_tableau_refresh_datasource.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_datasource.py
@@ -55,9 +55,8 @@ class TestTableauRefreshDatasourceOperator(unittest.TestCase):
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
 
-    @patch('airflow.providers.tableau.sensors.tableau_job_status.TableauJobStatusSensor')
     @patch('airflow.providers.tableau.operators.tableau_refresh_datasource.TableauHook')
-    def test_execute_blocking(self, mock_tableau_hook, mock_tableau_job_status_sensor):
+    def test_execute_blocking(self, mock_tableau_hook):
         """
         Test execute blocking
         """
@@ -69,12 +68,8 @@ class TestTableauRefreshDatasourceOperator(unittest.TestCase):
 
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
-        mock_tableau_job_status_sensor.assert_called_once_with(
+        mock_tableau_hook.get_job_status.assert_called_once_with(
             job_id=job_id,
-            site_id=self.kwargs['site_id'],
-            tableau_conn_id='tableau_default',
-            task_id='wait_until_succeeded',
-            dag=None,
         )
 
     @patch('airflow.providers.tableau.operators.tableau_refresh_datasource.TableauHook')

--- a/tests/providers/tableau/operators/test_tableau_refresh_datasource.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_datasource.py
@@ -68,7 +68,7 @@ class TestTableauRefreshDatasourceOperator(unittest.TestCase):
 
         mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
-        mock_tableau_hook.get_job_status.assert_called_once_with(
+        mock_tableau_hook.waiting_until_succeeded.assert_called_once_with(
             job_id=job_id,
         )
 

--- a/tests/providers/tableau/operators/test_tableau_refresh_datasource.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_datasource.py
@@ -1,0 +1,90 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest.mock import Mock, patch
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.providers.tableau.operators.tableau_refresh_datasource import TableauRefreshDatasourceOperator
+
+
+class TestTableauRefreshDatasourceOperator(unittest.TestCase):
+    """
+    Test class for TableauRefreshDatasourceOperator
+    """
+
+    def setUp(self):
+        """
+        setup
+        """
+        self.mock_datasources = []
+        for i in range(3):
+            mock_datasource = Mock()
+            mock_datasource.id = i
+            mock_datasource.name = f'ds_{i}'
+            self.mock_datasources.append(mock_datasource)
+        self.kwargs = {'site_id': 'test_site', 'task_id': 'task', 'dag': None}
+
+    @patch('airflow.providers.tableau.operators.tableau_refresh_datasource.TableauHook')
+    def test_execute(self, mock_tableau_hook):
+        """
+        Test Execute
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauRefreshDatasourceOperator(blocking=False, datasource_name='ds_2', **self.kwargs)
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+
+    @patch('airflow.providers.tableau.sensors.tableau_job_status.TableauJobStatusSensor')
+    @patch('airflow.providers.tableau.operators.tableau_refresh_datasource.TableauHook')
+    def test_execute_blocking(self, mock_tableau_hook, mock_tableau_job_status_sensor):
+        """
+        Test execute blocking
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauRefreshDatasourceOperator(datasource_name='ds_2', **self.kwargs)
+
+        job_id = operator.execute(context={})
+
+        mock_tableau_hook.server.datasources.refresh.assert_called_once_with(2)
+        assert mock_tableau_hook.server.datasources.refresh.return_value.id == job_id
+        mock_tableau_job_status_sensor.assert_called_once_with(
+            job_id=job_id,
+            site_id=self.kwargs['site_id'],
+            tableau_conn_id='tableau_default',
+            task_id='wait_until_succeeded',
+            dag=None,
+        )
+
+    @patch('airflow.providers.tableau.operators.tableau_refresh_datasource.TableauHook')
+    def test_execute_missing_datasource(self, mock_tableau_hook):
+        """
+        Test execute missing datasource
+        """
+        mock_tableau_hook.get_all = Mock(return_value=self.mock_datasources)
+        mock_tableau_hook.return_value.__enter__ = Mock(return_value=mock_tableau_hook)
+        operator = TableauRefreshDatasourceOperator(datasource_name='test', **self.kwargs)
+
+        with pytest.raises(AirflowException):
+            operator.execute({})

--- a/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
@@ -55,9 +55,8 @@ class TestTableauRefreshWorkbookOperator(unittest.TestCase):
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
 
-    @patch('airflow.providers.tableau.sensors.tableau_job_status.TableauJobStatusSensor')
     @patch('airflow.providers.tableau.operators.tableau_refresh_workbook.TableauHook')
-    def test_execute_blocking(self, mock_tableau_hook, mock_tableau_job_status_sensor):
+    def test_execute_blocking(self, mock_tableau_hook):
         """
         Test execute blocking
         """
@@ -69,12 +68,8 @@ class TestTableauRefreshWorkbookOperator(unittest.TestCase):
 
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
-        mock_tableau_job_status_sensor.assert_called_once_with(
+        mock_tableau_hook.get_job_status.assert_called_once_with(
             job_id=job_id,
-            site_id=self.kwargs['site_id'],
-            tableau_conn_id='tableau_default',
-            task_id='wait_until_succeeded',
-            dag=None,
         )
 
     @patch('airflow.providers.tableau.operators.tableau_refresh_workbook.TableauHook')

--- a/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
@@ -68,7 +68,7 @@ class TestTableauRefreshWorkbookOperator(unittest.TestCase):
 
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
-        mock_tableau_hook.get_job_status.assert_called_once_with(
+        mock_tableau_hook.waiting_until_succeeded.assert_called_once_with(
             job_id=job_id,
         )
 


### PR DESCRIPTION
Hello all,
I propose you a new Airflow Operator for Tableau: `TableauRefreshDatasourceOperator`. This new operator uses the Tableau API to refresh an existing Datasource published in a Tableau Server. 

The operator is very similar to `TableauRefreshWorkbookOperator`, but I thought it was more clear and clean to create a new one instead to modify the existing one.

The operator is very useful to refresh data sources, not in time set way but in an asynchronous way, in my case, it is very useful to add the refresh after my ETL pipelines. I'm currently using this operator in my Airflow installation.

### Changes:

1. Created TableauRefreshDatasourceOperator
2. Created unit test for TableauRefreshDatasourceOperator
3. Added the operator to the provider.yaml file


Thank you.