### PR TITLE
refactor: fixed type annotation for 'sql' in MySqlOperator

### DIFF
--- a/airflow/providers/mysql/operators/mysql.py
+++ b/airflow/providers/mysql/operators/mysql.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import ast
-from typing import Dict, Iterable, Mapping, Optional, Union
+from typing import Dict, Iterable, List, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
@@ -56,7 +56,7 @@ class MySqlOperator(BaseOperator):
     def __init__(
         self,
         *,
-        sql: str,
+        sql: Union[str, List[str]],
         mysql_conn_id: str = 'mysql_default',
         parameters: Optional[Union[Mapping, Iterable]] = None,
         autocommit: bool = False,


### PR DESCRIPTION
Each SQL Operator that uses DbApiHook can receive a str representing a sql statement, a list of str (sql statements), or reference to a template file.
But type annotation in MySqlOperator is 'str' only.
This leads to misunderstandings in IDE if list was used.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
