### PR TITLE
Improve diagnostics message when users have secret_key misconfigured

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -22,7 +22,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import httpx
-from httpx import HTTPStatusError
 from itsdangerous import TimedJSONWebSignatureSerializer
 
 from airflow.configuration import AirflowConfigException, conf

--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import httpx
+from httpx import HTTPStatusError
 from itsdangerous import TimedJSONWebSignatureSerializer
 
 from airflow.configuration import AirflowConfigException, conf
@@ -186,6 +187,11 @@ class FileTaskHandler(logging.Handler):
                 )
                 response.encoding = "utf-8"
 
+                if response.status_code == 403:
+                    log += "*** !!!! Please make sure that all your webservers and workers have" \
+                           " the same 'secret_key' configured in 'webserver' section !!!!!\n***"
+                    log += "*** See more at https://airflow.apache.org/docs/apache-airflow/" \
+                           "stable/configurations-ref.html#secret-key\n***"
                 # Check if the resource was properly fetched
                 response.raise_for_status()
 


### PR DESCRIPTION
Recently fixed log open-access vulnerability have caused
quite a lot of questions and issues from the affected users who
did not have webserver/secret_key configured for their workers
(effectively leading to random value for those keys for workers)

This PR explicitly explains the possible reason for the problem and
encourages the user to configure their webserver's secret_key
in both - workers and webserver.

Related to: #17251 and a number of similar slack discussions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
