### PR TITLE
Adding EdgeModifier support for chain()

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1554,9 +1554,9 @@ def chain(
     r"""
     Given a number of tasks, builds a dependency chain.
 
-    This function accepts values of BaseOperator (aka tasks), EdgeModifiers (aka Labels), XComArg, or lists containing
-    any mix of these types (or a mix in the same list). If you want to chain between two lists you must
-    ensure they have the same length.
+    This function accepts values of BaseOperator (aka tasks), EdgeModifiers (aka Labels), XComArg, or lists
+    containing any mix of these types (or a mix in the same list). If you want to chain between two lists
+    you must ensure they have the same length.
 
     Using classic operators/sensors:
 

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1546,11 +1546,10 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         return getattr(self, '_is_dummy', False)
 
 
-def chain(
-    *tasks: Union[
-        BaseOperator, "XComArg", EdgeModifier, Sequence[Union[BaseOperator, "XComArg", EdgeModifier]]
-    ]
-):
+Chainable = Union[BaseOperator, "XComArg", EdgeModifier]
+
+
+def chain(*tasks: Union[Chainable, Sequence[Chainable]]) -> None:
     r"""
     Given a number of tasks, builds a dependency chain.
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -115,9 +115,9 @@ Drivy
 Dsn
 Dynamodb
 EDITMSG
+ETag
 EdgeModifier
 EdgeModifiers
-ETag
 Eg
 EmrAddSteps
 EmrCreateJobFlow

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -115,6 +115,8 @@ Drivy
 Dsn
 Dynamodb
 EDITMSG
+EdgeModifier
+EdgeModifiers
 ETag
 Eg
 EmrAddSteps

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -414,8 +414,12 @@ class TestBaseOperatorMethods(unittest.TestCase):
         assert [op5] == op3.get_direct_relatives(upstream=False)
         assert {op4, op5} == set(op6.get_direct_relatives(upstream=True))
 
-        assert {"label": "label1"} == dag.get_edge_info(upstream_task_id=op1.task_id, downstream_task_id=op2.task_id)
-        assert {"label": "label2"} == dag.get_edge_info(upstream_task_id=op1.task_id, downstream_task_id=op3.task_id)
+        assert {"label": "label1"} == dag.get_edge_info(
+            upstream_task_id=op1.task_id, downstream_task_id=op2.task_id
+        )
+        assert {"label": "label2"} == dag.get_edge_info(
+            upstream_task_id=op1.task_id, downstream_task_id=op3.task_id
+        )
 
         # Begin test for `XComArgs`
         [xlabel1, xlabel2] = [Label(label=f"xcomarg_label{i}") for i in range(1, 3)]
@@ -430,8 +434,12 @@ class TestBaseOperatorMethods(unittest.TestCase):
         assert [xop5.operator] == xop3.operator.get_direct_relatives(upstream=False)
         assert {xop4.operator, xop5.operator} == set(xop6.operator.get_direct_relatives(upstream=True))
 
-        assert {"label": "xcomarg_label1"} == dag.get_edge_info(upstream_task_id=xop1.operator.task_id, downstream_task_id=xop2.operator.task_id)
-        assert {"label": "xcomarg_label2"} == dag.get_edge_info(upstream_task_id=xop1.operator.task_id, downstream_task_id=xop3.operator.task_id)
+        assert {"label": "xcomarg_label1"} == dag.get_edge_info(
+            upstream_task_id=xop1.operator.task_id, downstream_task_id=xop2.operator.task_id
+        )
+        assert {"label": "xcomarg_label2"} == dag.get_edge_info(
+            upstream_task_id=xop1.operator.task_id, downstream_task_id=xop3.operator.task_id
+        )
 
     def test_chain_not_support_type(self):
         dag = DAG(dag_id='test_chain', start_date=datetime.now())


### PR DESCRIPTION
Closes: #17083

- Added support for EdgeModifier in chain() helper function
- Added additional tests in test_baseoperator.py

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
