### PR TITLE
Chart: Remove hard-coded namespace in port-forward instructions

### DIFF
--- a/docs/helm-chart/quick-start.rst
+++ b/docs/helm-chart/quick-start.rst
@@ -61,9 +61,13 @@ It may take a few minutes. Confirm the pods are up:
    kubectl get pods --namespace $NAMESPACE
    helm list --namespace $NAMESPACE
 
-Run ``kubectl port-forward svc/airflow-webserver 8080:8080 -n airflow``
+Run the following command
 to port-forward the Airflow UI to http://localhost:8080/ to confirm
 Airflow is working.
+
+.. code-block:: bash
+
+   kubectl port-forward svc/$RELEASE_NAME-webserver 8080:8080 --namespace $NAMESPACE
 
 Extending Airflow Image
 -----------------------


### PR DESCRIPTION
The port-forward command had a hard-coded namespace.

This fixes it and improves formatting - from inline to code-block

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
