### PR TITLE
Fix wrong Postgres search_path set up instructions

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -213,8 +213,17 @@ We recommend using the ``psycopg2`` driver and specifying it in your SqlAlchemy 
 
    postgresql+psycopg2://<user>:<password>@<host>/<db>
 
-Also note that since SqlAlchemy does not expose a way to target a specific schema in the database URI, you may
-want to set a default schema for your user with a SQL statement similar to ``ALTER USER airflow_user SET search_path = airflow, public, utility;``
+Also note that since SqlAlchemy does not expose a way to target a specific schema in the database URI, you need to ensure schema ``public`` is in your Postgres user's search_path.
+
+If you created a new Postgres account for Airflow:
+
+* The default search_path for new Postgres user is: ``"$user", public``, no change is needed.
+
+If you use a current Postgres user with custom search_path, search_path can be changed by the command:
+
+.. code-block:: sql
+
+   ALTER USER airflow_user SET search_path = public;
 
 For more information regarding setup of the PostgresSQL connection, see `PostgreSQL dialect <https://docs.sqlalchemy.org/en/13/dialects/postgresql.html>`__ in SQLAlchemy documentation.
 

--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -214,7 +214,7 @@ We recommend using the ``psycopg2`` driver and specifying it in your SqlAlchemy 
    postgresql+psycopg2://<user>:<password>@<host>/<db>
 
 Also note that since SqlAlchemy does not expose a way to target a specific schema in the database URI, you may
-want to set a default schema for your role with a SQL statement similar to ``ALTER ROLE airflow_user SET search_path = airflow, public, utility;``
+want to set a default schema for your user with a SQL statement similar to ``ALTER USER airflow_user SET search_path = airflow, public, utility;``
 
 For more information regarding setup of the PostgresSQL connection, see `PostgreSQL dialect <https://docs.sqlalchemy.org/en/13/dialects/postgresql.html>`__ in SQLAlchemy documentation.
 

--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -214,7 +214,7 @@ We recommend using the ``psycopg2`` driver and specifying it in your SqlAlchemy 
    postgresql+psycopg2://<user>:<password>@<host>/<db>
 
 Also note that since SqlAlchemy does not expose a way to target a specific schema in the database URI, you may
-want to set a default schema for your role with a SQL statement similar to ``ALTER ROLE username SET search_path = airflow, foobar;``
+want to set a default schema for your role with a SQL statement similar to ``ALTER ROLE airflow_user SET search_path = airflow, public, utility;``
 
 For more information regarding setup of the PostgresSQL connection, see `PostgreSQL dialect <https://docs.sqlalchemy.org/en/13/dialects/postgresql.html>`__ in SQLAlchemy documentation.
 


### PR DESCRIPTION
In the set up instructions for Postgres database backend, the instructed command for setting search_path to the correct schema lacks `public` and `utility`, which prevented SqlAlchemy to find all those required schemas.
