### PR TITLE
Update hasicorp-vault.rst to describe use of config

### DIFF
--- a/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
+++ b/docs/apache-airflow-providers-hashicorp/secrets-backends/hashicorp-vault.rst
@@ -130,3 +130,41 @@ Verify that you can get the secret from ``vault``:
 
 Note that the secret ``Key`` is ``value``, and secret ``Value`` is ``world`` and
 ``mount_point`` is ``airflow``.
+
+Storing and Retrieving Config
+""""""""""""""""""""""""""""""""
+
+If you have set ``config_path`` as ``config`` and ``mount_point`` as ``airflow``, then for config ``sql_alchemy_conn_secret`` with
+``sql_alchemy_conn_value`` as value, you would want to store your secret as:
+
+.. code-block:: bash
+
+    vault kv put airflow/config/sql_alchemy_conn_value value=postgres://user:pass@host:5432/db?ssl_mode=disable
+
+Verify that you can get the secret from ``vault``:
+
+.. code-block:: console
+
+    ❯ vault kv get airflow/config/sql_alchemy_conn_value
+    ====== Metadata ======
+    Key              Value
+    ---              -----
+    created_time     2020-03-28T02:10:54.301784Z
+    deletion_time    n/a
+    destroyed        false
+    version          1
+
+    ==== Data ====
+    Key      Value
+    ---      -----
+    value    postgres://user:pass@host:5432/db?ssl_mode=disable
+
+Then you can use above secret for ``sql_alchemy_conn_secret`` in your configuration file.
+
+.. code-block:: ini
+
+    [core]
+     sql_alchemy_conn_secret: "sql_alchemy_conn_value"
+
+Note that the secret ``Key`` is ``value``, and secret ``Value`` is ``postgres://user:pass@host:5432/db?ssl_mode=disable`` and
+``mount_point`` is ``airflow``.


### PR DESCRIPTION
This page shows use of Hashicorp Vault to use for Connections and Variables. But we can also use it for storing some of the attributes from Airflow configuration file. There is no concrete example for the latter use-case in the documentation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
