### PR TITLE
Use `dag_maker` fixture in test_scheduler_job.py

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -184,18 +184,18 @@ class TestSchedulerJob:
 
     @mock.patch('airflow.jobs.scheduler_job.TaskCallbackRequest')
     @mock.patch('airflow.jobs.scheduler_job.Stats.incr')
-    def test_process_executor_events(self, mock_stats_incr, mock_task_callback):
+    def test_process_executor_events(self, mock_stats_incr, mock_task_callback, dag_maker):
         dag_id = "test_process_executor_events"
         dag_id2 = "test_process_executor_events_2"
         task_id_1 = 'dummy_task'
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        dag2 = DAG(dag_id=dag_id2, start_date=DEFAULT_DATE)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
-        DummyOperator(dag=dag2, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id, full_filepath="/test_path1/") as dag:
+            task1 = DummyOperator(task_id=task_id_1)
+        with dag_maker(dag_id=dag_id2, full_filepath="/test_path1/") as dag2:
+            DummyOperator(task_id=task_id_1)
         dag.fileloc = "/test_path1/"
         dag2.fileloc = "/test_path1/"
-
+        mock_stats_incr.reset_mock()
         executor = MockExecutor(do_update=False)
         task_callback = mock.MagicMock()
         mock_task_callback.return_value = task_callback
@@ -237,10 +237,9 @@ class TestSchedulerJob:
         ti1.refresh_from_db()
         assert ti1.state == State.SUCCESS
         self.scheduler_job.processor_agent.send_callback_to_execute.assert_not_called()
-
         mock_stats_incr.assert_called_once_with('scheduler.tasks.killed_externally')
 
-    def test_process_executor_events_uses_inmemory_try_number(self):
+    def test_process_executor_events_uses_inmemory_try_number(self, dag_maker):
         execution_date = DEFAULT_DATE
         dag_id = "dag_id"
         task_id = "task_id"
@@ -252,8 +251,8 @@ class TestSchedulerJob:
         event_buffer = {TaskInstanceKey(dag_id, task_id, execution_date, try_number): (State.SUCCESS, None)}
         executor.get_event_buffer.return_value = event_buffer
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        task = DummyOperator(dag=dag, task_id=task_id)
+        with dag_maker(dag_id=dag_id):
+            task = DummyOperator(task_id=task_id)
 
         with create_session() as session:
             ti = TaskInstance(task, DEFAULT_DATE)
@@ -265,33 +264,22 @@ class TestSchedulerJob:
         # task instance key
         assert event_buffer == {}
 
-    def test_execute_task_instances_is_paused_wont_execute(self):
+    def test_execute_task_instances_is_paused_wont_execute(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_execute_task_instances_is_paused_wont_execute'
         task_id_1 = 'dummy_task'
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dagmodel = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.BACKFILL_JOB,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
         ti1 = TaskInstance(task1, DEFAULT_DATE)
         ti1.state = State.SCHEDULED
         session.merge(ti1)
         session.merge(dr1)
-        session.add(dagmodel)
         session.flush()
 
         self.scheduler_job._critical_section_execute_task_instances(session)
@@ -300,32 +288,20 @@ class TestSchedulerJob:
         assert State.SCHEDULED == ti1.state
         session.rollback()
 
-    def test_execute_task_instances_no_dagrun_task_will_execute(self):
+    def test_execute_task_instances_no_dagrun_task_will_execute(self, dag_maker):
         """
         Tests that tasks without dagrun still get executed.
         """
         dag_id = 'SchedulerJobTest.test_execute_task_instances_no_dagrun_task_will_execute'
         task_id_1 = 'dummy_task'
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
         ti1 = TaskInstance(task1, DEFAULT_DATE)
         ti1.state = State.SCHEDULED
         ti1.execution_date = ti1.execution_date + datetime.timedelta(days=1)
@@ -338,32 +314,22 @@ class TestSchedulerJob:
         assert State.QUEUED == ti1.state
         session.rollback()
 
-    def test_execute_task_instances_backfill_tasks_wont_execute(self):
+    def test_execute_task_instances_backfill_tasks_wont_execute(self, dag_maker):
         """
         Tests that backfill tasks won't get executed.
         """
         dag_id = 'SchedulerJobTest.test_execute_task_instances_backfill_tasks_wont_execute'
         task_id_1 = 'dummy_task'
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.BACKFILL_JOB,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
+
         ti1 = TaskInstance(task1, dr1.execution_date)
         ti1.refresh_from_db()
         ti1.state = State.SCHEDULED
@@ -379,28 +345,17 @@ class TestSchedulerJob:
         assert State.SCHEDULED == ti1.state
         session.rollback()
 
-    def test_find_executable_task_instances_backfill_nodagrun(self):
+    def test_find_executable_task_instances_backfill_nodagrun(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_backfill_nodagrun'
         task_id_1 = 'dummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=16)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id, max_active_tasks=16) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
             run_type=DagRunType.BACKFILL_JOB,
             execution_date=dag.following_schedule(dr1.execution_date),
@@ -428,30 +383,19 @@ class TestSchedulerJob:
         assert ti_with_dagrun.key in res_keys
         session.rollback()
 
-    def test_find_executable_task_instances_pool(self):
+    def test_find_executable_task_instances_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_pool'
         task_id_1 = 'dummy'
         task_id_2 = 'dummydummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=16)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1, pool='a')
-        task2 = DummyOperator(dag=dag, task_id=task_id_2, pool='b')
+        with dag_maker(dag_id=dag_id, max_active_tasks=16) as dag:
+            task1 = DummyOperator(task_id=task_id_1, pool='a')
+            task2 = DummyOperator(task_id=task_id_2, pool='b')
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=dag.following_schedule(dr1.execution_date),
@@ -484,44 +428,28 @@ class TestSchedulerJob:
         assert tis[3].key in res_keys
         session.rollback()
 
-    def test_find_executable_task_instances_order_execution_date(self):
+    def test_find_executable_task_instances_order_execution_date(self, dag_maker):
+        """
+        Test that task instances follow execution_date order priority. If two dagruns with
+        different execution dates are scheduled, tasks with earliest dagrun execution date will first
+        be executed
+        """
         dag_id_1 = 'SchedulerJobTest.test_find_executable_task_instances_order_execution_date-a'
         dag_id_2 = 'SchedulerJobTest.test_find_executable_task_instances_order_execution_date-b'
         task_id = 'task-a'
-        dag_1 = DAG(dag_id=dag_id_1, start_date=DEFAULT_DATE, max_active_tasks=16)
-        dag_2 = DAG(dag_id=dag_id_2, start_date=DEFAULT_DATE, max_active_tasks=16)
-        dag1_task = DummyOperator(dag=dag_1, task_id=task_id)
-        dag2_task = DummyOperator(dag=dag_2, task_id=task_id)
+        with dag_maker(dag_id=dag_id_1, max_active_tasks=16) as dag_1:
+            dag1_task = DummyOperator(task_id=task_id)
+        dr1 = dag_maker.create_dagrun(execution_date=DEFAULT_DATE + timedelta(hours=1))
+
+        with dag_maker(dag_id=dag_id_2, max_active_tasks=16) as dag_2:
+            dag2_task = DummyOperator(task_id=task_id)
+        dr2 = dag_maker.create_dagrun()
+
         dag_1 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_1))
         dag_2 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_2))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-
-        dag_model_1 = DagModel(
-            dag_id=dag_id_1,
-            is_paused=False,
-            max_active_tasks=dag_1.concurrency,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model_1)
-        dag_model_2 = DagModel(
-            dag_id=dag_id_2,
-            is_paused=False,
-            concurrency=dag_2.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model_2)
-        dr1 = dag_1.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE + timedelta(hours=1),
-            state=State.RUNNING,
-        )
-        dr2 = dag_2.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
 
         tis = [
             TaskInstance(dag1_task, dr1.execution_date),
@@ -537,44 +465,23 @@ class TestSchedulerJob:
         assert [ti.key for ti in res] == [tis[1].key]
         session.rollback()
 
-    def test_find_executable_task_instances_order_priority(self):
+    def test_find_executable_task_instances_order_priority(self, dag_maker):
         dag_id_1 = 'SchedulerJobTest.test_find_executable_task_instances_order_priority-a'
         dag_id_2 = 'SchedulerJobTest.test_find_executable_task_instances_order_priority-b'
         task_id = 'task-a'
-        dag_1 = DAG(dag_id=dag_id_1, start_date=DEFAULT_DATE, max_active_tasks=16)
-        dag_2 = DAG(dag_id=dag_id_2, start_date=DEFAULT_DATE, max_active_tasks=16)
-        dag1_task = DummyOperator(dag=dag_1, task_id=task_id, priority_weight=1)
-        dag2_task = DummyOperator(dag=dag_2, task_id=task_id, priority_weight=4)
+        with dag_maker(dag_id=dag_id_1, max_active_tasks=16) as dag_1:
+            dag1_task = DummyOperator(task_id=task_id, priority_weight=1)
+        dr1 = dag_maker.create_dagrun()
+
+        with dag_maker(dag_id=dag_id_2, max_active_tasks=16) as dag_2:
+            dag2_task = DummyOperator(task_id=task_id, priority_weight=4)
+        dr2 = dag_maker.create_dagrun()
+
         dag_1 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_1))
         dag_2 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_2))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-
-        dag_model_1 = DagModel(
-            dag_id=dag_id_1,
-            is_paused=False,
-            max_active_tasks=dag_1.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model_1)
-        dag_model_2 = DagModel(
-            dag_id=dag_id_2,
-            is_paused=False,
-            max_active_tasks=dag_2.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model_2)
-        dr1 = dag_1.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-        dr2 = dag_2.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
 
         tis = [
             TaskInstance(dag1_task, dr1.execution_date),
@@ -590,44 +497,22 @@ class TestSchedulerJob:
         assert [ti.key for ti in res] == [tis[1].key]
         session.rollback()
 
-    def test_find_executable_task_instances_order_execution_date_and_priority(self):
+    def test_find_executable_task_instances_order_execution_date_and_priority(self, dag_maker):
         dag_id_1 = 'SchedulerJobTest.test_find_executable_task_instances_order_execution_date_and_priority-a'
         dag_id_2 = 'SchedulerJobTest.test_find_executable_task_instances_order_execution_date_and_priority-b'
         task_id = 'task-a'
-        dag_1 = DAG(dag_id=dag_id_1, start_date=DEFAULT_DATE, max_active_tasks=16)
-        dag_2 = DAG(dag_id=dag_id_2, start_date=DEFAULT_DATE, max_active_tasks=16)
-        dag1_task = DummyOperator(dag=dag_1, task_id=task_id, priority_weight=1)
-        dag2_task = DummyOperator(dag=dag_2, task_id=task_id, priority_weight=4)
+        with dag_maker(dag_id=dag_id_1, max_active_tasks=16) as dag_1:
+            dag1_task = DummyOperator(task_id=task_id, priority_weight=1)
+        dr1 = dag_maker.create_dagrun()
+
+        with dag_maker(dag_id=dag_id_2, max_active_tasks=16) as dag_2:
+            dag2_task = DummyOperator(task_id=task_id, priority_weight=4)
+        dr2 = dag_maker.create_dagrun(execution_date=DEFAULT_DATE + timedelta(hours=1))
         dag_1 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_1))
         dag_2 = SerializedDAG.from_dict(SerializedDAG.to_dict(dag_2))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-
-        dag_model_1 = DagModel(
-            dag_id=dag_id_1,
-            is_paused=False,
-            max_active_tasks=dag_1.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model_1)
-        dag_model_2 = DagModel(
-            dag_id=dag_id_2,
-            is_paused=False,
-            max_active_tasks=dag_2.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model_2)
-        dr1 = dag_1.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-        dr2 = dag_2.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE + timedelta(hours=1),
-            state=State.RUNNING,
-        )
 
         tis = [
             TaskInstance(dag1_task, dr1.execution_date),
@@ -643,30 +528,20 @@ class TestSchedulerJob:
         assert [ti.key for ti in res] == [tis[1].key]
         session.rollback()
 
-    def test_find_executable_task_instances_in_default_pool(self):
+    def test_find_executable_task_instances_in_default_pool(self, dag_maker):
         set_default_pool_slots(1)
 
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_in_default_pool'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        op1 = DummyOperator(dag=dag, task_id='dummy1')
-        op2 = DummyOperator(dag=dag, task_id='dummy2')
+        with dag_maker(dag_id=dag_id) as dag:
+            op1 = DummyOperator(task_id='dummy1')
+            op2 = DummyOperator(task_id='dummy2')
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         executor = MockExecutor(do_update=True)
         self.scheduler_job = SchedulerJob(executor=executor)
         session = settings.Session()
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+
+        dr1 = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=dag.following_schedule(dr1.execution_date),
@@ -697,28 +572,17 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_nonexistent_pool(self):
+    def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'
         task_id = 'dummy_wrong_pool'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=16)
-        task = DummyOperator(dag=dag, task_id=task_id, pool="this_pool_doesnt_exist")
+        with dag_maker(dag_id=dag_id, max_active_tasks=16) as dag:
+            task = DummyOperator(task_id=task_id, pool="this_pool_doesnt_exist")
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr = dag_maker.create_dagrun()
 
         ti = TaskInstance(task, dr.execution_date)
         ti.state = State.SCHEDULED
@@ -730,29 +594,17 @@ class TestSchedulerJob:
         assert 0 == len(res)
         session.rollback()
 
-    def test_infinite_pool(self):
+    def test_infinite_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_infinite_pool'
         task_id = 'dummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, concurrency=16)
-        task = DummyOperator(dag=dag, task_id=task_id, pool="infinite_pool")
+        with dag_maker(dag_id=dag_id, concurrency=16) as dag:
+            task = DummyOperator(task_id=task_id, pool="infinite_pool")
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            concurrency=dag.concurrency,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-
+        dr = dag_maker.create_dagrun()
         ti = TaskInstance(task, dr.execution_date)
         ti.state = State.SCHEDULED
         session.merge(ti)
@@ -765,55 +617,30 @@ class TestSchedulerJob:
         assert 1 == len(res)
         session.rollback()
 
-    def test_find_executable_task_instances_none(self):
+    def test_find_executable_task_instances_none(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_none'
         task_id_1 = 'dummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=16)
-        DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id, max_active_tasks=16) as dag:
+            DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-        session.flush()
 
         assert 0 == len(self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session))
         session.rollback()
 
-    def test_find_executable_task_instances_concurrency(self):
+    def test_find_executable_task_instances_concurrency(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_concurrency'
         task_id_1 = 'dummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=2)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id, max_active_tasks=2) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=dag.following_schedule(dr1.execution_date),
@@ -852,28 +679,18 @@ class TestSchedulerJob:
         assert 0 == len(res)
         session.rollback()
 
-    def test_find_executable_task_instances_concurrency_queued(self):
+    def test_find_executable_task_instances_concurrency_queued(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_concurrency_queued'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=3)
-        task1 = DummyOperator(dag=dag, task_id='dummy1')
-        task2 = DummyOperator(dag=dag, task_id='dummy2')
-        task3 = DummyOperator(dag=dag, task_id='dummy3')
+        with dag_maker(dag_id=dag_id, max_active_tasks=3) as dag:
+            task1 = DummyOperator(task_id='dummy1')
+            task2 = DummyOperator(task_id='dummy2')
+            task3 = DummyOperator(task_id='dummy3')
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dag_run = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+
+        dag_run = dag_maker.create_dagrun()
 
         ti1 = TaskInstance(task1, dag_run.execution_date)
         ti2 = TaskInstance(task2, dag_run.execution_date)
@@ -895,13 +712,13 @@ class TestSchedulerJob:
         session.rollback()
 
     # TODO: This is a hack, I think I need to just remove the setting and have it on always
-    def test_find_executable_task_instances_task_concurrency(self):
+    def test_find_executable_task_instances_task_concurrency(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_task_concurrency'
         task_id_1 = 'dummy'
         task_id_2 = 'dummy2'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=16)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1, task_concurrency=2)
-        task2 = DummyOperator(dag=dag, task_id=task_id_2)
+        with dag_maker(dag_id=dag_id, max_active_tasks=16) as dag:
+            task1 = DummyOperator(task_id=task_id_1, task_concurrency=2)
+            task2 = DummyOperator(task_id=task_id_2)
 
         executor = MockExecutor(do_update=True)
         self.scheduler_job = SchedulerJob(executor=executor)
@@ -910,11 +727,7 @@ class TestSchedulerJob:
         self.scheduler_job.dagbag.bag_dag(dag, root_dag=dag)
         self.scheduler_job.dagbag.sync_to_db(session=session)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=dag.following_schedule(dr1.execution_date),
@@ -988,22 +801,18 @@ class TestSchedulerJob:
         assert 1 == len(res)
         session.rollback()
 
-    def test_change_state_for_executable_task_instances_no_tis_with_state(self):
+    def test_change_state_for_executable_task_instances_no_tis_with_state(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_change_state_for__no_tis_with_state'
         task_id_1 = 'dummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=2)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id, max_active_tasks=2) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
         date = DEFAULT_DATE
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=date,
-            state=State.RUNNING,
-        )
+        dr1 = dag_maker.create_dagrun()
         date = dag.following_schedule(date)
         dr2 = dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
@@ -1034,32 +843,22 @@ class TestSchedulerJob:
 
         session.rollback()
 
-    def test_enqueue_task_instances_with_queued_state(self):
+    def test_enqueue_task_instances_with_queued_state(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_enqueue_task_instances_with_queued_state'
         task_id_1 = 'dummy'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
+        with dag_maker(dag_id=dag_id, start_date=DEFAULT_DATE) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dag_model = dag_maker.dag_model
+
+        dr1 = dag_maker.create_dagrun()
         ti1 = TaskInstance(task1, dr1.execution_date)
         ti1.dag_model = dag_model
         session.merge(ti1)
-        session.flush()
 
         with patch.object(BaseExecutor, 'queue_command') as mock_queue_command:
             self.scheduler_job._enqueue_task_instances_with_queued_state([ti1])
@@ -1067,7 +866,7 @@ class TestSchedulerJob:
         assert mock_queue_command.called
         session.rollback()
 
-    def test_critical_section_execute_task_instances(self):
+    def test_critical_section_execute_task_instances(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_execute_task_instances'
         task_id_1 = 'dummy_task'
         task_id_2 = 'dummy_task_nonexistent_queue'
@@ -1075,27 +874,17 @@ class TestSchedulerJob:
         # because before scheduler._execute_task_instances would only
         # check the num tasks once so if max_active_tasks was 3,
         # we could execute arbitrarily many tasks in the second run
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=3)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
-        task2 = DummyOperator(dag=dag, task_id=task_id_2)
+        with dag_maker(dag_id=dag_id, max_active_tasks=3) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
+            task2 = DummyOperator(task_id=task_id_2)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
         # create first dag run with 1 running and 1 queued
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+
+        dr1 = dag_maker.create_dagrun()
 
         ti1 = TaskInstance(task1, dr1.execution_date)
         ti2 = TaskInstance(task2, dr1.execution_date)
@@ -1144,7 +933,7 @@ class TestSchedulerJob:
         assert {State.QUEUED, State.SCHEDULED} == {ti3.state, ti4.state}
         assert 1 == res
 
-    def test_execute_task_instances_limit(self):
+    def test_execute_task_instances_limit(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_execute_task_instances_limit'
         task_id_1 = 'dummy_task'
         task_id_2 = 'dummy_task_2'
@@ -1152,30 +941,23 @@ class TestSchedulerJob:
         # because before scheduler._execute_task_instances would only
         # check the num tasks once so if max_active_tasks was 3,
         # we could execute arbitrarily many tasks in the second run
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=16)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
-        task2 = DummyOperator(dag=dag, task_id=task_id_2)
+        with dag_maker(dag_id=dag_id, max_active_tasks=16) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
+            task2 = DummyOperator(task_id=task_id_2)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
         date = dag.start_date
         tis = []
         for _ in range(0, 4):
+            date = dag.following_schedule(date)
             dr = dag.create_dagrun(
                 run_type=DagRunType.SCHEDULED,
                 execution_date=date,
                 state=State.RUNNING,
             )
-            date = dag.following_schedule(date)
             ti1 = TaskInstance(task1, dr.execution_date)
             ti2 = TaskInstance(task2, dr.execution_date)
             tis.append(ti1)
@@ -1206,37 +988,30 @@ class TestSchedulerJob:
             ti.refresh_from_db()
             assert State.QUEUED == ti.state
 
-    def test_execute_task_instances_unlimited(self):
+    def test_execute_task_instances_unlimited(self, dag_maker):
         """Test that max_tis_per_query=0 is unlimited"""
 
         dag_id = 'SchedulerJobTest.test_execute_task_instances_unlimited'
         task_id_1 = 'dummy_task'
         task_id_2 = 'dummy_task_2'
 
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, max_active_tasks=1024)
-        task1 = DummyOperator(dag=dag, task_id=task_id_1)
-        task2 = DummyOperator(dag=dag, task_id=task_id_2)
+        with dag_maker(dag_id=dag_id, max_active_tasks=1024) as dag:
+            task1 = DummyOperator(task_id=task_id_1)
+            task2 = DummyOperator(task_id=task_id_2)
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dag_model = DagModel(
-            dag_id=dag_id,
-            is_paused=False,
-            max_active_tasks=dag.max_active_tasks,
-            has_task_concurrency_limits=False,
-        )
-        session.add(dag_model)
         date = dag.start_date
         tis = []
         for _ in range(0, 20):
+            date = dag.following_schedule(date)
             dr = dag.create_dagrun(
                 run_type=DagRunType.SCHEDULED,
                 execution_date=date,
                 state=State.RUNNING,
             )
-            date = dag.following_schedule(date)
             ti1 = TaskInstance(task1, dr.execution_date)
             ti2 = TaskInstance(task2, dr.execution_date)
             tis.append(ti1)
@@ -1256,37 +1031,21 @@ class TestSchedulerJob:
         assert res == 36
         session.rollback()
 
-    def test_change_state_for_tis_without_dagrun(self):
-        dag1 = DAG(dag_id='test_change_state_for_tis_without_dagrun', start_date=DEFAULT_DATE)
+    def test_change_state_for_tis_without_dagrun(self, dag_maker):
+        with dag_maker(dag_id='test_change_state_for_tis_without_dagrun') as dag1:
+            DummyOperator(task_id='dummy', owner='airflow')
+            DummyOperator(task_id='dummy_b', owner='airflow')
+        dr1 = dag_maker.create_dagrun()
 
-        DummyOperator(task_id='dummy', dag=dag1, owner='airflow')
+        with dag_maker(dag_id='test_change_state_for_tis_without_dagrun_dont_change') as dag2:
+            DummyOperator(task_id='dummy', owner='airflow')
+        dr2 = dag_maker.create_dagrun()
 
-        DummyOperator(task_id='dummy_b', dag=dag1, owner='airflow')
-
-        dag2 = DAG(dag_id='test_change_state_for_tis_without_dagrun_dont_change', start_date=DEFAULT_DATE)
-
-        DummyOperator(task_id='dummy', dag=dag2, owner='airflow')
-
-        dag3 = DAG(dag_id='test_change_state_for_tis_without_dagrun_no_dagrun', start_date=DEFAULT_DATE)
-
-        DummyOperator(task_id='dummy', dag=dag3, owner='airflow')
+        # Using dag_maker for below dag will create a dagrun and we don't want a dagrun
+        with dag_maker(dag_id='test_change_state_for_tis_without_dagrun_no_dagrun') as dag3:
+            DummyOperator(task_id='dummy', owner='airflow')
 
         session = settings.Session()
-        dr1 = dag1.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
-
-        dr2 = dag2.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
 
         ti1a = dr1.get_task_instance(task_id='dummy', session=session)
         ti1a.state = State.SCHEDULED
@@ -1359,26 +1118,13 @@ class TestSchedulerJob:
         ti2.refresh_from_db(session=session)
         assert ti2.state == State.SCHEDULED
 
-    def test_adopt_or_reset_orphaned_tasks(self):
+    def test_adopt_or_reset_orphaned_tasks(self, dag_maker):
         session = settings.Session()
-        dag = DAG(
-            'test_execute_helper_reset_orphaned_tasks',
-            start_date=DEFAULT_DATE,
-            default_args={'owner': 'owner1'},
-        )
-
-        with dag:
+        with dag_maker('test_execute_helper_reset_orphaned_tasks') as dag:
             op1 = DummyOperator(task_id='op1')
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
+        dr = dag_maker.create_dagrun()
         dr2 = dag.create_dagrun(
             run_type=DagRunType.BACKFILL_JOB,
             state=State.RUNNING,
@@ -1405,22 +1151,24 @@ class TestSchedulerJob:
         ti2 = dr2.get_task_instance(task_id=op1.task_id, session=session)
         assert ti2.state == State.QUEUED, "Tasks run by Backfill Jobs should not be reset"
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "initial_task_state, expected_task_state",
         [
             [State.UP_FOR_RETRY, State.FAILED],
             [State.QUEUED, State.NONE],
             [State.SCHEDULED, State.NONE],
             [State.UP_FOR_RESCHEDULE, State.NONE],
-        ]
+        ],
     )
     def test_scheduler_loop_should_change_state_for_tis_without_dagrun(
-        self, initial_task_state, expected_task_state
+        self, initial_task_state, expected_task_state, dag_maker
     ):
         session = settings.Session()
         dag_id = 'test_execute_helper_should_change_state_for_tis_without_dagrun'
-        dag = DAG(dag_id, start_date=DEFAULT_DATE, default_args={'owner': 'owner1'})
-
-        with dag:
+        with dag_maker(
+            dag_id,
+            start_date=DEFAULT_DATE + timedelta(days=1),
+        ) as dag:
             op1 = DummyOperator(task_id='op1')
 
         # Write Dag to DB
@@ -1430,13 +1178,10 @@ class TestSchedulerJob:
 
         dag = DagBag(read_dags_from_db=True, include_examples=False).get_dag(dag_id)
         # Create DAG run with FAILED state
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
+        dr = dag_maker.create_dagrun(
             state=State.FAILED,
             execution_date=DEFAULT_DATE + timedelta(days=1),
             start_date=DEFAULT_DATE + timedelta(days=1),
-            session=session,
         )
         ti = dr.get_task_instance(task_id=op1.task_id, session=session)
         ti.state = initial_task_state
@@ -1497,7 +1242,7 @@ class TestSchedulerJob:
         self.scheduler_job.executor.end.assert_called_once()
         mock_processor_agent.return_value.end.reset_mock(side_effect=True)
 
-    def test_dagrun_timeout_verify_max_active_runs(self):
+    def test_dagrun_timeout_verify_max_active_runs(self, dag_maker):
         """
         Test if a a dagrun will not be scheduled if max_dag_runs
         has been reached and dagrun_timeout is not reached
@@ -1505,11 +1250,10 @@ class TestSchedulerJob:
         Test if a a dagrun would be scheduled if max_dag_runs has
         been reached but dagrun_timeout is also reached
         """
-        dag = DAG(dag_id='test_scheduler_verify_max_active_runs_and_dagrun_timeout', start_date=DEFAULT_DATE)
+        with dag_maker(dag_id='test_scheduler_verify_max_active_runs_and_dagrun_timeout') as dag:
+            DummyOperator(task_id='dummy')
         dag.max_active_runs = 1
         dag.dagrun_timeout = datetime.timedelta(seconds=60)
-
-        DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag.bag_dag(dag, root_dag=dag)
@@ -1566,14 +1310,13 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_dagrun_timeout_fails_run(self):
+    def test_dagrun_timeout_fails_run(self, dag_maker):
         """
         Test if a a dagrun will be set failed if timeout, even without max_active_runs
         """
-        dag = DAG(dag_id='test_scheduler_fail_dagrun_timeout', start_date=DEFAULT_DATE)
+        with dag_maker(dag_id='test_scheduler_fail_dagrun_timeout') as dag:
+            DummyOperator(task_id='dummy')
         dag.dagrun_timeout = datetime.timedelta(seconds=60)
-
-        DummyOperator(task_id='dummy', dag=dag, owner='airflow')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.dagbag.bag_dag(dag, root_dag=dag)
@@ -1620,20 +1363,20 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    @parameterized.expand([(State.SUCCESS, "success"), (State.FAILED, "task_failure")])
-    def test_dagrun_callbacks_are_called(self, state, expected_callback_msg):
+    @pytest.mark.parametrize(
+        "state, expected_callback_msg", [(State.SUCCESS, "success"), (State.FAILED, "task_failure")]
+    )
+    def test_dagrun_callbacks_are_called(self, state, expected_callback_msg, dag_maker):
         """
         Test if DagRun is successful, and if Success callbacks is defined, it is sent to DagFileProcessor.
         Also test that SLA Callback Function is called.
         """
-        dag = DAG(
+        with dag_maker(
             dag_id='test_dagrun_callbacks_are_called',
-            start_date=DEFAULT_DATE,
             on_success_callback=lambda x: print("success"),
             on_failure_callback=lambda x: print("failed"),
-        )
-
-        DummyOperator(task_id='dummy', dag=dag, owner='airflow')
+        ) as dag:
+            DummyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.processor_agent = mock.Mock()
@@ -1679,13 +1422,13 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_dagrun_callbacks_commited_before_sent(self):
+    def test_dagrun_callbacks_commited_before_sent(self, dag_maker):
         """
         Tests that before any callbacks are sent to the processor, the session is committed. This ensures
         that the dagrun details are up to date when the callbacks are run.
         """
-        dag = DAG(dag_id='test_dagrun_callbacks_commited_before_sent', start_date=DEFAULT_DATE)
-        DummyOperator(task_id='dummy', dag=dag, owner='airflow')
+        with dag_maker(dag_id='test_dagrun_callbacks_commited_before_sent') as dag:
+            DummyOperator(task_id='dummy')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.processor_agent = mock.Mock()
@@ -1737,17 +1480,15 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    @parameterized.expand([(State.SUCCESS,), (State.FAILED,)])
-    def test_dagrun_callbacks_are_not_added_when_callbacks_are_not_defined(self, state):
+    @pytest.mark.parametrize("state", [State.SUCCESS, State.FAILED])
+    def test_dagrun_callbacks_are_not_added_when_callbacks_are_not_defined(self, state, dag_maker):
         """
         Test if no on_*_callback are defined on DAG, Callbacks not registered and sent to DAG Processor
         """
-        dag = DAG(
+        with dag_maker(
             dag_id='test_dagrun_callbacks_are_not_added_when_callbacks_are_not_defined',
-            start_date=DEFAULT_DATE,
-        )
-
-        BashOperator(task_id='test_task', dag=dag, owner='airflow', bash_command='echo hi')
+        ) as dag:
+            BashOperator(task_id='test_task', bash_command='echo hi')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         self.scheduler_job.processor_agent = mock.Mock()
@@ -1786,33 +1527,30 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_do_not_schedule_removed_task(self):
-        dag = DAG(dag_id='test_scheduler_do_not_schedule_removed_task', start_date=DEFAULT_DATE)
-        DummyOperator(task_id='dummy', dag=dag, owner='airflow')
+    def test_do_not_schedule_removed_task(self, dag_maker):
+        with dag_maker(dag_id='test_scheduler_do_not_schedule_removed_task') as dag:
+            DummyOperator(task_id='dummy')
 
         session = settings.Session()
-        dag.sync_to_db(session=session)
-        session.flush()
 
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dr = dag.create_dagrun(
-            execution_date=DEFAULT_DATE,
-            run_type=DagRunType.SCHEDULED,
-            state=State.RUNNING,
-            session=session,
-        )
+        dr = dag_maker.create_dagrun()
         assert dr is not None
 
         # Re-create the DAG, but remove the task
-        dag = DAG(dag_id='test_scheduler_do_not_schedule_removed_task', start_date=DEFAULT_DATE)
+        # Delete DagModel first to avoid duplicate record
+        session.query(DagModel).delete()
+        with dag_maker(
+            dag_id='test_scheduler_do_not_schedule_removed_task',
+            start_date=dag.following_schedule(DEFAULT_DATE),
+        ) as dag:
+            pass
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         res = self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session)
 
         assert [] == res
-        session.rollback()
-        session.close()
 
     @provide_session
     def evaluate_dagrun(
@@ -2172,22 +1910,20 @@ class TestSchedulerJob:
 
         assert len(task_instances_list) == 1
 
-    def test_scheduler_verify_pool_full_2_slots_per_task(self):
+    def test_scheduler_verify_pool_full_2_slots_per_task(self, dag_maker):
         """
         Test task instances not queued when pool is full.
 
         Variation with non-default pool_slots
         """
-        dag = DAG(dag_id='test_scheduler_verify_pool_full_2_slots_per_task', start_date=DEFAULT_DATE)
-
-        BashOperator(
-            task_id='dummy',
-            dag=dag,
-            owner='airflow',
-            pool='test_scheduler_verify_pool_full_2_slots_per_task',
-            pool_slots=2,
-            bash_command='echo hi',
-        )
+        with dag_maker(dag_id='test_scheduler_verify_pool_full_2_slots_per_task') as dag:
+            BashOperator(
+                task_id='dummy',
+                owner='airflow',
+                pool='test_scheduler_verify_pool_full_2_slots_per_task',
+                pool_slots=2,
+                bash_command='echo hi',
+            )
 
         dagbag = DagBag(
             dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"),
@@ -2211,13 +1947,13 @@ class TestSchedulerJob:
         # Create 5 dagruns, which will create 5 task instances.
         date = DEFAULT_DATE
         for _ in range(5):
+            date = dag.following_schedule(date)
             dr = dag.create_dagrun(
                 run_type=DagRunType.SCHEDULED,
                 execution_date=date,
                 state=State.RUNNING,
             )
             self.scheduler_job._schedule_dag_run(dr, session)
-            date = dag.following_schedule(date)
 
         task_instances_list = self.scheduler_job._executable_task_instances_to_queued(
             max_tis=32, session=session
@@ -2302,45 +2038,41 @@ class TestSchedulerJob:
             for task_instance in task_instances_list2
         )
 
-    def test_scheduler_verify_priority_and_slots(self):
+    def test_scheduler_verify_priority_and_slots(self, dag_maker):
         """
         Test task instances with higher priority are not queued
         when pool does not have enough slots.
 
         Though tasks with lower priority might be executed.
         """
-        dag = DAG(dag_id='test_scheduler_verify_priority_and_slots', start_date=DEFAULT_DATE)
-
-        # Medium priority, not enough slots
-        BashOperator(
-            task_id='test_scheduler_verify_priority_and_slots_t0',
-            dag=dag,
-            owner='airflow',
-            pool='test_scheduler_verify_priority_and_slots',
-            pool_slots=2,
-            priority_weight=2,
-            bash_command='echo hi',
-        )
-        # High priority, occupies first slot
-        BashOperator(
-            task_id='test_scheduler_verify_priority_and_slots_t1',
-            dag=dag,
-            owner='airflow',
-            pool='test_scheduler_verify_priority_and_slots',
-            pool_slots=1,
-            priority_weight=3,
-            bash_command='echo hi',
-        )
-        # Low priority, occupies second slot
-        BashOperator(
-            task_id='test_scheduler_verify_priority_and_slots_t2',
-            dag=dag,
-            owner='airflow',
-            pool='test_scheduler_verify_priority_and_slots',
-            pool_slots=1,
-            priority_weight=1,
-            bash_command='echo hi',
-        )
+        with dag_maker(dag_id='test_scheduler_verify_priority_and_slots') as dag:
+            # Medium priority, not enough slots
+            BashOperator(
+                task_id='test_scheduler_verify_priority_and_slots_t0',
+                owner='airflow',
+                pool='test_scheduler_verify_priority_and_slots',
+                pool_slots=2,
+                priority_weight=2,
+                bash_command='echo hi',
+            )
+            # High priority, occupies first slot
+            BashOperator(
+                task_id='test_scheduler_verify_priority_and_slots_t1',
+                owner='airflow',
+                pool='test_scheduler_verify_priority_and_slots',
+                pool_slots=1,
+                priority_weight=3,
+                bash_command='echo hi',
+            )
+            # Low priority, occupies second slot
+            BashOperator(
+                task_id='test_scheduler_verify_priority_and_slots_t2',
+                owner='airflow',
+                pool='test_scheduler_verify_priority_and_slots',
+                pool_slots=1,
+                priority_weight=1,
+                bash_command='echo hi',
+            )
 
         dagbag = DagBag(
             dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"),
@@ -2361,11 +2093,7 @@ class TestSchedulerJob:
         self.scheduler_job = SchedulerJob(executor=self.null_exec)
         self.scheduler_job.processor_agent = mock.MagicMock()
 
-        dr = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr = dag_maker.create_dagrun()
         self.scheduler_job._schedule_dag_run(dr, session)
 
         task_instances_list = self.scheduler_job._executable_task_instances_to_queued(
@@ -2515,7 +2243,7 @@ class TestSchedulerJob:
         session.close()
 
     @pytest.mark.quarantined
-    def test_retry_still_in_executor(self):
+    def test_retry_still_in_executor(self, dag_maker):
         """
         Checks if the scheduler does not put a task in limbo, when a task is retried
         but is still present in the executor.
@@ -2524,12 +2252,10 @@ class TestSchedulerJob:
         dagbag = DagBag(dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"), include_examples=False)
         dagbag.dags.clear()
 
-        dag = DAG(dag_id='test_retry_still_in_executor', start_date=DEFAULT_DATE, schedule_interval="@once")
-        dag_task1 = BashOperator(
-            task_id='test_retry_handling_op', bash_command='exit 1', retries=1, dag=dag, owner='airflow'
-        )
-
-        dag.clear()
+        with dag_maker(dag_id='test_retry_still_in_executor', schedule_interval="@once") as dag:
+            dag_task1 = BashOperator(
+                task_id='test_retry_handling_op', bash_command='exit 1', retries=1, dag=dag, owner='airflow'
+            )
         dag.is_subdag = False
 
         with create_session() as session:
@@ -2614,7 +2340,7 @@ class TestSchedulerJob:
         assert ti.try_number == 2
         assert ti.state == State.UP_FOR_RETRY
 
-    def test_dag_get_active_runs(self):
+    def test_dag_get_active_runs(self, dag_maker):
         """
         Test to check that a DAG returns its active runs
         """
@@ -2628,27 +2354,17 @@ class TestSchedulerJob:
         dag_name1 = 'get_active_runs_test'
 
         default_args = {'owner': 'airflow', 'depends_on_past': False, 'start_date': start_date}
-        dag1 = DAG(dag_name1, schedule_interval='* * * * *', max_active_runs=1, default_args=default_args)
+        with dag_maker(
+            dag_name1, schedule_interval='* * * * *', max_active_runs=1, default_args=default_args
+        ) as dag1:
 
-        run_this_1 = DummyOperator(task_id='run_this_1', dag=dag1)
-        run_this_2 = DummyOperator(task_id='run_this_2', dag=dag1)
-        run_this_2.set_upstream(run_this_1)
-        run_this_3 = DummyOperator(task_id='run_this_3', dag=dag1)
-        run_this_3.set_upstream(run_this_2)
+            run_this_1 = DummyOperator(task_id='run_this_1')
+            run_this_2 = DummyOperator(task_id='run_this_2')
+            run_this_2.set_upstream(run_this_1)
+            run_this_3 = DummyOperator(task_id='run_this_3')
+            run_this_3.set_upstream(run_this_2)
 
-        session = settings.Session()
-        orm_dag = DagModel(dag_id=dag1.dag_id)
-        session.merge(orm_dag)
-        session.commit()
-        session.close()
-
-        dag1.clear()
-
-        dr = dag1.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=start_date,
-            state=State.RUNNING,
-        )
+        dr = dag_maker.create_dagrun()
 
         # We had better get a dag run
         assert dr is not None
@@ -2721,23 +2437,16 @@ class TestSchedulerJob:
         session = settings.Session()
         assert 0 == self.scheduler_job.adopt_or_reset_orphaned_tasks(session=session)
 
-    def test_adopt_or_reset_orphaned_tasks_external_triggered_dag(self):
+    def test_adopt_or_reset_orphaned_tasks_external_triggered_dag(self, dag_maker):
         dag_id = 'test_reset_orphaned_tasks_external_triggered_dag'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        task_id = dag_id + '_task'
-        DummyOperator(task_id=task_id, dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
+            task_id = dag_id + '_task'
+            DummyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            external_trigger=True,
-            session=session,
-        )
+        dr1 = dag_maker.create_dagrun(external_trigger=True)
         ti = dr1.get_task_instances(session=session)[0]
         ti.state = State.QUEUED
         session.merge(ti)
@@ -2747,24 +2456,19 @@ class TestSchedulerJob:
         num_reset_tis = self.scheduler_job.adopt_or_reset_orphaned_tasks(session=session)
         assert 1 == num_reset_tis
 
-    def test_adopt_or_reset_orphaned_tasks_backfill_dag(self):
+    def test_adopt_or_reset_orphaned_tasks_backfill_dag(self, dag_maker):
         dag_id = 'test_adopt_or_reset_orphaned_tasks_backfill_dag'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        task_id = dag_id + '_task'
-        DummyOperator(task_id=task_id, dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
+            task_id = dag_id + '_task'
+            DummyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
         session.add(self.scheduler_job)
         session.flush()
 
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.BACKFILL_JOB,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
+        dr1 = dag_maker.create_dagrun(run_type=DagRunType.BACKFILL_JOB)
+
         ti = dr1.get_task_instances(session=session)[0]
         ti.state = State.SCHEDULED
         session.merge(ti)
@@ -2775,20 +2479,17 @@ class TestSchedulerJob:
         assert 0 == self.scheduler_job.adopt_or_reset_orphaned_tasks(session=session)
         session.rollback()
 
-    def test_reset_orphaned_tasks_nonexistent_dagrun(self):
+    def test_reset_orphaned_tasks_nonexistent_dagrun(self, dag_maker):
         """Make sure a task in an orphaned state is not reset if it has no dagrun."""
         dag_id = 'test_reset_orphaned_tasks_nonexistent_dagrun'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        task_id = dag_id + '_task'
-        task = DummyOperator(task_id=task_id, dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
+            task_id = dag_id + '_task'
+            task = DummyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
 
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
-        session.add(ti)
-        session.flush()
-
         ti.refresh_from_db()
         ti.state = State.SCHEDULED
         session.merge(ti)
@@ -2797,24 +2498,18 @@ class TestSchedulerJob:
         assert 0 == self.scheduler_job.adopt_or_reset_orphaned_tasks(session=session)
         session.rollback()
 
-    def test_reset_orphaned_tasks_no_orphans(self):
+    def test_reset_orphaned_tasks_no_orphans(self, dag_maker):
         dag_id = 'test_reset_orphaned_tasks_no_orphans'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        task_id = dag_id + '_task'
-        DummyOperator(task_id=task_id, dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
+            task_id = dag_id + '_task'
+            DummyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
         session.add(self.scheduler_job)
         session.flush()
 
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            state=State.RUNNING,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
+        dr1 = dag_maker.create_dagrun()
         tis = dr1.get_task_instances(session=session)
         tis[0].state = State.RUNNING
         tis[0].queued_by_job_id = self.scheduler_job.id
@@ -2826,25 +2521,19 @@ class TestSchedulerJob:
         tis[0].refresh_from_db()
         assert State.RUNNING == tis[0].state
 
-    def test_reset_orphaned_tasks_non_running_dagruns(self):
+    def test_reset_orphaned_tasks_non_running_dagruns(self, dag_maker):
         """Ensure orphaned tasks with non-running dagruns are not reset."""
         dag_id = 'test_reset_orphaned_tasks_non_running_dagruns'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        task_id = dag_id + '_task'
-        DummyOperator(task_id=task_id, dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
+            task_id = dag_id + '_task'
+            DummyOperator(task_id=task_id)
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
         session.add(self.scheduler_job)
         session.flush()
 
-        dr1 = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            state=State.SUCCESS,
-            execution_date=DEFAULT_DATE,
-            start_date=DEFAULT_DATE,
-            session=session,
-        )
+        dr1 = dag_maker.create_dagrun()
         tis = dr1.get_task_instances(session=session)
         assert 1 == len(tis)
         tis[0].state = State.SCHEDULED
@@ -2856,11 +2545,11 @@ class TestSchedulerJob:
         assert 0 == self.scheduler_job.adopt_or_reset_orphaned_tasks(session=session)
         session.rollback()
 
-    def test_adopt_or_reset_orphaned_tasks_stale_scheduler_jobs(self):
+    def test_adopt_or_reset_orphaned_tasks_stale_scheduler_jobs(self, dag_maker):
         dag_id = 'test_adopt_or_reset_orphaned_tasks_stale_scheduler_jobs'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        DummyOperator(task_id='task1', dag=dag)
-        DummyOperator(task_id='task2', dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily'):
+            DummyOperator(task_id='task1')
+            DummyOperator(task_id='task2')
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
@@ -2874,12 +2563,10 @@ class TestSchedulerJob:
         session.add(old_job)
         session.flush()
 
-        dr1 = dag.create_dagrun(
+        dr1 = dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=DEFAULT_DATE,
             start_date=timezone.utcnow(),
-            state=State.RUNNING,
-            session=session,
         )
 
         ti1, ti2 = dr1.get_task_instances(session=session)
@@ -2906,11 +2593,11 @@ class TestSchedulerJob:
         if old_job.processor_agent:
             old_job.processor_agent.end()
 
-    def test_send_sla_callbacks_to_processor_sla_disabled(self):
+    def test_send_sla_callbacks_to_processor_sla_disabled(self, dag_maker):
         """Test SLA Callbacks are not sent when check_slas is False"""
         dag_id = 'test_send_sla_callbacks_to_processor_sla_disabled'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        DummyOperator(task_id='task1', dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily') as dag:
+            DummyOperator(task_id='task1')
 
         with patch.object(settings, "CHECK_SLAS", False):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -2921,11 +2608,11 @@ class TestSchedulerJob:
             self.scheduler_job._send_sla_callbacks_to_processor(dag)
             self.scheduler_job.processor_agent.send_sla_callback_request_to_execute.assert_not_called()
 
-    def test_send_sla_callbacks_to_processor_sla_no_task_slas(self):
+    def test_send_sla_callbacks_to_processor_sla_no_task_slas(self, dag_maker):
         """Test SLA Callbacks are not sent when no task SLAs are defined"""
         dag_id = 'test_send_sla_callbacks_to_processor_sla_no_task_slas'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        DummyOperator(task_id='task1', dag=dag)
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily') as dag:
+            DummyOperator(task_id='task1')
 
         with patch.object(settings, "CHECK_SLAS", True):
             self.scheduler_job = SchedulerJob(subdir=os.devnull)
@@ -2936,11 +2623,11 @@ class TestSchedulerJob:
             self.scheduler_job._send_sla_callbacks_to_processor(dag)
             self.scheduler_job.processor_agent.send_sla_callback_request_to_execute.assert_not_called()
 
-    def test_send_sla_callbacks_to_processor_sla_with_task_slas(self):
+    def test_send_sla_callbacks_to_processor_sla_with_task_slas(self, dag_maker):
         """Test SLA Callbacks are sent to the DAG Processor when SLAs are defined on tasks"""
         dag_id = 'test_send_sla_callbacks_to_processor_sla_with_task_slas'
-        dag = DAG(dag_id=dag_id, start_date=DEFAULT_DATE, schedule_interval='@daily')
-        DummyOperator(task_id='task1', dag=dag, sla=timedelta(seconds=60))
+        with dag_maker(dag_id=dag_id, schedule_interval='@daily') as dag:
+            DummyOperator(task_id='task1', sla=timedelta(seconds=60))
 
         # Used Serialized DAG as Serialized DAG is used in Scheduler
         dag = SerializedDAG.from_json(SerializedDAG.to_json(dag))
@@ -2956,7 +2643,7 @@ class TestSchedulerJob:
                 full_filepath=dag.fileloc, dag_id=dag_id
             )
 
-    def test_create_dag_runs(self):
+    def test_create_dag_runs(self, dag_maker):
         """
         Test various invariants of _create_dag_runs.
 
@@ -2964,12 +2651,8 @@ class TestSchedulerJob:
         - That the run created is on QUEUED State
         - That dag_model has next_dagrun
         """
-        dag = DAG(dag_id='test_create_dag_runs', start_date=DEFAULT_DATE)
-
-        DummyOperator(
-            task_id='dummy',
-            dag=dag,
-        )
+        with dag_maker(dag_id='test_create_dag_runs') as dag:
+            DummyOperator(task_id='dummy')
 
         dagbag = DagBag(
             dag_folder=os.devnull,
@@ -2995,19 +2678,17 @@ class TestSchedulerJob:
 
     @freeze_time(DEFAULT_DATE + datetime.timedelta(days=1, seconds=9))
     @mock.patch('airflow.jobs.scheduler_job.Stats.timing')
-    def test_start_dagruns(self, stats_timing):
+    def test_start_dagruns(self, stats_timing, dag_maker):
         """
         Test that _start_dagrun:
 
         - moves runs to RUNNING State
         - emit the right DagRun metrics
         """
-        dag = DAG(dag_id='test_start_dag_runs', start_date=DEFAULT_DATE)
-
-        DummyOperator(
-            task_id='dummy',
-            dag=dag,
-        )
+        with dag_maker(dag_id='test_start_dag_runs') as dag:
+            DummyOperator(
+                task_id='dummy',
+            )
 
         dagbag = DagBag(
             dag_folder=os.devnull,
@@ -3035,17 +2716,16 @@ class TestSchedulerJob:
 
         assert dag.get_last_dagrun().creating_job_id == self.scheduler_job.id
 
-    def test_extra_operator_links_not_loaded_in_scheduler_loop(self):
+    def test_extra_operator_links_not_loaded_in_scheduler_loop(self, dag_maker):
         """
         Test that Operator links are not loaded inside the Scheduling Loop (that does not include
         DagFileProcessorProcess) especially the critical loop of the Scheduler.
 
         This is to avoid running User code in the Scheduler and prevent any deadlocks
         """
-        dag = DAG(dag_id='test_extra_operator_links_not_loaded_in_scheduler', start_date=DEFAULT_DATE)
-
-        # This CustomOperator has Extra Operator Links registered via plugins
-        _ = CustomOperator(task_id='custom_task', dag=dag)
+        with dag_maker(dag_id='test_extra_operator_links_not_loaded_in_scheduler') as dag:
+            # This CustomOperator has Extra Operator Links registered via plugins
+            _ = CustomOperator(task_id='custom_task')
 
         dagbag = DagBag(
             dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"),
@@ -3071,17 +2751,15 @@ class TestSchedulerJob:
         # Test that custom_task has no Operator Links (after de-serialization) in the Scheduling Loop
         assert not custom_task.operator_extra_links
 
-    def test_scheduler_create_dag_runs_does_not_raise_error(self, caplog):
+    def test_scheduler_create_dag_runs_does_not_raise_error(self, caplog, dag_maker):
         """
         Test that scheduler._create_dag_runs does not raise an error when the DAG does not exist
         in serialized_dag table
         """
-        dag = DAG(dag_id='test_scheduler_create_dag_runs_does_not_raise_error', start_date=DEFAULT_DATE)
-
-        DummyOperator(
-            task_id='dummy',
-            dag=dag,
-        )
+        with dag_maker(dag_id='test_scheduler_create_dag_runs_does_not_raise_error') as dag:
+            DummyOperator(
+                task_id='dummy',
+            )
 
         dagbag = DagBag(
             dag_folder=os.devnull,
@@ -3107,23 +2785,20 @@ class TestSchedulerJob:
                 "DAG 'test_scheduler_create_dag_runs_does_not_raise_error' not found in serialized_dag table",
             ]
 
-    def test_bulk_write_to_db_external_trigger_dont_skip_scheduled_run(self):
+    def test_bulk_write_to_db_external_trigger_dont_skip_scheduled_run(self, dag_maker):
         """
         Test that externally triggered Dag Runs should not affect (by skipping) next
         scheduled DAG runs
         """
-        dag = DAG(
+        with dag_maker(
             dag_id='test_bulk_write_to_db_external_trigger_dont_skip_scheduled_run',
-            start_date=DEFAULT_DATE,
             schedule_interval="*/1 * * * *",
             max_active_runs=5,
             catchup=True,
-        )
-
-        DummyOperator(task_id='dummy', dag=dag, owner='airflow')
+        ) as dag:
+            DummyOperator(task_id='dummy', owner='airflow')
 
         session = settings.Session()
-        dag.clear()
         dagbag = DagBag(
             dag_folder=os.path.join(settings.DAGS_FOLDER, "no_dags.py"),
             include_examples=False,
@@ -3170,22 +2845,19 @@ class TestSchedulerJob:
         dag_model = session.query(DagModel).get(dag.dag_id)
         assert dag_model.next_dagrun == DEFAULT_DATE + timedelta(minutes=1)
 
-    def test_scheduler_create_dag_runs_check_existing_run(self):
+    def test_scheduler_create_dag_runs_check_existing_run(self, dag_maker):
         """
         Test that if a dag run exists, scheduler._create_dag_runs does not raise an error.
         And if a Dag Run does not exist it creates next Dag Run. In both cases the Scheduler
         sets next execution date as DagModel.next_dagrun
         """
-        dag = DAG(
+        with dag_maker(
             dag_id='test_scheduler_create_dag_runs_check_existing_run',
-            start_date=DEFAULT_DATE,
             schedule_interval=timedelta(days=1),
-        )
-
-        DummyOperator(
-            task_id='dummy',
-            dag=dag,
-        )
+        ) as dag:
+            DummyOperator(
+                task_id='dummy',
+            )
 
         session = settings.Session()
         assert dag.get_last_dagrun(session) is None
@@ -3206,7 +2878,7 @@ class TestSchedulerJob:
 
         dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
 
-        dagrun = dag.create_dagrun(
+        dagrun = dag_maker.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=dag_model.next_dagrun,
             start_date=timezone.utcnow(),
@@ -3231,19 +2903,16 @@ class TestSchedulerJob:
         session.rollback()
 
     @conf_vars({('scheduler', 'use_job_schedule'): "false"})
-    def test_do_schedule_max_active_runs_dag_timed_out(self):
+    def test_do_schedule_max_active_runs_dag_timed_out(self, dag_maker):
         """Test that tasks are set to a finished state when their DAG times out"""
 
-        dag = DAG(
+        with dag_maker(
             dag_id='test_max_active_run_with_dag_timed_out',
-            start_date=DEFAULT_DATE,
             schedule_interval='@once',
             max_active_runs=1,
             catchup=True,
-        )
-        dag.dagrun_timeout = datetime.timedelta(seconds=1)
-
-        with dag:
+            dagrun_timeout=datetime.timedelta(seconds=1),
+        ) as dag:
             task1 = BashOperator(
                 task_id='task1',
                 bash_command=' for((i=1;i<=600;i+=1)); do sleep "$i";  done',
@@ -3296,10 +2965,10 @@ class TestSchedulerJob:
         run2_ti = run2.get_task_instance(task1.task_id, session)
         assert run2_ti.state == State.QUEUED
 
-    def test_do_schedule_max_active_runs_task_removed(self):
+    def test_do_schedule_max_active_runs_task_removed(self, dag_maker):
         """Test that tasks in removed state don't count as actively running."""
 
-        with DAG(
+        with dag_maker(
             dag_id='test_do_schedule_max_active_runs_task_removed',
             start_date=DEFAULT_DATE,
             schedule_interval='@once',
@@ -3340,15 +3009,14 @@ class TestSchedulerJob:
         ti = run1.get_task_instance(task1.task_id, session)
         assert ti.state == State.QUEUED
 
-    def test_do_schedule_max_active_runs_and_manual_trigger(self):
+    def test_do_schedule_max_active_runs_and_manual_trigger(self, dag_maker):
         """
         Make sure that when a DAG is already at max_active_runs, that manually triggered
         dagruns don't start running.
         """
 
-        with DAG(
+        with dag_maker(
             dag_id='test_max_active_run_plus_manual_trigger',
-            start_date=DEFAULT_DATE,
             schedule_interval='@once',
             max_active_runs=1,
         ) as dag:
@@ -3370,9 +3038,7 @@ class TestSchedulerJob:
         dagbag.bag_dag(dag=dag, root_dag=dag)
         dagbag.sync_to_db(session=session)
 
-        dag_run = dag.create_dagrun(
-            run_type=DagRunType.SCHEDULED,
-            execution_date=DEFAULT_DATE,
+        dag_run = dag_maker.create_dagrun(
             state=State.QUEUED,
             session=session,
         )
@@ -3394,7 +3060,7 @@ class TestSchedulerJob:
 
         # Now that this one is running, manually trigger a dag.
 
-        dag.create_dagrun(
+        dag_maker.create_dagrun(
             run_type=DagRunType.MANUAL,
             execution_date=DEFAULT_DATE + timedelta(hours=1),
             state=State.QUEUED,


### PR DESCRIPTION
This change adds `dag_maker` fixture to test_scheduler_job.py. This
will help us create `dagruns` each time we create a dag

The dag_maker fixture was also updated
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
