### PR TITLE
Fix bool conversion Verify parameter in Tableau Hook

### DIFF
--- a/airflow/providers/tableau/hooks/tableau.py
+++ b/airflow/providers/tableau/hooks/tableau.py
@@ -65,11 +65,12 @@ class TableauHook(BaseHook):
         self.conn = self.get_connection(self.tableau_conn_id)
         self.site_id = site_id or self.conn.extra_dejson.get('site_id', '')
         self.server = Server(self.conn.host)
-        verify = self.conn.extra_dejson.get('verify', 'True')
-        try:
-            verify = bool(strtobool(verify))
-        except ValueError:
-            pass
+        verify = self.conn.extra_dejson.get('verify', True)
+        if isinstance(verify, str):
+            try:
+                verify = bool(strtobool(verify))
+            except ValueError:
+                pass
         self.server.add_http_options(
             options_dict={'verify': verify, 'cert': self.conn.extra_dejson.get('cert', None)}
         )

--- a/tests/providers/tableau/hooks/test_tableau.py
+++ b/tests/providers/tableau/hooks/test_tableau.py
@@ -74,6 +74,16 @@ class TestTableauHook(unittest.TestCase):
         )
         db.merge_conn(
             models.Connection(
+                conn_id='tableau_test_ssl_bool_param_connection',
+                conn_type='tableau',
+                host='tableau',
+                login='user',
+                password='password',
+                extra='{"verify": false}',
+            )
+        )
+        db.merge_conn(
+            models.Connection(
                 conn_id='tableau_test_ssl_connection_default',
                 conn_type='tableau',
                 host='tableau',
@@ -165,6 +175,25 @@ class TestTableauHook(unittest.TestCase):
         Test get conn with default SSL disabled parameters
         """
         with TableauHook(tableau_conn_id='tableau_test_ssl_false_connection') as tableau_hook:
+            mock_server.assert_called_once_with(tableau_hook.conn.host)
+            mock_server.return_value.add_http_options.assert_called_once_with(
+                options_dict={'verify': False, 'cert': None}
+            )
+            mock_tableau_auth.assert_called_once_with(
+                username=tableau_hook.conn.login,
+                password=tableau_hook.conn.password,
+                site_id='',
+            )
+            mock_server.return_value.auth.sign_in.assert_called_once_with(mock_tableau_auth.return_value)
+        mock_server.return_value.auth.sign_out.assert_called_once_with()
+
+    @patch('airflow.providers.tableau.hooks.tableau.TableauAuth')
+    @patch('airflow.providers.tableau.hooks.tableau.Server')
+    def test_get_conn_ssl_bool_param(self, mock_server, mock_tableau_auth):
+        """
+        Test get conn with SSL Verify parameter as bool
+        """
+        with TableauHook(tableau_conn_id='tableau_test_ssl_bool_param_connection') as tableau_hook:
             mock_server.assert_called_once_with(tableau_hook.conn.host)
             mock_server.return_value.add_http_options.assert_called_once_with(
                 options_dict={'verify': False, 'cert': None}


### PR DESCRIPTION
Hello all,
During the RC tests, I founded this bug (generated from my PR #16365). The bug is present when the user set in `Extra` parameter field in a `Tableau Connection` the parameter `Verify` equals to `false` or `true`. During the JSON parsing, the value is automatically read as `bool`, so the explicit conversion `str` to `bool` is not necessary.

```
[2021-07-21, 07:15:33 UTC] {taskinstance.py:1455} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/taskinstance.py", line 1182, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1285, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1315, in _execute_task
    result = task_copy.execute(context=context)
  File "/opt/airflow/airflow/providers/tableau/operators/tableau_refresh_workbook.py", line 70, in execute
    with TableauHook(self.site_id, self.tableau_conn_id) as tableau_hook:
  File "/opt/airflow/airflow/providers/tableau/hooks/tableau.py", line 70, in __init__
    verify = bool(strtobool(verify))
  File "/usr/local/lib/python3.8/distutils/util.py", line 313, in strtobool
    val = val.lower()
AttributeError: 'bool' object has no attribute 'lower'
```
**Code changes:**

1. Added check type before conversion for `Verify` parameter
2. Added test in TableauHook tests to check this situation

Thank you

