### PR TITLE
Prevent running `airflow db init\upgrade` in parallel

### DIFF
--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -104,4 +104,6 @@ def create_global_lock(session=None, pg_lock_id=1, lock_name='init', mysql_lock_
             session.connection().execute(f"select RELEASE_LOCK('{lock_name}');")
 
         if dialect.name == 'mssql':
-            session.connection().execute(f"sp_releaseapplock @Resource = '{lock_name}';")
+            session.connection().execute(
+                f"sp_releaseapplock @Resource = '{lock_name}', @LockOwner = 'Session';"
+            )


### PR DESCRIPTION
Make sure that multiple db initialization processes on the same db are executed one after another.

Tested manually by running airflow db init in 2 separate bash sessions.
Made sure that migrations only started in one command line and the other resumed after the first has finished and did nothing.

closes: #16310
related PR: #10151