### PR TITLE
Strip non-ascii characters in pod name on k8s executor

### DIFF
--- a/airflow/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/kubernetes/kubernetes_helper_functions.py
@@ -19,6 +19,7 @@ import logging
 from typing import Dict, Optional
 
 from dateutil import parser
+from slugify import slugify
 
 from airflow.models.taskinstance import TaskInstanceKey
 
@@ -37,7 +38,7 @@ def _strip_unsafe_kubernetes_special_chars(string: str) -> str:
     :param string: The requested Pod name
     :return: Pod name stripped of any unsafe characters
     """
-    return ''.join(ch.lower() for ch in list(string) if ch.isalnum())
+    return slugify(string, separator='', lowercase=True)
 
 
 def create_pod_id(dag_id: str, task_id: str) -> str:

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -64,6 +64,9 @@ class TestAirflowKubernetesScheduler(unittest.TestCase):
             ("MYDAGID", "MYTASKID"),
             ("my_dag_id", "my_task_id"),
             ("mydagid" * 200, "my_task_id" * 200),
+            ("my_dág_id", "my_tásk_id"),
+            ("Компьютер", "niedołężność"),
+            ("影師嗎", "中華民國;$"),
         ]
 
         cases.extend(


### PR DESCRIPTION
Strip non-ascii characters in pod name on k8s executor.
(Maybe we can use package unidecode to translate for example á -> a or ñ -> n, but I think that's not necessary, because this is only for the pod name, ignoring the characters is simpler)

closes: #16992 
