### PR TITLE
#16976 Add json.dumps() for templated fields objects: 'dict' and 'list'

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -970,6 +970,8 @@ class Airflow(AirflowBaseView):
             content = getattr(task, template_field)
             renderer = task.template_fields_renderers.get(template_field, template_field)
             if renderer in renderers:
+                if isinstance(content, (dict, list)):
+                    content = json.dumps(content, sort_keys=True, indent=4)
                 html_dict[template_field] = renderers[renderer](content)
             else:
                 html_dict[template_field] = Markup("<pre><code>{}</pre></code>").format(pformat(content))


### PR DESCRIPTION
closes: #16976

Add json.dumps() for templated fields objects: 'dict' and 'list', which was existed in Apache Airflow version 2.0.2