### PR TITLE
Fix typo in GoogleCloudStorageToBigQueryOperator

### DIFF
--- a/airflow/contrib/operators/gcs_to_bq.py
+++ b/airflow/contrib/operators/gcs_to_bq.py
@@ -31,13 +31,13 @@ warnings.warn(
 class GoogleCloudStorageToBigQueryOperator(GCSToBigQueryOperator):
     """
     This class is deprecated.
-    Please use `airflow.providers.google.cloud.transfers.gcs_to_bq.GCSToBigQueryOperator`.
+    Please use `airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSToBigQueryOperator`.
     """
 
     def __init__(self, *args, **kwargs):
         warnings.warn(
             """This class is deprecated.
-            Please use `airflow.providers.google.cloud.transfers.gcs_to_bq.GCSToBigQueryOperator`.""",
+            Please use `airflow.providers.google.cloud.transfers.gcs_to_bigquery.GCSToBigQueryOperator`.""",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_bigquery.py
@@ -31,7 +31,7 @@ LABELS = {'k1': 'v1'}
 DESCRIPTION = "Test Description"
 
 
-class TestGoogleCloudStorageToBigQueryOperator(unittest.TestCase):
+class TestGCSToBigQueryOperator(unittest.TestCase):
     @mock.patch('airflow.providers.google.cloud.transfers.gcs_to_bigquery.BigQueryHook')
     def test_execute_explicit_project_legacy(self, bq_hook):
         operator = GCSToBigQueryOperator(


### PR DESCRIPTION
This PR includes a couple of fixes in the deprecation message of the `GoogleCloudStorageToBigQueryOperator` module and the `GCSToBigQueryOperator` test. 

closes: #17155