### PR TITLE
Chart: fix running with uid 0

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -144,6 +144,7 @@ spec:
             periodSeconds: {{ .Values.scheduler.livenessProbe.periodSeconds }}
             exec:
               command:
+              - /entrypoint
               - python
               - -Wignore
               - -c


### PR DESCRIPTION
This fixes running the chart with uid 0:

```
helm upgrade --install --set uid=0 test airflow/airflow
```

Closes: #17679