### PR TITLE
update return value for sql, template and flex template operators

### DIFF
--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -690,7 +690,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
             environment=self.environment,
         )
 
-        return job
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
@@ -809,7 +809,7 @@ class DataflowStartFlexTemplateOperator(BaseOperator):
             on_new_job_id_callback=set_current_job_id,
         )
 
-        return job
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
@@ -912,7 +912,7 @@ class DataflowStartSqlJobOperator(BaseOperator):
             on_new_job_id_callback=set_current_job_id,
         )
 
-        return job
+        return {"job_id": self.job_id}
 
     def on_kill(self) -> None:
         self.log.info("On kill.")


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
 
closes: #17180
fixes issue #17180
currently the DataflowStartSqlJobOperator, DataflowTemplatedJobStartOperator, and DataflowStartFlexTemplateOperator return a job object. It doesn't have any job_id but instead an id attribute. 
This is not consistent with other Operator (DataflowCreatePythonJobOperator and DataflowCreateJavaJobOperator) and consequently the dag example for dataflow job status sensor doesn't work when using DataflowTemplatedJobStartOperator (or DataflowStartSqlJobOperator or DataflowStartFlexTemplateOperator) before the sensor --> generating an error (see issue #17180)
To make the dag example working, the XCOM return_value attribute "id" has to be used in the dag example instead of "job_id".
Or more simply the return value of these operators should be : 
return {"job_id": self.job_id}
instead of : 
return job 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
