### PR TITLE
Fix messed-up changelog in 3 providers

### DIFF
--- a/airflow/providers/airbyte/CHANGELOG.rst
+++ b/airflow/providers/airbyte/CHANGELOG.rst
@@ -22,14 +22,6 @@ Changelog
 2.1.0
 .....
 
-Breaking changes
-~~~~~~~~~~~~~~~~
-
-
-Features
-~~~~~~~~
-
-
 Bug Fixes
 ~~~~~~~~~
 

--- a/airflow/providers/apache/druid/CHANGELOG.rst
+++ b/airflow/providers/apache/druid/CHANGELOG.rst
@@ -22,14 +22,6 @@ Changelog
 2.0.1
 .....
 
-Breaking changes
-~~~~~~~~~~~~~~~~
-
-
-Features
-~~~~~~~~
-
-
 Bug Fixes
 ~~~~~~~~~
 

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -22,13 +22,11 @@ Changelog
 2.0.1
 .....
 
-Breaking changes
-~~~~~~~~~~~~~~~~
-
 
 Features
 ~~~~~~~~
 
+* ``Enable using custom pod launcher in Kubernetes Pod Operator (#16945)``
 
 Bug Fixes
 ~~~~~~~~~
@@ -41,25 +39,6 @@ Bug Fixes
    * ``Simplify &#39;default_args&#39; in Kubernetes example DAGs (#16870)``
    * ``Enable using custom pod launcher in Kubernetes Pod Operator (#16945)``
    * ``Prepare documentation for July release of providers. (#17015)``
-   * ``Updating task dependencies (#16624)``
-   * ``Removes pylint from our toolchain (#16682)``
-
-2.1.0
-.....
-
-
-Features
-~~~~~~~~
-
-* ``Enable using custom pod launcher in Kubernetes Pod Operator (#16945)``
-
-Bug Fixes
-~~~~~~~~~
-
-* ``BugFix: Using &#39;json&#39; string in template_field causes issue with K8s Operators (#16930)``
-
-.. Below changes are excluded from the changelog. Move them to
-   appropriate section above if needed. Do not delete the lines(!):
    * ``Updating task dependencies (#16624)``
    * ``Removes pylint from our toolchain (#16682)``
    * ``Prepare documentation for July release of providers. (#17015)``

--- a/airflow/providers/snowflake/CHANGELOG.rst
+++ b/airflow/providers/snowflake/CHANGELOG.rst
@@ -22,18 +22,10 @@ Changelog
 2.1.0
 .....
 
-Breaking changes
-~~~~~~~~~~~~~~~~
-
-
 Features
 ~~~~~~~~
 
 * ``Adding: Snowflake Role in snowflake provider hook (#16735)``
-
-Bug Fixes
-~~~~~~~~~
-
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):


### PR DESCRIPTION
Some last minute chnages cause 3 providers to have
slightly messed-up changelogs.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
