### PR TITLE
Drop support for Airflow 1.10 in entrypoint_prod.sh and improve MSSQL compatibility

### DIFF
--- a/docs/docker-stack/entrypoint.rst
+++ b/docs/docker-stack/entrypoint.rst
@@ -94,31 +94,13 @@ You can read more about it in the "Support arbitrary user ids" chapter in the
 Waits for Airflow DB connection
 -------------------------------
 
-In case Postgres or MySQL DB is used, the entrypoint will wait until the airflow DB connection becomes
-available. This happens always when you use the default entrypoint.
+The entrypoint is waiting for a connection to the database independent of the database engine. This allows us to increase
+the stability of the environment.
 
-The script detects backend type depending on the URL schema and assigns default port numbers if not specified
-in the URL. Then it loops until the connection to the host/port specified can be established
+Waiting for connection involves executing ``airflow db check`` command, which means that a ``select 1 as is_alive;`` statement
+is executed. Then it loops until the the command will be successful.
 It tries :envvar:`CONNECTION_CHECK_MAX_COUNT` times and sleeps :envvar:`CONNECTION_CHECK_SLEEP_TIME` between checks
 To disable check, set ``CONNECTION_CHECK_MAX_COUNT=0``.
-
-Supported schemes:
-
-* ``postgres://`` - default port 5432
-* ``mysql://``    - default port 3306
-* ``sqlite://``
-
-In case of SQLite backend, there is no connection to establish and waiting is skipped.
-
-For older than Airflow 1.10.14, waiting for connection involves checking if a matching port is open.
-The host information is derived from the variables :envvar:`AIRFLOW__CORE__SQL_ALCHEMY_CONN` and
-:envvar:`AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD`. If :envvar:`AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD` variable
-is passed to the container, it is evaluated as a command to execute and result of this evaluation is used
-as :envvar:`AIRFLOW__CORE__SQL_ALCHEMY_CONN`. The :envvar:`AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD` variable
-takes precedence over the :envvar:`AIRFLOW__CORE__SQL_ALCHEMY_CONN` variable.
-
-For newer versions, the ``airflow db check`` command is used, which means that a ``select 1 as is_alive;`` query
-is executed. This also means that you can keep your password in secret backend.
 
 Waits for celery broker connection
 ----------------------------------

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -153,13 +153,6 @@ function create_www_user() {
        --lastname "${_AIRFLOW_WWW_USER_LASTNME="Admin"}" \
        --email "${_AIRFLOW_WWW_USER_EMAIL="airflowadmin@example.com"}" \
        --role "${_AIRFLOW_WWW_USER_ROLE="Admin"}" \
-       --password "${local_password}" ||
-    airflow create_user \
-       --username "${_AIRFLOW_WWW_USER_USERNAME="admin"}" \
-       --firstname "${_AIRFLOW_WWW_USER_FIRSTNAME="Airflow"}" \
-       --lastname "${_AIRFLOW_WWW_USER_LASTNME="Admin"}" \
-       --email "${_AIRFLOW_WWW_USER_EMAIL="airflowadmin@example.com"}" \
-       --role "${_AIRFLOW_WWW_USER_ROLE="Admin"}" \
        --password "${local_password}" || true
 }
 
@@ -193,30 +186,13 @@ function set_pythonpath_for_root_user() {
 }
 
 function wait_for_airflow_db() {
-    # Check if Airflow has a command to check the connection to the database.
-    if ! airflow db check --help >/dev/null 2>&1; then
-        run_check_with_retries "airflow db check"
-    else
-        # Verify connections to the Airflow DB by guessing the database address based on environment variables,
-        # then uses netcat to check that the host is reachable.
-        # This is only used by Airflow 1.10+ as there are no built-in commands to check the db connection.
-        local connection_url
-        if [[ -n "${AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD=}" ]]; then
-            connection_url="$(eval "${AIRFLOW__CORE__SQL_ALCHEMY_CONN_CMD}")"
-        else
-            # if no DB configured - use sqlite db by default
-            connection_url="${AIRFLOW__CORE__SQL_ALCHEMY_CONN:="sqlite:///${AIRFLOW_HOME}/airflow.db"}"
-        fi
-        # SQLite doesn't require a remote connection, so we don't have to wait.
-        if [[ ${connection_url} != sqlite* ]]; then
-            wait_for_connection "${connection_url}"
-        fi
-    fi
+    # Wait for the command to run successfully to validate the database connection.
+    run_check_with_retries "airflow db check"
 }
 
 function upgrade_db() {
     # Runs airflow db upgrade
-    airflow db upgrade || airflow upgradedb || true
+    airflow upgradedb || true
 }
 
 function wait_for_celery_backend() {
@@ -232,8 +208,8 @@ function wait_for_celery_backend() {
 }
 
 function exec_to_bash_or_python_command_if_specified() {
-    # If one of the commands: 'airflow', 'bash', 'python' is used, either run appropriate
-    # command with exec or update the command line parameters
+    # If one of the commands: 'bash', 'python' is used, either run appropriate
+    # command with exec
     if [[ ${AIRFLOW_COMMAND} == "bash" ]]; then
        shift
        exec "/bin/bash" "${@}"

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -192,7 +192,7 @@ function wait_for_airflow_db() {
 
 function upgrade_db() {
     # Runs airflow db upgrade
-    airflow upgradedb || true
+    airflow db upgrade || true
 }
 
 function wait_for_celery_backend() {


### PR DESCRIPTION
The 1.10 series reached end of life, so the Dockerfile on main can drop support it.

Additionally, this solves one problem that the user reported. We used CLI check for Airflow 1.10 to check the database connection, and for Airflow 2.0 legacy check, which only supports some database engines.  However, we should do it the other way around. For Airflow 2.0, we should use a CLI check. 

If we use CLI Check, we have MSSQL and any other backend support automatically.

For details, see: https://github.com/apache/airflow/pull/16857
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
