### PR TITLE
Use one interpreter for Airflow and gunicorn

### DIFF
--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -391,6 +391,8 @@ def webserver(args):
         )
 
         run_args = [
+            sys.executable,
+            '-m',
             'gunicorn',
             '--workers',
             str(num_workers),

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,7 @@ install_requires =
     flask-login>=0.3, <0.5
     flask-wtf>=0.14.3, <0.15
     graphviz>=0.12
-    gunicorn>=19.5.0
+    gunicorn>=20.1.0
     httpx
     importlib_metadata>=1.7;python_version<"3.9"
     importlib_resources~=1.4


### PR DESCRIPTION
Similar to: https://github.com/apache/airflow/pull/17156 Close: https://github.com/apache/airflow/issues/17804

If the user has a misconfigured Python environment, they may have problems locating the gunicorn binary. Luckily, newer versions of Gunicorn support starting gunicorn using `python -m`, which is more stable.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
