### PR TITLE
Fix triggerer query where limit is not supported in some DB versions

### DIFF
--- a/airflow/models/trigger.py
+++ b/airflow/models/trigger.py
@@ -184,12 +184,10 @@ class Trigger(Base):
         # Find triggers who do NOT have an alive triggerer_id, and then assign
         # up to `capacity` of those to us.
         trigger_ids_query = (
-            session.query(cls.id)
-            .filter(cls.triggerer_id.notin_(alive_triggerer_ids))
-            .limit(capacity)
-            .subquery()
+            session.query(cls.id).filter(cls.triggerer_id.notin_(alive_triggerer_ids)).limit(capacity).all()
         )
-        session.query(cls).filter(cls.id.in_(trigger_ids_query)).update(
+        session.query(cls).filter(cls.id.in_([i.id for i in trigger_ids_query])).update(
             {cls.triggerer_id: triggerer_id},
             synchronize_session=False,
         )
+        session.commit()

--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -54,7 +54,7 @@ class DateTimeTrigger(BaseTrigger):
         unexpectedly, or handles a DST change poorly.
         """
         # Sleep an hour at a time while it's more than 2 hours away
-        while (self.moment - timezone.utcnow()).total_hours() > 2:
+        while (self.moment - timezone.utcnow()).total_seconds() > 2 * 3600:
             await asyncio.sleep(3600)
         # Sleep a second at a time otherwise
         while self.moment > timezone.utcnow():


### PR DESCRIPTION
This PR fixes the triggerrer query where limit is not supported in some DB versions and also fixed the issue where total_hours was used on a timedelta.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
