### PR TITLE
Adding JWT, IP filtering, and direct session login support for SalesforceHook 

### DIFF
--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -25,10 +25,10 @@ retrieve data from it, and write that data to a file for other uses.
 """
 import logging
 import time
-from requests import Session
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
+from requests import Session
 from simple_salesforce import Salesforce, api
 
 from airflow.hooks.base import BaseHook
@@ -71,7 +71,7 @@ class SalesforceHook(BaseHook):
         self,
         salesforce_conn_id: str = default_conn_name,
         session_id: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> None:
         super().__init__()
         self.conn_id = salesforce_conn_id
@@ -103,15 +103,11 @@ class SalesforceHook(BaseHook):
             "extra__salesforce__organization_id": StringField(
                 lazy_gettext("Organization ID"), widget=BS3TextFieldWidget()
             ),
-            "extra__salesforce__instance": StringField(
-                lazy_gettext("Instance"), widget=BS3TextFieldWidget()
-            ),
+            "extra__salesforce__instance": StringField(lazy_gettext("Instance"), widget=BS3TextFieldWidget()),
             "extra__salesforce__instance_url": StringField(
                 lazy_gettext("Instance URL"), widget=BS3TextFieldWidget()
             ),
-            "extra__salesforce__proxies": StringField(
-                lazy_gettext("Proxies"), widget=BS3TextFieldWidget()
-            ),
+            "extra__salesforce__proxies": StringField(lazy_gettext("Proxies"), widget=BS3TextFieldWidget()),
             "extra__salesforce__version": StringField(
                 lazy_gettext("Salesforce API Version"), widget=BS3TextFieldWidget()
             ),

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -25,6 +25,7 @@ retrieve data from it, and write that data to a file for other uses.
 """
 import logging
 import time
+from requests import Session
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
@@ -44,12 +45,21 @@ class SalesforceHook(BaseHook):
     :param conn_id: The name of the connection that has the parameters needed to connect to Salesforce.
         The connection should be of type `Salesforce`.
     :type conn_id: str
+    :param session_id: The access token for a given HTTP request session.
+    :type session_id: str
+    :param session: A custom HTTP request session. This enables the use of requests Session features not
+        otherwise exposed by `simple_salesforce`.
+    :type session: requests.Session
 
     .. note::
-        To connect to Salesforce make sure the connection includes a Username, Password, and Security Token.
-        If in sandbox, enter a Domain value of 'test'.  Login methods such as IP filtering and JWT are not
-        supported currently.
+        A connection to Salesforce can be created via several authentication options:
 
+        * Password: Provide Username, Password, and Security Token
+        * Direct Session: Provide a `session_id` and either Instance or Instance URL
+        * OAuth 2.0 JWT: Provide a Consumer Key and either a Private Key or Private Key File Path
+        * IP Filtering: Provide Username, Password, and an Organization ID
+
+        If in sandbox, enter a Domain value of 'test'.
     """
 
     conn_name_attr = "salesforce_conn_id"
@@ -57,10 +67,17 @@ class SalesforceHook(BaseHook):
     conn_type = "salesforce"
     hook_name = "Salesforce"
 
-    def __init__(self, salesforce_conn_id: str = default_conn_name) -> None:
+    def __init__(
+        self,
+        salesforce_conn_id: str = default_conn_name,
+        session_id: Optional[str] = None,
+        session: Optional[Session] = None
+    ) -> None:
         super().__init__()
         self.conn_id = salesforce_conn_id
         self.conn = None
+        self.session_id = session_id
+        self.session = session
 
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
@@ -74,6 +91,33 @@ class SalesforceHook(BaseHook):
                 lazy_gettext("Security Token"), widget=BS3PasswordFieldWidget()
             ),
             "extra__salesforce__domain": StringField(lazy_gettext("Domain"), widget=BS3TextFieldWidget()),
+            "extra__salesforce__consumer_key": StringField(
+                lazy_gettext("Consumer Key"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__private_key_file_path": PasswordField(
+                lazy_gettext("Private Key File Path"), widget=BS3PasswordFieldWidget()
+            ),
+            "extra__salesforce__private_key": PasswordField(
+                lazy_gettext("Private Key"), widget=BS3PasswordFieldWidget()
+            ),
+            "extra__salesforce__organization_id": StringField(
+                lazy_gettext("Organization ID"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__instance": StringField(
+                lazy_gettext("Instance"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__instance_url": StringField(
+                lazy_gettext("Instance URL"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__proxies": StringField(
+                lazy_gettext("Proxies"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__version": StringField(
+                lazy_gettext("Salesforce API Version"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__client_id": StringField(
+                lazy_gettext("Client ID"), widget=BS3TextFieldWidget()
+            ),
         }
 
     @staticmethod
@@ -83,9 +127,6 @@ class SalesforceHook(BaseHook):
             "hidden_fields": ["schema", "port", "extra", "host"],
             "relabeling": {
                 "login": "Username",
-            },
-            "placeholders": {
-                "extra__salesforce__domain": "(Optional)  Set to 'test' if working in sandbox mode.",
             },
         }
 
@@ -98,7 +139,18 @@ class SalesforceHook(BaseHook):
                 username=connection.login,
                 password=connection.password,
                 security_token=extras["extra__salesforce__security_token"],
-                domain=extras["extra__salesforce__domain"] or "login",
+                domain=extras["extra__salesforce__domain"] or None,
+                session_id=self.session_id,
+                instance=extras["extra__salesforce__instance"] or None,
+                instance_url=extras["extra__salesforce__instance_url"] or None,
+                organizationId=extras["extra__salesforce__organization_id"] or None,
+                version=extras["extra__salesforce__version"] or api.DEFAULT_API_VERSION,
+                proxies=extras["extra__salesforce__proxies"] or None,
+                session=self.session,
+                client_id=extras["extra__salesforce__client_id"] or None,
+                consumer_key=extras["extra__salesforce__consumer_key"] or None,
+                privatekey_file=extras["extra__salesforce__private_key_file_path"] or None,
+                privatekey=extras["extra__salesforce__private_key"] or None,
             )
         return self.conn
 

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -19,22 +19,72 @@
 
 Salesforce Connection
 =====================
-The Salesforce connection type provides connection to Salesforce.
+The Salesforce connection type provides connection to Salesforce via several authentication options:
+
+    * Password
+    * Direct Session
+    * OAuth 2.0 JWT
+    * IP Filtering
 
 Configuring the Connection
 --------------------------
-Username (required)
+Username (optional)
     Specify the email address used to login to your account.
 
-Password (required)
+    Use for Password authentication or IP Filtering.
+
+Password (optional)
     Specify the password associated with the account.
 
-Security Token (required)
+    Use for Password authentication or IP Filtering.
+
+Security Token (optional)
     Specify the Salesforce security token for the username.
+
+    Use for Password authentication.
+
+Consumer Key (optional)
+    the consumer key generated for the user.
+
+    Use for OAuth 2.0 JWT authentication.
+
+Private Key (optional)
+    The private key to use for signing the JWT. Provide this or a Private Key File Path (both are not necessary).
+
+    Use for OAuth 2.0 JWT authentication.
+
+Private Key File Path (optional)
+    A local path to the private key to be used for signing the JWT. Provide this or a Private Key (both are not necessary).
+
+    Use for OAuth 2.0 JWT authentication.
+
+Organization ID (optional)
+    The ID of the organization tied to the Salesforce instance.
+
+    Use for IP Filtering.
+
+Instance (optional)
+    The domain name of the Salesforce instance, (i.e. `na1.salesforce.com`).
+
+    Use for Direct Session access.  When calling the `SalesforceHook` a `session_id` also needs to be provided.
+
+Instance URL (optional)
+    The full URL of the Salesforce instance, (i.e. `https://na1.salesforce.com`). When calling the `SalesforceHook` a `session_id` also needs to be provided.
+
+    Use for Direct Session access.
 
 Domain (optional)
     The domain to using for connecting to Salesforce. Use common domains, such as 'login'
     or 'test', or Salesforce My domain. If not used, will default to 'login'.
+
+Proxies (optional)
+    A mapping of scheme-to-proxy server(s).
+
+Salesforce API Version (optional)
+    The version of the Salesforce API to use.  If not specified a default value will be used.
+
+Client ID (optional)
+    The ID of the client.
 
 For security reason we suggest you to use one of the secrets Backend to create this
 connection (Using ENVIRONMENT VARIABLE or Hashicorp Vault, GCP Secrets Manager etc).
@@ -45,6 +95,3 @@ following the standard syntax of DB connections - where extras are passed as par
   .. code-block:: bash
 
     export AIRFLOW_CONN_SALESFORCE_DEFAULT='http://your_username:your_password@https%3A%2F%2Fyour_host.lightning.force.com?security_token=your_token'
-
-.. note::
-  Airflow currently does not support other login methods such as IP filtering and JWT.

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -81,7 +81,7 @@ Proxies (optional)
     A mapping of scheme-to-proxy server(s).
 
 Salesforce API Version (optional)
-    The version of the Salesforce API to use.  If not specified a default value will be used.
+    The version of the Salesforce API to use when attempting to connect.  If not specified a default value will be used.
 
 Client ID (optional)
     The ID of the client.


### PR DESCRIPTION
Closes: #17192

- Adding login and authentication support when using the `SalesforceHook`:
  - JWT bearer authentication
  - IP filtering (allow-listing)
  - Direct session/instance access

- New fields were also added to the connection form for the "Salesforce" type:
  ![image](https://user-images.githubusercontent.com/48934154/128040196-299a2726-db55-4c5f-96fb-b82123c71d8c.png)

- Connection documentation has also been updated to describe each connection field and what type of login/authentication is related.

- Refactored unit tests to include mock implementations of the 4 supported auth/login types.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
