### PR TITLE
Update CONTRIBUTING.rst and CONTRIBUTORS_QUICK_START.rst files with jq installation instructions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -208,11 +208,18 @@ You can configure the Docker-based Breeze development environment as follows:
 1. Install the latest versions of the Docker Community Edition
    and Docker Compose and add them to the PATH.
 
-2. Install jq on your machine, using the following command:
+2. Install jq on your machine. The exact command depends on the operating system (or Linux distribution) you use.
+For example, on Ubuntu:
 
 .. code-block:: bash
 
   sudo apt install jq
+
+or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
+
+.. code-block:: bash
+
+  brew install jq
 
 3. Enter Breeze: ``./breeze``
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -208,27 +208,33 @@ You can configure the Docker-based Breeze development environment as follows:
 1. Install the latest versions of the Docker Community Edition
    and Docker Compose and add them to the PATH.
 
-2. Enter Breeze: ``./breeze``
+2. Install jq on your machine, using the following command:
+
+.. code-block:: bash
+
+  sudo apt install jq
+
+3. Enter Breeze: ``./breeze``
 
    Breeze starts with downloading the Airflow CI image from
    the Docker Hub and installing all required dependencies.
 
-3. Enter the Docker environment and mount your local sources
+4. Enter the Docker environment and mount your local sources
    to make them immediately visible in the environment.
 
-4. Create a local virtualenv, for example:
+5. Create a local virtualenv, for example:
 
 .. code-block:: bash
 
    mkvirtualenv myenv --python=python3.6
 
-5. Initialize the created environment:
+6. Initialize the created environment:
 
 .. code-block:: bash
 
    ./breeze initialize-local-virtualenv --python 3.6
 
-6. Open your IDE (for example, PyCharm) and select the virtualenv you created
+7. Open your IDE (for example, PyCharm) and select the virtualenv you created
    as the project's default virtualenv in your IDE.
 
 Step 3: Connect with People

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -44,6 +44,7 @@ Prerequisites
 1. Docker Community Edition
 2. Docker Compose
 3. pyenv (you can also use pyenv-virtualenv or virtualenvwrapper)
+4. jq
 
 
 Installing Prerequisites on Ubuntu
@@ -174,6 +175,18 @@ Pyenv and setting up virtual-env
 
   $ pyenv activate airflow-env
 
+
+
+Installing jq
+--------------------------------
+
+``jq`` is a lightweight and flexible command-line JSON processor.
+
+Install ``jq`` with the following command:
+
+.. code-block:: bash
+
+  $ sudo apt install jq
 
 
 


### PR DESCRIPTION
### What files have been modified?
1. CONTRIBUTING.RST
2. CONTRIBUTORS_QUICK_START.rst

### What changes will be made as part of this PR or how does this PR help?
This pull request updates the above mentioned two documentation files by adding the installation information for the `jq` library and marks it as a prerequisite for installing `breeze`. After moving to the ghrc.io images, users are facing issue in setting up breeze and the error that comes up while setting up breeze is as follows:
```
airflow/scripts/ci/libraries/_build_images.sh: line 427: jq: command not found
``` 
Please refer to the below screenshot for the same error message.
![image](https://user-images.githubusercontent.com/6072170/126025000-7694fcfd-36b6-4dab-8e2f-a6a2cba3dd3a.png)

Installing `jq` library on the local machine fixes this issue. This can be done using `sudo apt install jq`. Below screenshot is a proof that the command works on Ubuntu 20.04 machine and installs `jq`.

![IMG_2363](https://user-images.githubusercontent.com/6072170/126025045-c4dd7697-347e-4cf8-91ab-183b74a9ada4.jpeg)

I have run the pre-commits for these changes using `pre-commit run` and it has finished successfully allowing me to commit the changes to the remote branch.
