### PR TITLE
Improve postgres provider logging

### DIFF
--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -125,6 +125,7 @@ class PostgresHook(DbApiHook):
         So if users want to be aware when the input file does not exist,
         they have to check its existence by themselves.
         """
+        self.log.info("Running copy expert: %s, filename: %s", sql, filename)
         if not os.path.isfile(filename):
             with open(filename, 'w'):
                 pass

--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -65,7 +65,6 @@ class PostgresOperator(BaseOperator):
         self.hook = None
 
     def execute(self, context):
-        self.log.info('Executing: %s', self.sql)
         self.hook = PostgresHook(postgres_conn_id=self.postgres_conn_id, schema=self.database)
         self.hook.run(self.sql, self.autocommit, parameters=self.parameters)
         for output in self.hook.conn.notices:


### PR DESCRIPTION
This change addresses the below mentioned issues:
1. Currently, the `PostgresOperator` logs the sql twice (once by `execute` method of operator and once by the underlying `run()` method of `DbApiHook`). For anyone looking at the logs, it appears the SQL ran twice which is not the case. Here's an example log file:
```log
[2021-07-25 00:01:02,825] {logging_mixin.py:112} INFO - Running <TaskInstance: example_dag.example_task 2021-07-24T04:00:00+00:00 [running]> on host 12345567
[2021-07-25 00:01:02,848] {postgres.py:69} INFO - Executing: truncate table XYZ;
[2021-07-25 00:01:02,857] {base_hook.py:89} INFO - Using connection to: id: app_db. Host: abc.com, Port: 5432, Schema: test, Login: some_user, Password: XXXXXXXX, extra: XXXXXXXX
[2021-07-25 00:01:02,867] {dbapi_hook.py:176} INFO - truncate table XYZ;
[2021-07-25 00:01:03,120] {taskinstance.py:1070} INFO - Marking task as SUCCESS.dag_id=example_dag, task_id=some_task, execution_date=20210724T040000, start_date=20210725T040102, end_date=20210725T040103

```
2. The `copy_expert` method of `PostgresHook` doesn't currently log the SQL executed against the db. This is helpful for debugging especially if you are calling `copy_expert` method directly as opposed to via `bulk_load` or `bulk_dump`.