### PR TITLE
Switch to 'smbprotocol' library

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,3 @@
-Improvements
-""""""""""""
-
-- The Samba hook now uses the `smbprotocol` library, exposing a much
-  bigger set of functionality and supporting SMB2/3 protocols.
-
-
 Airflow 2.1.2, 2021-07-14
 -------------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,10 @@
+Improvements
+""""""""""""
+
+- The Samba hook now uses the `smbprotocol` library, exposing a much
+  bigger set of functionality and supporting SMB2/3 protocols.
+
+
 Airflow 2.1.2, 2021-07-14
 -------------------------
 

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -16,11 +16,42 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
+from functools import wraps
+from logging import getLogger
+from shutil import copyfileobj
+from typing import Optional
 
-from smbclient import SambaClient
+from smbclient import (
+    getxattr,
+    link,
+    listdir,
+    listxattr,
+    lstat,
+    makedirs,
+    mkdir,
+    open_file,
+    readlink,
+    register_session,
+    remove,
+    removedirs,
+    removexattr,
+    rename,
+    replace,
+    rmdir,
+    scandir,
+    setxattr,
+    stat,
+    stat_volume,
+    symlink,
+    truncate,
+    unlink,
+    utime,
+    walk,
+)
 
 from airflow.hooks.base import BaseHook
+
+LOGGER = getLogger(__name__)
 
 
 class SambaHook(BaseHook):
@@ -31,52 +62,202 @@ class SambaHook(BaseHook):
     conn_type = 'samba'
     hook_name = 'Samba'
 
-    def __init__(self, samba_conn_id: str = default_conn_name) -> None:
+    def __init__(self, samba_conn_id: str = default_conn_name, share: Optional[str] = None) -> None:
         super().__init__()
-        self.conn = self.get_connection(samba_conn_id)
+        conn = self.get_connection(samba_conn_id)
 
-    def get_conn(self) -> SambaClient:
-        """
-        Return a samba client object.
+        if not conn.login:
+            LOGGER.info("Login not provided")
 
-        You can provide optional parameters in the extra fields of
-        your connection.
+        if not conn.password:
+            LOGGER.info("Password not provided")
 
-        Below is an inexhaustive list of these parameters:
+        self._host = conn.host
+        self._share = share or conn.schema
+        self._connection_cache = connection_cache = {}
+        self._conn_kwargs = {
+            "username": conn.login,
+            "password": conn.password,
+            "port": conn.port or 445,
+            "connection_cache": connection_cache,
+        }
 
-        `logdir`
-          Base directory name for log/debug files.
+    def __enter__(self):
+        # This immediately connects to the host (which can be
+        # perceived as a benefit), but also help work around an issue:
+        #
+        # https://github.com/jborean93/smbprotocol/issues/109.
+        register_session(self._host, **self._conn_kwargs)
+        return self
 
-        `kerberos`
-          Try to authenticate with kerberos.
+    def __exit__(self, exc_type, exc_value, traceback):
+        for host, connection in self._connection_cache.items():
+            LOGGER.info("Disconnecting from %s", host)
+            connection.disconnect()
+        self._connection_cache.clear()
 
-        `workgroup`
-          Set the SMB domain of the username.
+    @property
+    def _base_url(self):
+        return f"//{self._host}/{self._share}"
 
-        `netbios_name`
-          This option allows you to override the NetBIOS name that
-          Samba uses for itself.
-
-        For additional details, see `smbclient.SambaClient`.
-        """
-        samba = SambaClient(
-            server=self.conn.host,
-            share=self.conn.schema,
-            username=self.conn.login,
-            ip=self.conn.host,
-            password=self.conn.password,
-            **self.conn.extra_dejson,
+    @wraps(link)
+    def link(self, src, dst, follow_symlinks=True):
+        return link(
+            self._base_url + "/" + src,
+            self._base_url + "/" + dst,
+            follow_symlinks=follow_symlinks,
+            **self._conn_kwargs,
         )
-        return samba
 
-    def push_from_local(self, destination_filepath: str, local_filepath: str) -> None:
+    @wraps(listdir)
+    def listdir(self, path):
+        return listdir(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(lstat)
+    def lstat(self, path):
+        return lstat(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(makedirs)
+    def makedirs(self, path, exist_ok=False):
+        return makedirs(self._base_url + "/" + path, exist_ok=exist_ok, **self._conn_kwargs)
+
+    @wraps(mkdir)
+    def mkdir(self, path):
+        return mkdir(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(open_file)
+    def open_file(
+        self,
+        path,
+        mode="r",
+        buffering=-1,
+        encoding=None,
+        errors=None,
+        newline=None,
+        share_access=None,
+        desired_access=None,
+        file_attributes=None,
+        file_type="file",
+    ):
+        return open_file(
+            self._base_url + "/" + path,
+            mode=mode,
+            buffering=buffering,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+            share_access=share_access,
+            desired_access=desired_access,
+            file_attributes=file_attributes,
+            file_type=file_type,
+            **self._conn_kwargs,
+        )
+
+    @wraps(readlink)
+    def readlink(self, path):
+        return readlink(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(remove)
+    def remove(self, path):
+        return remove(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(removedirs)
+    def removedirs(self, path):
+        return removedirs(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(rename)
+    def rename(self, src, dst):
+        return rename(self._base_url + "/" + src, self._base_url + "/" + dst, **self._conn_kwargs)
+
+    @wraps(replace)
+    def replace(self, src, dst):
+        return replace(self._base_url + "/" + src, self._base_url + "/" + dst, **self._conn_kwargs)
+
+    @wraps(rmdir)
+    def rmdir(self, path):
+        return rmdir(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(scandir)
+    def scandir(self, path, search_pattern="*"):
+        return scandir(
+            self._base_url + "/" + path,
+            search_pattern=search_pattern,
+            **self._conn_kwargs,
+        )
+
+    @wraps(stat)
+    def stat(self, path, follow_symlinks=True):
+        return stat(self._base_url + "/" + path, follow_symlinks=follow_symlinks, **self._conn_kwargs)
+
+    @wraps(stat_volume)
+    def stat_volume(self, path):
+        return stat_volume(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(symlink)
+    def symlink(self, src, dst, target_is_directory=False):
+        return symlink(
+            self._base_url + "/" + src,
+            self._base_url + "/" + dst,
+            target_is_directory=target_is_directory,
+            **self._conn_kwargs,
+        )
+
+    @wraps(truncate)
+    def truncate(self, path, length):
+        return truncate(self._base_url + "/" + path, length, **self._conn_kwargs)
+
+    @wraps(unlink)
+    def unlink(self, path):
+        return unlink(self._base_url + "/" + path, **self._conn_kwargs)
+
+    @wraps(utime)
+    def utime(self, path, times=None, ns=None, follow_symlinks=True):
+        return utime(
+            self._base_url + "/" + path,
+            times=times,
+            ns=ns,
+            follow_symlinks=follow_symlinks,
+            **self._conn_kwargs,
+        )
+
+    @wraps(walk)
+    def walk(self, path, topdown=True, onerror=None, follow_symlinks=False):
+        return walk(
+            self._base_url + "/" + path,
+            topdown=topdown,
+            onerror=onerror,
+            follow_symlinks=follow_symlinks,
+            **self._conn_kwargs,
+        )
+
+    @wraps(getxattr)
+    def getxattr(self, path, attribute, follow_symlinks=True):
+        return getxattr(
+            self._base_url + "/" + path, attribute, follow_symlinks=follow_symlinks, **self._conn_kwargs
+        )
+
+    @wraps(listxattr)
+    def listxattr(self, path, follow_symlinks=True):
+        return listxattr(self._base_url + "/" + path, follow_symlinks=follow_symlinks, **self._conn_kwargs)
+
+    @wraps(removexattr)
+    def removexattr(self, path, attribute, follow_symlinks=True):
+        return removexattr(
+            self._base_url + "/" + path, attribute, follow_symlinks=follow_symlinks, **self._conn_kwargs
+        )
+
+    @wraps(setxattr)
+    def setxattr(self, path, attribute, value, flags=0, follow_symlinks=True):
+        return setxattr(
+            self._base_url + "/" + path,
+            attribute,
+            value,
+            flags=flags,
+            follow_symlinks=follow_symlinks,
+            **self._conn_kwargs,
+        )
+
+    def push_from_local(self, destination_filepath: str, local_filepath: str):
         """Push local file to samba server"""
-        samba = self.get_conn()
-        if samba.exists(destination_filepath):
-            if samba.isfile(destination_filepath):
-                samba.remove(destination_filepath)
-        else:
-            folder = os.path.dirname(destination_filepath)
-            if not samba.exists(folder):
-                samba.mkdir(folder)
-        samba.upload(local_filepath, destination_filepath)
+        with open(local_filepath, "rb") as f, self.open_file(destination_filepath, mode="w") as g:
+            copyfileobj(f, g)

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -20,39 +20,21 @@ from functools import wraps
 from shutil import copyfileobj
 from typing import Optional
 
-from smbclient import (
-    getxattr,
-    link,
-    listdir,
-    listxattr,
-    lstat,
-    makedirs,
-    mkdir,
-    open_file,
-    readlink,
-    register_session,
-    remove,
-    removedirs,
-    removexattr,
-    rename,
-    replace,
-    rmdir,
-    scandir,
-    setxattr,
-    stat,
-    stat_volume,
-    symlink,
-    truncate,
-    unlink,
-    utime,
-    walk,
-)
+import smbclient
 
 from airflow.hooks.base import BaseHook
 
 
 class SambaHook(BaseHook):
-    """Allows for interaction with an samba server."""
+    """Allows for interaction with a Samba server.
+
+    :param samba_conn_id: The connection id reference.
+    :type samba_conn_id: str
+    :param share:
+        An optional share name. If this is unset then the "schema" field of
+        the connection is used in its place.
+    :type share: str
+    """
 
     conn_name_attr = 'samba_conn_id'
     default_conn_name = 'samba_default'
@@ -84,7 +66,7 @@ class SambaHook(BaseHook):
         # perceived as a benefit), but also help work around an issue:
         #
         # https://github.com/jborean93/smbprotocol/issues/109.
-        register_session(self._host, **self._conn_kwargs)
+        smbclient.register_session(self._host, **self._conn_kwargs)
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -97,32 +79,32 @@ class SambaHook(BaseHook):
     def _base_url(self):
         return f"//{self._host}/{self._share}"
 
-    @wraps(link)
+    @wraps(smbclient.link)
     def link(self, src, dst, follow_symlinks=True):
-        return link(
+        return smbclient.link(
             self._base_url + "/" + src,
             self._base_url + "/" + dst,
             follow_symlinks=follow_symlinks,
             **self._conn_kwargs,
         )
 
-    @wraps(listdir)
+    @wraps(smbclient.listdir)
     def listdir(self, path):
-        return listdir(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.listdir(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(lstat)
+    @wraps(smbclient.lstat)
     def lstat(self, path):
-        return lstat(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.lstat(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(makedirs)
+    @wraps(smbclient.makedirs)
     def makedirs(self, path, exist_ok=False):
-        return makedirs(self._base_url + "/" + path, exist_ok=exist_ok, **self._conn_kwargs)
+        return smbclient.makedirs(self._base_url + "/" + path, exist_ok=exist_ok, **self._conn_kwargs)
 
-    @wraps(mkdir)
+    @wraps(smbclient.mkdir)
     def mkdir(self, path):
-        return mkdir(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.mkdir(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(open_file)
+    @wraps(smbclient.open_file)
     def open_file(
         self,
         path,
@@ -136,7 +118,7 @@ class SambaHook(BaseHook):
         file_attributes=None,
         file_type="file",
     ):
-        return open_file(
+        return smbclient.open_file(
             self._base_url + "/" + path,
             mode=mode,
             buffering=buffering,
@@ -150,66 +132,68 @@ class SambaHook(BaseHook):
             **self._conn_kwargs,
         )
 
-    @wraps(readlink)
+    @wraps(smbclient.readlink)
     def readlink(self, path):
-        return readlink(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.readlink(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(remove)
+    @wraps(smbclient.remove)
     def remove(self, path):
-        return remove(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.remove(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(removedirs)
+    @wraps(smbclient.removedirs)
     def removedirs(self, path):
-        return removedirs(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.removedirs(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(rename)
+    @wraps(smbclient.rename)
     def rename(self, src, dst):
-        return rename(self._base_url + "/" + src, self._base_url + "/" + dst, **self._conn_kwargs)
+        return smbclient.rename(self._base_url + "/" + src, self._base_url + "/" + dst, **self._conn_kwargs)
 
-    @wraps(replace)
+    @wraps(smbclient.replace)
     def replace(self, src, dst):
-        return replace(self._base_url + "/" + src, self._base_url + "/" + dst, **self._conn_kwargs)
+        return smbclient.replace(self._base_url + "/" + src, self._base_url + "/" + dst, **self._conn_kwargs)
 
-    @wraps(rmdir)
+    @wraps(smbclient.rmdir)
     def rmdir(self, path):
-        return rmdir(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.rmdir(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(scandir)
+    @wraps(smbclient.scandir)
     def scandir(self, path, search_pattern="*"):
-        return scandir(
+        return smbclient.scandir(
             self._base_url + "/" + path,
             search_pattern=search_pattern,
             **self._conn_kwargs,
         )
 
-    @wraps(stat)
+    @wraps(smbclient.stat)
     def stat(self, path, follow_symlinks=True):
-        return stat(self._base_url + "/" + path, follow_symlinks=follow_symlinks, **self._conn_kwargs)
+        return smbclient.stat(
+            self._base_url + "/" + path, follow_symlinks=follow_symlinks, **self._conn_kwargs
+        )
 
-    @wraps(stat_volume)
+    @wraps(smbclient.stat_volume)
     def stat_volume(self, path):
-        return stat_volume(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.stat_volume(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(symlink)
+    @wraps(smbclient.symlink)
     def symlink(self, src, dst, target_is_directory=False):
-        return symlink(
+        return smbclient.symlink(
             self._base_url + "/" + src,
             self._base_url + "/" + dst,
             target_is_directory=target_is_directory,
             **self._conn_kwargs,
         )
 
-    @wraps(truncate)
+    @wraps(smbclient.truncate)
     def truncate(self, path, length):
-        return truncate(self._base_url + "/" + path, length, **self._conn_kwargs)
+        return smbclient.truncate(self._base_url + "/" + path, length, **self._conn_kwargs)
 
-    @wraps(unlink)
+    @wraps(smbclient.unlink)
     def unlink(self, path):
-        return unlink(self._base_url + "/" + path, **self._conn_kwargs)
+        return smbclient.unlink(self._base_url + "/" + path, **self._conn_kwargs)
 
-    @wraps(utime)
+    @wraps(smbclient.utime)
     def utime(self, path, times=None, ns=None, follow_symlinks=True):
-        return utime(
+        return smbclient.utime(
             self._base_url + "/" + path,
             times=times,
             ns=ns,
@@ -217,9 +201,9 @@ class SambaHook(BaseHook):
             **self._conn_kwargs,
         )
 
-    @wraps(walk)
+    @wraps(smbclient.walk)
     def walk(self, path, topdown=True, onerror=None, follow_symlinks=False):
-        return walk(
+        return smbclient.walk(
             self._base_url + "/" + path,
             topdown=topdown,
             onerror=onerror,
@@ -227,25 +211,27 @@ class SambaHook(BaseHook):
             **self._conn_kwargs,
         )
 
-    @wraps(getxattr)
+    @wraps(smbclient.getxattr)
     def getxattr(self, path, attribute, follow_symlinks=True):
-        return getxattr(
+        return smbclient.getxattr(
             self._base_url + "/" + path, attribute, follow_symlinks=follow_symlinks, **self._conn_kwargs
         )
 
-    @wraps(listxattr)
+    @wraps(smbclient.listxattr)
     def listxattr(self, path, follow_symlinks=True):
-        return listxattr(self._base_url + "/" + path, follow_symlinks=follow_symlinks, **self._conn_kwargs)
+        return smbclient.listxattr(
+            self._base_url + "/" + path, follow_symlinks=follow_symlinks, **self._conn_kwargs
+        )
 
-    @wraps(removexattr)
+    @wraps(smbclient.removexattr)
     def removexattr(self, path, attribute, follow_symlinks=True):
-        return removexattr(
+        return smbclient.removexattr(
             self._base_url + "/" + path, attribute, follow_symlinks=follow_symlinks, **self._conn_kwargs
         )
 
-    @wraps(setxattr)
+    @wraps(smbclient.setxattr)
     def setxattr(self, path, attribute, value, flags=0, follow_symlinks=True):
-        return setxattr(
+        return smbclient.setxattr(
             self._base_url + "/" + path,
             attribute,
             value,

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -17,7 +17,6 @@
 # under the License.
 
 from functools import wraps
-from logging import getLogger
 from shutil import copyfileobj
 from typing import Optional
 
@@ -51,8 +50,6 @@ from smbclient import (
 
 from airflow.hooks.base import BaseHook
 
-LOGGER = getLogger(__name__)
-
 
 class SambaHook(BaseHook):
     """Allows for interaction with an samba server."""
@@ -67,10 +64,10 @@ class SambaHook(BaseHook):
         conn = self.get_connection(samba_conn_id)
 
         if not conn.login:
-            LOGGER.info("Login not provided")
+            self.log.info("Login not provided")
 
         if not conn.password:
-            LOGGER.info("Password not provided")
+            self.log.info("Password not provided")
 
         self._host = conn.host
         self._share = share or conn.schema
@@ -92,7 +89,7 @@ class SambaHook(BaseHook):
 
     def __exit__(self, exc_type, exc_value, traceback):
         for host, connection in self._connection_cache.items():
-            LOGGER.info("Disconnecting from %s", host)
+            self.log.info("Disconnecting from %s", host)
             connection.disconnect()
         self._connection_cache.clear()
 

--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -29,6 +29,9 @@ from airflow.hooks.base import BaseHook
 class SambaHook(BaseHook):
     """Allows for interaction with a Samba server.
 
+    The hook should be used as a context manager in order to correctly
+    set up a session and disconnect open connections upon exit.
+
     :param samba_conn_id: The connection id reference.
     :type samba_conn_id: str
     :param share:

--- a/docs/apache-airflow-providers-samba/index.rst
+++ b/docs/apache-airflow-providers-samba/index.rst
@@ -71,7 +71,7 @@ PIP requirements
 PIP package         Version required
 ==================  ==================
 ``apache-airflow``  ``>=2.1.0``
-``pysmbclient``     ``>=0.1.3``
+``smbprotocol``     ``>=1.5.0``
 ==================  ==================
 
 .. include:: ../../airflow/providers/samba/CHANGELOG.rst

--- a/setup.py
+++ b/setup.py
@@ -425,7 +425,7 @@ salesforce = [
     'tableauserverclient',
 ]
 samba = [
-    'pysmbclient>=0.1.3',
+    'smbprotocol>=1.5.0',
 ]
 segment = [
     'analytics-python>=1.2.9',

--- a/tests/providers/samba/hooks/test_samba.py
+++ b/tests/providers/samba/hooks/test_samba.py
@@ -16,23 +16,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 import unittest
+from inspect import getfullargspec
 from unittest import mock
-from unittest.mock import call
 
 import pytest
+from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
 from airflow.providers.samba.hooks.samba import SambaHook
 
-connection = Connection(
+PATH_PARAMETER_NAMES = {"path", "src", "dst"}
+
+CONNECTION = Connection(
     host='ip',
     schema='share',
     login='username',
     password='password',
-    extra=json.dumps({'workgroup': 'workgroup'}),
 )
 
 
@@ -41,90 +42,89 @@ class TestSambaHook(unittest.TestCase):
         with pytest.raises(AirflowException):
             SambaHook('conn')
 
-    @mock.patch('airflow.providers.samba.hooks.samba.SambaClient')
+    @mock.patch('airflow.providers.samba.hooks.samba.register_session')
     @mock.patch('airflow.hooks.base.BaseHook.get_connection')
-    def test_get_conn(self, get_conn_mock, get_client_mock):
-        get_conn_mock.return_value = connection
-        hook = SambaHook('samba_default')
-        conn = hook.get_conn()
-        assert str(get_client_mock.mock_calls[0].workgroup) == "workgroup"
-        assert conn is get_client_mock()
-        get_conn_mock.assert_called_once_with('samba_default')
+    def test_context_manager(self, get_conn_mock, register_session):
+        get_conn_mock.return_value = CONNECTION
+        register_session.return_value = None
+        with SambaHook('samba_default'):
+            assert register_session.mock_calls[0].args == (CONNECTION.host,)
+            assert register_session.mock_calls[0].kwargs == {
+                "username": CONNECTION.login,
+                "password": CONNECTION.password,
+                "port": 445,
+                "connection_cache": {},
+            }
+            cache = register_session.mock_calls[0].kwargs.get("connection_cache")
+            mock_connection = mock.Mock()
+            mock_connection.disconnect.return_value = None
+            cache["foo"] = mock_connection
 
-    @mock.patch('airflow.providers.samba.hooks.samba.SambaHook.get_conn')
+        # Test that the connection was disconnected upon exit.
+        assert len(mock_connection.disconnect.mock_calls) == 1
+
+    @parameterized.expand(
+        [
+            "getxattr",
+            "link",
+            "listdir",
+            "listxattr",
+            "lstat",
+            "makedirs",
+            "mkdir",
+            "open_file",
+            "readlink",
+            "remove",
+            "removedirs",
+            "removexattr",
+            "rename",
+            "replace",
+            "rmdir",
+            "scandir",
+            "setxattr",
+            "stat",
+            "stat_volume",
+            "symlink",
+            "truncate",
+            "unlink",
+            "utime",
+            "walk",
+        ],
+    )
     @mock.patch('airflow.hooks.base.BaseHook.get_connection')
-    def test_push_from_local_should_succeed_if_destination_has_same_name_but_not_a_file(
-        self, base_conn_mock, samba_hook_mock
-    ):
-        base_conn_mock.return_value = connection
-        samba_hook_mock.get_conn.return_value = mock.Mock()
-
-        samba_hook_mock.return_value.exists.return_value = True
-        samba_hook_mock.return_value.isfile.return_value = False
-        samba_hook_mock.return_value.exists.return_value = True
-
+    def test_method(self, name, get_conn_mock):
+        get_conn_mock.return_value = CONNECTION
         hook = SambaHook('samba_default')
-        destination_filepath = "/path/to/dest/file"
-        local_filepath = "/path/to/local/file"
-        hook.push_from_local(destination_filepath=destination_filepath, local_filepath=local_filepath)
+        connection_settings = {
+            'connection_cache': {},
+            'username': CONNECTION.login,
+            'password': CONNECTION.password,
+            'port': 445,
+        }
+        with mock.patch('airflow.providers.samba.hooks.samba.' + name) as p:
+            kwargs = {}
+            method = getattr(hook, name)
+            spec = getfullargspec(method)
 
-        base_conn_mock.assert_called_once_with('samba_default')
-        samba_hook_mock.assert_called_once()
-        samba_hook_mock.return_value.exists.assert_called_once_with(destination_filepath)
-        samba_hook_mock.return_value.isfile.assert_called_once_with(destination_filepath)
-        samba_hook_mock.return_value.remove.assert_not_called()
-        samba_hook_mock.return_value.upload.assert_called_once_with(local_filepath, destination_filepath)
+            if spec.defaults:
+                for default in reversed(spec.defaults):
+                    arg = spec.args.pop()
+                    kwargs[arg] = default
 
-    @mock.patch('airflow.providers.samba.hooks.samba.SambaHook.get_conn')
-    @mock.patch('airflow.hooks.base.BaseHook.get_connection')
-    def test_push_from_local_should_delete_file_if_exists_and_save_file(
-        self, base_conn_mock, samba_hook_mock
-    ):
-        base_conn_mock.return_value = connection
-        samba_hook_mock.get_conn.return_value = mock.Mock()
+            # Ignore "self" argument.
+            args = spec.args[1:]
 
-        samba_hook_mock.return_value.exists.return_value = False
-        samba_hook_mock.return_value.exists.return_value = False
+            method(*args, **kwargs)
+            assert len(p.mock_calls) == 1
 
-        hook = SambaHook('samba_default')
-        destination_folder = "/path/to/dest"
-        destination_filepath = destination_folder + "/file"
-        local_filepath = "/path/to/local/file"
-        hook.push_from_local(destination_filepath=destination_filepath, local_filepath=local_filepath)
+            # Verify positional arguments. If the argument is a path parameter, then we expect
+            # the hook implementation to fully qualify the path.
+            for arg, provided in zip(args, p.mock_calls[0].args):
+                if arg in PATH_PARAMETER_NAMES:
+                    expected = "//" + CONNECTION.host + "/" + CONNECTION.schema + "/" + arg
+                else:
+                    expected = arg
+                assert expected == provided
 
-        base_conn_mock.assert_called_once_with('samba_default')
-        samba_hook_mock.assert_called_once()
-        samba_hook_mock.return_value.exists.assert_has_calls(
-            [call(destination_filepath), call(destination_folder)]
-        )
-        samba_hook_mock.return_value.isfile.assert_not_called()
-        samba_hook_mock.return_value.remove.assert_not_called()
-        samba_hook_mock.return_value.mkdir.assert_called_once_with(destination_folder)
-        samba_hook_mock.return_value.upload.assert_called_once_with(local_filepath, destination_filepath)
-
-    @mock.patch('airflow.providers.samba.hooks.samba.SambaHook.get_conn')
-    @mock.patch('airflow.hooks.base.BaseHook.get_connection')
-    def test_push_from_local_should_create_directory_if_not_exist_and_save_file(
-        self, base_conn_mock, samba_hook_mock
-    ):
-        base_conn_mock.return_value = connection
-        samba_hook_mock.get_conn.return_value = mock.Mock()
-
-        samba_hook_mock.return_value.exists.return_value = False
-        samba_hook_mock.return_value.exists.return_value = False
-
-        hook = SambaHook('samba_default')
-        destination_folder = "/path/to/dest"
-        destination_filepath = destination_folder + "/file"
-        local_filepath = "/path/to/local/file"
-        hook.push_from_local(destination_filepath=destination_filepath, local_filepath=local_filepath)
-
-        base_conn_mock.assert_called_once_with('samba_default')
-        samba_hook_mock.assert_called_once()
-        samba_hook_mock.return_value.exists.assert_has_calls(
-            [call(destination_filepath), call(destination_folder)]
-        )
-        samba_hook_mock.return_value.isfile.assert_not_called()
-        samba_hook_mock.return_value.remove.assert_not_called()
-        samba_hook_mock.return_value.mkdir.assert_called_once_with(destination_folder)
-        samba_hook_mock.return_value.upload.assert_called_once_with(local_filepath, destination_filepath)
+            # We expect keyword arguments to include the connection settings.
+            assert dict(kwargs, **connection_settings) == p.mock_calls[0].kwargs

--- a/tests/providers/samba/hooks/test_samba.py
+++ b/tests/providers/samba/hooks/test_samba.py
@@ -42,7 +42,7 @@ class TestSambaHook(unittest.TestCase):
         with pytest.raises(AirflowException):
             SambaHook('conn')
 
-    @mock.patch('airflow.providers.samba.hooks.samba.register_session')
+    @mock.patch('smbclient.register_session')
     @mock.patch('airflow.hooks.base.BaseHook.get_connection')
     def test_context_manager(self, get_conn_mock, register_session):
         get_conn_mock.return_value = CONNECTION
@@ -101,7 +101,7 @@ class TestSambaHook(unittest.TestCase):
             'password': CONNECTION.password,
             'port': 445,
         }
-        with mock.patch('airflow.providers.samba.hooks.samba.' + name) as p:
+        with mock.patch('smbclient.' + name) as p:
             kwargs = {}
             method = getattr(hook, name)
             spec = getfullargspec(method)


### PR DESCRIPTION
This change switches the Samba hook implementation to the [smbprotocol](https://pypi.org/project/smbprotocol/) library.

As discussed in #14054 the current implementation uses an unmaintained and outdated library.

In addition, the implementation suggested here conveniently exposes a large part of the user-friendly API provided by the underlying library. For example, to use the `smbclient.getxattr` function, one would call `samba_hook.getxattr` (with connection details being automatically provided).

---

closes: #14054
