### PR TITLE
Add timeout when asking whether to rebuild image

### DIFF
--- a/confirm
+++ b/confirm
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-set -euo pipefail
+set -uo pipefail
 
 if [[ -n "${FORCE_ANSWER_TO_QUESTIONS=}" ]]; then
     RESPONSE=${FORCE_ANSWER_TO_QUESTIONS}
@@ -31,8 +31,8 @@ if [[ -n "${FORCE_ANSWER_TO_QUESTIONS=}" ]]; then
     esac
 else
     echo
-    echo "Please confirm ${1}. Are you sure? [y/N/q]"
-    read -r RESPONSE
+    echo "Please confirm ${1} (or wait 4 seconds to skip it). Are you sure? [y/N/q]"
+    read -t 4 -r RESPONSE
 fi
 
 case "${RESPONSE}" in


### PR DESCRIPTION
This PR adds timeout to answer the question, whether to rebuild
image when `breeze` is invoked or when pre-commit is run.

This reflects the typical use cases where rebuild is mostly not
needed, only in case of some tests which require new dependencies
to be included.

User has still 4 seconds to answer Y and have the images rebuilt
and just the presence of the question will be enough to get the
user trigger it from time to time.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
