### PR TITLE
Add ExecStop to systemd service files.

### DIFF
--- a/scripts/systemd/airflow-worker.service
+++ b/scripts/systemd/airflow-worker.service
@@ -27,6 +27,7 @@ User=airflow
 Group=airflow
 Type=simple
 ExecStart=/bin/airflow celery worker
+ExecStop=/bin/airflow celery stop
 Restart=on-failure
 RestartSec=10s
 


### PR DESCRIPTION
Add `ExecStop` to systemd service files and use `airflow celery stop` command for graceful shutdown.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
