### PR TITLE
Suggest to use secrets backend for variable when it contains sensitive data

### DIFF
--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -91,13 +91,16 @@ Variables
 ---------
 
 You should avoid usage of Variables outside an operator's ``execute()`` method or Jinja templates if possible,
-as Variables create a connection to metadata DB of Airflow to fetch the value, which can slow down parsing and place extra load on the DB.
+as Variables create a connection to metadata DB of Airflow to fetch the value, which can slow down parsing and
+place extra load on the DB.
 
 Airflow parses all the DAGs in the background at a specific period.
-The default period is set using ``processor_poll_interval`` config, which is by default 1 second. During parsing, Airflow creates a new connection to the metadata DB for each DAG.
+The default period is set using ``processor_poll_interval`` config, which is by default 1 second.
+During parsing, Airflow creates a new connection to the metadata DB for each DAG.
 This can result in a lot of open connections.
 
-The best way of using variables is via a Jinja template, which will delay reading the value until the task execution. The template syntax to do this is:
+The best way of using variables is via a Jinja template, which will delay reading the value until the task execution.
+The template syntax to do this is:
 
 .. code-block::
 
@@ -109,8 +112,12 @@ or if you need to deserialize a json object from the variable :
 
     {{ var.json.<variable_name> }}
 
-An alternative option is to use environment variables in the top-level python code or use Environment Variables to create and manage Airflow variables. to manage Airflow Variables. This will avoid new connections to Airflow metadata DB every time Airflow parses the python file. For more information, see: :ref:`managing_variables`.
+For security purpose, you're recommended to use the :ref:`Secrets Backend<secrets_backend_configuration>`
+for any variable that contains sensitive data.
 
+An alternative option is to use environment variables in the top-level Python code or use environment variables to
+create and manage Airflow variables. This will avoid new connections to Airflow metadata DB every time
+Airflow parses the Python file. For more information, see: :ref:`managing_variables`.
 
 Top level Python Code
 ---------------------

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -95,7 +95,7 @@ as Variables create a connection to metadata DB of Airflow to fetch the value, w
 place extra load on the DB.
 
 Airflow parses all the DAGs in the background at a specific period.
-The default period is set using ``processor_poll_interval`` config, which is by default 1 second.
+The default period is set using the ``processor_poll_interval`` config, which is 1 second by default.
 During parsing, Airflow creates a new connection to the metadata DB for each DAG.
 This can result in a lot of open connections.
 

--- a/docs/apache-airflow/security/index.rst
+++ b/docs/apache-airflow/security/index.rst
@@ -15,8 +15,6 @@
     specific language governing permissions and limitations
     under the License.
 
-
-
 Security
 ========
 

--- a/docs/apache-airflow/security/secrets/secrets-backend/index.rst
+++ b/docs/apache-airflow/security/secrets/secrets-backend/index.rst
@@ -15,8 +15,7 @@
     specific language governing permissions and limitations
     under the License.
 
-
-Secrets backend
+Secrets Backend
 ---------------
 
 .. versionadded:: 1.10.10


### PR DESCRIPTION
Closes: #14200 

Changes proposed in this pull request:

* Suggest to use secrets backend when variable contains sensitive data

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
