### PR TITLE
Skip PV's lost+found dir when cleaning logs (k8s)

### DIFF
--- a/scripts/in_container/prod/clean-logs.sh
+++ b/scripts/in_container/prod/clean-logs.sh
@@ -30,7 +30,7 @@ echo "Cleaning logs every $EVERY seconds"
 
 while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
-  find "${DIRECTORY}"/logs -mtime +"${RETENTION}" -name '*.log' -delete
+  find "${DIRECTORY}"/logs -type d -name 'lost+found' -prune -mtime +"${RETENTION}" -name '*.log' -delete
 
   seconds=$(( $(date -u +%s) % EVERY))
   (( seconds < 1 )) || sleep $((EVERY - seconds))


### PR DESCRIPTION
When using an RWX PV for sharing logs between pods, some storage providers create a lost+found directory. This directory is only accessible by root; therefore, the log-groomer container will fail with the execution of the find command and enter a CrashLoopBackOff state and fail to do its work.

To avoid this error, this change skips the lost+found directory.
