### PR TITLE
Separate infer_data_interval for data interval timetables

### DIFF
--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -43,13 +43,6 @@ class _DataIntervalTimetable(Timetable):
     def validate(self) -> None:
         self._schedule.validate()
 
-    def infer_data_interval(self, run_after: DateTime) -> DataInterval:
-        # Get the last complete period before run_after, e.g. if a DAG run is
-        # scheduled at each midnight, the data interval of a manually triggered
-        # run at 1am 25th is between 0am 24th and 0am 25th.
-        end = self._schedule.get_prev(self._schedule.align(run_after))
-        return DataInterval(start=self._schedule.get_prev(end), end=end)
-
     def next_dagrun_info(
         self,
         last_automated_dagrun: Optional[DateTime],
@@ -86,6 +79,13 @@ class CronDataIntervalTimetable(_DataIntervalTimetable):
     def __init__(self, cron: str, timezone: datetime.tzinfo) -> None:
         self._schedule = CronSchedule(cron, timezone)
 
+    def infer_data_interval(self, run_after: DateTime) -> DataInterval:
+        # Get the last complete period before run_after, e.g. if a DAG run is
+        # scheduled at each midnight, the data interval of a manually triggered
+        # run at 1am 25th is between 0am 24th and 0am 25th.
+        end = self._schedule.get_prev(self._schedule.align(run_after))
+        return DataInterval(start=self._schedule.get_prev(end), end=end)
+
 
 class DeltaDataIntervalTimetable(_DataIntervalTimetable):
     """Timetable that schedules data intervals with a time delta.
@@ -97,3 +97,6 @@ class DeltaDataIntervalTimetable(_DataIntervalTimetable):
 
     def __init__(self, delta: Delta) -> None:
         self._schedule = DeltaSchedule(delta)
+
+    def infer_data_interval(self, run_after: DateTime) -> DataInterval:
+        return DataInterval(start=self._schedule.get_prev(run_after), end=run_after)


### PR DESCRIPTION
CronDataIntervalTimetable and DeltaDataIntervalTimetable needs different infer_data_interval implementations because since the 'align' method aligns the time *forward*, CronDataIntervalTimetable needs to call get_prev one more time than DeltaDataIntervalTimetable to get the correct interval.
