### PR TITLE
Declared readonly variables in configure_environment.sh

### DIFF
--- a/scripts/in_container/configure_environment.sh
+++ b/scripts/in_container/configure_environment.sh
@@ -18,8 +18,8 @@
 # Script to check licences for all code. Can be started from any working directory
 export FILES_DIR="/files"
 export AIRFLOW_BREEZE_CONFIG_DIR="${FILES_DIR}/airflow-breeze-config"
-VARIABLES_ENV_FILE="variables.env"
-TMUX_CONF_FILE=".tmux.conf"
+readonly VARIABLES_ENV_FILE="variables.env"
+readonly TMUX_CONF_FILE=".tmux.conf"
 
 if [[ -d "${FILES_DIR}" ]]; then
     export AIRFLOW__CORE__DAGS_FOLDER="/files/dags"


### PR DESCRIPTION
Declared readonly variables to be used in scripts . 

readonly VARIABLES_ENV_FILE="variables.env"
readonly TMUX_CONF_FILE=".tmux.conf"


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
