### PR TITLE
ECSOperator returns last logs when ECS task fails

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -182,7 +182,7 @@ class ECSOperator(BaseOperator):
         propagate_tags: Optional[str] = None,
         quota_retry: Optional[dict] = None,
         reattach: bool = False,
-        number_logs_exception=10,
+        number_logs_exception: int = 10,
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -143,9 +143,9 @@ class ECSOperator(BaseOperator):
         This is to avoid relaunching a new task when the connection drops between Airflow and ECS while
         the task is running (when the Airflow worker is restarted for example).
     :type reattach: bool
-    :param number_logs_exception: number of lines from the last Cloudwatch logs to return in the
+    :param number_logs_exception: Number of lines from the last Cloudwatch logs to return in the
         AirflowException if an ECS task is stopped (to receive Airflow alerts with the logs of what
-        failed in the code running in ECS)
+        failed in the code running in ECS).
     :type number_logs_exception: int
     """
 

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -389,7 +389,8 @@ class ECSOperator(BaseOperator):
                 if container.get('lastStatus') == 'STOPPED' and container['exitCode'] != 0:
                     last_logs = "\n".join(self._last_log_messages(self.number_logs_exception))
                     raise AirflowException(
-                        f"This task is not in success state - last logs from Cloudwatch:\n{last_logs}"
+                        f"This task is not in success state - last {self.number_logs_exception} "
+                        f"logs from Cloudwatch:\n{last_logs}"
                     )
                 elif container.get('lastStatus') == 'PENDING':
                     raise AirflowException(f'This task is still pending {task}')

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -136,7 +136,8 @@ class ECSOperator(BaseOperator):
         Only required if you want logs to be shown in the Airflow UI after your job has
         finished.
     :type awslogs_stream_prefix: str
-    :param quota_retry: Config if and how to retry _start_task() for transient errors.
+    :param quota_retry: Config if and how to retry the launch of a new ECS task, to handle
+        transient errors.
     :type quota_retry: dict
     :param reattach: If set to True, will check if the task previously launched by the task_instance
         is already running. If so, the operator will attach to it instead of starting a new task.

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -136,13 +136,16 @@ class ECSOperator(BaseOperator):
         Only required if you want logs to be shown in the Airflow UI after your job has
         finished.
     :type awslogs_stream_prefix: str
+    :param quota_retry: Config if and how to retry _start_task() for transient errors.
+    :type quota_retry: dict
     :param reattach: If set to True, will check if the task previously launched by the task_instance
         is already running. If so, the operator will attach to it instead of starting a new task.
         This is to avoid relaunching a new task when the connection drops between Airflow and ECS while
         the task is running (when the Airflow worker is restarted for example).
     :type reattach: bool
-    :param quota_retry: Config if and how to retry _start_task() for transient errors.
-    :type quota_retry: dict
+    :param number_logs_exception: number of lines from the last Cloudwatch logs to return in the AirflowException if
+        an ECS task is stopped (to receive Airflow alerts with the logs of what failed in the code running in ECS)
+    :type number_logs_exception: int
     """
 
     ui_color = '#f0ede4'
@@ -178,6 +181,7 @@ class ECSOperator(BaseOperator):
         propagate_tags: Optional[str] = None,
         quota_retry: Optional[dict] = None,
         reattach: bool = False,
+        number_logs_exception=10,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -201,6 +205,7 @@ class ECSOperator(BaseOperator):
         self.awslogs_region = awslogs_region
         self.propagate_tags = propagate_tags
         self.reattach = reattach
+        self.number_logs_exception = number_logs_exception
 
         if self.awslogs_region is None:
             self.awslogs_region = region_name
@@ -343,9 +348,12 @@ class ECSOperator(BaseOperator):
     def _aws_logs_enabled(self):
         return self.awslogs_group and self.awslogs_stream_prefix
 
+    def _last_log_messages(self, number_messages):
+        return [log["message"] for log in deque(self._cloudwatch_log_events(), maxlen=number_messages)]
+
     def _last_log_message(self):
         try:
-            return deque(self._cloudwatch_log_events(), maxlen=1).pop()["message"]
+            return self._last_log_messages(1)[0]
         except IndexError:
             return None
 
@@ -378,7 +386,10 @@ class ECSOperator(BaseOperator):
             containers = task['containers']
             for container in containers:
                 if container.get('lastStatus') == 'STOPPED' and container['exitCode'] != 0:
-                    raise AirflowException(f'This task is not in success state {task}')
+                    last_log_messages = "\n".join(self._last_log_messages(self.number_logs_exception))
+                    raise AirflowException(
+                        f"This task is not in success state - last logs from Cloudwatch:\n{last_log_messages}"
+                    )
                 elif container.get('lastStatus') == 'PENDING':
                     raise AirflowException(f'This task is still pending {task}')
                 elif 'error' in container.get('reason', '').lower():

--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -143,8 +143,9 @@ class ECSOperator(BaseOperator):
         This is to avoid relaunching a new task when the connection drops between Airflow and ECS while
         the task is running (when the Airflow worker is restarted for example).
     :type reattach: bool
-    :param number_logs_exception: number of lines from the last Cloudwatch logs to return in the AirflowException if
-        an ECS task is stopped (to receive Airflow alerts with the logs of what failed in the code running in ECS)
+    :param number_logs_exception: number of lines from the last Cloudwatch logs to return in the
+        AirflowException if an ECS task is stopped (to receive Airflow alerts with the logs of what
+        failed in the code running in ECS)
     :type number_logs_exception: int
     """
 
@@ -386,9 +387,9 @@ class ECSOperator(BaseOperator):
             containers = task['containers']
             for container in containers:
                 if container.get('lastStatus') == 'STOPPED' and container['exitCode'] != 0:
-                    last_log_messages = "\n".join(self._last_log_messages(self.number_logs_exception))
+                    last_logs = "\n".join(self._last_log_messages(self.number_logs_exception))
                     raise AirflowException(
-                        f"This task is not in success state - last logs from Cloudwatch:\n{last_log_messages}"
+                        f"This task is not in success state - last logs from Cloudwatch:\n{last_logs}"
                     )
                 elif container.get('lastStatus') == 'PENDING':
                     raise AirflowException(f'This task is still pending {task}')

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -417,7 +417,7 @@ class TestECSOperator(unittest.TestCase):
     @mock.patch.object(ECSOperator, '_last_log_messages', return_value=["Log output"])
     def test_execute_xcom_with_log(self, mock_cloudwatch_log_message):
         self.ecs.do_xcom_push = True
-        assert self.ecs.execute(None) == mock_cloudwatch_log_message.return_value[-1]
+        assert self.ecs.execute(None) == "Log output"
 
     @mock.patch.object(ECSOperator, '_last_log_messages', return_value=[])
     def test_execute_xcom_with_no_log(self, mock_cloudwatch_log_message):

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -230,7 +230,7 @@ class TestECSOperator(unittest.TestCase):
             self.ecs._check_success_task()
 
         assert str(ctx.value) == (
-            f"This task is not in success state - last logs from Cloudwatch:\n1\n2\n3\n4\n5"
+            f"This task is not in success state - last 10 logs from Cloudwatch:\n1\n2\n3\n4\n5"
         )
         client_mock.describe_tasks.assert_called_once_with(cluster='c', tasks=['arn'])
 

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -229,10 +229,8 @@ class TestECSOperator(unittest.TestCase):
         with pytest.raises(Exception) as ctx:
             self.ecs._check_success_task()
 
-        expected_last_logs = "\n".join(mock_last_log_messages.return_value)
-        assert (
-            str(ctx.value)
-            == f"This task is not in success state - last logs from Cloudwatch:\n{expected_last_logs}"
+        assert str(ctx.value) == (
+            f"This task is not in success state - last logs from Cloudwatch:\n1\n2\n3\n4\n5"
         )
         client_mock.describe_tasks.assert_called_once_with(cluster='c', tasks=['arn'])
 

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -248,7 +248,7 @@ class TestECSOperator(unittest.TestCase):
             self.ecs._check_success_task()
 
         assert str(ctx.value) == (
-            f"This task is not in success state - last 10 logs from Cloudwatch:\n1\n2\n3\n4\n5"
+            "This task is not in success state - last 10 logs from Cloudwatch:\n1\n2\n3\n4\n5"
         )
         client_mock.describe_tasks.assert_called_once_with(cluster='c', tasks=['arn'])
 

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -217,7 +217,9 @@ class TestECSOperator(unittest.TestCase):
         client_mock.get_waiter.return_value.wait.assert_called_once_with(cluster='c', tasks=['arn'])
         assert sys.maxsize == client_mock.get_waiter.return_value.config.max_attempts
 
-    @mock.patch.object(ECSOperator, '_cloudwatch_log_events', return_value=({"message": str(i)} for i in range(10)))
+    @mock.patch.object(
+        ECSOperator, '_cloudwatch_log_events', return_value=({"message": str(i)} for i in range(10))
+    )
     def test_last_log_messages(self, mock_cloudwatch_log_events):
         client_mock = mock.Mock()
         self.ecs.arn = 'arn'

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -264,7 +264,7 @@ class TestECSOperator(unittest.TestCase):
         with pytest.raises(Exception) as ctx:
             self.ecs._check_success_task()
 
-        assert str(ctx.value) == (f"This task is not in success state - last 10 logs from Cloudwatch:\n")
+        assert str(ctx.value) == "This task is not in success state - last 10 logs from Cloudwatch:\n"
         client_mock.describe_tasks.assert_called_once_with(cluster='c', tasks=['arn'])
 
     def test_check_success_tasks_raises_pending(self):

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -217,6 +217,14 @@ class TestECSOperator(unittest.TestCase):
         client_mock.get_waiter.return_value.wait.assert_called_once_with(cluster='c', tasks=['arn'])
         assert sys.maxsize == client_mock.get_waiter.return_value.config.max_attempts
 
+    @mock.patch.object(ECSOperator, '_cloudwatch_log_events', return_value=({"message": str(i)} for i in range(10)))
+    def test_last_log_messages(self, mock_cloudwatch_log_events):
+        client_mock = mock.Mock()
+        self.ecs.arn = 'arn'
+        self.ecs.client = client_mock
+
+        assert self.ecs._last_log_messages(5) == ["5", "6", "7", "8", "9"]
+
     @mock.patch.object(ECSOperator, '_last_log_messages', return_value=["1", "2", "3", "4", "5"])
     def test_check_success_tasks_raises_cloudwatch_logs(self, mock_last_log_messages):
         client_mock = mock.Mock()

--- a/tests/providers/amazon/aws/operators/test_ecs.py
+++ b/tests/providers/amazon/aws/operators/test_ecs.py
@@ -217,7 +217,8 @@ class TestECSOperator(unittest.TestCase):
         client_mock.get_waiter.return_value.wait.assert_called_once_with(cluster='c', tasks=['arn'])
         assert sys.maxsize == client_mock.get_waiter.return_value.config.max_attempts
 
-    def test_check_success_tasks_raises(self):
+    @mock.patch.object(ECSOperator, '_last_log_messages', return_value=["1", "2", "3", "4", "5"])
+    def test_check_success_tasks_raises_cloudwatch_logs(self, mock_last_log_messages):
         client_mock = mock.Mock()
         self.ecs.arn = 'arn'
         self.ecs.client = client_mock
@@ -228,11 +229,11 @@ class TestECSOperator(unittest.TestCase):
         with pytest.raises(Exception) as ctx:
             self.ecs._check_success_task()
 
-        # Ordering of str(dict) is not guaranteed.
-        assert "This task is not in success state " in str(ctx.value)
-        assert "'name': 'foo'" in str(ctx.value)
-        assert "'lastStatus': 'STOPPED'" in str(ctx.value)
-        assert "'exitCode': 1" in str(ctx.value)
+        expected_last_logs = "\n".join(mock_last_log_messages.return_value)
+        assert (
+            str(ctx.value)
+            == f"This task is not in success state - last logs from Cloudwatch:\n{expected_last_logs}"
+        )
         client_mock.describe_tasks.assert_called_once_with(cluster='c', tasks=['arn'])
 
     def test_check_success_tasks_raises_pending(self):
@@ -415,17 +416,17 @@ class TestECSOperator(unittest.TestCase):
         xcom_del_mock.assert_called_once()
         assert self.ecs.arn == 'arn:aws:ecs:us-east-1:012345678910:task/d8c67b3c-ac87-4ffe-a847-4785bc3a8b55'
 
-    @mock.patch.object(ECSOperator, '_last_log_message', return_value="Log output")
+    @mock.patch.object(ECSOperator, '_last_log_messages', return_value=["Log output"])
     def test_execute_xcom_with_log(self, mock_cloudwatch_log_message):
         self.ecs.do_xcom_push = True
-        assert self.ecs.execute(None) == mock_cloudwatch_log_message.return_value
+        assert self.ecs.execute(None) == mock_cloudwatch_log_message.return_value[-1]
 
-    @mock.patch.object(ECSOperator, '_last_log_message', return_value=None)
+    @mock.patch.object(ECSOperator, '_last_log_messages', return_value=[])
     def test_execute_xcom_with_no_log(self, mock_cloudwatch_log_message):
         self.ecs.do_xcom_push = True
-        assert self.ecs.execute(None) == mock_cloudwatch_log_message.return_value
+        assert self.ecs.execute(None) is None
 
-    @mock.patch.object(ECSOperator, '_last_log_message', return_value="Log output")
+    @mock.patch.object(ECSOperator, '_last_log_messages', return_value=["Log output"])
     def test_execute_xcom_disabled(self, mock_cloudwatch_log_message):
         self.ecs.do_xcom_push = False
         assert self.ecs.execute(None) is None


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/17038

This PR changes the message in the AirflowException when the ECS task launched by ECSOperator is stopped. 

**Before:**
The message when it failed was:
`This task is not in success state {<huge JSON from AWS containing all the ECS task details>}`

**Now:**
The message is:
```
This task is not in success state - last logs from Cloudwatch:
<last_logs_from_cloudwatch>
```
which makes it much more useful to understand what failed in the underlying code directly from the alert.

The number of logs can be customized with the parameter `number_logs_exception`.

FYI @uranusjr 
