### PR TITLE
Attempt to fix MsSQL locks - released between sessions

### DIFF
--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -28,7 +28,7 @@ from airflow.utils.process_utils import execute_interactive
 def initdb(args):
     """Initializes the metadata database"""
     print("DB: " + repr(settings.engine.url))
-    db.initdb()
+    db.initdb_with_session()
     print("Initialization done")
 
 
@@ -36,7 +36,7 @@ def resetdb(args):
     """Resets the metadata database"""
     print("DB: " + repr(settings.engine.url))
     if args.yes or input("This will drop existing tables if they exist. Proceed? (y/n)").upper() == "Y":
-        db.resetdb()
+        db.resetdb_with_session()
     else:
         print("Cancelled")
 
@@ -45,7 +45,7 @@ def resetdb(args):
 def upgradedb(args):
     """Upgrades the metadata database"""
     print("DB: " + repr(settings.engine.url))
-    db.upgradedb()
+    db.upgradedb_with_session()
     print("Upgrades done")
 
 

--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -159,7 +159,7 @@ class StandaloneCommand:
         """Makes sure all the tables are created."""
         # Set up DB tables
         self.print_output("standalone", "Checking database is initialized")
-        db.initdb()
+        db.initdb_with_session()
         self.print_output("standalone", "Database ready")
         # See if a user needs creating
         # We want a streamlined first-run experience, but we do not want to

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -573,14 +573,19 @@ def create_default_connections(session=None):
 
 
 @provide_session
-def initdb(session=None):
+def initdb_with_session(session=None):
+    """Initialize Airflow database with session."""
+    initdb(session=session)
+
+
+def initdb(session):
     """Initialize Airflow database."""
     upgradedb(session=session)
 
     if conf.getboolean('core', 'LOAD_DEFAULT_CONNECTIONS'):
         create_default_connections(session=session)
 
-    with create_global_lock(session=session):
+    with create_global_lock(session=session, pg_lock_id=1, lock_name="init"):
 
         dagbag = DagBag()
         # Save DAGs in the ORM
@@ -702,7 +707,12 @@ def auto_migrations_available(session=None):
 
 
 @provide_session
-def upgradedb(session=None):
+def upgradedb_with_session(session=None):
+    """Upgrade the database with session."""
+    upgradedb(session=session)
+
+
+def upgradedb(session):
     """Upgrade the database."""
     # alembic adds significant import time, so we import it lazily
     from alembic import command
@@ -723,7 +733,12 @@ def upgradedb(session=None):
 
 
 @provide_session
-def resetdb(session=None):
+def resetdb_with_session(session=None):
+    """Upgrade the database with session."""
+    resetdb(session=session)
+
+
+def resetdb(session):
     """Clear out the database"""
     log.info("Dropping tables that exist")
 
@@ -733,7 +748,7 @@ def resetdb(session=None):
         drop_airflow_models(connection)
         drop_flask_models(connection)
 
-    initdb(session=session)
+        initdb(session=session)
 
 
 def drop_airflow_models(connection):

--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -74,7 +74,7 @@ def provide_session(func: Callable[..., RT]) -> Callable[..., RT]:
 
 @provide_session
 @contextlib.contextmanager
-def create_global_lock(session=None, pg_lock_id=1, lock_name='init', mysql_lock_timeout=1800):
+def create_global_lock(session, pg_lock_id, lock_name, mysql_lock_timeout=1800):
     """Contextmanager that will create and teardown a global db lock."""
     dialect = session.connection().dialect
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def reset_db():
 
     from airflow.utils import db
 
-    db.resetdb()
+    db.resetdb_with_session()
     yield
 
 
@@ -170,7 +170,7 @@ def initial_db_init():
     else:
         from airflow.utils import db
 
-        db.resetdb()
+        db.resetdb_with_session()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/test_utils/perf/sql_queries.py
+++ b/tests/test_utils/perf/sql_queries.py
@@ -108,9 +108,9 @@ def reset_db():
     """
     Wrapper function that calls the airflow resetdb function.
     """
-    from airflow.utils.db import resetdb
+    from airflow.utils.db import resetdb_with_session
 
-    resetdb()
+    resetdb_with_session()
 
 
 def run_scheduler_job(with_db_reset=False) -> None:


### PR DESCRIPTION
Seems that the errors we have with MsSQL locks failing the tests
are coming from prematurely ended sessions. It looks like when the
session ends for MSSQL, the 'session' level locks are released
if the same thread opened more than one session via provide_session
decorator. This change separates out the auto-session-provided
init/upgrade/reset so that we know for the init/upgrade/reset
we always have at most one session.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
