### PR TITLE
Move the DagRun-TaskInstance relationship to TaskInstance

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING, Any, Iterable, List, NamedTuple, Optional, Tup
 from sqlalchemy import Boolean, Column, Index, Integer, PickleType, String, UniqueConstraint, and_, func, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import backref, relationship, synonym
+from sqlalchemy.orm import synonym
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import expression
 
@@ -87,13 +87,6 @@ class DagRun(Base, LoggingMixin):
         UniqueConstraint('dag_id', 'execution_date'),
         UniqueConstraint('dag_id', 'run_id'),
         Index('idx_last_scheduling_decision', last_scheduling_decision),
-    )
-
-    task_instances = relationship(
-        TI,
-        primaryjoin=and_(TI.dag_id == dag_id, TI.execution_date == execution_date),  # type: ignore
-        foreign_keys=(dag_id, execution_date),
-        backref=backref('dag_run', uselist=False),
     )
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -318,6 +318,16 @@ class TaskInstance(Base, LoggingMixin):
     # If adding new fields here then remember to add them to
     # refresh_from_db() or they won't display in the UI correctly
 
+    dag_run = relationship(
+        "DagRun",
+        primaryjoin="""and_(
+            TaskInstance.dag_id == DagRun.dag_id,"
+            TaskInstance.execution_date == DagRun.execution_date,
+        )""",
+        foreign_keys=(dag_id, execution_date),
+        backref="task_insntances",
+    )
+
     __table_args__ = (
         Index('ti_dag_state', dag_id, state),
         Index('ti_dag_date', dag_id, execution_date),
@@ -2142,7 +2152,5 @@ globals()['kcah_acitats'[::-1].upper()] = False
 if STATICA_HACK:  # pragma: no cover
 
     from airflow.job.base_job import BaseJob
-    from airflow.models.dagrun import DagRun
 
-    TaskInstance.dag_run = relationship(DagRun)
     TaskInstance.queued_by_job = relationship(BaseJob)


### PR DESCRIPTION
@ashb I think this is what’s needed?

Fix #16896, close #16960.

`DagRun.task_instances` is not actually used in Airflow anywhere, so the static check hack is not needed for the new relationship’s backref. But the backref itself is kept for compatibility.

String reference is used instead to avoid circular imports.

Not sure how this should be tested.