### PR TITLE
Decreases cassandra memory use during Integration tests

### DIFF
--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -19,6 +19,9 @@ version: "2.2"
 services:
   cassandra:
     image: cassandra:3.0
+    environment:
+      HEAP_NEWSIZE: 128M
+      MAX_HEAP_SIZE: 256M
     volumes:
       - /dev/urandom:/dev/random   # Required to get non-blocking entropy source
       - cassandra-db-volume:/var/lib/cassandra


### PR DESCRIPTION
Seems that Cassandra was the main reason why a lot of memory
was used during our integration tests. This has been overlooked
before but seems that cassandra will always take as much as 25%
of available memory by default and it meant for the GitHub public
runners it was ~2 GB. Also for the self-hosted runners, even if
they had a lot of memory, cassandra could eat up big chunk of the
memory.

With the settings added in PR Cassandra will take ~750 MB of memory
total.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
