### PR TITLE
Use `dag_maker` fixture in models/test_taskinstance.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -480,6 +480,7 @@ def dag_maker(request):
                     self.start_date = DEFAULT_DATE
             self.kwargs['start_date'] = self.start_date
             self.dag = DAG(dag_id, **self.kwargs)
+            self.dag.fileloc = request.module.__file__
             return self
 
     return DagFactory()


### PR DESCRIPTION
The change applies dag_maker fixture in test_taskinstance.py


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
