### PR TITLE
fix backfill can not backfill at time 00:00 if set default_timezone=Asia/Shanghai

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -167,18 +167,14 @@ class DagRun(Base, LoggingMixin):
         """
         DR = DagRun
 
-        exec_date = func.cast(self.execution_date, DateTime)
-
-        dr = (
-            session.query(DR)
-            .filter(
-                DR.dag_id == self.dag_id,
-                func.cast(DR.execution_date, DateTime) == exec_date,
-                DR.run_id == self.run_id,
-            )
-            .one()
+        dr = DR.find(
+            dag_id=self.dag_id,
+            run_id=self.run_id,
+            execution_date=self.execution_date,
+            session=session
         )
 
+        dr = dr[0]
         self.id = dr.id
         self.state = dr.state
 


### PR DESCRIPTION
In case of existing issue, reference it using one of the following:
related: #16961

in backfill function, there are two methods, which are `self._get_dag_run(next_run_date, dag, session=session)` and `self._task_instances_for_dag_run(dag_run, session=session)` in backfill_job.py. In `_get_dag_run` method it use `runs = DagRun.find(dag_id=dag.dag_id, execution_date=run_date, session=session)` to find dagrun, but in `_instances_for_dag_run` it use `dagrun.refresh_from_db` to find dagrun, this method to find dagrun is different from `DagRun.find` so it will cause can not find dagrun when execution_date = 00:00 if set default_timezone=Asia/Shanghai, now I make them the same way to find dagrun, it can backfill successfully.
**^ Add meaningful description above**
