### PR TITLE
docs(celery): reworded, add actual multiple queues example

### DIFF
--- a/docs/apache-airflow/executor/celery.rst
+++ b/docs/apache-airflow/executor/celery.rst
@@ -208,9 +208,9 @@ the queue that tasks get assigned to when not specified, as well as which
 queue Airflow workers listen to when started.
 
 Workers can listen to one or multiple queues of tasks. When a worker is
-started (using the command ``airflow celery worker``), a set of comma-delimited
-queue names can be specified (e.g. ``airflow celery worker -q spark``). This worker
-will then only pick up tasks wired to the specified queue(s).
+started (using command ``airflow celery worker``), a set of comma-delimited queue
+names (no whitespaces) can be given (e.g. ``airflow celery worker -q spark,quark``).
+This worker will then only pick up tasks wired to the specified queue(s).
 
 This can be useful if you need specialized workers, either from a
 resource perspective (for say very lightweight tasks where one worker


### PR DESCRIPTION
I was reading the documentation to learn how to define multiple queues, but the example is incomplete, so I had to experiment on the CLI to see what works:

This failed: 
`airflow celery worker -q spark, park`  

This works:
 `airflow celery worker -q spark,quark`

This PR updates the documentation to clarify the command line syntax.