### PR TITLE
Open relative extra links in place

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -190,8 +190,9 @@ export function callModal(t, d, extraLinks, tryNumbers, sd) {
           cache: false,
           success(data) {
             externalLink.attr('href', data.url);
-            // open absolute (external) links in a new tab/window and relative (local) links directly
-            if(/^(?:[a-z]+:)?\/\//.test(data.url)) {
+            // open absolute (external) links in a new tab/window and relative (local) links
+            // directly
+            if (/^(?:[a-z]+:)?\/\//.test(data.url)) {
               externalLink.attr('target', '_blank');
             }
             externalLink.removeClass('disabled');

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -190,8 +190,10 @@ export function callModal(t, d, extraLinks, tryNumbers, sd) {
           cache: false,
           success(data) {
             externalLink.attr('href', data.url);
-            if(/^(?:[a-z]+:)?\/\//.test(data.url))
+            // open absolute (external) links in a new tab/window and relative (local) links directly
+            if(/^(?:[a-z]+:)?\/\//.test(data.url)) {
               externalLink.attr('target', '_blank');
+            }
             externalLink.removeClass('disabled');
             linkTooltip.tooltip('disable');
           },

--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -178,7 +178,7 @@ export function callModal(t, d, extraLinks, tryNumbers, sd) {
       }&dag_id=${encodeURIComponent(dagId)
       }&execution_date=${encodeURIComponent(executionDate)
       }&link_name=${encodeURIComponent(link)}`;
-      const externalLink = $('<a href="#" class="btn btn-primary disabled" target="_blank"></a>');
+      const externalLink = $('<a href="#" class="btn btn-primary disabled"></a>');
       const linkTooltip = $('<span class="tool-tip" data-toggle="tooltip" style="padding-right: 2px; padding-left: 3px" data-placement="top" '
         + 'title="link not yet available"></span>');
       linkTooltip.append(externalLink);
@@ -190,6 +190,8 @@ export function callModal(t, d, extraLinks, tryNumbers, sd) {
           cache: false,
           success(data) {
             externalLink.attr('href', data.url);
+            if(/^(?:[a-z]+:)?\/\//.test(data.url))
+              externalLink.attr('target', '_blank');
             externalLink.removeClass('disabled');
             linkTooltip.tooltip('disable');
           },


### PR DESCRIPTION
This PR changes the existing behavior of ["extra links" added to operators](https://github.com/apache/airflow/blob/main/docs/apache-airflow/howto/define_extra_link.rst) such that any _relative_ links open in place rather than in a new window/tab.  This is consistent with the way other links/buttons in Airflow work today.  Any absolute links will continue to open in a new window/tab as they do today.

For the purposes of this change, a "relative" link is defined as any link url that does not satisfy the following regular expression: `^(?:[a-z]+:)?//`.  See [this stack overflow post](https://stackoverflow.com/a/19709846) for more in depth discussion.


_Note: As a first time contributor, I've followed the contributing documentation as much as possible.  I could not find any existing tests to update for the www js code, so given the simplicity of this change, I did not add any tests, however, I did run all WWW tests as well as static analysis.  Please let me know if i missed something or this is otherwise unacceptable.  Looking forward to feedback!_
