### PR TITLE
Only run 2.2.0 providers commands for Airflow >= 2.2.0

### DIFF
--- a/scripts/in_container/run_install_and_test_provider_packages.sh
+++ b/scripts/in_container/run_install_and_test_provider_packages.sh
@@ -216,6 +216,12 @@ function discover_all_auth_backends() {
     group_end
 }
 
+function ver() {
+  # convert SemVer number to comparable string (strips pre-release version)
+  # shellcheck disable=SC2086,SC2183
+  printf "%04d%04d%04d%.0s" ${1//[.-]/ }
+}
+
 setup_provider_packages
 verify_parameters
 install_airflow_as_specified
@@ -227,6 +233,13 @@ discover_all_hooks
 discover_all_connection_form_widgets
 discover_all_field_behaviours
 discover_all_extra_links
-discover_all_logging_handlers
-discover_all_secrets_backends
-discover_all_auth_backends
+
+# The commands below are available only for airflow version 2.2.0+
+airflow_version=$(airflow version)
+airflow_version_comparable=$(ver "${airflow_version}")
+min_airflow_version_comparable=$(ver "2.2.0")
+if (( airflow_version_comparable >= min_airflow_version_comparable )); then
+    discover_all_logging_handlers
+    discover_all_secrets_backends
+    discover_all_auth_backends
+fi


### PR DESCRIPTION
We test providers also for older versions of Airflow and not all
older version of airflow have the same set of provider commands
available.

With this change the new provider commands are only tested for Airflow
versions that supports them.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
