### PR TITLE
Chart docs: better note for logs existing pvc permissions

### DIFF
--- a/docs/helm-chart/manage-logs.rst
+++ b/docs/helm-chart/manage-logs.rst
@@ -75,7 +75,8 @@ In this approach, Airflow will log to an existing ``ReadWriteMany`` PVC. You pas
       --set logs.persistence.enabled=true \
       --set logs.persistence.existingClaim=my-volume-claim
 
-Note that the Airflow user (default uid ``50000``) needs write permission on the volume.
+Note that the volume will need to writable by the Airflow user. The easiest way is to ensure GID ``0`` has write permission.
+More information can be found in the :ref:`Docker image entrypoint documentation <docker-stack:arbitrary-docker-user>`.
 
 Elasticsearch
 -------------


### PR DESCRIPTION
It's better to call out the GID needing write than the UID, even though both would work.

(thanks @potiuk)