### PR TITLE
docs(dagowner): describe dag owner more carefully

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -221,7 +221,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
     :param task_id: a unique, meaningful id for the task
     :type task_id: str
-    :param owner: str, the owner of the task. Using a meaningful description
+    :param owner: the owner of the task. Using a meaningful description
         (e.g. user/person/team/role name) to clarify ownership is recommended.
     :type owner: str
     :param email: the 'to' email address(es) used in email alerts. This can be a

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -221,7 +221,8 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
     :param task_id: a unique, meaningful id for the task
     :type task_id: str
-    :param owner: the owner of the task, using the unix username is recommended
+    :param owner: str, the owner of the task. Using a meaningful description
+        (e.g. user/person/team/role name) to clarify ownership is recommended.
     :type owner: str
     :param email: the 'to' email address(es) used in email alerts. This can be a
         single email or multiple ones. Multiple addresses can be specified as a


### PR DESCRIPTION
This PR expands on the purpose of the DAG `owner` parameter, following clarification from a community member on slack.

See also https://stackoverflow.com/questions/38520458/how-should-i-use-the-right-owner-task-in-airflow