### PR TITLE
fix EXTRA_LOGGER_NAMES param and related docs

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -104,7 +104,7 @@ DEFAULT_LOGGING_CONFIG: Dict[str, Any] = {
             'filters': ['mask_secrets'],
         },
         'flask_appbuilder': {
-            'handler': ['console'],
+            'handlers': ['console'],
             'level': FAB_LOG_LEVEL,
             'propagate': True,
         },
@@ -120,7 +120,7 @@ EXTRA_LOGGER_NAMES: str = conf.get('logging', 'EXTRA_LOGGER_NAMES', fallback=Non
 if EXTRA_LOGGER_NAMES:
     new_loggers = {
         logger_name.strip(): {
-            'handler': ['console'],
+            'handlers': ['console'],
             'level': LOG_LEVEL,
             'propagate': True,
         }

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -594,7 +594,7 @@
       type: string
       example: ~
       default: "task"
-    - name: extra_loggers
+    - name: extra_logger_names
       description: |
         A comma\-separated list of third-party logger names that will be configured to print messages to
         consoles\.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -329,8 +329,8 @@ task_log_reader = task
 
 # A comma\-separated list of third-party logger names that will be configured to print messages to
 # consoles\.
-# Example: extra_loggers = connexion,sqlalchemy
-extra_loggers =
+# Example: extra_logger_names = connexion,sqlalchemy
+extra_logger_names =
 
 # When you start an airflow worker, airflow starts a tiny web server
 # subprocess to serve the workers local log files to the airflow main


### PR DESCRIPTION
I noticed that extra_loggers parameter doesn't work as intented because it's actually called [extra_logger_names](https://github.com/apache/airflow/blob/main/airflow/config_templates/airflow_local_settings.py#L119) and because of the handler`s` typo. This PR changes the docs to the `extra_logger_names` parameter and removes the typo.
