### PR TITLE
refactor: fixed type annotation for 'sql' param in PostgresOperator

### DIFF
--- a/airflow/providers/postgres/operators/postgres.py
+++ b/airflow/providers/postgres/operators/postgres.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Iterable, Mapping, Optional, Union
+from typing import Iterable, List, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
@@ -49,7 +49,7 @@ class PostgresOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: str,
+        sql: Union[str, List[str]],
         postgres_conn_id: str = 'postgres_default',
         autocommit: bool = False,
         parameters: Optional[Union[Mapping, Iterable]] = None,


### PR DESCRIPTION
According to the documentation sql param of PostgresOperator can receive a str representing a sql statement,    a list of str (sql statements), or reference to a template file.
But type annotation is `str` only. 
This leads to misunderstandings in IDE if list was used.

------
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
