### PR TITLE
Mark DAG.param as a decorated field

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -651,7 +651,7 @@ class SerializedDAG(DAG, BaseSerialization):
     not pickle-able. SerializedDAG works for all DAGs.
     """
 
-    _decorated_fields = {'schedule_interval', 'default_args', '_access_control'}
+    _decorated_fields = {'schedule_interval', 'default_args', 'params', '_access_control'}
 
     @staticmethod
     def __get_constructor_defaults():


### PR DESCRIPTION
Fix #17582.

This mainly affects how this field is deserialized; previously it would be deserialized as-is, which is problematic if the param is a nested dict since the inner dicts were serialized with the `{"__type": "dict", "__val": ...}` wrapper and not deserialized properly.

I am not at all familiar with the related logic and not sure if I am doing the right thing.