### PR TITLE
deprecate dummy trigger rule infavor of always

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -73,6 +73,12 @@ https://developers.google.com/style/inclusive-documentation
 
 -->
 
+### Dummy trigger rule has been deprecated
+
+`TriggerRule.DUMMY` is replaced by `TriggerRule.ALWAYS`.
+This is only name change, no functionality changes made.
+This change is backward compatible however `TriggerRule.DUMMY` will be removed in next major release.
+
 ### DAG concurrency settings have been renamed
 
 `[core] dag_concurrency` setting in `airflow.cfg` has been renamed to `[core] max_active_tasks_per_dag`

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -348,7 +348,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     :param trigger_rule: defines the rule by which dependencies are applied
         for the task to get triggered. Options are:
         ``{ all_success | all_failed | all_done | one_success |
-        one_failed | none_failed | none_failed_or_skipped | none_skipped | dummy}``
+        one_failed | none_failed | none_failed_or_skipped | none_skipped | always}``
         default is ``all_success``. Options can be set as string or
         using the constants defined in the static class
         ``airflow.utils.TriggerRule``
@@ -541,6 +541,14 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         self.end_date = end_date
         if end_date:
             self.end_date = timezone.convert_to_utc(end_date)
+
+        if trigger_rule == "dummy":
+            warnings.warn(
+                "dummy Trigger Rule is deprecated. Please use `TriggerRule.ALWAYS`.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            trigger_rule = TriggerRule.ALWAYS
 
         if not TriggerRule.is_valid(trigger_rule):
             raise AirflowException(

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -61,8 +61,8 @@ class TriggerRuleDep(BaseTIDep):
             yield self._passing_status(reason="The task instance did not have any upstream tasks.")
             return
 
-        if ti.task.trigger_rule == TR.DUMMY:
-            yield self._passing_status(reason="The task had a dummy trigger rule set.")
+        if ti.task.trigger_rule == TR.ALWAYS:
+            yield self._passing_status(reason="The task had a always trigger rule set.")
             return
         # see if the task name is in the task upstream for our task
         successes, skipped, failed, upstream_failed, done = self._get_states_count_upstream_ti(

--- a/airflow/utils/trigger_rule.py
+++ b/airflow/utils/trigger_rule.py
@@ -31,6 +31,7 @@ class TriggerRule:
     NONE_FAILED_OR_SKIPPED = 'none_failed_or_skipped'
     NONE_SKIPPED = 'none_skipped'
     DUMMY = 'dummy'
+    ALWAYS = 'always'
 
     _ALL_TRIGGER_RULES: Set[str] = set()
 

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -337,7 +337,7 @@ However, this is just the default behaviour, and you can control it using the ``
 * ``none_failed``: All upstream tasks have not ``failed`` or ``upstream_failed`` - that is, all upstream tasks have succeeded or been skipped
 * ``none_failed_or_skipped``: All upstream tasks have not ``failed`` or ``upstream_failed``, and at least one upstream task has succeeded.
 * ``none_skipped``: No upstream task is in a ``skipped`` state - that is, all upstream tasks are in a ``success``, ``failed``, or ``upstream_failed`` state
-* ``dummy``: No dependencies at all, run this task at any time
+* ``always``: No dependencies at all, run this task at any time
 
 You can also combine this with the :ref:`concepts:depends-on-past` functionality if you wish.
 

--- a/tests/ti_deps/deps/test_trigger_rule_dep.py
+++ b/tests/ti_deps/deps/test_trigger_rule_dep.py
@@ -48,11 +48,11 @@ class TestTriggerRuleDep(unittest.TestCase):
         ti = self._get_task_instance(TriggerRule.ALL_DONE, State.UP_FOR_RETRY)
         assert TriggerRuleDep().is_met(ti=ti)
 
-    def test_dummy_tr(self):
+    def test_always_tr(self):
         """
-        The dummy trigger rule should always pass this dep
+        The always trigger rule should always pass this dep
         """
-        ti = self._get_task_instance(TriggerRule.DUMMY, State.UP_FOR_RETRY)
+        ti = self._get_task_instance(TriggerRule.ALWAYS, State.UP_FOR_RETRY)
         assert TriggerRuleDep().is_met(ti=ti)
 
     def test_one_success_tr_success(self):

--- a/tests/utils/test_trigger_rule.py
+++ b/tests/utils/test_trigger_rule.py
@@ -32,4 +32,5 @@ class TestTriggerRule(unittest.TestCase):
         assert TriggerRule.is_valid(TriggerRule.NONE_FAILED_OR_SKIPPED)
         assert TriggerRule.is_valid(TriggerRule.NONE_SKIPPED)
         assert TriggerRule.is_valid(TriggerRule.DUMMY)
-        assert len(TriggerRule.all_triggers()) == 9
+        assert TriggerRule.is_valid(TriggerRule.ALWAYS)
+        assert len(TriggerRule.all_triggers()) == 10


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/15994

This PR handles:

- Deprecating dummy trigger rule.
- Introducing ~null~ always trigger rule.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
