### PR TITLE
Update pre-commit checks - flynt to 0.66

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -250,6 +250,13 @@ repos:
         exclude: |
           (?x)
           ^airflow/_vendor/
+  - repo: https://github.com/ikamensh/flynt/
+    rev: '0.66'
+    hooks:
+      - id: flynt
+        exclude: |
+          (?x)
+          ^airflow/_vendor/
   - repo: local
     hooks:
       - id: lint-openapi
@@ -622,14 +629,6 @@ repos:
         files: airflow/config_templates/config\.yml$
         require_serial: true
         additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
-      - id: flynt
-        name: Convert to f-strings with flynt
-        entry: flynt
-        language: python
-        language_version: python3
-        additional_dependencies: ['flynt==0.63']
-        files: \.py$
-        exclude: ^airflow/_vendor/
       - id: ui-lint
         name: ESLint against airflow/ui
         language: node

--- a/dev/airflow-license
+++ b/dev/airflow-license
@@ -68,7 +68,7 @@ def parse_license_file(project_name):
 
 
 if __name__ == "__main__":
-    print("{:<30}|{:<50}||{:<20}||{:<10}".format("PROJECT", "URL", "LICENSE TYPE DEFINED", "DETECTED"))
+    print(f"{'PROJECT':<30}|{'URL':<50}||{'LICENSE TYPE DEFINED':<20}||{'DETECTED':<10}")
 
     notices = get_notices()
 


### PR DESCRIPTION
Additionally, we now download flynt configurations from the official repository, which allows us to automatically download updates using the `pre-commit autoupdate` command
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
