### PR TITLE
Only allows supported field types to be used in custom connections

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -25,7 +25,7 @@ from collections import OrderedDict
 from typing import Any, Dict, NamedTuple, Set
 
 import jsonschema
-from wtforms import Field
+from wtforms import BooleanField, Field, IntegerField, PasswordField, StringField
 
 from airflow.utils import yaml
 from airflow.utils.entry_points import entry_points_with_dist
@@ -35,6 +35,8 @@ try:
 except ImportError:
     # Try back-ported to PY<37 `importlib_resources`.
     import importlib_resources
+
+ALLOWED_FIELD_CLASSES = [IntegerField, PasswordField, StringField, BooleanField]
 
 log = logging.getLogger(__name__)
 
@@ -274,6 +276,16 @@ class ProvidersManager:
             if 'get_connection_form_widgets' in hook_class.__dict__:
                 widgets = hook_class.get_connection_form_widgets()
                 if widgets:
+                    for widget in widgets.values():
+                        if widget.field_class not in ALLOWED_FIELD_CLASSES:
+                            log.warning(
+                                "The hook_class '%s' uses field of unsupported class '%s'. "
+                                "Only '%s' field classes are supported",
+                                hook_class_name,
+                                widget.field_class,
+                                ALLOWED_FIELD_CLASSES,
+                            )
+                        return
                     self._add_widgets(provider_package, hook_class, widgets)
             if 'get_ui_field_behaviour' in hook_class.__dict__:
                 field_behaviours = hook_class.get_ui_field_behaviour()

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -285,7 +285,7 @@ class ProvidersManager:
                                 widget.field_class,
                                 ALLOWED_FIELD_CLASSES,
                             )
-                        return
+                            return
                     self._add_widgets(provider_package, hook_class, widgets)
             if 'get_ui_field_behaviour' in hook_class.__dict__:
                 field_behaviours = hook_class.get_ui_field_behaviour()


### PR DESCRIPTION
Only four field types are supported in Connection Forms:
String, Password, Integer, Boolean.

Previously when custom connections tried to use other field
type, ConnectionForm behaved in a very strange way - the
connection form reloaded quickly hiding the actual error
and no error was printed making it next to impossible to figure
out the root cause of the problem.

With this change, non-supported field types generate Warning
and the Connections that use them are not added to the list of
supported connections.

Fixes: #17193

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
