### PR TITLE
dataflowjobstatus sensor dag example fixed for issue #17180

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_dataflow.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataflow.py
@@ -166,7 +166,7 @@ with models.DAG(
     # [START howto_sensor_wait_for_job_status]
     wait_for_python_job_async_done = DataflowJobStatusSensor(
         task_id="wait-for-python-job-async-done",
-        job_id="{{task_instance.xcom_pull('start-python-job-async')['id']}}",
+        job_id="{{task_instance.xcom_pull('start-python-job-async')['job_id']}}",
         expected_statuses={DataflowJobStatus.JOB_STATE_DONE},
         location='europe-west3',
     )

--- a/airflow/providers/google/cloud/example_dags/example_dataflow.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataflow.py
@@ -166,7 +166,7 @@ with models.DAG(
     # [START howto_sensor_wait_for_job_status]
     wait_for_python_job_async_done = DataflowJobStatusSensor(
         task_id="wait-for-python-job-async-done",
-        job_id="{{task_instance.xcom_pull('start-python-job-async')['job_id']}}",
+        job_id="{{task_instance.xcom_pull('start-python-job-async')['id']}}",
         expected_statuses={DataflowJobStatus.JOB_STATE_DONE},
         location='europe-west3',
     )

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -690,7 +690,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
             environment=self.environment,
         )
 
-        return job
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
@@ -809,7 +809,7 @@ class DataflowStartFlexTemplateOperator(BaseOperator):
             on_new_job_id_callback=set_current_job_id,
         )
 
-        return job
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
@@ -912,7 +912,7 @@ class DataflowStartSqlJobOperator(BaseOperator):
             on_new_job_id_callback=set_current_job_id,
         )
 
-        return job
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->


---
**^ Add meaningful description above**

closes issue #17180

Update to the DAG examples for DataflowJobStatusSensor to avoid error.
The current example pulls XCOM to get Dataflow job id from XCOM attributes.
However an incorrect attribute name is used in the current DAG example.

the XCOM doesn't have any attribute named "job_id" when using :
job_id="{{task_instance.xcom_pull('start-python-job-async')['job_id']}}",
instead "id" has to be used to get the related Dataflow job id.


