### PR TITLE
Update warning about MariaDB and multiple schedulers

### DIFF
--- a/docs/apache-airflow/concepts/scheduler.rst
+++ b/docs/apache-airflow/concepts/scheduler.rst
@@ -123,13 +123,14 @@ The following databases are fully supported and provide an "optimal" experience:
 
 .. warning::
 
-  MariaDB does not implement the ``SKIP LOCKED`` or ``NOWAIT`` SQL clauses (see `MDEV-13115
-  <https://jira.mariadb.org/browse/MDEV-13115>`_). Without these features running multiple schedulers is not
-  supported and deadlock errors have been reported.
+  MariaDB did not implement the ``SKIP LOCKED`` or ``NOWAIT`` SQL clauses until version
+  `10.6.0 <https://jira.mariadb.org/browse/MDEV-25433?jql=project%20%3D%20MDEV%20AND%20fixVersion%20%3D%2010.6.0>`_.
+  Without these features, running multiple schedulers is not supported and deadlock errors have been reported. MariaDB
+  10.6.0 and following may work appropriately with multiple schedulers, but this has not been tested.
 
 .. warning::
 
-  MySQL 5.x also does not support ``SKIP LOCKED`` or ``NOWAIT``, and additionally is more prone to deciding
+  MySQL 5.x does not support ``SKIP LOCKED`` or ``NOWAIT``, and additionally is more prone to deciding
   queries are deadlocked, so running with more than a single scheduler on MySQL 5.x is not supported or
   recommended.
 


### PR DESCRIPTION
The documentation for the scheduler relating to MariaDB currently references a Jira issue that is now closed. I have updated the docs to state that the effectiveness of using of MariaDB 10.6+ with multiple schedulers is now uncertain. This is a stopgap until #16907 is complete which should answer the question definitively.

related: #16907 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
