### PR TITLE
Ensure a DAG is acyclic when running DAG.cli()

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -75,6 +75,7 @@ from airflow.timetables.schedules import Schedule
 from airflow.timetables.simple import NullTimetable, OnceTimetable
 from airflow.typing_compat import Literal, RePatternType
 from airflow.utils import timezone
+from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.file import correct_maybe_zipped
 from airflow.utils.helpers import validate_key
@@ -1959,6 +1960,8 @@ class DAG(LoggingMixin):
 
     def cli(self):
         """Exposes a CLI specific to this DAG"""
+        check_cycle(self)
+
         from airflow.cli import cli_parser
 
         parser = cli_parser.get_parser(dag_parser=True)

--- a/airflow/utils/dag_cycle_tester.py
+++ b/airflow/utils/dag_cycle_tester.py
@@ -16,15 +16,19 @@
 # under the License.
 """DAG Cycle tester"""
 from collections import defaultdict, deque
+from typing import TYPE_CHECKING
 
 from airflow.exceptions import AirflowDagCycleException
+
+if TYPE_CHECKING:
+    from airflow.models import DAG
 
 CYCLE_NEW = 0
 CYCLE_IN_PROGRESS = 1
 CYCLE_DONE = 2
 
 
-def test_cycle(dag):
+def test_cycle(dag: "DAG") -> None:
     """
     A wrapper function of `check_cycle` for backward compatibility purpose.
     New code should use `check_cycle` instead since this function name `test_cycle` starts with 'test_' and
@@ -40,10 +44,10 @@ def test_cycle(dag):
     return check_cycle(dag)
 
 
-def check_cycle(dag):
-    """
-    Check to see if there are any cycles in the DAG. Returns False if no cycle found,
-    otherwise raises exception.
+def check_cycle(dag: "DAG") -> None:
+    """Check to see if there are any cycles in the DAG.
+
+    :raises AirflowDagCycleException: If cycle is found in the DAG.
     """
     # default of int is 0 which corresponds to CYCLE_NEW
     visited = defaultdict(int)


### PR DESCRIPTION
Fix #17079.

I also took the chance to fix the incorrect description in `dag_cycle_tester.check_cycle` (it does not return False when no cycles re found), and added type annotations.