### PR TITLE
Made S3ToRedshiftOperator transaction safe

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -118,10 +118,10 @@ class S3ToRedshiftOperator(BaseOperator):
         copy_statement = self._build_copy_query(credentials_block, copy_options)
 
         if self.truncate_table:
-            truncate_statement = f'TRUNCATE TABLE {self.schema}.{self.table};'
+            delete_statement = f'DELETE FROM {self.schema}.{self.table};'
             sql = f"""
             BEGIN;
-            {truncate_statement}
+            {delete_statement}
             {copy_statement}
             COMMIT
             """

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -145,10 +145,10 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                         'aws_access_key_id=aws_access_key_id;aws_secret_access_key=aws_secret_access_key'
                         ;
                      '''
-        truncate_statement = f'TRUNCATE TABLE {schema}.{table};'
+        delete_statement = f'DELETE FROM {schema}.{table};'
         transaction = f"""
                     BEGIN;
-                    {truncate_statement}
+                    {delete_statement}
                     {copy_statement}
                     COMMIT
                     """


### PR DESCRIPTION
Made S3ToRedshiftOperator transaction safe. Now all SQL statements are running in one transaction.
Closes: #14888.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
