### PR TITLE
Handle and log exceptions raised during task callback

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1363,7 +1363,7 @@ class TaskInstance(Base, LoggingMixin):
                 try:
                     task.on_failure_callback(context)
                 except Exception:
-                    log.exception("Failed when executing execute on_failure_callback:")
+                    self.log.exception("Error when executing on_failure_callback")
         elif self.state == State.SUCCESS:
             task = self.task
             if task.on_success_callback is not None:
@@ -1371,7 +1371,7 @@ class TaskInstance(Base, LoggingMixin):
                 try:
                     task.on_success_callback(context)
                 except Exception:
-                    log.exception("Failed when executing execute on_success_callback:")
+                    self.log.exception("Error when executing on_success_callback")
         elif self.state == State.UP_FOR_RETRY:
             task = self.task
             if task.on_retry_callback is not None:
@@ -1380,7 +1380,7 @@ class TaskInstance(Base, LoggingMixin):
                 try:
                     task.on_retry_callback(context)
                 except Exception:
-                    log.exception("Failed when executing execute on_retry_callback:")
+                    self.log.exception("Error when executing on_retry_callback")
 
     @provide_session
     def run(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1360,18 +1360,27 @@ class TaskInstance(Base, LoggingMixin):
             if task.on_failure_callback is not None:
                 context = self.get_template_context()
                 context["exception"] = error
-                task.on_failure_callback(context)
+                try:
+                    task.on_failure_callback(context)
+                except Exception:
+                    log.exception("Failed when executing execute on_failure_callback:")
         elif self.state == State.SUCCESS:
             task = self.task
             if task.on_success_callback is not None:
                 context = self.get_template_context()
-                task.on_success_callback(context)
+                try:
+                    task.on_success_callback(context)
+                except Exception:
+                    log.exception("Failed when executing execute on_success_callback:")
         elif self.state == State.UP_FOR_RETRY:
             task = self.task
             if task.on_retry_callback is not None:
                 context = self.get_template_context()
                 context["exception"] = error
-                task.on_retry_callback(context)
+                try:
+                    task.on_retry_callback(context)
+                except Exception:
+                    log.exception("Failed when executing execute on_retry_callback:")
 
     @provide_session
     def run(

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1743,10 +1743,17 @@ class TestTaskInstance(unittest.TestCase):
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
-    def test_success_callback_handles_and_logs_exception(self):
+    @parameterized.expand(
+        [
+            (State.SUCCESS, "Error when executing on_success_callback"),
+            (State.UP_FOR_RETRY, "Error when executing on_retry_callback"),
+            (State.FAILED, "Error when executing on_failure_callback"),
+        ]
+    )
+    def test_finished_callbacks_handle_and_log_exception(self, finished_state, expected_message):
         called = completed = False
 
-        def on_success_callable(context):
+        def on_finish_callable(context):
             nonlocal called, completed
             called = True
             raise KeyError
@@ -1758,16 +1765,22 @@ class TestTaskInstance(unittest.TestCase):
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         )
         task = DummyOperator(
-            task_id='op', email='test@test.test', on_success_callback=on_success_callable, dag=dag
+            task_id='op',
+            email='test@test.test',
+            on_success_callback=on_finish_callable,
+            on_retry_callback=on_finish_callable,
+            on_failure_callback=on_finish_callable,
+            dag=dag,
         )
+
         ti = TI(task=task, execution_date=datetime.datetime.now())
         ti._log = mock.Mock()
-        ti.state = State.SUCCESS
+        ti.state = finished_state
         ti._run_finished_callback()
 
         assert called
         assert not completed
-        ti.log.exception.assert_called_once_with("Error when executing on_success_callback")
+        ti.log.exception.assert_called_once_with(expected_message)
 
     def test_handle_failure(self):
         start_date = timezone.datetime(2016, 6, 1)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1743,6 +1743,32 @@ class TestTaskInstance(unittest.TestCase):
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
+    def test_success_callback_handles_and_logs_exception(self):
+        called = completed = False
+
+        def on_success_callable(context):
+            nonlocal called, completed
+            called = True
+            raise KeyError
+            completed = True
+
+        dag = DAG(
+            'test_success_callback_handles_exception',
+            start_date=DEFAULT_DATE,
+            end_date=DEFAULT_DATE + datetime.timedelta(days=10),
+        )
+        task = DummyOperator(
+            task_id='op', email='test@test.test', on_success_callback=on_success_callable, dag=dag
+        )
+        ti = TI(task=task, execution_date=datetime.datetime.now())
+        ti._log = mock.Mock()
+        ti.state = State.SUCCESS
+        ti._run_finished_callback()
+
+        assert called
+        assert not completed
+        ti.log.exception.assert_called_once_with("Error when executing on_success_callback")
+
     def test_handle_failure(self):
         start_date = timezone.datetime(2016, 6, 1)
         dag = models.DAG(dag_id="test_handle_failure", schedule_interval=None, start_date=start_date)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Currently, an exception thrown in a task-level callback will be unhandled, so potentially important parts of the callback (for example, sending a slack notification after a job failure) may be skipped. This can make it really difficult to identify and fix errors in callbacks.

To demonstrate, here'a a simple DAG with an error in the callback function:
```python
from airflow.models import DAG
from airflow import utils
from airflow.operators.python import PythonOperator

def message():
    print('Hello, world.')

def broken_callback(context=None):
    print(f"Callback started")
    print(f"Task {context['taskID']} finished successfully")  # raises keyError
    print("Callback complete.")

with DAG(f'dag-with-broken-callback', schedule_interval=None, start_date=utils.dates.days_ago(1), ) as dag2:
    
    task = PythonOperator(
        task_id='task',
        python_callable=message,
        on_success_callback=broken_callback,
    )
```

The task execution logs will cut off where the exception is thrown:
```
[2021-07-30, 16:25:44 UTC] {logging_mixin.py:109} INFO - Hello, world.
[2021-07-30, 16:25:44 UTC] {python.py:151} INFO - Done. Returned value was: None
[2021-07-30, 16:25:44 UTC] {taskinstance.py:1144} INFO - Marking task as SUCCESS. dag_id=dag-with-broken-callback, task_id=task, execution_date=20210730T162540, start_date=20210730T162544, end_date=20210730T162544
[2021-07-30, 16:25:44 UTC] {local_task_job.py:151} INFO - Task exited with return code 0
[2021-07-30, 16:25:44 UTC] {logging_mixin.py:109} INFO - Callback started
<nothing>
```

And the unhandled exception will show up in the executor logs:
```
Running <TaskInstance: dag-with-broken-callback.task 2021-07-30T16:25:40.187231+00:00 [queued]> on host 466ea2c2e992
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 33, in <module>
    sys.exit(load_entry_point('apache-airflow', 'console_scripts', 'airflow')())
  File "/opt/airflow/airflow/__main__.py", line 40, in main
    args.func(args)
  File "/opt/airflow/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/opt/airflow/airflow/utils/cli.py", line 91, in wrapper
    return f(*args, **kwargs)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 256, in task_run
    _run_task_by_selected_method(args, dag, ti)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 84, in _run_task_by_selected_method
    _run_task_by_local_task_job(args, ti)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 141, in _run_task_by_local_task_job
    run_job.run()
  File "/opt/airflow/airflow/jobs/base_job.py", line 245, in run
    self._execute()
  File "/opt/airflow/airflow/jobs/local_task_job.py", line 128, in _execute
    self.handle_task_exit(return_code)
  File "/opt/airflow/airflow/jobs/local_task_job.py", line 163, in handle_task_exit
    self.task_instance._run_finished_callback(error=error)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1377, in _run_finished_callback
    task.on_success_callback(context)
  File "/opt/airflow/dags/test_callback.py", line 10, in broken_callback
    print(f"Task {context['taskID']} finished successfully")  # raises keyError
KeyError: 'taskID'
[2021-07-30 16:25:45,078] {sequential_executor.py:66} ERROR - Failed to execute task Command '['airflow', 'tasks', 'run', 'dag-with-broken-callback', 'task', '2021-07-30T16:25:40.187231+00:00', '--local', '--pool', 'default_pool', '--subd
ir', '/opt/airflow/dags/test_callback.py']' returned non-zero exit status 1..
[2021-07-30 16:25:45,079] {scheduler_job.py:577} INFO - Executor reports execution of dag-with-broken-callback.task execution_date=2021-07-30 16:25:40.187231+00:00 exited with status failed for try_number 1
[2021-07-30 16:25:45,129] {dagrun.py:435} INFO - Marking run <DagRun dag-with-broken-callback @ 2021-07-30 16:25:40.187231+00:00: manual__2021-07-30T16:25:40.187231+00:00, externally triggered: True> successful
```

By handling this exception and logging it, we can make callback failures much easier to identify and fix. After this change, the task logs look like this:
```
[2021-07-30, 16:26:45 UTC] {logging_mixin.py:109} INFO - Hello, world.
[2021-07-30, 16:26:45 UTC] {python.py:151} INFO - Done. Returned value was: None
[2021-07-30, 16:26:45 UTC] {taskinstance.py:1144} INFO - Marking task as SUCCESS. dag_id=dag-with-broken-callback, task_id=task, execution_date=20210730T162642, start_date=20210730T162645, end_date=20210730T162645
[2021-07-30, 16:26:45 UTC] {local_task_job.py:151} INFO - Task exited with return code 0
[2021-07-30, 16:26:45 UTC] {logging_mixin.py:109} INFO - Callback started
[2021-07-30, 16:26:45 UTC] {taskinstance.py:1357} ERROR - Failed when executing on_success_callback
Traceback (most recent call last):
  File "/opt/airflow/airflow/models/taskinstance.py", line 1355, in _run_finished_callback
    task.on_success_callback(context)
  File "/opt/airflow/dags/test_callback.py", line 10, in broken_callback
    print(f"Task {context['taskID']} finished successfully")  # raises keyError
KeyError: 'taskID'
[2021-07-30, 16:26:45 UTC] {local_task_job.py:258} INFO - 0 downstream tasks scheduled from follow-on schedule check
```

This removes the stacktrace from the executor logs. If we want to avoid changing this behaviour then we could also re-raise the exception after logging. Thoughts?