### PR TITLE
Adds Github Oauth example with team based authorization

### DIFF
--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -149,8 +149,10 @@ Here is an example of what you might have in your webserver_config.py:
     import os
 
     AUTH_TYPE = AUTH_OAUTH
-    AUTH_ROLES_SYNC_AT_LOGIN = True  # checks roles on every login
-    AUTH_USER_REGISTRATION = True  # allow users who are not already in the FAB DB to register
+    AUTH_ROLES_SYNC_AT_LOGIN = True  # Checks roles on every login
+    AUTH_USER_REGISTRATION = (
+        True  # allow users who are not already in the FAB DB to register
+    )
     # Make sure to replace this with the path to your security manager class
     FAB_SECURITY_MANAGER_CLASS = "your_module.your_security_manager_class"
     AUTH_ROLES_MAPPING = {
@@ -191,9 +193,9 @@ webserver_config.py itself if you wish.
 
     FAB_ADMIN_ROLE = "Admin"
     FAB_VIEWER_ROLE = "Viewer"
-    FAB_PUBLIC_ROLE = "Public"  # public means unauthorized
-    TEAM_ID_A_FROM_GITHUB = 123 # Replace these with real team IDs for your org
-    TEAM_ID_B_FROM_GITHUB = 456 # Replace these with real team IDs for your org
+    FAB_PUBLIC_ROLE = "Public"  # "Public" role is given no permissions
+    TEAM_ID_A_FROM_GITHUB = 123  # Replace these with real team IDs for your org
+    TEAM_ID_B_FROM_GITHUB = 456  # Replace these with real team IDs for your org
 
 
     def team_parser(team_payload: Dict[str, Any]) -> List[int]:
@@ -204,7 +206,7 @@ webserver_config.py itself if you wish.
     def map_roles(team_list: List[int]) -> List[str]:
         # Associate the team IDs with Roles here.
         # The expected output is a list of roles that FAB will use to Authorize the user.
-        
+
         team_role_map = {
             TEAM_ID_A_FROM_GITHUB: FAB_ADMIN_ROLE,
             TEAM_ID_B_FROM_GITHUB: FAB_VIEWER_ROLE,
@@ -220,7 +222,7 @@ webserver_config.py itself if you wish.
         def get_oauth_user_info(
             self, provider: str, resp: Any
         ) -> Dict[str, Union[str, List[str]]]:
-            
+
             # Creates the user info payload from Github.
             # The user previously allowed your app to act on thier behalf,
             #   so now we can query the user and teams endpoints for their data.
@@ -233,8 +235,7 @@ webserver_config.py itself if you wish.
             teams = team_parser(team_data.json())
             roles = map_roles(teams)
             log.debug(
-                f"User info from Github: {user_data}\n"
-                f"Team info from Github: {teams}"
+                f"User info from Github: {user_data}\n" f"Team info from Github: {teams}"
             )
             return {"username": "github_" + user_data.get("login"), "role_keys": roles}
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -133,6 +133,112 @@ the comments removed and configured in the ``$AIRFLOW_HOME/webserver_config.py``
 For more details, please refer to
 `Security section of FAB documentation <https://flask-appbuilder.readthedocs.io/en/latest/security.html>`_.
 
+Example using team based Authorization with Github OAuth
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+There are a few steps required in order to use team-based authorization with Github OAuth.
+
+* configure OAuth through the FAB config in webserver_config.py
+* create a custom security manager class and supply it to FAB in webserver_config.py
+* map the roles returned by your security manager class to roles that FAB understands.
+
+Here is an example of what you might have in your webserver_config.py:
+
+.. code-block:: python
+
+    from flask_appbuilder.security.manager import AUTH_OAUTH
+    import os
+
+    AUTH_TYPE = AUTH_OAUTH
+    AUTH_ROLES_SYNC_AT_LOGIN = True  # checks roles on every login
+    AUTH_USER_REGISTRATION = True  # allow users who are not already in the FAB DB to register
+    # Make sure to replace this with the path to your security manager class
+    FAB_SECURITY_MANAGER_CLASS = "your_module.your_security_manager_class"
+    AUTH_ROLES_MAPPING = {
+        "Viewer": ["Viewer"],
+        "Admin": ["Admin"],
+    }
+    # If you wish, you can add multiple OAuth providers.
+    OAUTH_PROVIDERS = [
+        {
+            "name": "github",
+            "icon": "fa-github",
+            "token_key": "access_token",
+            "remote_app": {
+                "client_id": os.getenv("OAUTH_APP_ID"),
+                "client_secret": os.getenv("OAUTH_APP_SECRET"),
+                "api_base_url": "https://api.github.com",
+                "client_kwargs": {"scope": "read:user, read:org"},
+                "access_token_url": "https://github.com/login/oauth/access_token",
+                "authorize_url": "https://github.com/login/oauth/authorize",
+                "request_token_url": None,
+            },
+        },
+    ]
+
+Here is an example of defining a custom security manager.
+This class must be available in Python's path, and could be defined in
+webserver_config.py itself if you wish.
+
+.. code-block:: python
+
+    from airflow.www.security import AirflowSecurityManager
+    import logging
+    from typing import Dict, Any, List, Union
+    import os
+
+    log = logging.getLogger(__name__)
+    log.setLevel(os.getenv("AIRFLOW__LOGGING__FAB_LOGGING_LEVEL", "INFO"))
+
+    FAB_ADMIN_ROLE = "Admin"
+    FAB_VIEWER_ROLE = "Viewer"
+    FAB_PUBLIC_ROLE = "Public"  # public means unauthorized
+    TEAM_ID_A_FROM_GITHUB = 123 # Replace these with real team IDs for your org
+    TEAM_ID_B_FROM_GITHUB = 456 # Replace these with real team IDs for your org
+
+
+    def team_parser(team_payload: Dict[str, Any]) -> List[int]:
+        # Parse the team payload from Github however you want here.
+        return [team["id"] for team in team_payload]
+
+
+    def map_roles(team_list: List[int]) -> List[str]:
+        # Associate the team IDs with Roles here.
+        # The expected output is a list of roles that FAB will use to Authorize the user.
+        
+        team_role_map = {
+            TEAM_ID_A_FROM_GITHUB: FAB_ADMIN_ROLE,
+            TEAM_ID_B_FROM_GITHUB: FAB_VIEWER_ROLE,
+        }
+        return list(set(team_role_map.get(team, FAB_PUBLIC_ROLE) for team in team_list))
+
+
+    class GithubTeamAuthorizer(AirflowSecurityManager):
+
+        # In this example, the oauth provider == 'github'.
+        # If you ever want to support other providers, see how it is done here:
+        # https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/security/manager.py#L550
+        def get_oauth_user_info(
+            self, provider: str, resp: Any
+        ) -> Dict[str, Union[str, List[str]]]:
+            
+            # Creates the user info payload from Github.
+            # The user previously allowed your app to act on thier behalf,
+            #   so now we can query the user and teams endpoints for their data.
+            # Username and team membership are added to the payload and returned to FAB.
+
+            remote_app = self.appbuilder.sm.oauth_remotes[provider]
+            me = remote_app.get("user")
+            user_data = me.json()
+            team_data = remote_app.get("user/teams")
+            teams = team_parser(team_data.json())
+            roles = map_roles(teams)
+            log.debug(
+                f"User info from Github: {user_data}\n"
+                f"Team info from Github: {teams}"
+            )
+            return {"username": "github_" + user_data.get("login"), "role_keys": roles}
+
+
 SSL
 ---
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -193,7 +193,7 @@ webserver_config.py itself if you wish.
 
     FAB_ADMIN_ROLE = "Admin"
     FAB_VIEWER_ROLE = "Viewer"
-    FAB_PUBLIC_ROLE = "Public"  # "Public" role is given no permissions
+    FAB_PUBLIC_ROLE = "Public"  # The "Public" role is given no permissions
     TEAM_ID_A_FROM_GITHUB = 123  # Replace these with real team IDs for your org
     TEAM_ID_B_FROM_GITHUB = 456  # Replace these with real team IDs for your org
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
---
Since Airflow 2 users must modify the default the security manager to use Github team membership for Authorization. This is a tall order for folks who may not be familiar with Airflow and FAB (like me).
This PR adds a section in the webserver documentation with an example of how to use github teams for authorization, along with GH OAuth for authentication. It demonstrates how to overwrite the default security manager and how to configure `webserver_config.py` so that FAB maps roles returned from the new custom security manager to roles that it expects.

See [this slack conversation](https://apache-airflow.slack.com/archives/C0146STM600/p1629395171159900) for more context

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
