### PR TITLE
Simplify bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -59,7 +59,7 @@ Any relevant logs to include? Put them here inside fenced
 **Are you willing to submit a PR?**
 
 <!---
-This is not required, but we are happy to guide you in contribution process
+This is absolutely not required, but we are happy to guide you in contribution process
 especially if you already have a good understanding of how to implement the fix.
 Airflow is a community-managed project and we love to bring new contributors in.
  -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,89 +8,58 @@ assignees: ''
 ---
 
 <!--
-
-Welcome to Apache Airflow!  For a smooth issue process, try to answer the following questions.
-Don't worry if they're not all applicable; just try to include what you can :-)
-
-If you need to include code snippets or logs, please put them in fenced code
-blocks.  If they're super-long, please use the details tag like
-<details><summary>super-long log</summary> lots of stuff </details>
-
-Please delete these comment blocks before submitting the issue.
-
--->
-
-<!--
-
-IMPORTANT!!!
-
-PLEASE CHECK "SIMILAR TO X EXISTING ISSUES" OPTION IF VISIBLE
-NEXT TO "SUBMIT NEW ISSUE" BUTTON!!!
-
-PLEASE CHECK IF THIS ISSUE HAS BEEN REPORTED PREVIOUSLY USING SEARCH!!!
+Welcome to Apache Airflow!
 
 Please complete the next sections or the issue will be closed.
-These questions are the first thing we need to know to understand the context.
-
 -->
 
 **Apache Airflow version**:
 
-**Apache Airflow Provider versions** (please include all providers that are relevant to your bug):
+<!-- AIRFLOW VERSION IS MANDATORY -->
 
-<!--
+**OS**:
 
-You can get a complete list of your provider versions with `pip freeze | grep apache-airflow-providers`.
+<!-- MANDATORY! You can get it via `cat /etc/oss-release` for example -->
 
--->
+**Apache Airflow Provider versions**:
 
-**Kubernetes version (if you are using kubernetes)** (use `kubectl version`):
+<!-- You can use `pip freeze | grep apache-airflow-providers` (you can leave only relevant ones)-->
 
-**Environment**:
+**Deployment**:
 
-- **Cloud provider or hardware configuration**:
-- **OS** (e.g. from /etc/os-release):
-- **Kernel** (e.g. `uname -a`):
-- **Install tools**:
-- **Others**:
+<!-- e.g. Virtualenv / VM / Docker-compose / K8S / Helm Chart / Managed Airflow Service -->
+
+<!-- Please include your deployment tools and versions: docker-compose, k8s, helm, etc -->
 
 **What happened**:
 
-<!-- (please include exact error messages if you can) -->
+<!-- Please include exact error messages if you can -->
 
 **What you expected to happen**:
 
 <!-- What do you think went wrong? -->
 
 **How to reproduce it**:
-<!---
 
+<!--
 As minimally and precisely as possible. Keep in mind we do not have access to your cluster or dags.
-
-If you are using kubernetes, please attempt to recreate the issue using minikube or kind.
-
-## Install minikube/kind
-
-- Minikube https://minikube.sigs.k8s.io/docs/start/
-- Kind https://kind.sigs.k8s.io/docs/user/quick-start/
-
 If this is a UI bug, please provide a screenshot of the bug or a link to a youtube video of the bug in action
-
-You can include images using the .md style of
-![alt text](http://url/to/img.png)
-
-To record a screencast, mac users can use QuickTime and then create an unlisted youtube video with the resulting .mov file.
-
---->
-
+You can include images/screen-casts etc. by drag-dropping the image here.
+-->
 
 **Anything else we need to know**:
 
 <!--
-
 How often does this problem occur? Once? Every time etc?
-
-Any relevant logs to include? Put them here in side a detail tag:
+Any relevant logs to include? Put them here inside fenced
+``` ``` blocks or inside a foldable details tag if it's long:
 <details><summary>x.log</summary> lots of stuff </details>
-
 -->
+
+**Are you willing to submit a PR?**
+
+<!---
+This is not required, but we are happy to guide you in contribution process
+especially if you already have a good understanding of how to implement the fix.
+Airflow is a community-managed project and we love to bring new contributors in.
+ -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -62,4 +62,5 @@ Any relevant logs to include? Put them here inside fenced
 This is absolutely not required, but we are happy to guide you in contribution process
 especially if you already have a good understanding of how to implement the fix.
 Airflow is a community-managed project and we love to bring new contributors in.
+Find us in #airflow-how-to-pr on Slack!
  -->


### PR DESCRIPTION
By looking at several tens of issues recently I think I got a bit
better understanding on what people are actually reporting and
which information is really important - and I think the report
template might be vastly shortened, leaving only the important
parts:

* removed some comments that were repetitve and a bit too polite
  (strenghtening the necessity of filling all details
* remove kernel. It's useless and default uname -a produced
  some superfluous artifacts (Github recognising that as issues)
* comment stressing that Airflow version/OS is mandatory
* deployment is now a separate entry detailing all options

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
