### PR TITLE
Pin snowflake-sqlalchemy

### DIFF
--- a/docs/apache-airflow-providers-snowflake/index.rst
+++ b/docs/apache-airflow-providers-snowflake/index.rst
@@ -80,7 +80,7 @@ PIP package                     Version required
 ==============================  ==================
 ``apache-airflow``              ``>=2.1.0``
 ``snowflake-connector-python``  ``>=2.4.1``
-``snowflake-sqlalchemy``        ``>=1.1.0``
+``snowflake-sqlalchemy``        ``>=1.1.0,<1.3``
 ==============================  ==================
 
 Cross provider package dependencies

--- a/setup.py
+++ b/setup.py
@@ -444,7 +444,7 @@ slack = [
 ]
 snowflake = [
     'snowflake-connector-python>=2.4.1',
-    'snowflake-sqlalchemy>=1.1.0,<1.3',
+    'snowflake-sqlalchemy>=1.1.0,<1.3',  # 1.3+ depends on sqlachemy 1.4
 ]
 spark = [
     'pyspark',

--- a/setup.py
+++ b/setup.py
@@ -444,7 +444,7 @@ slack = [
 ]
 snowflake = [
     'snowflake-connector-python>=2.4.1',
-    'snowflake-sqlalchemy>=1.1.0',
+    'snowflake-sqlalchemy>=1.1.0,<1.3',
 ]
 spark = [
     'pyspark',


### PR DESCRIPTION
snowflake-sqlalchemy 1.3 now depends on sqlalchemy 1.4+, so pin to a max of 1.2.x.

The webserver cannot start when we have sqlalchemy 1.4, throwing the following exceptions:

```airflow._vendor.connexion.exceptions.ResolverError: <ResolverError: columns>```

and

```AttributeError: columns```

A workaround for any users trying to install `apache-airflow-providers-snowflake`, simply also add `snowflake-sqlalchemy==1.2.5` (as of writing) to avoid pulling in the latest version of `snowflake-sqlalchemy`, and as a result, the latest `sqlalchemy`.

Closes: #17453