### PR TITLE
doc: fixed docstring for sql param in Neo4jOperator

### DIFF
--- a/airflow/providers/neo4j/operators/neo4j.py
+++ b/airflow/providers/neo4j/operators/neo4j.py
@@ -30,8 +30,8 @@ class Neo4jOperator(BaseOperator):
         :ref:`howto/operator:Neo4jOperator`
 
     :param sql: the sql code to be executed. Can receive a str representing a
-        sql statement, a list of str (sql statements)
-    :type sql: str or list[str]
+        sql statement
+    :type sql: str
     :param neo4j_conn_id: Reference to :ref:`Neo4j connection id <howto/connection:neo4j>`.
     :type neo4j_conn_id: str
     """


### PR DESCRIPTION
Neo4jHook has own 'run' method implementation and it can't use list of string for sql param.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
