### PR TITLE
Fixes detection of version 2 of docker-compose

### DIFF
--- a/breeze
+++ b/breeze
@@ -591,9 +591,9 @@ function breeze::prepare_command_file() {
     cat <<EOF >"${file}"
 #!/usr/bin/env bash
 docker_compose_version=\$(docker-compose --version)
-if [[ \${docker_compose_version} =~ .*version\ 2.* ]]; then
+if [[ \${docker_compose_version} =~ .*version\ v2.* ]]; then
   echo
-  echo "${COLOR_RED}Docker Compose Beta version 2has bug that prevents breeze from running.${COLOR_RESET}"
+  echo "${COLOR_RED}Docker Compose Beta version v2 has a bug that prevents breeze from running.${COLOR_RESET}"
   echo "${COLOR_RED}You have: \${docker_compose_version}.${COLOR_RESET}"
   echo
   echo "${COLOR_YELLOW}Please switch to stable version via Docker Desktop -> Experimental or by running:${COLOR_RESET}"


### PR DESCRIPTION
Docker compose 2 added `v` in front of the version :(

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
