### PR TITLE
Improve cross-links to operators and hooks references

### DIFF
--- a/docs/apache-airflow-providers/operators-and-hooks-ref/index.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/index.rst
@@ -19,6 +19,8 @@
 Operators and Hooks Reference
 =============================
 
+Here is a list of operators and hooks that are released independently of the Airflow core. A list of core operators is available in the documentation for ``apache-airflow``: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`.
+
 .. toctree::
     :maxdepth: 2
     :glob:

--- a/docs/apache-airflow/concepts/operators.rst
+++ b/docs/apache-airflow/concepts/operators.rst
@@ -32,7 +32,7 @@ Airflow has a very extensive set of operators available, with some built-in to t
 - :class:`~airflow.operators.python.PythonOperator` - calls an arbitrary Python function
 - :class:`~airflow.operators.email.EmailOperator` - sends an email
 
-For a list of all core operators, see: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`.
+For a list of all core operators, see: :doc:`Core Operators and Hooks Reference </operators-and-hooks-ref>`.
 
 If the operator you need isn't installed with Airflow by default, you can probably find it as part of our huge set of community :doc:`provider packages <apache-airflow-providers:index>`. Some popular operators from here include:
 

--- a/docs/apache-airflow/concepts/operators.rst
+++ b/docs/apache-airflow/concepts/operators.rst
@@ -32,7 +32,7 @@ Airflow has a very extensive set of operators available, with some built-in to t
 - :class:`~airflow.operators.python.PythonOperator` - calls an arbitrary Python function
 - :class:`~airflow.operators.email.EmailOperator` - sends an email
 
-For a list of all core operators, see: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`__.
+For a list of all core operators, see: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`.
 
 If the operator you need isn't installed with Airflow by default, you can probably find it as part of our huge set of community :doc:`provider packages <apache-airflow-providers:index>`. Some popular operators from here include:
 

--- a/docs/apache-airflow/concepts/operators.rst
+++ b/docs/apache-airflow/concepts/operators.rst
@@ -26,16 +26,17 @@ An Operator is conceptually a template for a predefined :doc:`Task <tasks>`, tha
 
         ping >> email
 
-Airflow has a very extensive set of operators available, with some built-in to the core or pre-installed providers, like:
+Airflow has a very extensive set of operators available, with some built-in to the core or pre-installed providers. Some popular operators from core include:
 
 - :class:`~airflow.operators.bash.BashOperator` - executes a bash command
 - :class:`~airflow.operators.python.PythonOperator` - calls an arbitrary Python function
 - :class:`~airflow.operators.email.EmailOperator` - sends an email
-- :class:`~airflow.providers.http.operators.http.SimpleHttpOperator` - sends an HTTP request
-- :class:`~airflow.providers.sqlite.operators.sqlite.SqliteOperator` - SQLite DB operator
 
-If the operator you need isn't installed with Airflow by default, you can probably find it as part of our huge set of community :doc:`apache-airflow-providers:index`. Some popular operators from here include:
+For a list of all core operators, see: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`__.
 
+If the operator you need isn't installed with Airflow by default, you can probably find it as part of our huge set of community :doc:`provider packages <apache-airflow-providers:index>`. Some popular operators from here include:
+
+- :class:`~airflow.providers.http.operators.http.SimpleHttpOperator`
 - :class:`~airflow.providers.mysql.operators.mysql.MySqlOperator`
 - :class:`~airflow.providers.postgres.operators.postgres.PostgresOperator`
 - :class:`~airflow.providers.microsoft.mssql.operators.mssql.MsSqlOperator`
@@ -47,7 +48,7 @@ If the operator you need isn't installed with Airflow by default, you can probab
 - :class:`~airflow.providers.mysql.transfers.presto_to_mysql.PrestoToMySqlOperator`
 - :class:`~airflow.providers.slack.operators.slack.SlackAPIOperator`
 
-But there are many, many more - you can see the list of those in our :doc:`apache-airflow-providers:index` documentation.
+But there are many, many more - you can see the list of those in our :doc:`providers packages <apache-airflow-providers:operators-and-hooks-ref/index>` documentation.
 
 .. note::
 


### PR DESCRIPTION
To make it easier to find core and providers operator references, I am adding a few more links.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
