### PR TITLE
Properly reset/adopt taskinstances and fix find_zombies 

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1195,9 +1195,14 @@ class SchedulerJob(BaseJob):
                         reset_tis_message.append(repr(ti))
                         ti.state = State.NONE
                         ti.queued_by_job_id = None
+                        # We have to reset this as the new Scheduler will spawn new
+                        # instances(LocalTaskJobs). Without this, when the old instances are marked
+                        # failed, zombie would kill this task
+                        ti.job_id = None
 
                     for ti in set(tis_to_reset_or_adopt) - set(to_reset):
                         ti.queued_by_job_id = self.id
+                        ti.job_id = None
 
                     Stats.incr('scheduler.orphaned_tasks.cleared', len(to_reset))
                     Stats.incr('scheduler.orphaned_tasks.adopted', len(tis_to_reset_or_adopt) - len(to_reset))

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -435,6 +435,7 @@ class TestDagFileProcessorManager:
             ti = TI(task, DEFAULT_DATE, State.RUNNING)
             local_job = LJ(ti)
             local_job.state = State.SHUTDOWN
+            local_job.latest_heartbeat = timezone.utcnow() - timedelta(days=2)
 
             session.add(local_job)
             session.commit()
@@ -480,6 +481,7 @@ class TestDagFileProcessorManager:
                 ti = TI(task, DEFAULT_DATE, State.RUNNING)
                 local_job = LJ(ti)
                 local_job.state = State.SHUTDOWN
+                local_job.latest_heartbeat = timezone.utcnow() - timedelta(days=2)
                 session.add(local_job)
                 session.commit()
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2466,6 +2466,7 @@ class TestSchedulerJob:
 
         session.refresh(ti1)
         assert ti1.state is None
+        assert ti1.job_id is None
         session.refresh(ti2)
         assert ti2.state == State.QUEUED
         session.rollback()


### PR DESCRIPTION
Currently, we fail long running SchedulerJob instances(LocalTaskJob) with no recent heartbeat
in reset_and_adopt_orphaned_tasks method of the Scheduler. Sometimes, this leads to the _find_zombies
method of the DAG file process manager running TaskCallbacks. This is how it happens:

When the scheduler dies and we reset task instances or adopt, we do not reset the ti.job_id and the
new SchedulerJob will create instances(LocalTaskJob) to run the new reset tasks. When the old job
which the task instances still has the job_id, has not heartbeated for long, the adopt_or_reset_orphaned
tasks will kill those jobs and subsequently or the _find_zombies method will find the tasks with the old jobID
and send a TaskCallback which will now fail the tasks being run by new schedulerjob instances

This was fixed by first, setting  ti.job_id to None
This helps to avoid clashing with the _find_zombies method which is now made to only act on jobs that are not
running and are also not heartbeating but the task is running.

In a situation where the _find_zombies method and adopt_or_reset_orphaned_task method run at the same time,
there would be conflict but now there won't be conflicts because _find_zombies only act on failed jobs with
running tasks and adopt_or_reset_orphaned_tasks kill jobs

Related: https://github.com/apache/airflow/issues/16023


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
