### PR TITLE
Deactivating DAGs which have been removed from files

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2807,7 +2807,6 @@ class DagModel(Base):
     def deactivate_deleted_dags(cls, alive_dag_filelocs: List[str], session=None):
         """
         Set ``is_active=False`` on the DAGs for which the DAG files have been removed.
-        Additionally change ``is_active=False`` to ``True`` if the DAG file exists.
 
         :param alive_dag_filelocs: file paths of alive DAGs
         :param session: ORM Session
@@ -2819,11 +2818,6 @@ class DagModel(Base):
             if dag_model.fileloc is not None:
                 if correct_maybe_zipped(dag_model.fileloc) not in alive_dag_filelocs:
                     dag_model.is_active = False
-                else:
-                    # If is_active is set as False and the DAG File still exists
-                    # Change is_active=True
-                    if not dag_model.is_active:
-                        dag_model.is_active = True
             else:
                 continue
 

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -633,3 +633,28 @@ class TestDagFileProcessor:
             )
             assert import_error.stacktrace == expected_stacktrace.format(invalid_dag_filename)
             session.rollback()
+
+    def test_process_file_should_deactivate_missing_dags(self):
+
+        dag_file = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), '../dags/test_only_dummy_tasks.py'
+        )
+
+        # write a DAG into the DB which is not present in its specified file
+        with create_session() as session:
+            orm_dag = DagModel(dag_id='missing_dag', is_active=True, fileloc=dag_file)
+            session.merge(orm_dag)
+            session.commit()
+
+        session = settings.Session()
+
+        dags = session.query(DagModel).all()
+        assert [dag.dag_id for dag in dags if dag.is_active] == ['missing_dag']
+
+        # re-parse the file and see that the DAG is no longer there
+        dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
+        dag_file_processor.process_file(dag_file, [])
+
+        dags = session.query(DagModel).all()
+        assert [dag.dag_id for dag in dags if dag.is_active] == ['test_only_dummy_tasks']
+        assert [dag.dag_id for dag in dags if not dag.is_active] == ['missing_dag']

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
 from unittest import mock
 
 import flask
@@ -128,7 +129,7 @@ def working_dags(tmpdir):
 
     with create_session() as session:
         for dag_id in TEST_FILTER_DAG_IDS:
-            filename = tmpdir / f"{dag_id}.py"
+            filename = os.path.join(tmpdir, f"{dag_id}.py")
             with open(filename, "w") as f:
                 f.writelines(dag_contents_template.format(dag_id))
             _process_file(filename, session)
@@ -138,7 +139,7 @@ def working_dags(tmpdir):
 def broken_dags(tmpdir, working_dags):
     with create_session() as session:
         for dag_id in TEST_FILTER_DAG_IDS:
-            filename = tmpdir / f"{dag_id}.py"
+            filename = os.path.join(tmpdir, f"{dag_id}.py")
             with open(filename, "w") as f:
                 f.writelines('airflow DAG')
             _process_file(filename, session)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Closes: https://github.com/apache/airflow/issues/11901
Closes: https://github.com/apache/airflow/issues/17516

Ensuring that the active DAGs in the DB are all actually present in their corresponding python files by reconciling the DB state and with the contents of a given DAG file on every parse operation. 

This _should_ prevent a lot of issues encountered when writing multiple DAGs per-file, renaming DAGs or dynamically generating DAGs based on a config file read at parse-time.

This will cause a few other functional changes:

1) DAGs will disappear from the UI if an ImportError is introduced in the underlying file.
2) DAGs will no longer be re-marked as active if they are inactive / missing but the file is present.
3) DAGs could be incorrectly marked inactive if there's an unexpected parsing error (I guess this is a tradeoff between false-poitives and false-negatives)

#### Validation:

I have validated these changes in a local breeze environment with the following DAG:

```python
from airflow.models import DAG
from airflow import utils
from airflow.operators.python import PythonOperator

NUM_DAGS=1

def message():
    print('Hello, world.')

for i in range(NUM_DAGS):
    with DAG(f'dag-{i}', schedule_interval=None, start_date=utils.dates.days_ago(1)) as dag:
        task = PythonOperator(
            task_id='task',
            python_callable=message
        )
        globals()[f"dag_{i}"] = dag

```

By changing the value of `NUM_DAGS` I can quickly change the number of DAG objects present in this file. 

Before this change, decreasing the value of `NUM_DAGS` would leave a bunch of stale DAGs in the UI. These could be triggered but would then fail as the executor was not able to load the specified task from the file.

After implementing this change, stale DAGs disappear from the UI shortly after decreasing the value of `NUM_DAGS`.

#### Questions:

1. Is there a good reason for Airflow to mark inactive DAGs as active if the file still exists? I looked through the [original PR which introduced this](https://github.com/apache/airflow/pull/5743/files) but couldn't find an explanation.

2. How significant is the performance hit incurred by updating the DAG table on every parse operation?
 
3. Will this change introduce any other functional changes that I haven't mentioned above?

#### Follow up:

If this PR is merged, we should also add some documentation which discusses dynamically generated DAGs, and explains how to generate multiple DAGs in a loop as shown in the example above.