### PR TITLE
Helm chart: add the number of retention days for log groomer through env vars.

### DIFF
--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -211,6 +211,11 @@ spec:
           {{- if .Values.scheduler.logGroomerSidecar.args }}
           args: {{ tpl (toYaml .Values.scheduler.logGroomerSidecar.args) . | nindent 12 }}
           {{- end }}
+          {{ if .Values.scheduler.logGroomerSidecar.retentionDays }}
+          env:
+            - name: AIRFLOW__LOG_RETENTION_DAYS
+              value: "{{ .Values.scheduler.logGroomerSidecar.retentionDays }}"
+          {{- end }}
           volumeMounts:
             - name: logs
               mountPath: {{ template "airflow_logs" . }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -200,6 +200,11 @@ spec:
           {{- if .Values.workers.logGroomerSidecar.args }}
           args: {{ tpl (toYaml .Values.workers.logGroomerSidecar.args) . | nindent 12 }}
           {{- end }}
+          {{ if .Values.workers.logGroomerSidecar.retentionDays }}
+          env:
+            - name: AIRFLOW__LOG_RETENTION_DAYS
+              value: "{{ .Values.workers.logGroomerSidecar.retentionDays }}"
+          {{- end }}
           resources:
 {{ toYaml .Values.workers.logGroomerSidecar.resources | indent 12 }}
           volumeMounts:

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -353,6 +353,12 @@ class SchedulerTest(unittest.TestCase):
 
         assert jmespath.search("spec.template.spec.containers[1].command", docs[0]) is None
         assert ["bash", "/clean-logs"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
+    
+    def test_log_groomer_collector_default_retention_days(self):
+        docs = render_chart(show_only=["templates/scheduler/scheduler-deployment.yaml"])
+
+        assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
+        assert "15" == jmespath.search("spec.template.spec.containers[1].env[0].value", docs[0]) 
 
     @parameterized.expand(
         [

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -397,6 +397,28 @@ class SchedulerTest(unittest.TestCase):
 
     @parameterized.expand(
         [
+            (None, None),
+            (30, "30"),
+        ]
+    )
+    def test_log_groomer_retention_days_overrides(self, retention_days, retention_result):
+        docs = render_chart(
+            values={"scheduler": {"logGroomerSidecar": {"retentionDays": retention_days}}},
+            show_only=["templates/scheduler/scheduler-deployment.yaml"],
+        )
+
+        if retention_result:
+            assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search(
+                "spec.template.spec.containers[1].env[0].name", docs[0]
+            )
+            assert retention_result == jmespath.search(
+                "spec.template.spec.containers[1].env[0].value", docs[0]
+            )
+        else:
+            assert jmespath.search("spec.template.spec.containers[1].env", docs[0]) is None
+
+    @parameterized.expand(
+        [
             ({"gitSync": {"enabled": True}},),
             ({"gitSync": {"enabled": True}, "persistence": {"enabled": True}},),
         ]

--- a/chart/tests/test_scheduler.py
+++ b/chart/tests/test_scheduler.py
@@ -353,12 +353,14 @@ class SchedulerTest(unittest.TestCase):
 
         assert jmespath.search("spec.template.spec.containers[1].command", docs[0]) is None
         assert ["bash", "/clean-logs"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
-    
+
     def test_log_groomer_collector_default_retention_days(self):
         docs = render_chart(show_only=["templates/scheduler/scheduler-deployment.yaml"])
 
-        assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
-        assert "15" == jmespath.search("spec.template.spec.containers[1].env[0].value", docs[0]) 
+        assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search(
+            "spec.template.spec.containers[1].env[0].name", docs[0]
+        )
+        assert "15" == jmespath.search("spec.template.spec.containers[1].env[0].value", docs[0])
 
     @parameterized.expand(
         [

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -422,6 +422,13 @@ class WorkerTest(unittest.TestCase):
 
         assert jmespath.search("spec.template.spec.containers[1].command", docs[0]) is None
         assert ["bash", "/clean-logs"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
+    
+    def test_log_groomer_collector_default_retention_days(self):
+        docs = render_chart(show_only=["templates/workers/worker-deployment.yaml"])
+
+        assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
+        assert "15" == jmespath.search("spec.template.spec.containers[1].env[0].value", docs[0]) 
+
 
     @parameterized.expand(
         [

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -422,13 +422,14 @@ class WorkerTest(unittest.TestCase):
 
         assert jmespath.search("spec.template.spec.containers[1].command", docs[0]) is None
         assert ["bash", "/clean-logs"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
-    
+
     def test_log_groomer_collector_default_retention_days(self):
         docs = render_chart(show_only=["templates/workers/worker-deployment.yaml"])
 
-        assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search("spec.template.spec.containers[1].env[0].name", docs[0])
-        assert "15" == jmespath.search("spec.template.spec.containers[1].env[0].value", docs[0]) 
-
+        assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search(
+            "spec.template.spec.containers[1].env[0].name", docs[0]
+        )
+        assert "15" == jmespath.search("spec.template.spec.containers[1].env[0].value", docs[0])
 
     @parameterized.expand(
         [

--- a/chart/tests/test_worker.py
+++ b/chart/tests/test_worker.py
@@ -464,6 +464,28 @@ class WorkerTest(unittest.TestCase):
         assert ["RELEASE-NAME"] == jmespath.search("spec.template.spec.containers[1].command", docs[0])
         assert ["Helm"] == jmespath.search("spec.template.spec.containers[1].args", docs[0])
 
+    @parameterized.expand(
+        [
+            (None, None),
+            (30, "30"),
+        ]
+    )
+    def test_log_groomer_retention_days_overrides(self, retention_days, retention_result):
+        docs = render_chart(
+            values={"workers": {"logGroomerSidecar": {"retentionDays": retention_days}}},
+            show_only=["templates/workers/worker-deployment.yaml"],
+        )
+
+        if retention_result:
+            assert "AIRFLOW__LOG_RETENTION_DAYS" == jmespath.search(
+                "spec.template.spec.containers[1].env[0].name", docs[0]
+            )
+            assert retention_result == jmespath.search(
+                "spec.template.spec.containers[1].env[0].value", docs[0]
+            )
+        else:
+            assert jmespath.search("spec.template.spec.containers[1].env", docs[0]) is None
+
     def test_dags_gitsync_sidecar_and_init_container(self):
         docs = render_chart(
             values={"dags": {"gitSync": {"enabled": True}}},

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1131,6 +1131,11 @@
                                 "/clean-logs"
                             ]
                         },
+                        "retentionDays": {
+                            "description": "Number of days to retain the logs when running the Airflow workers log groomer sidecar.",
+                            "type": "integer",
+                            "default": 15
+                        },
                         "resources": {
                             "description": "Resources for Airflow workers log groomer sidecar.",
                             "type": "object",
@@ -1373,6 +1378,11 @@
                                 "bash",
                                 "/clean-logs"
                             ]
+                        },
+                        "retentionDays": {
+                            "description": "Number of days to retain the logs when running the Airflow scheduler log groomer sidecar.",
+                            "type": "integer",
+                            "default": 15
                         },
                         "resources": {
                             "description": "Resources for log groomer sidecar.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -453,6 +453,8 @@ workers:
     command: ~
     # Args to use when running the Airflow worker log groomer sidecar (templated).
     args: ["bash", "/clean-logs"]
+    # Number of days to retain logs
+    retentionDays: 15
     resources: {}
     #  limits:
     #   cpu: 100m
@@ -546,6 +548,8 @@ scheduler:
     command: ~
     # Args to use when running the Airflow scheduler log groomer sidecar (templated).
     args: ["bash", "/clean-logs"]
+    # Number of days to retain logs
+    retentionDays: 15
     resources: {}
     #  limits:
     #   cpu: 100m


### PR DESCRIPTION
Allow users to specify the number of days they would like the log grooming sidecar to retain logs (both for scheduler/worker templates).

Log grooming script's env var:
https://github.com/apache/airflow/blob/c4d043d9f8b28f2ad80c9912e7690bc6620bd753/scripts/in_container/prod/clean-logs.sh#L23

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
