### PR TITLE
Support for passing arguments to SqlSensor underlying hooks

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -286,8 +286,11 @@ class Connection(Base, LoggingMixin):
         if self._extra and self.is_extra_encrypted:
             self._extra = fernet.rotate(self._extra.encode('utf-8')).decode()
 
-    def get_hook(self):
-        """Return hook based on conn_type."""
+    def get_hook(self, hook_kwargs: Dict):
+        """
+        Return hook based on conn_type.If hook_kwargs dictionary is provided,
+        then it is passed "spread" to the hook constructor.
+        """
         hook_class_name, conn_id_param, package_name, hook_name = ProvidersManager().hooks.get(
             self.conn_type, (None, None, None, None)
         )
@@ -301,7 +304,7 @@ class Connection(Base, LoggingMixin):
                 "Could not import %s when discovering %s %s", hook_class_name, hook_name, package_name
             )
             raise
-        return hook_class(**{conn_id_param: self.conn_id})
+        return hook_class(**{conn_id_param: self.conn_id}, **hook_kwargs)
 
     def __repr__(self):
         return self.conn_id

--- a/tests/sensors/test_sql_sensor.py
+++ b/tests/sensors/test_sql_sensor.py
@@ -242,6 +242,22 @@ class TestSqlSensor(TestHiveEnvironment):
             op.poke(None)
         assert "self.success is present, but not callable -> [1]" == str(ctx.value)
 
+    @mock.patch('airflow.sensors.sql.BaseHook')
+    def test_sql_sensor_bigquery_hook_kwargs(self, mock_hook):
+        op = SqlSensor(
+            task_id='sql_sensor_check',
+            conn_id='postgres_default',
+            sql="SELECT 1",
+            hook_kwargs={
+                'use_legacy_sql': False,
+                'location': 'test_location',
+            },
+        )
+
+        mock_hook.get_connection('google_cloud_default').conn_type = "google_cloud_platform"
+        assert op._get_hook().use_legacy_sql
+        assert op._get_hook().location == 'test_location'
+
     @unittest.skipIf(
         'AIRFLOW_RUNALL_TESTS' not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set"
     )


### PR DESCRIPTION
closes: #13750
related: #17315

`SqlSensor` relies on underlying hooks that are automatically injected (DI) depending on the connection type provided to the `SqlSensor`. However, from time to time (but mainly in `BigqueryHook`) it is needed to pre-configure the "to-be-injected" hook because some default params do not fit the current config.

For example, if using SqlSensor with Bigquery it by default configures the SQL dialect to "legacy SQL", and there is no way to change this through configuration. Instead the SqlSensor has to be extended and some functions overwritten (as mentioned in the #13750).

To be able to customise the underlying hook there are 2 approaches to fix this:
* Bring your own hook: instantiate a hook and provide it to the sensor already configured so it just checks that it inherits from `DbApiHook` but doesn't try to instantiate on its own.
* Pass over the params you want SqlSensor to use to instantiate the hook.

Either one has it's drawbacks:
* Cannot be used if DAG is defined with yaml/json/config-file, since to instantiate a Hook requires "intelligence", relying solely in config seems more maintainable in the future.
* The "tell us what's wrong, we got you covered" does not follow very well the "[open but closed](https://en.wikipedia.org/wiki/Open%E2%80%93closed_principle)" principle.

Knowing that, and that @uranusjr approves this second approach, and also given the known limitations, this PR makes the SqlSensor pass over the hook_kwargs to the connection hook locator that returns an instantiated hook.