### PR TITLE
Import Hooks lazily individually in providers manager

### DIFF
--- a/airflow/cli/commands/provider_command.py
+++ b/airflow/cli/commands/provider_command.py
@@ -21,6 +21,8 @@ from airflow.cli.simple_table import AirflowConsole
 from airflow.providers_manager import ProvidersManager
 from airflow.utils.cli import suppress_logs_and_warning
 
+ERROR_IMPORTING_HOOK = "Error when importing hook!"
+
 
 def _remove_rst_syntax(value: str) -> str:
     return re.sub("[`_<>]", "", value.strip(" \n."))
@@ -68,10 +70,10 @@ def hooks_list(args):
         output=args.output,
         mapper=lambda x: {
             "connection_type": x[0],
-            "class": x[1].connection_class,
-            "conn_id_attribute_name": x[1].connection_id_attribute_name,
-            'package_name': x[1].package_name,
-            'hook_name': x[1].hook_name,
+            "class": x[1].hook_class_name if x[1] else ERROR_IMPORTING_HOOK,
+            "conn_id_attribute_name": x[1].connection_id_attribute_name if x[1] else ERROR_IMPORTING_HOOK,
+            'package_name': x[1].package_name if x[1] else ERROR_IMPORTING_HOOK,
+            'hook_name': x[1].hook_name if x[1] else ERROR_IMPORTING_HOOK,
         },
     )
 
@@ -84,7 +86,7 @@ def connection_form_widget_list(args):
         output=args.output,
         mapper=lambda x: {
             "connection_parameter_name": x[0],
-            "class": x[1].connection_class,
+            "class": x[1].hook_class_name,
             'package_name': x[1].package_name,
             'field_type': x[1].field.field_class.__name__,
         },

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -288,9 +288,13 @@ class Connection(Base, LoggingMixin):
 
     def get_hook(self):
         """Return hook based on conn_type."""
-        hook_class_name, conn_id_param, package_name, hook_name = ProvidersManager().hooks.get(
-            self.conn_type, (None, None, None, None)
-        )
+        (
+            hook_class_name,
+            conn_id_param,
+            package_name,
+            hook_name,
+            connection_type,
+        ) = ProvidersManager().hooks.get(self.conn_type, (None, None, None, None, None))
 
         if not hook_class_name:
             raise AirflowException(f'Unknown hook type "{self.conn_type}"')

--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -195,10 +195,32 @@
     },
     "hook-class-names": {
       "type": "array",
-      "description": "Hook class names that provide connection types to core",
+      "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
       "items": {
-        "type": "string"
+          "type": "string"
+      },
+      "deprecated": {
+        "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
+        "deprecatedVersion": "2.2"
       }
+    },
+    "connection-types": {
+      "type": "array",
+      "description": "Map of connection types mapped to hook class names",
+      "items": {
+          "type": "object",
+          "properties": {
+              "connection-type": {
+                  "description": "Type of connection defined by the provider",
+                  "type": "string"
+              },
+              "hook-class-name": {
+                  "description": "Hook class name that implements the connection type",
+                  "type": "string"
+              }
+          }
+      },
+      "required": ["connection-type", "hook-class-name"]
     },
     "extra-links": {
       "type": "array",

--- a/airflow/provider.yaml.schema.json
+++ b/airflow/provider.yaml.schema.json
@@ -206,7 +206,7 @@
     },
     "connection-types": {
       "type": "array",
-      "description": "Map of connection types mapped to hook class names",
+      "description": "Array of connection types mapped to hook class names",
       "items": {
           "type": "object",
           "properties": {

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -16,7 +16,7 @@
     },
     "hook-class-names": {
       "type": "array",
-      "description": "Hook class names that provide connection types to core((deprecated by connection-types)",
+      "description": "Hook class names that provide connection types to core (deprecated by connection-types)",
       "items": {
         "type": "string"
       },

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -22,7 +22,7 @@
       },
       "deprecated": {
         "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
-        "deprecatedVersion": "2.2"
+        "deprecatedVersion": "2.2.0"
       }
     },
     "connection-types": {

--- a/airflow/provider_info.schema.json
+++ b/airflow/provider_info.schema.json
@@ -16,10 +16,32 @@
     },
     "hook-class-names": {
       "type": "array",
-      "description": "Hook class names that provide connection types to core",
+      "description": "Hook class names that provide connection types to core((deprecated by connection-types)",
       "items": {
         "type": "string"
+      },
+      "deprecated": {
+        "description": "The hook-class-names property has been deprecated in favour of connection-types which is more performant version allowing to only import individual Hooks rather than all hooks at once",
+        "deprecatedVersion": "2.2"
       }
+    },
+    "connection-types": {
+      "type": "array",
+      "description": "Map of connection types mapped to hook class names.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "connection-type": {
+            "description": "Type of connection defined by the provider",
+            "type": "string"
+          },
+          "hook-class-name": {
+            "description": "Hook class name that implements the connection type",
+            "type": "string"
+          }
+        }
+      },
+      "required": ["connection-type", "hook-class-name"]
     },
     "extra-links": {
       "type": "array",

--- a/airflow/providers/airbyte/provider.yaml
+++ b/airflow/providers/airbyte/provider.yaml
@@ -54,3 +54,7 @@ sensors:
 
 hook-class-names:
   - airflow.providers.airbyte.hooks.airbyte.AirbyteHook
+
+connection-types:
+  - hook-class-name: airflow.providers.airbyte.hooks.airbyte.AirbyteHook
+    connection-type: airbyte

--- a/airflow/providers/alibaba/provider.yaml
+++ b/airflow/providers/alibaba/provider.yaml
@@ -52,3 +52,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.alibaba.cloud.hooks.oss.OSSHook
+
+connection-types:
+  - hook-class-name: airflow.providers.alibaba.cloud.hooks.oss.OSSHook
+    connection-type: oss

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -400,6 +400,14 @@ hook-class-names:
   - airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook
   - airflow.providers.amazon.aws.hooks.emr.EmrHook
 
+connection-types:
+  - hook-class-name: airflow.providers.amazon.aws.hooks.s3.S3Hook
+    connection-type: s3
+  - hook-class-name: airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook
+    connection-type: aws
+  - hook-class-name: airflow.providers.amazon.aws.hooks.emr.EmrHook
+    connection-type: emr
+
 secrets-backends:
   - airflow.providers.amazon.aws.secrets.secrets_manager.SecretsManagerBackend
   - airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend

--- a/airflow/providers/apache/cassandra/provider.yaml
+++ b/airflow/providers/apache/cassandra/provider.yaml
@@ -50,3 +50,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.cassandra.hooks.cassandra.CassandraHook
+    connection-type: cassandra

--- a/airflow/providers/apache/drill/provider.yaml
+++ b/airflow/providers/apache/drill/provider.yaml
@@ -47,3 +47,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.apache.drill.hooks.drill.DrillHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.drill.hooks.drill.DrillHook
+    connection-type: drill

--- a/airflow/providers/apache/druid/provider.yaml
+++ b/airflow/providers/apache/druid/provider.yaml
@@ -51,6 +51,10 @@ hooks:
 hook-class-names:
   - airflow.providers.apache.druid.hooks.druid.DruidDbApiHook
 
+connection-types:
+  - hook-class-name: airflow.providers.apache.druid.hooks.druid.DruidDbApiHook
+    connection-type: druid
+
 transfers:
   - source-integration-name: Apache Hive
     target-integration-name: Apache Druid

--- a/airflow/providers/apache/hdfs/provider.yaml
+++ b/airflow/providers/apache/hdfs/provider.yaml
@@ -60,3 +60,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.hdfs.hooks.hdfs.HDFSHook
+    connection-type: hdfs

--- a/airflow/providers/apache/hive/provider.yaml
+++ b/airflow/providers/apache/hive/provider.yaml
@@ -83,3 +83,11 @@ hook-class-names:
   - airflow.providers.apache.hive.hooks.hive.HiveCliHook
   - airflow.providers.apache.hive.hooks.hive.HiveServer2Hook
   - airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveCliHook
+    connection-type: hive_cli
+  - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveServer2Hook
+    connection-type: hiveserver2
+  - hook-class-name: airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook
+    connection-type: hive_metastore

--- a/airflow/providers/apache/livy/provider.yaml
+++ b/airflow/providers/apache/livy/provider.yaml
@@ -53,3 +53,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.apache.livy.hooks.livy.LivyHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.livy.hooks.livy.LivyHook
+    connection-type: livy

--- a/airflow/providers/apache/pig/provider.yaml
+++ b/airflow/providers/apache/pig/provider.yaml
@@ -47,3 +47,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.apache.pig.hooks.pig.PigCliHook
+
+connection-types:
+  - connection-type: pig_cli
+    hook-class-name: airflow.providers.apache.pig.hooks.pig.PigCliHook

--- a/airflow/providers/apache/spark/provider.yaml
+++ b/airflow/providers/apache/spark/provider.yaml
@@ -58,3 +58,11 @@ hook-class-names:
   - airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook
   - airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook
   - airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.spark.hooks.spark_jdbc.SparkJDBCHook
+    connection-type: spark_jdbc
+  - hook-class-name: airflow.providers.apache.spark.hooks.spark_sql.SparkSqlHook
+    connection-type: spark_sql
+  - hook-class-name: airflow.providers.apache.spark.hooks.spark_submit.SparkSubmitHook
+    connection-type: spark

--- a/airflow/providers/apache/sqoop/provider.yaml
+++ b/airflow/providers/apache/sqoop/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.apache.sqoop.hooks.sqoop.SqoopHook
+
+connection-types:
+  - hook-class-name: airflow.providers.apache.sqoop.hooks.sqoop.SqoopHook
+    connection-type: sqoop

--- a/airflow/providers/asana/provider.yaml
+++ b/airflow/providers/asana/provider.yaml
@@ -46,3 +46,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.asana.hooks.asana.AsanaHook
+
+connection-types:
+  - hook-class-name: airflow.providers.asana.hooks.asana.AsanaHook
+    connection-type: asana

--- a/airflow/providers/cloudant/provider.yaml
+++ b/airflow/providers/cloudant/provider.yaml
@@ -42,3 +42,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.cloudant.hooks.cloudant.CloudantHook
+
+connection-types:
+  - hook-class-name: airflow.providers.cloudant.hooks.cloudant.CloudantHook
+    connection-type: cloudant

--- a/airflow/providers/cncf/kubernetes/provider.yaml
+++ b/airflow/providers/cncf/kubernetes/provider.yaml
@@ -63,3 +63,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook
+
+connection-types:
+  - hook-class-name: airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook
+    connection-type: kubernetes

--- a/airflow/providers/databricks/provider.yaml
+++ b/airflow/providers/databricks/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.databricks.hooks.databricks.DatabricksHook
+
+connection-types:
+  - hook-class-name: airflow.providers.databricks.hooks.databricks.DatabricksHook
+    connection-type: databricks

--- a/airflow/providers/dingding/provider.yaml
+++ b/airflow/providers/dingding/provider.yaml
@@ -50,3 +50,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.dingding.hooks.dingding.DingdingHook
+
+connection-types:
+  - hook-class-name: airflow.providers.dingding.hooks.dingding.DingdingHook
+    connection-type: dingding

--- a/airflow/providers/discord/provider.yaml
+++ b/airflow/providers/discord/provider.yaml
@@ -47,3 +47,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.discord.hooks.discord_webhook.DiscordWebhookHook
+
+connection-types:
+  - hook-class-name: airflow.providers.discord.hooks.discord_webhook.DiscordWebhookHook
+    connection-type: discord

--- a/airflow/providers/docker/provider.yaml
+++ b/airflow/providers/docker/provider.yaml
@@ -58,3 +58,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.docker.hooks.docker.DockerHook
+
+connection-types:
+  - hook-class-name: airflow.providers.docker.hooks.docker.DockerHook
+    connection-type: docker

--- a/airflow/providers/elasticsearch/provider.yaml
+++ b/airflow/providers/elasticsearch/provider.yaml
@@ -47,5 +47,9 @@ hooks:
 hook-class-names:
   - airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchHook
 
+connection-types:
+  - hook-class-name: airflow.providers.elasticsearch.hooks.elasticsearch.ElasticsearchHook
+    connection-type: elasticsearch
+
 logging:
   - airflow.providers.elasticsearch.log.es_task_handler.ElasticsearchTaskHandler

--- a/airflow/providers/exasol/provider.yaml
+++ b/airflow/providers/exasol/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.exasol.hooks.exasol.ExasolHook
+
+connection-types:
+  - hook-class-name: airflow.providers.exasol.hooks.exasol.ExasolHook
+    connection-type: exasol

--- a/airflow/providers/facebook/provider.yaml
+++ b/airflow/providers/facebook/provider.yaml
@@ -43,3 +43,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook
+
+connection-types:
+  - hook-class-name: airflow.providers.facebook.ads.hooks.ads.FacebookAdsReportingHook
+    connection-type: facebook_social

--- a/airflow/providers/ftp/provider.yaml
+++ b/airflow/providers/ftp/provider.yaml
@@ -45,3 +45,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.ftp.hooks.ftp.FTPHook
+
+connection-types:
+  - hook-class-name: airflow.providers.ftp.hooks.ftp.FTPHook
+    connection-type: ftp

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -87,13 +87,13 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
     """
 
     conn_name_attr = 'gcp_conn_id'
-    default_conn_name = 'google_cloud_default'
-    conn_type = 'google_cloud_platform'
-    hook_name = 'Google Cloud'
+    default_conn_name = 'google_cloud_bigquery_default'
+    conn_type = 'gcpbigquery'
+    hook_name = 'Google Bigquery'
 
     def __init__(
         self,
-        gcp_conn_id: str = default_conn_name,
+        gcp_conn_id: str = GoogleBaseHook.default_conn_name,
         delegate_to: Optional[str] = None,
         use_legacy_sql: bool = True,
         location: Optional[str] = None,

--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -87,7 +87,7 @@ class CloudSQLHook(GoogleBaseHook):
     """
 
     conn_name_attr = 'gcp_conn_id'
-    default_conn_name = 'google_cloud_default'
+    default_conn_name = 'google_cloud_sql_default'
     conn_type = 'gcpcloudsql'
     hook_name = 'Google Cloud SQL'
 
@@ -725,7 +725,7 @@ class CloudSQLDatabaseHook(BaseHook):
     """
 
     conn_name_attr = 'gcp_cloudsql_conn_id'
-    default_conn_name = 'google_cloud_sql_default'
+    default_conn_name = 'google_cloud_sqldb_default'
     conn_type = 'gcpcloudsqldb'
     hook_name = 'Google Cloud SQL Database'
 

--- a/airflow/providers/google/cloud/hooks/compute_ssh.py
+++ b/airflow/providers/google/cloud/hooks/compute_ssh.py
@@ -95,7 +95,7 @@ class ComputeEngineSSHHook(SSHHook):
     """
 
     conn_name_attr = 'gcp_conn_id'
-    default_conn_name = 'google_cloud_default'
+    default_conn_name = 'google_cloud_ssh_default'
     conn_type = 'gcpssh'
     hook_name = 'Google Cloud SSH'
 

--- a/airflow/providers/google/cloud/hooks/dataprep.py
+++ b/airflow/providers/google/cloud/hooks/dataprep.py
@@ -38,7 +38,7 @@ class GoogleDataprepHook(BaseHook):
     """
 
     conn_name_attr = 'dataprep_conn_id'
-    default_conn_name = 'dataprep_default'
+    default_conn_name = 'google_cloud_dataprep_default'
     conn_type = 'dataprep'
     hook_name = 'Google Dataprep'
 

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -747,6 +747,22 @@ hook-class-names:
   - airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
   - airflow.providers.google.leveldb.hooks.leveldb.LevelDBHook
 
+connection-types:
+  - hook-class-name: airflow.providers.google.common.hooks.base_google.GoogleBaseHook
+    connection-type: google_cloud_platform
+  - hook-class-name: airflow.providers.google.cloud.hooks.dataprep.GoogleDataprepHook
+    connection-type: dataprep
+  - hook-class-name: airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLHook
+    connection-type: gcpcloudsql
+  - hook-class-name: airflow.providers.google.cloud.hooks.cloud_sql.CloudSQLDatabaseHook
+    connection-type: gcpcloudsqldb
+  - hook-class-name: airflow.providers.google.cloud.hooks.bigquery.BigQueryHook
+    connection-type: gcpbigquery
+  - hook-class-name: airflow.providers.google.cloud.hooks.compute_ssh.ComputeEngineSSHHook
+    connection-type: gcpssh
+  - hook-class-name: airflow.providers.google.leveldb.hooks.leveldb.LevelDBHook
+    connection-type: leveldb
+
 extra-links:
   - airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleLink
   - airflow.providers.google.cloud.operators.bigquery.BigQueryConsoleIndexableLink

--- a/airflow/providers/grpc/provider.yaml
+++ b/airflow/providers/grpc/provider.yaml
@@ -47,3 +47,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.grpc.hooks.grpc.GrpcHook
+
+connection-types:
+  - hook-class-name: airflow.providers.grpc.hooks.grpc.GrpcHook
+    connection-type: grpc

--- a/airflow/providers/hashicorp/provider.yaml
+++ b/airflow/providers/hashicorp/provider.yaml
@@ -44,5 +44,9 @@ hooks:
 hook-class-names:
   - airflow.providers.hashicorp.hooks.vault.VaultHook
 
+connection-types:
+  - hook-class-name: airflow.providers.hashicorp.hooks.vault.VaultHook
+    connection-type: vault
+
 secrets-backends:
   - airflow.providers.hashicorp.secrets.vault.VaultBackend

--- a/airflow/providers/http/provider.yaml
+++ b/airflow/providers/http/provider.yaml
@@ -54,3 +54,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.http.hooks.http.HttpHook
+
+connection-types:
+  - hook-class-name: airflow.providers.http.hooks.http.HttpHook
+    connection-type: http

--- a/airflow/providers/imap/provider.yaml
+++ b/airflow/providers/imap/provider.yaml
@@ -44,3 +44,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.imap.hooks.imap.ImapHook
+
+connection-types:
+  - hook-class-name: airflow.providers.imap.hooks.imap.ImapHook
+    connection-type: imap

--- a/airflow/providers/jdbc/provider.yaml
+++ b/airflow/providers/jdbc/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.jdbc.hooks.jdbc.JdbcHook
+
+connection-types:
+  - hook-class-name: airflow.providers.jdbc.hooks.jdbc.JdbcHook
+    connection-type: jdbc

--- a/airflow/providers/jenkins/provider.yaml
+++ b/airflow/providers/jenkins/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.jenkins.hooks.jenkins.JenkinsHook
+
+connection-types:
+  - hook-class-name: airflow.providers.jenkins.hooks.jenkins.JenkinsHook
+    connection-type: jenkins

--- a/airflow/providers/jira/provider.yaml
+++ b/airflow/providers/jira/provider.yaml
@@ -53,3 +53,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.jira.hooks.jira.JiraHook
+
+connection-types:
+  - hook-class-name: airflow.providers.jira.hooks.jira.JiraHook
+    connection-type: jira

--- a/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_container_instance.py
@@ -41,6 +41,11 @@ class AzureContainerInstanceHook(AzureBaseHook):
     :type azure_conn_id: str
     """
 
+    conn_name_attr = 'azure_conn_id'
+    default_conn_name = 'azure_default'
+    conn_type = 'azure_container_instance'
+    hook_name = 'Azure Container Instance'
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(sdk_client=ContainerInstanceManagementClient, *args, **kwargs)
         self.connection = self.get_conn()

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -166,6 +166,32 @@ hook-class-names:
   - airflow.providers.microsoft.azure.hooks.azure_data_factory.AzureDataFactoryHook
   - airflow.providers.microsoft.azure.hooks.azure_container_registry.AzureContainerRegistryHook
 
+connection-types:
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.base_azure.AzureBaseHook
+    connection-type: azure
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.adx.AzureDataExplorerHook
+    connection-type: azure_data_explorer
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.azure_batch.AzureBatchHook
+    connection-type: azure_batch
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.azure_cosmos.AzureCosmosDBHook
+    connection-type: azure_cosmos
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.azure_data_lake.AzureDataLakeHook
+    connection-type: azure_data_lake
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.azure_fileshare.AzureFileShareHook
+    connection-type: azure_fileshare
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.azure_container_volume.AzureContainerVolumeHook
+    connection-type: azure_container_volume
+  - hook-class-name: >-
+      airflow.providers.microsoft.azure.hooks.azure_container_instance.AzureContainerInstanceHook
+    connection-type: azure_container_instance
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.wasb.WasbHook
+    connection-type: wasb
+  - hook-class-name: airflow.providers.microsoft.azure.hooks.azure_data_factory.AzureDataFactoryHook
+    connection-type: azure_data_factory
+  - hook-class-name: >-
+      airflow.providers.microsoft.azure.hooks.azure_container_registry.AzureContainerRegistryHook
+    connection-type: azure_container_registry
+
 secrets-backends:
   - airflow.providers.microsoft.azure.secrets.azure_key_vault.AzureKeyVaultBackend
 

--- a/airflow/providers/microsoft/mssql/provider.yaml
+++ b/airflow/providers/microsoft/mssql/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook
+
+connection-types:
+  - hook-class-name: airflow.providers.microsoft.mssql.hooks.mssql.MsSqlHook
+    connection-type: mssql

--- a/airflow/providers/mongo/provider.yaml
+++ b/airflow/providers/mongo/provider.yaml
@@ -46,3 +46,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.mongo.hooks.mongo.MongoHook
+
+connection-types:
+  - hook-class-name: airflow.providers.mongo.hooks.mongo.MongoHook
+    connection-type: mongo

--- a/airflow/providers/mysql/provider.yaml
+++ b/airflow/providers/mysql/provider.yaml
@@ -67,3 +67,7 @@ transfers:
 
 hook-class-names:
   - airflow.providers.mysql.hooks.mysql.MySqlHook
+
+connection-types:
+  - hook-class-name: airflow.providers.mysql.hooks.mysql.MySqlHook
+    connection-type: mysql

--- a/airflow/providers/neo4j/provider.yaml
+++ b/airflow/providers/neo4j/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.neo4j.hooks.neo4j.Neo4jHook
+
+connection-types:
+  - hook-class-name: airflow.providers.neo4j.hooks.neo4j.Neo4jHook
+    connection-type: neo4j

--- a/airflow/providers/odbc/provider.yaml
+++ b/airflow/providers/odbc/provider.yaml
@@ -42,3 +42,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.odbc.hooks.odbc.OdbcHook
+
+connection-types:
+  - hook-class-name: airflow.providers.odbc.hooks.odbc.OdbcHook
+    connection-type: odbc

--- a/airflow/providers/opsgenie/provider.yaml
+++ b/airflow/providers/opsgenie/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.opsgenie.hooks.opsgenie_alert.OpsgenieAlertHook
+
+connection-types:
+  - hook-class-name: airflow.providers.opsgenie.hooks.opsgenie_alert.OpsgenieAlertHook
+    connection-type: opsgenie

--- a/airflow/providers/oracle/provider.yaml
+++ b/airflow/providers/oracle/provider.yaml
@@ -53,3 +53,7 @@ transfers:
 
 hook-class-names:
   - airflow.providers.oracle.hooks.oracle.OracleHook
+
+connection-types:
+  - hook-class-name: airflow.providers.oracle.hooks.oracle.OracleHook
+    connection-type: oracle

--- a/airflow/providers/postgres/provider.yaml
+++ b/airflow/providers/postgres/provider.yaml
@@ -51,3 +51,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.postgres.hooks.postgres.PostgresHook
+
+connection-types:
+  - hook-class-name: airflow.providers.postgres.hooks.postgres.PostgresHook
+    connection-type: postgres

--- a/airflow/providers/presto/provider.yaml
+++ b/airflow/providers/presto/provider.yaml
@@ -43,3 +43,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.presto.hooks.presto.PrestoHook
+
+connection-types:
+  - hook-class-name: airflow.providers.presto.hooks.presto.PrestoHook
+    connection-type: presto

--- a/airflow/providers/qubole/provider.yaml
+++ b/airflow/providers/qubole/provider.yaml
@@ -56,5 +56,9 @@ hooks:
 hook-class-names:
   - airflow.providers.qubole.hooks.qubole.QuboleHook
 
+connection-types:
+  - hook-class-name: airflow.providers.qubole.hooks.qubole.QuboleHook
+    connection-type: qubole
+
 extra-links:
   - airflow.providers.qubole.operators.qubole.QDSLink

--- a/airflow/providers/redis/provider.yaml
+++ b/airflow/providers/redis/provider.yaml
@@ -53,3 +53,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.redis.hooks.redis.RedisHook
+
+connection-types:
+  - hook-class-name: airflow.providers.redis.hooks.redis.RedisHook
+    connection-type: redis

--- a/airflow/providers/salesforce/provider.yaml
+++ b/airflow/providers/salesforce/provider.yaml
@@ -57,4 +57,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.salesforce.hooks.salesforce.SalesforceHook
-  - airflow.providers.salesforce.hooks.tableau.TableauHook
+
+connection-types:
+  - hook-class-name: airflow.providers.salesforce.hooks.salesforce.SalesforceHook
+    connection-type: salesforce

--- a/airflow/providers/samba/provider.yaml
+++ b/airflow/providers/samba/provider.yaml
@@ -42,3 +42,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.samba.hooks.samba.SambaHook
+
+connection-types:
+  - hook-class-name: airflow.providers.samba.hooks.samba.SambaHook
+    connection-type: samba

--- a/airflow/providers/segment/provider.yaml
+++ b/airflow/providers/segment/provider.yaml
@@ -47,3 +47,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.segment.hooks.segment.SegmentHook
+
+connection-types:
+  - hook-class-name: airflow.providers.segment.hooks.segment.SegmentHook
+    connection-type: segment

--- a/airflow/providers/sftp/provider.yaml
+++ b/airflow/providers/sftp/provider.yaml
@@ -56,3 +56,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.sftp.hooks.sftp.SFTPHook
+
+connection-types:
+  - hook-class-name: airflow.providers.sftp.hooks.sftp.SFTPHook
+    connection-type: sftp

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -50,3 +50,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook
+
+connection-types:
+  - hook-class-name: airflow.providers.slack.hooks.slack_webhook.SlackWebhookHook
+    connection-type: slackwebhook

--- a/airflow/providers/snowflake/provider.yaml
+++ b/airflow/providers/snowflake/provider.yaml
@@ -63,3 +63,7 @@ transfers:
 
 hook-class-names:
   - airflow.providers.snowflake.hooks.snowflake.SnowflakeHook
+
+connection-types:
+  - hook-class-name: airflow.providers.snowflake.hooks.snowflake.SnowflakeHook
+    connection-type: snowflake

--- a/airflow/providers/sqlite/provider.yaml
+++ b/airflow/providers/sqlite/provider.yaml
@@ -48,3 +48,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.sqlite.hooks.sqlite.SqliteHook
+
+connection-types:
+  - hook-class-name: airflow.providers.sqlite.hooks.sqlite.SqliteHook
+    connection-type: sqlite

--- a/airflow/providers/ssh/provider.yaml
+++ b/airflow/providers/ssh/provider.yaml
@@ -50,3 +50,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.ssh.hooks.ssh.SSHHook
+
+connection-types:
+  - hook-class-name: airflow.providers.ssh.hooks.ssh.SSHHook
+    connection-type: ssh

--- a/airflow/providers/tableau/provider.yaml
+++ b/airflow/providers/tableau/provider.yaml
@@ -55,3 +55,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.tableau.hooks.tableau.TableauHook
+
+connection-types:
+  - hook-class-name: airflow.providers.tableau.hooks.tableau.TableauHook
+    connection-type: tableau

--- a/airflow/providers/trino/provider.yaml
+++ b/airflow/providers/trino/provider.yaml
@@ -41,3 +41,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.trino.hooks.trino.TrinoHook
+
+connection-types:
+  - hook-class-name: airflow.providers.trino.hooks.trino.TrinoHook
+    connection-type: trino

--- a/airflow/providers/vertica/provider.yaml
+++ b/airflow/providers/vertica/provider.yaml
@@ -47,3 +47,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.vertica.hooks.vertica.VerticaHook
+
+connection-types:
+  - hook-class-name: airflow.providers.vertica.hooks.vertica.VerticaHook
+    connection-type: vertica

--- a/airflow/providers/yandex/provider.yaml
+++ b/airflow/providers/yandex/provider.yaml
@@ -57,3 +57,7 @@ hooks:
 
 hook-class-names:
   - airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook
+
+connection-types:
+  - hook-class-name: airflow.providers.yandex.hooks.yandex.YandexCloudBaseHook
+    connection-type: yandexcloud

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3101,8 +3101,9 @@ def lazy_add_provider_discovered_options_to_connection_form():
             ('mesos_framework-id', 'Mesos Framework ID'),
         ]
         providers_manager = ProvidersManager()
-        for connection_type, (_, _, _, hook_name) in providers_manager.hooks.items():
-            _connection_types.append((connection_type, hook_name))
+        for connection_type, provider_info in providers_manager.hooks.items():
+            if provider_info:
+                _connection_types.append((connection_type, provider_info.hook_name))
         return _connection_types
 
     ConnectionForm.conn_type = SelectField(


### PR DESCRIPTION
This change implements lazy loading of individual hooks for providers
manager. First the hooks list is discovered by the manager when
hooks are accessed, but the hooks are not immediately
imported - the hooks initially keep just a callable that will
be used to retrieve the hook when first accessed.

Besides listing details of all hooks, all Hooks are only imported when we
want to retrieve the list of available field behaviours and widgets
(which only happens in webserver and should happen anyway whenever one
of those are needed because they are all collectively used in the
connection view).

In the case when hooks are accessed in tasks
(connection.get_hook()) only the individual Hooks are
imported when accessed.

The change deprecates 'hook-class-names' json-schema and replaces it
with 'connection-types' because we need to know connection-type
for each HookClass name declaratively so that we can utilse
it in connection.get_hook() mehtod (otherwise we do not know
which Hooks conrrespond to which connection type without importing
them).

The change is backwards compatible. It adds deprecation
warnings in case providers use the 'hook-class-names' property
only and log warnings in case it provides both `hook-class-names`
and `connection-types` but there are inconsistencies between
those.

Part of this change is also to fix some inconsistencies found
when all hooks were added to connection-types arrays, which
make potetntially backwards-incompatible changes to Google Provider
where some hooks were useing `google_cloud_default` name for
default_connection_type, but they were in fact using different,
specialized Hook.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
