### PR TITLE
ECSOperator / pass context to self.xcom_pull as it was missing (when using reattach)

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -220,7 +220,7 @@ class ECSOperator(BaseOperator):
         self.client = self.get_hook().get_conn()
 
         if self.reattach:
-            self._try_reattach_task()
+            self._try_reattach_task(context)
 
         if not self.arn:
             self._start_task(context)
@@ -301,7 +301,7 @@ class ECSOperator(BaseOperator):
             execution_date=context["ti"].execution_date,
         )
 
-    def _try_reattach_task(self):
+    def _try_reattach_task(self, context):
         task_def_resp = self.client.describe_task_definition(taskDefinition=self.task_definition)
         ecs_task_family = task_def_resp['taskDefinition']['family']
 
@@ -312,6 +312,7 @@ class ECSOperator(BaseOperator):
 
         # Check if the ECS task previously launched is already running
         previous_task_arn = self.xcom_pull(
+            context,
             task_ids=self.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.task_id),
             key=self.REATTACH_XCOM_KEY,
         )

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -80,6 +80,7 @@ class TestECSOperator(unittest.TestCase):
 
     def setUp(self):
         self.set_up_operator()
+        self.mock_context = mock.MagicMock()
 
     def test_init(self):
         assert self.ecs.region_name == 'eu-west-1'
@@ -340,7 +341,7 @@ class TestECSOperator(unittest.TestCase):
         }
 
         self.ecs.reattach = True
-        self.ecs.execute(None)
+        self.ecs.execute(self.mock_context)
 
         self.aws_hook_mock.return_value.get_conn.assert_called_once()
         extend_args = {}
@@ -357,6 +358,7 @@ class TestECSOperator(unittest.TestCase):
 
         start_mock.assert_not_called()
         xcom_pull_mock.assert_called_once_with(
+            self.mock_context,
             key=self.ecs.REATTACH_XCOM_KEY,
             task_ids=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id),
         )
@@ -389,7 +391,7 @@ class TestECSOperator(unittest.TestCase):
         client_mock.run_task.return_value = RESPONSE_WITHOUT_FAILURES
 
         self.ecs.reattach = True
-        self.ecs.execute(None)
+        self.ecs.execute(self.mock_context)
 
         self.aws_hook_mock.return_value.get_conn.assert_called_once()
         extend_args = {}
@@ -403,7 +405,7 @@ class TestECSOperator(unittest.TestCase):
         reattach_mock.assert_called_once()
         client_mock.run_task.assert_called_once()
         xcom_set_mock.assert_called_once_with(
-            None,
+            self.mock_context,
             key=self.ecs.REATTACH_XCOM_KEY,
             task_id=self.ecs.REATTACH_XCOM_TASK_ID_TEMPLATE.format(task_id=self.ecs.task_id),
             value="arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55",


### PR DESCRIPTION
FYI @darwinyip 

This is to fix a bug I found with context not being passed to xcom_pull (used for the `reattach` feature)
```
Traceback (most recent call last):
  File "/home/airflow/.local/bin/airflow", line 8, in <module>
    sys.exit(main())
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/__main__.py", line 40, in main
    args.func(args)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/utils/cli.py", line 91, in wrapper
    return f(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/cli/commands/task_command.py", line 393, in task_test
    ti.run(ignore_task_deps=True, ignore_ti_state=True, test_mode=True)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1432, in run
    self._run_raw_task(
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/utils/session.py", line 67, in wrapper
    return func(*args, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1157, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1331, in _prepare_and_execute_task_with_callbacks
    result = self._execute_task(context, task_copy)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/models/taskinstance.py", line 1356, in _execute_task
    result = task_copy.execute(context=context)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 218, in execute
    self._try_reattach_task()
  File "/home/airflow/.local/lib/python3.8/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 309, in _try_reattach_task
    previous_task_arn = self.xcom_pull(
TypeError: xcom_pull() missing 1 required positional argument: 'context'
```

I updated the unit tests and ran that new code locally to make sure it was working as expected.

@o-nikolas @kaxil 

