### PR TITLE
Add links to provider's documentation

### DIFF
--- a/airflow/utils/docs.py
+++ b/airflow/utils/docs.py
@@ -31,3 +31,8 @@ def get_docs_url(page: Optional[str] = None) -> str:
     if page:
         result = result + page
     return result
+
+
+def get_doc_url_for_provider(provider_name: str, provider_version: str) -> str:
+    """Prepare link to Airflow Provider documentation."""
+    return f'https://airflow.apache.org/docs/{provider_name}/{provider_version}/'

--- a/airflow/www/templates/airflow/providers.html
+++ b/airflow/www/templates/airflow/providers.html
@@ -40,7 +40,7 @@ under the License.
 
     {% for provider in providers %}
       <tr>
-          <td>{{ provider["package_name"] }}</td>
+          <td><a href="{{ provider['documentation_url'] }}">{{ provider["package_name"] }}</a></td>
           <td>{{ provider["version"] }}</td>
           <td>{{ provider["description"]}}</td>
       </tr>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -111,7 +111,7 @@ from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_deps import RUNNING_DEPS, SCHEDULER_QUEUED_DEPS
 from airflow.utils import json as utils_json, timezone, yaml
 from airflow.utils.dates import infer_time_unit, scale_time_units
-from airflow.utils.docs import get_docs_url
+from airflow.utils.docs import get_doc_url_for_provider, get_docs_url
 from airflow.utils.helpers import alchemy_to_dict
 from airflow.utils.log import secrets_masker
 from airflow.utils.log.log_reader import TaskLogReader
@@ -3403,6 +3403,7 @@ class ProviderView(AirflowBaseView):
                 "package_name": provider_info["package-name"],
                 "description": self._clean_description(provider_info["description"]),
                 "version": pi[0],
+                "documentation_url": get_doc_url_for_provider(provider_info["package-name"], pi[0]),
             }
             providers.append(provider_data)
 

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -95,9 +95,11 @@ def test_plugin_endpoint_should_not_be_unauthenticated(app):
 
 def test_should_list_providers_on_page_with_details(admin_client):
     resp = admin_client.get('/provider')
-    beam_package = "<td>apache-airflow-providers-apache-beam</td>"
+    beam_href = "<a href=\"https://airflow.apache.org/docs/apache-airflow-providers-apache-beam/"
+    beam_text = "apache-airflow-providers-apache-beam</a>"
     beam_description = "<a href=\"https://beam.apache.org/\">Apache Beam</a>"
-    check_content_in_response(beam_package, resp)
+    check_content_in_response(beam_href, resp)
+    check_content_in_response(beam_text, resp)
     check_content_in_response(beam_description, resp)
     check_content_in_response("Providers", resp)
 


### PR DESCRIPTION
The provider package names in the UI are now linked to the
documentation of the provider (in the exact version provider is
installed in!).

Follow up after #15385

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
