### PR TITLE
Add Docker Sensor

### DIFF
--- a/airflow/providers/docker/hooks/docker.py
+++ b/airflow/providers/docker/hooks/docker.py
@@ -17,12 +17,70 @@
 # under the License.
 from typing import Dict, Optional
 
-from docker import APIClient
+from docker import APIClient, tls
 from docker.errors import APIError
 
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+
+def get_client(
+    docker_conn_id=None,
+    docker_url=None,
+    api_version=None,
+    tls_ca_cert=None,
+    tls_client_cert=None,
+    tls_client_key=None,
+    tls_ssl_version=None,
+    tls_hostname=None,
+):
+    """
+    Build an Docker client for use from network or connection configuration to use with a DockerClientHook
+
+    :param docker_conn_id: The :ref:`Docker connection id <howto/connection:docker>`
+    :type docker_conn_id: str
+    :param docker_url: URL of the host running the docker daemon.
+    :type docker_url: str
+    :param api_version: Remote API version. Set to ``auto`` to automatically
+        detect the server's version.
+    :type api_version: str
+    :param tls_ca_cert: Path to a PEM-encoded certificate authority
+        to secure the docker connection.
+    :type tls_ca_cert: str
+    :param tls_client_cert: Path to the PEM-encoded certificate
+        used to authenticate docker client.
+    :type tls_client_cert: str
+    :param tls_client_key: Path to the PEM-encoded key used to authenticate docker client.
+    :type tls_client_key: str
+    :param tls_ssl_version: Version of SSL to use when communicating with docker daemon.
+    :type tls_ssl_version: str
+    :param tls_hostname: Hostname to match against
+        the docker server certificate or False to disable the check.
+    :type tls_hostname: str or bool
+    """
+    tls_config = None
+    if tls_ca_cert and tls_client_cert and tls_client_key:
+        # Ignore type error on SSL version here - it is deprecated and type annotation is wrong
+        # it should be string
+        tls_config = tls.TLSConfig(
+            ca_cert=tls_ca_cert,
+            client_cert=(tls_client_cert, tls_client_key),
+            verify=True,
+            ssl_version=tls_ssl_version,
+            assert_hostname=tls_hostname,
+        )
+        docker_url = docker_url.replace('tcp://', 'https://')
+    if docker_conn_id:
+        hook = DockerHook(
+            docker_conn_id=docker_conn_id,
+            base_url=docker_url,
+            version=api_version,
+            tls=tls_config,
+        )
+        return hook.get_conn()
+    else:
+        return APIClient(base_url=docker_url, version=api_version, tls=tls_config)
 
 
 class DockerHook(BaseHook, LoggingMixin):

--- a/airflow/providers/docker/hooks/docker_client.py
+++ b/airflow/providers/docker/hooks/docker_client.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,48 +14,27 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Implements Docker operator"""
+
+import ast
+from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List, Optional, Union
 
+from docker import APIClient
+from docker.errors import APIError
 from docker.types import Mount
 
 from airflow.exceptions import AirflowException
-from airflow.models import BaseOperator
-from airflow.providers.docker.hooks.docker import get_client
-from airflow.providers.docker.hooks.docker_client import DockerClientHook
+from airflow.hooks.base import BaseHook
+from airflow.utils.log.logging_mixin import LoggingMixin
 
 
-class DockerOperator(BaseOperator):
+class DockerClientHook(BaseHook, LoggingMixin):
     """
-    Execute a command inside a docker container.
-
-    By default, a temporary directory is
-    created on the host and mounted into a container to allow storing files
-    that together exceed the default disk size of 10GB in a container.
-    In this case The path to the mounted directory can be accessed
-    via the environment variable ``AIRFLOW_TMP_DIR``.
-
-    If the volume cannot be mounted, warning is printed and an attempt is made to execute the docker
-    command without the temporary folder mounted. This is to make it works by default with remote docker
-    engine or when you run docker-in-docker solution and temporary directory is not shared with the
-    docker engine. Warning is printed in logs in this case.
-
-    If you know you run DockerOperator with remote engine or via docker-in-docker
-    you should set ``mount_tmp_dir`` parameter to False. In this case, you can still use
-    ``mounts`` parameter to mount already existing named volumes in your Docker Engine
-    to achieve similar capability where you can store files exceeding default disk size
-    of the container,
-
-    If a login to a private registry is required prior to pulling the image, a
-    Docker connection needs to be configured in Airflow and the connection ID
-    be provided with the parameter ``docker_conn_id``.
+    Interact with a Docker engine
 
     :param image: Docker image from which to create the container.
         If image tag is omitted, "latest" will be used.
     :type image: str
-    :param api_version: Remote API version. Set to ``auto`` to automatically
-        detect the server's version.
-    :type api_version: str
     :param command: Command to be run in the container. (templated)
     :type command: str or list
     :param container_name: Name of the container. Optional (templated)
@@ -65,9 +43,6 @@ class DockerOperator(BaseOperator):
         This value gets multiplied with 1024. See
         https://docs.docker.com/engine/reference/run/#cpu-share-constraint
     :type cpus: float
-    :param docker_url: URL of the host running the docker daemon.
-        Default is unix://var/run/docker.sock
-    :type docker_url: str
     :param environment: Environment variables to set in the container. (templated)
     :type environment: dict
     :param private_environment: Private environment variables to set in the container.
@@ -84,19 +59,6 @@ class DockerOperator(BaseOperator):
     :type host_tmp_dir: str
     :param network_mode: Network mode for the container.
     :type network_mode: str
-    :param tls_ca_cert: Path to a PEM-encoded certificate authority
-        to secure the docker connection.
-    :type tls_ca_cert: str
-    :param tls_client_cert: Path to the PEM-encoded certificate
-        used to authenticate docker client.
-    :type tls_client_cert: str
-    :param tls_client_key: Path to the PEM-encoded key used to authenticate docker client.
-    :type tls_client_key: str
-    :param tls_hostname: Hostname to match against
-        the docker server certificate or False to disable the check.
-    :type tls_hostname: str or bool
-    :param tls_ssl_version: Version of SSL to use when communicating with docker daemon.
-    :type tls_ssl_version: str
     :param mount_tmp_dir: Specify whether the temporary directory should be bind-mounted
         from the host to the container. Defaults to True
     :type mount_tmp_dir: bool
@@ -115,11 +77,6 @@ class DockerOperator(BaseOperator):
     :param working_dir: Working directory to
         set on the container (equivalent to the -w switch the docker client)
     :type working_dir: str
-    :param xcom_all: Push all the stdout or just the last line.
-        The default is False (last line).
-    :type xcom_all: bool
-    :param docker_conn_id: The :ref:`Docker connection id <howto/connection:docker>`
-    :type docker_conn_id: str
     :param dns: Docker custom DNS servers
     :type dns: list[str]
     :param dns_search: Docker custom DNS search domain
@@ -140,40 +97,25 @@ class DockerOperator(BaseOperator):
     :type cap_add: list[str]
     """
 
-    template_fields = ('command', 'environment', 'container_name')
-    template_ext = (
-        '.sh',
-        '.bash',
-    )
-
     def __init__(
         self,
-        *,
+        cli: APIClient,
         image: str,
-        api_version: Optional[str] = None,
         command: Optional[Union[str, List[str]]] = None,
         container_name: Optional[str] = None,
         cpus: float = 1.0,
-        docker_url: str = 'unix://var/run/docker.sock',
         environment: Optional[Dict] = None,
         private_environment: Optional[Dict] = None,
         force_pull: bool = False,
         mem_limit: Optional[Union[float, str]] = None,
         host_tmp_dir: Optional[str] = None,
         network_mode: Optional[str] = None,
-        tls_ca_cert: Optional[str] = None,
-        tls_client_cert: Optional[str] = None,
-        tls_client_key: Optional[str] = None,
-        tls_hostname: Optional[Union[str, bool]] = None,
-        tls_ssl_version: Optional[str] = None,
         mount_tmp_dir: bool = True,
         tmp_dir: str = '/tmp/airflow',
         user: Optional[Union[str, int]] = None,
         mounts: Optional[List[Mount]] = None,
         entrypoint: Optional[Union[str, List[str]]] = None,
         working_dir: Optional[str] = None,
-        xcom_all: bool = False,
-        docker_conn_id: Optional[str] = None,
         dns: Optional[List[str]] = None,
         dns_search: Optional[List[str]] = None,
         auto_remove: bool = False,
@@ -186,14 +128,13 @@ class DockerOperator(BaseOperator):
     ) -> None:
 
         super().__init__(**kwargs)
-        self.api_version = api_version
-        self.auto_remove = auto_remove
+        self.cli = cli
         self.command = command
         self.container_name = container_name
         self.cpus = cpus
         self.dns = dns
         self.dns_search = dns_search
-        self.docker_url = docker_url
+        self.auto_remove = auto_remove
         self.environment = environment or {}
         self._private_environment = private_environment or {}
         self.force_pull = force_pull
@@ -201,79 +142,128 @@ class DockerOperator(BaseOperator):
         self.mem_limit = mem_limit
         self.host_tmp_dir = host_tmp_dir
         self.network_mode = network_mode
-        self.tls_ca_cert = tls_ca_cert
-        self.tls_client_cert = tls_client_cert
-        self.tls_client_key = tls_client_key
-        self.tls_hostname = tls_hostname
-        self.tls_ssl_version = tls_ssl_version
         self.mount_tmp_dir = mount_tmp_dir
         self.tmp_dir = tmp_dir
         self.user = user
         self.mounts = mounts or []
         self.entrypoint = entrypoint
         self.working_dir = working_dir
-        self.xcom_all = xcom_all
-        self.docker_conn_id = docker_conn_id
         self.shm_size = shm_size
         self.tty = tty
         self.privileged = privileged
         self.cap_add = cap_add
         self.extra_hosts = extra_hosts
-        if kwargs.get('xcom_push') is not None:
-            raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
+        self.container = None
 
-        self.cli = None
-        self.cli_hook = None
-
-    def execute(self, context) -> Optional[str]:
-        self.cli = get_client(
-            self.docker_conn_id,
-            self.docker_url,
-            self.api_version,
-            self.tls_ca_cert,
-            self.tls_client_cert,
-            self.tls_client_key,
-            self.tls_ssl_version,
-            self.tls_hostname,
-        )
+    def run_image(self) -> Optional[str]:
+        """Run the docker image and command associated with this hook"""
+        self.log.info('Starting docker container from image %s', self.image)
         if not self.cli:
             raise Exception("The 'cli' should be initialized before!")
+        if self.force_pull or not self.cli.images(name=self.image):
+            self._pull_image()
+        if self.mount_tmp_dir:
+            with TemporaryDirectory(prefix='airflowtmp', dir=self.host_tmp_dir) as host_tmp_dir_generated:
+                tmp_mount = Mount(self.tmp_dir, host_tmp_dir_generated, "bind")
+                try:
+                    return self._run_image_with_mounts(self.mounts + [tmp_mount], add_tmp_variable=True)
+                except APIError as e:
+                    if host_tmp_dir_generated in str(e):
+                        self.log.warning(
+                            "Using remote engine or docker-in-docker and mounting temporary "
+                            "volume from host is not supported. Falling back to "
+                            "`mount_tmp_dir=False` mode. You can set `mount_tmp_dir` parameter"
+                            " to False to disable mounting and remove the warning"
+                        )
+                        return self._run_image_with_mounts(self.mounts, add_tmp_variable=False)
+                    raise
+        else:
+            return self._run_image_with_mounts(self.mounts, add_tmp_variable=False)
 
-        self.cli_hook = DockerClientHook(
-            self.cli,
-            self.image,
-            self.command,
-            self.container_name,
-            self.cpus,
-            self.environment,
-            self._private_environment,
-            self.force_pull,
-            self.mem_limit,
-            self.host_tmp_dir,
-            self.network_mode,
-            self.mount_tmp_dir,
-            self.tmp_dir,
-            self.user,
-            self.mounts,
-            self.entrypoint,
-            self.working_dir,
-            self.dns,
-            self.dns_search,
-            self.shm_size,
-            self.tty,
-            self.privileged,
-            self.cap_add,
-            self.extra_hosts,
+    def _run_image_with_mounts(self, target_mounts, add_tmp_variable: bool) -> Optional[str]:
+        if add_tmp_variable:
+            self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
+        else:
+            self.environment.pop('AIRFLOW_TMP_DIR', None)
+        self.container = self.cli.create_container(
+            command=self.format_command(self.command),
+            name=self.container_name,
+            environment={**self.environment, **self._private_environment},
+            host_config=self.cli.create_host_config(
+                auto_remove=False,
+                mounts=target_mounts,
+                network_mode=self.network_mode,
+                shm_size=self.shm_size,
+                dns=self.dns,
+                dns_search=self.dns_search,
+                cpu_shares=int(round(self.cpus * 1024)),
+                mem_limit=self.mem_limit,
+                cap_add=self.cap_add,
+                extra_hosts=self.extra_hosts,
+                privileged=self.privileged,
+            ),
+            image=self.image,
+            user=self.user,
+            entrypoint=self.format_command(self.entrypoint),
+            working_dir=self.working_dir,
+            tty=self.tty,
         )
+        lines = self.cli.attach(container=self.container['Id'], stdout=True, stderr=True, stream=True)
+        try:
+            self.cli.start(self.container['Id'])
 
-        (res_lines, line) = self.cli_hook.run_image()
-        if self.do_xcom_push:
-            return res_lines if self.xcom_all else line
+            line = ''
+            res_lines = []
+            for line in lines:
+                if hasattr(line, 'decode'):
+                    # Note that lines returned can also be byte sequences so we have to handle decode here
+                    line = line.decode('utf-8')
+                line = line.strip()
+                res_lines.append(line)
+                self.log.info(line)
+
+            result = self.cli.wait(self.container['Id'])
+            if result['StatusCode'] != 0:
+                res_lines = "\n".join(res_lines)
+                raise AirflowException('docker container failed: ' + repr(result) + f"lines {res_lines}")
+            return (res_lines, line)
+        finally:
+            if self.auto_remove:
+                self.cli.remove_container(self.container['Id'])
+
+    def _pull_image(self):
+        self.log.info('Pulling docker image %s', self.image)
+        latest_status = {}
+        for output in self.cli.pull(self.image, stream=True, decode=True):
+            if isinstance(output, str):
+                self.log.info("%s", output)
+                continue
+            if isinstance(output, dict) and 'status' in output:
+                output_status = output["status"]
+                if 'id' not in output:
+                    self.log.info("%s", output_status)
+                    continue
+
+                output_id = output["id"]
+                if latest_status.get(output_id) != output_status:
+                    self.log.info("%s: %s", output_id, output_status)
+                    latest_status[output_id] = output_status
+
+    def stop(self):
+        self.log.info('Stopping docker container')
+        self.cli.stop(self.container['Id'])
 
     @staticmethod
     def format_command(command: Union[str, List[str]]) -> Union[List[str], str]:
-        return DockerClientHook.format_command(command)
+        """
+        Retrieve command(s). if command string starts with [, it returns the command list)
 
-    def on_kill(self) -> None:
-        if self.cli_hook is not None:
-            self.cli_hook.stop()
+        :param command: Docker command or entrypoint
+        :type command: str | List[str]
+
+        :return: the command (or commands)
+        :rtype: str | List[str]
+        """
+        if isinstance(command, str) and command.strip().find('[') == 0:
+            return ast.literal_eval(command)
+        return command

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -21,6 +21,7 @@ import requests
 from docker import types
 
 from airflow.exceptions import AirflowException
+from airflow.providers.docker.hooks.docker import get_client
 from airflow.providers.docker.operators.docker import DockerOperator
 from airflow.utils.strings import get_random_string
 
@@ -102,7 +103,16 @@ class DockerSwarmOperator(DockerOperator):
         self.service = None
 
     def execute(self, context) -> None:
-        self.cli = self._get_cli()
+        self.cli = get_client(
+            self.docker_conn_id,
+            self.docker_url,
+            self.api_version,
+            self.tls_ca_cert,
+            self.tls_client_cert,
+            self.tls_client_key,
+            self.tls_ssl_version,
+            self.tls_hostname,
+        )
 
         self.environment['AIRFLOW_TMP_DIR'] = self.tmp_dir
 

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -42,6 +42,10 @@ integrations:
     external-doc-url: https://docs.docker.com/engine/swarm/
     logo: /integration-logos/docker/Docker-Swarm.png
     tags: [software]
+  - integration-name: Docker Client
+    external-doc-url: https://docker-py.readthedocs.io/en/stable/api.html
+    logo: /integration-logos/docker/Docker.png
+    tags: [software]
 
 operators:
   - integration-name: Docker
@@ -51,10 +55,19 @@ operators:
     python-modules:
       - airflow.providers.docker.operators.docker_swarm
 
+sensors:
+  - integration-name: Docker
+    python-modules:
+      - airflow.providers.docker.sensors.docker
+
 hooks:
   - integration-name: Docker
     python-modules:
       - airflow.providers.docker.hooks.docker
+  - integration-name: Docker Client
+    python-modules:
+      - airflow.providers.docker.hooks.docker_client
 
 hook-class-names:
   - airflow.providers.docker.hooks.docker.DockerHook
+  - airflow.providers.docker.hooks.docker.DockerClientHook

--- a/airflow/providers/docker/sensors/__init__.py
+++ b/airflow/providers/docker/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/docker/hooks/test_docker.py
+++ b/tests/providers/docker/hooks/test_docker.py
@@ -163,3 +163,28 @@ class TestDockerHook(unittest.TestCase):
         hook = hook_class_mock.return_value
         assert hook_class_mock.call_count == 1
         assert hook.get_conn.call_count == 1
+
+    @mock.patch('airflow.providers.docker.hooks.docker.tls.TLSConfig')
+    def test_get_client_with_tls(self, tls_class_mock, docker_client_mock):
+        tls_mock = mock.Mock()
+        tls_class_mock.return_value = tls_mock
+
+        get_client(
+            docker_url='unix://var/run/docker.sock',
+            api_version='1.19',
+            tls_client_cert='cert.pem',
+            tls_ca_cert='ca.pem',
+            tls_client_key='key.pem',
+        )
+
+        tls_class_mock.assert_called_once_with(
+            assert_hostname=None,
+            ca_cert='ca.pem',
+            client_cert=('cert.pem', 'key.pem'),
+            ssl_version=None,
+            verify=True,
+        )
+
+        docker_client_mock.assert_called_once_with(
+            base_url='unix://var/run/docker.sock', tls=tls_mock, version='1.19'
+        )

--- a/tests/providers/docker/hooks/test_docker_client.py
+++ b/tests/providers/docker/hooks/test_docker_client.py
@@ -1,0 +1,319 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+import unittest
+from unittest import mock
+from unittest.mock import call
+
+import pytest
+from docker.errors import APIError
+
+from airflow.exceptions import AirflowException
+
+try:
+    from docker import APIClient
+    from docker.types import Mount
+
+    from airflow.providers.docker.hooks.docker_client import DockerClientHook
+except ImportError:
+    pass
+
+
+TEMPDIR_MOCK_RETURN_VALUE = '/mkdtemp'
+
+
+class TestDockerClientHook(unittest.TestCase):
+    def setUp(self):
+        self.tempdir_patcher = mock.patch('airflow.providers.docker.hooks.docker_client.TemporaryDirectory')
+        self.tempdir_mock = self.tempdir_patcher.start()
+        self.tempdir_mock.return_value.__enter__.return_value = TEMPDIR_MOCK_RETURN_VALUE
+
+        self.client_mock = mock.Mock(spec=APIClient)
+        self.client_mock.create_container.return_value = {'Id': 'some_id'}
+        self.client_mock.images.return_value = []
+        self.client_mock.attach.return_value = ['container log 1', 'container log 2']
+        self.client_mock.pull.return_value = {"status": "pull log"}
+        self.client_mock.wait.return_value = {"StatusCode": 0}
+        self.client_mock.create_host_config.return_value = mock.Mock()
+        self.client_class_patcher = mock.patch(
+            'airflow.providers.docker.hooks.docker_client.APIClient',
+            return_value=self.client_mock,
+        )
+        self.client_class_mock = self.client_class_patcher.start()
+
+    def tearDown(self) -> None:
+        self.tempdir_patcher.stop()
+        self.client_class_patcher.stop()
+
+    def test_execute(self):
+        hook = DockerClientHook(
+            cli=self.client_mock,
+            command='env',
+            environment={'UNIT': 'TEST'},
+            private_environment={'PRIVATE': 'MESSAGE'},
+            image='ubuntu:latest',
+            network_mode='bridge',
+            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
+            entrypoint='["sh", "-c"]',
+            working_dir='/container/path',
+            shm_size=1000,
+            host_tmp_dir='/host/airflow',
+            container_name='test_container',
+            tty=True,
+        )
+        hook.run_image()
+
+        self.client_mock.create_container.assert_called_once_with(
+            command='env',
+            name='test_container',
+            environment={'AIRFLOW_TMP_DIR': '/tmp/airflow', 'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
+            host_config=self.client_mock.create_host_config.return_value,
+            image='ubuntu:latest',
+            user=None,
+            entrypoint=['sh', '-c'],
+            working_dir='/container/path',
+            tty=True,
+        )
+        self.client_mock.create_host_config.assert_called_once_with(
+            mounts=[
+                Mount(source='/host/path', target='/container/path', type='bind'),
+                Mount(source='/mkdtemp', target='/tmp/airflow', type='bind'),
+            ],
+            network_mode='bridge',
+            shm_size=1000,
+            cpu_shares=1024,
+            mem_limit=None,
+            auto_remove=False,
+            dns=None,
+            dns_search=None,
+            cap_add=None,
+            extra_hosts=None,
+            privileged=False,
+        )
+        self.tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
+        self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
+        self.client_mock.attach.assert_called_once_with(
+            container='some_id', stdout=True, stderr=True, stream=True
+        )
+        self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
+        self.client_mock.wait.assert_called_once_with('some_id')
+        assert hook.cli.pull('ubuntu:latest', stream=True, decode=True) == self.client_mock.pull.return_value
+
+    def test_execute_no_temp_dir(self):
+        hook = DockerClientHook(
+            cli=self.client_mock,
+            command='env',
+            environment={'UNIT': 'TEST'},
+            private_environment={'PRIVATE': 'MESSAGE'},
+            image='ubuntu:latest',
+            network_mode='bridge',
+            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
+            mount_tmp_dir=False,
+            entrypoint='["sh", "-c"]',
+            working_dir='/container/path',
+            shm_size=1000,
+            host_tmp_dir='/host/airflow',
+            container_name='test_container',
+            tty=True,
+        )
+        hook.run_image()
+
+        self.client_mock.create_container.assert_called_once_with(
+            command='env',
+            name='test_container',
+            environment={'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
+            host_config=self.client_mock.create_host_config.return_value,
+            image='ubuntu:latest',
+            user=None,
+            entrypoint=['sh', '-c'],
+            working_dir='/container/path',
+            tty=True,
+        )
+        self.client_mock.create_host_config.assert_called_once_with(
+            mounts=[
+                Mount(source='/host/path', target='/container/path', type='bind'),
+            ],
+            network_mode='bridge',
+            shm_size=1000,
+            cpu_shares=1024,
+            mem_limit=None,
+            auto_remove=False,
+            dns=None,
+            dns_search=None,
+            cap_add=None,
+            extra_hosts=None,
+            privileged=False,
+        )
+        self.tempdir_mock.assert_not_called()
+        self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
+        self.client_mock.attach.assert_called_once_with(
+            container='some_id', stdout=True, stderr=True, stream=True
+        )
+        self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
+        self.client_mock.wait.assert_called_once_with('some_id')
+        assert hook.cli.pull('ubuntu:latest', stream=True, decode=True) == self.client_mock.pull.return_value
+
+    def test_execute_fallback_temp_dir(self):
+        self.client_mock.create_container.side_effect = [
+            APIError(message="wrong path: " + TEMPDIR_MOCK_RETURN_VALUE),
+            {'Id': 'some_id'},
+        ]
+        hook = DockerClientHook(
+            cli=self.client_mock,
+            command='env',
+            environment={'UNIT': 'TEST'},
+            private_environment={'PRIVATE': 'MESSAGE'},
+            image='ubuntu:latest',
+            network_mode='bridge',
+            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
+            mount_tmp_dir=True,
+            entrypoint='["sh", "-c"]',
+            working_dir='/container/path',
+            shm_size=1000,
+            host_tmp_dir='/host/airflow',
+            container_name='test_container',
+            tty=True,
+        )
+        with self.assertLogs(hook.log, level=logging.WARNING) as captured:
+            hook.run_image()
+            assert (
+                "WARNING:airflow.providers.docker.hooks.docker_client.DockerClientHook:Using remote engine "
+                "or docker-in-docker and mounting temporary volume from host is not supported"
+                in captured.output[0]
+            )
+        self.client_mock.create_container.assert_has_calls(
+            [
+                call(
+                    command='env',
+                    name='test_container',
+                    environment={'AIRFLOW_TMP_DIR': '/tmp/airflow', 'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
+                    host_config=self.client_mock.create_host_config.return_value,
+                    image='ubuntu:latest',
+                    user=None,
+                    entrypoint=['sh', '-c'],
+                    working_dir='/container/path',
+                    tty=True,
+                ),
+                call(
+                    command='env',
+                    name='test_container',
+                    environment={'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
+                    host_config=self.client_mock.create_host_config.return_value,
+                    image='ubuntu:latest',
+                    user=None,
+                    entrypoint=['sh', '-c'],
+                    working_dir='/container/path',
+                    tty=True,
+                ),
+            ]
+        )
+        self.client_mock.create_host_config.assert_has_calls(
+            [
+                call(
+                    mounts=[
+                        Mount(source='/host/path', target='/container/path', type='bind'),
+                        Mount(source='/mkdtemp', target='/tmp/airflow', type='bind'),
+                    ],
+                    network_mode='bridge',
+                    shm_size=1000,
+                    cpu_shares=1024,
+                    mem_limit=None,
+                    auto_remove=False,
+                    dns=None,
+                    dns_search=None,
+                    cap_add=None,
+                    extra_hosts=None,
+                    privileged=False,
+                ),
+                call(
+                    mounts=[
+                        Mount(source='/host/path', target='/container/path', type='bind'),
+                    ],
+                    network_mode='bridge',
+                    shm_size=1000,
+                    cpu_shares=1024,
+                    mem_limit=None,
+                    auto_remove=False,
+                    dns=None,
+                    dns_search=None,
+                    cap_add=None,
+                    extra_hosts=None,
+                    privileged=False,
+                ),
+            ]
+        )
+        self.tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
+        self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
+        self.client_mock.attach.assert_called_once_with(
+            container='some_id', stdout=True, stderr=True, stream=True
+        )
+        self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
+        self.client_mock.wait.assert_called_once_with('some_id')
+        assert hook.cli.pull('ubuntu:latest', stream=True, decode=True) == self.client_mock.pull.return_value
+
+    def test_private_environment_is_private(self):
+        hook = DockerClientHook(
+            cli=self.client_mock, private_environment={'PRIVATE': 'MESSAGE'}, image='ubuntu:latest'
+        )
+        assert hook._private_environment == {
+            'PRIVATE': 'MESSAGE'
+        }, "To keep this private, it must be an underscored attribute."
+
+    def test_execute_container_fails(self):
+        self.client_mock.wait.return_value = {"StatusCode": 1}
+        hook = DockerClientHook(cli=self.client_mock, image='ubuntu')
+        with pytest.raises(AirflowException):
+            hook.run_image()
+
+    def test_auto_remove_container_fails(self):
+        self.client_mock.wait.return_value = {"StatusCode": 1}
+        hook = DockerClientHook(cli=self.client_mock, image='ubuntu', auto_remove=True)
+        hook.container = {'Id': 'some_id'}
+        with pytest.raises(AirflowException):
+            hook.run_image()
+
+        self.client_mock.remove_container.assert_called_once_with('some_id')
+
+    @staticmethod
+    def test_stop():
+        client_mock = mock.Mock(spec=APIClient)
+
+        hook = DockerClientHook(cli=client_mock, image='ubuntu')
+        hook.container = {'Id': 'some_id'}
+
+        hook.stop()
+
+        client_mock.stop.assert_called_once_with('some_id')
+
+    def test_extra_hosts(self):
+        hosts_obj = mock.Mock()
+        hook = DockerClientHook(cli=self.client_mock, image='test', extra_hosts=hosts_obj)
+        hook.run_image()
+        self.client_mock.create_container.assert_called_once()
+        assert 'host_config' in self.client_mock.create_container.call_args[1]
+        assert 'extra_hosts' in self.client_mock.create_host_config.call_args[1]
+        assert hosts_obj is self.client_mock.create_host_config.call_args[1]['extra_hosts']
+
+    def test_privileged(self):
+        privileged = mock.Mock()
+        hook = DockerClientHook(cli=self.client_mock, image='test', privileged=privileged)
+        hook.run_image()
+        self.client_mock.create_container.assert_called_once()
+        assert 'host_config' in self.client_mock.create_container.call_args[1]
+        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
+        assert privileged is self.client_mock.create_host_config.call_args[1]['privileged']

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -119,34 +119,6 @@ class TestDockerOperator(unittest.TestCase):
             'PRIVATE': 'MESSAGE'
         }, "To keep this private, it must be an underscored attribute."
 
-    @mock.patch('airflow.providers.docker.operators.docker.tls.TLSConfig')
-    def test_execute_tls(self, tls_class_mock):
-        tls_mock = mock.Mock()
-        tls_class_mock.return_value = tls_mock
-
-        operator = DockerOperator(
-            docker_url='tcp://127.0.0.1:2376',
-            image='ubuntu',
-            owner='unittest',
-            task_id='unittest',
-            tls_client_cert='cert.pem',
-            tls_ca_cert='ca.pem',
-            tls_client_key='key.pem',
-        )
-        operator.execute(None)
-
-        tls_class_mock.assert_called_once_with(
-            assert_hostname=None,
-            ca_cert='ca.pem',
-            client_cert=('cert.pem', 'key.pem'),
-            ssl_version=None,
-            verify=True,
-        )
-
-        self.client_class_mock.assert_called_once_with(
-            base_url='https://127.0.0.1:2376', tls=tls_mock, version=None
-        )
-
     def test_execute_unicode_logs(self):
         self.hook_mock.run_image.return_value = (['unicode container log 😁'], '')
 

--- a/tests/providers/docker/operators/test_docker.py
+++ b/tests/providers/docker/operators/test_docker.py
@@ -18,10 +18,8 @@
 import logging
 import unittest
 from unittest import mock
-from unittest.mock import call
 
 import pytest
-from docker.errors import APIError
 
 from airflow.exceptions import AirflowException
 
@@ -29,7 +27,7 @@ try:
     from docker import APIClient
     from docker.types import Mount
 
-    from airflow.providers.docker.hooks.docker import DockerHook
+    from airflow.providers.docker.hooks.docker_client import DockerClientHook
     from airflow.providers.docker.operators.docker import DockerOperator
 except ImportError:
     pass
@@ -40,25 +38,24 @@ TEMPDIR_MOCK_RETURN_VALUE = '/mkdtemp'
 
 class TestDockerOperator(unittest.TestCase):
     def setUp(self):
-        self.tempdir_patcher = mock.patch('airflow.providers.docker.operators.docker.TemporaryDirectory')
-        self.tempdir_mock = self.tempdir_patcher.start()
-        self.tempdir_mock.return_value.__enter__.return_value = TEMPDIR_MOCK_RETURN_VALUE
+
+        self.hook_mock = mock.Mock(spec=DockerClientHook)
+        self.hook_mock.run_image.return_value = (['container log 1', 'container log 2'], 'container log 2')
+        self.hook_class_patcher = mock.patch(
+            'airflow.providers.docker.operators.docker.DockerClientHook',
+            return_value=self.hook_mock,
+        )
+        self.hook_class_mock = self.hook_class_patcher.start()
 
         self.client_mock = mock.Mock(spec=APIClient)
-        self.client_mock.create_container.return_value = {'Id': 'some_id'}
-        self.client_mock.images.return_value = []
-        self.client_mock.attach.return_value = ['container log 1', 'container log 2']
-        self.client_mock.pull.return_value = {"status": "pull log"}
-        self.client_mock.wait.return_value = {"StatusCode": 0}
-        self.client_mock.create_host_config.return_value = mock.Mock()
         self.client_class_patcher = mock.patch(
-            'airflow.providers.docker.operators.docker.APIClient',
+            'airflow.providers.docker.hooks.docker.APIClient',
             return_value=self.client_mock,
         )
         self.client_class_mock = self.client_class_patcher.start()
 
     def tearDown(self) -> None:
-        self.tempdir_patcher.stop()
+        self.hook_class_patcher.stop()
         self.client_class_patcher.stop()
 
     def test_execute(self):
@@ -85,209 +82,34 @@ class TestDockerOperator(unittest.TestCase):
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'
         )
 
-        self.client_mock.create_container.assert_called_once_with(
-            command='env',
-            name='test_container',
-            environment={'AIRFLOW_TMP_DIR': '/tmp/airflow', 'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
-            host_config=self.client_mock.create_host_config.return_value,
-            image='ubuntu:latest',
-            user=None,
-            entrypoint=['sh', '-c'],
-            working_dir='/container/path',
-            tty=True,
-        )
-        self.client_mock.create_host_config.assert_called_once_with(
-            mounts=[
-                Mount(source='/host/path', target='/container/path', type='bind'),
-                Mount(source='/mkdtemp', target='/tmp/airflow', type='bind'),
-            ],
-            network_mode='bridge',
-            shm_size=1000,
-            cpu_shares=1024,
-            mem_limit=None,
-            auto_remove=False,
-            dns=None,
-            dns_search=None,
-            cap_add=None,
-            extra_hosts=None,
-            privileged=False,
-        )
-        self.tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
-        self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
-        self.client_mock.attach.assert_called_once_with(
-            container='some_id', stdout=True, stderr=True, stream=True
-        )
-        self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
-        self.client_mock.wait.assert_called_once_with('some_id')
-        assert (
-            operator.cli.pull('ubuntu:latest', stream=True, decode=True) == self.client_mock.pull.return_value
+        self.hook_class_mock.assert_called_once_with(
+            self.client_mock,
+            'ubuntu:latest',
+            'env',
+            'test_container',
+            1.0,
+            {'UNIT': 'TEST'},
+            {'PRIVATE': 'MESSAGE'},
+            False,
+            None,
+            '/host/airflow',
+            'bridge',
+            True,
+            '/tmp/airflow',
+            None,
+            [{'Target': '/container/path', 'Source': '/host/path', 'Type': 'bind', 'ReadOnly': False}],
+            '["sh", "-c"]',
+            '/container/path',
+            None,
+            None,
+            1000,
+            True,
+            False,
+            None,
+            None,
         )
 
-    def test_execute_no_temp_dir(self):
-        operator = DockerOperator(
-            api_version='1.19',
-            command='env',
-            environment={'UNIT': 'TEST'},
-            private_environment={'PRIVATE': 'MESSAGE'},
-            image='ubuntu:latest',
-            network_mode='bridge',
-            owner='unittest',
-            task_id='unittest',
-            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
-            mount_tmp_dir=False,
-            entrypoint='["sh", "-c"]',
-            working_dir='/container/path',
-            shm_size=1000,
-            host_tmp_dir='/host/airflow',
-            container_name='test_container',
-            tty=True,
-        )
-        operator.execute(None)
-
-        self.client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
-        )
-
-        self.client_mock.create_container.assert_called_once_with(
-            command='env',
-            name='test_container',
-            environment={'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
-            host_config=self.client_mock.create_host_config.return_value,
-            image='ubuntu:latest',
-            user=None,
-            entrypoint=['sh', '-c'],
-            working_dir='/container/path',
-            tty=True,
-        )
-        self.client_mock.create_host_config.assert_called_once_with(
-            mounts=[
-                Mount(source='/host/path', target='/container/path', type='bind'),
-            ],
-            network_mode='bridge',
-            shm_size=1000,
-            cpu_shares=1024,
-            mem_limit=None,
-            auto_remove=False,
-            dns=None,
-            dns_search=None,
-            cap_add=None,
-            extra_hosts=None,
-            privileged=False,
-        )
-        self.tempdir_mock.assert_not_called()
-        self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
-        self.client_mock.attach.assert_called_once_with(
-            container='some_id', stdout=True, stderr=True, stream=True
-        )
-        self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
-        self.client_mock.wait.assert_called_once_with('some_id')
-        assert (
-            operator.cli.pull('ubuntu:latest', stream=True, decode=True) == self.client_mock.pull.return_value
-        )
-
-    def test_execute_fallback_temp_dir(self):
-        self.client_mock.create_container.side_effect = [
-            APIError(message="wrong path: " + TEMPDIR_MOCK_RETURN_VALUE),
-            {'Id': 'some_id'},
-        ]
-        operator = DockerOperator(
-            api_version='1.19',
-            command='env',
-            environment={'UNIT': 'TEST'},
-            private_environment={'PRIVATE': 'MESSAGE'},
-            image='ubuntu:latest',
-            network_mode='bridge',
-            owner='unittest',
-            task_id='unittest',
-            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
-            mount_tmp_dir=True,
-            entrypoint='["sh", "-c"]',
-            working_dir='/container/path',
-            shm_size=1000,
-            host_tmp_dir='/host/airflow',
-            container_name='test_container',
-            tty=True,
-        )
-        with self.assertLogs(operator.log, level=logging.WARNING) as captured:
-            operator.execute(None)
-            assert (
-                "WARNING:airflow.task.operators:Using remote engine or docker-in-docker "
-                "and mounting temporary volume from host is not supported" in captured.output[0]
-            )
-        self.client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
-        )
-        self.client_mock.create_container.assert_has_calls(
-            [
-                call(
-                    command='env',
-                    name='test_container',
-                    environment={'AIRFLOW_TMP_DIR': '/tmp/airflow', 'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
-                    host_config=self.client_mock.create_host_config.return_value,
-                    image='ubuntu:latest',
-                    user=None,
-                    entrypoint=['sh', '-c'],
-                    working_dir='/container/path',
-                    tty=True,
-                ),
-                call(
-                    command='env',
-                    name='test_container',
-                    environment={'UNIT': 'TEST', 'PRIVATE': 'MESSAGE'},
-                    host_config=self.client_mock.create_host_config.return_value,
-                    image='ubuntu:latest',
-                    user=None,
-                    entrypoint=['sh', '-c'],
-                    working_dir='/container/path',
-                    tty=True,
-                ),
-            ]
-        )
-        self.client_mock.create_host_config.assert_has_calls(
-            [
-                call(
-                    mounts=[
-                        Mount(source='/host/path', target='/container/path', type='bind'),
-                        Mount(source='/mkdtemp', target='/tmp/airflow', type='bind'),
-                    ],
-                    network_mode='bridge',
-                    shm_size=1000,
-                    cpu_shares=1024,
-                    mem_limit=None,
-                    auto_remove=False,
-                    dns=None,
-                    dns_search=None,
-                    cap_add=None,
-                    extra_hosts=None,
-                    privileged=False,
-                ),
-                call(
-                    mounts=[
-                        Mount(source='/host/path', target='/container/path', type='bind'),
-                    ],
-                    network_mode='bridge',
-                    shm_size=1000,
-                    cpu_shares=1024,
-                    mem_limit=None,
-                    auto_remove=False,
-                    dns=None,
-                    dns_search=None,
-                    cap_add=None,
-                    extra_hosts=None,
-                    privileged=False,
-                ),
-            ]
-        )
-        self.tempdir_mock.assert_called_once_with(dir='/host/airflow', prefix='airflowtmp')
-        self.client_mock.images.assert_called_once_with(name='ubuntu:latest')
-        self.client_mock.attach.assert_called_once_with(
-            container='some_id', stdout=True, stderr=True, stream=True
-        )
-        self.client_mock.pull.assert_called_once_with('ubuntu:latest', stream=True, decode=True)
-        self.client_mock.wait.assert_called_once_with('some_id')
-        assert (
-            operator.cli.pull('ubuntu:latest', stream=True, decode=True) == self.client_mock.pull.return_value
-        )
+        self.hook_mock.run_image.assert_called_once_with()
 
     def test_private_environment_is_private(self):
         operator = DockerOperator(
@@ -326,7 +148,7 @@ class TestDockerOperator(unittest.TestCase):
         )
 
     def test_execute_unicode_logs(self):
-        self.client_mock.attach.return_value = ['unicode container log 😁']
+        self.hook_mock.run_image.return_value = (['unicode container log 😁'], '')
 
         originalRaiseExceptions = logging.raiseExceptions
         logging.raiseExceptions = True
@@ -338,67 +160,22 @@ class TestDockerOperator(unittest.TestCase):
             logging.raiseExceptions = originalRaiseExceptions
             print_exception_mock.assert_not_called()
 
-    def test_execute_container_fails(self):
-        self.client_mock.wait.return_value = {"StatusCode": 1}
+    def test_run_image_fails(self):
+        self.hook_mock.run_image.side_effect = AirflowException()
         operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
         with pytest.raises(AirflowException):
             operator.execute(None)
-
-    def test_auto_remove_container_fails(self):
-        self.client_mock.wait.return_value = {"StatusCode": 1}
-        operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest', auto_remove=True)
-        operator.container = {'Id': 'some_id'}
-        with pytest.raises(AirflowException):
-            operator.execute(None)
-
-        self.client_mock.remove_container.assert_called_once_with('some_id')
 
     @staticmethod
     def test_on_kill():
-        client_mock = mock.Mock(spec=APIClient)
+        hook_mock = mock.Mock(spec=DockerClientHook)
 
         operator = DockerOperator(image='ubuntu', owner='unittest', task_id='unittest')
-        operator.cli = client_mock
-        operator.container = {'Id': 'some_id'}
+        operator.cli_hook = hook_mock
 
         operator.on_kill()
 
-        client_mock.stop.assert_called_once_with('some_id')
-
-    def test_execute_no_docker_conn_id_no_hook(self):
-        # Create the DockerOperator
-        operator = DockerOperator(image='publicregistry/someimage', owner='unittest', task_id='unittest')
-
-        # Mock out the DockerHook
-        hook_mock = mock.Mock(name='DockerHook mock', spec=DockerHook)
-        hook_mock.get_conn.return_value = self.client_mock
-        operator.get_hook = mock.Mock(
-            name='DockerOperator.get_hook mock', spec=DockerOperator.get_hook, return_value=hook_mock
-        )
-
-        operator.execute(None)
-        assert operator.get_hook.call_count == 0, 'Hook called though no docker_conn_id configured'
-
-    @mock.patch('airflow.providers.docker.operators.docker.DockerHook')
-    def test_execute_with_docker_conn_id_use_hook(self, hook_class_mock):
-        # Create the DockerOperator
-        operator = DockerOperator(
-            image='publicregistry/someimage',
-            owner='unittest',
-            task_id='unittest',
-            docker_conn_id='some_conn_id',
-        )
-
-        # Mock out the DockerHook
-        hook_mock = mock.Mock(name='DockerHook mock', spec=DockerHook)
-        hook_mock.get_conn.return_value = self.client_mock
-        hook_class_mock.return_value = hook_mock
-
-        operator.execute(None)
-
-        assert self.client_class_mock.call_count == 0, 'Client was called on the operator instead of the hook'
-        assert hook_class_mock.call_count == 1, 'Hook was not called although docker_conn_id configured'
-        assert self.client_mock.pull.call_count == 1, 'Image was not pulled using operator client'
+        hook_mock.stop.assert_called_once_with()
 
     def test_execute_xcom_behavior(self):
         self.client_mock.pull.return_value = [b'{"status":"pull log"}']
@@ -463,21 +240,3 @@ class TestDockerOperator(unittest.TestCase):
         assert xcom_push_result == 'container log 2'
         assert xcom_all_result == ['container log 1', 'container log 2']
         assert no_xcom_push_result is None
-
-    def test_extra_hosts(self):
-        hosts_obj = mock.Mock()
-        operator = DockerOperator(task_id='test', image='test', extra_hosts=hosts_obj)
-        operator.execute(None)
-        self.client_mock.create_container.assert_called_once()
-        assert 'host_config' in self.client_mock.create_container.call_args[1]
-        assert 'extra_hosts' in self.client_mock.create_host_config.call_args[1]
-        assert hosts_obj is self.client_mock.create_host_config.call_args[1]['extra_hosts']
-
-    def test_privileged(self):
-        privileged = mock.Mock()
-        operator = DockerOperator(task_id='test', image='test', privileged=privileged)
-        operator.execute(None)
-        self.client_mock.create_container.assert_called_once()
-        assert 'host_config' in self.client_mock.create_container.call_args[1]
-        assert 'privileged' in self.client_mock.create_host_config.call_args[1]
-        assert privileged is self.client_mock.create_host_config.call_args[1]['privileged']

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -30,9 +30,9 @@ from airflow.providers.docker.operators.docker_swarm import DockerSwarmOperator
 
 
 class TestDockerSwarmOperator(unittest.TestCase):
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    @mock.patch('airflow.providers.docker.operators.docker_swarm.get_client')
     @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_execute(self, types_mock, client_class_mock):
+    def test_execute(self, types_mock, get_client_mock):
 
         mock_obj = mock.Mock()
 
@@ -56,7 +56,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
 
-        client_class_mock.return_value = client_mock
+        get_client_mock.return_value = client_mock
 
         operator = DockerSwarmOperator(
             api_version='1.19',
@@ -86,8 +86,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')
 
-        client_class_mock.assert_called_once_with(
-            base_url='unix://var/run/docker.sock', tls=None, version='1.19'
+        get_client_mock.assert_called_once_with(
+            None, 'unix://var/run/docker.sock', '1.19', None, None, None, None, None
         )
 
         client_mock.service_logs.assert_called_once_with(
@@ -102,9 +102,9 @@ class TestDockerSwarmOperator(unittest.TestCase):
         assert client_mock.tasks.call_count == 5
         client_mock.remove_service.assert_called_once_with('some_id')
 
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    @mock.patch('airflow.providers.docker.operators.docker_swarm.get_client')
     @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_auto_remove(self, types_mock, client_class_mock):
+    def test_auto_remove(self, types_mock, get_client_mock):
 
         mock_obj = mock.Mock()
 
@@ -118,16 +118,16 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
 
-        client_class_mock.return_value = client_mock
+        get_client_mock.return_value = client_mock
 
         operator = DockerSwarmOperator(image='', auto_remove=True, task_id='unittest', enable_logging=False)
         operator.execute(None)
 
         client_mock.remove_service.assert_called_once_with('some_id')
 
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    @mock.patch('airflow.providers.docker.operators.docker_swarm.get_client')
     @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_no_auto_remove(self, types_mock, client_class_mock):
+    def test_no_auto_remove(self, types_mock, get_client_mock):
 
         mock_obj = mock.Mock()
 
@@ -141,7 +141,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
 
-        client_class_mock.return_value = client_mock
+        get_client_mock.return_value = client_mock
 
         operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest', enable_logging=False)
         operator.execute(None)
@@ -151,9 +151,9 @@ class TestDockerSwarmOperator(unittest.TestCase):
         ), 'Docker service being removed even when `auto_remove` set to `False`'
 
     @parameterized.expand([('failed',), ('shutdown',), ('rejected',), ('orphaned',), ('remove',)])
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    @mock.patch('airflow.providers.docker.operators.docker_swarm.get_client')
     @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_non_complete_service_raises_error(self, status, types_mock, client_class_mock):
+    def test_non_complete_service_raises_error(self, status, types_mock, get_client_mock):
 
         mock_obj = mock.Mock()
 
@@ -167,7 +167,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
 
-        client_class_mock.return_value = client_mock
+        get_client_mock.return_value = client_mock
 
         operator = DockerSwarmOperator(image='', auto_remove=False, task_id='unittest', enable_logging=False)
         msg = "Service did not complete: {'ID': 'some_id'}"
@@ -175,9 +175,9 @@ class TestDockerSwarmOperator(unittest.TestCase):
             operator.execute(None)
         assert str(ctx.value) == msg
 
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
+    @mock.patch('airflow.providers.docker.operators.docker_swarm.get_client')
     @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_logging_with_requests_timeout(self, types_mock, client_class_mock):
+    def test_logging_with_requests_timeout(self, types_mock, get_client_mock):
 
         mock_obj = mock.Mock()
 
@@ -202,7 +202,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
 
-        client_class_mock.return_value = client_mock
+        get_client_mock.return_value = client_mock
 
         operator = DockerSwarmOperator(
             api_version='1.19',

--- a/tests/providers/docker/sensors/__init__.py
+++ b/tests/providers/docker/sensors/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/docker/sensors/test_docker.py
+++ b/tests/providers/docker/sensors/test_docker.py
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+from unittest import mock
+
+from airflow.exceptions import AirflowException
+from airflow.providers.docker.sensors.docker import DockerSensor
+
+
+@mock.patch('airflow.providers.docker.sensors.docker.APIClient', autospec=True)
+@mock.patch('airflow.providers.docker.sensors.docker.DockerClientHook')
+class TestDockerOperator(unittest.TestCase):
+    def test_sensor_ok_on_container_success(self, hook_class, client_class):
+        sensor = DockerSensor(image='ubuntu', task_id='unittest')
+        sensor.cli = client_class.return_value
+        assert sensor.poke({})
+
+    def test_sensor_ng_on_container_failure(self, hook_class, client_class):
+        sensor = DockerSensor(image='ubuntu', task_id='unittest')
+        sensor.cli = client_class.return_value
+        hook = hook_class.return_value
+        hook.run_image.side_effect = AirflowException()
+        assert not sensor.poke({})

--- a/tests/providers/docker/sensors/test_docker.py
+++ b/tests/providers/docker/sensors/test_docker.py
@@ -22,17 +22,19 @@ from airflow.exceptions import AirflowException
 from airflow.providers.docker.sensors.docker import DockerSensor
 
 
-@mock.patch('airflow.providers.docker.sensors.docker.APIClient', autospec=True)
+@mock.patch('airflow.providers.docker.sensors.docker.get_client', autospec=True)
 @mock.patch('airflow.providers.docker.sensors.docker.DockerClientHook')
 class TestDockerOperator(unittest.TestCase):
-    def test_sensor_ok_on_container_success(self, hook_class, client_class):
+    def test_sensor_ok_on_container_success(self, hook_class, get_client_mock):
+        get_client_mock.return_value = mock.Mock()
         sensor = DockerSensor(image='ubuntu', task_id='unittest')
-        sensor.cli = client_class.return_value
+        sensor.cli = get_client_mock.return_value
         assert sensor.poke({})
 
-    def test_sensor_ng_on_container_failure(self, hook_class, client_class):
+    def test_sensor_ng_on_container_failure(self, hook_class, get_client_mock):
+        get_client_mock.return_value = mock.Mock()
         sensor = DockerSensor(image='ubuntu', task_id='unittest')
-        sensor.cli = client_class.return_value
+        sensor.cli = get_client_mock.return_value
         hook = hook_class.return_value
         hook.run_image.side_effect = AirflowException()
         assert not sensor.poke({})


### PR DESCRIPTION
Add Docker Sensor that succeeds based on whether a Docker container successfully exits.

Also moves a lot of logic for running docker containers from DockerOperator to a new hook class.
