### PR TITLE
FIX changelog provider docker 2.0.0

### DIFF
--- a/airflow/providers/docker/CHANGELOG.rst
+++ b/airflow/providers/docker/CHANGELOG.rst
@@ -40,6 +40,8 @@ The ``volumes`` parameter in
 was replaced by the ``mounts`` parameter, which uses the newer
 `mount syntax <https://docs.docker.com/storage/>`__ instead of ``--bind``.
 
+.. warning:: The DockerOperator mount the TemporaryDirectory 'airflowtmp/...' in all case, making fail any docker in docker usage
+
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):
    * ``Updated documentation for June 2021 provider release (#16294)``


### PR DESCRIPTION
Since there is a regression in version 2.0.0 , the changelog that is directly show by the documentation ( and so the airflow website ) should let know people about.

this PR will add an option to disable the mount of the temporary directory -> https://github.com/apache/airflow/pull/16932