### PR TITLE
Fix `airflow celery stop` to accept the pid file.

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1383,7 +1383,7 @@ CELERY_COMMANDS = (
         name='stop',
         help="Stop the Celery worker gracefully",
         func=lazy_load_command('airflow.cli.commands.celery_command.stop_worker'),
-        args=(),
+        args=(ARG_PID,),
     ),
 )
 

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -183,7 +183,10 @@ def worker(args):
 def stop_worker(args):
     """Sends SIGTERM to Celery worker"""
     # Read PID from file
-    pid_file_path, _, _, _ = setup_locations(process=WORKER_PROCESS_NAME)
+    if args.pid:
+        pid_file_path = args.pid
+    else:
+        pid_file_path, _, _, _ = setup_locations(process=WORKER_PROCESS_NAME)
     pid = read_pid_from_pidfile(pid_file_path)
 
     # Send SIGTERM


### PR DESCRIPTION
**Background**
Airflow celery cli provides a nice interface to launch workers and stop them. This cli setup works very well when there is one worker running on node without a custom PID specified. But if a worker is launched with custom `--pid` file then `airflow celery stop` command is not capable of stopping the worker. In our setup, we run multiple workers on same node subscribed to different queues. The only way to stop worker is to provide `SIGTERM`, which isn't always the best strategy as it is not always graceful.

**Changes made**
Add an additional argument to the `airflow celery stop` command, `--pid`. If this argument is present then the cli will kill worker associated with pid present in specified pidfile.
