### PR TITLE
Add a note about XCOMs push condition for K8sPodOperator docs

### DIFF
--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -119,7 +119,6 @@ See the following example on how this occurs:
     :language: python
     :start-after: [START howto_operator_k8s_write_xcom]
     :end-before: [END howto_operator_k8s_write_xcom]
-    
 .. note::
   XCOMs will be pushed only for tasks marked as ``State.SUCCESS``.
 

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -119,6 +119,9 @@ See the following example on how this occurs:
     :language: python
     :start-after: [START howto_operator_k8s_write_xcom]
     :end-before: [END howto_operator_k8s_write_xcom]
+    
+.. note::
+  XCOMs will be pushed only for tasks marked as ``State.SUCCESS``.
 
 Reference
 ^^^^^^^^^


### PR DESCRIPTION
My team was thinking like XCOMs can be used for both cases no matter how tasks are completed you just have to write to the file `/airflow/xcom/return.json`.  
Which is not an accurate understanding. I do not aware of how it is done for other operators, at least I think this note can warn users about this restriction.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
