### PR TITLE
Ignores exception raised during closing SSH connection

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -149,7 +149,13 @@ class SSHOperator(BaseOperator):
                         and not stdout.channel.recv_ready()
                     ):
                         stdout.channel.shutdown_read()
-                        stdout.channel.close()
+                        try:
+                            stdout.channel.close()
+                        except Exception as e:
+                            # there is a race that when shutdown_read has been called and when
+                            # you try to close the connection, the socket is already closed
+                            # We should ignore such errors (but we should log them with warning)
+                            self.log.warning("Ignoring exception on close: ", e)
                         break
 
                 stdout.close()

--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -151,11 +151,11 @@ class SSHOperator(BaseOperator):
                         stdout.channel.shutdown_read()
                         try:
                             stdout.channel.close()
-                        except Exception as e:
+                        except Exception:
                             # there is a race that when shutdown_read has been called and when
                             # you try to close the connection, the socket is already closed
                             # We should ignore such errors (but we should log them with warning)
-                            self.log.warning("Ignoring exception on close: ", e)
+                            self.log.warning("Ignoring exception on close", exc_info=True)
                         break
 
                 stdout.close()


### PR DESCRIPTION
Sometimes, when the connection gets closed after shutdown, a race
condition causes "bad socket" error to be thrown. Actually there
is nothing wrong that can happen when closing a closed connection
so we should ignore any exceptions from close command here.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
