### PR TITLE
Updating breeze static-check command for running all tests on the last commit

### DIFF
--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -350,7 +350,7 @@ Run all tests for last commit :
 
 .. code-block:: bash
 
-     ./breeze static-check all -- --ref-from HEAD^ --ref-to HEAD
+     ./breeze static-check all -- --from-ref HEAD^ --to-ref HEAD
 
 
 The ``license`` check is run via a separate script and a separate Docker image containing the


### PR DESCRIPTION
The previous command read `./breeze static-check all -- --ref-from HEAD^ --ref-to HEAD`, however the `options` used should be `--from-ref` and `--to-ref`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
