### PR TITLE
Chart: Use stable API versions where available

### DIFF
--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -43,6 +43,11 @@ Default Airflow version is updated to ``2.1.2``
 
 The default Airflow version that is installed with the Chart is now ``2.1.3``, previously it was ``2.1.2``.
 
+``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths`` parameters have been removed
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths`` parameters have been removed as they had previously had no effect on rendered YAML output.
+
 Airflow Helm Chart 1.1.0
 ------------------------
 

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -48,10 +48,10 @@ Removed ``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths``
 
 ``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths`` parameters have been removed as they had previously had no effect on rendered YAML output.
 
-Change of default `path` on Ingress
+Change of default ``path`` on Ingress
 """""""""""""""""""""""""""""""""""
 
-With the move to support the stable Kubernetes Ingress API the default path has been changed from being unset to `/`. For most Ingress controllers this should not change the behavior of the resulting Ingress resource.
+With the move to support the stable Kubernetes Ingress API the default path has been changed from being unset to ``/``. For most Ingress controllers this should not change the behavior of the resulting Ingress resource.
 
 Airflow Helm Chart 1.1.0
 ------------------------

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -43,10 +43,15 @@ Default Airflow version is updated to ``2.1.2``
 
 The default Airflow version that is installed with the Chart is now ``2.1.3``, previously it was ``2.1.2``.
 
-``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths`` parameters have been removed
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Removed ``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths`` parameters
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 ``ingress.flower.precedingPaths`` and ``ingress.flower.succeedingPaths`` parameters have been removed as they had previously had no effect on rendered YAML output.
+
+Change of default `path` on Ingress
+"""""""""""""""""""""""""""""""""""
+
+With the move to support the stable Kubernetes Ingress API the default path has been changed from being unset to `/`. For most Ingress controllers this should not change the behavior of the resulting Ingress resource.
 
 Airflow Helm Chart 1.1.0
 ------------------------

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -592,3 +592,13 @@ Create the name of the cleanup service account to use
   {{- $_ := set $config "auths" $auth -}}
   {{ $config | toJson | print }}
 {{- end }}
+
+{{/* Allow Kubernetes Version to be overridden. Credit to https://github.com/prometheus-community/helm-charts for Regex. */}}
+{{- define "kubeVersion" -}}
+  {{- $kubeVersion := default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+  {{/* Special use case for Amazon EKS, Google GKE */}}
+  {{- if and (regexMatch "\\d+\\.\\d+\\.\\d+-(?:eks|gke).+" $kubeVersion) (not .Values.kubeVersionOverride) -}}
+    {{- $kubeVersion = regexFind "\\d+\\.\\d+\\.\\d+" $kubeVersion -}}
+  {{- end -}}
+  {{- $kubeVersion -}}
+{{- end -}}

--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -22,7 +22,11 @@
 {{- $nodeSelector := or .Values.cleanup.nodeSelector .Values.nodeSelector }}
 {{- $affinity := or .Values.cleanup.affinity .Values.affinity }}
 {{- $tolerations := or .Values.cleanup.tolerations .Values.tolerations }}
+{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
+apiVersion: batch/v1
+{{- else }}
 apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-cleanup

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -20,7 +20,8 @@
 #################################
 {{- if .Values.flower.enabled }}
 {{- if and .Values.ingress.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
-{{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+{{- $apiIsStable := semverCompare ">= 1.19.x" (include "kubeVersion" .) -}}
+{{- if $apiIsStable }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -49,7 +50,7 @@ spec:
     - http:
         paths:
           - backend:
-              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              {{- if $apiIsStable }}
               service:
                 name: {{ .Release.Name }}-flower
                 port:
@@ -60,14 +61,14 @@ spec:
               {{- end }}
             {{- if .Values.ingress.flower.path }}
             path: {{ .Values.ingress.flower.path }}
-            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            {{- if $apiIsStable }}
             pathType: {{ .Values.ingress.flower.pathType }}
             {{- end }}
             {{- end }}
       {{- if .Values.ingress.flower.host }}
       host: {{ .Values.ingress.flower.host }}
       {{- end }}
-  {{- if and .Values.ingress.flower.ingressClassName (semverCompare ">= 1.19.x" (include "kubeVersion" .)) }}
+  {{- if and .Values.ingress.flower.ingressClassName $apiIsStable }}
   ingressClassName: {{ .Values.ingress.flower.ingressClassName }}
   {{- end }}
 {{- end }}

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -20,7 +20,11 @@
 #################################
 {{- if .Values.flower.enabled }}
 {{- if and .Values.ingress.enabled (or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor")) }}
+{{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-flower-ingress
@@ -44,13 +48,27 @@ spec:
     - http:
         paths:
           - backend:
+              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              service:
+                name: {{ .Release.Name }}-flower
+                port:
+                  name: flower-ui
+              {{- else }}
               serviceName: {{ .Release.Name }}-flower
               servicePort: flower-ui
+              {{- end }}
+
             {{- if .Values.ingress.flower.path }}
             path: {{ .Values.ingress.flower.path }}
+            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            pathType: {{ .Values.ingress.flower.pathType }}
+            {{- end }}
             {{- end }}
       {{- if .Values.ingress.flower.host }}
       host: {{ .Values.ingress.flower.host }}
       {{- end }}
+  {{- if and .Values.ingress.flower.ingressClassName (semverCompare ">= 1.19.x" (include "kubeVersion" .)) }}
+  ingressClassName: {{ .Values.ingress.flower.ingressClassName }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -34,8 +34,9 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-  {{- if .Values.ingress.flower.annotations }}
-  annotations: {{ toYaml .Values.ingress.flower.annotations | nindent 4 }}
+  {{- with .Values.ingress.flower.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.ingress.flower.tls.enabled }}
@@ -57,7 +58,6 @@ spec:
               serviceName: {{ .Release.Name }}-flower
               servicePort: flower-ui
               {{- end }}
-
             {{- if .Values.ingress.flower.path }}
             path: {{ .Values.ingress.flower.path }}
             {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -36,7 +36,7 @@ metadata:
     heritage: {{ .Release.Service }}
   {{- with .Values.ingress.flower.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.ingress.flower.tls.enabled }}

--- a/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml
@@ -20,7 +20,11 @@
 #################################
 {{- if and .Values.pgbouncer.enabled .Values.pgbouncer.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
+{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 metadata:
   name: {{ .Release.Name }}-pgbouncer-pdb
   labels:

--- a/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
+++ b/chart/templates/scheduler/scheduler-poddisruptionbudget.yaml
@@ -20,7 +20,11 @@
 #################################
 {{- if .Values.scheduler.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
+{{- if semverCompare ">= 1.21.x" (include "kubeVersion" .) }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 metadata:
   name: {{ .Release.Name }}-scheduler-pdb
   labels:

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -35,7 +35,7 @@ metadata:
     heritage: {{ .Release.Service }}
   {{- with .Values.ingress.web.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- if .Values.ingress.web.tls.enabled }}

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -19,7 +19,11 @@
 ## Airflow Webserver Ingress
 #################################
 {{- if .Values.ingress.enabled }}
+{{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-airflow-ingress
@@ -47,23 +51,56 @@ spec:
         paths:
           {{- range .Values.ingress.web.precedingPaths }}
           - path: {{ .path }}
+            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                  name: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
           - backend:
+              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              service:
+                name: {{ .Release.Name }}-webserver
+                port:
+                  name: airflow-ui
+              {{- else }}
               serviceName: {{ .Release.Name }}-webserver
               servicePort: airflow-ui
-{{- if .Values.ingress.web.path }}
+              {{- end }}
+            {{- if .Values.ingress.web.path }}
             path: {{ .Values.ingress.web.path }}
-{{- end }}
+            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            pathType: {{ .Values.ingress.web.pathType }}
+            {{- end }}
+            {{- end }}
           {{- range .Values.ingress.web.succeedingPaths }}
           - path: {{ .path }}
+            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                  name: {{ .servicePort }}
+              {{- else }}
               serviceName: {{ .serviceName }}
               servicePort: {{ .servicePort }}
+              {{- end }}
           {{- end }}
-{{- if .Values.ingress.web.host }}
+      {{- if .Values.ingress.web.host }}
       host: {{ .Values.ingress.web.host }}
-{{- end }}
+      {{- end }}
+  {{- if and .Values.ingress.web.ingressClassName (semverCompare ">= 1.19.x" (include "kubeVersion" .)) }}
+  ingressClassName: {{ .Values.ingress.web.ingressClassName }}
+  {{- end }}
 {{- end }}

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -33,12 +33,10 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-{{- if .Values.ingress.web.annotations }}
+  {{- with .Values.ingress.web.annotations }}
   annotations:
-{{- with .Values.ingress.web.annotations }}
-{{ toYaml . | indent 4 }}
-{{- end }}
-{{- end}}
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.ingress.web.tls.enabled }}
   tls:

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -19,7 +19,8 @@
 ## Airflow Webserver Ingress
 #################################
 {{- if .Values.ingress.enabled }}
-{{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+{{- $apiIsStable := semverCompare ">= 1.19.x" (include "kubeVersion" .) -}}
+{{- if $apiIsStable }}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -49,11 +50,11 @@ spec:
         paths:
           {{- range .Values.ingress.web.precedingPaths }}
           - path: {{ .path }}
-            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            {{- if $apiIsStable }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
                 port:
@@ -64,7 +65,7 @@ spec:
               {{- end }}
           {{- end }}
           - backend:
-              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              {{- if $apiIsStable }}
               service:
                 name: {{ .Release.Name }}-webserver
                 port:
@@ -75,17 +76,17 @@ spec:
               {{- end }}
             {{- if .Values.ingress.web.path }}
             path: {{ .Values.ingress.web.path }}
-            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            {{- if $apiIsStable }}
             pathType: {{ .Values.ingress.web.pathType }}
             {{- end }}
             {{- end }}
           {{- range .Values.ingress.web.succeedingPaths }}
           - path: {{ .path }}
-            {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+            {{- if $apiIsStable }}
             pathType: {{ .pathType }}
             {{- end }}
             backend:
-              {{- if semverCompare ">= 1.19.x" (include "kubeVersion" .) }}
+              {{- if $apiIsStable }}
               service:
                 name: {{ .serviceName }}
                 port:
@@ -98,7 +99,7 @@ spec:
       {{- if .Values.ingress.web.host }}
       host: {{ .Values.ingress.web.host }}
       {{- end }}
-  {{- if and .Values.ingress.web.ingressClassName (semverCompare ">= 1.19.x" (include "kubeVersion" .)) }}
+  {{- if and .Values.ingress.web.ingressClassName $apiIsStable }}
   ingressClassName: {{ .Values.ingress.web.ingressClassName }}
   {{- end }}
 {{- end }}

--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -32,6 +32,7 @@ from kubernetes.client.api_client import ApiClient
 api_client = ApiClient()
 
 BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v"
+DEFAULT_KUBERNETES_VERSION = "1.22.0"
 
 crd_lookup = {
     'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501
@@ -89,7 +90,7 @@ def validate_k8s_object(instance, kubernetes_version):
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None, kubernetes_version="1.19.0"):
+def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None, kubernetes_version=DEFAULT_KUBERNETES_VERSION):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """

--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import json
 import subprocess
 import sys
 from functools import lru_cache
@@ -23,7 +24,6 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Tuple
 
 import jmespath
-import json
 import jsonschema
 import requests
 import yaml
@@ -51,7 +51,11 @@ def get_schema_k8s(api_version, kind, kubernetes_version):
         url = f'{BASE_URL_SPEC}{kubernetes_version}/{kind}-{api_version}.json'
     request = requests.get(url)
     request.raise_for_status()
-    schema = json.loads(request.text.replace('kubernetesjsonschema.dev', 'raw.githubusercontent.com/yannh/kubernetes-json-schema/master'))
+    schema = json.loads(
+        request.text.replace(
+            'kubernetesjsonschema.dev', 'raw.githubusercontent.com/yannh/kubernetes-json-schema/master'
+        )
+    )
     return schema
 
 
@@ -90,7 +94,13 @@ def validate_k8s_object(instance, kubernetes_version):
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None, kubernetes_version=DEFAULT_KUBERNETES_VERSION):
+def render_chart(
+    name="RELEASE-NAME",
+    values=None,
+    show_only=None,
+    chart_dir=None,
+    kubernetes_version=DEFAULT_KUBERNETES_VERSION,
+):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
@@ -100,7 +110,16 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=Non
         content = yaml.dump(values)
         tmp_file.write(content.encode())
         tmp_file.flush()
-        command = ["helm", "template", name, chart_dir, '--values', tmp_file.name, '--kube-version', kubernetes_version]
+        command = [
+            "helm",
+            "template",
+            name,
+            chart_dir,
+            '--values',
+            tmp_file.name,
+            '--kube-version',
+            kubernetes_version,
+        ]
         if show_only:
             for i in show_only:
                 command.extend(["--show-only", i])

--- a/chart/tests/helm_template_generator.py
+++ b/chart/tests/helm_template_generator.py
@@ -23,6 +23,7 @@ from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Tuple
 
 import jmespath
+import json
 import jsonschema
 import requests
 import yaml
@@ -30,26 +31,26 @@ from kubernetes.client.api_client import ApiClient
 
 api_client = ApiClient()
 
-BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.15.0"
+BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v"
 
 crd_lookup = {
     'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501
 }
 
 
-def get_schema_k8s(api_version, kind):
+def get_schema_k8s(api_version, kind, kubernetes_version):
     api_version = api_version.lower()
     kind = kind.lower()
 
     if '/' in api_version:
         ext, _, api_version = api_version.partition("/")
         ext = ext.split(".")[0]
-        url = f'{BASE_URL_SPEC}/{kind}-{ext}-{api_version}.json'
+        url = f'{BASE_URL_SPEC}{kubernetes_version}/{kind}-{ext}-{api_version}.json'
     else:
-        url = f'{BASE_URL_SPEC}/{kind}-{api_version}.json'
+        url = f'{BASE_URL_SPEC}{kubernetes_version}/{kind}-{api_version}.json'
     request = requests.get(url)
     request.raise_for_status()
-    schema = request.json()
+    schema = json.loads(request.text.replace('kubernetesjsonschema.dev', 'raw.githubusercontent.com/yannh/kubernetes-json-schema/master'))
     return schema
 
 
@@ -64,16 +65,16 @@ def get_schema_crd(api_version, kind):
 
 
 @lru_cache(maxsize=None)
-def create_validator(api_version, kind):
+def create_validator(api_version, kind, kubernetes_version):
     schema = get_schema_crd(api_version, kind)
     if not schema:
-        schema = get_schema_k8s(api_version, kind)
+        schema = get_schema_k8s(api_version, kind, kubernetes_version)
     jsonschema.Draft7Validator.check_schema(schema)
     validator = jsonschema.Draft7Validator(schema)
     return validator
 
 
-def validate_k8s_object(instance):
+def validate_k8s_object(instance, kubernetes_version):
     # Skip PostgresSQL chart
     labels = jmespath.search("metadata.labels", instance)
     if "helm.sh/chart" in labels:
@@ -84,11 +85,11 @@ def validate_k8s_object(instance):
     if chart and 'postgresql' in chart:
         return
 
-    validate = create_validator(instance.get("apiVersion"), instance.get("kind"))
+    validate = create_validator(instance.get("apiVersion"), instance.get("kind"), kubernetes_version)
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None):
+def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None, kubernetes_version="1.19.0"):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
@@ -98,7 +99,7 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=Non
         content = yaml.dump(values)
         tmp_file.write(content.encode())
         tmp_file.flush()
-        command = ["helm", "template", name, chart_dir, '--values', tmp_file.name]
+        command = ["helm", "template", name, chart_dir, '--values', tmp_file.name, '--kube-version', kubernetes_version]
         if show_only:
             for i in show_only:
                 command.extend(["--show-only", i])
@@ -106,7 +107,7 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=Non
         k8s_objects = yaml.full_load_all(templates)
         k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore
         for k8s_object in k8s_objects:
-            validate_k8s_object(k8s_object)
+            validate_k8s_object(k8s_object, kubernetes_version)
         return k8s_objects
 
 

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -48,6 +48,15 @@ class CleanupPodsTest(unittest.TestCase):
             "readOnly": True,
         } in jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].volumeMounts", docs[0])
 
+
+    def test_should_pass_validation_with_v1beta1_api(self):
+        render_chart(
+            values={"cleanup": {"enabled": True}},
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+            kubernetes_version='1.16.0',
+        )  # checks that no validation exception is raised
+
+
     def test_should_change_image_when_set_airflow_image(self):
         docs = render_chart(
             values={

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -48,14 +48,12 @@ class CleanupPodsTest(unittest.TestCase):
             "readOnly": True,
         } in jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].volumeMounts", docs[0])
 
-
     def test_should_pass_validation_with_v1beta1_api(self):
         render_chart(
             values={"cleanup": {"enabled": True}},
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
             kubernetes_version='1.16.0',
         )  # checks that no validation exception is raised
-
 
     def test_should_change_image_when_set_airflow_image(self):
         docs = render_chart(

--- a/chart/tests/test_ingress_flower.py
+++ b/chart/tests/test_ingress_flower.py
@@ -45,3 +45,13 @@ class IngressFlowerTest(unittest.TestCase):
             show_only=["templates/flower/flower-ingress.yaml"],
         )
         assert jmespath.search("metadata.annotations", docs[0]) == {"aa": "bb", "cc": "dd"}
+
+    def test_should_set_ingress_class_name(self):
+        docs = render_chart(
+            values={
+                "ingress": {"enabled": True, "flower": {"ingressClassName": "foo"}},
+                "executor": "CeleryExecutor",
+            },
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )
+        assert "foo" == jmespath.search("spec.ingressClassName", docs[0])

--- a/chart/tests/test_ingress_web.py
+++ b/chart/tests/test_ingress_web.py
@@ -23,11 +23,17 @@ from tests.helm_template_generator import render_chart
 
 
 class IngressWebTest(unittest.TestCase):
-    def test_should_pass_validation_with_just_ingress_enabled(self):
+    def test_should_pass_validation_with_just_ingress_enabled_v1(self):
         render_chart(
             values={"ingress": {"enabled": True}},
             show_only=["templates/webserver/webserver-ingress.yaml"],
-            kubernetes_version='1.22.0',
+        )  # checks that no validation exception is raised
+
+    def test_should_pass_validation_with_just_ingress_enabled_v1beta1(self):
+        render_chart(
+            values={"ingress": {"enabled": True}},
+            show_only=["templates/webserver/webserver-ingress.yaml"],
+            kubernetes_version='1.16.0',
         )  # checks that no validation exception is raised
 
     def test_should_allow_more_than_one_annotation(self):

--- a/chart/tests/test_ingress_web.py
+++ b/chart/tests/test_ingress_web.py
@@ -42,3 +42,10 @@ class IngressWebTest(unittest.TestCase):
             show_only=["templates/webserver/webserver-ingress.yaml"],
         )
         assert {"aa": "bb", "cc": "dd"} == jmespath.search("metadata.annotations", docs[0])
+
+    def test_should_set_ingress_class_name(self):
+        docs = render_chart(
+            values={"ingress": {"enabled": True, "web": {"ingressClassName": "foo"}}},
+            show_only=["templates/webserver/webserver-ingress.yaml"],
+        )
+        assert "foo" == jmespath.search("spec.ingressClassName", docs[0])

--- a/chart/tests/test_ingress_web.py
+++ b/chart/tests/test_ingress_web.py
@@ -27,6 +27,7 @@ class IngressWebTest(unittest.TestCase):
         render_chart(
             values={"ingress": {"enabled": True}},
             show_only=["templates/webserver/webserver-ingress.yaml"],
+            kubernetes_version='1.22.0',
         )  # checks that no validation exception is raised
 
     def test_should_allow_more_than_one_annotation(self):

--- a/chart/tests/test_pdb_pgbouncer.py
+++ b/chart/tests/test_pdb_pgbouncer.py
@@ -17,8 +17,6 @@
 
 import unittest
 
-import jmespath
-
 from tests.helm_template_generator import render_chart
 
 
@@ -35,4 +33,3 @@ class PgbouncerPdbTest(unittest.TestCase):
             show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
             kubernetes_version='1.16.0',
         )  # checks that no validation exception is raised
-

--- a/chart/tests/test_pdb_pgbouncer.py
+++ b/chart/tests/test_pdb_pgbouncer.py
@@ -22,26 +22,17 @@ import jmespath
 from tests.helm_template_generator import render_chart
 
 
-class IngressFlowerTest(unittest.TestCase):
-    def test_should_pass_validation_with_just_ingress_enabled_v1(self):
+class PgbouncerPdbTest(unittest.TestCase):
+    def test_should_pass_validation_with_just_pdb_enabled_v1(self):
         render_chart(
-            values={"ingress": {"enabled": True}, "executor": "CeleryExecutor"},
-            show_only=["templates/flower/flower-ingress.yaml"],
+            values={"pgbouncer": {"enabled": True, "podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
 
-    def test_should_pass_validation_with_just_ingress_enabled_v1beta1(self):
+    def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
         render_chart(
-            values={"ingress": {"enabled": True}, "executor": "CeleryExecutor"},
-            show_only=["templates/flower/flower-ingress.yaml"],
+            values={"pgbouncer": {"enabled": True, "podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/pgbouncer/pgbouncer-poddisruptionbudget.yaml"],
             kubernetes_version='1.16.0',
         )  # checks that no validation exception is raised
 
-    def test_should_allow_more_than_one_annotation(self):
-        docs = render_chart(
-            values={
-                "ingress": {"enabled": True, "flower": {"annotations": {"aa": "bb", "cc": "dd"}}},
-                "executor": "CeleryExecutor",
-            },
-            show_only=["templates/flower/flower-ingress.yaml"],
-        )
-        assert jmespath.search("metadata.annotations", docs[0]) == {"aa": "bb", "cc": "dd"}

--- a/chart/tests/test_pdb_scheduler.py
+++ b/chart/tests/test_pdb_scheduler.py
@@ -22,26 +22,18 @@ import jmespath
 from tests.helm_template_generator import render_chart
 
 
-class IngressFlowerTest(unittest.TestCase):
-    def test_should_pass_validation_with_just_ingress_enabled_v1(self):
+class SchedulerPdbTest(unittest.TestCase):
+    def test_should_pass_validation_with_just_pdb_enabled_v1(self):
         render_chart(
-            values={"ingress": {"enabled": True}, "executor": "CeleryExecutor"},
-            show_only=["templates/flower/flower-ingress.yaml"],
+            values={"scheduler": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/scheduler/scheduler-poddisruptionbudget.yaml"],
         )  # checks that no validation exception is raised
 
-    def test_should_pass_validation_with_just_ingress_enabled_v1beta1(self):
+    def test_should_pass_validation_with_just_pdb_enabled_v1beta1(self):
         render_chart(
-            values={"ingress": {"enabled": True}, "executor": "CeleryExecutor"},
-            show_only=["templates/flower/flower-ingress.yaml"],
+            values={"scheduler": {"podDisruptionBudget": {"enabled": True}}},
+            show_only=["templates/scheduler/scheduler-poddisruptionbudget.yaml"],
             kubernetes_version='1.16.0',
         )  # checks that no validation exception is raised
 
-    def test_should_allow_more_than_one_annotation(self):
-        docs = render_chart(
-            values={
-                "ingress": {"enabled": True, "flower": {"annotations": {"aa": "bb", "cc": "dd"}}},
-                "executor": "CeleryExecutor",
-            },
-            show_only=["templates/flower/flower-ingress.yaml"],
-        )
-        assert jmespath.search("metadata.annotations", docs[0]) == {"aa": "bb", "cc": "dd"}
+

--- a/chart/tests/test_pdb_scheduler.py
+++ b/chart/tests/test_pdb_scheduler.py
@@ -17,8 +17,6 @@
 
 import unittest
 
-import jmespath
-
 from tests.helm_template_generator import render_chart
 
 
@@ -35,5 +33,3 @@ class SchedulerPdbTest(unittest.TestCase):
             show_only=["templates/scheduler/scheduler-poddisruptionbudget.yaml"],
             kubernetes_version='1.16.0',
         )  # checks that no validation exception is raised
-
-

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -34,6 +34,13 @@
             "default": "",
             "x-docsSection": null
         },
+        "kubeVersionOverride": {
+            "description": "Provide a Kubernetes version (used for API Version selection) to override the auto-detected version",
+            "type": "string",
+            "default": "",
+            "x-docsSection": null
+        },
+
         "uid": {
             "description": "User of airflow user.",
             "type": "integer",
@@ -125,8 +132,18 @@
                             "type": "string",
                             "default": ""
                         },
+                        "pathType": {
+                            "description": "The pathType for the web Ingress.",
+                            "type": "string",
+                            "default": ""
+                        },
                         "host": {
                             "description": "The hostname for the web Ingress.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "description": "The Ingress Class for the web Ingress.",
                             "type": "string",
                             "default": ""
                         },
@@ -174,8 +191,18 @@
                             "type": "string",
                             "default": ""
                         },
+                        "pathType": {
+                            "description": "The pathType for the flower Ingress.",
+                            "type": "string",
+                            "default": ""
+                        },
                         "host": {
                             "description": "The hostname for the flower Ingress.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "ingressClassName": {
+                            "description": "The Ingress Class for the flower Ingress.",
                             "type": "string",
                             "default": ""
                         },
@@ -195,16 +222,6 @@
                                     "default": ""
                                 }
                             }
-                        },
-                        "precedingPaths": {
-                            "description": "HTTP paths to add to the flower Ingress before the default path.",
-                            "type": "array",
-                            "default": []
-                        },
-                        "succeedingPaths": {
-                            "description": "HTTP paths to add to the flower Ingress after the default path.",
-                            "type": "array",
-                            "default": []
                         }
                     }
                 }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -129,7 +129,7 @@
                         "path": {
                             "description": "The path for the web Ingress.",
                             "type": "string",
-                            "default": ""
+                            "default": "/"
                         },
                         "pathType": {
                             "description": "The pathType for the web Ingress (required for Kubernetes 1.19 and above).",
@@ -188,7 +188,7 @@
                         "path": {
                             "description": "The path for the flower Ingress.",
                             "type": "string",
-                            "default": ""
+                            "default": "/"
                         },
                         "pathType": {
                             "description": "The pathType for the flower Ingress (required for Kubernetes 1.19 and above).",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -40,7 +40,6 @@
             "default": "",
             "x-docsSection": null
         },
-
         "uid": {
             "description": "User of airflow user.",
             "type": "integer",
@@ -133,9 +132,9 @@
                             "default": ""
                         },
                         "pathType": {
-                            "description": "The pathType for the web Ingress.",
+                            "description": "The pathType for the web Ingress (required for Kubernetes 1.19 and above).",
                             "type": "string",
-                            "default": ""
+                            "default": "ImplementationSpecific"
                         },
                         "host": {
                             "description": "The hostname for the web Ingress.",
@@ -192,9 +191,9 @@
                             "default": ""
                         },
                         "pathType": {
-                            "description": "The pathType for the flower Ingress.",
+                            "description": "The pathType for the flower Ingress (required for Kubernetes 1.19 and above).",
                             "type": "string",
-                            "default": ""
+                            "default": "ImplementationSpecific"
                         },
                         "host": {
                             "description": "The hostname for the flower Ingress.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -99,7 +99,7 @@ ingress:
     annotations: {}
 
     # The path for the web Ingress
-    path: ""
+    path: "/"
 
     # The pathType for the above path (used only with Kubernetes v1.19 and above)
     pathType: "ImplementationSpecific"
@@ -129,7 +129,7 @@ ingress:
     annotations: {}
 
     # The path for the flower Ingress
-    path: ""
+    path: "/"
 
     # The pathType for the above path (used only with Kubernetes v1.19 and above)
     pathType: "ImplementationSpecific"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -102,7 +102,7 @@ ingress:
     path: ""
 
     # The pathType for the above path (used only with Kubernetes v1.19 and above)
-    pathType: ""
+    pathType: "ImplementationSpecific"
 
     # The hostname for the web Ingress
     host: ""
@@ -132,7 +132,7 @@ ingress:
     path: ""
 
     # The pathType for the above path (used only with Kubernetes v1.19 and above)
-    pathType: ""
+    pathType: "ImplementationSpecific"
 
     # The hostname for the flower Ingress
     host: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -25,6 +25,9 @@ fullnameOverride: ""
 # Provide a name to substitute for the name of the chart
 nameOverride: ""
 
+# Provide a Kubernetes version (used for API Version selection) to override the auto-detected version
+kubeVersionOverride: ""
+
 # User and group of airflow user
 uid: 50000
 gid: 0
@@ -98,8 +101,14 @@ ingress:
     # The path for the web Ingress
     path: ""
 
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: ""
+
     # The hostname for the web Ingress
     host: ""
+
+    # The Ingress Class for the web Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
 
     # configs for web Ingress TLS
     tls:
@@ -122,8 +131,14 @@ ingress:
     # The path for the flower Ingress
     path: ""
 
+    # The pathType for the above path (used only with Kubernetes v1.19 and above)
+    pathType: ""
+
     # The hostname for the flower Ingress
     host: ""
+
+    # The Ingress Class for the flower Ingress (used only with Kubernetes v1.19 and above)
+    ingressClassName: ""
 
     # configs for web Ingress TLS
     tls:
@@ -131,12 +146,6 @@ ingress:
       enabled: false
       # the name of a pre-created Secret containing a TLS private key and certificate
       secretName: ""
-
-    # HTTP paths to add to the flower Ingress before the default path
-    precedingPaths: []
-
-    # Http paths to add to the flower Ingress after the default path
-    succeedingPaths: []
 
 # Network policy configuration
 networkPolicies:


### PR DESCRIPTION
Fixes #17188 

Uses stable versions of Ingress, PodDisruptionBudget and CronJob APIs where available. There is no change for users of Kubernetes versions older than 1.19. Also tidies up some inconsistencies between the two Ingresses and removes variables on the flower Ingress which didn't do anything.