### PR TITLE
Use built-in ``cached_property`` on Python 3.8 for Asana provider

### DIFF
--- a/airflow/providers/asana/hooks/asana.py
+++ b/airflow/providers/asana/hooks/asana.py
@@ -21,7 +21,11 @@ from typing import Any, Dict
 
 from asana import Client
 from asana.error import NotFoundError
-from cached_property import cached_property
+
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
 
 from airflow.hooks.base import BaseHook
 

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,7 @@ amazon = [
 apache_beam = [
     'apache-beam>=2.20.0',
 ]
-asana = ['asana>=0.10', 'cached-property>=1.5.2']
+asana = ['asana>=0.10']
 async_packages = [
     'eventlet>= 0.9.7',
     'gevent>=0.13',


### PR DESCRIPTION
Functionality is the same, this just removes one dep for Py 3.8+

(same as https://github.com/apache/airflow/pull/14606)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
