### PR TITLE
Ask for provider versions in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,6 +36,13 @@ These questions are the first thing we need to know to understand the context.
 
 **Apache Airflow version**:
 
+**Apache Airflow Provider versions** (please include all providers that are relevant to your bug):
+
+<!--
+
+You can get a complete list of your provider versions with `pip freeze | grep apache-airflow-providers`.
+
+-->
 
 **Kubernetes version (if you are using kubernetes)** (use `kubectl version`):
 


### PR DESCRIPTION
We get a lot of bug reports for providers, and it's rare that the
versions being used are in the initial report. Let's ask for them.