### PR TITLE
Include exit code in AirflowException str when BashOperator fails.

### DIFF
--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -173,7 +173,9 @@ class BashOperator(BaseOperator):
         if self.skip_exit_code is not None and result.exit_code == self.skip_exit_code:
             raise AirflowSkipException(f"Bash command returned exit code {self.skip_exit_code}. Skipping.")
         elif result.exit_code != 0:
-            raise AirflowException('Bash command failed. The command returned a non-zero exit code.')
+            raise AirflowException(
+                f'Bash command failed. The command returned a non-zero exit code {result.exit_code}.'
+            )
         return result.output
 
     def on_kill(self) -> None:

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -101,7 +101,7 @@ class TestBashOperator(unittest.TestCase):
     def test_raise_exception_on_non_zero_exit_code(self):
         bash_operator = BashOperator(bash_command='exit 42', task_id='test_return_value', dag=None)
         with pytest.raises(
-            AirflowException, match="Bash command failed\\. The command returned a non-zero exit code\\."
+            AirflowException, match="Bash command failed\\. The command returned a non-zero exit code 42\\."
         ):
             bash_operator.execute(context={})
 
@@ -119,7 +119,7 @@ class TestBashOperator(unittest.TestCase):
 
     def test_command_not_found(self):
         with pytest.raises(
-            AirflowException, match="Bash command failed\\. The command returned a non-zero exit code\\."
+            AirflowException, match="Bash command failed\\. The command returned a non-zero exit code 127\\."
         ):
             BashOperator(task_id='abc', bash_command='set -e; something-that-isnt-on-path').execute({})
 


### PR DESCRIPTION
Right now upon failure, BashOperator will only raise AirflowException saying there is some non-zero exit code but does NOT specify which non-zero code it is! Consequently, that prevents user from providing specific actions in `on_failure_callback()` w.r.t. different exit codes.

In comparison, many other operators or hooks in the repo already include the non-zero exit code in their exception strings, to name a few:

- [spark_sql.py](https://github.com/apache/airflow/blob/main/airflow/providers/apache/spark/hooks/spark_sql.py#L194)
- [spark_submit.py](https://github.com/apache/airflow/blob/main/airflow/providers/apache/spark/hooks/spark_submit.py#L445)
- [azure_container_instances.py](https://github.com/apache/airflow/blob/main/airflow/providers/microsoft/azure/operators/azure_container_instances.py#L279)
- [dataflow.py](https://github.com/apache/airflow/blob/main/airflow/providers/google/cloud/hooks/dataflow.py#L1017)

This PR simply

- adds that non-zero exit code to the exception string for BashOperator as well,
- and also updates its unit tests accordingly. Unit tested in local breeze environment.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
