### PR TITLE
Fix dag_processing.last_duration metric random holes

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -724,8 +724,8 @@ class DagFileProcessorManager(LoggingMixin):
             if last_run:
                 seconds_ago = (now - last_run).total_seconds()
                 Stats.gauge(f'dag_processing.last_run.seconds_ago.{file_name}', seconds_ago)
-            if runtime:
-                Stats.timing(f'dag_processing.last_duration.{file_name}', runtime)
+            if last_runtime:
+                Stats.timing(f'dag_processing.last_duration.{file_name}', last_runtime)
 
             rows.append((file_path, processor_pid, runtime, num_dags, num_errors, last_runtime, last_run))
 

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -724,8 +724,6 @@ class DagFileProcessorManager(LoggingMixin):
             if last_run:
                 seconds_ago = (now - last_run).total_seconds()
                 Stats.gauge(f'dag_processing.last_run.seconds_ago.{file_name}', seconds_ago)
-            if last_runtime:
-                Stats.timing(f'dag_processing.last_duration.{file_name}', last_runtime)
 
             rows.append((file_path, processor_pid, runtime, num_dags, num_errors, last_runtime, last_run))
 
@@ -892,6 +890,9 @@ class DagFileProcessorManager(LoggingMixin):
             run_count=self.get_run_count(processor.file_path) + 1,
         )
         self._file_stats[processor.file_path] = stat
+
+        file_name = os.path.splitext(os.path.basename(processor.file_path))[0].replace(os.sep, '.')
+        Stats.timing(f'dag_processing.last_duration.{file_name}', stat.last_duration)
 
     def collect_results(self) -> None:
         """Collect the result from any finished DAG processors"""

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -723,8 +723,6 @@ class TestDagFileProcessorManager:
 
         self.run_processor_manager_one_loop(manager, parent_pipe)
         last_runtime = manager.get_last_runtime(manager.file_paths[0])
-        manager.last_stat_print_time = 0
-        self.run_processor_manager_one_loop(manager, parent_pipe)
 
         child_pipe.close()
         parent_pipe.close()

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -721,16 +721,15 @@ class TestDagFileProcessorManager:
             async_mode=async_mode,
         )
 
-        with create_session():
-            self.run_processor_manager_one_loop(manager, parent_pipe)
-            last_runtime = manager.get_last_runtime(manager.file_paths[0])
-            manager.last_stat_print_time = 0
-            self.run_processor_manager_one_loop(manager, parent_pipe)
+        self.run_processor_manager_one_loop(manager, parent_pipe)
+        last_runtime = manager.get_last_runtime(manager.file_paths[0])
+        manager.last_stat_print_time = 0
+        self.run_processor_manager_one_loop(manager, parent_pipe)
 
         child_pipe.close()
         parent_pipe.close()
 
-        statsd_timing_mock.assert_called_once_with('dag_processing.last_duration.temp_dag', last_runtime)
+        statsd_timing_mock.assert_called_with('dag_processing.last_duration.temp_dag', last_runtime)
 
 
 class TestDagFileProcessorAgent(unittest.TestCase):

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -27,6 +27,7 @@ import threading
 import unittest
 from datetime import datetime, timedelta
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from unittest import mock
 from unittest.mock import MagicMock, PropertyMock
 
@@ -693,6 +694,48 @@ class TestDagFileProcessorManager:
             parent_pipe.close()
             child_pipe.close()
             thread.join(timeout=1.0)
+
+    @conf_vars({('core', 'load_examples'): 'False'})
+    @mock.patch('airflow.dag_processing.manager.Stats.timing')
+    def test_send_file_processing_statsd_timing(self, statsd_timing_mock, tmpdir):
+        # arrange
+        filename_to_parse = tmpdir / 'temp_dag.py'
+        # Generate dag
+        dag_code = dedent(
+            """
+        from airflow import DAG
+        dag = DAG(dag_id='temp_dag', schedule_interval='0 0 * * *')
+        """
+        )
+        with open(filename_to_parse, 'w') as file_to_parse:
+            file_to_parse.writelines(dag_code)
+
+        child_pipe, parent_pipe = multiprocessing.Pipe()
+
+        async_mode = 'sqlite' not in conf.get('core', 'sql_alchemy_conn')
+        manager = DagFileProcessorManager(
+            dag_directory=tmpdir,
+            max_runs=1,
+            processor_timeout=timedelta.max,
+            signal_conn=child_pipe,
+            dag_ids=[],
+            pickle_dags=False,
+            async_mode=async_mode,
+        )
+
+        # act
+        with create_session():
+            self.run_processor_manager_one_loop(manager, parent_pipe)
+
+        child_pipe.close()
+        parent_pipe.close()
+
+        # assert
+        # we check that after processing the file and removing it from DagFileProcessorManager._processors,
+        # the statistics on the last processing was sent to the statsd
+        statsd_timing_mock.assert_called_once_with(
+            'dag_processing.last_duration.temp_dag', manager.get_last_runtime(manager.file_paths[0])
+        )
 
 
 class TestDagFileProcessorAgent(unittest.TestCase):


### PR DESCRIPTION
Fixes for [17513](https://github.com/apache/airflow/issues/17513)

Problem with metrics arises at the moment when between the intervals AIRFLOV__SHEDULER__PRINT_STATS_INTERVAL file processing ends and dag processor is removed from DagFileProcessorManager._processors and as a result the DagFileProcessorManager.get_start_time method returns Nona and no statistics are sent on the file, moreover, this metric does not display the total processing time of the file, it shows time from the beginning of processing file until the call to DagFileProcessorManager._log_file_processing_stats.