### PR TITLE
Fix clean-logs after improper skipping of lost+found

### DIFF
--- a/scripts/in_container/prod/clean-logs.sh
+++ b/scripts/in_container/prod/clean-logs.sh
@@ -30,7 +30,10 @@ echo "Cleaning logs every $EVERY seconds"
 
 while true; do
   echo "Trimming airflow logs to ${RETENTION} days."
-  find "${DIRECTORY}"/logs -type d -name 'lost+found' -prune -mtime +"${RETENTION}" -name '*.log' -delete
+  find "${DIRECTORY}"/logs \
+    -type d -name 'lost+found' -prune -o \
+    -type f -mtime +"${RETENTION}" -name '*.log' -print0 | \
+    xargs -0 rm -f
 
   seconds=$(( $(date -u +%s) % EVERY))
   (( seconds < 1 )) || sleep $((EVERY - seconds))


### PR DESCRIPTION
The fisxin #17547 was not working properly because -prune and
-delete in find cannot be combined. The -prune is still needed
to solve the problem of non-readable `lost+found` directory that
failed find but it should be run in connection to xargs that
should delete the found files.

Fixes #17733

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
