### PR TITLE
Chart: Allow podTemplate to be templated

### DIFF
--- a/chart/templates/configmaps/configmap.yaml
+++ b/chart/templates/configmaps/configmap.yaml
@@ -58,7 +58,7 @@ data:
 {{- if semverCompare ">=1.10.12" .Values.airflowVersion }}
   pod_template_file.yaml: |-
 {{- if .Values.podTemplate }}
-    {{ .Values.podTemplate | nindent 4 }}
+    {{ tpl .Values.podTemplate . | nindent 4 }}
 {{- else }}
 {{ tpl (.Files.Get "files/pod-template-file.kubernetes-helm-yaml") . | nindent 4 }}
 {{- end }}

--- a/chart/tests/test_configmap.py
+++ b/chart/tests/test_configmap.py
@@ -74,3 +74,22 @@ class ConfigmapTest(unittest.TestCase):
         )
 
         assert jmespath.search('data."krb5.conf"', docs[0]) == "\nkrb5content\n"
+
+    def test_pod_template_is_templated(self):
+        docs = render_chart(
+            values={
+                "executor": "KubernetesExecutor",
+                "podTemplate": """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy-name
+  labels:
+    mylabel: {{ .Release.Name }}
+""",
+            },
+            show_only=["templates/configmaps/configmap.yaml"],
+        )
+
+        pod_template_file = jmespath.search('data."pod_template_file.yaml"', docs[0])
+        assert "mylabel: RELEASE-NAME" in pod_template_file

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2757,7 +2757,7 @@
             "default": false
         },
         "podTemplate": {
-            "description": "The contents of ``pod_template_file.yaml`` used for KubernetesExecutor workers. The default (see ``files/pod-template-file.kubernetes-helm-yaml``) already takes into account normal ``workers`` configuration parameters (e.g. ``workers.resources``), so you normally won't need to override this directly.",
+            "description": "The contents of ``pod_template_file.yaml`` used for KubernetesExecutor workers (templated). The default (see ``files/pod-template-file.kubernetes-helm-yaml``) already takes into account normal ``workers`` configuration parameters (e.g. ``workers.resources``), so you normally won't need to override this directly.",
             "type": [
                 "string",
                 "null"
@@ -2765,7 +2765,7 @@
             "x-docsSection": "Airflow",
             "default": null,
             "examples": [
-                "apiVersion: v1\nkind: Pod\nmetadata:\n  name: dummy-name\n  labels:\n    tier: airflow\n    component: worker\n    release: my-release\nspec:\n  priorityClassName: high-priority\n  containers:\n    - name: base\n    ..."
+                "apiVersion: v1\nkind: Pod\nmetadata:\n  name: dummy-name\n  labels:\n    tier: airflow\n    component: worker\n    release: {{ .Release.Name }}\nspec:\n  priorityClassName: high-priority\n  containers:\n    - name: base\n    ..."
             ]
         },
         "dags": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1127,8 +1127,8 @@ config:
 # If true, it creates ClusterRole/ClusterRolebinding (with access to entire cluster)
 multiNamespaceMode: false
 
-# `podTemplate` is a string containing the contents of `pod_template_file.yaml` used for KubernetesExecutor
-# workers. The default `podTemplate` will use normal `workers` configuration parameters
+# `podTemplate` is a templated string containing the contents of `pod_template_file.yaml` used for
+# KubernetesExecutor workers. The default `podTemplate` will use normal `workers` configuration parameters
 # (e.g. `workers.resources`). As such, you normally won't need to override this directly, however,
 # you can still provide a completely custom `pod_template_file.yaml` if desired.
 # If not set, a default one is created using `files/pod-template-file.kubernetes-helm-yaml`.
@@ -1145,7 +1145,7 @@ podTemplate: ~
 #     labels:
 #       tier: airflow
 #       component: worker
-#       release: my-release
+#       release: {{ .Release.Name }}
 #   spec:
 #     priorityClassName: high-priority
 #     containers:


### PR DESCRIPTION
We should allow the user to use a templated string for `podTemplate`, as it allows one to start with the template file and just modifying as required instead of needing to grab the rendered yaml.

related: #16833