### PR TITLE
Adding SalesforceToS3Operator to Amazon Provider

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -654,7 +654,7 @@ Here is the list of packages and their extras:
 Package                    Extras
 ========================== ===========================
 airbyte                    http
-amazon                     apache.hive,exasol,ftp,google,imap,mongo,mysql,postgres,ssh
+amazon                     apache.hive,exasol,ftp,google,imap,mongo,mysql,postgres,salesforce,ssh
 apache.beam                google
 apache.druid               apache.hive
 apache.hive                amazon,microsoft.mssql,mysql,presto,samba,vertica

--- a/airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.py
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+This is a basic example DAG for using `SalesforceToS3Operator` to retrieve Salesforce customer
+data and upload to an S3 bucket.
+"""
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.providers.amazon.aws.operators.s3_copy_object import S3CopyObjectOperator
+from airflow.providers.amazon.aws.operators.s3_delete_objects import S3DeleteObjectsOperator
+from airflow.providers.amazon.aws.transfers.salesforce_to_s3 import SalesforceToS3Operator
+
+BASE_PATH = "salesforce/customers"
+FILE_NAME = "customer_daily_extract_{{ ds_nodash }}.csv"
+LANDING_BUCKET = "landing-bucket"
+S3_KEY = f"{BASE_PATH}/{FILE_NAME}"
+
+AWS_CONN_ID = "s3"
+
+
+with DAG(
+    dag_id="example_salesforce_to_s3_transfer",
+    schedule_interval="@daily",
+    start_date=datetime(2021, 7, 8),
+    catchup=False,
+    default_args={"retries": 1},
+    tags=["example"],
+    default_view="graph",
+) as dag:
+    # [START howto_operator_salesforce_to_s3_transfer]
+    upload_salesforce_data_to_s3_landing = SalesforceToS3Operator(
+        task_id="upload_salesforce_data_to_s3",
+        salesforce_query="SELECT Id, Name, Company, Phone, Email, LastModifiedDate, IsActive FROM Customers",
+        s3_bucket_name=LANDING_BUCKET,
+        s3_key=S3_KEY,
+        salesforce_conn_id="salesforce",
+        replace=True,
+        aws_conn_id=AWS_CONN_ID,
+    )
+    # [END howto_operator_salesforce_to_s3_transfer]
+
+    date_prefixes = "{{ execution_date.strftime('%Y/%m/%d') }}"
+
+    store_to_s3_data_lake = S3CopyObjectOperator(
+        task_id="store_to_s3_data_lake",
+        source_bucket_key=upload_salesforce_data_to_s3_landing.output,
+        dest_bucket_name="data_lake",
+        dest_bucket_key=f"{BASE_PATH}/{date_prefixes}/{FILE_NAME}",
+        aws_conn_id=AWS_CONN_ID,
+    )
+
+    delete_data_from_s3_landing = S3DeleteObjectsOperator(
+        task_id="delete_data_from_s3_landing",
+        bucket=LANDING_BUCKET,
+        keys=S3_KEY,
+        aws_conn_id=AWS_CONN_ID,
+    )
+
+    store_to_s3_data_lake >> delete_data_from_s3_landing
+
+    # Task dependency created via `XComArgs`:
+    #   upload_salesforce_data_to_s3_landing >> store_to_s3_data_lake_raw

--- a/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
@@ -106,7 +106,7 @@ class SalesforceToS3Operator(BaseOperator):
         self.gzip = gzip
         self.acl_policy = acl_policy
 
-    def execute(self, context: Dict) -> str:
+    def execute(self, context: Dict) -> Dict:
         salesforce_hook = SalesforceHook(conn_id=self.salesforce_conn_id)
         response = salesforce_hook.make_query(
             query=self.salesforce_query,
@@ -138,4 +138,4 @@ class SalesforceToS3Operator(BaseOperator):
             s3_uri = f"s3://{self.s3_bucket_name}/{self.s3_key}"
             self.log.info(f"Salesforce data uploaded to S3 at {s3_uri}.")
 
-            return s3_uri
+            return {"s3_uri": s3_uri, "s3_bucket_name": self.s3_bucket_name, "s3_key": self.s3_key}

--- a/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import tempfile
+from typing import Dict, Optional
+
+from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
+
+
+class SalesforceToS3Operator(BaseOperator):
+    """
+    Submits a Salesforce query and uploads the results to AWS S3.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:SalesforceToS3Operator`
+
+    :param salesforce_query: The query to send to Salesforce.
+    :type salesforce_query: str
+    :param s3_bucket_name: The bucket name to upload to.
+    :type s3_bucket_name: str
+    :param s3_key: The object name to set when uploading the file.
+    :type s3_key: str
+    :param salesforce_conn_id: The name of the connection that has the parameters needed
+        to connect to Salesforce.
+    :type salesforce_conn_id: str
+    :param export_format: Desired format of files to be exported.
+    :type export_format: str
+    :param query_params: Additional optional arguments to be passed to the HTTP request querying Salesforce.
+    :type query_params: dict
+    :param include_deleted: True if the query should include deleted records.
+    :type include_deleted: bool
+    :param coerce_to_timestamp: True if you want all datetime fields to be converted into Unix timestamps.
+        False if you want them to be left in the same format as they were in Salesforce.
+        Leaving the value as False will result in datetimes being strings. Default: False
+    :type coerce_to_timestamp: bool
+    :param record_time_added: True if you want to add a Unix timestamp field
+        to the resulting data that marks when the data was fetched from Salesforce. Default: False
+    :type record_time_added: bool
+    :param aws_conn_id: The name of the connection that has the parameters we need to connect to S3.
+    :type aws_conn_id: str
+    :type replace: bool
+    :param encrypt: If True, the file will be encrypted on the server-side by S3 and will
+        be stored in an encrypted form while at rest in S3.
+    :type encrypt: bool
+    :param gzip: If True, the file will be compressed locally.
+    :type gzip: bool
+    :param acl_policy: String specifying the canned ACL policy for the file being uploaded
+        to the S3 bucket.
+    :type acl_policy: str
+    """
+
+    template_fields = ("salesforce_query", "s3_bucket_name", "s3_key")
+    template_ext = (".sql",)
+    template_fields_renderers = {"salesforce_query": "sql"}
+
+    def __init__(
+        self,
+        *,
+        salesforce_query: str,
+        s3_bucket_name: str,
+        s3_key: str,
+        salesforce_conn_id: str,
+        export_format: str = "csv",
+        query_params: Optional[Dict] = None,
+        include_deleted: bool = False,
+        coerce_to_timestamp: bool = False,
+        record_time_added: bool = False,
+        aws_conn_id: str = "aws_default",
+        replace: bool = False,
+        encrypt: bool = False,
+        gzip: bool = False,
+        acl_policy: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.salesforce_query = salesforce_query
+        self.s3_bucket_name = s3_bucket_name
+        self.s3_key = s3_key
+        self.salesforce_conn_id = salesforce_conn_id
+        self.export_format = export_format
+        self.query_params = query_params
+        self.include_deleted = include_deleted
+        self.coerce_to_timestamp = coerce_to_timestamp
+        self.record_time_added = record_time_added
+        self.aws_conn_id = aws_conn_id
+        self.replace = replace
+        self.encrypt = encrypt
+        self.gzip = gzip
+        self.acl_policy = acl_policy
+
+    def execute(self, context: Dict):
+        salesforce_hook = SalesforceHook(conn_id=self.salesforce_conn_id)
+        response = salesforce_hook.make_query(
+            query=self.salesforce_query,
+            include_deleted=self.include_deleted,
+            query_params=self.query_params,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "salesforce_temp_file")
+            salesforce_hook.write_object_to_file(
+                query_results=response["records"],
+                filename=path,
+                fmt=self.export_format,
+                coerce_to_timestamp=self.coerce_to_timestamp,
+                record_time_added=self.record_time_added,
+            )
+
+            s3_hook = S3Hook(aws_conn_id=self.aws_conn_id)
+            s3_hook.load_file(
+                filename=path,
+                key=self.s3_key,
+                bucket_name=self.s3_bucket_name,
+                replace=self.replace,
+                encrypt=self.encrypt,
+                gzip=self.gzip,
+                acl_policy=self.acl_policy,
+            )
+
+            s3_uri = f"s3://{self.s3_bucket_name}/{self.s3_key}"
+            self.log.info(f"Salesforce data uploaded to S3 at {s3_uri}.")
+
+            return s3_uri

--- a/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
@@ -89,7 +89,7 @@ class SalesforceToS3Operator(BaseOperator):
         gzip: bool = False,
         acl_policy: Optional[str] = None,
         **kwargs,
-    ):
+    ) -> None:
         super().__init__(**kwargs)
         self.salesforce_query = salesforce_query
         self.s3_bucket_name = s3_bucket_name
@@ -106,7 +106,7 @@ class SalesforceToS3Operator(BaseOperator):
         self.gzip = gzip
         self.acl_policy = acl_policy
 
-    def execute(self, context: Dict):
+    def execute(self, context: Dict) -> str:
         salesforce_hook = SalesforceHook(conn_id=self.salesforce_conn_id)
         response = salesforce_hook.make_query(
             query=self.salesforce_query,

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -22,6 +22,7 @@ description: |
     Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
 versions:
+  - 2.1.0
   - 2.0.0
   - 1.4.0
   - 1.3.0

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -22,7 +22,6 @@ description: |
     Amazon integration (including `Amazon Web Services (AWS) <https://aws.amazon.com/>`__).
 
 versions:
-  - 2.1.0
   - 2.0.0
   - 1.4.0
   - 1.3.0
@@ -375,11 +374,9 @@ transfers:
     python-module: airflow.providers.amazon.aws.transfers.s3_to_redshift
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: SSH File Transfer Protocol (SFTP)
-    how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/s3_to_sftp.rst
     python-module: airflow.providers.amazon.aws.transfers.s3_to_sftp
   - source-integration-name: SSH File Transfer Protocol (SFTP)
     target-integration-name: Amazon Simple Storage Service (S3)
-    how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/sftp_to_s3.rst
     python-module: airflow.providers.amazon.aws.transfers.sftp_to_s3
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: File Transfer Protocol (FTP)
@@ -390,6 +387,10 @@ transfers:
   - source-integration-name: File Transfer Protocol (FTP)
     target-integration-name: Amazon Simple Storage Service (S3)
     python-module: airflow.providers.amazon.aws.transfers.ftp_to_s3
+  - source-integration-name: Salesforce
+    target-integration-name: Amazon Simple Storage Service (S3)
+    how-to-guide: /docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst
+    python-module: airflow.providers.amazon.aws.transfers.salesforce_to_s3
 
 hook-class-names:
   - airflow.providers.amazon.aws.hooks.s3.S3Hook

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -378,8 +378,8 @@ transfers:
     python-module: airflow.providers.amazon.aws.transfers.s3_to_sftp
   - source-integration-name: SSH File Transfer Protocol (SFTP)
     target-integration-name: Amazon Simple Storage Service (S3)
-    python-module: airflow.providers.amazon.aws.transfers.sftp_to_s3
     how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/sftp_to_s3.rst
+    python-module: airflow.providers.amazon.aws.transfers.sftp_to_s3
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: File Transfer Protocol (FTP)
     python-module: airflow.providers.amazon.aws.transfers.s3_to_ftp

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -374,10 +374,12 @@ transfers:
     python-module: airflow.providers.amazon.aws.transfers.s3_to_redshift
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: SSH File Transfer Protocol (SFTP)
+    how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/s3_to_sftp.rst
     python-module: airflow.providers.amazon.aws.transfers.s3_to_sftp
   - source-integration-name: SSH File Transfer Protocol (SFTP)
     target-integration-name: Amazon Simple Storage Service (S3)
     python-module: airflow.providers.amazon.aws.transfers.sftp_to_s3
+    how-to-guide: /docs/apache-airflow-providers-amazon/operators/transfer/sftp_to_s3.rst
   - source-integration-name: Amazon Simple Storage Service (S3)
     target-integration-name: File Transfer Protocol (FTP)
     python-module: airflow.providers.amazon.aws.transfers.s3_to_ftp

--- a/airflow/providers/dependencies.json
+++ b/airflow/providers/dependencies.json
@@ -11,6 +11,7 @@
     "mongo",
     "mysql",
     "postgres",
+    "salesforce",
     "ssh"
   ],
   "apache.beam": [

--- a/docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst
@@ -1,0 +1,53 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Salesforce To S3 Operator
+==============================
+
+.. contents::
+  :depth: 1
+  :local:
+
+.. _howto/operator:SalesforceToS3Operator:
+
+Overview
+--------
+
+Use the
+:class:`~airflow.providers.amazon.aws.transfers.salesforce_to_s3.SalesforceToS3Operator`
+to execute a Salesforce query to fetch data and upload to S3.  The results of the query
+are initially written to a local, temporary directory and then uploaded to an S3 bucket.
+
+Extract Customer Data from Salesforce
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example demonstrates a use case of extracting customer data from a Salesforce
+instance and upload to a "landing" bucket in S3.
+
+.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.py
+    :language: python
+    :start-after: [START howto_operator_salesforce_to_s3_transfer]
+    :end-before: [END howto_operator_salesforce_to_s3_transfer]
+
+Reference
+---------
+
+This operator uses the :class:`~airflow.providers.salesforce.hooks.salesforce.SalesforceHook`
+to interact with Salesforce.  This hook is built with functionality from the Simple Salesforce
+package.
+
+For further information, review the `Simple Salesforce Documentation <https://simple-salesforce.readthedocs.io/en/latest/>`__.

--- a/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
@@ -1,0 +1,121 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from collections import OrderedDict
+from unittest import mock
+
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.amazon.aws.transfers.salesforce_to_s3 import SalesforceToS3Operator
+from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
+
+TASK_ID = "test-task-id"
+QUERY = "SELECT id, company FROM Lead WHERE company = 'Hello World Inc'"
+SALESFORCE_CONNECTION_ID = "test-salesforce-connection"
+S3_BUCKET = "test-bucket"
+S3_KEY = "path/to/test-file-path/test-file.json"
+EXPECTED_S3_URI = f"s3://{S3_BUCKET}/{S3_KEY}"
+AWS_CONNECTION_ID = "aws_default"
+SALESFORCE_RESPONSE = {
+    'records': [
+        OrderedDict(
+            [
+                (
+                    'attributes',
+                    OrderedDict(
+                        [('type', 'Lead'), ('url', '/services/data/v42.0/sobjects/Lead/00Q3t00001eJ7AnEAK')]
+                    ),
+                ),
+                ('Id', '00Q3t00001eJ7AnEAK'),
+                ('Company', 'Hello World Inc'),
+            ]
+        )
+    ],
+    'totalSize': 1,
+    'done': True,
+}
+QUERY_PARAMS = {"DEFAULT_SETTING": "ENABLED"}
+EXPORT_FORMAT = "json"
+INCLUDE_DELETED = COERCE_TO_TIMESTAMP = RECORD_TIME_ADDED = True
+REPLACE = ENCRYPT = GZIP = False
+ACL_POLICY = None
+
+
+class TestSalesforceToGcsOperator(unittest.TestCase):
+    @mock.patch.object(S3Hook, 'load_file')
+    @mock.patch.object(SalesforceHook, 'write_object_to_file')
+    @mock.patch.object(SalesforceHook, 'make_query')
+    def test_execute(self, mock_make_query, mock_write_object_to_file, mock_load_file):
+        mock_make_query.return_value = SALESFORCE_RESPONSE
+
+        operator = SalesforceToS3Operator(
+            task_id=TASK_ID,
+            salesforce_query=QUERY,
+            s3_bucket_name=S3_BUCKET,
+            s3_key=S3_KEY,
+            salesforce_conn_id=SALESFORCE_CONNECTION_ID,
+            export_format=EXPORT_FORMAT,
+            query_params=QUERY_PARAMS,
+            include_deleted=INCLUDE_DELETED,
+            coerce_to_timestamp=COERCE_TO_TIMESTAMP,
+            record_time_added=RECORD_TIME_ADDED,
+            aws_conn_id=AWS_CONNECTION_ID,
+            replace=REPLACE,
+            encrypt=ENCRYPT,
+            gzip=GZIP,
+            acl_policy=ACL_POLICY,
+        )
+
+        assert operator.task_id == TASK_ID
+        assert operator.salesforce_query == QUERY
+        assert operator.s3_bucket_name == S3_BUCKET
+        assert operator.s3_key == S3_KEY
+        assert operator.salesforce_conn_id == SALESFORCE_CONNECTION_ID
+        assert operator.export_format == EXPORT_FORMAT
+        assert operator.query_params == QUERY_PARAMS
+        assert operator.include_deleted == INCLUDE_DELETED
+        assert operator.coerce_to_timestamp == COERCE_TO_TIMESTAMP
+        assert operator.record_time_added == RECORD_TIME_ADDED
+        assert operator.aws_conn_id == AWS_CONNECTION_ID
+        assert operator.replace == REPLACE
+        assert operator.encrypt == ENCRYPT
+        assert operator.gzip == GZIP
+        assert operator.acl_policy == ACL_POLICY
+
+        assert EXPECTED_S3_URI == operator.execute({})
+
+        mock_make_query.assert_called_once_with(
+            query=QUERY, include_deleted=INCLUDE_DELETED, query_params=QUERY_PARAMS
+        )
+
+        mock_write_object_to_file.assert_called_once_with(
+            query_results=SALESFORCE_RESPONSE['records'],
+            filename=mock.ANY,
+            fmt=EXPORT_FORMAT,
+            coerce_to_timestamp=COERCE_TO_TIMESTAMP,
+            record_time_added=RECORD_TIME_ADDED,
+        )
+
+        mock_load_file.assert_called_once_with(
+            bucket_name=S3_BUCKET,
+            key=S3_KEY,
+            filename=mock.ANY,
+            replace=REPLACE,
+            encrypt=ENCRYPT,
+            gzip=GZIP,
+            acl_policy=ACL_POLICY,
+        )

--- a/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
@@ -28,7 +28,6 @@ QUERY = "SELECT id, company FROM Lead WHERE company = 'Hello World Inc'"
 SALESFORCE_CONNECTION_ID = "test-salesforce-connection"
 S3_BUCKET = "test-bucket"
 S3_KEY = "path/to/test-file-path/test-file.json"
-EXPECTED_S3_URI = f"s3://{S3_BUCKET}/{S3_KEY}"
 AWS_CONNECTION_ID = "aws_default"
 SALESFORCE_RESPONSE = {
     'records': [
@@ -96,7 +95,13 @@ class TestSalesforceToGcsOperator(unittest.TestCase):
         assert operator.gzip == GZIP
         assert operator.acl_policy == ACL_POLICY
 
-        assert EXPECTED_S3_URI == operator.execute({})
+        expected_op_output = {
+            "s3_uri": f"s3://{S3_BUCKET}/{S3_KEY}",
+            "s3_bucket_name": S3_BUCKET,
+            "s3_key": S3_KEY,
+        }
+
+        assert expected_op_output == operator.execute({})
 
         mock_make_query.assert_called_once_with(
             query=QUERY, include_deleted=INCLUDE_DELETED, query_params=QUERY_PARAMS


### PR DESCRIPTION
Closes: #16891 

Creating an operator to extract data from Salesforce and upload to S3: `SalesforceToS3Operator`

Items contained in this PR include:
- Operator code: `airflow/providers/amazon/aws/transfers/salesforce_to_s3.py`
- Operator documentation: `docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst`
- Operator unit test: `tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py`
- Example DAG: `airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.py`
- Updated Amazon `provider.yaml`