### PR TITLE
Parse JSON template parameters field for MySQL operator

### DIFF
--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import ast
 from typing import Dict, Iterable, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
@@ -37,6 +38,8 @@ class MySqlOperator(BaseOperator):
     :param mysql_conn_id: Reference to :ref:`mysql connection id <howto/connection:mysql>`.
     :type mysql_conn_id: str
     :param parameters: (optional) the parameters to render the SQL query with.
+        Template reference are recognized by str ending in '.json'
+        (templated)
     :type parameters: dict or iterable
     :param autocommit: if True, each command is automatically committed.
         (default value: False)
@@ -66,6 +69,11 @@ class MySqlOperator(BaseOperator):
         self.autocommit = autocommit
         self.parameters = parameters
         self.database = database
+
+    def prepare_template(self) -> None:
+        """Parse template file for attribute parameters."""
+        if isinstance(self.parameters, str):
+            self.parameters = ast.literal_eval(self.parameters)
 
     def execute(self, context: Dict) -> None:
         self.log.info('Executing: %s', self.sql)

--- a/tests/providers/mysql/operators/test_mysql.py
+++ b/tests/providers/mysql/operators/test_mysql.py
@@ -15,8 +15,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import os
 import unittest
 from contextlib import closing
+from tempfile import NamedTemporaryFile
 
 import pytest
 from parameterized import parameterized
@@ -108,3 +110,19 @@ class TestMySql(unittest.TestCase):
                 op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
             except OperationalError as e:
                 assert "Unknown database 'foobar'" in str(e)
+
+    def test_mysql_operator_resolve_parameters_template_json_file(self):
+
+        with NamedTemporaryFile(suffix='.json') as f:
+            f.write(b"{\n \"foo\": \"{{ ds }}\"}")
+            f.flush()
+            template_dir = os.path.dirname(f.name)
+            template_file = os.path.basename(f.name)
+
+            with DAG("test-dag", start_date=DEFAULT_DATE, template_searchpath=template_dir):
+                task = MySqlOperator(task_id="op1", parameters=template_file, sql="SELECT 1")
+
+            task.resolve_template_files()
+
+        assert isinstance(task.parameters, dict)
+        assert task.parameters["foo"] == "{{ ds }}"


### PR DESCRIPTION
In PR #16914, we added `.json` to template extensions, it will be used for `parameters` field which supposed to be dict or list. 
So it will be good to parse JSON files for parameters.
Now it fails: 
![image](https://user-images.githubusercontent.com/33004847/126143920-f06ca2d3-779b-4084-9978-ea6c36086718.png)

After fix:
![image](https://user-images.githubusercontent.com/33004847/126144154-30609127-7f6e-433f-9d26-4b258f05eb85.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
