### PR TITLE
Relax version constraint on ``Flask-Appbuilder``

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,7 +100,7 @@ install_requires =
     #      https://github.com/readthedocs/sphinx_rtd_theme/issues/1115
     docutils<0.17
     flask>=1.1.0, <2.0
-    flask-appbuilder~=3.3
+    flask-appbuilder>=3.2, <4.0.0
     flask-caching>=1.5.0, <2.0.0
     flask-login>=0.3, <0.5
     flask-wtf>=0.14.3, <0.15


### PR DESCRIPTION
FAB 3.3 has some issues with permissions as mentioned in https://github.com/apache/airflow/issues/16202 and https://github.com/dpgaspar/Flask-AppBuilder/issues/1667

~There is no reason we should require >= 3.3~ (This was added in https://github.com/apache/airflow/pull/15792)

Allow more versions as discussed in https://github.com/apache/airflow/pull/16630#discussion_r657926149 to be more permissive

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
