### PR TITLE
Fix missing whitespace in ``apply_default`` deprecation message

### DIFF
--- a/airflow/utils/decorators.py
+++ b/airflow/utils/decorators.py
@@ -36,7 +36,7 @@ def apply_defaults(func: T) -> T:
     warnings.warn(
         "This decorator is deprecated. \n"
         "\n"
-        "In previous versions, all subclasses of BaseOperator must use apply_default decorator for the"
+        "In previous versions, all subclasses of BaseOperator must use apply_default decorator for the "
         "`default_args` feature to work properly.\n"
         "\n"
         "In current version, it is optional. The decorator is applied automatically using the metaclass.\n",


### PR DESCRIPTION
Before:

```
In previous versions, all subclasses of BaseOperator must use apply_default decorator for the`default_args` feature to work properly.
```

After:

```
In previous versions, all subclasses of BaseOperator must use apply_default decorator for the `default_args` feature to work properly.
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
