### PR TITLE
Remove hard-coded container name for trino

### DIFF
--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -19,7 +19,6 @@ version: "2.2"
 services:
   trino:
     image: ghcr.io/apache/airflow-trino:359-2021.07.04
-    container_name: trino
     hostname: trino
     domainname: example.com
 


### PR DESCRIPTION
This had no negative effect because we only run trino during
integration tests but it could actually prevent two integration
tests run in parallel on the same machine if we choose otherwise
and it will look better in logs:

```
NAME
airflow-integration-mysql_pinot_1
airflow-integration-mysql_statsd-exporter_1
airflow-integration-mysql_redis_1
airflow-integration-mysql_mysql_1
airflow-integration-mysql_cassandra_1
airflow-integration-mysql_grafana_1
airflow-integration-mysql_openldap_1
trino
airflow-integration-mysql_kdc-server-example-com_1
airflow-integration-mysql_mongo_1
airflow-integration-mysql_rabbitmq_1
airflow-integration-mysql_airflow_run_908822c9c10f
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
