### PR TITLE
fix: use template

### DIFF
--- a/chart/templates/rbac/pod-log-reader-rolebinding.yaml
+++ b/chart/templates/rbac/pod-log-reader-rolebinding.yaml
@@ -48,6 +48,6 @@ roleRef:
   name: {{ .Release.Name }}-pod-log-reader-role
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-webserver
+    name: {{ include "webserver.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}


### PR DESCRIPTION
Replace release name based webserver service account with template, allowing proper rolebinding to overridden serviceaccount name.