### PR TITLE
Add error check for config_file parameter in GKEStartPodOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -295,9 +295,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
         # There is no need to manage the kube_config file, as it will be generated automatically.
         # All Kubernetes parameters (except config_file) are also valid for the GKEStartPodOperator.
         if self.config_file:
-            raise AirflowException(
-                "config_file is not an allowed parameter for the GKEStartPodOperator."
-            )
+            raise AirflowException("config_file is not an allowed parameter for the GKEStartPodOperator.")
 
     def execute(self, context) -> Optional[str]:
         hook = GoogleBaseHook(gcp_conn_id=self.gcp_conn_id)
@@ -309,7 +307,6 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 "keyword project_id parameter or as project_id extra "
                 "in Google Cloud connection definition. Both are not set!"
             )
-       
 
         # Write config to a temp file and set the environment variable to point to it.
         # This is to avoid race conditions of reading/writing a single file

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -303,6 +303,12 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 "keyword project_id parameter or as project_id extra "
                 "in Google Cloud connection definition. Both are not set!"
             )
+        # There is no need to manage the kube_config file, as it will be generated automatically.
+        # All Kubernetes parameters (except config_file) are also valid for the GKEStartPodOperator.
+        if self.config_file:
+            raise AirflowException(
+                "config_file is not an allowed parameter for the GKEStartPodOperator."
+            )
 
         # Write config to a temp file and set the environment variable to point to it.
         # This is to avoid race conditions of reading/writing a single file

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -292,6 +292,12 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 "Credentials (ADC) strategy for authorization, create an empty connection "
                 "called `google_cloud_default`.",
             )
+        # There is no need to manage the kube_config file, as it will be generated automatically.
+        # All Kubernetes parameters (except config_file) are also valid for the GKEStartPodOperator.
+        if self.config_file:
+            raise AirflowException(
+                "config_file is not an allowed parameter for the GKEStartPodOperator."
+            )
 
     def execute(self, context) -> Optional[str]:
         hook = GoogleBaseHook(gcp_conn_id=self.gcp_conn_id)
@@ -303,12 +309,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 "keyword project_id parameter or as project_id extra "
                 "in Google Cloud connection definition. Both are not set!"
             )
-        # There is no need to manage the kube_config file, as it will be generated automatically.
-        # All Kubernetes parameters (except config_file) are also valid for the GKEStartPodOperator.
-        if self.config_file:
-            raise AirflowException(
-                "config_file is not an allowed parameter for the GKEStartPodOperator."
-            )
+       
 
         # Write config to a temp file and set the environment variable to point to it.
         # This is to avoid race conditions of reading/writing a single file

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -184,8 +184,16 @@ class TestGKEPodOperator(unittest.TestCase):
 
     def test_config_file_throws_error(self):
         with pytest.raises(AirflowException):
-            self.gke_op.config_file = "/path/to/alternative/kubeconfig"
-            self.gke_op.execute(None)
+            GKEStartPodOperator(
+                project_id=TEST_GCP_PROJECT_ID,
+                location=PROJECT_LOCATION,
+                cluster_name=CLUSTER_NAME,
+                task_id=PROJECT_TASK_ID,
+                name=TASK_NAME,
+                namespace=NAMESPACE,
+                image=IMAGE,
+                config_file = "/path/to/alternative/kubeconfig"
+            )
 
     @mock.patch.dict(os.environ, {})
     @mock.patch(

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -192,7 +192,7 @@ class TestGKEPodOperator(unittest.TestCase):
                 name=TASK_NAME,
                 namespace=NAMESPACE,
                 image=IMAGE,
-                config_file = "/path/to/alternative/kubeconfig"
+                config_file="/path/to/alternative/kubeconfig"
             )
 
     @mock.patch.dict(os.environ, {})

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -182,6 +182,11 @@ class TestGKEPodOperator(unittest.TestCase):
 
         assert self.gke_op.config_file == FILE_NAME
 
+    def test_config_file_throws_error(self):
+        with pytest.raises(AirflowException):
+            self.gke_op.config_file = "/path/to/alternative/kubeconfig"
+            self.gke_op.execute(None)
+
     @mock.patch.dict(os.environ, {})
     @mock.patch(
         "airflow.hooks.base.BaseHook.get_connections",

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -192,7 +192,7 @@ class TestGKEPodOperator(unittest.TestCase):
                 name=TASK_NAME,
                 namespace=NAMESPACE,
                 image=IMAGE,
-                config_file="/path/to/alternative/kubeconfig"
+                config_file="/path/to/alternative/kubeconfig",
             )
 
     @mock.patch.dict(os.environ, {})


### PR DESCRIPTION
In [the GKEStartPodOperator documentation](https://airflow.apache.org/docs/apache-airflow-providers-google/stable/operators/cloud/kubernetes_engine.html) we specify that "There is no need to manage the kube_config file, as it will be generated automatically. All Kubernetes parameters (except config_file) are also valid for the GKEStartPodOperator". However, we don't check to see if a user passes in the `config_file` parameter when they're using the `GKEStartPodOperator`. I added a check with a helpful error message. 
