### PR TITLE
Enable using custom pod launcher in Kubernetes Pod Operator

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -301,6 +301,11 @@ class KubernetesPodOperator(BaseOperator):
         )
 
     @staticmethod
+    def _get_pod_launcher(**kwargs):
+        return pod_launcher.PodLauncher(kube_client=kwargs.get('client'),
+                                        extract_xcom=kwargs.get('do_xcom_push'))
+
+    @staticmethod
     def create_labels_for_pod(context) -> dict:
         """
         Generate labels for the pod to track the pod in case of Operator crash
@@ -354,7 +359,7 @@ class KubernetesPodOperator(BaseOperator):
                     f'More than one pod running with labels: {label_selector}'
                 )
 
-            launcher = pod_launcher.PodLauncher(kube_client=client, extract_xcom=self.do_xcom_push)
+            launcher = self._get_pod_launcher(client=client, do_xcom_push=self.do_xcom_push)
 
             if len(pod_list.items) == 1:
                 try_numbers_match = self._try_numbers_match(context, pod_list.items[0])

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -160,6 +160,12 @@ class KubernetesPodOperator(BaseOperator):
     :param termination_grace_period: Termination grace period if task killed in UI,
         defaults to kubernetes default
     :type termination_grace_period: int
+    :param pod_launcher_class: Class used to manage lifecycle of target pod.
+        For more advanced users this is a way to use custom pod launcher and,
+        for example, conduct additional activities upon pods creation and deletion.
+        This class needs to inherit from pod_launcher.PodLauncher and accept
+        the same arguments in object constructor.
+        defaults to airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher
     """
 
     template_fields: Iterable[str] = (

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -166,6 +166,7 @@ class KubernetesPodOperator(BaseOperator):
         This class needs to inherit from pod_launcher.PodLauncher and accept
         the same arguments in object constructor.
         defaults to airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher
+    :type pod_launcher_class: Type[pod_launcher.PodLauncher]
     """
 
     template_fields: Iterable[str] = (

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -357,7 +357,7 @@ class KubernetesPodOperator(BaseOperator):
                     f'More than one pod running with labels: {label_selector}'
                 )
 
-            launcher = self._get_pod_launcher()
+            launcher = self.create_pod_launcher()
 
             if len(pod_list.items) == 1:
                 try_numbers_match = self._try_numbers_match(context, pod_list.items[0])


### PR DESCRIPTION
Minor refactor of `KubernetesPodOperator` enabling easy switch of pod launcher used inside this class.

**Motivation**
In our project we use custom pod launcher which inherits from standard `pod_launcher.PodLauncher`. With current structure of the code it's not easy to use custom pod launcher as `execute` method needs to be rewritten.

To give you better understanding of why we need custom pod launcher below you can find our abstract custom pod launcher class, with which we can conduct actions specific to our use-cases/environment tied to lifecycle of pod created by KubernetesPodOperator.
```
class PodLauncherWithHooks(PodLauncher):
    def run_pod_async(self, pod, **kwargs):
        self.before_create_hook(pod)

        result = super(PodLauncherWithHooks, self).run_pod_async(pod, **kwargs)

        self.after_create_hook(pod, result)

        return result

    def delete_pod(self, pod):
        self.before_delete_hook(pod)

        result = super(PodLauncherWithHooks, self).delete_pod(pod)

        self.after_delete_hook(pod)

        return result

    def before_create_hook(self, pod):
        pass

    def after_create_hook(self, pod, result):
        pass

    def before_delete_hook(self, pod):
        pass

    def after_delete_hook(self, pod):
        pass
```