### PR TITLE
fix a broken link in an ssh-related warning message

### DIFF
--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -87,7 +87,7 @@ You are using ssh authentication for your gitsync repo, however you currently ha
 making you susceptible to man-in-the-middle attacks!
 
 Information on how to set knownHosts can be found here:
-https://airflow.apache.org/docs/helm-chart/latest/production-guide.html#knownhosts
+https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#knownhosts
 
 {{- end }}
 


### PR DESCRIPTION
Warning Message:

    #####################################################
    #  WARNING: You should set dags.gitSync.knownHosts  #
    #####################################################

    You are using ssh authentication for your gitsync repo, however you currently have SSH known_hosts verification disabled,
    making you susceptible to man-in-the-middle attacks!

    Information on how to set knownHosts can be found here:
    https://airflow.apache.org/docs/helm-chart/latest/production-guide.html#knownhosts

broken: https://airflow.apache.org/docs/helm-chart/latest/production-guide.html#knownhosts
fixed: https://airflow.apache.org/docs/helm-chart/stable/production-guide.html#knownhosts