### PR TITLE
deduplicate running jobs on BigQueryInsertJobOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -2247,16 +2247,13 @@ class BigQueryInsertJobOperator(BaseOperator):
         hook: BigQueryHook,
         job_id: str,
     ) -> BigQueryJob:
-        # Submit a new job
-        job = hook.insert_job(
+        # Submit a new job and wait for it to complete and get the result.
+        return hook.insert_job(
             configuration=self.configuration,
             project_id=self.project_id,
             location=self.location,
             job_id=job_id,
         )
-        # Start the job and wait for it to complete and get the result.
-        job.result()
-        return job
 
     @staticmethod
     def _handle_job_error(job: BigQueryJob) -> None:

--- a/tests/providers/google/cloud/operators/test_bigquery.py
+++ b/tests/providers/google/cloud/operators/test_bigquery.py
@@ -930,7 +930,7 @@ class TestBigQueryInsertJobOperator:
             }
         }
 
-        mock_hook.return_value.insert_job.return_value.result.side_effect = Conflict("any")
+        mock_hook.return_value.insert_job.side_effect = Conflict("any")
         job = MagicMock(
             job_id=real_job_id,
             error_result=False,


### PR DESCRIPTION
The `job.result` method already invokes on the `hook.insert_job` method, so basically it's duplicated beside of the referenced issue.
https://github.com/apache/airflow/blob/ef1b1242a8907c1f526bb354945cd5eefa3a85e7/airflow/providers/google/cloud/hooks/bigquery.py#L1639-L1641

In addition, In my opinion, the `insert_job` method should only responsible to inserting a job not verifying the job is completed and wait for it.


---


related: #17493