### PR TITLE
Example DAG-related updates for Apache Drill

### DIFF
--- a/airflow/providers/apache/drill/example_dags/__init__.py
+++ b/airflow/providers/apache/drill/example_dags/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/apache/drill/example_dags/example_drill_dag.py
+++ b/airflow/providers/apache/drill/example_dags/example_drill_dag.py
@@ -23,7 +23,6 @@ from airflow.models import DAG
 from airflow.providers.apache.drill.operators.drill import DrillOperator
 from airflow.utils.dates import days_ago
 
-
 with DAG(
     dag_id='example_drill_dag',
     schedule_interval=None,

--- a/airflow/providers/apache/drill/example_dags/example_drill_dag.py
+++ b/airflow/providers/apache/drill/example_dags/example_drill_dag.py
@@ -23,13 +23,9 @@ from airflow.models import DAG
 from airflow.providers.apache.drill.operators.drill import DrillOperator
 from airflow.utils.dates import days_ago
 
-args = {
-    'owner': 'Airflow',
-}
 
 with DAG(
     dag_id='example_drill_dag',
-    default_args=args,
     schedule_interval=None,
     start_date=days_ago(2),
     tags=['example'],

--- a/airflow/providers/apache/drill/example_dags/example_drill_dag.py
+++ b/airflow/providers/apache/drill/example_dags/example_drill_dag.py
@@ -17,8 +17,7 @@
 # under the License.
 
 """
-Example Airflow DAG to submit Apache Spark applications using
-`SparkSubmitOperator`, `SparkJDBCOperator` and `SparkSqlOperator`.
+Example Airflow DAG to execute SQL in an Apache Drill environment using the `DrillOperator`.
 """
 from airflow.models import DAG
 from airflow.providers.apache.drill.operators.drill import DrillOperator


### PR DESCRIPTION
Making a few updates for the new Apache Drill example DAG:
- Adding an `__init__.py` file in the `example_dags` directory
- Updating the docstring for the example DAG
  - The current docstring references Apache Spark operators
- Removing the `default_args` pattern for specifying these args outside of the `DAG()` instantiation as well as only setting the owner
  - Keeping this change consistent with the other update made to most other example DAGs recently

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
