### PR TITLE
Warn that job_heartbeat_sec must be less than scheduler_health_check_threshold

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1687,7 +1687,8 @@
       description: |
         Task instances listen for external kill signal (when you clear tasks
         from the CLI or the UI), this defines the frequency at which they should
-        listen (in seconds).
+        listen (in seconds). Make sure that this value is not higher than scheduler_health_check_threshold
+        (default value 30) or tasks may be spuriously marked as zombie.
       version_added: ~
       type: string
       example: ~
@@ -1758,7 +1759,8 @@
       description: |
         If the last scheduler heartbeat happened more than scheduler_health_check_threshold
         ago (in seconds), scheduler is considered unhealthy.
-        This is used by the health check in the "/health" endpoint
+        This is used by the health check in the "/health" endpoint. Make sure that this value is higher
+        than job_heartbeat_sec (default value 5) or tasks may be spuriously marked as zombie.
       version_added: 1.10.2
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -841,7 +841,8 @@ tls_key =
 [scheduler]
 # Task instances listen for external kill signal (when you clear tasks
 # from the CLI or the UI), this defines the frequency at which they should
-# listen (in seconds).
+# listen (in seconds). Make sure that this value is not higher than scheduler_health_check_threshold
+# (default value 30) or tasks may be spuriously marked as zombie.
 job_heartbeat_sec = 5
 
 # How often (in seconds) to check and tidy up 'running' TaskInstancess
@@ -876,7 +877,8 @@ pool_metrics_interval = 5.0
 
 # If the last scheduler heartbeat happened more than scheduler_health_check_threshold
 # ago (in seconds), scheduler is considered unhealthy.
-# This is used by the health check in the "/health" endpoint
+# This is used by the health check in the "/health" endpoint. Make sure that this value is higher
+# than job_heartbeat_sec (default value 5) or tasks may be spuriously marked as zombie.
 scheduler_health_check_threshold = 30
 
 # How often (in seconds) should the scheduler check for orphaned tasks and SchedulerJobs


### PR DESCRIPTION
Adds note to the configuration reference warning that setting  `job_heartbeat_sec` to a value greater than `scheduler_health_check_threshold` will lead to tasks being marked as zombie.

related: #16573