### PR TITLE
Avoid endless redirect loop when user has no roles

### DIFF
--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -18,7 +18,7 @@
 from functools import wraps
 from typing import Callable, Optional, Sequence, Tuple, TypeVar, cast
 
-from flask import current_app, flash, redirect, request, url_for
+from flask import current_app, flash, g, redirect, request, url_for
 
 T = TypeVar("T", bound=Callable)
 
@@ -30,6 +30,9 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
         @wraps(func)
         def decorated(*args, **kwargs):
             appbuilder = current_app.appbuilder
+            if not g.user.is_anonymous and not g.user.roles:
+                return redirect(url_for("Airflow.no_roles"))
+
             if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
                 return func(*args, **kwargs)
             else:

--- a/airflow/www/templates/airflow/no_roles.html
+++ b/airflow/www/templates/airflow/no_roles.html
@@ -28,8 +28,9 @@
     <img src="{{ url_for('static', filename='pin_100.png') }}" width="50px" alt="pin-logo" />
     <h1>Your user has no roles!</h1>
     <p>Unfortunately your user has no roles, and therefore you cannot use Airflow.</p>
-    <p>Please contact your Airflow administrator or <a href="{{ logout_url }}">log out</a> to try
-      again.</p>
+    <p>Please contact your Airflow administrator
+      (<a href="https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html#web-authentication">authentication</a>
+      may be misconfigured) or <a href="{{ logout_url }}">log out</a> to try again.</p>
     <p>{{ hostname }}</p>
   </div>
 </body>

--- a/airflow/www/templates/airflow/no_roles.html
+++ b/airflow/www/templates/airflow/no_roles.html
@@ -1,0 +1,36 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Airflow</title>
+  <link rel="icon" type="image/png" href="{{ url_for('static', filename='pin_32.png') }}">
+</head>
+<body>
+  <div style="font-family: verdana; text-align: center; margin-top: 200px;">
+    <img src="{{ url_for('static', filename='pin_100.png') }}" width="50px" alt="pin-logo" />
+    <h1>Your user has no roles!</h1>
+    <p>Unfortunately your user has no roles, and therefore you cannot use Airflow.</p>
+    <p>Please contact your Airflow administrator or <a href="{{ logout_url }}">log out</a> to try
+      again.</p>
+    <p>{{ hostname }}</p>
+  </div>
+</body>
+</html>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -527,6 +527,20 @@ class Airflow(AirflowBaseView):
 
         return wwwutils.json_response(payload)
 
+    @expose('/no_roles')
+    def no_roles(self):
+        """Show 'user has no roles' on screen (instead of an endless redirect loop)"""
+        if g.user.is_anonymous or g.user.roles:
+            return redirect(url_for("Airflow.index"))
+
+        return render_template(
+            'airflow/no_roles.html',
+            hostname=socket.getfqdn()
+            if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
+            else 'redact',
+            logout_url=current_app.appbuilder.get_url_for_logout,
+        )
+
     @expose('/home')
     @auth.has_access(
         [

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -24,7 +24,6 @@ def client_with_login(app, **kwargs):
         client = app.test_client()
         resp = client.post("/login/", data=kwargs)
         assert resp.status_code == 302
-        assert resp.headers["location"] == "http://localhost/"
     return client
 
 

--- a/tests/test_utils/www.py
+++ b/tests/test_utils/www.py
@@ -24,6 +24,7 @@ def client_with_login(app, **kwargs):
         client = app.test_client()
         resp = client.post("/login/", data=kwargs)
         assert resp.status_code == 302
+        assert resp.headers["location"] == "http://localhost/"
     return client
 
 

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -759,3 +759,44 @@ def test_get_logs_with_metadata_failure(dag_faker_client):
     )
     check_content_not_in_response('"message":', resp)
     check_content_not_in_response('"metadata":', resp)
+
+
+@pytest.fixture(scope="module")
+def user_no_roles(acl_app):
+    user = create_user(
+        acl_app,
+        username="no_roles_user",
+        role_name="User",
+    )
+    user.roles = []
+    return user
+
+
+@pytest.fixture()
+def client_no_roles(acl_app, user_no_roles):
+    return client_with_login(
+        acl_app,
+        username="no_roles_user",
+        password="no_roles_user",
+    )
+
+
+@pytest.fixture()
+def client_anonymous(acl_app):
+    return acl_app.test_client()
+
+
+@pytest.mark.parametrize(
+    "client, url, expected_content",
+    [
+        ["client_no_roles", "/home", "Your user has no roles!"],
+        ["client_no_roles", "/no_roles", "Your user has no roles!"],
+        ["client_all_dags", "/home", "DAGs - Airflow"],
+        ["client_all_dags", "/no_roles", "DAGs - Airflow"],
+        ["client_anonymous", "/home", "Sign In"],
+        ["client_anonymous", "/no_roles", "Sign In"],
+    ],
+)
+def test_no_roles_redirect(request, client, url, expected_content):
+    resp = request.getfixturevalue(client).get(url, follow_redirects=True)
+    check_content_in_response(expected_content, resp)

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -766,7 +766,7 @@ def user_no_roles(acl_app):
     user = create_user(
         acl_app,
         username="no_roles_user",
-        role_name="User",
+        role_name="no_roles_user_role",
     )
     user.roles = []
     return user


### PR DESCRIPTION

With the (relatively) new FAB feature of role mapping, we've had
multiple instances of users getting no roles and running into an endless
redirect loop of / -> /home -> /login. This intercepts users in this
state and sends them to a new "no_roles" page explaining the situation.

![Screen Shot 2021-08-16 at 1 19 46 PM](https://user-images.githubusercontent.com/66968678/129618551-3b38bb09-910a-49c6-acf6-5d3af315dd38.png)

Closes #16783
