### PR TITLE
Support secret backends/airflow.cfg for celery broker in entrypoint_prod.sh

### DIFF
--- a/docs/docker-stack/entrypoint.rst
+++ b/docs/docker-stack/entrypoint.rst
@@ -105,7 +105,7 @@ To disable check, set ``CONNECTION_CHECK_MAX_COUNT=0``.
 Waits for celery broker connection
 ----------------------------------
 
-In case Postgres or MySQL DB is used, and one of the ``scheduler``, ``celery``, ``worker``, or ``flower``
+In case CeleryExecutor is used, and one of the ``scheduler``, ``celery``, ``worker``, or ``flower``
 commands are used the entrypoint will wait until the celery broker DB connection is available.
 
 The script detects backend type depending on the URL schema and assigns default port numbers if not specified
@@ -120,12 +120,7 @@ Supported schemes:
 * ``postgres://``            - default port 5432
 * ``mysql://``               - default port 3306
 
-Waiting for connection involves checking if a matching port is open.
-The host information is derived from the variables :envvar:`AIRFLOW__CELERY__BROKER_URL` and
-:envvar:`AIRFLOW__CELERY__BROKER_URL_CMD`. If :envvar:`AIRFLOW__CELERY__BROKER_URL_CMD` variable
-is passed to the container, it is evaluated as a command to execute and result of this evaluation is used
-as :envvar:`AIRFLOW__CELERY__BROKER_URL`. The :envvar:`AIRFLOW__CELERY__BROKER_URL_CMD` variable
-takes precedence over the :envvar:`AIRFLOW__CELERY__BROKER_URL` variable.
+Waiting for connection involves checking if a matching port is open. The host information is derived from the Airflow configuration.
 
 .. _entrypoint:commands:
 

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -195,15 +195,14 @@ function upgrade_db() {
     airflow db upgrade || true
 }
 
-function wait_for_celery_backend() {
+function wait_for_celery_broker() {
     # Verifies connection to Celery Broker
-    if [[ -n "${AIRFLOW__CELERY__BROKER_URL_CMD=}" ]]; then
-        wait_for_connection "$(eval "${AIRFLOW__CELERY__BROKER_URL_CMD}")"
-    else
-        AIRFLOW__CELERY__BROKER_URL=${AIRFLOW__CELERY__BROKER_URL:=}
-        if [[ -n ${AIRFLOW__CELERY__BROKER_URL=} ]]; then
-            wait_for_connection "${AIRFLOW__CELERY__BROKER_URL}"
-        fi
+    local executor
+    executor="$(airflow config get-value core executor)"
+    if [[ "${executor=}" == "CeleryExecutor" ]]; then
+        local connection_url
+        connection_url="$(airflow config get-value celery broker_url)"
+        wait_for_connection "${connection_url}"
     fi
 }
 
@@ -322,7 +321,7 @@ fi
 # Note: the broker backend configuration concerns only a subset of Airflow components
 if [[ ${AIRFLOW_COMMAND} =~ ^(scheduler|celery|worker|flower)$ ]] \
     && [[ "${CONNECTION_CHECK_MAX_COUNT}" -gt "0" ]]; then
-    wait_for_celery_backend
+    wait_for_celery_broker
 fi
 
 exec "airflow" "${@}"

--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -199,7 +199,7 @@ function wait_for_celery_broker() {
     # Verifies connection to Celery Broker
     local executor
     executor="$(airflow config get-value core executor)"
-    if [[ "${executor=}" == "CeleryExecutor" ]]; then
+    if [[ "${executor}" == "CeleryExecutor" ]]; then
         local connection_url
         connection_url="$(airflow config get-value celery broker_url)"
         wait_for_connection "${connection_url}"


### PR DESCRIPTION
Previously, we used to determine the URL based on two environment variables: `AIRFLOW__CELERY__BROKER_URL`, `AIRFLOW__CELERY__BROKER_URL_CMD`, but it is not enough.  Airflow also allows us to set URL using `AIRFLOW__CELERY__BROKER_URL_SECRET` environment variable or `airflow.cfg` file  Sometimes the default value may also be sufficient for some users - `redis://redis:6379/0`
Now, we run the check only when Celery is used and we use the built-in airflow commands to determine the connection URL, which means that the value determined by `entrypoint_prod.sh` and airflow match.

For details, see: https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
