### PR TITLE
Core: Enable the use of __init_subclass__ in subclasses of BaseOperator

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -191,8 +191,8 @@ class BaseOperatorMeta(abc.ABCMeta):
 
         return cast(T, apply_defaults)
 
-    def __new__(cls, name, bases, namespace):
-        new_cls = super().__new__(cls, name, bases, namespace)
+    def __new__(cls, name, bases, namespace, **kwargs):
+        new_cls = super().__new__(cls, name, bases, namespace, **kwargs)
         new_cls.__init__ = cls._apply_defaults(new_cls.__init__)
         return new_cls
 


### PR DESCRIPTION
This fixes a regression in 2.1 where subclasses of BaseOperator could no
longer use `__init_subclass__` to allow class instantiation time
customization.

Related BPO: https://bugs.python.org/issue29581

closes: https://github.com/apache/airflow/issues/17014