### PR TITLE
Add Triggerer warning banner in UI

### DIFF
--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -24,6 +24,8 @@ import time
 from collections import deque
 from typing import Deque, Dict, Set, Tuple, Type
 
+from sqlalchemy import func
+
 from airflow.compat.asyncio import create_task
 from airflow.configuration import conf
 from airflow.jobs.base_job import BaseJob

--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -74,7 +74,7 @@ class TriggererJob(BaseJob):
         in the trigger table).
         This is used for the warning boxes in the UI.
         """
-        return session.query(Trigger).count() > 0
+        return session.query(func.count(Trigger.id)).scalar() > 0
 
     def _exit_gracefully(self, signum, frame) -> None:  # pylint: disable=unused-argument
         """Helper method to clean up processor_agent to avoid leaving orphan processes."""

--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -69,8 +69,9 @@ class TriggererJob(BaseJob):
         signal.signal(signal.SIGINT, self._exit_gracefully)
         signal.signal(signal.SIGTERM, self._exit_gracefully)
 
+    @classmethod
     @provide_session
-    def is_needed(self, session) -> bool:
+    def is_needed(cls, session) -> bool:
         """
         Tests if the triggerer job needs to be run (i.e., if there are triggers
         in the trigger table).

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -65,7 +65,7 @@
       <p>The DAGs list may not update, and new tasks will not be scheduled.</p>
     </div>
   {% endif %}
-  {% if triggerer_job is defined and triggerer_job.is_needed() and (not triggerer_job or not triggerer_job.is_alive()) %}
+  {% if triggerer_job is defined and (not triggerer_job or not triggerer_job.is_alive()) %}
     <div class="alert alert-warning">
       <p>The triggerer does not appear to be running.
       {% if triggerer_job %}

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -65,6 +65,21 @@
       <p>The DAGs list may not update, and new tasks will not be scheduled.</p>
     </div>
   {% endif %}
+  {% if triggerer_job is defined and triggerer_job.is_needed() and (not triggerer_job or not triggerer_job.is_alive()) %}
+    <div class="alert alert-warning">
+      <p>The triggerer does not appear to be running.
+      {% if triggerer_job %}
+      Last heartbeat was received
+      <time class="scheduler-last-heartbeat"
+        title="{{ triggerer_job.latest_heartbeat.isoformat() }}"
+        datetime="{{ triggerer_job.latest_heartbeat.isoformat() }}"
+        data-datetime-convert="false"
+      >{{ macros.datetime_diff_for_humans(triggerer_job.latest_heartbeat) }}</time>.
+      {% endif %}
+      </p>
+      <p>Triggers will not run, and any deferred operator will remain deferred until it times out and fails.</p>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block footer %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -97,6 +97,7 @@ from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob
 from airflow.jobs.scheduler_job import SchedulerJob
+from airflow.jobs.triggerer_job import TriggererJob
 from airflow.models import DAG, Connection, DagModel, DagTag, Log, SlaMiss, TaskFail, XCom, errors
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dagcode import DagCode
@@ -467,6 +468,7 @@ class AirflowBaseView(BaseView):
             *args,
             # Cache this at most once per request, not for the lifetime of the view instance
             scheduler_job=lazy_object_proxy.Proxy(SchedulerJob.most_recent_job),
+            triggerer_job=lazy_object_proxy.Proxy(TriggererJob.most_recent_job),
             **kwargs,
         )
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -464,11 +464,13 @@ class AirflowBaseView(BaseView):
     }
 
     def render_template(self, *args, **kwargs):
+        # Add triggerer_job only if we need it
+        if TriggererJob.is_needed():
+            kwargs["triggerer_job"] = lazy_object_proxy.Proxy(TriggererJob.most_recent_job)
         return super().render_template(
             *args,
             # Cache this at most once per request, not for the lifetime of the view instance
             scheduler_job=lazy_object_proxy.Proxy(SchedulerJob.most_recent_job),
-            triggerer_job=lazy_object_proxy.Proxy(TriggererJob.most_recent_job),
             **kwargs,
         )
 

--- a/tests/jobs/test_triggerer_job.py
+++ b/tests/jobs/test_triggerer_job.py
@@ -73,6 +73,21 @@ def test_is_alive():
 
 
 @pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
+def test_is_needed(session):
+    """Checks the triggerer-is-needed logic"""
+    # No triggers, no need
+    triggerer_job = TriggererJob(None, heartrate=10, state=State.RUNNING)
+    assert triggerer_job.is_needed() is False
+    # Add a trigger, it's needed
+    trigger = TimeDeltaTrigger(datetime.timedelta(days=7))
+    trigger_orm = Trigger.from_object(trigger)
+    trigger_orm.id = 1
+    session.add(trigger_orm)
+    session.commit()
+    assert triggerer_job.is_needed() is True
+
+
+@pytest.mark.skipif(sys.version_info.minor <= 6 and sys.version_info.major <= 3, reason="No triggerer on 3.6")
 def test_capacity_decode():
     """
     Tests that TriggererJob correctly sets capacity to a valid value passed in as a CLI arg,

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -33,7 +33,7 @@ from tests.test_utils.www import check_content_in_response, check_content_not_in
 
 
 def test_index(admin_client):
-    with assert_queries_count(44):
+    with assert_queries_count(45):
         resp = admin_client.get('/', follow_redirects=True)
     check_content_in_response('DAGs', resp)
 


### PR DESCRIPTION
This adds a "triggerer is not running" banner in the Web UI, similar to the one that shows when the scheduler is not running.

As well as checking for a TriggererJob, though, it also checks to make sure there are pending triggers - this ensures Airflow users who do not use Deferred Operators are not affected.