### PR TITLE
Handle connection parameters added to Extra and custom fields

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3226,6 +3226,11 @@ class ConnectionModelView(AirflowModelView):
             for key in self.extra_fields
             if key in form.data and key.startswith(f"extra__{conn_type}__")
         }
+
+        # If values are added to the classic `Extra` field, include these values along with custom-field extras.
+        if form.data.get("extra"):
+            extra.update(json.loads(form.data.get("extra")))
+
         if extra.keys():
             form.extra.data = json.dumps(extra)
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3227,7 +3227,8 @@ class ConnectionModelView(AirflowModelView):
             if key in form.data and key.startswith(f"extra__{conn_type}__")
         }
 
-        # If values are added to the classic `Extra` field, include these values along with custom-field extras.
+        # If parameters are added to the classic `Extra` field, include these values along with
+        # custom-field extras.
         if form.data.get("extra"):
             extra.update(json.loads(form.data.get("extra")))
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3221,6 +3221,7 @@ class ConnectionModelView(AirflowModelView):
     def process_form(self, form, is_created):
         """Process form data."""
         conn_type = form.data['conn_type']
+        conn_id = form.data["conn_id"]
         extra = {
             key: form.data[key]
             for key in self.extra_fields
@@ -3229,8 +3230,23 @@ class ConnectionModelView(AirflowModelView):
 
         # If parameters are added to the classic `Extra` field, include these values along with
         # custom-field extras.
-        if form.data.get("extra"):
-            extra.update(json.loads(form.data.get("extra")))
+        extra_conn_params = form.data.get("extra")
+
+        if extra_conn_params:
+            try:
+                extra.update(json.loads(extra_conn_params))
+            except (JSONDecodeError, TypeError):
+                flash(
+                    Markup(
+                        "<p>The <em>Extra</em> connection field contained an invalid value for Conn ID: "
+                        f"<q>{conn_id}</q>.</p>"
+                        "<p>If connection parameters need to be added to <em>Extra</em>, "
+                        "please make sure they are in the form of a single, valid JSON object.</p><br>"
+                        "The following <em>Extra</em> parameters were <b>not</b> added to the connection:<br>"
+                        f"{extra_conn_params}",
+                    ),
+                    category="error",
+                )
 
         if extra.keys():
             form.extra.data = json.dumps(extra)


### PR DESCRIPTION
Closes: #17235

Adding logic to handle connection parameters added to the classic `Extra` fields as well as part of custom fields which use `Extra` under the hood.  Currently if parameters are added to the classic `Extra` field, they are overwritten by values in custom fields.

This PR will combine "extras" from both types, if applicable, so existing hooks can still use the `Extra` field within connections if needed.

Additionally, a flash error is displayed if the value in the classic `Extra` field is not valid JSON.  The connection entry is still created however but without the values in the `Extra` field. For example:
![image](https://user-images.githubusercontent.com/48934154/127511830-c0e0b351-5d66-425e-8664-fa2b7a0b9a60.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
