### PR TITLE
Stop attempting to pull base python image when pulling commit hash

### DIFF
--- a/scripts/ci/libraries/_push_pull_remove_images.sh
+++ b/scripts/ci/libraries/_push_pull_remove_images.sh
@@ -145,7 +145,10 @@ function push_pull_remove_images::pull_ci_images_if_needed() {
     python_image_hash=$(docker images -q "${AIRFLOW_PYTHON_BASE_IMAGE}" 2> /dev/null || true)
     if [[ -z "${python_image_hash=}" || "${FORCE_PULL_IMAGES}" == "true" || \
             ${CHECK_IF_BASE_PYTHON_IMAGE_UPDATED} == "true" ]]; then
-        push_pull_remove_images::pull_base_python_image
+        if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} == "latest" ]]; then
+            # Pull base python image when building latest image
+            push_pull_remove_images::pull_base_python_image
+        fi
     fi
     if [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         push_pull_remove_images::pull_image_if_not_present_or_forced \
@@ -160,7 +163,10 @@ function push_pull_remove_images::pull_prod_images_if_needed() {
     python_image_hash=$(docker images -q "${AIRFLOW_PYTHON_BASE_IMAGE}" 2> /dev/null || true)
     if [[ -z "${python_image_hash=}" || "${FORCE_PULL_IMAGES}" == "true"  || \
             ${CHECK_IF_BASE_PYTHON_IMAGE_UPDATED} == "true" ]]; then
-        push_pull_remove_images::pull_base_python_image
+        if [[ ${GITHUB_REGISTRY_PULL_IMAGE_TAG} == "latest" ]]; then
+            # Pull base python image when building latest image
+            push_pull_remove_images::pull_base_python_image
+        fi
     fi
     if [[ "${DOCKER_CACHE}" == "pulled" ]]; then
         # "Build" segment of production image


### PR DESCRIPTION
When we publish latest images, we also publish Python base images
for them, so that we know where the base images are taken from.
This is not happening when we build "per-build" images - we only
publish the resulting images rather than base python images because
we do not need the base python images. This change was implemented
after ghcr.io move and it was not reflected in --github-id
switch handling, so ./breeze command with --github-id specified,
failed trying to pull base python image with the same ID.

This PR makes sure that we only pull base python image when we
build/pull latest images, not the per-build ones.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
