### PR TITLE
Avoid redirect loop for users with no permissions

### DIFF
--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -33,7 +33,7 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
         @wraps(func)
         def decorated(*args, **kwargs):
             appbuilder = current_app.appbuilder
-            if not g.user.is_anonymous and not appbuilder.sm.get_current_user_permissions():
+            if not g.user.is_anonymous and not appbuilder.sm.current_user_has_permissions():
                 return (
                     render_template(
                         'airflow/no_roles_permissions.html',

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -15,10 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import socket
 from functools import wraps
 from typing import Callable, Optional, Sequence, Tuple, TypeVar, cast
 
-from flask import current_app, flash, g, redirect, request, url_for
+from flask import current_app, flash, g, redirect, render_template, request, url_for
+
+from airflow.configuration import conf
 
 T = TypeVar("T", bound=Callable)
 
@@ -30,8 +33,17 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
         @wraps(func)
         def decorated(*args, **kwargs):
             appbuilder = current_app.appbuilder
-            if not g.user.is_anonymous and not g.user.roles:
-                return redirect(url_for("Airflow.no_roles"))
+            if not g.user.is_anonymous and not appbuilder.sm.get_current_user_permissions():
+                return (
+                    render_template(
+                        'airflow/no_roles_permissions.html',
+                        hostname=socket.getfqdn()
+                        if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
+                        else 'redact',
+                        logout_url=current_app.appbuilder.get_url_for_logout,
+                    ),
+                    403,
+                )
 
             if appbuilder.sm.check_authorization(permissions, request.args.get('dag_id', None)):
                 return func(*args, **kwargs)

--- a/airflow/www/auth.py
+++ b/airflow/www/auth.py
@@ -40,7 +40,7 @@ def has_access(permissions: Optional[Sequence[Tuple[str, str]]] = None) -> Calla
                         hostname=socket.getfqdn()
                         if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
                         else 'redact',
-                        logout_url=current_app.appbuilder.get_url_for_logout,
+                        logout_url=appbuilder.get_url_for_logout,
                     ),
                     403,
                 )

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -343,6 +343,12 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             perms.update({(perm.permission.name, perm.view_menu.name) for perm in role.permissions})
         return perms
 
+    def current_user_has_permissions(self) -> bool:
+        for role in self.get_user_roles():
+            if role.permissions:
+                return True
+        return False
+
     def get_readable_dags(self, user):
         """Gets the DAGs readable by authenticated user."""
         return self.get_accessible_dags([permissions.ACTION_CAN_READ], user)

--- a/airflow/www/templates/airflow/no_roles_permissions.html
+++ b/airflow/www/templates/airflow/no_roles_permissions.html
@@ -26,7 +26,7 @@
 <body>
   <div style="font-family: verdana; text-align: center; margin-top: 200px;">
     <img src="{{ url_for('static', filename='pin_100.png') }}" width="50px" alt="pin-logo" />
-    <h1>Your user has no roles!</h1>
+    <h1>Your user has no roles and/or permissions!</h1>
     <p>Unfortunately your user has no roles, and therefore you cannot use Airflow.</p>
     <p>Please contact your Airflow administrator
       (<a href="https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html#web-authentication">authentication</a>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -532,20 +532,6 @@ class Airflow(AirflowBaseView):
 
         return wwwutils.json_response(payload)
 
-    @expose('/no_roles')
-    def no_roles(self):
-        """Show 'user has no roles' on screen (instead of an endless redirect loop)"""
-        if g.user.is_anonymous or g.user.roles:
-            return redirect(url_for("Airflow.index"))
-
-        return render_template(
-            'airflow/no_roles.html',
-            hostname=socket.getfqdn()
-            if conf.getboolean('webserver', 'EXPOSE_HOSTNAME', fallback=True)
-            else 'redact',
-            logout_url=current_app.appbuilder.get_url_for_logout,
-        )
-
     @expose('/home')
     @auth.has_access(
         [

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -343,6 +343,27 @@ class TestSecurity(unittest.TestCase):
             mock_get_user_roles.return_value = []
             assert len(self.security_manager.get_current_user_permissions()) == 0
 
+    @mock.patch('airflow.www.security.g')
+    def test_current_user_has_permissions(self, mock_g):
+        with self.app.app_context():
+            user = api_connexion_utils.create_user(
+                self.app,
+                "current_user_has_permissions",
+                "current_user_has_permissions",
+                permissions=[("can_some_action", "SomeBaseView")],
+            )
+            mock_g.user = user
+            assert self.security_manager.current_user_has_permissions()
+
+            # Role, but no permissions
+            role = user.roles[0]
+            role.permissions = []
+            assert not self.security_manager.current_user_has_permissions()
+
+            # No role
+            user.roles = []
+            assert not self.security_manager.current_user_has_permissions()
+
     def test_get_accessible_dag_ids(self):
         role_name = 'MyRole1'
         permission_action = [permissions.ACTION_CAN_READ]

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -33,7 +33,7 @@ from tests.test_utils.www import check_content_in_response, check_content_not_in
 
 
 def test_index(admin_client):
-    with assert_queries_count(46):
+    with assert_queries_count(47):
         resp = admin_client.get('/', follow_redirects=True)
     check_content_in_response('DAGs', resp)
 


### PR DESCRIPTION
Like we recently did for users with no roles, also handle it gracefully
when users have no permissions instead of letting them get stuck in a
redirect loop.

This also changes the approach to rendering the template as a 403 for
the originally requested URI instead of redirecting to a separate endpoint.

![Screen Shot 2021-08-25 at 6 06 38 PM](https://user-images.githubusercontent.com/66968678/130879907-d8795467-6a3a-4af7-a1ea-fbe6b46fb1ef.png)

Closes: #16587