### PR TITLE
Sane detection of the host/port in entrypoint prod

### DIFF
--- a/scripts/in_container/prod/entrypoint_prod.sh
+++ b/scripts/in_container/prod/entrypoint_prod.sh
@@ -75,6 +75,7 @@ function run_nc() {
     nc -zvvn "${ip}" "${port}"
 }
 
+
 function wait_for_connection {
     # Waits for Connection to the backend specified via URL passed as first parameter
     # Detects backend type depending on the URL schema and assigns
@@ -83,24 +84,12 @@ function wait_for_connection {
     # It tries `CONNECTION_CHECK_MAX_COUNT` times and sleeps `CONNECTION_CHECK_SLEEP_TIME` between checks
     local connection_url
     connection_url="${1}"
-    local detected_backend=""
-    local detected_host=""
-    local detected_port=""
-
-    # Auto-detect DB parameters
-    # Examples:
-    #  postgres://YourUserName:password@YourHostname:5432/YourDatabaseName
-    #  postgres://YourUserName:password@YourHostname:5432/YourDatabaseName
-    #  postgres://YourUserName:@YourHostname:/YourDatabaseName
-    #  postgres://YourUserName@YourHostname/YourDatabaseName
-    [[ ${connection_url} =~ ([^:]*)://([^:@]*):?([^@]*)@?([^/:]*):?([0-9]*)/([^\?]*)\??(.*) ]] && \
-        detected_backend=${BASH_REMATCH[1]} &&
-        # Not used USER match
-        # Not used PASSWORD match
-        detected_host=${BASH_REMATCH[4]} &&
-        detected_port=${BASH_REMATCH[5]} &&
-        # Not used SCHEMA match
-        # Not used PARAMS match
+    local detected_backend
+    detected_backend=$(python -c "from urllib.parse import urlsplit; import sys; print(urlsplit(sys.argv[1]).scheme)" "${connection_url}")
+    local detected_host
+    detected_host=$(python -c "from urllib.parse import urlsplit; import sys; print(urlsplit(sys.argv[1]).hostname)" "${connection_url}")
+    local detected_port
+    detected_port=$(python -c "from urllib.parse import urlsplit; import sys; print(urlsplit(sys.argv[1]).port or '')" "${connection_url}")
 
     echo BACKEND="${BACKEND:=${detected_backend}}"
     readonly BACKEND


### PR DESCRIPTION
The previous regexp parsing was well, not perfect closely following the
ancient Chinese proverb "If you have problem, introduce regexp - you
will have two problems".

This PR replaces regexp matching with python urlsplit method.

Close: https://github.com/apache/airflow/issues/17828
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
