### PR TITLE
Increase width for "Run" column

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -167,7 +167,7 @@ function lastDagRunsHandler(error, json) {
 function drawDagStatsForDag(dagId, states) {
   const g = d3.select(`svg#dag-run-${dagId.replace(/\./g, '__dot__')}`)
     .attr('height', diameter + (strokeWidthHover * 2))
-    .attr('width', '110px')
+    .attr('width', '120px')
     .selectAll('g')
     .data(states)
     .enter()

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -154,7 +154,7 @@
                   {% endfor %}
                 </td>
                 {# Column 4: Dag Runs #}
-                <td style="padding:0; width:120px;">
+                <td style="padding:0; width:130px;">
                   {{ loading_dots(classes='js-loading-dag-stats text-muted') }}
                   <svg height="10" width="10" id="dag-run-{{ dag.safe_dag_id }}" style="display: block;"></svg>
                 </td>


### PR DESCRIPTION
closes: #17810

After Airflow 2.1.3 upgrade the "Run" column became too small for the queued status:

![image](https://user-images.githubusercontent.com/1991286/130658273-fee93023-2660-4a04-b825-e4594545eefe.png)

This PR increases a bit the width in that column to not cut out part of the status:

![image](https://user-images.githubusercontent.com/1991286/130658385-97ae8f4d-c975-4e78-acc3-e56e6bfd3c43.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
