### PR TITLE
fix port overriding in cli for postgres

### DIFF
--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -1670,7 +1670,10 @@ def shell(args):
     elif url.get_backend_name() == 'postgresql':
         env = os.environ.copy()
         env['PGHOST'] = url.host or ""
-        env['PGPORT'] = url.port or ""
+        # Port should be cast from int to string before beeing put in env
+        env['PGPORT'] = ""
+        if url.port:
+            env['PGPORT'] = str(url.port)
         env['PGUSER'] = url.username or ""
         # PostgreSQL does not allow the use of PGPASSFILE if the current user is root.
         env["PGPASSWORD"] = url.password or ""


### PR DESCRIPTION
When configuring the sql alchemy url like this :
```
sql_alchemy_conn = postgresql://user:password@localhost:9999/airflowdb
```
Then the Airflow shell can't be used, because the port is incorrectly propagated.
This PR fixes this issue.
