### PR TITLE
Fixed to check number key from jenkins response

### DIFF
--- a/airflow/providers/jenkins/operators/jenkins_job_trigger.py
+++ b/airflow/providers/jenkins/operators/jenkins_job_trigger.py
@@ -168,7 +168,7 @@ class JenkinsJobTriggerOperator(BaseOperator):
             )
             if location_answer is not None:
                 json_response = json.loads(location_answer['body'])
-                if 'executable' in json_response:
+                if 'executable' in json_response and 'number' in json_response['executable']:
                     build_number = json_response['executable']['number']
                     self.log.info('Job executed on Jenkins side with the build number %s', build_number)
                     return build_number


### PR DESCRIPTION
I have a case where the number key is missing in the jenkins response.
The work in Jenkins is working fine.
The cause seems to be that jenkins did not pass the job number information, but the airflow side also checks it, and when there is no number key, it needs to be modified to ride the retry logic.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
