### PR TITLE
Doc: Fix docstrings for ``MongoToS3Operator``

### DIFF
--- a/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mongo_to_s3.py
@@ -43,7 +43,7 @@ class MongoToS3Operator(BaseOperator):
     :type mongo_query: Union[list, dict]
     :param mongo_projection: optional parameter to filter the returned fields by
         the query. It can be a list of fields names to include or a dictionary
-        for excluding fields (e.g `projection={"_id": 0}`
+        for excluding fields (e.g ``projection={"_id": 0}`` )
     :type mongo_projection: Union[list, dict]
     :param s3_bucket: reference to a specific S3 bucket to store the data
     :type s3_bucket: str


### PR DESCRIPTION
The doc was missing closing parentheses and had markdown formatted in-line code-block instead of rst one

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
