### PR TITLE
[Airflow 13779] use provided parameters in the wait_for_pipeline_state hook

### DIFF
--- a/airflow/providers/google/cloud/hooks/datafusion.py
+++ b/airflow/providers/google/cloud/hooks/datafusion.py
@@ -464,15 +464,7 @@ class DataFusionHook(GoogleBaseHook):
             raise AirflowException(f"Starting a pipeline failed with code {response.status}")
 
         response_json = json.loads(response.data)
-        pipeline_id = response_json[0]["runId"]
-        self.wait_for_pipeline_state(
-            success_states=SUCCESS_STATES + [PipelineStates.RUNNING],
-            pipeline_name=pipeline_name,
-            pipeline_id=pipeline_id,
-            namespace=namespace,
-            instance_url=instance_url,
-        )
-        return pipeline_id
+        return response_json[0]["runId"]
 
     def stop_pipeline(self, pipeline_name: str, instance_url: str, namespace: str = "default") -> None:
         """

--- a/tests/providers/google/cloud/hooks/test_datafusion.py
+++ b/tests/providers/google/cloud/hooks/test_datafusion.py
@@ -20,7 +20,7 @@ from unittest import mock
 
 import pytest
 
-from airflow.providers.google.cloud.hooks.datafusion import SUCCESS_STATES, DataFusionHook, PipelineStates
+from airflow.providers.google.cloud.hooks.datafusion import DataFusionHook
 from tests.providers.google.cloud.utils.base_gcp_mock import mock_base_gcp_hook_default_project_id
 
 API_VERSION = "v1beta1"
@@ -180,8 +180,7 @@ class TestDataFusionHook:
         assert result == data
 
     @mock.patch(HOOK_STR.format("DataFusionHook._cdap_request"))
-    @mock.patch(HOOK_STR.format("DataFusionHook.wait_for_pipeline_state"))
-    def test_start_pipeline(self, mock_wait_for_pipeline_state, mock_request, hook):
+    def test_start_pipeline(self, mock_request, hook):
         run_id = 1234
         mock_request.return_value = mock.MagicMock(status=200, data=f'[{{"runId":{run_id}}}]')
 
@@ -196,13 +195,6 @@ class TestDataFusionHook:
         ]
         mock_request.assert_called_once_with(
             url=f"{INSTANCE_URL}/v3/namespaces/default/start", method="POST", body=body
-        )
-        mock_wait_for_pipeline_state.assert_called_once_with(
-            instance_url=INSTANCE_URL,
-            namespace="default",
-            pipeline_name=PIPELINE_NAME,
-            pipeline_id=run_id,
-            success_states=SUCCESS_STATES + [PipelineStates.RUNNING],
         )
 
     @mock.patch(HOOK_STR.format("DataFusionHook._cdap_request"))


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/13779

Give a possibility to run `wait_for_pipeline_state` with default or provided parameters, remove unnecessary call inside `start_pipeline` hook.

Why I removed `wait_for_pipeline_state`  from `start_pipeline` hook. By this call, I think we have a bug in this operator, for example when we have pipeline which starting more than `300` seconds, so it have a starting status, we get the error because this pipepline is not in correct state after `300` seconds. Even when we pass our parameters `sucess_states` and `pipeline_timeout` we get this error in this case, so I think when I pass both parameters the logic should use them not default. Why we have `300` second and these `SUCCESS_STATES + [PipelineStates.RUNNING]`, because we had these values in the `wait_for_pipeline_state` call which I removed from hook, I think we should replace this 300 second and use default value from `__init__` method (this is a open question I think)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
