### PR TITLE
s3 unify_bucket_name_and_key simplify

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -75,15 +75,14 @@ def unify_bucket_name_and_key(func: T) -> T:
     def wrapper(*args, **kwargs) -> T:
         bound_args = function_signature.bind(*args, **kwargs)
 
-        def get_key_name() -> Optional[str]:
-            if 'wildcard_key' in bound_args.arguments:
-                return 'wildcard_key'
-            if 'key' in bound_args.arguments:
-                return 'key'
+        if 'wildcard_key' in bound_args.arguments:
+            key_name = 'wildcard_key'
+        elif 'key' in bound_args.arguments:
+            key_name = 'key'
+        else:
             raise ValueError('Missing key parameter!')
 
-        key_name = get_key_name()
-        if key_name and 'bucket_name' not in bound_args.arguments:
+        if 'bucket_name' not in bound_args.arguments:
             bound_args.arguments['bucket_name'], bound_args.arguments[key_name] = S3Hook.parse_s3_url(
                 bound_args.arguments[key_name]
             )


### PR DESCRIPTION
This `if key_name ...` part was doing nothing.

`key_name` in previous code was always a one of two thing.
Never empty, None, etc. (the typing annotation was wrong)
So` if key_name` always evaluated to `True`.

It is possible to move the key_name logic to be only under
missing bucket_name case, it would be slightly faster,
but then missing argument case would be maybe harder
to debug.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
