### PR TITLE
Add root to tree refresh url

### DIFF
--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -29,6 +29,7 @@ import getMetaValue from './meta_value';
 const dagId = getMetaValue('dag_id');
 const treeDataUrl = getMetaValue('tree_data');
 const numRuns = getMetaValue('num_runs');
+const urlRoot = getMetaValue('root');
 
 function toDateString(ts) {
   const dt = new Date(ts * 1000);
@@ -424,7 +425,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleRefresh() {
     $('#loading-dots').css('display', 'inline-block');
-    $.get(`${treeDataUrl}?dag_id=${dagId}&num_runs=${numRuns}`)
+    $.get(`${treeDataUrl}?dag_id=${dagId}&num_runs=${numRuns}&root=${urlRoot}`)
       .done(
         (runs) => {
           const newData = {

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -36,6 +36,7 @@
 {% block head_meta %}
   {{ super() }}
   <meta name="num_runs" content="{{ num_runs }}">
+  <meta name="root" content="{{ root if root else '' }}">
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
We were not passing the root to the `/tree_data` api call. Therefore, filtering upstream of a task would be reset during auto-refresh even though root was still defined.

Fixes #17533

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
