### PR TITLE
Switch Alibaba OSS tests to us-east-1

### DIFF
--- a/tests/providers/alibaba/cloud/hooks/test_oss.py
+++ b/tests/providers/alibaba/cloud/hooks/test_oss.py
@@ -26,7 +26,7 @@ from airflow.providers.alibaba.cloud.hooks.oss import OSSHook
 from tests.providers.alibaba.cloud.utils.test_utils import skip_test_if_no_valid_conn_id
 
 TEST_CONN_ID = os.environ.get('TEST_OSS_CONN_ID', 'oss_default')
-TEST_REGION = os.environ.get('TEST_OSS_REGION', 'cn-hangzhou')
+TEST_REGION = os.environ.get('TEST_OSS_REGION', 'us-east-1')
 TEST_BUCKET = os.environ.get('TEST_OSS_BUCKET', 'test-bucket')
 
 

--- a/tests/providers/alibaba/cloud/operators/test_oss.py
+++ b/tests/providers/alibaba/cloud/operators/test_oss.py
@@ -34,7 +34,7 @@ from airflow.providers.alibaba.cloud.operators.oss import (
 from tests.providers.alibaba.cloud.utils.test_utils import skip_test_if_no_valid_conn_id
 
 TEST_CONN_ID = os.environ.get('TEST_OSS_CONN_ID', 'oss_default')
-TEST_REGION = os.environ.get('TEST_OSS_REGION', 'cn-hangzhou')
+TEST_REGION = os.environ.get('TEST_OSS_REGION', 'us-east-1')
 TEST_BUCKET = os.environ.get('TEST_OSS_BUCKET', 'test-bucket')
 TEST_FILE_PATH = '/tmp/airflow-test'
 

--- a/tests/providers/alibaba/cloud/sensors/test_oss_key.py
+++ b/tests/providers/alibaba/cloud/sensors/test_oss_key.py
@@ -33,7 +33,7 @@ from airflow.providers.alibaba.cloud.sensors.oss_key import OSSKeySensor
 from tests.providers.alibaba.cloud.utils.test_utils import skip_test_if_no_valid_conn_id
 
 TEST_CONN_ID = os.environ.get('TEST_OSS_CONN_ID', 'oss_default')
-TEST_REGION = os.environ.get('TEST_OSS_REGION', 'cn-hangzhou')
+TEST_REGION = os.environ.get('TEST_OSS_REGION', 'us-east-1')
 TEST_BUCKET = os.environ.get('TEST_OSS_BUCKET', 'test-bucket')
 TEST_FILE_PATH = '/tmp/airflow-test'
 


### PR DESCRIPTION
The tests were using cn-hengzou before which - due to the
limitations in cross-border communication with China behaved
erratically and caused a number of transient errors.

Since GitHub Actions Public runners and our Self-hosted runners
run in US-east (Azure/AWS), switching to us-east-1 should address
the stability of tests.

Ideally we should switch to mocking, but that might be done
separately.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
