### PR TITLE
Chart: Update the default Airflow version to ``2.1.3``

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: airflow
 version: 1.2.0-rc1
-appVersion: 2.1.2
+appVersion: 2.1.3
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
 home: https://airflow.apache.org/

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -33,6 +33,16 @@ assists users migrating to a new version.
 .. More tips can be found in the guide:
    https://developers.google.com/style/inclusive-documentation
 
+Run ``helm repo update`` before upgrading the chart to the latest version.
+
+Airflow Helm Chart 1.2.0 (dev)
+------------------------------
+
+Default Airflow version is updated to ``2.1.2``
+"""""""""""""""""""""""""""""""""""""""""""""""
+
+The default Airflow version that is installed with the Chart is now ``2.1.3``, previously it was ``2.1.2``.
+
 Airflow Helm Chart 1.1.0
 ------------------------
 

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -61,13 +61,13 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.1.2",
+            "default": "2.1.3",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
             "type": "string",
-            "default": "2.1.2",
+            "default": "2.1.3",
             "x-docsSection": "Common"
         },
         "nodeSelector": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -37,10 +37,10 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.1.2"
+defaultAirflowTag: "2.1.3"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.1.2"
+airflowVersion: "2.1.3"
 
 # Images
 images:


### PR DESCRIPTION
Since 2.1.3 is out we should use that as the default Airflow version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
