### PR TITLE
Do not delete running DAG from the UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1523,6 +1523,14 @@ class Airflow(AirflowBaseView):
         except DagFileExists:
             flash(f"Dag id {dag_id} is still in DagBag. Remove the DAG file first.", 'error')
             return redirect(request.referrer)
+        except AirflowException:
+            flash(
+                f"Cannot delete DAG with id {dag_id} because some task instances of the DAG "
+                "are still running. Please mark the  task instances as "
+                "failed/succeeded before deleting the DAG",
+                "error",
+            )
+            return redirect(request.referrer)
 
         flash(f"Deleting DAG with id {dag_id}. May take a couple minutes to fully disappear.")
 


### PR DESCRIPTION
Currently, we do not consider if a DAG has finished running when deleting
the DAG from the UI, consequently, the running task instances are not deleted.

When the DAG appear again in the UI and we rerun it, say we have catchup set to True,
those running task instances that were not deleted would be rerun and an external state change
of the task instances would be detected by the LocalTaskJob thereby sending SIGTERM to the task runner

This change resolves this by making sure that DAGs are not deleted when the task instances are still
running

Related: https://github.com/apache/airflow/issues/10026



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
