### PR TITLE
Adds more explanatory message when SecretsMasker is not configured

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -102,7 +102,12 @@ def _secrets_masker() -> "SecretsMasker":
     for flt in logging.getLogger('airflow.task').filters:
         if isinstance(flt, SecretsMasker):
             return flt
-    raise RuntimeError("No SecretsMasker found!")
+    raise RuntimeError(
+        "Logging Configuration Error! No SecretsMasker found! If you have custom logging, please make "
+        "sure you configure it taking airflow configuration as a base as explained at "
+        "https://airflow.apache.org/docs/apache-airflow/stable/logging-monitoring/logging-tasks.html"
+        "#advanced-configuration"
+    )
 
 
 class SecretsMasker(logging.Filter):


### PR DESCRIPTION
The secrets masker added in 2.1.0 introduced requirement that
at least one SecretsMasker needs to be configured per task.

However this introduced problems for several users who migrated
from Airflow 1.10 and had their custom logging configuration
done without first copying the base airflow configuration.

The message about missing SecretsMasker was pretty cryptic for the
users. This PR changes the message to be much more descriptive
and pointing the user to the right place in documentation
explaining how advanced logging configuration should be done.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
