### PR TITLE
[Airflow 16934] fix delete task_instance also deleted dag_run too when sla

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -456,9 +456,6 @@ class DagFileProcessor(LoggingMixin):
                 if ti.task_id in dag.task_ids:
                     ti.task = dag.get_task(ti.task_id)
                     blocking_tis.append(ti)
-                else:
-                    session.delete(ti)
-                    session.commit()
 
             task_list = "\n".join(sla.task_id + ' on ' + sla.execution_date.isoformat() for sla in slas)
             blocking_task_list = "\n".join(

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -456,6 +456,14 @@ class DagFileProcessor(LoggingMixin):
                 if ti.task_id in dag.task_ids:
                     ti.task = dag.get_task(ti.task_id)
                     blocking_tis.append(ti)
+                else:
+                    # avoid use session.delete(ti), it will delete dag_run too
+                    session.query(TI).filter(
+                        TI.dag_id == ti.dag_id,
+                        TI.task_id == ti.task_id,
+                        TI.execution_date == ti.execution_date,
+                    ).delete()
+                    session.commit()
 
             task_list = "\n".join(sla.task_id + ' on ' + sla.execution_date.isoformat() for sla in slas)
             blocking_task_list = "\n".join(


### PR DESCRIPTION
delete(ti) will also delete the dag_run(do by the sqla relationship)

#16934 

It's not sla check duty to delete the missed task_instance
