### PR TITLE
Remove /dagrun/create and disable /dagrun/edit generated by F.A.B

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import json
 from datetime import datetime as dt
 
 import pendulum
@@ -30,25 +29,14 @@ from flask_appbuilder.forms import DynamicForm
 from flask_babel import lazy_gettext
 from flask_wtf import FlaskForm
 from wtforms import widgets
-from wtforms.fields import (
-    BooleanField,
-    Field,
-    IntegerField,
-    PasswordField,
-    SelectField,
-    StringField,
-    TextAreaField,
-)
+from wtforms.fields import Field, IntegerField, PasswordField, SelectField, StringField, TextAreaField
 from wtforms.validators import InputRequired, Optional
 
 from airflow.configuration import conf
 from airflow.utils import timezone
-from airflow.utils.types import DagRunType
-from airflow.www.validators import ValidJson
 from airflow.www.widgets import (
     AirflowDateTimePickerROWidget,
     AirflowDateTimePickerWidget,
-    BS3TextAreaROWidget,
     BS3TextFieldROWidget,
 )
 
@@ -128,58 +116,6 @@ class DateTimeWithNumRunsWithDagRunsForm(DateTimeWithNumRunsForm):
     """Date time and number of runs and dag runs form for graph and gantt view"""
 
     execution_date = SelectField("DAG run")
-
-
-class DagRunForm(DynamicForm):
-    """Form for adding DAG Run"""
-
-    dag_id = StringField(lazy_gettext('Dag Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
-    start_date = DateTimeWithTimezoneField(lazy_gettext('Start Date'), widget=AirflowDateTimePickerWidget())
-    end_date = DateTimeWithTimezoneField(lazy_gettext('End Date'), widget=AirflowDateTimePickerWidget())
-    run_id = StringField(lazy_gettext('Run Id'), validators=[InputRequired()], widget=BS3TextFieldWidget())
-    state = SelectField(
-        lazy_gettext('State'),
-        choices=(
-            ('success', 'success'),
-            ('running', 'running'),
-            ('failed', 'failed'),
-        ),
-        widget=Select2Widget(),
-        validators=[InputRequired()],
-    )
-    execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'),
-        widget=AirflowDateTimePickerWidget(),
-        validators=[InputRequired()],
-    )
-    external_trigger = BooleanField(lazy_gettext('External Trigger'))
-    conf = TextAreaField(
-        lazy_gettext('Conf'), validators=[ValidJson(), Optional()], widget=BS3TextAreaFieldWidget()
-    )
-
-    def populate_obj(self, item):
-        """Populates the attributes of the passed obj with data from the form’s fields."""
-        super().populate_obj(item)
-        item.run_type = DagRunType.from_run_id(item.run_id)
-        if item.conf:
-            item.conf = json.loads(item.conf)
-
-
-class DagRunEditForm(DagRunForm):
-    """Form for editing DAG Run"""
-
-    dag_id = StringField(lazy_gettext('Dag Id'), validators=[InputRequired()], widget=BS3TextFieldROWidget())
-    start_date = DateTimeWithTimezoneField(lazy_gettext('Start Date'), widget=AirflowDateTimePickerROWidget())
-    end_date = DateTimeWithTimezoneField(lazy_gettext('End Date'), widget=AirflowDateTimePickerROWidget())
-    run_id = StringField(lazy_gettext('Run Id'), validators=[InputRequired()], widget=BS3TextFieldROWidget())
-    execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'),
-        widget=AirflowDateTimePickerROWidget(),
-        validators=[InputRequired()],
-    )
-    conf = TextAreaField(
-        lazy_gettext('Conf'), validators=[ValidJson(), Optional()], widget=BS3TextAreaROWidget()
-    )
 
 
 class TaskInstanceEditForm(DynamicForm):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -120,8 +120,6 @@ from airflow.www import auth, utils as wwwutils
 from airflow.www.decorators import action_logging, gzipped
 from airflow.www.forms import (
     ConnectionForm,
-    DagRunEditForm,
-    DagRunForm,
     DateTimeForm,
     DateTimeWithNumRunsForm,
     DateTimeWithNumRunsWithDagRunsForm,
@@ -3542,7 +3540,6 @@ class DagRunModelView(AirflowModelView):
 
     class_permission_name = permissions.RESOURCE_DAG_RUN
     method_permission_name = {
-        'add': 'create',
         'list': 'read',
         'action_clear': 'delete',
         'action_muldelete': 'delete',
@@ -3551,14 +3548,12 @@ class DagRunModelView(AirflowModelView):
         'action_set_success': 'edit',
     }
     base_permissions = [
-        permissions.ACTION_CAN_CREATE,
         permissions.ACTION_CAN_READ,
         permissions.ACTION_CAN_EDIT,
         permissions.ACTION_CAN_DELETE,
         permissions.ACTION_CAN_ACCESS_MENU,
     ]
 
-    add_columns = ['state', 'dag_id', 'execution_date', 'run_id', 'external_trigger', 'conf']
     list_columns = [
         'state',
         'dag_id',
@@ -3581,14 +3576,10 @@ class DagRunModelView(AirflowModelView):
         'end_date',
         'external_trigger',
     ]
-    edit_columns = ['state', 'dag_id', 'execution_date', 'start_date', 'end_date', 'run_id', 'conf']
 
     base_order = ('execution_date', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]
-
-    add_form = DagRunForm
-    edit_form = DagRunEditForm
 
     formatters_columns = {
         'execution_date': wwwutils.datetime_f('execution_date'),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -120,6 +120,7 @@ from airflow.www import auth, utils as wwwutils
 from airflow.www.decorators import action_logging, gzipped
 from airflow.www.forms import (
     ConnectionForm,
+    DagRunEditForm,
     DateTimeForm,
     DateTimeWithNumRunsForm,
     DateTimeWithNumRunsWithDagRunsForm,
@@ -3576,10 +3577,13 @@ class DagRunModelView(AirflowModelView):
         'end_date',
         'external_trigger',
     ]
+    edit_columns = ['state', 'dag_id', 'execution_date', 'start_date', 'end_date', 'run_id', 'conf']
 
     base_order = ('execution_date', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]
+
+    edit_form = DagRunEditForm
 
     formatters_columns = {
         'execution_date': wwwutils.datetime_f('execution_date'),


### PR DESCRIPTION
This came up during a conversaion with @ashb. Currently we are exposing the ability to directly create and edit a DagRun instance via F.A.B.’s CRUD view generation (the plus and edit icons on the DagRun list view). But these views don’t really make a lot of sense; creating a DagRun requires doing more than just adding a DagRun instance to the database (which is why triggering a DAG run in the home view uses `/trigger` instead). The `/dagrun/add` view provides essentially a way to manually modify Airflow’s internal state. So this view is removed.

The story with `/dagrun/edit` is similar. The only thing on a DagRun that can be reasonably edited is the state (running, failed, skipped, etc.), but that should also do more things than just setting the state, which is why we have *Mark Failed*, *Mark Success*, and *Clear* action buttons. Unfortunately, we can’t remove the field since we need the `can_edit` permission for those state-setting action methods, so instead all fields in the edit form is disabled so the user can’t modify anything on the DagRun.