### PR TITLE
Add info log how to fix: More than one pod running with labels

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -353,8 +353,7 @@ class KubernetesPodOperator(BaseOperator):
             pod_list = self.client.list_namespaced_pod(self.namespace, label_selector=label_selector)
 
             if len(pod_list.items) > 1 and self.reattach_on_restart:
-                self.log.info("Please set is_delete_operator_pod=True \
-+                    when you instantiate KubernetesPodOperator in your dag to fix the problem")
+                self.log.info("Please set reattach_on_restart=False to fix the problem")
                 raise AirflowException(
                     f'More than one pod running with labels: {label_selector}'
                 )

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -353,6 +353,8 @@ class KubernetesPodOperator(BaseOperator):
             pod_list = self.client.list_namespaced_pod(self.namespace, label_selector=label_selector)
 
             if len(pod_list.items) > 1 and self.reattach_on_restart:
+                self.log.info("Please set is_delete_operator_pod=True \
++                    when you instantiate KubernetesPodOperator in your dag to fix the problem")
                 raise AirflowException(
                     f'More than one pod running with labels: {label_selector}'
                 )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Logs information how to fix issue with: "More than one pod running with labels" - using is_delete_operator_pod argument when creating new KubernetesPodOperator
This is just a simple update which adds an extra info log how to avoid the mentioned problem. It does not change a logic at all.
Flag ensures that every time a pod is being deleted. So we always end up with single and unique running pod.

related: #10544
Accidentally closed: #17285 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
