### PR TITLE
Add warning about https configuration in SimpleHttpOperator

### DIFF
--- a/docs/apache-airflow-providers-http/operators.rst
+++ b/docs/apache-airflow-providers-http/operators.rst
@@ -45,6 +45,27 @@ SimpleHttpOperator
 Use the :class:`~airflow.providers.http.operators.http.SimpleHttpOperator` to call HTTP requests and get
 the response text back.
 
+.. warning:: Configuring ``https`` via SimpleHttpOperator is counter-intuitive
+
+   For historical reasons, configuring ``HTTPS`` connectivity via HTTP operator is, well, difficult and
+   counter-intuitive. The Operator defaults to ``http`` protocol and you can change the schema used by the
+   operator via ``scheme`` connection attribute. However this field was originally added to connection for
+   database type of URIs, where database schemes are set traditionally as first component of URI ``path``.
+   Therefore if you want to configure as ``https`` connection via URI, you need to pass ``https`` scheme
+   to the SimpleHttpOperator. AS stupid as it looks, your connection URI will look like this:
+   ``http://your_host:443/https``. Then if you want to use different URL paths in SimpleHttpOperator
+   you should pass your path as ``endpoint`` parameter when running the task. For example to run a query to
+   ``https://your_host:443/my_endpoint`` you need to set the endpoint parameter to ``my_endpoint``.
+   Alternatively, if you want, you could also percent-encode the host including the ``https://`` prefix,
+   and as long it contains ``://`` (percent-encoded ``%3a%2f%2f``), the first component of the path will
+   not be used as scheme. Your URI definition might then look like: ``http://https%3a%2f%2fyour_host:443/``
+   In this case however the ``path`` will not be used at all - you still need to use ``endpoint``
+   parameter in the task if wish to make a request with specific path. As counter-intuitive as it is, this
+   is historically the way how the operator/hook works and it's not easy to change without breaking
+   backwards compatibility because there are other operators build on top of the ``SimpleHttpOperator`` that
+   rely on that functionality and there are many users using it already.
+
+
 In the first example we are calling a ``POST`` with json data and succeed when we get the same json data back
 otherwise the task will fail.
 


### PR DESCRIPTION
For historical reasons, configuring ``https`` via SimpleHttpOperator
is well, complex.

This PR adds warning which informs the users about it as well
provides explanation why it is like that and gives some helpful
examples, so that people do not have to look for answers in
StackOverflow questions or GitHub issues or JIRAs (as they did
so far - for example #17780 and in
https://issues.apache.org/jira/browse/AIRFLOW-2910 or
https://stackoverflow.com/questions/51630344
and many other questions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
