### PR TITLE
Add support for configs, secrets, networks and replicas for DockerSwarmOperator

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -116,11 +116,11 @@ class DockerSwarmOperator(DockerOperator):
         *,
         image: str,
         enable_logging: bool = True,
-        configs: List[ConfigReference] = None,
-        secrets: List[SecretReference] = None,
+        configs: Optional[List[ConfigReference]] = None,
+        secrets: Optional[List[SecretReference]] = None,
         mode: str = "replicated",
         replicas: int = 1,
-        networks: List[Union[str, NetworkAttachmentConfig]] = None,
+        networks: Optional[List[Union[str, NetworkAttachmentConfig]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -19,7 +19,6 @@ from typing import List, Optional, Union
 
 import requests
 from docker import types
-from docker.types import ServiceMode, ConfigReference, NetworkAttachmentConfig, SecretReference
 
 from airflow.exceptions import AirflowException
 from airflow.providers.docker.operators.docker import DockerOperator
@@ -114,10 +113,10 @@ class DockerSwarmOperator(DockerOperator):
         *,
         image: str,
         enable_logging: bool = True,
-        configs: Optional[List[ConfigReference]] = None,
-        secrets: Optional[List[SecretReference]] = None,
-        mode: Optional[ServiceMode] = None,
-        networks: Optional[List[Union[str, NetworkAttachmentConfig]]] = None,
+        configs: Optional[List[types.ConfigReference]] = None,
+        secrets: Optional[List[types.SecretReference]] = None,
+        mode: Optional[types.ServiceMode] = None,
+        networks: Optional[List[Union[str, types.NetworkAttachmentConfig]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 """Run ephemeral Docker Swarm services"""
-from typing import Optional, List, Union
+from typing import List, Optional, Union
 
 import requests
 from docker import types
-from docker.types.services import ConfigReference, SecretReference, NetworkAttachmentConfig
+from docker.types.services import ConfigReference, NetworkAttachmentConfig, SecretReference
 
 from airflow.exceptions import AirflowException
 from airflow.providers.docker.operators.docker import DockerOperator
@@ -121,7 +121,7 @@ class DockerSwarmOperator(DockerOperator):
         mode: str = "replicated",
         replicas: int = 1,
         networks: List[Union[str, NetworkAttachmentConfig]] = None,
-        **kwargs
+        **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
 

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -154,7 +154,7 @@ class DockerSwarmOperator(DockerOperator):
                     user=self.user,
                     tty=self.tty,
                     configs=self.configs,
-                    secrets=self.secrets, 
+                    secrets=self.secrets,
                 ),
                 restart_policy=types.RestartPolicy(condition='none'),
                 resources=types.Resources(mem_limit=self.mem_limit),

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -94,6 +94,19 @@ class DockerSwarmOperator(DockerOperator):
         Supported only if the Docker engine is using json-file or journald logging drivers.
         The `tty` parameter should be set to use this with Python applications.
     :type enable_logging: bool
+    :param configs: List of docker configs to be exposed to the containers of the swarm service.
+        The configs are ConfigReference objects as per the docker api
+        [https://docker-py.readthedocs.io/en/stable/services.html#docker.models.services.ServiceCollection.create]_
+    :type configs: list[ConfigReference]
+    :param secrets: List of docker secrets to be exposed to the containers of the swarm service.
+        The secrets are SecretReference objects as per the docker create_service api.
+        [https://docker-py.readthedocs.io/en/stable/services.html#docker.models.services.ServiceCollection.create]_
+    :type secrets: list[SecretReference]
+    :param mode: Indicate whether a service should be deployed as a replicated or global service.
+        Can be either `replicated` or `global`
+    :type mode: str
+    :param replicas: Number of replicas. For replicated services only.
+    :type replicas: int
     """
 
     def __init__(

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -154,7 +154,7 @@ class DockerSwarmOperator(DockerOperator):
                     user=self.user,
                     tty=self.tty,
                     configs=self.configs,
-                    secrets=self.secrets,
+                    secrets=self.secrets, 
                 ),
                 restart_policy=types.RestartPolicy(condition='none'),
                 resources=types.Resources(mem_limit=self.mem_limit),

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -103,6 +103,8 @@ class DockerSwarmOperator(DockerOperator):
         enable_logging: bool = True,
         configs: List[ConfigReference] = None,
         secrets: List[SecretReference] = None,
+        mode: str = "replicated",
+        replicas: int = 1,
         **kwargs
     ) -> None:
         super().__init__(image=image, **kwargs)
@@ -111,6 +113,8 @@ class DockerSwarmOperator(DockerOperator):
         self.service = None
         self.configs = configs if configs is not None else []
         self.secrets = secrets if secrets is not None else []
+        self.mode = mode
+        self.replicas = replicas
 
     def execute(self, context) -> None:
         self.cli = self._get_cli()
@@ -140,6 +144,7 @@ class DockerSwarmOperator(DockerOperator):
             ),
             name=f'airflow-{get_random_string()}',
             labels={'name': f'airflow__{self.dag_id}__{self.task_id}'},
+            mode=types.ServiceMode(mode=self.mode, replicas=self.replicas),
         )
 
         self.log.info('Service started: %s', str(self.service))

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -107,6 +107,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         assert csargs == (mock_obj,)
         assert cskwargs['labels'] == {'name': 'airflow__adhoc_airflow__unittest'}
         assert cskwargs['name'].startswith('airflow-')
+        assert cskwargs['mode'] == types.ServiceMode(mode="replicated", replicas=3)
         assert client_mock.tasks.call_count == 5
         client_mock.remove_service.assert_called_once_with('some_id')
 

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -23,6 +23,7 @@ import pytest
 import requests
 from docker import APIClient
 from docker.types import Mount
+from docker.types.services import ConfigReference, SecretReference
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
@@ -69,6 +70,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
             mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
             auto_remove=True,
             tty=True,
+            configs=[ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
+            secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
         )
         operator.execute(None)
 
@@ -82,6 +85,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
             mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
             tty=True,
             env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'},
+            configs=[ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
+            secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -80,7 +80,10 @@ class TestDockerSwarmOperator(unittest.TestCase):
         operator.execute(None)
 
         types_mock.TaskTemplate.assert_called_once_with(
-            container_spec=mock_obj, restart_policy=mock_obj, resources=mock_obj, networks=["dummy_network"],
+            container_spec=mock_obj,
+            restart_policy=mock_obj,
+            resources=mock_obj,
+            networks=["dummy_network"],
         )
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest',

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -23,7 +23,7 @@ import pytest
 import requests
 from docker import APIClient
 from docker.types import Mount
-from docker.types.services import ConfigReference, SecretReference
+from docker.types.services import ConfigReference, SecretReference, ServiceMode
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
@@ -56,7 +56,6 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
-        types_mock.ServiceMode.return_value = mock_obj
 
         client_class_mock.return_value = client_mock
 
@@ -73,8 +72,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             tty=True,
             configs=[ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
             secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
-            mode="replicated",
-            replicas=3,
+            mode=ServiceMode(mode="replicated", replicas=3),
             networks=["dummy_network"],
         )
         operator.execute(None)
@@ -97,7 +95,6 @@ class TestDockerSwarmOperator(unittest.TestCase):
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')
-        types_mock.ServiceMode.assert_called_once_with(mode="replicated", replicas=3)
 
         client_class_mock.assert_called_once_with(
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -56,6 +56,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
+        types_mock.ServiceMode.return_value = mock_obj
 
         client_class_mock.return_value = client_mock
 
@@ -72,6 +73,8 @@ class TestDockerSwarmOperator(unittest.TestCase):
             tty=True,
             configs=[ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
             secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
+            mode="replicated",
+            replicas=3,
         )
         operator.execute(None)
 
@@ -90,6 +93,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')
+        types_mock.ServiceMode.assert_called_once_with(mode="replicated", replicas=3)
 
         client_class_mock.assert_called_once_with(
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -75,11 +75,12 @@ class TestDockerSwarmOperator(unittest.TestCase):
             secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
             mode="replicated",
             replicas=3,
+            networks=["dummy_network"],
         )
         operator.execute(None)
 
         types_mock.TaskTemplate.assert_called_once_with(
-            container_spec=mock_obj, restart_policy=mock_obj, resources=mock_obj
+            container_spec=mock_obj, restart_policy=mock_obj, resources=mock_obj, networks=["dummy_network"],
         )
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest',

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -21,9 +21,7 @@ from unittest import mock
 
 import pytest
 import requests
-from docker import APIClient
-from docker.types import Mount
-from docker.types.services import ConfigReference, SecretReference, ServiceMode
+from docker import APIClient, types
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
@@ -67,12 +65,12 @@ class TestDockerSwarmOperator(unittest.TestCase):
             mem_limit='128m',
             user='unittest',
             task_id='unittest',
-            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
+            mounts=[types.Mount(source='/host/path', target='/container/path', type='bind')],
             auto_remove=True,
             tty=True,
-            configs=[ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
-            secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
-            mode=ServiceMode(mode="replicated", replicas=3),
+            configs=[types.ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
+            secrets=[types.SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
+            mode=types.ServiceMode(mode="replicated", replicas=3),
             networks=["dummy_network"],
         )
         operator.execute(None)
@@ -87,11 +85,11 @@ class TestDockerSwarmOperator(unittest.TestCase):
             image='ubuntu:latest',
             command='env',
             user='unittest',
-            mounts=[Mount(source='/host/path', target='/container/path', type='bind')],
+            mounts=[types.Mount(source='/host/path', target='/container/path', type='bind')],
             tty=True,
             env={'UNIT': 'TEST', 'AIRFLOW_TMP_DIR': '/tmp/airflow'},
-            configs=[ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
-            secrets=[SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
+            configs=[types.ConfigReference(config_id="dummy_cfg_id", config_name="dummy_cfg_name")],
+            secrets=[types.SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')


### PR DESCRIPTION
This PR adds the following functionality to the DockerSwarmOperator : 
- support for setting secrets and configs exposed to the started service
- support for specifying networks that can be joined by the containers of the service
- support for specifying the number of replicas for the swarm service

This features are essential in order to run the DockerSwarmOperator on a production environment with shared secrets, configs and networks.

The issue #7955 also mentions the need  for this features.

P.S: this is my first contribution to Airflow. Tried to follow the contribution guidelines. Forgive any missed step and looking forward for your feedback !

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
