### PR TITLE
Contributing Guide :: Replace stop_airflow script with command

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -421,7 +421,7 @@ MySQL Workbench with Host ``127.0.0.1``, port ``23306``, user ``root`` and passw
 
 .. code-block:: bash
 
-  root@f3619b74c59a:/opt/airflow# ./stop_airflow.sh
+  root@f3619b74c59a:/opt/airflow# stop_airflow.sh
   root@f3619b74c59a:/opt/airflow# exit
   $ breeze stop
 


### PR DESCRIPTION
**Replace stop_airflow script with command**

The Contributing quick start guide mentions `./stop_airflow,` whereas the actual script is mapped to `stop_airflow` via a soft link. Updated the same on the docs
