### PR TITLE
Airflow exceptions pass-thru during "on_execute_callback"

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -337,7 +337,9 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         section of the API.
     :type on_failure_callback: TaskStateChangeCallback
     :param on_execute_callback: much like the ``on_failure_callback`` except
-        that it is executed right before the task is executed.
+        that it is executed right before the task is executed; if an Airflow
+        exception is raised during the execution, this will prevent the task
+        from being executed (all other exceptions are logged and ignored).
     :type on_execute_callback: TaskStateChangeCallback
     :param on_retry_callback: much like the ``on_failure_callback`` except
         that it is executed when retries occur.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1345,6 +1345,8 @@ class TaskInstance(Base, LoggingMixin):
         try:
             if task.on_execute_callback:
                 task.on_execute_callback(context)
+        except AirflowException:
+            raise
         except Exception:
             self.log.exception("Failed when executing execute callback")
 


### PR DESCRIPTION
Previously, any exception raised during the execution of `on_execute_callback` would be logged and ignored.

This proposal changes the behavior such that an exception deriving from `AirflowException` is allowed through – the equivalent of an exception raised during the execution of the actual task.

That is, one can for example raise `AirflowSkipException` from inside the callback:

- The task is not executed (because an `AirflowException` derived exception was raised)
- The task is marked as `State.SKIPPED`