### PR TITLE
Extend init_containers defined in pod_override

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -287,7 +287,8 @@ class PodGenerator:
             client_spec.containers = PodGenerator.reconcile_containers(
                 base_spec.containers, client_spec.containers
             )
-            merged_spec = extend_object_field(base_spec, client_spec, 'volumes')
+            merged_spec = extend_object_field(base_spec, client_spec, 'init_containers')
+            merged_spec = extend_object_field(base_spec, merged_spec, 'volumes')
             return merge_objects(base_spec, merged_spec)
 
         return None

--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -113,7 +113,7 @@ create a V1pod with a single container, and overwrite the fields as follows:
     :start-after: [START task_with_volume]
     :end-before: [END task_with_volume]
 
-Note that volume mounts, environment variables, ports, and devices will all be extended instead of overwritten. Note also that the volumes and the init_containers from the spec will be extended.
+Note that the following fields **will all be extended** instead of overwritten. From *spec*: volumes, and init_containers. From *container*: volume mounts, environment variables, ports, and devices.
 
 To add a sidecar container to the launched pod, create a V1pod with an empty first container with the
 name ``base`` and a second container containing your desired sidecar.

--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -113,7 +113,7 @@ create a V1pod with a single container, and overwrite the fields as follows:
     :start-after: [START task_with_volume]
     :end-before: [END task_with_volume]
 
-Note that volume mounts, environment variables, ports, and devices will all be extended instead of overwritten.
+Note that volume mounts, environment variables, ports, and devices will all be extended instead of overwritten. Note also that the volumes and the init_containers from the spec will be extended.
 
 To add a sidecar container to the launched pod, create a V1pod with an empty first container with the
 name ``base`` and a second container containing your desired sidecar.

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -632,13 +632,10 @@ class TestPodGenerator(unittest.TestCase):
         assert client_spec == res
 
     def test_reconcile_specs_init_containers(self):
-        base_objs = [k8s.V1Container(name='base_container1')]
-        client_objs = [k8s.V1Container(name='client_container1')]
-        base_spec = k8s.V1PodSpec(priority=1, containers=[], init_containers=base_objs)
-        client_spec = k8s.V1PodSpec(priority=2, containers=[], init_containers=client_objs)
+        base_spec = k8s.V1PodSpec(containers=[], init_containers=[k8s.V1Container(name='base_container1')])
+        client_spec = k8s.V1PodSpec(containers=[], init_containers=[k8s.V1Container(name='client_container1')])
         res = PodGenerator.reconcile_specs(base_spec, client_spec)
-        client_spec.init_containers = base_spec.init_containers + client_spec.init_containers
-        assert client_spec == res
+        assert res.init_containers == base_spec.init_containers + client_spec.init_containers
 
     def test_deserialize_model_file(self):
         path = sys.path[0] + '/tests/kubernetes/pod.yaml'

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -633,7 +633,9 @@ class TestPodGenerator(unittest.TestCase):
 
     def test_reconcile_specs_init_containers(self):
         base_spec = k8s.V1PodSpec(containers=[], init_containers=[k8s.V1Container(name='base_container1')])
-        client_spec = k8s.V1PodSpec(containers=[], init_containers=[k8s.V1Container(name='client_container1')])
+        client_spec = k8s.V1PodSpec(
+            containers=[], init_containers=[k8s.V1Container(name='client_container1')]
+        )
         res = PodGenerator.reconcile_specs(base_spec, client_spec)
         assert res.init_containers == base_spec.init_containers + client_spec.init_containers
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -631,6 +631,15 @@ class TestPodGenerator(unittest.TestCase):
         client_spec.active_deadline_seconds = 100
         assert client_spec == res
 
+    def test_reconcile_specs_init_containers(self):
+        base_objs = [k8s.V1Container(name='base_container1')]
+        client_objs = [k8s.V1Container(name='client_container1')]
+        base_spec = k8s.V1PodSpec(priority=1, containers=[], init_containers=base_objs)
+        client_spec = k8s.V1PodSpec(priority=2, containers=[], init_containers=client_objs)
+        res = PodGenerator.reconcile_specs(base_spec, client_spec)
+        client_spec.init_containers = base_spec.init_containers + client_spec.init_containers
+        assert client_spec == res
+
     def test_deserialize_model_file(self):
         path = sys.path[0] + '/tests/kubernetes/pod.yaml'
         result = PodGenerator.deserialize_model_file(path)


### PR DESCRIPTION
If you add an init_container in pod_override the specified init_containers in the pod-template-file for kubernetes are ovewritten instead of extended as it is the case of the volumes for example. 
So, for example, if you have a git sync ini_container but you define another init container, the task won't be executed because airflow won't find the dags as the init_container is replaced.

This change is just extending the init_container defined in the pod_override with the existing ones defined in the pod template file for kubernetes. In that sense you can define new extra init_containers.
