### PR TITLE
Hard-remove parallell locks at cleanup

### DIFF
--- a/scripts/ci/libraries/_parallel.sh
+++ b/scripts/ci/libraries/_parallel.sh
@@ -52,6 +52,7 @@ function parallel::kill_stale_semaphore_locks() {
             rm -f "${s}" 2>/dev/null
         fi
     done
+    rm -rf "${HOME}/.parallel"
 }
 
 


### PR DESCRIPTION
Some stale parallel locks might be a reason for hanging tests
This is an attempt to hard-remove all the .parallel remnant
directories in hope that it will avoid some of the hangs.

Unfortunately in our approach we try to reuse runners between
runs which might cause some remnants from the previous runs to
impact subsequent runs. When we move to GCP we will try to spin
off a new runner for every job to make sure the real "true clean
state" is used when running a job.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
