### PR TITLE
Docs: Make the providers operators/hooks reference much more usable

### DIFF
--- a/docs/apache-airflow-providers/operators-and-hooks-ref/apache.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/apache.rst
@@ -20,8 +20,8 @@ ASF: Apache Software Foundation
 
 Airflow supports various software created by `Apache Software Foundation <https://www.apache.org/foundation/>`__.
 
-Software operators and hooks
-----------------------------
+Software
+--------
 
 These integrations allow you to perform various operations within software developed by Apache Software
 Foundation.
@@ -31,8 +31,8 @@ Foundation.
    :header-separator: "
 
 
-Transfer operators and hooks
-----------------------------
+Transfers
+---------
 
 These integrations allow you to copy data from/to software developed by Apache Software
 Foundation.

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/aws.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/aws.rst
@@ -24,8 +24,8 @@ Airflow has support for `Amazon Web Services <https://aws.amazon.com/>`__.
 
 All hooks are based on :mod:`airflow.providers.amazon.aws.hooks.base_aws`.
 
-Service operators and hooks
-'''''''''''''''''''''''''''
+Services
+''''''''
 
 These integrations allow you to perform various operations within the Amazon Web Services.
 
@@ -33,8 +33,8 @@ These integrations allow you to perform various operations within the Amazon Web
    :tags: aws
    :header-separator: "
 
-Transfer operators and hooks
-''''''''''''''''''''''''''''
+Transfers
+'''''''''
 
 These integrations allow you to copy data from/to Amazon Web Services.
 

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/azure.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/azure.rst
@@ -23,8 +23,8 @@ Airflow has limited support for `Microsoft Azure <https://azure.microsoft.com/>`
 Some hooks are based on :mod:`airflow.providers.microsoft.azure.hooks.base_azure`
 which authenticate Azure's Python SDK Clients.
 
-Service operators and hooks
-'''''''''''''''''''''''''''
+Services
+''''''''
 
 These integrations allow you to perform various operations within the Microsoft Azure.
 
@@ -32,8 +32,8 @@ These integrations allow you to perform various operations within the Microsoft 
    :tags: azure
    :header-separator: "
 
-Transfer operators and hooks
-''''''''''''''''''''''''''''
+Transfers
+'''''''''
 
 These integrations allow you to copy data from/to Microsoft Azure.
 

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/google.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/google.rst
@@ -41,8 +41,8 @@ Airflow has extensive support for the `Google Cloud <https://cloud.google.com/>`
     <https://github.com/apache/airflow/tree/main/airflow/providers/google/cloud/example_dags/>`_
 
 
-Service operators and hooks
-"""""""""""""""""""""""""""
+Services
+""""""""
 
 These integrations allow you to perform various operations within the Google Cloud.
 
@@ -51,8 +51,8 @@ These integrations allow you to perform various operations within the Google Clo
    :header-separator: !
 
 
-Transfer operators and hooks
-""""""""""""""""""""""""""""
+Transfers
+"""""""""
 
 These integrations allow you to copy data from/to Google Cloud.
 

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/index.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/index.rst
@@ -22,7 +22,7 @@ Operators and Hooks Reference
 Here is a list of operators and hooks that are released independently of the Airflow core. A list of core operators is available in the documentation for ``apache-airflow``: :doc:`Core Operators and Hooks Reference <operators-and-hooks-ref>`.
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
     :glob:
 
     *

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/protocol.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/protocol.rst
@@ -18,8 +18,8 @@
 Protocol integrations
 ---------------------
 
-Protocol operators and hooks
-''''''''''''''''''''''''''''
+Protocols
+'''''''''
 
 These integrations allow you to perform various operations within various services using standardized
 communication protocols or interface.
@@ -28,8 +28,8 @@ communication protocols or interface.
    :tags: protocol
    :header-separator: "
 
-Transfer operators and hooks
-''''''''''''''''''''''''''''
+Transfers
+'''''''''
 
 These integrations allow you to copy data.
 

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/services.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/services.rst
@@ -18,8 +18,8 @@
 Services
 --------
 
-Service operators and hooks
-'''''''''''''''''''''''''''
+Services
+''''''''
 
 These integrations allow you to perform various operations within various services.
 
@@ -28,8 +28,8 @@ These integrations allow you to perform various operations within various servic
    :header-separator: "
 
 
-Transfer operators and hooks
-''''''''''''''''''''''''''''
+Transfers
+'''''''''
 
 These integrations allow you to perform various operations within various services.
 

--- a/docs/apache-airflow-providers/operators-and-hooks-ref/software.rst
+++ b/docs/apache-airflow-providers/operators-and-hooks-ref/software.rst
@@ -18,8 +18,8 @@
 Software integrations
 ---------------------
 
-Software operators and hooks
-''''''''''''''''''''''''''''
+Software
+''''''''
 
 These integrations allow you to perform various operations using various software.
 
@@ -28,8 +28,8 @@ These integrations allow you to perform various operations using various softwar
    :header-separator: "
 
 
-Transfer operators and hooks
-''''''''''''''''''''''''''''
+Transfers
+'''''''''
 
 These integrations allow you to copy data.
 


### PR DESCRIPTION
The providers operators/hooks reference contained only top-level list of
groups of providers, which make them less-usable than they could be as
the users did not see at this page links to particular operators/hooks,
it was not really visible what is "available" (discoverability) and
the more detailed "Service" and "Transfer" pages are not really
readable enough to give "at a glance" overview what is available.

This change improves that, removes the repeated multiple times
"operators and hooks" which was kind of annoying, and increases
the TOC-level to 3 giving a nice overview of all available and
exposed operator and hooks.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
