### PR TITLE
Add pre/post execution hooks

### DIFF
--- a/airflow/operators/subdag.py
+++ b/airflow/operators/subdag.py
@@ -156,6 +156,7 @@ class SubDagOperator(BaseSensorOperator):
             session.commit()
 
     def pre_execute(self, context):
+        super().pre_execute(context)
         execution_date = context['execution_date']
         dag_run = self._get_dagrun(execution_date)
 
@@ -184,6 +185,7 @@ class SubDagOperator(BaseSensorOperator):
         return dag_run.state != State.RUNNING
 
     def post_execute(self, context, result=None):
+        super().post_execute(context)
         execution_date = context['execution_date']
         dag_run = self._get_dagrun(execution_date=execution_date)
         self.log.info("Execution finished. State is %s", dag_run.state)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -541,6 +541,30 @@ class TestBaseOperatorMethods(unittest.TestCase):
             # where the deprecated class was used
             assert warning.filename == __file__
 
+    def test_pre_execute_hook(self):
+        called = False
+
+        def hook(context):
+            nonlocal called
+            called = True
+
+        op = DummyOperator(task_id="test_task", pre_execute=hook)
+        op_copy = op.prepare_for_execution()
+        op_copy.pre_execute({})
+        assert called
+
+    def test_post_execute_hook(self):
+        called = False
+
+        def hook(context, result):
+            nonlocal called
+            called = True
+
+        op = DummyOperator(task_id="test_task", post_execute=hook)
+        op_copy = op.prepare_for_execution()
+        op_copy.post_execute({})
+        assert called
+
 
 class CustomOp(DummyOperator):
     template_fields = ("field", "field2")

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -872,6 +872,8 @@ class TestStringifiedDAGs(unittest.TestCase):
             '_log': base_operator.log,
             '_outlets': [],
             '_upstream_task_ids': set(),
+            '_pre_execute_hook': None,
+            '_post_execute_hook': None,
             'depends_on_past': False,
             'do_xcom_push': True,
             'doc': None,


### PR DESCRIPTION
This adds optional operator parameters `pre_execute` and `post_execute`, both of which run synchronously immediately before and after task execution.

For example, this can be used to skip execution for a particular day of the week:
```python
from croniter import match

def execute_unless(cron_expr):
    def hook(context):
        if match(cron_expr, context["execution_date"]):
            raise AirflowSkipException()
    return hook

DummyOperator(..., pre_execute=execute_unless("* * * * sat"))
```

Related: #17545