### PR TITLE
Add XCom.clear so it's hookable in custom XCom backend

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -703,12 +703,11 @@ class TaskInstance(Base, LoggingMixin):
         :type session: Session
         """
         self.log.debug("Clearing XCom data")
-        session.query(XCom).filter(
-            XCom.dag_id == self.dag_id,
-            XCom.task_id == self.task_id,
-            XCom.execution_date == self.execution_date,
-        ).delete()
-        session.commit()
+        XCom.clear(
+            dag_id=self.dag_id,
+            task_id=self.task_id,
+            execution_date=self.execution_date,
+        )
         self.log.debug("XCom data cleared")
 
     @property

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -707,7 +707,9 @@ class TaskInstance(Base, LoggingMixin):
             dag_id=self.dag_id,
             task_id=self.task_id,
             execution_date=self.execution_date,
+            session=session,
         )
+        session.commit()
         self.log.debug("XCom data cleared")
 
     @property

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -709,7 +709,6 @@ class TaskInstance(Base, LoggingMixin):
             execution_date=self.execution_date,
             session=session,
         )
-        session.commit()
         self.log.debug("XCom data cleared")
 
     @property

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -222,9 +222,8 @@ class BaseXCom(Base, LoggingMixin):
     def clear(
         cls,
         execution_date: pendulum.DateTime,
-        dag_id: Optional[str] = None,
-        task_id: Optional[str] = None,
-        include_prior_dates: bool = False,
+        dag_id: str,
+        task_id: str,
         session: Session = None,
     ) -> None:
         """
@@ -232,34 +231,17 @@ class BaseXCom(Base, LoggingMixin):
 
         :param execution_date: Execution date for the task
         :type execution_date: pendulum.datetime
-        :param dag_id: If provided, only pulls XCom from this DAG.
-            If None (default), the DAG of the calling task is used.
+        :param dag_id: Only pulls XCom from this DAG.
         :type dag_id: str
-        :param task_id: Only XComs from task with matching id will be
-            pulled. Can pass None to remove the filter.
+        :param task_id: Only XComs from task with matching id will be pulled.
         :type task_id: str
-        :param include_prior_dates: If False, only XComs from the current
-            execution_date are returned. If True, XComs from previous dates
-            are returned as well.
-        :type include_prior_dates: bool
         :param session: database session
         :type session: sqlalchemy.orm.session.Session
         """
-        filters = []
-
-        if dag_id:
-            filters.append(cls.dag_id == dag_id)
-
-        if task_id:
-            filters.append(cls.task_id == task_id)
-
-        if include_prior_dates:
-            filters.append(cls.execution_date <= execution_date)
-        else:
-            filters.append(cls.execution_date == execution_date)
-
         session.query(cls).filter(
-            and_(*filters)
+            cls.dag_id == dag_id,
+            cls.task_id == task_id,
+            cls.execution_date == execution_date,
         ).delete()
         session.commit()
 

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -243,7 +243,6 @@ class BaseXCom(Base, LoggingMixin):
             cls.task_id == task_id,
             cls.execution_date == execution_date,
         ).delete()
-        session.commit()
 
     @staticmethod
     def serialize_value(value: Any):

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -231,7 +231,7 @@ class BaseXCom(Base, LoggingMixin):
 
         :param execution_date: Execution date for the task
         :type execution_date: pendulum.datetime
-        :param dag_id: DAG ID to clear XCom of.
+        :param dag_id: ID of DAG to clear the XCom for.
         :type dag_id: str
         :param task_id: Only XComs from task with matching id will be cleared.
         :type task_id: str

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -231,9 +231,9 @@ class BaseXCom(Base, LoggingMixin):
 
         :param execution_date: Execution date for the task
         :type execution_date: pendulum.datetime
-        :param dag_id: Only pulls XCom from this DAG.
+        :param dag_id: DAG ID to clear XCom of.
         :type dag_id: str
-        :param task_id: Only XComs from task with matching id will be pulled.
+        :param task_id: Only XComs from task with matching id will be cleared.
         :type task_id: str
         :param session: database session
         :type session: sqlalchemy.orm.session.Session


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Airflow supports custom XCom backend, but there are still a direct xcom query in `TaskInstance`, which breaks the custom XCom backend do proper pre/post processing when deleting values in XCom storage.

This pull requests add a new interface `XCom.clear` to `BaseXCom` and use it when clearing results for given dags and tasks, instead of directly querying and operating the underlying database.

The change in this pull request will allow the custom XCom backend process the data lifecycle easier, and is fully backwards compatible.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
