### PR TITLE
Fix log links on graph TI modal

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -157,7 +157,7 @@ function draw() {
       // A task node
       const task = tasks[nodeId];
       let tryNumber;
-      if (nodeId in taskInstances) tryNumber = taskInstances[nodeId].tryNumber;
+      if (nodeId in taskInstances) tryNumber = taskInstances[nodeId].try_number;
       else tryNumber = 0;
 
       if (task.task_type === 'SubDagOperator') callModal(nodeId, executionDate, task.extra_links, tryNumber, true);


### PR DESCRIPTION
The graph view should show the "Download Log" and "View Logs in {remote
logging system}", like is done on the tree view.

Before:
![Screen Shot 2021-08-26 at 4 08 32 PM](https://user-images.githubusercontent.com/66968678/131043824-d31b6f39-722a-4bba-a58c-7c72fe73fad1.png)

After:
![Screen Shot 2021-08-26 at 4 07 59 PM](https://user-images.githubusercontent.com/66968678/131043845-a4c69cad-9c19-4714-af4c-e8c30d1b0194.png)


