### PR TITLE
Add User Assigned Identity Functionality to AzureContainerInstancesOperator

### DIFF
--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -128,7 +128,7 @@ class AzureContainerInstancesOperator(BaseOperator):
                     memory_in_gb=14.0,
                     cpu=4.0,
                     gpu=GpuResource(count=1, sku='K80'),
-                    user_assigned_identities=['/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}']
+                    user_assigned_identities=['/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'],
                     command=["/bin/echo", "world"],
                     task_id="start_container"
                 )

--- a/airflow/providers/microsoft/azure/operators/azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/operators/azure_container_instances.py
@@ -240,7 +240,7 @@ class AzureContainerInstancesOperator(BaseOperator):
         if self.user_assigned_identities:
             params_identity = {
                 "type": "UserAssigned",
-                "user_assigned_identities": {uaid: {} for uaid in self.user_assigned_identities}
+                "user_assigned_identities": {uaid: {} for uaid in self.user_assigned_identities},
             }
 
         exit_code = 1


### PR DESCRIPTION
Azure Python SDK module [azure.mgmt.containerinstance.ContainerInstanceManagementClient](https://docs.microsoft.com/en-us/python/api/azure-mgmt-containerinstance/azure.mgmt.containerinstance.containerinstancemanagementclient?view=azure-python) has a feature for attaching [UserAssignedIdentities](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) while launching containers.

AzureContainerInstancesOperator hasn't implemented this feature until now, this PR provides this option.