### PR TITLE
Add more ``project_urls`` for PyPI

### DIFF
--- a/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
+++ b/dev/provider_packages/SETUP_TEMPLATE.py.jinja2
@@ -82,6 +82,9 @@ def do_setup():
             'Documentation': 'https://airflow.apache.org/docs/{{ PACKAGE_PIP_NAME }}/{{RELEASE}}/',
             'Bug Tracker': 'https://github.com/apache/airflow/issues',
             'Source Code': 'https://github.com/apache/airflow',
+            'Slack Chat': 'https://s.apache.org/airflow-slack',
+            'Twitter': 'https://twitter.com/ApacheAirflow',
+            'YouTube': 'https://www.youtube.com/channel/UCSXwxpWZQ7XZ1WL3wqevChA/',
         },
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,9 @@ project_urls =
     Documentation=https://airflow.apache.org/docs/
     Bug Tracker=https://github.com/apache/airflow/issues
     Source Code=https://github.com/apache/airflow
+    Slack Chat=https://s.apache.org/airflow-slack
+    Twitter=https://twitter.com/ApacheAirflow
+    YouTube=https://www.youtube.com/channel/UCSXwxpWZQ7XZ1WL3wqevChA/
 
 [options]
 zip_safe = False


### PR DESCRIPTION
This adds more of our urls for display on PyPI similar to

![image](https://user-images.githubusercontent.com/8811558/129288728-1d6e2365-0bba-436f-a822-b2afb3b06369.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
