### PR TITLE
Only call `task_runner.return_code` from `LocalTaskJob._execute`

### DIFF
--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -110,7 +110,6 @@ class StandardTaskRunner(BaseTaskRunner):
             return
 
         # Reap the child process - it may already be finished
-        _ = self.return_code(timeout=0)
 
         if self.process and self.process.is_running():
             rcs = reap_process_group(self.process.pid, self.log)


### PR DESCRIPTION
Currently, task_runner.return_code is called from task_runner.terminate
causing extra call of the return_code after it has returned 0.

This PR removes the extra call and ensures task_runner.return_code is only
called from LocalTaskJob._execute method



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
