### PR TITLE
Make sure "production-readiness` of docker-compose is well explained

### DIFF
--- a/docs/apache-airflow/start/docker.rst
+++ b/docs/apache-airflow/start/docker.rst
@@ -22,6 +22,21 @@ Running Airflow in Docker
 
 This quick-start guide will allow you to quickly start Airflow with :doc:`CeleryExecutor </executor/celery>` in Docker. This is the fastest way to start Airflow.
 
+Production readiness
+====================
+
+.. warning::
+    DO NOT expect the Docker Compose below will be enough to run production-ready Docker Compose Airflow installation using it.
+    This is truly ``quick-start`` docker-compose for you to get Airflow up and running locally and get your hands dirty with
+    Airflow, but configuring Docker-Compose installation that is ready for production, requires an intrinsic knowledge of
+    Docker Compose, a lot of customization and possibly even writing the Docker Compose file that will suit your needs
+    from the scratch. It's probably OK if you want to run Docker Compose-based deployment, but short of becoming a
+    Docker Compose expert, it's highly unlikely you will get robust deployment with it.
+
+    If you want to get an easy to configure Docker-based deployment that Airflow Community develops, supports and
+    can provide support with deployment, you should consider using Kubernetes and deploying Airflow using
+    :doc:`Official Airflow Community Helm Chart<helm-chart:index>`.
+
 Before you begin
 ================
 


### PR DESCRIPTION
Many Airflow users are using the docker-compose `quick-start` as
production-ready solution despite notes in the compose file.

This PR adds better warning and a link that we can give thsoe
users so tha they can understand that in order to use docker-compose
they need to become really docker-compose experts if they want to
run their own docker-compose production-ready installation and that
they should not expect that this docker-compose will be good for
their needs (and that they will have support from community based
on the fact tha community publishes the docker-compose)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
