### PR TITLE
Move Model collation args tests to correct folder

### DIFF
--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+from pytest import param
+
+from airflow.models.base import get_id_collation_args
+from tests.test_utils.config import conf_vars
+
+
+@pytest.mark.parametrize(
+    ("dsn", "expected", "extra"),
+    [
+        param("postgres://host/the_database", {}, {}, id="postgres"),
+        param("mysql://host/the_database", {"collation": "utf8mb3_general_ci"}, {}, id="mysql"),
+        param("mysql+pymsql://host/the_database", {"collation": "utf8mb3_general_ci"}, {}, id="mysql+pymsql"),
+        param(
+            "mysql://host/the_database",
+            {"collation": "ascii"},
+            {('core', 'sql_engine_collation_for_ids'): 'ascii'},
+            id="mysql with explicit config",
+        ),
+        param(
+            "postgres://host/the_database",
+            {"collation": "ascii"},
+            {('core', 'sql_engine_collation_for_ids'): 'ascii'},
+            id="postgres with explicit config",
+        ),
+    ],
+)
+def test_collation(dsn, expected, extra):
+    with conf_vars({('core', 'sql_alchemy_conn'): dsn, **extra}):
+        assert expected == get_id_collation_args()

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -19,7 +19,6 @@
 
 import unittest
 from datetime import timedelta
-from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
@@ -27,7 +26,6 @@ from freezegun import freeze_time
 
 from airflow.exceptions import AirflowException, AirflowRescheduleException, AirflowSensorTimeout
 from airflow.models import DagBag, TaskInstance, TaskReschedule
-from airflow.models.base import get_id_collation_args
 from airflow.models.dag import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.sensors.base import BaseSensorOperator, poke_mode_only
@@ -657,42 +655,3 @@ class TestPokeModeOnly(unittest.TestCase):
         sensor = DummyPokeOnlySensor(task_id='foo', mode='poke', poke_changes_mode=True, dag=self.dag)
         with pytest.raises(ValueError):
             sensor.poke({})
-
-
-class TestCollation(unittest.TestCase):
-    @mock.patch.dict(
-        'os.environ',
-        AIRFLOW__CORE__SQL_ALCHEMY_CONN='postgres://host/the_database',
-    )
-    def test_collation_empty_on_non_mysql(self):
-        assert {} == get_id_collation_args()
-
-    @mock.patch.dict(
-        'os.environ',
-        AIRFLOW__CORE__SQL_ALCHEMY_CONN='mysql://host/the_database',
-    )
-    def test_collation_set_on_mysql(self):
-        assert {"collation": "utf8mb3_general_ci"} == get_id_collation_args()
-
-    @mock.patch.dict(
-        'os.environ',
-        AIRFLOW__CORE__SQL_ALCHEMY_CONN='mysql+pymsql://host/the_database',
-    )
-    def test_collation_set_on_mysql_with_pymsql(self):
-        assert {"collation": "utf8mb3_general_ci"} == get_id_collation_args()
-
-    @mock.patch.dict(
-        'os.environ',
-        AIRFLOW__CORE__SQL_ALCHEMY_CONN='mysql://host/the_database',
-        AIRFLOW__CORE__SQL_ENGINE_COLLATION_FOR_IDS='ascii',
-    )
-    def test_collation_override_on_non_mysql(self):
-        assert {"collation": "ascii"} == get_id_collation_args()
-
-    @mock.patch.dict(
-        'os.environ',
-        AIRFLOW__CORE__SQL_ALCHEMY_CONN='postgres://host/the_database',
-        AIRFLOW__CORE__SQL_ENGINE_COLLATION_FOR_IDS='ascii',
-    )
-    def test_collation_override_on_mysql(self):
-        assert {"collation": "ascii"} == get_id_collation_args()


### PR DESCRIPTION
The tests for this got added to test_base.py in #17729, which is the right file name, but inside tests/sensors/, which isn't right :)

Created a new tests/models/test_base.py for this.

And cos I'm on a "removing lines of code" kick I've parameterized it too so it a "data driven" test.
