### PR TITLE
Allow setting specific cwd for BashOperator

### DIFF
--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -51,7 +51,8 @@ class SubprocessHook(BaseHook):
         :param env: Optional dict containing environment variables to be made available to the shell
             environment in which ``command`` will be executed.  If omitted, ``os.environ`` will be used.
         :param output_encoding: encoding to use for decoding stdout
-        :param cwd: the bash cwd. If it is None, generate a temporary directory which will be cleaned afterwards
+        :param cwd: the bash cwd.
+            If it is None, generate a temporary directory which will be cleaned afterwards
         :return: :class:`namedtuple` containing ``exit_code`` and ``output``, the last line from stderr
             or stdout
         """

--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -39,19 +39,19 @@ class SubprocessHook(BaseHook):
         command: List[str],
         env: Optional[Dict[str, str]] = None,
         output_encoding: str = 'utf-8',
-        bash_cwd: str = None,
+        cwd: str = None,
     ) -> SubprocessResult:
         """
         Execute the command.
 
-        If `bash_cwd` is None, execute the command in a temporary directory which will be cleaned afterwards.
+        If `cwd` is None, execute the command in a temporary directory which will be cleaned afterwards.
         If ``env`` is not supplied, ``os.environ`` is passed
 
         :param command: the command to run
         :param env: Optional dict containing environment variables to be made available to the shell
             environment in which ``command`` will be executed.  If omitted, ``os.environ`` will be used.
         :param output_encoding: encoding to use for decoding stdout
-        :param bash_cwd: the bash cwd. If it is None, generate a temporary directory which will be cleaned afterwards
+        :param cwd: the bash cwd. If it is None, generate a temporary directory which will be cleaned afterwards
         :return: :class:`namedtuple` containing ``exit_code`` and ``output``, the last line from stderr
             or stdout
         """
@@ -87,11 +87,11 @@ class SubprocessHook(BaseHook):
             self.log.info('Command exited with return code %s', self.sub_process.returncode)
             return line
 
-        if bash_cwd is None:
+        if cwd is None:
             with TemporaryDirectory(prefix='airflowtmp') as tmp_dir:
                 line = __run_subprocess(tmp_dir)
         else:
-            line = __run_subprocess(bash_cwd)
+            line = __run_subprocess(cwd)
 
         return SubprocessResult(exit_code=self.sub_process.returncode, output=line)
 

--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -44,7 +44,7 @@ class SubprocessHook(BaseHook):
         """
         Execute the command.
 
-        If `cwd` is None, execute the command in a temporary directory which will be cleaned afterwards.
+        If ``cwd`` is None, execute the command in a temporary directory which will be cleaned afterwards.
         If ``env`` is not supplied, ``os.environ`` is passed
 
         :param command: the command to run

--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -51,8 +51,8 @@ class SubprocessHook(BaseHook):
         :param env: Optional dict containing environment variables to be made available to the shell
             environment in which ``command`` will be executed.  If omitted, ``os.environ`` will be used.
         :param output_encoding: encoding to use for decoding stdout
-        :param cwd: the bash cwd.
-            If it is None, generate a temporary directory which will be cleaned afterwards
+        :param cwd: Working directory to run the command in.
+            If None (default), the command is run in a temporary directory.
         :return: :class:`namedtuple` containing ``exit_code`` and ``output``, the last line from stderr
             or stdout
         """

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -146,11 +146,6 @@ class BashOperator(BaseOperator):
         self.output_encoding = output_encoding
         self.skip_exit_code = skip_exit_code
         self.cwd = cwd
-        if self.cwd is not None:
-            if not os.path.exists(self.cwd):
-                raise AirflowException(f"Can not find the cwd: {cwd}")
-            if not os.path.isdir(self.cwd):
-                raise AirflowException(f"The cwd {cwd} must be a directory")
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
@@ -174,6 +169,11 @@ class BashOperator(BaseOperator):
         return env
 
     def execute(self, context):
+        if self.cwd is not None:
+            if not os.path.exists(self.cwd):
+                raise AirflowException(f"Can not find the cwd: {self.cwd}")
+            if not os.path.isdir(self.cwd):
+                raise AirflowException(f"The cwd {self.cwd} must be a directory")
         env = self.get_env(context)
         result = self.subprocess_hook.run_command(
             command=['bash', '-c', self.bash_command],

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -50,9 +50,9 @@ class BashOperator(BaseOperator):
         in ``skipped`` state (default: 99). If set to ``None``, any non-zero
         exit code will be treated as a failure.
     :type skip_exit_code: int
-    :param bash_cwd: The folder that the command is executed.
+    :param cwd: The folder that the command is executed.
         If it is None, the operator will a temporary directory which will be cleaned afterwards.
-    :type bash_cwd: str
+    :type cwd: str
 
     Airflow will evaluate the exit code of the bash command. In general, a non-zero exit code will result in
     task failure and zero will result in task success. Exit code ``99`` (or another set in ``skip_exit_code``)
@@ -137,7 +137,7 @@ class BashOperator(BaseOperator):
         env: Optional[Dict[str, str]] = None,
         output_encoding: str = 'utf-8',
         skip_exit_code: int = 99,
-        bash_cwd: str = None,
+        cwd: str = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -145,12 +145,12 @@ class BashOperator(BaseOperator):
         self.env = env
         self.output_encoding = output_encoding
         self.skip_exit_code = skip_exit_code
-        self.bash_cwd = bash_cwd
-        if self.bash_cwd is not None:
-            if not os.path.exists(self.bash_cwd):
-                raise AirflowException(f"Can not find the bash_cwd: {bash_cwd}")
-            if not os.path.isdir(self.bash_cwd):
-                raise AirflowException(f"The bash_cwd {bash_cwd} must be a folder")
+        self.cwd = cwd
+        if self.cwd is not None:
+            if not os.path.exists(self.cwd):
+                raise AirflowException(f"Can not find the cwd: {cwd}")
+            if not os.path.isdir(self.cwd):
+                raise AirflowException(f"The cwd {cwd} must be a folder")
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
@@ -179,7 +179,7 @@ class BashOperator(BaseOperator):
             command=['bash', '-c', self.bash_command],
             env=env,
             output_encoding=self.output_encoding,
-            bash_cwd=self.bash_cwd,
+            cwd=self.cwd,
         )
         if self.skip_exit_code is not None and result.exit_code == self.skip_exit_code:
             raise AirflowSkipException(f"Bash command returned exit code {self.skip_exit_code}. Skipping.")

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -50,6 +50,9 @@ class BashOperator(BaseOperator):
         in ``skipped`` state (default: 99). If set to ``None``, any non-zero
         exit code will be treated as a failure.
     :type skip_exit_code: int
+    :param bash_cwd: The folder that the command is executed.
+        If it is None, the operator will a temporary directory which will be cleaned afterwards.
+    :type bash_cwd: str
 
     Airflow will evaluate the exit code of the bash command. In general, a non-zero exit code will result in
     task failure and zero will result in task success. Exit code ``99`` (or another set in ``skip_exit_code``)
@@ -134,6 +137,7 @@ class BashOperator(BaseOperator):
         env: Optional[Dict[str, str]] = None,
         output_encoding: str = 'utf-8',
         skip_exit_code: int = 99,
+        bash_cwd: str = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -141,6 +145,12 @@ class BashOperator(BaseOperator):
         self.env = env
         self.output_encoding = output_encoding
         self.skip_exit_code = skip_exit_code
+        self.bash_cwd = bash_cwd
+        if self.bash_cwd is not None:
+            if not os.path.exists(self.bash_cwd):
+                raise AirflowException(f"Can not find the bash_cwd: {bash_cwd}")
+            if not os.path.isdir(self.bash_cwd):
+                raise AirflowException(f"The bash_cwd {bash_cwd} must be a folder")
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 
@@ -169,6 +179,7 @@ class BashOperator(BaseOperator):
             command=['bash', '-c', self.bash_command],
             env=env,
             output_encoding=self.output_encoding,
+            bash_cwd=self.bash_cwd,
         )
         if self.skip_exit_code is not None and result.exit_code == self.skip_exit_code:
             raise AirflowSkipException(f"Bash command returned exit code {self.skip_exit_code}. Skipping.")

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -150,7 +150,7 @@ class BashOperator(BaseOperator):
             if not os.path.exists(self.cwd):
                 raise AirflowException(f"Can not find the cwd: {cwd}")
             if not os.path.isdir(self.cwd):
-                raise AirflowException(f"The cwd {cwd} must be a folder")
+                raise AirflowException(f"The cwd {cwd} must be a directory")
         if kwargs.get('xcom_push') is not None:
             raise AirflowException("'xcom_push' was deprecated, use 'BaseOperator.do_xcom_push' instead")
 

--- a/airflow/operators/bash.py
+++ b/airflow/operators/bash.py
@@ -50,8 +50,8 @@ class BashOperator(BaseOperator):
         in ``skipped`` state (default: 99). If set to ``None``, any non-zero
         exit code will be treated as a failure.
     :type skip_exit_code: int
-    :param cwd: The folder that the command is executed.
-        If it is None, the operator will a temporary directory which will be cleaned afterwards.
+    :param cwd: Working directory to execute the command in.
+        If None (default), the command is run in a temporary directory.
     :type cwd: str
 
     Airflow will evaluate the exit code of the bash command. In general, a non-zero exit code will result in

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -44,6 +44,7 @@ Booleans
 Boto
 BounceX
 Bq
+cwd
 CSRFProtect
 Cancelled
 Cassanda

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -44,7 +44,6 @@ Booleans
 Boto
 BounceX
 Bq
-cwd
 CSRFProtect
 Cancelled
 Cassanda

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -16,11 +16,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
-import shutil as _shutil
 import unittest
 from datetime import datetime, timedelta
-from tempfile import NamedTemporaryFile, TemporaryDirectory, TemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -132,7 +130,7 @@ class TestBashOperator(unittest.TestCase):
         assert line == val
 
     def test_cwd_does_not_exist(self):
-        test_cmd = f'set -e; echo "xxxx" |tee outputs.txt'
+        test_cmd = 'set -e; echo "xxxx" |tee outputs.txt'
         with TemporaryDirectory(prefix='test_command_with_cwd') as tmp_dir:
             # There should be no exceptions when creating the operator
             bash_operator = BashOperator(task_id='abc', bash_command=test_cmd, cwd=tmp_dir)
@@ -140,7 +138,7 @@ class TestBashOperator(unittest.TestCase):
             bash_operator.execute({})
 
     def test_cwd_is_file(self):
-        test_cmd = f'set -e; echo "xxxx" |tee outputs.txt'
+        test_cmd = 'set -e; echo "xxxx" |tee outputs.txt'
         with NamedTemporaryFile(suffix="var.env") as tmp_file:
             # Test if the cwd is a file_path
             with pytest.raises(AirflowException, match=f"The cwd {tmp_file.name} must be a directory"):
@@ -148,7 +146,7 @@ class TestBashOperator(unittest.TestCase):
 
     def test_valid_cwd(self):
 
-        test_cmd = f'set -e; echo "xxxx" |tee outputs.txt'
+        test_cmd = 'set -e; echo "xxxx" |tee outputs.txt'
         with TemporaryDirectory(prefix='test_command_with_cwd') as test_cwd_folder:
             # Test everything went alright
             result = BashOperator(task_id='abc', bash_command=test_cmd, cwd=test_cwd_folder).execute({})

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -137,10 +137,6 @@ class TestBashOperator(unittest.TestCase):
         test_cmd = f'set -e; echo "xxxx" |tee outputs.txt'
 
         with TemporaryDirectory(prefix='test_command_with_cwd') as test_cwd_folder:
-
-            with pytest.raises(AirflowException, match=f"Can not find the cwd: {test_cwd_folder}"):
-                BashOperator(task_id='abc', bash_command=test_cmd, cwd=f"{test_cwd_folder}/aa/").execute({})
-
             # Test if the cwd is a file_path
             test_1_file_path = f'{test_cwd_folder}/test1.txt'
             with open(test_1_file_path, 'w') as tmp_file:
@@ -155,6 +151,9 @@ class TestBashOperator(unittest.TestCase):
             assert result == "xxxx"
             with open(f'{test_cwd_folder}/outputs.txt') as tmp_file:
                 assert tmp_file.read().splitlines()[0] == "xxxx"
+        bash_operator = BashOperator(task_id='abc', bash_command=test_cmd, cwd=test_cwd_folder)
+        with pytest.raises(AirflowException, match=f"Can not find the cwd: {test_cwd_folder}"):
+            bash_operator.execute({})
 
     @parameterized.expand(
         [

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -139,23 +139,23 @@ class TestBashOperator(unittest.TestCase):
         # The command is echo a string to a file into cwd folder and return the string as the output
         test_cmd = f'set -e; echo "xxxx" |tee {test_file_name}'
 
-        # Test the the bash_cwd doesn't exist
+        # Test the the cwd doesn't exist
         if os.path.exists(test_cwd_folder):
             _shutil.rmtree(test_cwd_folder)
-        with pytest.raises(AirflowException, match=f"Can not find the bash_cwd: {test_cwd_folder}"):
-            BashOperator(task_id='abc', bash_command=test_cmd, bash_cwd=test_cwd_folder).execute({})
+        with pytest.raises(AirflowException, match=f"Can not find the cwd: {test_cwd_folder}"):
+            BashOperator(task_id='abc', bash_command=test_cmd, cwd=test_cwd_folder).execute({})
 
         os.makedirs(test_cwd_folder)
 
-        # Test if the bash_cwd is a file_path
+        # Test if the cwd is a file_path
         with open(test_cwd_file_path, 'w') as tmp_file:
             tmp_file.write("xxxxx")
-            with pytest.raises(AirflowException, match=f"The bash_cwd {test_cwd_file_path} must be a folder"):
-                BashOperator(task_id='abc', bash_command=test_cmd, bash_cwd=test_cwd_file_path).execute({})
+            with pytest.raises(AirflowException, match=f"The cwd {test_cwd_file_path} must be a folder"):
+                BashOperator(task_id='abc', bash_command=test_cmd, cwd=test_cwd_file_path).execute({})
         os.remove(test_cwd_file_path)
 
         # Test everything goes alright
-        result = BashOperator(task_id='abc', bash_command=test_cmd, bash_cwd=test_cwd_folder).execute({})
+        result = BashOperator(task_id='abc', bash_command=test_cmd, cwd=test_cwd_folder).execute({})
         assert result == "xxxx"
         with open(test_cwd_file_path) as tmp_file:
             assert tmp_file.read().splitlines()[0] == "xxxx"

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -150,7 +150,7 @@ class TestBashOperator(unittest.TestCase):
 
         test_cmd = f'set -e; echo "xxxx" |tee outputs.txt'
         with TemporaryDirectory(prefix='test_command_with_cwd') as test_cwd_folder:
-            # Test everything goes alright
+            # Test everything went alright
             result = BashOperator(task_id='abc', bash_command=test_cmd, cwd=test_cwd_folder).execute({})
             assert result == "xxxx"
             with open(f'{test_cwd_folder}/outputs.txt') as tmp_file:

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -132,8 +132,10 @@ class TestBashOperator(unittest.TestCase):
     def test_cwd_does_not_exist(self):
         test_cmd = 'set -e; echo "xxxx" |tee outputs.txt'
         with TemporaryDirectory(prefix='test_command_with_cwd') as tmp_dir:
-            # There should be no exceptions when creating the operator
-            bash_operator = BashOperator(task_id='abc', bash_command=test_cmd, cwd=tmp_dir)
+            # Get a temporary folder
+            pass
+        # There should be no exceptions when creating the operator even the `cwd` doesn't exist
+        bash_operator = BashOperator(task_id='abc', bash_command=test_cmd, cwd=tmp_dir)
         with pytest.raises(AirflowException, match=f"Can not find the cwd: {tmp_dir}"):
             bash_operator.execute({})
 

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -132,7 +132,7 @@ class TestBashOperator(unittest.TestCase):
     def test_cwd_does_not_exist(self):
         test_cmd = 'set -e; echo "xxxx" |tee outputs.txt'
         with TemporaryDirectory(prefix='test_command_with_cwd') as tmp_dir:
-            # Get a temporary folder
+            # Get a nonexistent temporary to do the test
             pass
         # There should be no exceptions when creating the operator even the `cwd` doesn't exist
         bash_operator = BashOperator(task_id='abc', bash_command=test_cmd, cwd=tmp_dir)

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -132,7 +132,7 @@ class TestBashOperator(unittest.TestCase):
     def test_cwd_does_not_exist(self):
         test_cmd = 'set -e; echo "xxxx" |tee outputs.txt'
         with TemporaryDirectory(prefix='test_command_with_cwd') as tmp_dir:
-            # Get a nonexistent temporary to do the test
+            # Get a nonexistent temporary directory to do the test
             pass
         # There should be no exceptions when creating the operator even the `cwd` doesn't exist
         bash_operator = BashOperator(task_id='abc', bash_command=test_cmd, cwd=tmp_dir)

--- a/tests/operators/test_bash.py
+++ b/tests/operators/test_bash.py
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import os
+import shutil as _shutil
 import unittest
 from datetime import datetime, timedelta
 from tempfile import NamedTemporaryFile
@@ -122,6 +124,41 @@ class TestBashOperator(unittest.TestCase):
             AirflowException, match="Bash command failed\\. The command returned a non-zero exit code 127\\."
         ):
             BashOperator(task_id='abc', bash_command='set -e; something-that-isnt-on-path').execute({})
+
+    def test_command_without_cwd(self):
+        val = "xxxx"
+        op = BashOperator(task_id='abc', bash_command=f'set -e; echo "{val}";')
+        line = op.execute({})
+        assert line == val
+
+    def test_command_with_cwd(self):
+
+        test_cwd_folder = "/tmp/airflow/test_bash/test_command_with_cwd"
+        test_file_name = "py_test.txt"
+        test_cwd_file_path = f"{test_cwd_folder}/{test_file_name}"
+        # The command is echo a string to a file into cwd folder and return the string as the output
+        test_cmd = f'set -e; echo "xxxx" |tee {test_file_name}'
+
+        # Test the the bash_cwd doesn't exist
+        if os.path.exists(test_cwd_folder):
+            _shutil.rmtree(test_cwd_folder)
+        with pytest.raises(AirflowException, match=f"Can not find the bash_cwd: {test_cwd_folder}"):
+            BashOperator(task_id='abc', bash_command=test_cmd, bash_cwd=test_cwd_folder).execute({})
+
+        os.makedirs(test_cwd_folder)
+
+        # Test if the bash_cwd is a file_path
+        with open(test_cwd_file_path, 'w') as tmp_file:
+            tmp_file.write("xxxxx")
+            with pytest.raises(AirflowException, match=f"The bash_cwd {test_cwd_file_path} must be a folder"):
+                BashOperator(task_id='abc', bash_command=test_cmd, bash_cwd=test_cwd_file_path).execute({})
+        os.remove(test_cwd_file_path)
+
+        # Test everything goes alright
+        result = BashOperator(task_id='abc', bash_command=test_cmd, bash_cwd=test_cwd_folder).execute({})
+        assert result == "xxxx"
+        with open(test_cwd_file_path) as tmp_file:
+            assert tmp_file.read().splitlines()[0] == "xxxx"
 
     @parameterized.expand(
         [


### PR DESCRIPTION
For this change, the `BashOperator` allows the user to specify the command folder.
As if the user wants to execute a command in the amount folder which contains lots of project scripts, he can just specify the bash_cwd to the folder and he doesn't need to switch the folder manually.

I did the pre-commit check and added the unit-test for the changes. 
If I miss other necessary works for creating the PR, please let me know.
Thanks a lot.

