### PR TITLE
Fix saving last choice of backend and other flags between breeze runs

### DIFF
--- a/breeze
+++ b/breeze
@@ -3578,6 +3578,10 @@ function breeze::determine_python_version_to_use_in_breeze() {
 
 breeze::setup_default_breeze_constants
 
+initialization::create_directories
+
+breeze::read_saved_environment_variables
+
 initialization::initialize_common_environment
 
 initialization::get_environment_for_builds_on_ci
@@ -3596,8 +3600,6 @@ breeze::parse_arguments "${@}"
 breeze::print_header_line
 
 build_images::forget_last_answer
-
-breeze::read_saved_environment_variables
 
 breeze::check_and_save_all_params
 

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -601,7 +601,6 @@ function initialization::set_output_color_variables() {
 # Common environment that is initialized by both Breeze and CI scripts
 function initialization::initialize_common_environment() {
     initialization::set_output_color_variables
-    initialization::create_directories
     initialization::initialize_base_variables
     initialization::initialize_branch_variables
     initialization::initialize_available_integrations

--- a/scripts/ci/libraries/_script_init.sh
+++ b/scripts/ci/libraries/_script_init.sh
@@ -31,6 +31,8 @@ readonly AIRFLOW_SOURCES
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 . "${AIRFLOW_SOURCES}/scripts/ci/libraries/_all_libs.sh"
 
+initialization::create_directories
+
 initialization::initialize_common_environment
 
 sanity_checks::basic_sanity_checks

--- a/tests/bats/bats_utils.bash
+++ b/tests/bats/bats_utils.bash
@@ -28,6 +28,8 @@ export SKIP_IN_CONTAINER_CHECK="true"
 # shellcheck source=scripts/ci/libraries/_all_libs.sh
 source "scripts/ci/libraries/_all_libs.sh"
 
+initialization::create_directories
+
 initialization::initialize_common_environment
 
 # shellcheck disable=SC1091


### PR DESCRIPTION
Breeze used to have the ability of storing the last choice of
backend and few other flags in the ".BUILD" directory. While
they were saved, one of the refactors changing the sequence
of initialization made the default value to override the one
provided by the .BUILD directory.

This PR changes the sequence of initialization slightly:

1) First we make sure that the .BUILD and few other temp dirs
   are created

2) Then we read variables stored there (if they are stored)

3) Then we follow through to the next steps of initialization and
   set the default values for parameters that do not have the
   values set yet

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
