### PR TITLE
Be verbose about failure to import airflow_local_settings

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -433,8 +433,11 @@ def import_local_settings():
         log.info("Loaded airflow_local_settings from %s .", airflow_local_settings.__file__)
     except ImportError:
         log.warning("Failed to import airflow_local_settings.", exc_info=True)
-    except ModuleNotFoundError:
-        log.debug("No airflow_local_settings to import.", exc_info=True)
+    except ModuleNotFoundError as e:
+        if e.name == "airflow_local_settings":
+            log.debug("No airflow_local_settings to import.", exc_info=True)
+        else:
+            log.warning("Failed to import airflow_local_settings due to a transitive module not found error.", exc_info=True)
 
 
 def initialize():

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -431,13 +431,15 @@ def import_local_settings():
             del globals()["policy"]
 
         log.info("Loaded airflow_local_settings from %s .", airflow_local_settings.__file__)
-    except ImportError:
-        log.warning("Failed to import airflow_local_settings.", exc_info=True)
     except ModuleNotFoundError as e:
         if e.name == "airflow_local_settings":
             log.debug("No airflow_local_settings to import.", exc_info=True)
         else:
-            log.warning("Failed to import airflow_local_settings due to a transitive module not found error.", exc_info=True)
+            log.critical("Failed to import airflow_local_settings due to a transitive module not found error.", exc_info=True)
+            raise e
+    except ImportError as e:
+        log.critical("Failed to import airflow_local_settings.", exc_info=True)
+        raise e
 
 
 def initialize():

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -435,7 +435,10 @@ def import_local_settings():
         if e.name == "airflow_local_settings":
             log.debug("No airflow_local_settings to import.", exc_info=True)
         else:
-            log.critical("Failed to import airflow_local_settings due to a transitive module not found error.", exc_info=True)
+            log.critical(
+                "Failed to import airflow_local_settings due to a transitive module not found error.",
+                exc_info=True,
+            )
             raise
     except ImportError:
         log.critical("Failed to import airflow_local_settings.", exc_info=True)

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -437,7 +437,7 @@ def import_local_settings():
         else:
             log.critical("Failed to import airflow_local_settings due to a transitive module not found error.", exc_info=True)
             raise
-    except ImportError as e:
+    except ImportError:
         log.critical("Failed to import airflow_local_settings.", exc_info=True)
         raise
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -432,7 +432,9 @@ def import_local_settings():
 
         log.info("Loaded airflow_local_settings from %s .", airflow_local_settings.__file__)
     except ImportError:
-        log.debug("Failed to import airflow_local_settings.", exc_info=True)
+        log.warning("Failed to import airflow_local_settings.", exc_info=True)
+    except ModuleNotFoundError:
+        log.debug("No airflow_local_settings to import.", exc_info=True)
 
 
 def initialize():

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -439,7 +439,7 @@ def import_local_settings():
             raise
     except ImportError as e:
         log.critical("Failed to import airflow_local_settings.", exc_info=True)
-        raise e
+        raise
 
 
 def initialize():

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -436,7 +436,7 @@ def import_local_settings():
             log.debug("No airflow_local_settings to import.", exc_info=True)
         else:
             log.critical("Failed to import airflow_local_settings due to a transitive module not found error.", exc_info=True)
-            raise e
+            raise
     except ImportError as e:
         log.critical("Failed to import airflow_local_settings.", exc_info=True)
         raise e

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -141,7 +141,7 @@ class TestLocalSettings(unittest.TestCase):
         from airflow import settings
 
         settings.import_local_settings()
-        log_mock.assert_called_once_with("Failed to import airflow_local_settings.", exc_info=True)
+        log_mock.assert_called_once_with("No airflow_local_settings to import.", exc_info=True)
 
     def test_policy_function(self):
         """


### PR DESCRIPTION
Currently, if the module exists, but has errors (for example syntax
error, or transitive import of module that does not exist),
the airflow scheduler will not show any error.

In my opinion `ImportError` of `airflow_local_settings` should
be a fatal error, but let it be a warning for now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
