### PR TITLE
Fix external_executor_id not being set for manually run jobs.

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -22,7 +22,7 @@ import logging
 import os
 import textwrap
 from contextlib import contextmanager, redirect_stderr, redirect_stdout, suppress
-from typing import List
+from typing import List, Optional
 
 from pendulum.parsing.exceptions import ParserError
 from sqlalchemy.orm.exc import NoResultFound
@@ -157,6 +157,7 @@ def _run_task_by_local_task_job(args, ti):
         ignore_task_deps=args.ignore_dependencies,
         ignore_ti_state=args.force,
         pool=args.pool,
+        external_executor_id=_extract_external_executor_id(args),
     )
     try:
         run_job.run()
@@ -182,6 +183,12 @@ def _run_raw_task(args, ti: TaskInstance) -> None:
         pool=args.pool,
         error_file=args.error_file,
     )
+
+
+def _extract_external_executor_id(args) -> Optional[str]:
+    if hasattr(args, "external_executor_id"):
+        return getattr(args, "external_executor_id")
+    return os.environ.get("external_executor_id", None)
 
 
 @contextmanager

--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -52,6 +52,7 @@ class LocalTaskJob(BaseJob):
         mark_success: bool = False,
         pickle_id: Optional[str] = None,
         pool: Optional[str] = None,
+        external_executor_id: Optional[str] = None,
         *args,
         **kwargs,
     ):
@@ -64,6 +65,7 @@ class LocalTaskJob(BaseJob):
         self.pool = pool
         self.pickle_id = pickle_id
         self.mark_success = mark_success
+        self.external_executor_id = external_executor_id
         self.task_runner = None
 
         # terminating state is used so that a job don't try to
@@ -92,6 +94,7 @@ class LocalTaskJob(BaseJob):
             ignore_ti_state=self.ignore_ti_state,
             job_id=self.id,
             pool=self.pool,
+            external_executor_id=self.external_executor_id,
         ):
             self.log.info("Task is not able to be run")
             return

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1128,6 +1128,7 @@ class TaskInstance(Base, LoggingMixin):
         test_mode: bool = False,
         job_id: Optional[str] = None,
         pool: Optional[str] = None,
+        external_executor_id: Optional[str] = None,
         session=None,
     ) -> bool:
         """
@@ -1153,6 +1154,8 @@ class TaskInstance(Base, LoggingMixin):
         :type job_id: str
         :param pool: specifies the pool to use to run the task instance
         :type pool: str
+        :param external_executor_id: The identifier of the celery executor
+        :type external_executor_id: str
         :param session: SQLAlchemy ORM Session
         :type session: Session
         :return: whether the state was changed to running or not
@@ -1234,6 +1237,7 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             session.add(Log(State.RUNNING, self))
         self.state = State.RUNNING
+        self.external_executor_id = external_executor_id
         self.end_date = None
         if not test_mode:
             session.merge(self)


### PR DESCRIPTION
**Summary of the problem:**
Currently the celery `task_id` is being stored only after a scheduler launched a task in its executor.
Then the celery `task_id` is being put on the `event_buffer` and the scheduler periodically reads out the `event_buffer` and stores the `external_executor_id`. 
Because manually trigger tasks enter the adoption flow -- as their executor instances are only there for the launching of that one specific tasks -- and the `external_executor_id` is not set, they won't get adopted. Instead they get killed. Meaning, any manually triggered task that doesn't have an `external_executor_id` from a previous scheduled run before being launched, might get killed if the adoption routines kicks in while the task is still running.

**Solution:**
I could imagine two solution:
1. After every manually triggered task, we read the event_buffer and store that in the task instances.
2. Every task that is triggered for Celery Executors automatically stores its `external_executor_id` at the start up of the task.

I implemented both but found the second version nicer.
I am looking for some feedback so please provide me with any you can think of :)

**Opened issues that are related:**
related: https://github.com/apache/airflow/issues/16023
