### PR TITLE
Improve graph view load time for dags with open groups

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -601,7 +601,7 @@ function focusGroup(nodeId) {
 }
 
 // Expands a group node
-function expandGroup(nodeId, node, focus = true, do_draw = true) {
+function expandGroup(nodeId, node, focus = true, shouldDraw = true) {
   node.children.forEach((val) => {
     // Set children nodes
     g.setNode(val.id, val.value);
@@ -638,7 +638,7 @@ function expandGroup(nodeId, node, focus = true, do_draw = true) {
     }
   });
 
-  if (do_draw) {
+  if (shouldDraw) {
     draw();
   }
 

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -462,6 +462,9 @@ function groupTooltip(nodeId, tis) {
 function updateNodesStates(tis) {
   g.nodes().forEach((nodeId) => {
     const { elem } = g.node(nodeId);
+    if (!elem) {
+        return;
+    }
     elem.setAttribute('class', `node enter ${getNodeState(nodeId, tis)}`);
     elem.setAttribute('data-toggle', 'tooltip');
 
@@ -598,7 +601,7 @@ function focusGroup(nodeId) {
 }
 
 // Expands a group node
-function expandGroup(nodeId, node, focus = true) {
+function expandGroup(nodeId, node, focus = true, do_draw = true) {
   node.children.forEach((val) => {
     // Set children nodes
     g.setNode(val.id, val.value);
@@ -635,7 +638,9 @@ function expandGroup(nodeId, node, focus = true) {
     }
   });
 
-  draw();
+  if (do_draw) {
+    draw();
+  }
 
   if (focus) {
     focusGroup(nodeId);
@@ -687,7 +692,7 @@ function expandSavedGroups(expandedGroups, node) {
 
   node.children.forEach((childNode) => {
     if (expandedGroups.has(childNode.id)) {
-      expandGroup(childNode.id, g.node(childNode.id), false);
+      expandGroup(childNode.id, g.node(childNode.id), false, false);
 
       expandSavedGroups(expandedGroups, childNode);
     }
@@ -699,10 +704,13 @@ const focusNodeId = localStorage.getItem(focusedGroupKey(dagId));
 const expandedGroups = getSavedGroups(dagId);
 
 // Always expand the root node
-expandGroup(null, nodes);
+expandGroup(null, nodes, false, false);
 
 // Expand the node that were previously expanded
 expandSavedGroups(expandedGroups, nodes);
+
+// Draw once after all groups have been expanded
+draw();
 
 // Restore focus (if available)
 if (g.hasNode(focusNodeId)) {

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -463,7 +463,7 @@ function updateNodesStates(tis) {
   g.nodes().forEach((nodeId) => {
     const { elem } = g.node(nodeId);
     if (!elem) {
-        return;
+      return;
     }
     elem.setAttribute('class', `node enter ${getNodeState(nodeId, tis)}`);
     elem.setAttribute('data-toggle', 'tooltip');

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -151,6 +151,8 @@ function draw() {
       // A group node
       if (d3.event.defaultPrevented) return;
       expandGroup(nodeId, node);
+      draw();
+      focusGroup(nodeId);
     } else if (nodeId in tasks) {
       // A task node
       const task = tasks[nodeId];
@@ -601,7 +603,7 @@ function focusGroup(nodeId) {
 }
 
 // Expands a group node
-function expandGroup(nodeId, node, focus = true, shouldDraw = true) {
+function expandGroup(nodeId, node) {
   node.children.forEach((val) => {
     // Set children nodes
     g.setNode(val.id, val.value);
@@ -637,14 +639,6 @@ function expandGroup(nodeId, node, focus = true, shouldDraw = true) {
       g.removeEdge(edge.v, edge.w);
     }
   });
-
-  if (shouldDraw) {
-    draw();
-  }
-
-  if (focus) {
-    focusGroup(nodeId);
-  }
 
   saveExpandedGroup(nodeId);
 }
@@ -692,7 +686,7 @@ function expandSavedGroups(expandedGroups, node) {
 
   node.children.forEach((childNode) => {
     if (expandedGroups.has(childNode.id)) {
-      expandGroup(childNode.id, g.node(childNode.id), false, false);
+      expandGroup(childNode.id, g.node(childNode.id));
 
       expandSavedGroups(expandedGroups, childNode);
     }
@@ -704,7 +698,7 @@ const focusNodeId = localStorage.getItem(focusedGroupKey(dagId));
 const expandedGroups = getSavedGroups(dagId);
 
 // Always expand the root node
-expandGroup(null, nodes, false, false);
+expandGroup(null, nodes);
 
 // Expand the node that were previously expanded
 expandSavedGroups(expandedGroups, nodes);


### PR DESCRIPTION
The main improvement is calling the expensive draw function only one 
time during the initial load instead of for each saved group.                          

The previous behavior could cause significat slowness for when loading
the graph view for large dags with open task groups.
