### PR TITLE
Do not seek error file when it is closed

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -112,6 +112,8 @@ def set_current_context(context: Context):
 
 def load_error_file(fd: IO[bytes]) -> Optional[Union[str, Exception]]:
     """Load and return error from error file"""
+    if fd.closed:
+        return None
     fd.seek(0, os.SEEK_SET)
     data = fd.read()
     if not data:

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -21,6 +21,7 @@ import os
 import time
 import unittest
 import urllib
+from tempfile import NamedTemporaryFile
 from typing import List, Optional, Union, cast
 from unittest import mock
 from unittest.mock import call, mock_open, patch
@@ -48,6 +49,7 @@ from airflow.models import (
     TaskReschedule,
     Variable,
 )
+from airflow.models.taskinstance import load_error_file, set_error_file
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import PythonOperator
@@ -118,6 +120,17 @@ class TestTaskInstance(unittest.TestCase):
 
     def tearDown(self):
         self.clean_db()
+
+    def test_load_error_file_returns_None_for_closed_file(self):
+        error_fd = NamedTemporaryFile()
+        error_fd.close()
+        assert not load_error_file(error_fd)
+
+    def test_load_error_file_loads_correctly(self):
+        error_message = "some random error message"
+        with NamedTemporaryFile() as error_fd:
+            set_error_file(error_fd.name, error=error_message)
+            assert load_error_file(error_fd) == error_message
 
     def test_set_task_dates(self):
         """

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -124,7 +124,7 @@ class TestTaskInstance(unittest.TestCase):
     def test_load_error_file_returns_None_for_closed_file(self):
         error_fd = NamedTemporaryFile()
         error_fd.close()
-        assert not load_error_file(error_fd)
+        assert load_error_file(error_fd) is None
 
     def test_load_error_file_loads_correctly(self):
         error_message = "some random error message"


### PR DESCRIPTION
We do not check if error file is closed before we seek it, which causes exceptions.
Sometimes, this error file does not exist e.g when the task state is changed externally.

This change fixes it by returning None when the file is closed so that custom text can be used for error.

```
...
 error = self.task_runner.deserialize_run_error()
  File "/home/ephraimbuddy/Documents/astronomer/airflow/airflow/task/task_runner/base_task_runner.py", line 105, in deserialize_run_error
    return load_error_file(self._error_file)
  File "/home/ephraimbuddy/Documents/astronomer/airflow/airflow/models/taskinstance.py", line 115, in load_error_file
    fd.seek(0, os.SEEK_SET)
  File "/usr/lib/python3.8/tempfile.py", line 612, in func_wrapper
    return func(*args, **kwargs)
ValueError: seek of closed file
```


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
