### PR TITLE
Fix breeze kind-cluster deploy failing with ECONREFUSED

### DIFF
--- a/scripts/docker/compile_www_assets.sh
+++ b/scripts/docker/compile_www_assets.sh
@@ -35,7 +35,7 @@ function compile_www_assets() {
         www_dir="$(python -m site --user-site)/airflow/www"
     fi
     pushd ${www_dir} || exit 1
-    yarn install --frozen-lockfile --no-cache
+    yarn install --frozen-lockfile --no-cache --network-concurrency=1
     yarn run prod
     find package.json yarn.lock static/css static/js -type f | sort | xargs md5sum > "${md5sum_file}"
     rm -rf "${www_dir}/node_modules"


### PR DESCRIPTION
Currently, kind-cluster deploy fails occasionally due to yarn install when compiling
assets. This PR fixes it by using the recommended option --network-concurrency=1 when
running yarn install

```
+ yarn install --frozen-lockfile --no-cache
/opt/airflow/airflow/www /opt/airflow
yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
error An unexpected error occurred: "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz: connect ECONNREFUSED 104.16.22.35:443".
info If you think this is a bug, please open a bug report with the information provided in "/opt/airflow/airflow/www/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command '/bin/bash -o pipefail -e -u -x -c if [[ ${AIRFLOW_INSTALLATION_METHOD} == "." ]]; then         bash /scripts/docker/compile_www_assets.sh;     fi;     if [[ ${INSTALL_FROM_DOCKER_CONTEXT_FILES} == "true" ]]; then         bash /scripts/docker/install_from_docker_context_files.sh;     elif [[ ${INSTALL_FROM_PYPI} == "true" ]]; then         bash /scripts/docker/install_airflow.sh;     fi;     if [[ -n "${ADDITIONAL_PYTHON_DEPS}" ]]; then         bash /scripts/docker/install_additional_dependencies.sh;     fi;     find /root/.local/ -name '*.pyc' -print0 | xargs -0 rm -r || true ;     find /root/.local/ -type d -name '__pycache__' -print0 | xargs -0 rm -r || true ;     find /root/.local -executable -print0 | xargs --null chmod g+x;     find /root/.local -print0 | xargs --null chmod g+rw' returned a non-zero code: 1

ERROR: The previous step completed with error. Please take a look at output above
```
See: https://github.com/yarnpkg/yarn/issues/5299


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
