### PR TITLE
Remove redundant note on HTTP Provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -340,14 +340,6 @@ http = [
     'requests>=2.26.0',
 ]
 http_provider = [
-    # NOTE ! The HTTP provider is NOT preinstalled by default when Airflow is installed - because it
-    #        depends on `requests` library and until `chardet` is mandatory dependency of `requests`
-    #        See https://github.com/psf/requests/pull/5797
-    #        This means that providers that depend on Http and cannot work without it, have to have
-    #        explicit dependency on `apache-airflow-providers-http` which needs to be pulled in for them.
-    #        Other cross-provider-dependencies are optional (usually cross-provider dependencies only enable
-    #        some features of providers and majority of those providers works). They result with an extra,
-    #        not with the `install-requires` dependency.
     'apache-airflow-providers-http',
 ]
 jdbc = [


### PR DESCRIPTION
Since https://github.com/apache/airflow/pull/16974 we have switched back to including HTTP provider and this comment now is not correct.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
