### PR TITLE
Chart docs: note uid write permissions for existing pvc

### DIFF
--- a/chart/CHANGELOG.txt
+++ b/chart/CHANGELOG.txt
@@ -52,6 +52,7 @@ Bug Fixes
 
 Doc only changes
 """"""""""""""""
+- Chart docs: note uid write permissions for existing pvc (#17170)
 - Chart Docs: Add single-line description for ``multiNamespaceMode`` (#17147)
 - Chart: Update description for Helm chart to include 'official' (#17040)
 - Chart: Better comment and example for ``podTemplate`` (#16859)

--- a/docs/helm-chart/manage-logs.rst
+++ b/docs/helm-chart/manage-logs.rst
@@ -75,6 +75,8 @@ In this approach, Airflow will log to an existing ``ReadWriteMany`` PVC. You pas
       --set logs.persistence.enabled=true \
       --set logs.persistence.existingClaim=my-volume-claim
 
+Note that the Airflow user (default uid 50000) needs write permission on the volume.
+
 Elasticsearch
 -------------
 

--- a/docs/helm-chart/manage-logs.rst
+++ b/docs/helm-chart/manage-logs.rst
@@ -75,7 +75,7 @@ In this approach, Airflow will log to an existing ``ReadWriteMany`` PVC. You pas
       --set logs.persistence.enabled=true \
       --set logs.persistence.existingClaim=my-volume-claim
 
-Note that the Airflow user (default uid 50000) needs write permission on the volume.
+Note that the Airflow user (default uid ``50000``) needs write permission on the volume.
 
 Elasticsearch
 -------------


### PR DESCRIPTION
Simple note to clarify the Airflow user needs write permission on existing pvc's.