### PR TITLE
add encoding config in FtpHook

### DIFF
--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -60,7 +60,7 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            encoding = params.extra_dejson.get("encoding", "latin-1")
+            encoding = params.extra_dejson.get("encoding", "utf-8")
             self.conn = ftplib.FTP(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
             self.conn.encoding = encoding
@@ -284,7 +284,7 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            encoding = params.extra_dejson.get("encoding", "latin-1")
+            encoding = params.extra_dejson.get("encoding", "utf-8")
 
             if params.port:
                 ftplib.FTP_TLS.port = params.port

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -60,8 +60,10 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
+            encoding = params.extra_dejson.get("encoding", "latin-1")
             self.conn = ftplib.FTP(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
+            self.conn.encoding = encoding
 
         return self.conn
 
@@ -282,11 +284,13 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
+            encoding = params.extra_dejson.get("encoding", "latin-1")
 
             if params.port:
                 ftplib.FTP_TLS.port = params.port
 
             self.conn = ftplib.FTP_TLS(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
+            self.conn.encoding = encoding
 
         return self.conn

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -60,10 +60,11 @@ class FTPHook(BaseHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            encoding = params.extra_dejson.get("encoding", "utf-8")
             self.conn = ftplib.FTP(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
-            self.conn.encoding = encoding
+            
+            if "encoding" in params.extra_dejson:
+                self.conn.encoding = params.extra_dejson["encoding"]
 
         return self.conn
 
@@ -284,13 +285,14 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            encoding = params.extra_dejson.get("encoding", "utf-8")
-
+            
             if params.port:
                 ftplib.FTP_TLS.port = params.port
 
             self.conn = ftplib.FTP_TLS(params.host, params.login, params.password)
             self.conn.set_pasv(pasv)
-            self.conn.encoding = encoding
+            
+            if "encoding" in params.extra_dejson:
+                self.conn.encoding = params.extra_dejson["encoding"]
 
         return self.conn

--- a/airflow/providers/ftp/hooks/ftp.py
+++ b/airflow/providers/ftp/hooks/ftp.py
@@ -285,7 +285,7 @@ class FTPSHook(FTPHook):
         if self.conn is None:
             params = self.get_connection(self.ftp_conn_id)
             pasv = params.extra_dejson.get("passive", True)
-            
+
             if params.port:
                 ftplib.FTP_TLS.port = params.port
 


### PR DESCRIPTION
The default ftplib package in FTP Hook is latin-1 encoding. If you encounter Chinese or other non-English languages, you will encounter garbled characters if you use list_directory and other methods, so you can add a configuration item to change the encoding in FTP Hook.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
