### PR TITLE
Doc: Recommend using same configs on all Airflow components

### DIFF
--- a/docs/apache-airflow/configurations-ref.rst
+++ b/docs/apache-airflow/configurations-ref.rst
@@ -22,6 +22,11 @@ Configuration Reference
 This page contains the list of all the available Airflow configurations that you
 can set in ``airflow.cfg`` file or using environment variables.
 
+Use the same configuration across all the Airflow components. While each component
+does not require all, some configurations need to be same otherwise they would not
+work as expected. A good example for that is :ref:`secret_key<config:webserver__secret_key>` which
+should be same on the Webserver and Worker to allow Webserver to fetch logs from Worker.
+
 .. note::
     For more information on setting the configuration, see :doc:`howto/set-config`
 

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -115,3 +115,9 @@ the example below.
 
 .. note::
     See :doc:`../modules_management` for details on how Python and Airflow manage modules.
+
+.. note::
+    Use the same configuration across all the Airflow components. While each component
+    does not require all, some configurations need to be same otherwise they would not
+    work as expected. A good example for that is :ref:`secret_key<config:webserver__secret_key>` which
+    should be same on the Webserver and Worker to allow Webserver to fetch logs from Worker.


### PR DESCRIPTION
Some users seem to be using different configs for different components. This doc makes it clear on what we recommend.

Context: https://github.com/apache/airflow/pull/16754#issuecomment-884419057

>I'm new to Airflow and I haven't seen an explicit part within the docs that says "all configuration must be shared between airflow components". In fact, all configuration keys are prefixed with some naming scheme which led me to think that some are common, some are for webserver etc... I personally don't like to have common configuration because changing a single setting requires a change in all components (hence restart) but I get that this is intentional for Airflow. I think this can be better communicated throughout the docs.


cc @tunix 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
