### PR TITLE
[DOCS] Update DAG.is_active property

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1873,9 +1873,10 @@ components:
           nullable: true
           description: Whether the DAG is paused.
         is_active:
-          type: boolean
-          nullable: true
           description: Whether the DAG is currently seen by the scheduler(s).
+          nullable: true
+          readOnly: true
+          type: boolean
         is_subdag:
           description: Whether the DAG is SubDAG.
           type: boolean


### PR DESCRIPTION
Description
---
Pretty simple patch updating documentation. Adds `readOnly=True` to `DAG.is_active`.

closes: #17639 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).

