### PR TITLE
Doc: Fix replacing Airflow version for Docker stack

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -111,6 +111,7 @@ release = PACKAGE_VERSION
 
 rst_epilog = f"""
 .. |version| replace:: {version}
+.. |airflow-version| replace:: {airflow.__version__}
 """
 
 # -- General configuration -----------------------------------------------------

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -27,45 +27,45 @@ Basic arguments
 
 Those are the most common arguments that you use when you want to build a custom image.
 
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| Build argument                           | Default value                            | Description                              |
-+==========================================+==========================================+==========================================+
-| ``PYTHON_BASE_IMAGE``                    | ``python:3.6-slim-buster``               | Base python image.                       |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_VERSION``                      | :subst-code:`|version|`                  | version of Airflow.                      |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_EXTRAS``                       | (see Dockerfile)                         | Default extras with which airflow is     |
-|                                          |                                          | installed.                               |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``ADDITIONAL_AIRFLOW_EXTRAS``            |                                          | Optional additional extras with which    |
-|                                          |                                          | airflow is installed.                    |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_HOME``                         | ``/opt/airflow``                         | Airflow’s HOME (that’s where logs and    |
-|                                          |                                          | SQLite databases are stored).            |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_USER_HOME_DIR``                | ``/home/airflow``                        | Home directory of the Airflow user.      |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_PIP_VERSION``                  | ``21.1``                                 | PIP version used.                        |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``PIP_PROGRESS_BAR``                     | ``on``                                   | Progress bar for PIP installation        |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_UID``                          | ``50000``                                | Airflow user UID.                        |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_GID``                          | ``50000``                                | Airflow group GID. Note that writable    |
-|                                          |                                          | files/dirs, created on behalf of airflow |
-|                                          |                                          | user are set to the ``root`` group (0)   |
-|                                          |                                          | to allow arbitrary UID to run the image. |
-+------------------------------------------+------------------------------------------+------------------------------------------+
-| ``AIRFLOW_CONSTRAINTS_REFERENCE``        |                                          | Reference (branch or tag) from GitHub    |
-|                                          |                                          | where constraints file is taken from     |
-|                                          |                                          | It can be ``constraints-main`` or        |
-|                                          |                                          | ``constraints-2-0`` for                  |
-|                                          |                                          | 2.0.* installation. In case of building  |
-|                                          |                                          | specific version you want to point it    |
-|                                          |                                          | to specific tag, for example             |
-|                                          |                                          | :subst-code:`constraints-|version|`.     |
-|                                          |                                          | Auto-detected if empty.                  |
-+------------------------------------------+------------------------------------------+------------------------------------------+
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| Build argument                           | Default value                            | Description                                 |
++==========================================+==========================================+=============================================+
+| ``PYTHON_BASE_IMAGE``                    | ``python:3.6-slim-buster``               | Base python image.                          |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_VERSION``                      | :subst-code:`|airflow-version|`          | version of Airflow.                         |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_EXTRAS``                       | (see Dockerfile)                         | Default extras with which airflow is        |
+|                                          |                                          | installed.                                  |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``ADDITIONAL_AIRFLOW_EXTRAS``            |                                          | Optional additional extras with which       |
+|                                          |                                          | airflow is installed.                       |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_HOME``                         | ``/opt/airflow``                         | Airflow’s HOME (that’s where logs and       |
+|                                          |                                          | SQLite databases are stored).               |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_USER_HOME_DIR``                | ``/home/airflow``                        | Home directory of the Airflow user.         |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_PIP_VERSION``                  | ``21.1``                                 | PIP version used.                           |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``PIP_PROGRESS_BAR``                     | ``on``                                   | Progress bar for PIP installation           |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_UID``                          | ``50000``                                | Airflow user UID.                           |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_GID``                          | ``50000``                                | Airflow group GID. Note that writable       |
+|                                          |                                          | files/dirs, created on behalf of airflow    |
+|                                          |                                          | user are set to the ``root`` group (0)      |
+|                                          |                                          | to allow arbitrary UID to run the image.    |
++------------------------------------------+------------------------------------------+---------------------------------------------+
+| ``AIRFLOW_CONSTRAINTS_REFERENCE``        |                                          | Reference (branch or tag) from GitHub       |
+|                                          |                                          | where constraints file is taken from        |
+|                                          |                                          | It can be ``constraints-main`` or           |
+|                                          |                                          | ``constraints-2-0`` for                     |
+|                                          |                                          | 2.0.* installation. In case of building     |
+|                                          |                                          | specific version you want to point it       |
+|                                          |                                          | to specific tag, for example                |
+|                                          |                                          | :subst-code:`constraints-|airflow-version|`.|
+|                                          |                                          | Auto-detected if empty.                     |
++------------------------------------------+------------------------------------------+---------------------------------------------+
 
 Image optimization options
 ..........................

--- a/docs/docker-stack/build.rst
+++ b/docs/docker-stack/build.rst
@@ -53,7 +53,7 @@ In the simplest case building your image consists of those steps:
 
 1) Create your own ``Dockerfile`` (name it ``Dockerfile``) where you add:
 
-* information what your image should be based on (for example ``FROM: apache/airflow:|version|-python3.8``
+* information what your image should be based on (for example ``FROM: apache/airflow:|airflow-version|-python3.8``
 
 * additional steps that should be executed in your image (typically in the form of ``RUN <command>``)
 

--- a/docs/docker-stack/index.rst
+++ b/docs/docker-stack/index.rst
@@ -44,12 +44,12 @@ Every time a new version of Airflow is released, the images are prepared in the
 `apache/airflow DockerHub <https://hub.docker.com/r/apache/airflow>`_
 for all the supported Python versions.
 
-You can find the following images there (Assuming Airflow version |version|):
+You can find the following images there (Assuming Airflow version |airflow-version|):
 
-* ``apache/airflow:latest``              - the latest released Airflow image with default Python version (3.6 currently)
-* ``apache/airflow:latest-pythonX.Y``    - the latest released Airflow image with specific Python version
-* ``apache/airflow:|version|``           - the versioned Airflow image with default Python version (3.6 currently)
-* ``apache/airflow:|version|-pythonX.Y`` - the versioned Airflow image with specific Python version
+* :subst-code:`apache/airflow:latest`              - the latest released Airflow image with default Python version (3.6 currently)
+* :subst-code:`apache/airflow:latest-pythonX.Y`    - the latest released Airflow image with specific Python version
+* :subst-code:`apache/airflow:|airflow-version|`           - the versioned Airflow image with default Python version (3.6 currently)
+* :subst-code:`apache/airflow:|airflow-version|-pythonX.Y` - the versioned Airflow image with specific Python version
 
 Those are "reference" images. They contain the most common set of extras, dependencies and providers that are
 often used by the users and they are good to "try-things-out" when you want to just take airflow for a spin,


### PR DESCRIPTION
currently it shows up as:

```
apache/airflow:|version| - the versioned Airflow image with default Python version (3.6 currently)
```

Example: http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/docker-stack/index.html or even https://airflow.apache.org/docs/docker-stack/index.html

This commit fixes it.

**Before**:

![image](https://user-images.githubusercontent.com/8811558/129997180-8ff3956d-2cfc-4f06-9dd8-fea60fed6c98.png)

**After**:

![image](https://user-images.githubusercontent.com/8811558/129997198-8d49d701-fabd-4daf-a3ba-1ab618d2b38d.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
