### PR TITLE
Fix broken MSSQL test

### DIFF
--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -187,7 +187,6 @@ class TestStandardTaskRunner:
         task = dag.get_task('task1')
 
         with create_session() as session:
-            dag.clear()
             dag.create_dagrun(
                 run_id="test",
                 state=State.RUNNING,
@@ -197,6 +196,7 @@ class TestStandardTaskRunner:
             )
             ti = TaskInstance(task=task, execution_date=DEFAULT_DATE)
             job1 = LocalTaskJob(task_instance=ti, ignore_ti_state=True)
+            session.commit()
 
             runner = StandardTaskRunner(job1)
             runner.start()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -62,15 +62,12 @@ class TestStandardTaskRunner:
         (as the test environment does not have enough context for the normal
         way to run) and ensures they reset back to normal on the way out.
         """
+        clear_db_runs()
         dictConfig(LOGGING_CONFIG)
         yield
         airflow_logger = logging.getLogger('airflow')
         airflow_logger.handlers = []
-        try:
-            clear_db_runs()
-        except Exception:
-            # It might happen that we lost connection to the server here so we need to ignore any errors here
-            pass
+        clear_db_runs()
 
     def test_start_and_terminate(self):
         local_task_job = mock.Mock()
@@ -227,6 +224,8 @@ class TestStandardTaskRunner:
 
         for process in processes:
             assert not psutil.pid_exists(process.pid), f"{process} is still alive"
+
+        session.close()
 
     @staticmethod
     def _procs_in_pgroup(pgid):


### PR DESCRIPTION
This broken test was causing the next test to use the db to fail. Also,
by not ignoring exceptions here we let the failure be exposed where
its broken, not in the next test that happens to run.

This was causing `TestBaseSensor.test_fail` to fail with:

```
pyodbc.ProgrammingError: ('42000', '[42000] [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]The server failed to resume the transaction. Desc:3300000006. (3971) (SQLExecDirectW)')
```
