### PR TITLE
Fix provider.yaml errors due to exit(0) in test

### DIFF
--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -409,6 +409,9 @@ transfers:
     target-integration-name: Amazon Simple Storage Service (S3)
     how-to-guide: /docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst
     python-module: airflow.providers.amazon.aws.transfers.salesforce_to_s3
+  - source-integration-name: Local
+    target-integration-name: Amazon Simple Storage Service (S3)
+    python-module: airflow.providers.amazon.aws.transfers.local_to_s3
 
 hook-class-names:  # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
   - airflow.providers.amazon.aws.hooks.s3.S3Hook

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -29,17 +29,16 @@ additional-dependencies:
   - pypsrp>=0.5.0
 
 integrations:
-  - integration-name: Windows Remote Management (WinRM)
-    external-doc-url: https://docs.microsoft.com/en-us/windows/win32/winrm/portal
-    logo: /integration-logos/winrm/WinRM.png
+  - integration-name: Windows PowerShell Remoting Protocol
+    external-doc-url: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/
     tags: [protocol]
 
 operators:
-  - integration-name: Windows Remote Management (WinRM)
+  - integration-name: Windows PowerShell Remoting Protocol
     python-modules:
-      - airflow.providers.microsoft.winrm.operators.winrm
+      - airflow.providers.microsoft.psrp.operators.psrp
 
 hooks:
-  - integration-name: Windows Remote Management (WinRM)
+  - integration-name: Windows PowerShell Remoting Protocol
     python-modules:
-      - airflow.providers.microsoft.winrm.hooks.winrm
+      - airflow.providers.microsoft.psrp.hooks.psrp

--- a/scripts/ci/pre_commit/pre_commit_check_provider_yaml_files.py
+++ b/scripts/ci/pre_commit/pre_commit_check_provider_yaml_files.py
@@ -96,7 +96,7 @@ def check_integration_duplicates(yaml_files: Dict[str, Dict]):
             "Please delete duplicates."
         )
         print(tabulate(duplicates, headers=["Integration name", "Number of occurrences"]))
-        sys.exit(0)
+        sys.exit(3)
 
 
 def assert_sets_equal(set1, set2):


### PR DESCRIPTION
There were a few errors in provider structure resulting from
accidental exit(0) in provider's tests. Luckily none of the changes
have been released yet.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
