### PR TITLE
Fix ``TimeSensorAsync``

### DIFF
--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -30,7 +30,7 @@ class BaseTrigger(abc.ABC):
 
     We use the same class for both situations, and rely on all Trigger classes
     to be able to return the (Airflow-JSON-encodable) arguments that will
-    let them be reinsantiated elsewhere.
+    let them be re-instantiated elsewhere.
     """
 
     def __init__(self):


### PR DESCRIPTION
When using the following example dag, it currently fails with `You cannot pass naive datetimes` error.
This happens because `TimeSensorAsync` passes a `datetime.time` object while `DateTimeTrigger` expects
a `datetime.datetime` object. This PR fixes it by adding a new trigger object: ``TimeTrigger``.

Example DAG:

```python
from datetime import timedelta

from airflow import DAG
from airflow.sensors.time_sensor import TimeSensorAsync
from airflow.utils import dates, timezone

with DAG(
    dag_id='example_date_time_async_operator',
    schedule_interval='0 0 * * *',
    start_date=dates.days_ago(2),
    dagrun_timeout=timedelta(minutes=60),
    tags=['example', 'example2', 'async'],
) as dag:

    TimeSensorAsync(task_id="test-2", target_time=timezone.time(22, 43, 0))
```

cc @andrewgodwin 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
