### PR TITLE
Create virtualenv via python call

### DIFF
--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -22,12 +22,13 @@ from collections import deque
 from typing import List, Optional
 
 import jinja2
+import virtualenv
 
 from airflow.utils.process_utils import execute_in_subprocess
 
 
 def _generate_virtualenv_cmd(tmp_dir: str, python_bin: str, system_site_packages: bool) -> List[str]:
-    cmd = ['virtualenv', tmp_dir]
+    cmd = [tmp_dir]
     if system_site_packages:
         cmd.append('--system-site-packages')
     if python_bin is not None:
@@ -92,7 +93,7 @@ def prepare_virtualenv(
     :rtype: str
     """
     virtualenv_cmd = _generate_virtualenv_cmd(venv_directory, python_bin, system_site_packages)
-    execute_in_subprocess(virtualenv_cmd)
+    virtualenv.cli_run(virtualenv_cmd)
     pip_cmd = _generate_pip_install_cmd(venv_directory, requirements)
     if pip_cmd:
         execute_in_subprocess(pip_cmd)

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -18,17 +18,17 @@
 #
 """Utilities for creating a virtual environment"""
 import os
+import sys
 from collections import deque
 from typing import List, Optional
 
 import jinja2
-import virtualenv
 
 from airflow.utils.process_utils import execute_in_subprocess
 
 
 def _generate_virtualenv_cmd(tmp_dir: str, python_bin: str, system_site_packages: bool) -> List[str]:
-    cmd = [tmp_dir]
+    cmd = [sys.executable, '-m', 'virtualenv', tmp_dir]
     if system_site_packages:
         cmd.append('--system-site-packages')
     if python_bin is not None:
@@ -93,7 +93,7 @@ def prepare_virtualenv(
     :rtype: str
     """
     virtualenv_cmd = _generate_virtualenv_cmd(venv_directory, python_bin, system_site_packages)
-    virtualenv.cli_run(virtualenv_cmd)
+    execute_in_subprocess(virtualenv_cmd)
     pip_cmd = _generate_pip_install_cmd(venv_directory, requirements)
     if pip_cmd:
         execute_in_subprocess(pip_cmd)

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import sys
 import unittest
 from unittest import mock
 
@@ -29,7 +30,9 @@ class TestPrepareVirtualenv(unittest.TestCase):
             venv_directory="/VENV", python_bin="pythonVER", system_site_packages=False, requirements=[]
         )
         assert "/VENV/bin/python" == python_bin
-        mock_execute_in_subprocess.assert_called_once_with(['virtualenv', '/VENV', '--python=pythonVER'])
+        mock_execute_in_subprocess.assert_called_once_with(
+            [sys.executable, '-m', 'virtualenv', '/VENV', '--python=pythonVER']
+        )
 
     @mock.patch('airflow.utils.python_virtualenv.execute_in_subprocess')
     def test_should_create_virtualenv_with_system_packages(self, mock_execute_in_subprocess):
@@ -38,7 +41,7 @@ class TestPrepareVirtualenv(unittest.TestCase):
         )
         assert "/VENV/bin/python" == python_bin
         mock_execute_in_subprocess.assert_called_once_with(
-            ['virtualenv', '/VENV', '--system-site-packages', '--python=pythonVER']
+            [sys.executable, '-m', 'virtualenv', '/VENV', '--system-site-packages', '--python=pythonVER']
         )
 
     @mock.patch('airflow.utils.python_virtualenv.execute_in_subprocess')
@@ -51,7 +54,9 @@ class TestPrepareVirtualenv(unittest.TestCase):
         )
         assert "/VENV/bin/python" == python_bin
 
-        mock_execute_in_subprocess.assert_any_call(['virtualenv', '/VENV', '--python=pythonVER'])
+        mock_execute_in_subprocess.assert_any_call(
+            [sys.executable, '-m', 'virtualenv', '/VENV', '--python=pythonVER']
+        )
 
         mock_execute_in_subprocess.assert_called_with(['/VENV/bin/pip', 'install', 'apache-beam[gcp]'])
 


### PR DESCRIPTION
This PR  creates virtualenv with python call instead of virtualenv binary to make it work with MWAA. Currently MWAA would fail on
```
FileNotFoundError: [Errno 2] No such file or directory: 'virtualenv': 'virtualenv'
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
