### PR TITLE
add deprecation notice for SubDagOperator

### DIFF
--- a/airflow/operators/subdag.py
+++ b/airflow/operators/subdag.py
@@ -15,7 +15,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""The module which provides a way to nest your DAGs and so your levels of complexity."""
+"""
+This module is deprecated. Please use :mod:`airflow.utils.task_group`.
+The module which provides a way to nest your DAGs and so your levels of complexity.
+"""
+
+import warnings
 from enum import Enum
 from typing import Dict, Optional
 
@@ -42,6 +47,9 @@ class SkippedStatePropagationOptions(Enum):
 
 class SubDagOperator(BaseSensorOperator):
     """
+    This class is deprecated.
+    Please use `airflow.utils.task_group.TaskGroup`.
+
     This runs a sub dag. By convention, a sub dag's dag_id
     should be prefixed by its parent and a dot. As in `parent.child`.
     Although SubDagOperator can occupy a pool/concurrency slot,
@@ -77,6 +85,12 @@ class SubDagOperator(BaseSensorOperator):
 
         self._validate_dag(kwargs)
         self._validate_pool(session)
+
+        warnings.warn(
+            """This class is deprecated. Please use `airflow.utils.task_group.TaskGroup`.""",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def _validate_dag(self, kwargs):
         dag = kwargs.get('dag') or DagContext.get_current_dag()

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -307,3 +307,12 @@ class TestSubDagOperator(unittest.TestCase):
             mock_skip.assert_called_once_with(context['dag_run'], context['execution_date'], [dummy_dag_task])
         else:
             mock_skip.assert_not_called()
+
+    def test_deprecation_warning(self):
+        dag = DAG('parent', default_args=default_args)
+        subdag = DAG('parent.test', default_args=default_args)
+        warning_message = """This class is deprecated. Please use `airflow.utils.task_group.TaskGroup`."""
+
+        with pytest.warns(DeprecationWarning) as warnings:
+            SubDagOperator(task_id='test', subdag=subdag, dag=dag)
+        assert warning_message == str(warnings[0].message)


### PR DESCRIPTION
Adding deprecation notice for `SubDagOperator`
closes: #12292
The [mailing list discussion](https://lists.apache.org/thread.html/ra52746f9c8274469d343b5f0251199de776e75ab75ded6830886fb6a%40%3Cdev.airflow.apache.org%3E) was before Airflow 2 was released. I think we have a good adoption of TasksGroup however 
I see users that are on Airflow 2 who still write new DAGs with `SubDagOperator` (Not sure why)

We know the general direction is to replace `SubDagOperator` with TasksGroup so I think we should place a deprecation notice.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
