### PR TITLE
Show error in UI when a DAG with same dag_id as another DAG is present

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -109,7 +109,10 @@ class AirflowDagDuplicatedIdException(AirflowException):
         self.existing = existing
 
     def __str__(self) -> str:
-        return f"Ignoring DAG {self.dag_id} from {self.incoming} - also found in {self.existing}"
+        if self.incoming == self.existing:
+            return f"Found multiple DAGs with ID {self.dag_id} in {self.incoming}, only one will be considered"
+        else:
+            return f"Ignoring DAG {self.dag_id} from {self.incoming} - also found in {self.existing}"
 
 
 class AirflowClusterPolicyViolation(AirflowException):

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -447,7 +447,7 @@ class DagBag(LoggingMixin):
                     subdag.is_subdag = True
                     self._bag_dag(dag=subdag, root_dag=root_dag, recursive=False)
 
-            conflict_fileloc = self._check_if_dupe(dag)
+            conflict_fileloc = self._check_if_duplicate(dag)
             if conflict_fileloc is not None:
                 raise AirflowDagDuplicatedIdException(
                     dag_id=dag.dag_id,

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -475,6 +475,11 @@ class DagBag(LoggingMixin):
         """
         from airflow.models.serialized_dag import SerializedDagModel  # Avoid circular import
 
+        # Check for duplicate ID DAGs in the same file/dagbag
+        other_dag = self.dags.get(dag.dag_id)
+        if other_dag is not None:
+            return other_dag.fileloc
+
         other_dag = session.query(SerializedDagModel).filter(
             SerializedDagModel.dag_id == dag.dag_id,
             SerializedDagModel.fileloc_hash != DagCode.dag_fileloc_hash(dag.fileloc)

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -468,7 +468,7 @@ class DagBag(LoggingMixin):
             raise
 
     @provide_session
-    def _check_if_dupe(self, dag, session=None):
+    def _check_if_duplicate(self, dag, session=None):
         """
         Checks if a DAG with the same ID already exists.
         If present, returns the fileloc of the existing DAG.


### PR DESCRIPTION
While the exception (`AirflowDagDuplicatedIdException`) already
existed, till now it was being raised only when both the DAGs with
same ID were in the same file.

Closes #17861.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
