### PR TITLE
Fix `retry_exponential_backoff` divide by zero error when retry delay is zero

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1066,6 +1066,14 @@ class TaskInstance(Base, LoggingMixin):
             # we must round up prior to converting to an int, otherwise a divide by zero error
             # will occur in the modded_hash calculation.
             min_backoff = int(math.ceil(delay.total_seconds() * (2 ** (self.try_number - 2))))
+
+            # In the case when delay.total_seconds() is 0, min_backoff will not be rounded up to 1.
+            # To address this, we impose a lower bound of 1 on min_backoff. This effectively makes
+            # the ceiling function unnecessary, but the ceiling function was retained to avoid
+            # introducing a breaking change.
+            if min_backoff < 1:
+                min_backoff = 1
+
             # deterministic per task instance
             ti_hash = int(
                 hashlib.sha1(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -621,13 +621,14 @@ class TestTaskInstance:
         date = ti.next_retry_datetime()
         assert date == ti.end_date + max_delay
 
-    def test_next_retry_datetime_short_intervals(self, dag_maker):
-        delay = datetime.timedelta(seconds=1)
+    @pytest.mark.parametrize("seconds", [0, 0.5, 1])
+    def test_next_retry_datetime_short_or_zero_intervals(self, dag_maker, seconds):
+        delay = datetime.timedelta(seconds=seconds)
         max_delay = datetime.timedelta(minutes=60)
 
         with dag_maker(dag_id='fail_dag'):
             task = BashOperator(
-                task_id='task_with_exp_backoff_and_short_time_interval',
+                task_id='task_with_exp_backoff_and_short_or_zero_time_interval',
                 bash_command='exit 1',
                 retries=3,
                 retry_delay=delay,

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -639,9 +639,7 @@ class TestTaskInstance:
         ti.end_date = pendulum.instance(timezone.utcnow())
 
         date = ti.next_retry_datetime()
-        # between 1 * 2^0.5 and 1 * 2^1 (15 and 30)
-        period = ti.end_date.add(seconds=15) - ti.end_date.add(seconds=1)
-        assert date in period
+        assert date == ti.end_date + datetime.timedelta(seconds=1)
 
     def test_reschedule_handling(self, dag_maker):
         """


### PR DESCRIPTION
When `retry_delay` is zero, the `retry_exponential_backoff` algorithm has a divide-by-zero error in the `modded_hash` calculation, which causes the scheduler to crash.

https://github.com/apache/airflow/commit/d1dceff69ab15f9ce28ea04215a693b81c8a93a2 attempted to address the divide-by-zero error by adding a ceiling function, but it doesn't account for this particular edge case. Using a lower bound instead would be a better implementation.

Fixes #17005.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
