### PR TITLE
fix: filter condition of taskinstance does not work #17535

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -85,7 +85,7 @@ function updateModalUrls() {
   }
 
   updateButtonUrl(buttons.ti, {
-    flt1_dag_id_equals: dagId,
+    _flt_3_dag_id: dagId,
     _flt_3_task_id: taskId,
     _oc_TaskInstanceModelView: executionDate,
   });

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -116,6 +116,23 @@ def test_task_start_date_filter(admin_client, url, content):
 
 
 @pytest.mark.parametrize(
+    "url, content",
+    [
+        (
+            "/taskinstance/list/?_flt_3_dag_id=test_dag",
+            "List Task Instance",
+        )
+    ],
+    ids=["instance"],
+)
+def test_task_dag_id_equals_filter(admin_client, url, content):
+    resp = admin_client.get(url)
+    # We aren't checking the logic of the dag_id filter itself (that is built
+    # in to FAB) but simply that dag_id filter was run
+    check_content_in_response(content, resp)
+
+
+@pytest.mark.parametrize(
     "test_url, expected_url",
     [
         ("", "/home"),


### PR DESCRIPTION
Make sure that after clicking the All Instances button in the Task Instance panel, the results will be filtered by dag_id and task_id.

In the old version of airflow, such as 1.7, The naming rule for url parameters is: `fltX_fieldName_filterType`, such as: 
`flt1_dag_id_equals`.
![image](https://user-images.githubusercontent.com/28948186/129028318-99acd59d-88e0-4e48-8756-4f0a798a8229.png)



But after airflow2.0, The naming rule becomes:
Starts with: `_flt_0_fieldName`
Ends with: `_flt_1_fieldName`
Contains: `_flt_2_fieldName`
Equal to: `_flt_3_fieldName`
Not Starts with: `_flt_4_fieldName`
Not Ends with: `_flt_5_fieldName`
Not Contains: `_flt_6_fieldName`
Not Equal to: `_flt_7_fieldName`
![image](https://user-images.githubusercontent.com/28948186/129027558-c03b1aee-2d5d-4bd1-ad54-ec972c2b8eb1.png)

So when we need to filter dag_id, the filter parameter should be: `_flt_3_dag_id`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
