### PR TITLE
KEDA task count query should ignore k8s queue

### DIFF
--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -50,6 +50,7 @@ spec:
           SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
           FROM task_instance
           WHERE (state='running' OR state='queued')
-{{ $k8s_queue := default (printf "kubernetes") .Values.config.celery_kubernetes_executor.kubernetes_queue -}}
-{{ eq .Values.executor "CeleryKubernetesExecutor" | ternary (printf "AND queue != '%s'" $k8s_queue) (print "") | indent 14 }}
+          {{- if eq .Values.executor "CeleryKubernetesExecutor" }}
+          AND queue != '{{ .Values.config.celery_kubernetes_executor.kubernetes_queue }}'
+          {{- end }}
 {{- end }}

--- a/chart/templates/workers/worker-kedaautoscaler.yaml
+++ b/chart/templates/workers/worker-kedaautoscaler.yaml
@@ -49,5 +49,7 @@ spec:
         query: >-
           SELECT ceil(COUNT(*)::decimal / {{ .Values.config.celery.worker_concurrency }})
           FROM task_instance
-          WHERE state='running' OR state='queued'
+          WHERE (state='running' OR state='queued')
+{{ $k8s_queue := default (printf "kubernetes") .Values.config.celery_kubernetes_executor.kubernetes_queue -}}
+{{ eq .Values.executor "CeleryKubernetesExecutor" | ternary (printf "AND queue != '%s'" $k8s_queue) (print "") | indent 14 }}
 {{- end }}

--- a/chart/tests/test_keda.py
+++ b/chart/tests/test_keda.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import jmespath
+import pytest
 from parameterized import parameterized
 
 from tests.helm_template_generator import render_chart
@@ -51,17 +52,29 @@ class TestKeda:
         else:
             assert docs == []
 
-    @parameterized.expand(
+    @staticmethod
+    def build_query(executor, concurrency=16, queue=None):
+        """Builds the query used by KEDA autoscaler to determine how many workers there should be"""
+        query = (
+            f"SELECT ceil(COUNT(*)::decimal / {concurrency}) "
+            "FROM task_instance WHERE (state='running' OR state='queued')"
+        )
+        if executor == 'CeleryKubernetesExecutor':
+            query += f" AND queue != '{queue or 'kubernetes'}'"
+        return query
+
+    @pytest.mark.parametrize(
+        'executor,concurrency',
         [
             ("CeleryExecutor", 8),
             ("CeleryExecutor", 16),
             ("CeleryKubernetesExecutor", 8),
             ("CeleryKubernetesExecutor", 16),
-        ]
+        ],
     )
     def test_keda_concurrency(self, executor, concurrency):
         """
-        Verify keda sql query is uses configured concurrency
+        Verify keda sql query uses configured concurrency
         """
         docs = render_chart(
             values={
@@ -71,19 +84,17 @@ class TestKeda:
             },
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
         )
-        expected_query = (
-            f"SELECT ceil(COUNT(*)::decimal / {concurrency}) "
-            "FROM task_instance WHERE (state='running' OR state='queued')"
-        )
+        expected_query = self.build_query(executor=executor, concurrency=concurrency)
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == expected_query
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        'executor,queue,should_filter',
         [
             ("CeleryExecutor", None, False),
             ("CeleryExecutor", 'my_queue', False),
             ("CeleryKubernetesExecutor", None, True),
             ("CeleryKubernetesExecutor", 'my_queue', True),
-        ]
+        ],
     )
     def test_keda_query_kubernetes_queue(self, executor, queue, should_filter):
         """
@@ -101,12 +112,7 @@ class TestKeda:
             values=values,
             show_only=["templates/workers/worker-kedaautoscaler.yaml"],
         )
-        expected_query = (
-            "SELECT ceil(COUNT(*)::decimal / 16) "
-            "FROM task_instance WHERE (state='running' OR state='queued')"
-        )
-        if should_filter:
-            expected_query += f" AND queue != '{queue or 'kubernetes'}'"
+        expected_query = self.build_query(executor=executor, queue=queue)
         assert jmespath.search("spec.triggers[0].metadata.query", docs[0]) == expected_query
 
     @parameterized.expand(

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1111,6 +1111,8 @@ config:
     reinit_frequency: '{{ .Values.kerberos.reinitFrequency }}'
     principal: '{{ .Values.kerberos.principal }}'
     ccache: '{{ .Values.kerberos.ccacheMountPath }}/{{ .Values.kerberos.ccacheFileName }}'
+  celery_kubernetes_executor:
+    kubernetes_queue: 'kubernetes'
   kubernetes:
     namespace: '{{ .Release.Namespace }}'
     airflow_configmap: '{{ include "airflow_config" . }}'


### PR DESCRIPTION
CeleryKubernetesExecutor lets us use both celery and kubernetes executors.

KEDA lets us scale down to zero when there are no celery tasks running.

The existing KEDA query doesn't look at task `queue` so it wil scale up to 1 if there is 
1 k8s task and 0 celery tasks.

We can prevent this from happening by ignoring the kubernetes queue in the KEDA query.
