### PR TITLE
Google Ads Hook: Support newer versions of the google-ads library

### DIFF
--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -34,7 +34,7 @@ Breaking changes
 
    In order to use the API's new proto-plus format, you can use the `search_proto_plus()` method.
 
-   For more information, please consult google's migration document: https://developers.google.com/google-ads/api/docs/client-libs/python/library-version-10
+   For more information, please consult `google-ads migration document <https://developers.google.com/google-ads/api/docs/client-libs/python/library-version-10>`__: 
 
 
 Features

--- a/airflow/providers/google/CHANGELOG.rst
+++ b/airflow/providers/google/CHANGELOG.rst
@@ -21,6 +21,22 @@ Changelog
 4.1.0
 .....
 
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* ``Updated GoogleAdsHook to support newer API versions after google deprecated v5. Google Ads v8 is the new default API. (#17111)``
+
+.. warning:: The underlying google-ads library had breaking changes.
+   
+   Previously the google ads library returned data as native protobuf messages. Now it returns data as proto-plus objects that behave more like conventional Python objects. 
+
+   To preserve compatibility the hook's `search()` converts the data back to native protobuf before returning it. Your existing operators *should* work as before, but due to the urgency of the v5 API being deprecated it was not tested too thoroughly. Therefore you should carefully evaluate your operator and hook functionality with this new version.
+
+   In order to use the API's new proto-plus format, you can use the `search_proto_plus()` method.
+
+   For more information, please consult google's migration document: https://developers.google.com/google-ads/api/docs/client-libs/python/library-version-10
+
+
 Features
 ~~~~~~~~
 

--- a/airflow/providers/google/ads/hooks/ads.py
+++ b/airflow/providers/google/ads/hooks/ads.py
@@ -23,9 +23,9 @@ try:
     from functools import cached_property
 except ImportError:
     from cached_property import cached_property
-from google.ads.google_ads.client import GoogleAdsClient
-from google.ads.google_ads.errors import GoogleAdsException
-from google.ads.google_ads.v2.types import GoogleAdsRow
+from google.ads.googleads.client import GoogleAdsClient
+from google.ads.googleads.errors import GoogleAdsException
+from google.ads.googleads.v8.services.types.google_ads_service import GoogleAdsRow
 from google.api_core.page_iterator import GRPCIterator
 from google.auth.exceptions import GoogleAuthError
 from googleapiclient.discovery import Resource
@@ -76,7 +76,7 @@ class GoogleAdsHook(BaseHook):
     :rtype: list[GoogleAdsRow]
     """
 
-    default_api_version = "v5"
+    default_api_version = "v8"
 
     def __init__(
         self,
@@ -90,15 +90,92 @@ class GoogleAdsHook(BaseHook):
         self.google_ads_conn_id = google_ads_conn_id
         self.google_ads_config: Dict[str, Any] = {}
 
+    def search(
+        self, client_ids: List[str], query: str, page_size: int = 10000, **kwargs
+    ) -> List[GoogleAdsRow]:
+        """
+        Pulls data from the Google Ads API and returns it as native protobuf
+        message instances (those seen in versions prior to 10.0.0 of the
+        google-ads library).
+
+        This method is for backwards compatibility with older versions of the
+        google_ads_hook.
+
+        Check out the search_proto_plus method to get API results in the new
+        default format of the google-ads library since v10.0.0 that behave
+        more like conventional python object (using proto-plus-python).
+
+        :param client_ids: Google Ads client ID(s) to query the API for.
+        :type client_ids: List[str]
+        :param query: Google Ads Query Language query.
+        :type query: str
+        :param page_size: Number of results to return per page. Max 10000.
+        :type page_size: int
+        :return: Google Ads API response, converted to Google Ads Row objects
+        :rtype: list[GoogleAdsRow]
+        """
+        data_proto_plus = self._search(client_ids, query, page_size, **kwargs)
+        data_native_pb = [row._pb for row in data_proto_plus]
+
+        return data_native_pb
+
+    def search_proto_plus(
+        self, client_ids: List[str], query: str, page_size: int = 10000, **kwargs
+    ) -> List[GoogleAdsRow]:
+        """
+        Pulls data from the Google Ads API and returns it as proto-plus-python
+        message instances that behave more like conventional python objects.
+
+        :param client_ids: Google Ads client ID(s) to query the API for.
+        :type client_ids: List[str]
+        :param query: Google Ads Query Language query.
+        :type query: str
+        :param page_size: Number of results to return per page. Max 10000.
+        :type page_size: int
+        :return: Google Ads API response, converted to Google Ads Row objects
+        :rtype: list[GoogleAdsRow]
+        """
+        return self._search(client_ids, query, page_size, **kwargs)
+
+    def list_accessible_customers(self) -> List[str]:
+        """
+        Returns resource names of customers directly accessible by the user authenticating the call.
+        The resulting list of customers is based on your OAuth credentials. The request returns a list
+        of all accounts that you are able to act upon directly given your current credentials. This will
+        not necessarily include all accounts within the account hierarchy; rather, it will only include
+        accounts where your authenticated user has been added with admin or other rights in the account.
+
+        ..seealso::
+            https://developers.google.com/google-ads/api/reference/rpc
+
+        :return: List of names of customers
+        """
+        try:
+            accessible_customers = self._get_customer_service.list_accessible_customers()
+            return accessible_customers.resource_names
+        except GoogleAdsException as ex:
+            for error in ex.failure.errors:
+                self.log.error('\tError with message "%s".', error.message)
+                if error.location:
+                    for field_path_element in error.location.field_path_elements:
+                        self.log.error('\t\tOn field: %s', field_path_element.field_name)
+            raise
+
     @cached_property
     def _get_service(self) -> Resource:
         """Connects and authenticates with the Google Ads API using a service account"""
+
+        client = self._get_client
+        return client.get_service("GoogleAdsService", version=self.api_version)
+
+    @cached_property
+    def _get_client(self) -> Resource:
         with NamedTemporaryFile("w", suffix=".json") as secrets_temp:
             self._get_config()
             self._update_config_with_secret(secrets_temp)
             try:
                 client = GoogleAdsClient.load_from_dict(self.google_ads_config)
-                return client.get_service("GoogleAdsService", version=self.api_version)
+                return client
             except GoogleAuthError as e:
                 self.log.error("Google Auth Error: %s", e)
                 raise
@@ -140,7 +217,7 @@ class GoogleAdsHook(BaseHook):
 
         self.google_ads_config["path_to_private_key_file"] = secrets_temp.name
 
-    def search(
+    def _search(
         self, client_ids: List[str], query: str, page_size: int = 10000, **kwargs
     ) -> List[GoogleAdsRow]:
         """
@@ -157,9 +234,17 @@ class GoogleAdsHook(BaseHook):
         :rtype: list[GoogleAdsRow]
         """
         service = self._get_service
-        iterators = (
-            service.search(client_id, query=query, page_size=page_size, **kwargs) for client_id in client_ids
-        )
+
+        iterators = []
+        for client_id in client_ids:
+            request = self._get_client.get_type("SearchGoogleAdsRequest")
+            request.customer_id = client_id
+            request.query = query
+            request.page_size = 10000
+
+            iterator = service.search(request=request)
+            iterators.append(iterator)
+
         self.log.info("Fetched Google Ads Iterators")
 
         return self._extract_rows(iterators)
@@ -188,28 +273,4 @@ class GoogleAdsHook(BaseHook):
                 if error.location:
                     for field_path_element in error.location.field_path_elements:
                         self.log.error("\t\tOn field: %s", field_path_element.field_name)
-            raise
-
-    def list_accessible_customers(self) -> List[str]:
-        """
-        Returns resource names of customers directly accessible by the user authenticating the call.
-        The resulting list of customers is based on your OAuth credentials. The request returns a list
-        of all accounts that you are able to act upon directly given your current credentials. This will
-        not necessarily include all accounts within the account hierarchy; rather, it will only include
-        accounts where your authenticated user has been added with admin or other rights in the account.
-
-        ..seealso::
-            https://developers.google.com/google-ads/api/reference/rpc
-
-        :return: List of names of customers
-        """
-        try:
-            accessible_customers = self._get_customer_service.list_accessible_customers()
-            return accessible_customers.resource_names
-        except GoogleAdsException as ex:
-            for error in ex.failure.errors:
-                self.log.error('\tError with message "%s".', error.message)
-                if error.location:
-                    for field_path_element in error.location.field_path_elements:
-                        self.log.error('\t\tOn field: %s', field_path_element.field_name)
             raise

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -90,7 +90,7 @@ PIP package                             Version required
 ======================================  ===================
 ``apache-airflow``                      ``>=2.1.0``
 ``PyOpenSSL``
-``google-ads``                          ``>=4.0.0,<8.0.0``
+``google-ads``                          ``>=10.0.0,<14.0.0``
 ``google-api-core``                     ``>=1.25.1,<2.0.0``
 ``google-api-python-client``            ``>=1.6.0,<2.0.0``
 ``google-auth-httplib2``                ``>=0.0.1``

--- a/docs/apache-airflow-providers-google/index.rst
+++ b/docs/apache-airflow-providers-google/index.rst
@@ -90,7 +90,7 @@ PIP package                             Version required
 ======================================  ===================
 ``apache-airflow``                      ``>=2.1.0``
 ``PyOpenSSL``
-``google-ads``                          ``>=10.0.0,<14.0.0``
+``google-ads``                          ``>=12.0.0``
 ``google-api-core``                     ``>=1.25.1,<2.0.0``
 ``google-api-python-client``            ``>=1.6.0,<2.0.0``
 ``google-auth-httplib2``                ``>=0.0.1``

--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,7 @@ flask_oauth = [
 ]
 google = [
     'PyOpenSSL',
-    'google-ads>=10.0.0,<14.0.0',
+    'google-ads>=12.0.0',
     'google-api-core>=1.25.1,<2.0.0',
     'google-api-python-client>=1.6.0,<2.0.0',
     'google-auth>=1.0.0,<2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -277,7 +277,7 @@ flask_oauth = [
 ]
 google = [
     'PyOpenSSL',
-    'google-ads>=4.0.0,<8.0.0',
+    'google-ads>=10.0.0,<14.0.0',
     'google-api-core>=1.25.1,<2.0.0',
     'google-api-python-client>=1.6.0,<2.0.0',
     'google-auth>=1.0.0,<2.0.0',

--- a/tests/providers/google/ads/operators/test_ads.py
+++ b/tests/providers/google/ads/operators/test_ads.py
@@ -37,7 +37,7 @@ IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 
 gcp_conn_id = "gcp_conn_id"
 google_ads_conn_id = "google_ads_conn_id"
-api_version = "v5"
+api_version = "v8"
 
 
 class TestGoogleAdsListAccountsOperator:


### PR DESCRIPTION
closes: #17111

# Description
This PR adjusts the google ads hook to support newer versions of the google-ads library. 

Before this PR google-ads library v7.0.0 was installed, while the latest version is 13.0.0. I presume the reason for this is because google introduced a backwards incompatible change in version 10.0.0.

This PR  should make the hook work with google-ads >= 10.0.0, but I have only tested it on the latest 13.0.0 version.

The biggest breaking change in the google-ads API was that instead of returning results as native protocol buffers, it's now returning the data in a simpler to use proto-plus format. 

To ensure backwards compatibility for older operators that use the hook, I made the `search()` method convert the data back into native protocol buffers. In addition to that I added a `search_proto_plus()` method that returns the data in the new proto-plus format.

You can get more information about that here:
https://developers.google.com/google-ads/api/docs/client-libs/python/library-version-10

# Other considerations
As discussed in #17111, google-ads version 12.0.0 is the last version to support python 3.6. The currently latest version 13.0.0 only supports python 3.7.

I am not sure what the best way is to handle that, but wanted to raise it here so that you can consider it.

# Testing
This is my first time submitting a pull request for airflow. 

Unfortunately I don't have a test environment set up. I apologize for that, but since google completely stopped supporting the v5 API and everyone's google ads integrations are broken due to this issue, I decided it may be worth submitting my fix even though I wasn't able to run unit tests on it.

 I did test the changes on my local installation with my operators and dags though.

Please let me know if you'd like me to adjust anything.