### PR TITLE
Fix for #16013 - CLI 'kubernetes cleanup-pods' fails on invalid label key

### DIFF
--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -96,16 +96,8 @@ def cleanup_pods(args):
         'try_number',
         'airflow_version',
     ]
-    list_kwargs = {
-        "namespace": namespace,
-        "limit": 500,
-        "label_selector": client.V1LabelSelector(
-            match_expressions=[
-                client.V1LabelSelectorRequirement(key=label, operator="Exists")
-                for label in airflow_pod_labels
-            ]
-        ),
-    }
+    list_kwargs = {"namespace": namespace, "limit": 500, "label_selector": ','.join(airflow_pod_labels)}
+
     while True:
         pod_list = kube_client.list_namespaced_pod(**list_kwargs)
         for pod in pod_list.items:

--- a/tests/cli/commands/test_kubernetes_command.py
+++ b/tests/cli/commands/test_kubernetes_command.py
@@ -55,12 +55,8 @@ class TestGenerateDagYamlCommand(unittest.TestCase):
 
 
 class TestCleanUpPodsCommand(unittest.TestCase):
-    label_selector = kubernetes.client.V1LabelSelector(
-        match_expressions=[
-            kubernetes.client.V1LabelSelectorRequirement(key=label, operator="Exists")
-            for label in ['dag_id', 'task_id', 'execution_date', 'try_number', 'airflow_version']
-        ]
-    )
+
+    label_selector = ','.join(['dag_id', 'task_id', 'execution_date', 'try_number', 'airflow_version'])
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
closes: #16013   

This is a workaround for the issue with `kubernetes-client` that results in an invalid API request by `V1LabelSelector` and `match_expressions`. This employs an alternative approach that matches the desired functionality by specifying the `label_selector` as a comma separated string of labels that the pod should have in order for it to be returned by `list_namespaced_pod`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
