### PR TITLE
Chart: Support extraContainers in k8s workers

### DIFF
--- a/chart/files/pod-template-file.kubernetes-helm-yaml
+++ b/chart/files/pod-template-file.kubernetes-helm-yaml
@@ -78,6 +78,9 @@ spec:
 {{- if .Values.workers.extraVolumeMounts }}
 {{ toYaml .Values.workers.extraVolumeMounts | indent 8 }}
 {{- end }}
+{{- if .Values.workers.extraContainers }}
+{{- toYaml .Values.workers.extraContainers | nindent 4 }}
+{{- end }}
   hostNetwork: false
   {{- if or .Values.registry.secretName .Values.registry.connection }}
   imagePullSecrets:

--- a/chart/tests/test_pod_template_file.py
+++ b/chart/tests/test_pod_template_file.py
@@ -439,6 +439,24 @@ class PodTemplateFileTest(unittest.TestCase):
             "image": "test-registry/test-repo:test-tag",
         } == jmespath.search("spec.initContainers[-1]", docs[0])
 
+    def test_should_add_extra_containers(self):
+        docs = render_chart(
+            values={
+                "workers": {
+                    "extraContainers": [
+                        {"name": "test-container", "image": "test-registry/test-repo:test-tag"}
+                    ],
+                },
+            },
+            show_only=["templates/pod-template-file.yaml"],
+            chart_dir=self.temp_chart_dir,
+        )
+
+        assert {
+            "name": "test-container",
+            "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.containers[-1]", docs[0])
+
     def test_should_add_pod_labels(self):
         docs = render_chart(
             values={"labels": {"label1": "value1", "label2": "value2"}},

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1046,7 +1046,7 @@
                     "default": true
                 },
                 "extraContainers": {
-                    "description": "Launch additional containers into workers.",
+                    "description": "Launch additional containers into workers. Note, if used with KubernetesExecutor, you are responsible for signaling sidecars to exit when the main container finishes so Airflow can continue the worker shutdown process!",
                     "type": "array",
                     "default": []
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -415,6 +415,8 @@ workers:
   safeToEvict: true
 
   # Launch additional containers into worker.
+  # Note: If used with KubernetesExecutor, you are responsible for signaling sidecars to exit when the main
+  # container finishes so Airflow can continue the worker shutdown process!
   extraContainers: []
   # Add additional init containers into workers.
   extraInitContainers: []

--- a/docs/helm-chart/using-additional-containers.rst
+++ b/docs/helm-chart/using-additional-containers.rst
@@ -26,10 +26,6 @@ You can define different containers for the scheduler, webserver and worker pods
 
 For example, sidecars that sync DAGs from object storage.
 
-.. note::
-
-   ``workers.extraContainers`` is only functional with ``CeleryExecutor``.
-
 .. code-block:: yaml
 
   scheduler:
@@ -42,6 +38,11 @@ For example, sidecars that sync DAGs from object storage.
       - name: s3-sync
         image: my-company/s3-sync:latest
         imagePullPolicy: Always
+
+.. note::
+
+   If you use ``workers.extraContainers`` with ``KubernetesExecutor``, you are responsible for signaling
+   sidecars to exit when the main container finishes so Airflow can continue the worker shutdown process!
 
 
 Init Containers


### PR DESCRIPTION
This allows extraContainers to be provided for k8s workers, however one
must keep in mind they are responsible for signaling any sidecars to
exit.

related: #16833