### PR TITLE
Fix failing test on MSSQL

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -296,6 +296,7 @@ class TestLocalTaskJob:
         ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
         ti.refresh_from_db()
         job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
+        settings.engine.dispose()
         process = multiprocessing.Process(target=job1.run)
         process.start()
         for _ in range(0, 50):

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -522,11 +522,12 @@ class TestLocalTaskJob:
         def success_callback(context):
             with shared_mem_lock:
                 success_callback_called.value += 1
+
             assert context['dag_run'].dag_id == 'test_mark_success'
 
         def task_function(ti):
-
             time.sleep(60)
+
             # This should not happen -- the state change should be noticed and the task should get killed
             with shared_mem_lock:
                 task_terminated_externally.value = 0
@@ -558,7 +559,7 @@ class TestLocalTaskJob:
         ti.state = State.SUCCESS
         session.merge(ti)
         session.commit()
-
+        ti.refresh_from_db()
         process.join()
         assert success_callback_called.value == 1
         assert task_terminated_externally.value == 1

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -309,7 +309,7 @@ class TestLocalTaskJob:
         session.merge(ti)
         session.commit()
 
-        process.join(timeout=10)
+        process.join()
         assert not process.is_alive()
         ti.refresh_from_db()
         assert State.SUCCESS == ti.state
@@ -559,7 +559,7 @@ class TestLocalTaskJob:
         session.merge(ti)
         session.commit()
 
-        process.join(timeout=10)
+        process.join()
         assert success_callback_called.value == 1
         assert task_terminated_externally.value == 1
         assert not process.is_alive()
@@ -600,7 +600,7 @@ class TestLocalTaskJob:
         process = multiprocessing.Process(target=job1.run)
         process.start()
         time.sleep(0.3)
-        process.join(timeout=10)
+        process.join()
         assert failure_callback_called.value == 1
         assert task_terminated_externally.value == 1
         assert not process.is_alive()
@@ -646,7 +646,7 @@ class TestLocalTaskJob:
             time.sleep(0.2)
         os.kill(process.pid, signal.SIGTERM)
         ti.refresh_from_db()
-        process.join(timeout=10)
+        process.join()
         assert failure_callback_called.value == 1
         assert task_terminated_externally.value == 1
         assert not process.is_alive()


### PR DESCRIPTION
This change fixes the failing test on MSSQL by disposing and creating a new connection
so as to use the new connection to make queries.

Also, timeouts on process join was removed because it's flaky

Closes: https://github.com/apache/airflow/issues/17326


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
