### PR TITLE
Regression on pid reset to allow task start after heartbeat

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1044,6 +1044,7 @@ class TaskInstance(Base, LoggingMixin):
         self.refresh_from_db(session=session, lock_for_update=True)
         self.job_id = job_id
         self.hostname = get_hostname()
+        self.pid = None
 
         if not ignore_all_deps and not ignore_ti_state and self.state == State.SUCCESS:
             Stats.incr('previously_succeeded', 1, 1)
@@ -1113,7 +1114,6 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             session.add(Log(State.RUNNING, self))
         self.state = State.RUNNING
-        self.pid = None
         self.end_date = None
         if not test_mode:
             session.merge(self)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1113,6 +1113,7 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             session.add(Log(State.RUNNING, self))
         self.state = State.RUNNING
+        self.pid = None
         self.end_date = None
         if not test_mode:
             session.merge(self)


### PR DESCRIPTION
It's a bug we have found in production in my company.

Here is the bug pattern:
- The task job is started with a previous run of taskinstance (retry) and an old pid
- The job take time to start for some reason (db load, system load ...) and not update the pid in database
- Then the task is killed by heartbeat cause the pid is different from pid in database

It's critical in case of sensors with reschedule mode cause it trigger a fail immediately.