### PR TITLE
Invalidate Vault cached prop when not authenticated

### DIFF
--- a/airflow/providers/hashicorp/_internal_client/vault_client.py
+++ b/airflow/providers/hashicorp/_internal_client/vault_client.py
@@ -191,8 +191,25 @@ class _VaultClient(LoggingMixin):
         self.radius_secret = radius_secret
         self.radius_port = radius_port
 
+    @property
+    def client(self):
+        """
+        Authentication to Vault can expire. This wrapper function checks that
+        it is still authenticated to Vault, and invalidates the cache if this
+        is not the case.
+
+        :rtype: hvac.Client
+        :return: Vault Client
+
+        """
+        if not self._client.is_authenticated():
+            # Invalidate the cache:
+            # https://github.com/pydanny/cached-property#invalidating-the-cache
+            self.__dict__.pop('_client', None)
+        return self._client
+
     @cached_property
-    def client(self) -> hvac.Client:
+    def _client(self) -> hvac.Client:
         """
         Return an authenticated Hashicorp Vault client.
 

--- a/tests/providers/hashicorp/_internal_client/test_vault_client.py
+++ b/tests/providers/hashicorp/_internal_client/test_vault_client.py
@@ -1003,3 +1003,30 @@ class TestVaultClient(TestCase):
         mock_client.secrets.kv.v1.create_or_update_secret.assert_called_once_with(
             mount_point='secret', secret_path='path', secret={'key': 'value'}, method="post"
         )
+
+    @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
+    def test_cached_property_invalidates_on_auth_failure(self, mock_hvac):
+        mock_client = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client
+
+        vault_client = _VaultClient(
+            auth_type="radius",
+            radius_host="radhost",
+            radius_port=8110,
+            radius_secret="pass",
+            kv_engine_version=1,
+            url="http://localhost:8180",
+        )
+
+        # Assert that the original mock_client is returned
+        assert vault_client.client == mock_client
+
+        # Prove that the mock_client is cached by changing the return
+        # value, but still receive the original mock client
+        mock_client_2 = mock.MagicMock()
+        mock_hvac.Client.return_value = mock_client_2
+        assert vault_client.client == mock_client
+        mock_client.is_authenticated.return_value = False
+        # assert that when the client is not authenticated the cache
+        # is invalidated, therefore returning the second client
+        assert vault_client.client == mock_client_2


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
The Vault integration caches the connection to Vault with `cached_property` but doesn't check to make sure the connection is still valid, for example a token could need to be refreshed. This change checks to see if the client is authenticated and then invalidates the cache if this is not the case.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
