### PR TITLE
Aligned button size in "Actions" group.

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -180,7 +180,7 @@
                   <div class="btn-group">
                     {% if dag %}
                     <div class="dropdown">
-                      <a aria-label="Trigger DAG" class="btn btn-default btn-icon-only{{ ' disabled' if not dag.can_trigger }} trigger-dropdown-btn" data-toggle="dropdown">
+                      <a aria-label="Trigger DAG" class="btn btn-sm btn-default btn-icon-only{{ ' disabled' if not dag.can_trigger }} trigger-dropdown-btn" data-toggle="dropdown">
                         <span class="material-icons" aria-hidden="true">play_arrow</span>
                       </a>
                       <ul class="dropdown-menu trigger-dropdown-menu">


### PR DESCRIPTION
In DAGs page, the 1<sup>st</sup> button (_"Trigger DAG" dropdown_) in "Actions" button group is too big, as others are `btn-sm`.

![image](https://user-images.githubusercontent.com/80445042/131293146-c8e683b4-d0ba-481f-8783-26f2d2b9e846.png)

P.S. cannot use `btn-group-sm` at outside, as it doesn't apply to dropdown.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
