### PR TITLE
Fix wrong connection name in Druid Hook

### DIFF
--- a/airflow/providers/apache/druid/hooks/druid.py
+++ b/airflow/providers/apache/druid/hooks/druid.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import time
+import warnings
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 import requests
@@ -136,11 +137,24 @@ class DruidDbApiHook(DbApiHook):
     For ingestion, please use druidHook.
     """
 
-    conn_name_attr = 'druid_broker_conn_id'
+    conn_name_attr = 'conn_id'
     default_conn_name = 'druid_broker_default'
     conn_type = 'druid'
     hook_name = 'Druid'
     supports_autocommit = False
+
+    def __init__(self, conn_id: str = None, druid_broker_conn_id: str = None, **kwargs) -> None:
+        if druid_broker_conn_id:
+            warnings.warn(
+                'The druid_broker_conn_id is deprecated, use conn_id instead',
+                PendingDeprecationWarning,
+                stacklevel=2,
+            )
+            conn_id = druid_broker_conn_id
+        if not conn_id:
+            conn_id = DruidDbApiHook.default_conn_name
+        self.conn_id = conn_id
+        super().__init__(**kwargs)
 
     def get_conn(self) -> connect:
         """Establish a connection to druid broker."""


### PR DESCRIPTION
The connection attribute name was wrong

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
