### PR TITLE
Improve executor validation in CLI

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -57,11 +57,14 @@ class DefaultHelpParser(argparse.ArgumentParser):
 
     def _check_value(self, action, value):
         """Override _check_value and check conditionally added command"""
-        executor = conf.get('core', 'EXECUTOR')
-        if value == 'celery' and executor not in (CELERY_EXECUTOR, CELERY_KUBERNETES_EXECUTOR):
-            message = f'celery subcommand works only with CeleryExecutor, your current executor: {executor}'
-            raise ArgumentError(action, message)
-        if value == 'kubernetes':
+        if action.dest == 'subcommand' and value == 'celery':
+            executor = conf.get('core', 'EXECUTOR')
+            if executor not in (CELERY_EXECUTOR, CELERY_KUBERNETES_EXECUTOR):
+                message = (
+                    f'celery subcommand works only with CeleryExecutor, your current executor: {executor}'
+                )
+                raise ArgumentError(action, message)
+        if action.dest == 'subcommand' and value == 'kubernetes':
             try:
                 import kubernetes.client  # noqa: F401
             except ImportError:

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -196,8 +196,21 @@ class TestCli(TestCase):
             cli_parser.positive_int(allow_zero=False)('0')
             cli_parser.positive_int(allow_zero=True)('-1')
 
+    def test_dag_parser_celery_command_require_celery_executor(self):
+        with conf_vars({('core', 'executor'): 'SequentialExecutor'}), contextlib.redirect_stderr(
+            io.StringIO()
+        ) as stderr:
+            parser = cli_parser.get_parser()
+            with self.assertRaises(SystemExit):
+                parser.parse_args(['celery'])
+            stderr = stderr.getvalue()
+        assert (
+            "airflow command error: argument GROUP_OR_COMMAND: celery subcommand "
+            "works only with CeleryExecutor, your current executor: SequentialExecutor, see help above."
+        ) in stderr
+
     @parameterized.expand(["CeleryExecutor", "CeleryKubernetesExecutor"])
-    def test_dag_parser_celery_command_required_celery_executor(self, executor):
+    def test_dag_parser_celery_command_accept_celery_executor(self, executor):
         with conf_vars({('core', 'executor'): executor}), contextlib.redirect_stderr(io.StringIO()) as stderr:
             parser = cli_parser.get_parser()
             with self.assertRaises(SystemExit):

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -28,10 +28,9 @@ import pytest
 from parameterized import parameterized
 
 from airflow.cli import cli_parser
-
-# Can not be `--snake_case` or contain uppercase letter
 from tests.test_utils.config import conf_vars
 
+# Can not be `--snake_case` or contain uppercase letter
 ILLEGAL_LONG_OPTION_PATTERN = re.compile("^--[a-z]+_[a-z]+|^--.*[A-Z].*")
 # Only can be `-[a-z]` or `-[A-Z]`
 LEGAL_SHORT_OPTION_PATTERN = re.compile("^-[a-zA-z]$")

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -25,10 +25,13 @@ from collections import Counter
 from unittest import TestCase
 
 import pytest
+from parameterized import parameterized
 
 from airflow.cli import cli_parser
 
 # Can not be `--snake_case` or contain uppercase letter
+from tests.test_utils.config import conf_vars
+
 ILLEGAL_LONG_OPTION_PATTERN = re.compile("^--[a-z]+_[a-z]+|^--.*[A-Z].*")
 # Only can be `-[a-z]` or `-[A-Z]`
 LEGAL_SHORT_OPTION_PATTERN = re.compile("^-[a-zA-z]$")
@@ -193,3 +196,22 @@ class TestCli(TestCase):
         with pytest.raises(argparse.ArgumentTypeError):
             cli_parser.positive_int(allow_zero=False)('0')
             cli_parser.positive_int(allow_zero=True)('-1')
+
+    @parameterized.expand(["CeleryExecutor", "CeleryKubernetesExecutor"])
+    def test_dag_parser_celery_command_required_celery_executor(self, executor):
+        with conf_vars({('core', 'executor'): executor}), contextlib.redirect_stderr(io.StringIO()) as stderr:
+            parser = cli_parser.get_parser()
+            with self.assertRaises(SystemExit):
+                parser.parse_args(['celery'])
+            stderr = stderr.getvalue()
+        assert (
+            "airflow celery command error: the following arguments are required: COMMAND, see help above."
+        ) in stderr
+
+    def test_dag_parser_config_command_dont_required_celery_executor(self):
+        with conf_vars({('core', 'executor'): "CeleryExecutor"}), contextlib.redirect_stderr(
+            io.StringIO()
+        ) as stdout:
+            parser = cli_parser.get_parser()
+            parser.parse_args(['config', 'get-value', 'celery', 'broker-url'])
+        assert stdout is not None


### PR DESCRIPTION
Previously, when a user tried to check configurations for celery, they got a message that the celery SUBCOMMAND is not supported. This is confusing as user was running `config get-value` and not `celery *`.
```
airflow config get-value celery broker-url
usage: airflow config get-value [-h] section option

Print the value of the configuration

positional arguments:
  section     The section name
  option      The option name

optional arguments:
  -h, --help  show this help message and exit

airflow config get-value command error: argument section: celery subcommand works only with CeleryExecutor, your current executor: LocalExecutor, see help above.
```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
