### PR TITLE
Refactored waiting function for Tableau Jobs

### DIFF
--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -140,26 +140,27 @@ class TableauHook(BaseHook):
             raise ValueError(f"Resource name {resource_name} is not found.")
         return Pager(resource.get)
 
-    def get_job_status(self, job_id: str) -> Enum:
+    def get_job_status(self, job_id: str) -> TableauJobFinishCode:
         """
         Get the current state of a defined Tableau Job.
         .. see also:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
 
         :param job_id: The id of the job to check.
         :type job_id: str
-        :rtype: Enum
+        :return: An Enum that describe the Tableau job’s return code
+        :rtype: TableauJobFinishCode
         """
         return TableauJobFinishCode(int(self.server.jobs.get_by_id(job_id).finish_code))
 
-    def wait_for_state(self, job_id: str, target_state: Enum, check_interval: float) -> bool:
+    def wait_for_state(self, job_id: str, target_state: TableauJobFinishCode, check_interval: float) -> bool:
         """
         Wait until the current state of a defined Tableau Job is equal
         to target_state or different from PENDING.
 
         :param job_id: The id of the job to check.
         :type job_id: str
-        :param target_state: target state of the job
-        :type target_state: Enum
+        :param target_state: Enum that describe the Tableau job’s target state
+        :type target_state: TableauJobFinishCode
         :param check_interval: time in seconds that the job should wait in
             between each instance state checks until operation is completed
         :type check_interval: float

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -50,6 +50,7 @@ class TableauHook(BaseHook):
 
     .. seealso:: https://tableau.github.io/server-client-python/docs/
 
+
     :param site_id: The id of the site where the workbook belongs to.
         It will connect to the default site if you don't provide an id.
     :type site_id: Optional[str]
@@ -125,6 +126,7 @@ class TableauHook(BaseHook):
         """
         Get all items of the given resource.
         .. see also:: https://tableau.github.io/server-client-python/docs/page-through-results
+
         :param resource_name: The name of the resource to paginate.
             For example: jobs or workbooks.
         :type resource_name: str
@@ -141,6 +143,7 @@ class TableauHook(BaseHook):
         """
         Get the current state of a defined Tableau Job.
         .. see also:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
+
         :param job_id: The id of the job to check.
         :type job_id: str
         :rtype: Enum

--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -46,11 +46,11 @@ class TableauJobFinishCode(Enum):
 class TableauHook(BaseHook):
     """
     Connects to the Tableau Server Instance and allows to communicate with it.
+
     Can be used as a context manager: automatically authenticates the connection
     when opened and signs out when closed.
 
     .. seealso:: https://tableau.github.io/server-client-python/docs/
-
 
     :param site_id: The id of the site where the workbook belongs to.
         It will connect to the default site if you don't provide an id.

--- a/airflow/providers/tableau/operators/tableau_refresh_workbook.py
+++ b/airflow/providers/tableau/operators/tableau_refresh_workbook.py
@@ -20,7 +20,11 @@ from tableauserverclient import WorkbookItem
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
-from airflow.providers.tableau.hooks.tableau import TableauHook, TableauJobFailedException
+from airflow.providers.tableau.hooks.tableau import (
+    TableauHook,
+    TableauJobFailedException,
+    TableauJobFinishCode,
+)
 
 
 class TableauRefreshWorkbookOperator(BaseOperator):
@@ -39,6 +43,9 @@ class TableauRefreshWorkbookOperator(BaseOperator):
         containing the credentials to authenticate to the Tableau Server. Default:
         'tableau_default'.
     :type tableau_conn_id: str
+    :param check_interval: time in seconds that the job should wait in
+        between each instance state checks until operation is completed
+    :type check_interval: float
     """
 
     def __init__(
@@ -48,6 +55,7 @@ class TableauRefreshWorkbookOperator(BaseOperator):
         site_id: Optional[str] = None,
         blocking: bool = True,
         tableau_conn_id: str = 'tableau_default',
+        check_interval: float = 20,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -55,6 +63,7 @@ class TableauRefreshWorkbookOperator(BaseOperator):
         self.site_id = site_id
         self.blocking = blocking
         self.tableau_conn_id = tableau_conn_id
+        self.check_interval = check_interval
 
     def execute(self, context: dict) -> str:
         """
@@ -69,7 +78,11 @@ class TableauRefreshWorkbookOperator(BaseOperator):
 
             job_id = self._refresh_workbook(tableau_hook, workbook.id)
             if self.blocking:
-                if not tableau_hook.waiting_until_succeeded(job_id=job_id):
+                if not tableau_hook.wait_for_state(
+                    job_id=job_id,
+                    check_interval=self.check_interval,
+                    target_state=TableauJobFinishCode.SUCCESS,
+                ):
                     raise TableauJobFailedException('The Tableau Refresh Workbook Job failed!')
 
             self.log.info('Workbook %s has been successfully refreshed.', self.workbook_name)

--- a/airflow/providers/tableau/operators/tableau_refresh_workbook.py
+++ b/airflow/providers/tableau/operators/tableau_refresh_workbook.py
@@ -30,6 +30,7 @@ from airflow.providers.tableau.hooks.tableau import (
 class TableauRefreshWorkbookOperator(BaseOperator):
     """
     Refreshes a Tableau Workbook/Extract
+
     .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#workbooks
 
     :param workbook_name: The name of the workbook to refresh.
@@ -68,6 +69,7 @@ class TableauRefreshWorkbookOperator(BaseOperator):
     def execute(self, context: dict) -> str:
         """
         Executes the Tableau Extract Refresh and pushes the job id to xcom.
+
         :param context: The task context during execution.
         :type context: dict
         :return: the id of the job that executes the extract refresh

--- a/airflow/providers/tableau/sensors/tableau_job_status.py
+++ b/airflow/providers/tableau/sensors/tableau_job_status.py
@@ -27,6 +27,7 @@ from airflow.sensors.base import BaseSensorOperator
 class TableauJobStatusSensor(BaseSensorOperator):
     """
     Watches the status of a Tableau Server Job.
+
     .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
 
     :param job_id: Id of the job to watch.
@@ -56,6 +57,7 @@ class TableauJobStatusSensor(BaseSensorOperator):
     def poke(self, context: dict) -> bool:
         """
         Pokes until the job has successfully finished.
+
         :param context: The task context during execution.
         :type context: dict
         :return: True if it succeeded and False if not.

--- a/airflow/providers/tableau/sensors/tableau_job_status.py
+++ b/airflow/providers/tableau/sensors/tableau_job_status.py
@@ -16,19 +16,17 @@
 # under the License.
 from typing import Optional
 
-from airflow.exceptions import AirflowException
-from airflow.providers.tableau.hooks.tableau import TableauHook, TableauJobFinishCode
+from airflow.providers.tableau.hooks.tableau import (
+    TableauHook,
+    TableauJobFailedException,
+    TableauJobFinishCode,
+)
 from airflow.sensors.base import BaseSensorOperator
-
-
-class TableauJobFailedException(AirflowException):
-    """An exception that indicates that a Job failed to complete."""
 
 
 class TableauJobStatusSensor(BaseSensorOperator):
     """
     Watches the status of a Tableau Server Job.
-
     .. seealso:: https://tableau.github.io/server-client-python/docs/api-ref#jobs
 
     :param job_id: Id of the job to watch.
@@ -58,17 +56,16 @@ class TableauJobStatusSensor(BaseSensorOperator):
     def poke(self, context: dict) -> bool:
         """
         Pokes until the job has successfully finished.
-
         :param context: The task context during execution.
         :type context: dict
         :return: True if it succeeded and False if not.
         :rtype: bool
         """
         with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
-            finish_code = TableauJobFinishCode(
-                int(tableau_hook.server.jobs.get_by_id(self.job_id).finish_code)
-            )
+            finish_code = tableau_hook.get_job_status(job_id=self.job_id)
             self.log.info('Current finishCode is %s (%s)', finish_code.name, finish_code.value)
+
             if finish_code in (TableauJobFinishCode.ERROR, TableauJobFinishCode.CANCELED):
                 raise TableauJobFailedException('The Tableau Refresh Workbook Job failed!')
+
             return finish_code == TableauJobFinishCode.SUCCESS

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -193,7 +193,12 @@ class TestTableauHook(unittest.TestCase):
         mock_pager.assert_called_once_with(mock_server.return_value.jobs.get)
 
     @parameterized.expand(
-        [(0, TableauJobFinishCode.SUCCESS), (1, TableauJobFinishCode.ERROR), (2, TableauJobFinishCode.CANCELED)])
+        [
+            (0, TableauJobFinishCode.SUCCESS),
+            (1, TableauJobFinishCode.ERROR),
+            (2, TableauJobFinishCode.CANCELED),
+        ]
+    )
     @patch('airflow.providers.tableau.hooks.tableau.Server')
     def test_get_job_status(self, finish_code, expected_status, mock_tableau_server):
         """

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -253,6 +253,20 @@ class TestTableauHook(unittest.TestCase):
                 job_id='j1', target_state=TableauJobFinishCode.ERROR, check_interval=1
             )
 
+        # Test CANCELLED Positive
+        with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
+            tableau_hook.get_job_status = MagicMock(
+                name='get_job_status',
+                side_effect=[
+                    TableauJobFinishCode.PENDING,
+                    TableauJobFinishCode.PENDING,
+                    TableauJobFinishCode.CANCELED,
+                ],
+            )
+            assert tableau_hook.wait_for_state(
+                job_id='j1', target_state=TableauJobFinishCode.CANCELED, check_interval=1
+            )
+
         # Test PENDING Positive
         with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
             tableau_hook.get_job_status = MagicMock(

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -16,9 +16,7 @@
 # under the License.
 
 import unittest
-from unittest import mock
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import MagicMock, patch
 
 from airflow import configuration, models
 from airflow.providers.tableau.hooks.tableau import TableauHook, TableauJobFinishCode
@@ -218,13 +216,20 @@ class TestTableauHook(unittest.TestCase):
         '''
         # Test SUCCESS
         with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
-            tableau_hook.get_job_status = MagicMock(name='get_job_status', side_effect=[TableauJobFinishCode.PENDING, TableauJobFinishCode.SUCCESS])
+            tableau_hook.get_job_status = MagicMock(
+                name='get_job_status',
+                side_effect=[TableauJobFinishCode.PENDING, TableauJobFinishCode.SUCCESS],
+            )
             assert tableau_hook.waiting_until_succeeded(job_id='j1')
 
         # Test Not SUCCESS
         with TableauHook(tableau_conn_id='tableau_test_password') as tableau_hook:
-            tableau_hook.get_job_status = MagicMock(name='get_job_status', side_effect=[TableauJobFinishCode.PENDING,
-                                                                                        TableauJobFinishCode.PENDING,
-                                                                                        TableauJobFinishCode.ERROR])
+            tableau_hook.get_job_status = MagicMock(
+                name='get_job_status',
+                side_effect=[
+                    TableauJobFinishCode.PENDING,
+                    TableauJobFinishCode.PENDING,
+                    TableauJobFinishCode.ERROR,
+                ],
+            )
             assert not tableau_hook.waiting_until_succeeded(job_id='j1')
-

--- a/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
@@ -40,7 +40,7 @@ class TestTableauRefreshWorkbookOperator(unittest.TestCase):
             mock_workbook.id = i
             mock_workbook.name = f'wb_{i}'
             self.mocked_workbooks.append(mock_workbook)
-        self.kwargs = {'site_id': 'test_site', 'task_id': 'task', 'dag': None}
+        self.kwargs = {'site_id': 'test_site', 'task_id': 'task', 'dag': None, 'check_interval': 1}
 
     @patch('airflow.providers.tableau.operators.tableau_refresh_workbook.TableauHook')
     def test_execute(self, mock_tableau_hook):
@@ -72,8 +72,8 @@ class TestTableauRefreshWorkbookOperator(unittest.TestCase):
 
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
-        mock_tableau_hook.waiting_until_succeeded.assert_called_once_with(
-            job_id=job_id,
+        mock_tableau_hook.wait_for_state.assert_called_once_with(
+            job_id=job_id, check_interval=1, target_state=TableauJobFinishCode.SUCCESS
         )
 
     @patch('airflow.providers.tableau.operators.tableau_refresh_workbook.TableauHook')

--- a/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
+++ b/tests/providers/tableau/operators/test_tableau_refresh_workbook.py
@@ -72,7 +72,9 @@ class TestTableauRefreshWorkbookOperator(unittest.TestCase):
 
         mock_tableau_hook.server.workbooks.refresh.assert_called_once_with(2)
         assert mock_tableau_hook.server.workbooks.refresh.return_value.id == job_id
-        mock_tableau_hook.server.jobs.get_by_id.assert_called_once_with(job_id)
+        mock_tableau_hook.waiting_until_succeeded.assert_called_once_with(
+            job_id=job_id,
+        )
 
     @patch('airflow.providers.tableau.operators.tableau_refresh_workbook.TableauHook')
     def test_execute_missing_workbook(self, mock_tableau_hook):


### PR DESCRIPTION
Hello all,
as suggested in PR #16937  I created a new PR with the following changes:

1. Creation function to get job status and to check the completion of a Tableau job in `TableauHook`
2. Refactored waiting check, removing the `TableauJobStatusSensor`, in `TableauRefreshWorkbookOperator`
3. Refactored job status check in `TableauJobStatusSensor`
4. Updated tests

Thank you