### PR TITLE
Fix release guide when copying artifacts

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -555,9 +555,9 @@ cd "${VERSION}"
 
 # Move the artifacts to svn folder & commit
 for f in ${AIRFLOW_DEV_SVN}/$RC/*; do
-    svn cp "$f" "${$(basename $f)/rc?/}"
+    svn cp "$f" "${$(basename $f)/}"
     # Those will be used to upload to PyPI
-    cp "$f" "${AIRFLOW_SOURCES}/dist/${$(basename $f)/rc?/}"
+    cp "$f" "${AIRFLOW_SOURCES}/dist/${$(basename $f)/}"
 done
 svn commit -m "Release Airflow ${VERSION} from ${RC}"
 


### PR DESCRIPTION
When copying artifacts from dev svn repo to release repo:

Before:

```
❯ for f in ${AIRFLOW_DEV_SVN}/$RC/*; do
echo "${$(basename $f)/rc?/}"
done
apache-airflow-2.1.2-sou.tar.gz
apache-airflow-2.1.2-sou.tar.gz.asc
apache-airflow-2.1.2-sou.tar.gz.sha512
apache-airflow-2.1.2.tar.gz
apache-airflow-2.1.2.tar.gz.asc
apache-airflow-2.1.2.tar.gz.sha512
apache_airflow-2.1.2-py3-none-any.whl
apache_airflow-2.1.2-py3-none-any.whl.asc
apache_airflow-2.1.2-py3-none-any.whl.sha512
```

After:

```
❯ for f in ${AIRFLOW_DEV_SVN}/$RC/*; do
echo "${$(basename $f)/}"
done
apache-airflow-2.1.2-source.tar.gz
apache-airflow-2.1.2-source.tar.gz.asc
apache-airflow-2.1.2-source.tar.gz.sha512
apache-airflow-2.1.2.tar.gz
apache-airflow-2.1.2.tar.gz.asc
apache-airflow-2.1.2.tar.gz.sha512
apache_airflow-2.1.2-py3-none-any.whl
apache_airflow-2.1.2-py3-none-any.whl.asc
apache_airflow-2.1.2-py3-none-any.whl.sha512
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
