### PR TITLE
PythonVritualenvOperator - Feature: Add support for private pypi repo packages in requirements

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -308,6 +308,8 @@ class PythonVirtualenvOperator(PythonOperator):
         string_args: Optional[Iterable[str]] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
+        repository_url: Optional[str] = None,
+        index_url: Optional[str] = None,
         **kwargs,
     ):
         if (
@@ -338,6 +340,9 @@ class PythonVirtualenvOperator(PythonOperator):
         self.python_version = python_version
         self.use_dill = use_dill
         self.system_site_packages = system_site_packages
+        self.repository_url = repository_url
+        self.index_url = index_url
+
         if not self.system_site_packages and self.use_dill and 'dill' not in self.requirements:
             self.requirements.append('dill')
         self.pickling_library = dill if self.use_dill else pickle
@@ -361,6 +366,8 @@ class PythonVirtualenvOperator(PythonOperator):
                 python_bin=f'python{self.python_version}' if self.python_version else None,
                 system_site_packages=self.system_site_packages,
                 requirements=self.requirements,
+                repository_url=self.repository_url,
+                index_url=self.index_url
             )
 
             self._write_args(input_filename)

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -264,10 +264,9 @@ class PythonVirtualenvOperator(PythonOperator):
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
-    :param repository_url: string with the private repo url.
-    :type repository_url: optional[str]
-    :param index_url: string with the index url of the private repo.
-    :type: index_url: optional[str]
+    :param connection_id: connection id can be set in case we want to login into a private
+    repository so retrieving the information of the private repository later.
+    :type connection_id: optional[str]
     """
 
     BASE_SERIALIZABLE_CONTEXT_KEYS = {
@@ -312,8 +311,7 @@ class PythonVirtualenvOperator(PythonOperator):
         string_args: Optional[Iterable[str]] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
-        repository_url: Optional[str] = None,
-        index_url: Optional[str] = None,
+        connection_id: Optional[str] = None,
         **kwargs,
     ):
         if (
@@ -344,8 +342,7 @@ class PythonVirtualenvOperator(PythonOperator):
         self.python_version = python_version
         self.use_dill = use_dill
         self.system_site_packages = system_site_packages
-        self.repository_url = repository_url
-        self.index_url = index_url
+        self.connection_id = connection_id
 
         if not self.system_site_packages and self.use_dill and 'dill' not in self.requirements:
             self.requirements.append('dill')
@@ -370,8 +367,7 @@ class PythonVirtualenvOperator(PythonOperator):
                 python_bin=f'python{self.python_version}' if self.python_version else None,
                 system_site_packages=self.system_site_packages,
                 requirements=self.requirements,
-                repository_url=self.repository_url,
-                index_url=self.index_url
+                connection_id=self.connection_id
             )
 
             self._write_args(input_filename)

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -264,6 +264,10 @@ class PythonVirtualenvOperator(PythonOperator):
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
+    :param repository_url: string with the private repo url.
+    :type repository_url: optional[str]
+    :param index_url: string with the index url of the private repo.
+    :type: index_url: optional[str]
     """
 
     BASE_SERIALIZABLE_CONTEXT_KEYS = {

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -124,15 +124,14 @@ def prepare_virtualenv(
     :type system_site_packages: bool
     :param requirements: List of additional python packages
     :type requirements: List[str]
-    :param connection_id: The private repository connection_id
-     case there are private packages to install.
+    :param connection_id: The connection ID of an http/https connection to use as the index
+        url for installing packages from a private PyPi repository
     :type connection_id: str
     :rtype: str
     """
     virtualenv_cmd = _generate_virtualenv_cmd(venv_directory, python_bin, system_site_packages)
     execute_in_subprocess(virtualenv_cmd)
-    pip_cmd = _generate_pip_install_cmd(
-        venv_directory, requirements, connection_id)
+    pip_cmd = _generate_pip_install_cmd(venv_directory, requirements, connection_id)
     if pip_cmd:
         execute_in_subprocess(pip_cmd)
 

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -47,17 +47,17 @@ def _generate_pip_install_cmd(tmp_dir: str,
     if connection_id:
         con: Connection = BaseHook.get_connection(connection_id)
         user = con.login
-        schema = con.schema or 'http'
+        schema = con.schema or 'https'
         password = con.get_password()
-        port = con.port
+        port = con.port or 8080
         host = con.host
+        host_suffix = con.extra_dejson.get('host_suffix', 'repository/python/simple')
         if user:
-            index_url = f"{schema}://{user}:{password}@{host}:{port}/repository/python/simple"
+            index_url = os.path.join(f"{schema}://{user}:{password}@{host}:{port}", host_suffix)
         else:
-            index_url = f"{schema}://{host}:{port}/repository/python/simple"
+            index_url = os.path.join(f"{schema}://{host}:{port}", host_suffix)
         private_cmd = [f'{tmp_dir}/bin/pip',
                        'install',
-                       f'--trusted-host', host,
                        f'--index-url', index_url,
                        f'--extra-index-url', 'https://pypi.org/simple'
                        ]

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -43,10 +43,12 @@ def _generate_pip_install_cmd(tmp_dir: str,
     if not requirements:
         return None
 
-    private_cmd = [f'{tmp_dir}/bin/pip', 'install']
-    public_cmd = [f'{tmp_dir}/bin/pip', 'install' f'--trusted-host {repository_url} -i {index_url}']
+    public_cmd = [f'{tmp_dir}/bin/pip', 'install']
+    private_cmd = [f'{tmp_dir}/bin/pip',
+                   'install',
+                   f'--trusted-host', f'{repository_url}',
+                   f'--extra-index-url',  f'{index_url}']
     if repository_url:
-        print(private_cmd + requirements)
         return private_cmd + requirements
     return public_cmd + requirements
 

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -52,13 +52,15 @@ def _generate_pip_install_cmd(tmp_dir: str,
         port = con.port
         host = con.host
         if user:
-            extra_index_url = f"{schema}://{user}:{password}@{host}:{port}/repository/python/simple"
+            index_url = f"{schema}://{user}:{password}@{host}:{port}/repository/python/simple"
         else:
-            extra_index_url = f"{schema}://{host}:{port}/repository/python/simple"
+            index_url = f"{schema}://{host}:{port}/repository/python/simple"
         private_cmd = [f'{tmp_dir}/bin/pip',
                        'install',
                        f'--trusted-host', host,
-                       f'--extra-index-url', extra_index_url]
+                       f'--index-url', index_url,
+                       f'--extra-index-url', 'https://pypi.org/simple'
+                       ]
         return private_cmd + requirements
 
     public_cmd = [f'{tmp_dir}/bin/pip', 'install']
@@ -112,7 +114,8 @@ def prepare_virtualenv(
     :type system_site_packages: bool
     :param requirements: List of additional python packages
     :type requirements: List[str]
-    :param connection_id: The private repository in case there are private packages to install.
+    :param connection_id: The private repository connection_id
+     case there are private packages to install.
     :type connection_id: str
     :rtype: str
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -160,6 +160,7 @@ install_requires =
     typing-extensions>=3.7.4;python_version<"3.8"
     unicodecsv>=0.14.1
     werkzeug~=1.0, >=1.0.1
+    pypiserver~=1.4
 
 [options.packages.find]
 include =

--- a/setup.cfg
+++ b/setup.cfg
@@ -160,7 +160,6 @@ install_requires =
     typing-extensions>=3.7.4;python_version<"3.8"
     unicodecsv>=0.14.1
     werkzeug~=1.0, >=1.0.1
-    pypiserver~=1.4
 
 [options.packages.find]
 include =

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -825,6 +825,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
     def test_private_repo_requirements(self):
 
         with create_session() as session:
+            self._clean_stop_pypi_server()
             self._initiate_pypi_server()
             session.execute("delete from connection where conn_id = 'private_repo_test_conn';")
             cn = Connection("private_repo_test_conn",

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -18,6 +18,7 @@
 import copy
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -834,6 +835,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             index_url="http://localhost:8080/repository/python/simple",
             system_site_packages=False,
         )
+        self._clean_stop_pypi_server()
 
     def test_range_requirements(self):
         def f():
@@ -883,6 +885,15 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             time.sleep(1.5)
         except Exception as e:
             pass
+
+    @staticmethod
+    def _clean_stop_pypi_server(port: bytes = b"8080"):
+        popen = subprocess.Popen(['netstat', '-lpn'], shell=False, stdout=subprocess.PIPE)
+        (data, err) = popen.communicate()
+        process = [process for process in data.split(b'\n') if port in process]
+        if process:
+            pid = process[0].split(b"LISTEN")[1].strip().split(b"/")[0]
+            subprocess.Popen(['kill', '-9', pid])
 
     @staticmethod
     def _invert_python_major_version():

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -843,8 +843,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
                        "private_pypi",
                        host="localhost",
                        schema="http",
-                       extra=json.dumps({"pypi_as_fallback": True,
-                                         "path": "/repository/python/simple"}),
+                       extra={"pypi_as_fallback": True, "path": "/repository/python/simple"},
                        port=8282)
 
         os.environ[f"AIRFLOW_CONN_{c.conn_id.upper()}"] = f'{c.get_uri()}'

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -829,7 +829,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         self._initiate_pypi_server()
         self._run_as_operator(
             f,
-            requirements=['funcsigs', 'flask'],
+            requirements=['flask', 'funcsigs'],
             repository_url="localhost",
             index_url="http://localhost:8080/repository/python/simple",
             system_site_packages=False,
@@ -882,7 +882,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
             subprocess.Popen(['pypi-server'])
             time.sleep(1.5)
         except Exception as e:
-            raise e
+            pass
 
     @staticmethod
     def _invert_python_major_version():


### PR DESCRIPTION
Currently PythonVritualenvOperator support requirements as a list of strings which indicates packages to install.
The current method is very naive and allow strict `pip install` and this doesn't allowed for example install packages from
private pypi repository. 

The code below, allow install packages from private repo as well from pypi server using fallback if not existing in the private repo.

