### PR TITLE
Chart: Update ``postgres`` subchart to ``10.5.3``

### DIFF
--- a/chart/Chart.lock
+++ b/chart/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 6.3.12
-digest: sha256:9c524b20b23abd5ec3a6e264dbf2bd2e2d50fb5a553d7c1d79f88efa0dc69cb9
-generated: "2021-03-02T18:40:05.677618583-05:00"
+  version: 10.5.3
+digest: sha256:d8ba564b767cbf73a4ca87cb3b97e0a75bc813ba0a58a1b0bd6c7154a608e783
+generated: "2021-07-20T23:05:18.37915+01:00"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -34,7 +34,7 @@ keywords:
   - scheduler
 dependencies:
   - name: postgresql
-    version: 6.3.12
+    version: 10.5.3
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled
 maintainers:

--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -75,7 +75,12 @@ def create_validator(api_version, kind):
 
 def validate_k8s_object(instance):
     # Skip PostgresSQL chart
-    chart = jmespath.search("metadata.labels.chart", instance)
+    labels = jmespath.search("metadata.labels", instance)
+    if "helm.sh/chart" in labels:
+        chart = labels["helm.sh/chart"]
+    else:
+        chart = labels.get("chart")
+
     if chart and 'postgresql' in chart:
         return
 

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -83,7 +83,11 @@ class TestBaseChartTest(unittest.TestCase):
         assert OBJECT_COUNT_IN_BASIC_DEPLOYMENT == len(k8s_objects)
         for k8s_object in k8s_objects:
             labels = jmespath.search('metadata.labels', k8s_object) or {}
-            if 'postgresql' in labels.get('chart'):
+            if 'helm.sh/chart' in labels:
+                chart_name = labels.get('helm.sh/chart')
+            else:
+                chart_name = labels.get('chart')
+            if chart_name and 'postgresql' in chart_name:
                 continue
             k8s_name = k8s_object['kind'] + ":" + k8s_object['metadata']['name']
             assert 'TEST-VALUE' == labels.get(


### PR DESCRIPTION
We were on 6.3.12 and this PR updates it to `10.5.3`. 

We have dropped support for Helm 2 already so Helm 3 users won't be affected. Secondly this postgres should only used for development, not production.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
