### PR TITLE
Remove  redundant ``numpy`` dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -121,9 +121,6 @@ install_requires =
     markdown>=2.5.2, <4.0
     markupsafe>=1.1.1, <2.0
     marshmallow-oneofschema>=2.0.1
-    # Numpy stopped releasing 3.6 binaries for 1.20.* series.
-    numpy<1.20;python_version<"3.7"
-    numpy;python_version>="3.7"
     # Required by vendored-in connexion
     openapi-spec-validator>=0.2.4
     pendulum~=2.0


### PR DESCRIPTION
Missed removing ``numpy`` from `setup.cfg` in https://github.com/apache/airflow/pull/17575. It was only added in setup.cfg in https://github.com/apache/airflow/pull/15209/files#diff-380c6a8ebbbce17d55d50ef17d3cf906

numpy already has `python_requires` metadata: https://github.com/numpy/numpy/blob/v1.20.3/setup.py#L473

so we don't need to set `numpy<1.20;python_version<"3.7"`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
