### PR TITLE
Use new Sphinx Autodoc mock import path

### DIFF
--- a/docs/exts/docroles.py
+++ b/docs/exts/docroles.py
@@ -21,7 +21,8 @@
 from functools import partial
 
 from docutils import nodes, utils
-from sphinx.ext.autodoc.importer import import_module, mock
+from sphinx.ext.autodoc.importer import import_module
+from sphinx.ext.autodoc.mock import mock
 
 
 class RoleException(Exception):


### PR DESCRIPTION
Sphinx is deprecating `sphinx.ext.autodoc.importer.mock` according to its documentation. See https://www.sphinx-doc.org/en/master/extdev/deprecated.html

This warning is generally not visible when documentation builds successfully and is buried in thousands of lines wwhen it fails, so probably nobody noticed it before. I wonder if we should find a way to make this kind of warnings more visible.