### PR TITLE
Fixed long delays never returning in DateTimeTrigger

### DIFF
--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -54,8 +54,8 @@ class DateTimeTrigger(BaseTrigger):
         unexpectedly, or handles a DST change poorly.
         """
         # Sleep an hour at a time while it's more than 2 hours away
-        while timezone.utcnow() - self.moment > datetime.timedelta(hours=2):
-            await (asyncio.sleep(3600))
+        while (self.moment - timezone.utcnow()).total_hours() > 2:
+            await asyncio.sleep(3600)
         # Sleep a second at a time otherwise
         while self.moment > timezone.utcnow():
             await asyncio.sleep(1)


### PR DESCRIPTION
This trigger was never actually firing for delays over two hours, as it was comparing a Pendulum.Period to a datetime.datetime, in a way that always returned `True` for certain dates (especially those a long time in the past).

This commit fixes the behaviour. This unfortunately seems un-testable, as it's not possible to interrupt asyncio's sleep() while it's in-flight.
