### PR TITLE
Fix redacting secrets in context exceptions.

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -144,6 +144,13 @@ class SecretsMasker(logging.Filter):
         )
         return frozenset(record.__dict__).difference({'msg', 'args'})
 
+    def _redact_exception_with_context(self, exception):
+        exception.args = (self.redact(v) for v in exception.args)
+        if exception.__context__:
+            self._redact_exception_with_context(exception.__context__)
+        if exception.__cause__:
+            self._redact_exception_with_context(exception.__cause__)
+
     def filter(self, record) -> bool:
         if self.ALREADY_FILTERED_FLAG in record.__dict__:
             # Filters are attached to multiple handlers and logs, keep a
@@ -157,8 +164,7 @@ class SecretsMasker(logging.Filter):
                 record.__dict__[k] = self.redact(v)
             if record.exc_info and record.exc_info[1] is not None:
                 exc = record.exc_info[1]
-                # I'm not sure if this is a good idea!
-                exc.args = (self.redact(v) for v in exc.args)
+                self._redact_exception_with_context(exc)
         record.__dict__[self.ALREADY_FILTERED_FLAG] = True
 
         return True

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -148,7 +148,7 @@ class SecretsMasker(logging.Filter):
         exception.args = (self.redact(v) for v in exception.args)
         if exception.__context__:
             self._redact_exception_with_context(exception.__context__)
-        if exception.__cause__:
+        if exception.__cause__ and exception.__cause__ is not exception.__context__:
             self._redact_exception_with_context(exception.__cause__)
 
     def filter(self, record) -> bool:


### PR DESCRIPTION
Secret masking did not work in implicit and
explicit context exceptions (see
https://www.python.org/dev/peps/pep-3134/)
When there was a `try/except/raise` sequence,
or `raise ... from` exception - the original
exceptions were not redacted.

Related: #17604

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
