### PR TITLE
Fix Basic Auth Failure OpenApi codegen

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -3476,7 +3476,8 @@ components:
 
 # The API will provide support for plugins to support various authorization mechanisms.
 # Detailed information will be available in the plugin specification.
-security: []
+security:
+  - Basic: []
 
 tags:
   - name: Config


### PR DESCRIPTION
This fixes basic auth not getting picked up in the openApi generated client code. The example specified here https://swagger.io/docs/specification/authentication/ also uses the same configuration to achieve basic auth in codegen clients

closes: apache#17172