### PR TITLE
Avoid logging in to GitHub Container Registry when not in CI

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -47,6 +47,7 @@ env:
   GITHUB_REGISTRY_WAIT_FOR_IMAGE: "false"
   INSTALL_PROVIDERS_FROM_SOURCES: "true"
   TARGET_COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  AIRFLOW_LOGIN_TO_GITHUB_REGISTRY: "true"
 
 concurrency:
   group: build-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ env:
   GITHUB_REGISTRY_PULL_IMAGE_TAG: "${{ github.event.pull_request.head.sha || github.sha }}"
   GITHUB_REGISTRY_PUSH_IMAGE_TAG: "latest"
   INSTALL_PROVIDERS_FROM_SOURCES: "true"
+  AIRFLOW_LOGIN_TO_GITHUB_REGISTRY: "true"
 
   # You can switch between building the image in "Build Images" workflow or building them in CI workflow
   # Separately for each job.

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -410,12 +410,15 @@ function build_images::get_docker_image_names() {
 # Also enable experimental features of docker (we need `docker manifest` command)
 function build_images::configure_docker_registry() {
     local token="${GITHUB_TOKEN}"
-    if [[ -z "${token}" ]] ; then
+    if [[ -z "${token}" ]]; then
         verbosity::print_info
         verbosity::print_info "Skip logging in to GitHub Registry. No Token available!"
         verbosity::print_info
-    fi
-    if [[ -n "${token}" ]]; then
+    elif [[ ${AIRFLOW_LOGIN_TO_GITHUB_REGISTRY=} != "true" ]]; then
+        verbosity::print_info
+        verbosity::print_info "Skip logging in to GitHub Registry. AIRFLOW_LOGIN_TO_GITHUB_REGISTRY != true"
+        verbosity::print_info
+    elif [[ -n "${token}"  ]]; then
         echo "${token}" | docker_v login \
             --username "${GITHUB_USERNAME:-apache}" \
             --password-stdin \

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -418,7 +418,7 @@ function build_images::configure_docker_registry() {
         verbosity::print_info
         verbosity::print_info "Skip logging in to GitHub Registry. AIRFLOW_LOGIN_TO_GITHUB_REGISTRY != true"
         verbosity::print_info
-    elif [[ -n "${token}"  ]]; then
+    elif [[ -n "${token}" ]]; then
         echo "${token}" | docker_v login \
             --username "${GITHUB_USERNAME:-apache}" \
             --password-stdin \


### PR DESCRIPTION
When GITHUB_TOKEN was set in environment, attempt to login to
https://ghcr.io/ was made. But GITHUB_TOKEN is commonly used to
authenticate and if you happened to not have access there the
attempt failed.

This PR only attempts to login when the
`AIRFLOW_LOGIN_TO_GITHUB_REGISTRY` variable is set to `true`
and sets the variable in CI.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
