### PR TITLE
Change pod id notation back to hyphen

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -453,7 +453,7 @@ class PodGenerator:
         # Strip trailing '-' and '.' as they can't be followed by '.'
         trimmed_pod_id = pod_id[:MAX_LABEL_LEN].rstrip('-.')
 
-        safe_pod_id = f"{trimmed_pod_id}.{safe_uuid}"
+        safe_pod_id = f"{trimmed_pod_id}-{safe_uuid}"
         return safe_pod_id
 
 


### PR DESCRIPTION
closes: #16611

Affects - KubernetesPodOperator's pod id naming notation

Fix for various issues related to container's IP self-resolution in Kubernetes. Period is typically interpreted as current container is having some level domain instead of dummy hostname that cannot be resolved from outside.
Previously, the container already had hyphen in name, but now period caused regressions.

See #16611 for more clarification and exact line references.