### PR TITLE
Fix elasticsearch-secret template port default function

### DIFF
--- a/chart/templates/secrets/elasticsearch-secret.yaml
+++ b/chart/templates/secrets/elasticsearch-secret.yaml
@@ -33,6 +33,6 @@ metadata:
 type: Opaque
 data:
   {{- with .Values.elasticsearch.connection }}
-  connection: {{ urlJoin (dict "scheme" "http" "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery)) "host" (printf "%s:%s" .host ((default .port 80) | toString) ) ) | b64enc | quote }}
+  connection: {{ urlJoin (dict "scheme" "http" "userinfo" (printf "%s:%s" (.user | urlquery) (.pass | urlquery)) "host" (printf "%s:%s" .host ((default 80 .port) | toString) ) ) | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -113,4 +113,3 @@ class ElasticsearchSecretTest(unittest.TestCase):
         )
 
         assert "http://username:password@elastichostname:2222" == connection
-        

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -103,17 +103,12 @@ class ElasticsearchSecretTest(unittest.TestCase):
                 "elasticsearch": {
                     "enabled": True,
                     "connection": {
-                        "user": "username!@#$%%^&*()",
-                        "pass": "password!@#$%%^&*()",
                         "host": "elastichostname",
-                        "port": 9200,
+                        "port": 2222,
                     },
                 }
             }
         )
 
-        assert (
-            "http://username%21%40%23$%25%25%5E&%2A%28%29:password%21%40%23$%25%25%5E&%2A%28%29@"
-            "elastichostname:9200" == connection
-        )
+        assert "http://elastichostname:2222" == connection
         

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -96,3 +96,24 @@ class ElasticsearchSecretTest(unittest.TestCase):
             "http://username%21%40%23$%25%25%5E&%2A%28%29:password%21%40%23$%25%25%5E&%2A%28%29@"
             "elastichostname:80" == connection
         )
+
+    def test_should_generate_secret_with_specified_port(self):
+        connection = self._get_connection(
+            {
+                "elasticsearch": {
+                    "enabled": True,
+                    "connection": {
+                        "user": "username!@#$%%^&*()",
+                        "pass": "password!@#$%%^&*()",
+                        "host": "elastichostname",
+                        "port": 9200,
+                    },
+                }
+            }
+        )
+
+        assert (
+            "http://username%21%40%23$%25%25%5E&%2A%28%29:password%21%40%23$%25%25%5E&%2A%28%29@"
+            "elastichostname:9200" == connection
+        )
+        

--- a/chart/tests/test_elasticsearch_secret.py
+++ b/chart/tests/test_elasticsearch_secret.py
@@ -103,6 +103,8 @@ class ElasticsearchSecretTest(unittest.TestCase):
                 "elasticsearch": {
                     "enabled": True,
                     "connection": {
+                        "user": "username",
+                        "pass": "password",
                         "host": "elastichostname",
                         "port": 2222,
                     },
@@ -110,5 +112,5 @@ class ElasticsearchSecretTest(unittest.TestCase):
             }
         )
 
-        assert "http://elastichostname:2222" == connection
+        assert "http://username:password@elastichostname:2222" == connection
         


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Default function in helm template should be "default DEFAULT_VALUE GIVEN_VALUE".
Original code can invoke elasticsearch host configuration error.

Refer `Using the default function` section below link.
https://helm.sh/docs/chart_template_guide/functions_and_pipelines/


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
