### PR TITLE
Improve image building documentation for new users

### DIFF
--- a/docs/apache-airflow-providers/index.rst
+++ b/docs/apache-airflow-providers/index.rst
@@ -21,6 +21,8 @@ Provider packages
 
 .. contents:: :local:
 
+.. _providers:community-maintained-providers:
+
 Community maintained providers
 ''''''''''''''''''''''''''''''
 
@@ -30,6 +32,9 @@ The core of Airflow scheduling system is delivered as ``apache-airflow`` package
 Those provider packages are separated per-provider (for example ``amazon``, ``google``, ``salesforce``
 etc.). Those packages are available as ``apache-airflow-providers`` packages - separately per each provider
 (for example there is an ``apache-airflow-providers-amazon`` or ``apache-airflow-providers-google`` package).
+
+The full list of community managed providers is available at
+`Providers Index <https://airflow.apache.org/docs/#providers-packages-docs-apache-airflow-providers-index-html>`_.
 
 You can install those provider packages separately in order to interface with a given service. For those
 providers that have corresponding extras, the provider packages (latest version from PyPI) are installed

--- a/docs/apache-airflow/start/docker-compose.yaml
+++ b/docs/apache-airflow/start/docker-compose.yaml
@@ -44,7 +44,11 @@
 version: '3'
 x-airflow-common:
   &airflow-common
+  # In order to add custom dependencies or upgrade provider packages you can use your extended image.
+  # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
+  # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
   image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:|version|}
+  # build: .
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
@@ -60,7 +64,7 @@ x-airflow-common:
     - ./dags:/opt/airflow/dags
     - ./logs:/opt/airflow/logs
     - ./plugins:/opt/airflow/plugins
-  user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-50000}"
+  user: "${AIRFLOW_UID:-50000}:${AIRFLOW_GID:-0}"
   depends_on:
     &airflow-common-depends-on
     redis:

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -86,7 +86,7 @@ Using custom images
 
 When you want to run Airflow locally, you might want to use an extended image, containing some additional dependencies - for
 example you might add new python packages, or upgrade airflow providers to a later version. This can be done very easily
-by placing your custom Dockerfile. Then you can use `docker-compose build` command to build your image (you need to
+by placing a custom Dockerfile alongside your `docker-compose.yaml`. Then you can use `docker-compose build` command to build your image (you need to
 do it only once) and you can also add `--build` to your `docker-compose` commands with flag to rebuild the images
 on-the-fly when you run other `docker-compose` commands.
 

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -90,7 +90,7 @@ by placing a custom Dockerfile alongside your `docker-compose.yaml`. Then you ca
 do it only once). You can also add the `--build` flag to your `docker-compose` commands to rebuild the images
 on-the-fly when you run other `docker-compose` commands.
 
-The examples of how you can extend the image with custom providers, python packages,
+Examples of how you can extend the image with custom providers, python packages,
 apt packages and more can be found in :doc:`Building the image <docker-stack:build>`.
 
 Initializing Environment

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -87,7 +87,7 @@ Using custom images
 When you want to run Airflow locally, you might want to use an extended image, containing some additional dependencies - for
 example you might add new python packages, or upgrade airflow providers to a later version. This can be done very easily
 by placing a custom Dockerfile alongside your `docker-compose.yaml`. Then you can use `docker-compose build` command to build your image (you need to
-do it only once) and you can also add `--build` to your `docker-compose` commands with flag to rebuild the images
+do it only once). You can also add the `--build` flag to your `docker-compose` commands to rebuild the images
 on-the-fly when you run other `docker-compose` commands.
 
 The examples of how you can extend the image with custom providers, python packages,

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -81,6 +81,18 @@ If you need install a new Python library or system library, you can :doc:`build 
 .. _initializing_docker_compose_environment:
 
 
+Using custom images
+===================
+
+When you want to run Airflow locally, you might want to use extended image, containing some additional dependencies - for
+example you might add new python packages, or upgrade airflow providers to a later version. This can be done very easily
+by placing your custom Dockerfile. Then you can use `docker-compose build` command to build your image (you need to
+do it only once) and you can also add `--build` to your `docker-compose` commands with flag to rebuild the images
+on-the-fly when you run other `docker-compose` commands.
+
+The examples of how you can extend the image with custom providers, python packages,
+apt packages and more can be found in :doc:`Building the image <docker-stack:build>`.
+
 Initializing Environment
 ========================
 

--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -84,7 +84,7 @@ If you need install a new Python library or system library, you can :doc:`build 
 Using custom images
 ===================
 
-When you want to run Airflow locally, you might want to use extended image, containing some additional dependencies - for
+When you want to run Airflow locally, you might want to use an extended image, containing some additional dependencies - for
 example you might add new python packages, or upgrade airflow providers to a later version. This can be done very easily
 by placing your custom Dockerfile. Then you can use `docker-compose build` command to build your image (you need to
 do it only once) and you can also add `--build` to your `docker-compose` commands with flag to rebuild the images

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -255,7 +255,7 @@ Example of upgrading Airflow Provider packages
 
 The :ref:`Airflow Providers <providers:community-maintained-providers>` are released independently of core
 Airflow and sometimes you might want to upgrade specific providers only to fix some problems or
-use features available in that provider. Here is an example of how you can do it
+use features available in that provider version. Here is an example of how you can do it
 
 .. exampleinclude:: docker-examples/extending/add-providers/Dockerfile
     :language: Dockerfile

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -250,6 +250,19 @@ You should be aware, about a few things:
 Examples of image extending
 ---------------------------
 
+Example of upgrading Airflow Provider packages
+..............................................
+
+The :ref:`Airflow Providers <providers:community-maintained-providers>` are released independently of the main
+Airflow and sometimes you might want to upgrade specific providers only to fix some problems or
+use features available in that provider. Here is an example of how you can do it
+
+.. exampleinclude:: docker-examples/extending/add-providers/Dockerfile
+    :language: Dockerfile
+    :start-after: [START Dockerfile]
+    :end-before: [END Dockerfile]
+
+
 Example of adding ``apt`` package
 .................................
 

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -253,7 +253,7 @@ Examples of image extending
 Example of upgrading Airflow Provider packages
 ..............................................
 
-The :ref:`Airflow Providers <providers:community-maintained-providers>` are released independently of the main
+The :ref:`Airflow Providers <providers:community-maintained-providers>` are released independently of core
 Airflow and sometimes you might want to upgrade specific providers only to fix some problems or
 use features available in that provider. Here is an example of how you can do it
 

--- a/docs/docker-stack/docker-examples/extending/add-apt-packages/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-apt-packages/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow
+FROM apache/airflow:2.1.2
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-build-essential-extend/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-build-essential-extend/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow
+FROM apache/airflow:2.1.2
 USER root
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docs/docker-stack/docker-examples/extending/add-providers/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/add-providers/Dockerfile
@@ -16,5 +16,6 @@
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
 FROM apache/airflow:2.1.2
-RUN pip install --no-cache-dir lxml
+RUN pip install --no-cache-dir apache-airflow-providers-docker==2.1.0
 # [END Dockerfile]
+

--- a/docs/docker-stack/docker-examples/extending/embedding-dags/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/embedding-dags/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow
+FROM apache/airflow:2.1.2
 
 COPY --chown=airflow:root test_dag.py /opt/airflow/dags
 

--- a/docs/docker-stack/docker-examples/extending/writable-directory/Dockerfile
+++ b/docs/docker-stack/docker-examples/extending/writable-directory/Dockerfile
@@ -15,7 +15,7 @@
 
 # This is an example Dockerfile. It is not intended for PRODUCTION use
 # [START Dockerfile]
-FROM apache/airflow
+FROM apache/airflow:2.1.2
 RUN umask 0002; \
     mkdir -p ~/writeable-directory
 # [END Dockerfile]


### PR DESCRIPTION
This PR improves documentation for building images of airflow,
specifically targetting users who do not have big experience with
building the images. It shows examples on how custom image building
can be easily used to upgrade provider packages as well as how
image building can be easily integrated in quick-start using
docker-compose.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
