### PR TITLE
Fix comment in Helm Chart for worker ``logGroomerSidecar``

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -449,9 +449,9 @@ workers:
   #   - "test.hostname.two"
 
   logGroomerSidecar:
-    # Command to use when running the Airflow scheduler log groomer sidecar (templated).
+    # Command to use when running the Airflow worker log groomer sidecar (templated).
     command: ~
-    # Args to use when running the Airflow scheduler log groomer sidecar (templated).
+    # Args to use when running the Airflow worker log groomer sidecar (templated).
     args: ["bash", "/clean-logs"]
     resources: {}
     #  limits:


### PR DESCRIPTION
It said `scheduler` instead of `worker`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
