### PR TITLE
Fixes unbound variable during remote image check in Breeze

### DIFF
--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -325,6 +325,8 @@ function build_images::compare_local_and_remote_build_cache_hash() {
     set +e
     local local_image_build_cache_file
     local_image_build_cache_file="${AIRFLOW_SOURCES}/manifests/local-build-cache-hash-${PYTHON_MAJOR_MINOR_VERSION}"
+    local remote_image_build_cache_file
+    remote_image_build_cache_file="${AIRFLOW_SOURCES}/manifests/remote-build-cache-hash-${PYTHON_MAJOR_MINOR_VERSION}"
     local remote_hash
     remote_hash=$(cat "${remote_image_build_cache_file}")
     local local_hash


### PR DESCRIPTION
The error would occur when comparing the hashes. It would not
result in big problem, simply unnecessary docker pull would
be run always when you rebuild the image, making it slightly
slower (as it would always have to pull the most recent
layers that you already rebuilt locally with your local
source changes).

```
Checking if the remote image needs to be pulled

ccc1270fce717b3e6918169c6de4d741262072ad78cc423fdd3e20f56134eb02
ccc1270fce717b3e6918169c6de4d741262072ad78cc423fdd3e20f56134eb02
/home/jarek/code/airflow/scripts/ci/libraries/_build_images.sh: line 329: remote_image_build_cache_file: unbound variable

Your image and the dockerhub have different or missing build cache hashes.
Local hash: 'eb64c3e26ab3b1e3c4cb38e691483d9f5f6508e5e71a06fed9b200c2d596'. Remote hash: ''.
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
