### PR TITLE
Adding JWT, IP filtering, and direct session login support for SalesforceHook

### DIFF
--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -109,7 +109,7 @@ class SalesforceHook(BaseHook):
             ),
             "extra__salesforce__proxies": StringField(lazy_gettext("Proxies"), widget=BS3TextFieldWidget()),
             "extra__salesforce__version": StringField(
-                lazy_gettext("Salesforce API Version"), widget=BS3TextFieldWidget()
+                lazy_gettext("API Version"), widget=BS3TextFieldWidget()
             ),
             "extra__salesforce__client_id": StringField(
                 lazy_gettext("Client ID"), widget=BS3TextFieldWidget()

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -134,7 +134,7 @@ class SalesforceHook(BaseHook):
             self.conn = Salesforce(
                 username=connection.login,
                 password=connection.password,
-                security_token=extras["extra__salesforce__security_token"],
+                security_token=extras["extra__salesforce__security_token"] or None,
                 domain=extras["extra__salesforce__domain"] or None,
                 session_id=self.session_id,
                 instance=extras["extra__salesforce__instance"] or None,

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -25,10 +25,10 @@ retrieve data from it, and write that data to a file for other uses.
 """
 import logging
 import time
-from requests import Session
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
+from requests import Session
 from simple_salesforce import Salesforce, api
 
 from airflow.hooks.base import BaseHook
@@ -71,7 +71,7 @@ class SalesforceHook(BaseHook):
         self,
         salesforce_conn_id: str = default_conn_name,
         session_id: Optional[str] = None,
-        session: Optional[Session] = None
+        session: Optional[Session] = None,
     ) -> None:
         super().__init__()
         self.conn_id = salesforce_conn_id
@@ -103,15 +103,11 @@ class SalesforceHook(BaseHook):
             "extra__salesforce__organization_id": StringField(
                 lazy_gettext("Organization ID"), widget=BS3TextFieldWidget()
             ),
-            "extra__salesforce__instance": StringField(
-                lazy_gettext("Instance"), widget=BS3TextFieldWidget()
-            ),
+            "extra__salesforce__instance": StringField(lazy_gettext("Instance"), widget=BS3TextFieldWidget()),
             "extra__salesforce__instance_url": StringField(
                 lazy_gettext("Instance URL"), widget=BS3TextFieldWidget()
             ),
-            "extra__salesforce__proxies": StringField(
-                lazy_gettext("Proxies"), widget=BS3TextFieldWidget()
-            ),
+            "extra__salesforce__proxies": StringField(lazy_gettext("Proxies"), widget=BS3TextFieldWidget()),
             "extra__salesforce__version": StringField(
                 lazy_gettext("Salesforce API Version"), widget=BS3TextFieldWidget()
             ),

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -25,6 +25,7 @@ retrieve data from it, and write that data to a file for other uses.
 """
 import logging
 import time
+from requests import Session
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
@@ -44,12 +45,21 @@ class SalesforceHook(BaseHook):
     :param conn_id: The name of the connection that has the parameters needed to connect to Salesforce.
         The connection should be of type `Salesforce`.
     :type conn_id: str
+    :param session_id: The access token for a given HTTP request session.
+    :type session_id: str
+    :param session: A custom HTTP request session. This enables the use of requests Session features not
+        otherwise exposed by `simple_salesforce`.
+    :type session: requests.Session
 
     .. note::
-        To connect to Salesforce make sure the connection includes a Username, Password, and Security Token.
-        If in sandbox, enter a Domain value of 'test'.  Login methods such as IP filtering and JWT are not
-        supported currently.
+        A connection to Salesforce can be created via several authentication options:
 
+        * Password: Provide Username, Password, and Security Token
+        * Direct Session: Provide a `session_id` and either Instance or Instance URL
+        * OAuth 2.0 JWT: Provide a Consumer Key and either a Private Key or Private Key File Path
+        * IP Filtering: Provide Username, Password, and an Organization ID
+
+        If in sandbox, enter a Domain value of 'test'.
     """
 
     conn_name_attr = "salesforce_conn_id"
@@ -57,10 +67,17 @@ class SalesforceHook(BaseHook):
     conn_type = "salesforce"
     hook_name = "Salesforce"
 
-    def __init__(self, salesforce_conn_id: str = default_conn_name) -> None:
+    def __init__(
+        self,
+        salesforce_conn_id: str = default_conn_name,
+        session_id: Optional[str] = None,
+        session: Optional[Session] = None
+    ) -> None:
         super().__init__()
         self.conn_id = salesforce_conn_id
         self.conn = None
+        self.session_id = session_id
+        self.session = session
 
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
@@ -74,6 +91,33 @@ class SalesforceHook(BaseHook):
                 lazy_gettext("Security Token"), widget=BS3PasswordFieldWidget()
             ),
             "extra__salesforce__domain": StringField(lazy_gettext("Domain"), widget=BS3TextFieldWidget()),
+            "extra__salesforce__consumer_key": StringField(
+                lazy_gettext("Consumer Key"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__private_key_file_path": PasswordField(
+                lazy_gettext("Private Key File Path"), widget=BS3PasswordFieldWidget()
+            ),
+            "extra__salesforce__private_key": PasswordField(
+                lazy_gettext("Private Key"), widget=BS3PasswordFieldWidget()
+            ),
+            "extra__salesforce__organization_id": StringField(
+                lazy_gettext("Organization ID"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__instance": StringField(
+                lazy_gettext("Instance"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__instance_url": StringField(
+                lazy_gettext("Instance URL"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__proxies": StringField(
+                lazy_gettext("Proxies"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__version": StringField(
+                lazy_gettext("Salesforce API Version"), widget=BS3TextFieldWidget()
+            ),
+            "extra__salesforce__client_id": StringField(
+                lazy_gettext("Client ID"), widget=BS3TextFieldWidget()
+            ),
         }
 
     @staticmethod
@@ -83,9 +127,6 @@ class SalesforceHook(BaseHook):
             "hidden_fields": ["schema", "port", "extra", "host"],
             "relabeling": {
                 "login": "Username",
-            },
-            "placeholders": {
-                "extra__salesforce__domain": "(Optional)  Set to 'test' if working in sandbox mode.",
             },
         }
 
@@ -98,7 +139,18 @@ class SalesforceHook(BaseHook):
                 username=connection.login,
                 password=connection.password,
                 security_token=extras["extra__salesforce__security_token"],
-                domain=extras["extra__salesforce__domain"] or "login",
+                domain=extras["extra__salesforce__domain"] or None,
+                session_id=self.session_id,
+                instance=extras["extra__salesforce__instance"] or None,
+                instance_url=extras["extra__salesforce__instance_url"] or None,
+                organizationId=extras["extra__salesforce__organization_id"] or None,
+                version=extras["extra__salesforce__version"] or api.DEFAULT_API_VERSION,
+                proxies=extras["extra__salesforce__proxies"] or None,
+                session=self.session,
+                client_id=extras["extra__salesforce__client_id"] or None,
+                consumer_key=extras["extra__salesforce__consumer_key"] or None,
+                privatekey_file=extras["extra__salesforce__private_key_file_path"] or None,
+                privatekey=extras["extra__salesforce__private_key"] or None,
             )
         return self.conn
 

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -19,22 +19,72 @@
 
 Salesforce Connection
 =====================
-The Salesforce connection type provides connection to Salesforce.
+The Salesforce connection type provides connection to Salesforce via several authentication options:
+
+    * Password
+    * Direct Session
+    * OAuth 2.0 JWT
+    * IP Filtering
 
 Configuring the Connection
 --------------------------
-Username (required)
+Username (optional)
     Specify the email address used to login to your account.
 
-Password (required)
+    Use for Password authentication or IP Filtering.
+
+Password (optional)
     Specify the password associated with the account.
 
-Security Token (required)
+    Use for Password authentication or IP Filtering.
+
+Security Token (optional)
     Specify the Salesforce security token for the username.
+
+    Use for Password authentication.
+
+Consumer Key (optional)
+    the consumer key generated for the user.
+
+    Use for OAuth 2.0 JWT authentication.
+
+Private Key (optional)
+    The private key to use for signing the JWT. Provide this or a Private Key File Path (both are not necessary).
+
+    Use for OAuth 2.0 JWT authentication.
+
+Private Key File Path (optional)
+    A local path to the private key to be used for signing the JWT. Provide this or a Private Key (both are not necessary).
+
+    Use for OAuth 2.0 JWT authentication.
+
+Organization ID (optional)
+    The ID of the organization tied to the Salesforce instance.
+
+    Use for IP Filtering.
+
+Instance (optional)
+    The domain name of the Salesforce instance, (i.e. `na1.salesforce.com`).
+
+    Use for Direct Session access.  When calling the `SalesforceHook` a `session_id` also needs to be provided.
+
+Instance URL (optional)
+    The full URL of the Salesforce instance, (i.e. `https://na1.salesforce.com`). When calling the `SalesforceHook` a `session_id` also needs to be provided.
+
+    Use for Direct Session access.
 
 Domain (optional)
     The domain to using for connecting to Salesforce. Use common domains, such as 'login'
     or 'test', or Salesforce My domain. If not used, will default to 'login'.
+
+Proxies (optional)
+    A mapping of scheme-to-proxy server(s).
+
+Salesforce API Version (optional)
+    The version of the Salesforce API to use.  If not specified a default value will be used.
+
+Client ID (optional)
+    The ID of the client.
 
 For security reason we suggest you to use one of the secrets Backend to create this
 connection (Using ENVIRONMENT VARIABLE or Hashicorp Vault, GCP Secrets Manager etc).
@@ -45,6 +95,3 @@ following the standard syntax of DB connections - where extras are passed as par
   .. code-block:: bash
 
     export AIRFLOW_CONN_SALESFORCE_DEFAULT='http://your_username:your_password@https%3A%2F%2Fyour_host.lightning.force.com?security_token=your_token'
-
-.. note::
-  Airflow currently does not support other login methods such as IP filtering and JWT.

--- a/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
+++ b/docs/apache-airflow-providers-salesforce/connections/salesforce.rst
@@ -81,7 +81,7 @@ Proxies (optional)
     A mapping of scheme-to-proxy server(s).
 
 Salesforce API Version (optional)
-    The version of the Salesforce API to use.  If not specified a default value will be used.
+    The version of the Salesforce API to use when attempting to connect.  If not specified a default value will be used.
 
 Client ID (optional)
     The ID of the client.

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -22,13 +22,14 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
-from requests import Session as request_session
 from numpy import nan
+from requests import Session as request_session
 from simple_salesforce import Salesforce, api
 
 from airflow.models.connection import Connection
 from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
 from airflow.utils.session import create_session
+
 
 class TestSalesforceHook(unittest.TestCase):
     def setUp(self):
@@ -75,7 +76,7 @@ class TestSalesforceHook(unittest.TestCase):
                 "extra__salesforce__security_token": "token",
                 "extra__salesforce__version": "42.0"
             }
-            '''
+            ''',
         )
         with create_session() as session:
             session.add(password_auth_conn)
@@ -131,15 +132,17 @@ class TestSalesforceHook(unittest.TestCase):
                 "extra__salesforce__security_token": "",
                 "extra__salesforce__version": "29.0"
             }
-            '''
+            ''',
         )
         with create_session() as session:
             session.add(direct_access_conn)
             session.commit()
 
-        self.salesforce_hook = SalesforceHook(
-            salesforce_conn_id="direct_access_conn", session_id="session_id"
-        )
+        with request_session() as session:
+            self.salesforce_hook = SalesforceHook(
+                salesforce_conn_id="direct_access_conn", session_id="session_id", session=session
+            )
+
         self.salesforce_hook.get_conn()
 
         extras = direct_access_conn.extra_dejson
@@ -154,7 +157,7 @@ class TestSalesforceHook(unittest.TestCase):
             organizationId=None,
             version=extras["extra__salesforce__version"],
             proxies=None,
-            session=None,
+            session=self.salesforce_hook.session,
             client_id=extras["extra__salesforce__client_id"],
             consumer_key=None,
             privatekey_file=None,
@@ -189,7 +192,7 @@ class TestSalesforceHook(unittest.TestCase):
                 "extra__salesforce__security_token": "",
                 "extra__salesforce__version": "34.0"
             }
-            '''
+            ''',
         )
         with create_session() as session:
             session.add(jwt_auth_conn)
@@ -245,7 +248,7 @@ class TestSalesforceHook(unittest.TestCase):
                 "extra__salesforce__security_token": "",
                 "extra__salesforce__version": ""
             }
-            '''
+            ''',
         )
         with create_session() as session:
             session.add(ip_filtering_auth_conn)

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -22,16 +22,24 @@ from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
+from requests import Session as request_session
 from numpy import nan
-from simple_salesforce import Salesforce
+from simple_salesforce import Salesforce, api
 
 from airflow.models.connection import Connection
 from airflow.providers.salesforce.hooks.salesforce import SalesforceHook
-
+from airflow.utils.session import create_session
 
 class TestSalesforceHook(unittest.TestCase):
     def setUp(self):
         self.salesforce_hook = SalesforceHook(salesforce_conn_id="conn_id")
+
+        with create_session() as session:
+            session.query(Connection).delete()
+
+    def tearDown(self):
+        with create_session() as session:
+            session.query(Connection).delete()
 
     def test_get_conn_exists(self):
         self.salesforce_hook.conn = Mock(spec=Salesforce)
@@ -40,24 +48,229 @@ class TestSalesforceHook(unittest.TestCase):
 
         assert self.salesforce_hook.conn.return_value is not None
 
-    @patch(
-        "airflow.providers.salesforce.hooks.salesforce.SalesforceHook.get_connection",
-        return_value=Connection(
-            login="username",
-            password="password",
-            extra='{"extra__salesforce__security_token": "token", "extra__salesforce__domain": "login"}',
-        ),
-    )
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
-    def test_get_conn(self, mock_salesforce, mock_get_connection):
+    def test_get_conn_password_auth(self, mock_salesforce):
+        """
+        Testing mock password authentication to Salesforce. Users should provide a username, password, and
+        security token in the Connection. Providing a client ID, Salesforce API version, proxy mapping, and
+        domain are optional. Connection params set as empty strings should be converted to `None`.
+        """
+
+        password_auth_conn = Connection(
+            conn_id="password_auth_conn",
+            conn_type="salesforce",
+            login=None,
+            password=None,
+            extra='''
+            {
+                "extra__salesforce__client_id": "my_client",
+                "extra__salesforce__consumer_key": "",
+                "extra__salesforce__domain": "test",
+                "extra__salesforce__instance": "",
+                "extra__salesforce__instance_url": "",
+                "extra__salesforce__organization_id": "",
+                "extra__salesforce__private_key": "",
+                "extra__salesforce__private_key_file_path": "",
+                "extra__salesforce__proxies": "",
+                "extra__salesforce__security_token": "token",
+                "extra__salesforce__version": "42.0"
+            }
+            '''
+        )
+        with create_session() as session:
+            session.add(password_auth_conn)
+            session.commit()
+
+        self.salesforce_hook = SalesforceHook(salesforce_conn_id="password_auth_conn")
         self.salesforce_hook.get_conn()
 
-        assert self.salesforce_hook.conn == mock_salesforce.return_value
+        extras = password_auth_conn.extra_dejson
         mock_salesforce.assert_called_once_with(
-            username=mock_get_connection.return_value.login,
-            password=mock_get_connection.return_value.password,
-            security_token=mock_get_connection.return_value.extra_dejson["extra__salesforce__security_token"],
-            domain=mock_get_connection.return_value.extra_dejson.get("extra__salesforce__domain"),
+            username=password_auth_conn.login,
+            password=password_auth_conn.password,
+            security_token=extras["extra__salesforce__security_token"],
+            domain=extras["extra__salesforce__domain"],
+            session_id=None,
+            instance=None,
+            instance_url=None,
+            organizationId=None,
+            version=extras["extra__salesforce__version"],
+            proxies=None,
+            session=None,
+            client_id=extras["extra__salesforce__client_id"],
+            consumer_key=None,
+            privatekey_file=None,
+            privatekey=None,
+        )
+
+    @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
+    def test_get_conn_direct_session_access(self, mock_salesforce):
+        """
+        Testing mock direct session access to Salesforce. Users should provide an instance
+        (or instance URL) in the Connection and set a `session_id` value when calling `SalesforceHook`.
+        Providing a client ID, Salesforce API version, proxy mapping, and domain are optional. Connection
+        params set as empty strings should be converted to `None`.
+        """
+
+        direct_access_conn = Connection(
+            conn_id="direct_access_conn",
+            conn_type="salesforce",
+            login=None,
+            password=None,
+            extra='''
+            {
+                "extra__salesforce__client_id": "my_client2",
+                "extra__salesforce__consumer_key": "",
+                "extra__salesforce__domain": "test",
+                "extra__salesforce__instance": "",
+                "extra__salesforce__instance_url": "https://my.salesforce.com",
+                "extra__salesforce__organization_id": "",
+                "extra__salesforce__private_key": "",
+                "extra__salesforce__private_key_file_path": "",
+                "extra__salesforce__proxies": "",
+                "extra__salesforce__security_token": "",
+                "extra__salesforce__version": "29.0"
+            }
+            '''
+        )
+        with create_session() as session:
+            session.add(direct_access_conn)
+            session.commit()
+
+        self.salesforce_hook = SalesforceHook(
+            salesforce_conn_id="direct_access_conn", session_id="session_id"
+        )
+        self.salesforce_hook.get_conn()
+
+        extras = direct_access_conn.extra_dejson
+        mock_salesforce.assert_called_once_with(
+            username=direct_access_conn.login,
+            password=direct_access_conn.password,
+            security_token=None,
+            domain=extras["extra__salesforce__domain"],
+            session_id=self.salesforce_hook.session_id,
+            instance=None,
+            instance_url=extras["extra__salesforce__instance_url"],
+            organizationId=None,
+            version=extras["extra__salesforce__version"],
+            proxies=None,
+            session=None,
+            client_id=extras["extra__salesforce__client_id"],
+            consumer_key=None,
+            privatekey_file=None,
+            privatekey=None,
+        )
+
+    @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
+    def test_get_conn_jwt_auth(self, mock_salesforce):
+        """
+        Testing mock JWT bearer authentication to Salesforce. Users should provide consumer key and private
+        key (or path to a private key) in the Connection. Providing a client ID, Salesforce API version, proxy
+        mapping, and domain are optional. Connection params set as empty strings should be converted to
+        `None`.
+        """
+
+        jwt_auth_conn = Connection(
+            conn_id="jwt_auth_conn",
+            conn_type="salesforce",
+            login=None,
+            password=None,
+            extra='''
+            {
+                "extra__salesforce__client_id": "my_client3",
+                "extra__salesforce__consumer_key": "consumer_key",
+                "extra__salesforce__domain": "login",
+                "extra__salesforce__instance": "",
+                "extra__salesforce__instance_url": "",
+                "extra__salesforce__organization_id": "",
+                "extra__salesforce__private_key": "private_key",
+                "extra__salesforce__private_key_file_path": "",
+                "extra__salesforce__proxies": "",
+                "extra__salesforce__security_token": "",
+                "extra__salesforce__version": "34.0"
+            }
+            '''
+        )
+        with create_session() as session:
+            session.add(jwt_auth_conn)
+            session.commit()
+
+        self.salesforce_hook = SalesforceHook(salesforce_conn_id="jwt_auth_conn")
+        self.salesforce_hook.get_conn()
+
+        extras = jwt_auth_conn.extra_dejson
+        mock_salesforce.assert_called_once_with(
+            username=jwt_auth_conn.login,
+            password=jwt_auth_conn.password,
+            security_token=None,
+            domain=extras["extra__salesforce__domain"],
+            session_id=None,
+            instance=None,
+            instance_url=None,
+            organizationId=None,
+            version=extras["extra__salesforce__version"],
+            proxies=None,
+            session=None,
+            client_id=extras["extra__salesforce__client_id"],
+            consumer_key=extras["extra__salesforce__consumer_key"],
+            privatekey_file=None,
+            privatekey=extras["extra__salesforce__private_key"],
+        )
+
+    @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
+    def test_get_conn_ip_filtering_auth(self, mock_salesforce):
+        """
+        Testing mock IP filtering (aka allow-listing) authentication to Salesforce. Users should provide
+        username, password, and organization ID in the Connection. Providing a client ID, Salesforce API
+        version, proxy mapping, and domain are optional. Connection params set as empty strings should be
+        converted to `None`.
+        """
+
+        ip_filtering_auth_conn = Connection(
+            conn_id="ip_filtering_auth_conn",
+            conn_type="salesforce",
+            login="username",
+            password="password",
+            extra='''
+            {
+                "extra__salesforce__client_id": "",
+                "extra__salesforce__consumer_key": "",
+                "extra__salesforce__domain": "",
+                "extra__salesforce__instance": "",
+                "extra__salesforce__instance_url": "",
+                "extra__salesforce__organization_id": "my_organization",
+                "extra__salesforce__private_key": "",
+                "extra__salesforce__private_key_file_path": "",
+                "extra__salesforce__proxies": "",
+                "extra__salesforce__security_token": "",
+                "extra__salesforce__version": ""
+            }
+            '''
+        )
+        with create_session() as session:
+            session.add(ip_filtering_auth_conn)
+            session.commit()
+
+        self.salesforce_hook = SalesforceHook(salesforce_conn_id="ip_filtering_auth_conn")
+        self.salesforce_hook.get_conn()
+
+        extras = ip_filtering_auth_conn.extra_dejson
+        mock_salesforce.assert_called_once_with(
+            username=ip_filtering_auth_conn.login,
+            password=ip_filtering_auth_conn.password,
+            security_token=None,
+            domain=None,
+            session_id=None,
+            instance=None,
+            instance_url=None,
+            organizationId=extras["extra__salesforce__organization_id"],
+            version=api.DEFAULT_API_VERSION,
+            proxies=None,
+            session=None,
+            client_id=None,
+            consumer_key=None,
+            privatekey_file=None,
+            privatekey=None,
         )
 
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -37,7 +37,7 @@ class TestSalesforceHook(unittest.TestCase):
 
     def _insert_conn_db_entry(conn_id, conn_object):
         with create_session() as session:
-            session.query(Connection).filter(Connection.conn_id==conn_id).delete()
+            session.query(Connection).filter(Connection.conn_id == conn_id).delete()
             session.add(conn_object)
             session.commit()
 

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -35,12 +35,11 @@ class TestSalesforceHook(unittest.TestCase):
     def setUp(self):
         self.salesforce_hook = SalesforceHook(salesforce_conn_id="conn_id")
 
+    def _insert_conn_db_entry(conn_id, conn_object):
         with create_session() as session:
-            session.query(Connection).delete()
-
-    def tearDown(self):
-        with create_session() as session:
-            session.query(Connection).delete()
+            session.query(Connection).filter(Connection.conn_id==conn_id).delete()
+            session.add(conn_object)
+            session.commit()
 
     def test_get_conn_exists(self):
         self.salesforce_hook.conn = Mock(spec=Salesforce)
@@ -78,9 +77,7 @@ class TestSalesforceHook(unittest.TestCase):
             }
             ''',
         )
-        with create_session() as session:
-            session.add(password_auth_conn)
-            session.commit()
+        TestSalesforceHook._insert_conn_db_entry(password_auth_conn.conn_id, password_auth_conn)
 
         self.salesforce_hook = SalesforceHook(salesforce_conn_id="password_auth_conn")
         self.salesforce_hook.get_conn()
@@ -134,9 +131,7 @@ class TestSalesforceHook(unittest.TestCase):
             }
             ''',
         )
-        with create_session() as session:
-            session.add(direct_access_conn)
-            session.commit()
+        TestSalesforceHook._insert_conn_db_entry(direct_access_conn.conn_id, direct_access_conn)
 
         with request_session() as session:
             self.salesforce_hook = SalesforceHook(
@@ -194,9 +189,7 @@ class TestSalesforceHook(unittest.TestCase):
             }
             ''',
         )
-        with create_session() as session:
-            session.add(jwt_auth_conn)
-            session.commit()
+        TestSalesforceHook._insert_conn_db_entry(jwt_auth_conn.conn_id, jwt_auth_conn)
 
         self.salesforce_hook = SalesforceHook(salesforce_conn_id="jwt_auth_conn")
         self.salesforce_hook.get_conn()
@@ -250,9 +243,7 @@ class TestSalesforceHook(unittest.TestCase):
             }
             ''',
         )
-        with create_session() as session:
-            session.add(ip_filtering_auth_conn)
-            session.commit()
+        TestSalesforceHook._insert_conn_db_entry(ip_filtering_auth_conn.conn_id, ip_filtering_auth_conn)
 
         self.salesforce_hook = SalesforceHook(salesforce_conn_id="ip_filtering_auth_conn")
         self.salesforce_hook.get_conn()


### PR DESCRIPTION
Closes: #17192

- Adding login and authentication support when using the `SalesforceHook`:
  - JWT bearer authentication
  - IP filtering (allow-listing)
  - Direct session/instance access

- New fields were also added to the connection form for the "Salesforce" type: 
  ![image](https://user-images.githubusercontent.com/48934154/128120371-550fe54d-b82f-4e48-8ae6-282ac084d047.png)


- Connection documentation has also been updated to describe each connection field and what type of login/authentication is related.

- Refactored unit tests to include mock implementations of the 4 supported auth/login types.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
