### PR TITLE
Fixed the broken json_client

### DIFF
--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -32,7 +32,7 @@ class Client(api_client.Client):
         if json is not None:
             params['json'] = json
         resp = getattr(self._session, method.lower())(**params)
-        if not resp.ok:
+        if resp.is_error:
             # It is justified here because there might be many resp types.
             try:
                 data = resp.json()


### PR DESCRIPTION
The json_client depends on httpx and thus the response doesn't contain
the attribute 'ok'. To fix the problem, the missing attribute has been changed
to is_error.

closes: #17527 