### PR TITLE
Correct the :mod: documentation for s3_to_redshift_operator

### DIFF
--- a/airflow/operators/s3_to_redshift_operator.py
+++ b/airflow/operators/s3_to_redshift_operator.py
@@ -17,7 +17,7 @@
 # under the License.
 """
 This module is deprecated.
-Please use :mod:`airflow.providers.amazon.aws.operators.s3_to_redshift`.
+Please use :mod:`airflow.providers.amazon.aws.transfers.s3_to_redshift`.
 """
 
 import warnings


### PR DESCRIPTION
### Problem

`airflow.providers.amazon.aws.operators.s3_to_redshift` is referenced in the docs but it does not exist.

### Solution

Update module to `airflow.providers.amazon.aws.transfers.s3_to_redshift`.