### PR TITLE
Add steps for building release package without breeze.

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -115,12 +115,17 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
         -o dist/apache-airflow-${VERSION_WITHOUT_RC}-source.tar.gz
     ```
 
-
 - Generate SHA512/ASC (If you have not generated a key yet, generate it by following instructions on http://www.apache.org/dev/openpgp.html#key-gen-generate-key)
 
     ```shell script
     ./breeze prepare-airflow-packages --package-format both
     ${AIRFLOW_REPO_ROOT}/dev/sign.sh dist/*
+    ```
+
+- If you aren't using Breeze for packaging, build the distribution and wheel files directly
+
+    ```shell script
+    python setup.py compile_assets sdist bdist_wheel
     ```
 
 - Tag & Push the latest constraints files. This pushes constraints with rc suffix (this is expected)!

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -126,6 +126,7 @@ The Release Candidate artifacts we vote upon should be the exact ones we vote ag
 
     ```shell script
     python setup.py compile_assets sdist bdist_wheel
+    ${AIRFLOW_REPO_ROOT}/dev/sign.sh dist/*
     ```
 
 - Tag & Push the latest constraints files. This pushes constraints with rc suffix (this is expected)!


### PR DESCRIPTION
Breeze typically handles converting a release tarball into distribution and wheel files. If Breeze isn't working on your machine, or you just aren't using it, `python setup.py compile_assets sdist bdist_wheel` works for creating the files.

This adds that step to the release docs.