### PR TITLE
Use `dag_maker` fixture in some test files under tests/models

### DIFF
--- a/tests/models/test_dagparam.py
+++ b/tests/models/test_dagparam.py
@@ -16,18 +16,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 from datetime import timedelta
 
 from airflow.decorators import task
-from airflow.models.dag import DAG
 from airflow.utils import timezone
-from airflow.utils.state import State
 from airflow.utils.types import DagRunType
-from tests.test_utils.db import clear_db_runs
+from tests.test_utils.db import clear_db_dags, clear_db_runs
 
 
-class TestDagParamRuntime(unittest.TestCase):
+class TestDagParamRuntime:
     DEFAULT_ARGS = {
         "owner": "test",
         "depends_on_past": True,
@@ -38,13 +35,20 @@ class TestDagParamRuntime(unittest.TestCase):
     VALUE = 42
     DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 
-    def tearDown(self):
-        super().tearDown()
+    @staticmethod
+    def clean_db():
         clear_db_runs()
+        clear_db_dags()
 
-    def test_dag_param_resolves(self):
+    def setup_method(self):
+        self.clean_db()
+
+    def teardown_method(self):
+        self.clean_db()
+
+    def test_dag_param_resolves(self, dag_maker):
         """Test dagparam resolves on operator execution"""
-        with DAG(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
+        with dag_maker(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
             value = dag.param('value', default=self.VALUE)
 
             @task
@@ -53,11 +57,9 @@ class TestDagParamRuntime(unittest.TestCase):
 
             xcom_arg = return_num(value)
 
-        dr = dag.create_dagrun(
+        dr = dag_maker.create_dagrun(
             run_id=DagRunType.MANUAL.value,
             start_date=timezone.utcnow(),
-            execution_date=self.DEFAULT_DATE,
-            state=State.RUNNING,
         )
 
         xcom_arg.operator.run(start_date=self.DEFAULT_DATE, end_date=self.DEFAULT_DATE)
@@ -65,9 +67,9 @@ class TestDagParamRuntime(unittest.TestCase):
         ti = dr.get_task_instances()[0]
         assert ti.xcom_pull() == self.VALUE
 
-    def test_dag_param_overwrite(self):
+    def test_dag_param_overwrite(self, dag_maker):
         """Test dag param is overwritten from dagrun config"""
-        with DAG(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
+        with dag_maker(dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS) as dag:
             value = dag.param('value', default=self.VALUE)
 
             @task
@@ -78,11 +80,9 @@ class TestDagParamRuntime(unittest.TestCase):
 
         assert dag.params['value'] == self.VALUE
         new_value = 2
-        dr = dag.create_dagrun(
+        dr = dag_maker.create_dagrun(
             run_id=DagRunType.MANUAL.value,
             start_date=timezone.utcnow(),
-            execution_date=self.DEFAULT_DATE,
-            state=State.RUNNING,
             conf={'value': new_value},
         )
 
@@ -91,9 +91,9 @@ class TestDagParamRuntime(unittest.TestCase):
         ti = dr.get_task_instances()[0]
         assert ti.xcom_pull() == new_value
 
-    def test_dag_param_default(self):
+    def test_dag_param_default(self, dag_maker):
         """Test dag param is overwritten from dagrun config"""
-        with DAG(
+        with dag_maker(
             dag_id="test_xcom_pass_to_op", default_args=self.DEFAULT_ARGS, params={'value': 'test'}
         ) as dag:
             value = dag.param('value')
@@ -104,12 +104,7 @@ class TestDagParamRuntime(unittest.TestCase):
 
             xcom_arg = return_num(value)
 
-        dr = dag.create_dagrun(
-            run_id=DagRunType.MANUAL.value,
-            start_date=timezone.utcnow(),
-            execution_date=self.DEFAULT_DATE,
-            state=State.RUNNING,
-        )
+        dr = dag_maker.create_dagrun(run_id=DagRunType.MANUAL.value, start_date=timezone.utcnow())
 
         xcom_arg.operator.run(start_date=self.DEFAULT_DATE, end_date=self.DEFAULT_DATE)
 

--- a/tests/models/test_timestamp.py
+++ b/tests/models/test_timestamp.py
@@ -19,24 +19,26 @@ import pendulum
 import pytest
 from freezegun import freeze_time
 
-from airflow.models import DAG, Log, TaskInstance
+from airflow.models import Log, TaskInstance
 from airflow.operators.dummy import DummyOperator
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
 from airflow.utils.state import State
-from tests.test_utils.db import clear_db_logs, clear_db_runs
+from tests.test_utils.db import clear_db_dags, clear_db_logs, clear_db_runs
 
 
 @pytest.fixture(autouse=True)
 def clear_db():
     clear_db_logs()
     clear_db_runs()
+    clear_db_dags()
     yield
 
 
-def add_log(execdate, session, timezone_override=None):
-    dag = DAG(dag_id='logging', default_args={'start_date': execdate})
-    task = DummyOperator(task_id='dummy', dag=dag, owner='airflow')
+def add_log(execdate, session, dag_maker, timezone_override=None):
+    with dag_maker(dag_id='logging', default_args={'start_date': execdate}):
+        task = DummyOperator(task_id='dummy')
+    dag_maker.create_dagrun()
     task_instance = TaskInstance(task=task, execution_date=execdate, state='success')
     session.merge(task_instance)
     log = Log(State.RUNNING, task_instance)
@@ -48,11 +50,11 @@ def add_log(execdate, session, timezone_override=None):
 
 
 @provide_session
-def test_timestamp_behaviour(session=None):
+def test_timestamp_behaviour(dag_maker, session=None):
     execdate = timezone.utcnow()
     with freeze_time(execdate):
         current_time = timezone.utcnow()
-        old_log = add_log(execdate, session)
+        old_log = add_log(execdate, session, dag_maker)
         session.expunge(old_log)
         log_time = session.query(Log).one().dttm
         assert log_time == current_time
@@ -60,11 +62,11 @@ def test_timestamp_behaviour(session=None):
 
 
 @provide_session
-def test_timestamp_behaviour_with_timezone(session=None):
+def test_timestamp_behaviour_with_timezone(dag_maker, session=None):
     execdate = timezone.utcnow()
     with freeze_time(execdate):
         current_time = timezone.utcnow()
-        old_log = add_log(execdate, session, timezone_override=pendulum.timezone('Europe/Warsaw'))
+        old_log = add_log(execdate, session, dag_maker, timezone_override=pendulum.timezone('Europe/Warsaw'))
         session.expunge(old_log)
         # No matter what timezone we set - we should always get back UTC
         log_time = session.query(Log).one().dttm

--- a/tests/models/test_xcom_arg.py
+++ b/tests/models/test_xcom_arg.py
@@ -18,11 +18,11 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from airflow import DAG
 from airflow.models.xcom_arg import XComArg
 from airflow.operators.bash import BashOperator
 from airflow.operators.python import PythonOperator
 from tests.test_utils.config import conf_vars
+from tests.test_utils.db import clear_db_dags, clear_db_runs
 
 DEFAULT_ARGS = {
     "owner": "test",
@@ -40,22 +40,30 @@ def assert_is_value(num: int):
         raise Exception("The test has failed")
 
 
-def build_python_op():
+def build_python_op(dag_maker):
     def f(task_id):
         return f"OP:{task_id}"
 
-    with DAG(dag_id="test_xcom_dag", default_args=DEFAULT_ARGS):
+    with dag_maker(dag_id="test_xcom_dag", default_args=DEFAULT_ARGS):
         operator = PythonOperator(
             python_callable=f,
             task_id="test_xcom_op",
             do_xcom_push=True,
         )
-        return operator
+    dag_maker.create_dagrun()
+    return operator
+
+
+@pytest.fixture(autouse=True)
+def clear_db():
+    clear_db_runs()
+    clear_db_dags()
+    yield
 
 
 class TestXComArgBuild:
-    def test_xcom_ctor(self):
-        python_op = build_python_op()
+    def test_xcom_ctor(self, dag_maker):
+        python_op = build_python_op(dag_maker)
         actual = XComArg(python_op, "test_key")
         assert actual
         assert actual.operator == python_op
@@ -72,8 +80,8 @@ class TestXComArgBuild:
             "dag_id='test_xcom_dag', key='test_key') }}"
         )
 
-    def test_xcom_key_is_empty_str(self):
-        python_op = build_python_op()
+    def test_xcom_key_is_empty_str(self, dag_maker):
+        python_op = build_python_op(dag_maker)
         actual = XComArg(python_op, key="")
         assert actual.key == ""
         assert (
@@ -81,8 +89,8 @@ class TestXComArgBuild:
             "dag_id='test_xcom_dag', key='') }}"
         )
 
-    def test_set_downstream(self):
-        with DAG("test_set_downstream", default_args=DEFAULT_ARGS):
+    def test_set_downstream(self, dag_maker):
+        with dag_maker("test_set_downstream", default_args=DEFAULT_ARGS):
             op_a = BashOperator(task_id="a", bash_command="echo a")
             op_b = BashOperator(task_id="b", bash_command="echo b")
             bash_op1 = BashOperator(task_id="c", bash_command="echo c")
@@ -91,13 +99,13 @@ class TestXComArgBuild:
             xcom_args_b = XComArg(op_b)
 
             bash_op1 >> xcom_args_a >> xcom_args_b >> bash_op2
-
+        dag_maker.create_dagrun()
         assert op_a in bash_op1.downstream_list
         assert op_b in op_a.downstream_list
         assert bash_op2 in op_b.downstream_list
 
-    def test_set_upstream(self):
-        with DAG("test_set_upstream", default_args=DEFAULT_ARGS):
+    def test_set_upstream(self, dag_maker):
+        with dag_maker("test_set_upstream", default_args=DEFAULT_ARGS):
             op_a = BashOperator(task_id="a", bash_command="echo a")
             op_b = BashOperator(task_id="b", bash_command="echo b")
             bash_op1 = BashOperator(task_id="c", bash_command="echo c")
@@ -106,19 +114,20 @@ class TestXComArgBuild:
             xcom_args_b = XComArg(op_b)
 
             bash_op1 << xcom_args_a << xcom_args_b << bash_op2
-
+        dag_maker.create_dagrun()
         assert op_a in bash_op1.upstream_list
         assert op_b in op_a.upstream_list
         assert bash_op2 in op_b.upstream_list
 
-    def test_xcom_arg_property_of_base_operator(self):
-        with DAG("test_xcom_arg_property_of_base_operator", default_args=DEFAULT_ARGS):
+    def test_xcom_arg_property_of_base_operator(self, dag_maker):
+        with dag_maker("test_xcom_arg_property_of_base_operator", default_args=DEFAULT_ARGS):
             op_a = BashOperator(task_id="a", bash_command="echo a")
+        dag_maker.create_dagrun()
 
         assert op_a.output == XComArg(op_a)
 
-    def test_xcom_key_getitem(self):
-        python_op = build_python_op()
+    def test_xcom_key_getitem(self, dag_maker):
+        python_op = build_python_op(dag_maker)
         actual = XComArg(python_op, key="another_key")
         assert actual.key == "another_key"
         actual_new_key = actual["another_key_2"]
@@ -128,8 +137,8 @@ class TestXComArgBuild:
 @pytest.mark.system("core")
 class TestXComArgRuntime:
     @conf_vars({("core", "executor"): "DebugExecutor"})
-    def test_xcom_pass_to_op(self):
-        with DAG(dag_id="test_xcom_pass_to_op", default_args=DEFAULT_ARGS) as dag:
+    def test_xcom_pass_to_op(self, dag_maker):
+        with dag_maker(dag_id="test_xcom_pass_to_op", default_args=DEFAULT_ARGS) as dag:
             operator = PythonOperator(
                 python_callable=lambda: VALUE,
                 task_id="return_value_1",
@@ -145,12 +154,12 @@ class TestXComArgRuntime:
         dag.run()
 
     @conf_vars({("core", "executor"): "DebugExecutor"})
-    def test_xcom_push_and_pass(self):
+    def test_xcom_push_and_pass(self, dag_maker):
         def push_xcom_value(key, value, **context):
             ti = context["task_instance"]
             ti.xcom_push(key, value)
 
-        with DAG(dag_id="test_xcom_push_and_pass", default_args=DEFAULT_ARGS) as dag:
+        with dag_maker(dag_id="test_xcom_push_and_pass", default_args=DEFAULT_ARGS) as dag:
             op1 = PythonOperator(
                 python_callable=push_xcom_value,
                 task_id="push_xcom_value",


### PR DESCRIPTION
This PR uses dag_maker fixtures in tests under tests/models

I left out tests/models/test_dag.py and tests/models/test_dagrun.py because they are testing DAG and DAGRUN tables. Happy to hear your opinion


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
