### PR TITLE
Add autoscaling subcluster support and remove defaults

### DIFF
--- a/airflow/providers/yandex/example_dags/example_yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/example_dags/example_yandexcloud_dataproc.py
@@ -50,6 +50,8 @@ with DAG(
         zone=AVAILABILITY_ZONE_ID,
         connection_id=CONNECTION_ID,
         s3_bucket=S3_BUCKET_NAME_FOR_JOB_LOGS,
+        computenode_count=1,
+        computenode_max_hosts_count=5,
     )
 
     create_hive_query = DataprocCreateHiveJobOperator(

--- a/airflow/providers/yandex/hooks/yandex.py
+++ b/airflow/providers/yandex/hooks/yandex.py
@@ -29,8 +29,8 @@ class YandexCloudBaseHook(BaseHook):
     """
     A base hook for Yandex.Cloud related tasks.
 
-    :param connection_id: The connection ID to use when fetching connection info.
-    :type connection_id: str
+    :param yandex_conn_id: The connection ID to use when fetching connection info.
+    :type yandex_conn_id: str
     """
 
     conn_name_attr = 'yandex_conn_id'

--- a/airflow/providers/yandex/hooks/yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/hooks/yandexcloud_dataproc.py
@@ -23,8 +23,8 @@ class DataprocHook(YandexCloudBaseHook):
     """
     A base hook for Yandex.Cloud Data Proc.
 
-    :param connection_id: The connection ID to use when fetching connection info.
-    :type connection_id: str
+    :param yandex_conn_id: The connection ID to use when fetching connection info.
+    :type yandex_conn_id: str
     """
 
     def __init__(self, *args, **kwargs) -> None:

--- a/airflow/providers/yandex/operators/yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/operators/yandexcloud_dataproc.py
@@ -74,19 +74,21 @@ class DataprocCreateClusterOperator(BaseOperator):
     :type computenode_max_count: int
     :param computenode_max_count: Maximum number of nodes of compute autoscaling subcluster.
     :param computenode_warmup_duration: The warmup time of the instance in seconds. During this time,
-                            traffic is sent to the instance, but instance metrics are not collected. In seconds.
+                                        traffic is sent to the instance,
+                                        but instance metrics are not collected. In seconds.
     :type computenode_warmup_duration: int
-    :param computenode_stabilization_duration: Minimum amount of time in seconds allotted for monitoring before
+    :param computenode_stabilization_duration: Minimum amount of time in seconds for monitoring before
                                    Instance Groups can reduce the number of instances in the group.
-                                   During this time, the group size doesn't decrease, even if the new metric values
-                                   indicate that it should. In seconds.
+                                   During this time, the group size doesn't decrease,
+                                   even if the new metric values indicate that it should. In seconds.
     :type computenode_stabilization_duration: int
     :param computenode_preemptible: Preemptible instances are stopped at least once every 24 hours,
                         and can be stopped at any time if their resources are needed by Compute.
     :type computenode_preemptible: bool
     :param computenode_cpu_utilization_target: Defines an autoscaling rule
                                    based on the average CPU utilization of the instance group.
-                                   in percents. 10-100. By default is not set and default autoscaling strategy is used.
+                                   in percents. 10-100.
+                                   By default is not set and default autoscaling strategy is used.
     :type computenode_cpu_utilization_target: int
     :param computenode_decommission_timeout: Timeout to gracefully decommission nodes during downscaling.
                                              In seconds.
@@ -130,7 +132,7 @@ class DataprocCreateClusterOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.folder_id = folder_id
-        self.connection_id = connection_id
+        self.yandex_conn_id = connection_id
         self.cluster_name = cluster_name
         self.cluster_description = cluster_description
         self.cluster_image_version = cluster_image_version
@@ -163,7 +165,7 @@ class DataprocCreateClusterOperator(BaseOperator):
 
     def execute(self, context) -> None:
         self.hook = DataprocHook(
-            connection_id=self.connection_id,
+            yandex_conn_id=self.yandex_conn_id,
         )
         operation_result = self.hook.client.create_cluster(
             folder_id=self.folder_id,
@@ -196,7 +198,7 @@ class DataprocCreateClusterOperator(BaseOperator):
             computenode_decommission_timeout=self.computenode_decommission_timeout,
         )
         context['task_instance'].xcom_push(key='cluster_id', value=operation_result.response.id)
-        context['task_instance'].xcom_push(key='yandexcloud_connection_id', value=self.connection_id)
+        context['task_instance'].xcom_push(key='yandexcloud_connection_id', value=self.yandex_conn_id)
 
 
 class DataprocDeleteClusterOperator(BaseOperator):
@@ -214,17 +216,17 @@ class DataprocDeleteClusterOperator(BaseOperator):
         self, *, connection_id: Optional[str] = None, cluster_id: Optional[str] = None, **kwargs
     ) -> None:
         super().__init__(**kwargs)
-        self.connection_id = connection_id
+        self.yandex_conn_id = connection_id
         self.cluster_id = cluster_id
         self.hook: Optional[DataprocHook] = None
 
     def execute(self, context) -> None:
         cluster_id = self.cluster_id or context['task_instance'].xcom_pull(key='cluster_id')
-        connection_id = self.connection_id or context['task_instance'].xcom_pull(
+        yandex_conn_id = self.yandex_conn_id or context['task_instance'].xcom_pull(
             key='yandexcloud_connection_id'
         )
         self.hook = DataprocHook(
-            connection_id=connection_id,
+            yandex_conn_id=yandex_conn_id,
         )
         self.hook.client.delete_cluster(cluster_id)
 
@@ -279,11 +281,11 @@ class DataprocCreateHiveJobOperator(BaseOperator):
 
     def execute(self, context) -> None:
         cluster_id = self.cluster_id or context['task_instance'].xcom_pull(key='cluster_id')
-        connection_id = self.connection_id or context['task_instance'].xcom_pull(
+        yandex_conn_id = self.connection_id or context['task_instance'].xcom_pull(
             key='yandexcloud_connection_id'
         )
         self.hook = DataprocHook(
-            connection_id=connection_id,
+            yandex_conn_id=yandex_conn_id,
         )
         self.hook.client.create_hive_job(
             query=self.query,
@@ -355,11 +357,11 @@ class DataprocCreateMapReduceJobOperator(BaseOperator):
 
     def execute(self, context) -> None:
         cluster_id = self.cluster_id or context['task_instance'].xcom_pull(key='cluster_id')
-        connection_id = self.connection_id or context['task_instance'].xcom_pull(
+        yandex_conn_id = self.connection_id or context['task_instance'].xcom_pull(
             key='yandexcloud_connection_id'
         )
         self.hook = DataprocHook(
-            connection_id=connection_id,
+            yandex_conn_id=yandex_conn_id,
         )
         self.hook.client.create_mapreduce_job(
             main_class=self.main_class,
@@ -432,11 +434,11 @@ class DataprocCreateSparkJobOperator(BaseOperator):
 
     def execute(self, context) -> None:
         cluster_id = self.cluster_id or context['task_instance'].xcom_pull(key='cluster_id')
-        connection_id = self.connection_id or context['task_instance'].xcom_pull(
+        yandex_conn_id = self.connection_id or context['task_instance'].xcom_pull(
             key='yandexcloud_connection_id'
         )
         self.hook = DataprocHook(
-            connection_id=connection_id,
+            yandex_conn_id=yandex_conn_id,
         )
         self.hook.client.create_spark_job(
             main_class=self.main_class,
@@ -509,11 +511,11 @@ class DataprocCreatePysparkJobOperator(BaseOperator):
 
     def execute(self, context) -> None:
         cluster_id = self.cluster_id or context['task_instance'].xcom_pull(key='cluster_id')
-        connection_id = self.connection_id or context['task_instance'].xcom_pull(
+        yandex_conn_id = self.connection_id or context['task_instance'].xcom_pull(
             key='yandexcloud_connection_id'
         )
         self.hook = DataprocHook(
-            connection_id=connection_id,
+            yandex_conn_id=yandex_conn_id,
         )
         self.hook.client.create_pyspark_job(
             main_python_file_uri=self.main_python_file_uri,

--- a/airflow/providers/yandex/operators/yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/operators/yandexcloud_dataproc.py
@@ -126,7 +126,6 @@ class DataprocCreateClusterOperator(BaseOperator):
         computenode_preemptible: bool = False,
         computenode_cpu_utilization_target: Optional[int] = None,
         computenode_decommission_timeout: Optional[int] = None,
-
         connection_id: Optional[str] = None,
         **kwargs,
     ) -> None:

--- a/airflow/providers/yandex/operators/yandexcloud_dataproc.py
+++ b/airflow/providers/yandex/operators/yandexcloud_dataproc.py
@@ -71,6 +71,26 @@ class DataprocCreateClusterOperator(BaseOperator):
     :type computenode_disk_type: str
     :param connection_id: ID of the Yandex.Cloud Airflow connection.
     :type connection_id: Optional[str]
+    :type computenode_max_count: int
+    :param computenode_max_count: Maximum number of nodes of compute autoscaling subcluster.
+    :param computenode_warmup_duration: The warmup time of the instance in seconds. During this time,
+                            traffic is sent to the instance, but instance metrics are not collected. In seconds.
+    :type computenode_warmup_duration: int
+    :param computenode_stabilization_duration: Minimum amount of time in seconds allotted for monitoring before
+                                   Instance Groups can reduce the number of instances in the group.
+                                   During this time, the group size doesn't decrease, even if the new metric values
+                                   indicate that it should. In seconds.
+    :type computenode_stabilization_duration: int
+    :param computenode_preemptible: Preemptible instances are stopped at least once every 24 hours,
+                        and can be stopped at any time if their resources are needed by Compute.
+    :type computenode_preemptible: bool
+    :param computenode_cpu_utilization_target: Defines an autoscaling rule
+                                   based on the average CPU utilization of the instance group.
+                                   in percents. 10-100. By default is not set and default autoscaling strategy is used.
+    :type computenode_cpu_utilization_target: int
+    :param computenode_decommission_timeout: Timeout to gracefully decommission nodes during downscaling.
+                                             In seconds.
+    :type computenode_decommission_timeout: int
     """
 
     def __init__(
@@ -78,25 +98,33 @@ class DataprocCreateClusterOperator(BaseOperator):
         *,
         folder_id: Optional[str] = None,
         cluster_name: Optional[str] = None,
-        cluster_description: str = '',
-        cluster_image_version: str = '1.1',
+        cluster_description: Optional[str] = '',
+        cluster_image_version: Optional[str] = None,
         ssh_public_keys: Optional[Union[str, Iterable[str]]] = None,
         subnet_id: Optional[str] = None,
         services: Iterable[str] = ('HDFS', 'YARN', 'MAPREDUCE', 'HIVE', 'SPARK'),
         s3_bucket: Optional[str] = None,
         zone: str = 'ru-central1-b',
         service_account_id: Optional[str] = None,
-        masternode_resource_preset: str = 's2.small',
-        masternode_disk_size: int = 15,
-        masternode_disk_type: str = 'network-ssd',
-        datanode_resource_preset: str = 's2.small',
-        datanode_disk_size: int = 15,
-        datanode_disk_type: str = 'network-ssd',
-        datanode_count: int = 2,
-        computenode_resource_preset: str = 's2.small',
-        computenode_disk_size: int = 15,
-        computenode_disk_type: str = 'network-ssd',
+        masternode_resource_preset: Optional[str] = None,
+        masternode_disk_size: Optional[int] = None,
+        masternode_disk_type: Optional[str] = None,
+        datanode_resource_preset: Optional[str] = None,
+        datanode_disk_size: Optional[int] = None,
+        datanode_disk_type: Optional[str] = None,
+        datanode_count: int = 1,
+        computenode_resource_preset: Optional[str] = None,
+        computenode_disk_size: Optional[int] = None,
+        computenode_disk_type: Optional[str] = None,
         computenode_count: int = 0,
+        computenode_max_hosts_count: Optional[int] = None,
+        computenode_measurement_duration: Optional[int] = None,
+        computenode_warmup_duration: Optional[int] = None,
+        computenode_stabilization_duration: Optional[int] = None,
+        computenode_preemptible: bool = False,
+        computenode_cpu_utilization_target: Optional[int] = None,
+        computenode_decommission_timeout: Optional[int] = None,
+
         connection_id: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -123,6 +151,14 @@ class DataprocCreateClusterOperator(BaseOperator):
         self.computenode_disk_size = computenode_disk_size
         self.computenode_disk_type = computenode_disk_type
         self.computenode_count = computenode_count
+        self.computenode_max_hosts_count = computenode_max_hosts_count
+        self.computenode_measurement_duration = computenode_measurement_duration
+        self.computenode_warmup_duration = computenode_warmup_duration
+        self.computenode_stabilization_duration = computenode_stabilization_duration
+        self.computenode_preemptible = computenode_preemptible
+        self.computenode_cpu_utilization_target = computenode_cpu_utilization_target
+        self.computenode_decommission_timeout = computenode_decommission_timeout
+
         self.hook: Optional[DataprocHook] = None
 
     def execute(self, context) -> None:
@@ -151,6 +187,13 @@ class DataprocCreateClusterOperator(BaseOperator):
             computenode_disk_size=self.computenode_disk_size,
             computenode_disk_type=self.computenode_disk_type,
             computenode_count=self.computenode_count,
+            computenode_max_hosts_count=self.computenode_max_hosts_count,
+            computenode_measurement_duration=self.computenode_measurement_duration,
+            computenode_warmup_duration=self.computenode_warmup_duration,
+            computenode_stabilization_duration=self.computenode_stabilization_duration,
+            computenode_preemptible=self.computenode_preemptible,
+            computenode_cpu_utilization_target=self.computenode_cpu_utilization_target,
+            computenode_decommission_timeout=self.computenode_decommission_timeout,
         )
         context['task_instance'].xcom_push(key='cluster_id', value=operation_result.response.id)
         context['task_instance'].xcom_push(key='yandexcloud_connection_id', value=self.connection_id)

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1227,6 +1227,7 @@ stringified
 subchart
 subclasses
 subclassing
+subcluster
 subcommand
 subcommands
 subdag
@@ -1363,6 +1364,7 @@ videointelligence
 virtualenv
 vm
 volumeMounts
+warmup
 wasb
 webProperty
 webhdfs

--- a/setup.py
+++ b/setup.py
@@ -476,7 +476,7 @@ winrm = [
     'pywinrm~=0.4',
 ]
 yandex = [
-    'yandexcloud>=0.22.0',
+    'yandexcloud>=0.97.0',
 ]
 zendesk = [
     'zdesk',

--- a/tests/providers/yandex/hooks/test_yandexcloud_dataproc.py
+++ b/tests/providers/yandex/hooks/test_yandexcloud_dataproc.py
@@ -35,7 +35,7 @@ CONNECTION_ID = 'yandexcloud_default'
 AVAILABILITY_ZONE_ID = 'ru-central1-c'
 
 CLUSTER_NAME = 'dataproc_cluster'
-CLUSTER_IMAGE_VERSION = '1.1'
+CLUSTER_IMAGE_VERSION = '1.4'
 
 # https://cloud.yandex.com/docs/resource-manager/operations/folder/get-id
 FOLDER_ID = 'my_folder_id'

--- a/tests/providers/yandex/operators/test_yandexcloud_dataproc.py
+++ b/tests/providers/yandex/operators/test_yandexcloud_dataproc.py
@@ -37,7 +37,7 @@ CONNECTION_ID = 'yandexcloud_default'
 AVAILABILITY_ZONE_ID = 'ru-central1-c'
 
 CLUSTER_NAME = 'dataproc_cluster'
-CLUSTER_IMAGE_VERSION = '1.1'
+CLUSTER_IMAGE_VERSION = '1.4'
 
 # https://cloud.yandex.com/docs/resource-manager/operations/folder/get-id
 FOLDER_ID = 'my_folder_id'
@@ -92,20 +92,27 @@ class DataprocClusterCreateOperatorTest(TestCase):
         operator.execute(context)
         create_cluster_mock.assert_called_once_with(
             cluster_description='',
-            cluster_image_version='1.1',
+            cluster_image_version='1.4',
             cluster_name=None,
             computenode_count=0,
-            computenode_disk_size=15,
-            computenode_disk_type='network-ssd',
-            computenode_resource_preset='s2.small',
-            datanode_count=2,
-            datanode_disk_size=15,
-            datanode_disk_type='network-ssd',
-            datanode_resource_preset='s2.small',
+            computenode_disk_size=None,
+            computenode_disk_type=None,
+            computenode_resource_preset=None,
+            computenode_max_hosts_count=None,
+            computenode_measurement_duration=None,
+            computenode_warmup_duration=None,
+            computenode_stabilization_duration=None,
+            computenode_preemptible=False,
+            computenode_cpu_utilization_target=None,
+            computenode_decommission_timeout=None,
+            datanode_count=1,
+            datanode_disk_size=None,
+            datanode_disk_type=None,
+            datanode_resource_preset=None,
             folder_id='my_folder_id',
-            masternode_disk_size=15,
-            masternode_disk_type='network-ssd',
-            masternode_resource_preset='s2.small',
+            masternode_disk_size=None,
+            masternode_disk_type=None,
+            masternode_resource_preset=None,
             s3_bucket='my_bucket_name',
             service_account_id=None,
             services=('HDFS', 'YARN', 'MAPREDUCE', 'HIVE', 'SPARK'),


### PR DESCRIPTION
Yandexcloud package dependency is updated.
New autoscaling feature is supported by the operator.
Default values are removed, so they can be set at the server side of the API. 
closes: #17031

I have tested the PR using the related example DAG for both airflow 2.0 and 1.10.
