### PR TITLE
Updating docstring in Apache Drill example DAG

### DIFF
--- a/airflow/providers/apache/drill/example_dags/example_drill_dag.py
+++ b/airflow/providers/apache/drill/example_dags/example_drill_dag.py
@@ -17,8 +17,7 @@
 # under the License.
 
 """
-Example Airflow DAG to submit Apache Spark applications using
-`SparkSubmitOperator`, `SparkJDBCOperator` and `SparkSqlOperator`.
+Example Airflow DAG to execute SQL in an Apache Drill environment using the `DrillOperator`.
 """
 from airflow.models import DAG
 from airflow.providers.apache.drill.operators.drill import DrillOperator


### PR DESCRIPTION
Updating the docstring in the Apache Drill example DAG.  The current docstring references Apache Spark operators.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
