### PR TITLE
Adding custom Salesforce connection type + SalesforceToS3Operator updates

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_salesforce_to_s3.py
@@ -54,19 +54,18 @@ with DAG(
 
     store_to_s3_data_lake = S3CopyObjectOperator(
         task_id="store_to_s3_data_lake",
-        source_bucket_key=upload_salesforce_data_to_s3_landing.output["s3_uri"],
+        source_bucket_key=upload_salesforce_data_to_s3_landing.output,
         dest_bucket_name="data_lake",
         dest_bucket_key=f"{BASE_PATH}/{date_prefixes}/{FILE_NAME}",
     )
 
     delete_data_from_s3_landing = S3DeleteObjectsOperator(
         task_id="delete_data_from_s3_landing",
-        bucket=upload_salesforce_data_to_s3_landing.output["s3_bucket_name"],
-        keys=upload_salesforce_data_to_s3_landing.output["s3_key"],
+        bucket=upload_salesforce_data_to_s3_landing.s3_bucket_name,
+        keys=upload_salesforce_data_to_s3_landing.s3_key,
     )
 
     store_to_s3_data_lake >> delete_data_from_s3_landing
 
     # Task dependencies created via `XComArgs`:
     #   upload_salesforce_data_to_s3_landing >> store_to_s3_data_lake
-    #   upload_salesforce_data_to_s3_landing >> delete_data_from_s3_landing

--- a/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/salesforce_to_s3.py
@@ -106,8 +106,8 @@ class SalesforceToS3Operator(BaseOperator):
         self.gzip = gzip
         self.acl_policy = acl_policy
 
-    def execute(self, context: Dict) -> Dict:
-        salesforce_hook = SalesforceHook(conn_id=self.salesforce_conn_id)
+    def execute(self, context: Dict) -> str:
+        salesforce_hook = SalesforceHook(salesforce_conn_id=self.salesforce_conn_id)
         response = salesforce_hook.make_query(
             query=self.salesforce_query,
             include_deleted=self.include_deleted,
@@ -138,4 +138,4 @@ class SalesforceToS3Operator(BaseOperator):
             s3_uri = f"s3://{self.s3_bucket_name}/{self.s3_key}"
             self.log.info(f"Salesforce data uploaded to S3 at {s3_uri}.")
 
-            return {"s3_uri": s3_uri, "s3_bucket_name": self.s3_bucket_name, "s3_key": self.s3_key}
+            return s3_uri

--- a/airflow/providers/google/cloud/transfers/salesforce_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/salesforce_to_gcs.py
@@ -97,7 +97,7 @@ class SalesforceToGcsOperator(BaseOperator):
         self.query_params = query_params
 
     def execute(self, context: Dict):
-        salesforce = SalesforceHook(conn_id=self.salesforce_conn_id)
+        salesforce = SalesforceHook(salesforce_conn_id=self.salesforce_conn_id)
         response = salesforce.make_query(
             query=self.query, include_deleted=self.include_deleted, query_params=self.query_params
         )

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -74,9 +74,9 @@ class SalesforceHook(BaseHook):
 
         return {
             "extra__salesforce__security_token": PasswordField(
-                lazy_gettext('Security Token'), widget=BS3PasswordFieldWidget()
+                lazy_gettext("Security Token"), widget=BS3PasswordFieldWidget()
             ),
-            "extra__salesforce__domain": StringField(lazy_gettext('Domain'), widget=BS3TextFieldWidget()),
+            "extra__salesforce__domain": StringField(lazy_gettext("Domain"), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -37,21 +37,18 @@ log = logging.getLogger(__name__)
 
 class SalesforceHook(BaseHook):
     """
-    Create new connection to Salesforce and allows you to pull data out of SFDC and save it to a file.
+    Creates new connection to Salesforce and allows you to pull data out of SFDC and save it to a file.
 
     You can then use that file with other Airflow operators to move the data into another data source.
 
-    :param conn_id: the name of the connection that has the parameters we need to connect to Salesforce.
-        The connection should be type `http` and include a user's security token in the `Extras` field.
+    :param conn_id: The name of the connection that has the parameters needed to connect to Salesforce.
+        The connection should be of type `Salesforce`.
     :type conn_id: str
 
     .. note::
-        For the HTTP connection type, you can include a
-        JSON structure in the `Extras` field.
-        We need a user's security token to connect to Salesforce.
-        So we define it in the `Extras` field as `{"security_token":"YOUR_SECURITY_TOKEN"}`
-
-        For sandbox mode, add `{"domain":"test"}` in the `Extras` field
+        To connect to Salesforce make sure the connection includes a Username, Password, and Security Token.
+        If in sandbox, enter a Domain value of 'test'.  Login methods such as IP filtering and JWT are not
+        supported currently.
 
     """
 

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -24,10 +24,11 @@ retrieve data from it, and write that data to a file for other uses.
       https://github.com/simple-salesforce/simple-salesforce
 """
 import logging
-import pandas as pd
 import time
-from simple_salesforce import Salesforce, api
 from typing import Any, Dict, Iterable, List, Optional
+
+import pandas as pd
+from simple_salesforce import Salesforce, api
 
 from airflow.hooks.base import BaseHook
 
@@ -75,9 +76,7 @@ class SalesforceHook(BaseHook):
             "extra__salesforce__security_token": PasswordField(
                 lazy_gettext('Security Token'), widget=BS3PasswordFieldWidget()
             ),
-            "extra__salesforce__domain": StringField(
-                lazy_gettext('Domain'), widget=BS3TextFieldWidget()
-            ),
+            "extra__salesforce__domain": StringField(lazy_gettext('Domain'), widget=BS3TextFieldWidget()),
         }
 
     @staticmethod

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -101,8 +101,8 @@ class SalesforceHook(BaseHook):
             self.conn = Salesforce(
                 username=connection.login,
                 password=connection.password,
-                security_token=extras['extra__salesforce__security_token'],
-                domain=extras.get('extra__salesforce__domain'),
+                security_token=extras["extra__salesforce__security_token"],
+                domain=extras["extra__salesforce__domain"] or "login",
             )
         return self.conn
 

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -57,7 +57,7 @@ class SalesforceHook(BaseHook):
     conn_type = "salesforce"
     hook_name = "Salesforce"
 
-    def __init__(self, salesforce_conn_id: str = "salesforce_default") -> None:
+    def __init__(self, salesforce_conn_id: str = default_conn_name) -> None:
         super().__init__()
         self.conn_id = salesforce_conn_id
         self.conn = None

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -55,4 +55,5 @@ hooks:
       - airflow.providers.salesforce.hooks.salesforce
 
 hook-class-names:
+  - airflow.providers.salesforce.hooks.salesforce.SalesforceHook
   - airflow.providers.salesforce.hooks.tableau.TableauHook

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -39,12 +39,10 @@ Domain (optional)
 For security reason we suggest you to use one of the secrets Backend to create this
 connection (Using ENVIRONMENT VARIABLE or Hashicorp Vault, GCP Secrets Manager etc).
 
-.. note::
-  When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
-  following the standard syntax of DB connections - where extras are passed as parameters
-  of the URI.
+When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
+following the standard syntax of DB connections - where extras are passed as parameters of the URI.
 
-  For example:
+For example:
 
   .. code-block:: bash
 

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -40,9 +40,7 @@ For security reason we suggest you to use one of the secrets Backend to create t
 connection (Using ENVIRONMENT VARIABLE or Hashicorp Vault, GCP Secrets Manager etc).
 
 When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
-following the standard syntax of DB connections - where extras are passed as parameters of the URI.
-
-For example:
+following the standard syntax of DB connections - where extras are passed as parameters of the URI. For example:
 
   .. code-block:: bash
 

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -19,55 +19,36 @@
 
 Salesforce Connection
 =====================
-The HTTP connection type provides connection to Salesforce.
+The Salesforce connection type provides connection to Salesforce.
 
 Configuring the Connection
 --------------------------
-Host (required)
-    specify the host address to connect: ``https://your_host.lightning.force.com``
-
-Login (required)
+Username (required)
     Specify the email address used to login to your account.
 
 Password (required)
     Specify the password associated with the account.
 
-Extra (required)
-    Specify the extra parameters (as json dictionary) that can be used in Salesforce
-    connection.
-    The following parameter is required:
+Security Token (required)
+    Specify the Salesforce security token for the username.
 
-    * ``security_token``: Salesforce token.
+Domain (optional)
+    The domain to using for connecting to Salesforce. Use common domains, such as 'login'
+    or 'test', or Salesforce My domain. If not used, will default to 'login'.
 
-    The following parameter is optional:
+For security reason we suggest you to use one of the secrets Backend to create this
+connection (Using ENVIRONMENT VARIABLE or Hashicorp Vault, GCP Secrets Manager etc).
 
-    * ``domain``: set to ``test`` if working in sandbox mode.
+.. note::
+  When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
+  following the standard syntax of DB connections - where extras are passed as parameters
+  of the URI.
 
-    For security reason we suggest you to use one of the secrets Backend to create this
-    connection (Using ENVIRONMENT VARIABLE or Hashicorp Vault, GCP Secrets Manager etc).
+  For example:
 
+  .. code-block:: bash
 
-    When specifying the connection as URI (in :envvar:`AIRFLOW_CONN_{CONN_ID}` variable) you should specify it
-    following the standard syntax of DB connections - where extras are passed as parameters
-    of the URI.
-
-    For example:
-
-    .. code-block:: bash
-
-       export AIRFLOW_CONN_SALESFORCE_DEFAULT='http://your_username:your_password@https%3A%2F%2Fyour_host.lightning.force.com?security_token=your_token'
-
-
-Examples for the **Extra** field
---------------------------------
-Setting up sandbox mode:
-
-.. code-block:: json
-
-    {
-      "security_token": "your_token",
-      "domain":"test"
-    }
+    export AIRFLOW_CONN_SALESFORCE_DEFAULT='http://your_username:your_password@https%3A%2F%2Fyour_host.lightning.force.com?security_token=your_token'
 
 .. note::
   Airflow currently does not support other login methods such as IP filtering and JWT.

--- a/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_salesforce_to_s3.py
@@ -95,13 +95,7 @@ class TestSalesforceToGcsOperator(unittest.TestCase):
         assert operator.gzip == GZIP
         assert operator.acl_policy == ACL_POLICY
 
-        expected_op_output = {
-            "s3_uri": f"s3://{S3_BUCKET}/{S3_KEY}",
-            "s3_bucket_name": S3_BUCKET,
-            "s3_key": S3_KEY,
-        }
-
-        assert expected_op_output == operator.execute({})
+        assert f"s3://{S3_BUCKET}/{S3_KEY}" == operator.execute({})
 
         mock_make_query.assert_called_once_with(
             query=QUERY, include_deleted=INCLUDE_DELETED, query_params=QUERY_PARAMS

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -31,7 +31,7 @@ from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
 
 class TestSalesforceHook(unittest.TestCase):
     def setUp(self):
-        self.salesforce_hook = SalesforceHook(conn_id="conn_id")
+        self.salesforce_hook = SalesforceHook(salesforce_conn_id="conn_id")
 
     def test_get_conn_exists(self):
         self.salesforce_hook.conn = Mock(spec=Salesforce)
@@ -43,7 +43,9 @@ class TestSalesforceHook(unittest.TestCase):
     @patch(
         "airflow.providers.salesforce.hooks.salesforce.SalesforceHook.get_connection",
         return_value=Connection(
-            login="username", password="password", extra='{"security_token": "token", "domain": "test"}'
+            login="username",
+            password="password",
+            extra='{"extra__salesforce__security_token": "token", "extra__salesforce__domain": "login"}'
         ),
     )
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
@@ -54,9 +56,8 @@ class TestSalesforceHook(unittest.TestCase):
         mock_salesforce.assert_called_once_with(
             username=mock_get_connection.return_value.login,
             password=mock_get_connection.return_value.password,
-            security_token=mock_get_connection.return_value.extra_dejson["security_token"],
-            instance_url=mock_get_connection.return_value.host,
-            domain=mock_get_connection.return_value.extra_dejson.get("domain"),
+            security_token=mock_get_connection.return_value.extra_dejson["extra__salesforce__security_token"],
+            domain=mock_get_connection.return_value.extra_dejson.get("extra__salesforce__domain"),
         )
 
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -45,7 +45,7 @@ class TestSalesforceHook(unittest.TestCase):
         return_value=Connection(
             login="username",
             password="password",
-            extra='{"extra__salesforce__security_token": "token", "extra__salesforce__domain": "login"}'
+            extra='{"extra__salesforce__security_token": "token", "extra__salesforce__domain": "login"}',
         ),
     )
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")


### PR DESCRIPTION
Closes: #8766

Creating a new Salesforce connection type.  Currently, the `security_token` is exposed in plain text and setting up the connection is not intuitive.

- [x] Update `SalesforceHook`
- [x] Update Salesforce connection docs
- [x] Update `SalesforceToS3Operator` and `SalesforceToGcsOperator`
- [x] Update Salesforce Hook test

Here is the new connection form:

![image](https://user-images.githubusercontent.com/48934154/126646400-002f9c48-65b2-410e-959e-055edf9c397f.png)

I also updated -- effectively reverted a change to -- the output of the `SalesforceToS3Operator` from a [previous PR of mine](https://github.com/apache/airflow/pull/17094) because of the issue mentioned in [this PR](https://github.com/apache/airflow/pull/16823).


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
