### PR TITLE
SFTPOperator grant batch and regexp functions

### DIFF
--- a/airflow/providers/sftp/example_dags/__init__.py
+++ b/airflow/providers/sftp/example_dags/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/sftp/example_dags/example_sftp_operator.py
+++ b/airflow/providers/sftp/example_dags/example_sftp_operator.py
@@ -20,24 +20,25 @@
 import os
 from datetime import timedelta
 
-from airflow.operators.python import PythonOperator
-
 from airflow import DAG
-from airflow.utils.edgemodifier import Label
 from airflow.operators.bash import BashOperator
-from airflow.providers.sftp.operators.sftp import SFTPOperator, SFTPOperation
+from airflow.operators.python import PythonOperator
+from airflow.providers.sftp.operators.sftp import SFTPOperation, SFTPOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils.dates import days_ago
+from airflow.utils.edgemodifier import Label
 
 
 def all_files_exist():
-    if os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/txt/file1.txt") and \
-        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/txt/file2.txt") and \
-        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/csv/file3.csv") and \
-        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/csv/file4.csv") and \
-        os.path.isfile("/tmp/transfer_file/from_remote/put_files_file1.txt") and \
-        os.path.isfile("/tmp/transfer_file/from_remote/put_files_file2.txt") and \
-        os.path.isfile("/tmp/transfer_file/from_remote/put_file_file1.txt"):
+    if (
+        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/txt/file1.txt")
+        and os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/txt/file2.txt")
+        and os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/csv/file3.csv")
+        and os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/csv/file4.csv")
+        and os.path.isfile("/tmp/transfer_file/from_remote/put_files_file1.txt")
+        and os.path.isfile("/tmp/transfer_file/from_remote/put_files_file2.txt")
+        and os.path.isfile("/tmp/transfer_file/from_remote/put_file_file1.txt")
+    ):
         return True
     else:
         raise FileExistsError("Failed transfer")
@@ -54,17 +55,18 @@ with DAG(
 ) as dag:
     create_test_files = BashOperator(
         task_id="create_test_files",
-        bash_command=f"""
-        mkdir /tmp/transfer_file & echo "transfer file from local" >> /tmp/transfer_file/put_file_file1.txt &
-            echo "transfer file from local" >> /tmp/transfer_file/put_file_without_full_remote_path_file2.txt &
-            echo "transfer file from local" >> /tmp/transfer_file/put_files_file1.txt &
-            echo "transfer file from local" >> /tmp/transfer_file/put_files_file2.txt &
+        bash_command="""
+        mkdir /tmp/transfer_file &
+        echo "transfer file from local" >> /tmp/transfer_file/put_file_file1.txt &
+        echo "transfer file from local" >> /tmp/transfer_file/put_file_without_full_remote_path_file2.txt &
+        echo "transfer file from local" >> /tmp/transfer_file/put_files_file1.txt &
+        echo "transfer file from local" >> /tmp/transfer_file/put_files_file2.txt &
         mkdir /tmp/dir_for_remote_transfer &
             touch /tmp/dir_for_remote_transfer/file1.txt &
             touch /tmp/dir_for_remote_transfer/file2.txt &
             touch /tmp/dir_for_remote_transfer/file3.csv &
             touch /tmp/dir_for_remote_transfer/file4.csv &
-        ls /tmp/transfer_file & ls /tmp/transfer_file & ls /tmp/dir_for_remote_transfer"""
+        ls /tmp/transfer_file & ls /tmp/transfer_file & ls /tmp/dir_for_remote_transfer""",
     )
 
     # transfer one file to remote server with full file_path
@@ -74,7 +76,7 @@ with DAG(
         local_filepath="/tmp/transfer_file/put_file_file1.txt",
         remote_filepath="/tmp/transfer_file/remote/put_file_file1.txt",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # transfer file without absolute remote file path
@@ -84,7 +86,7 @@ with DAG(
         local_filepath="/tmp/transfer_file/put_file_without_full_remote_path_file2.txt",
         remote_filepath="/tmp/transfer_file/remote/",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # transfer 2 files without absolute remote file path
@@ -94,7 +96,7 @@ with DAG(
         local_filepath=["/tmp/transfer_file/put_files_file1.txt", "/tmp/transfer_file/put_files_file2.txt"],
         remote_filepath="/tmp/transfer_file/remote/",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # transfer all files with match ".*.txt" pattern in directory to remote path
@@ -105,7 +107,7 @@ with DAG(
         remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
         regexp_mask=".*.txt",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # transfer all files with match ".*.csv" pattern in directory to remote path
@@ -116,13 +118,13 @@ with DAG(
         remote_folder="/tmp/dir_for_remote_transfer/remote/csv/",
         regexp_mask=".*.csv",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # drop all local tmp files
     drop_local_test_files = BashOperator(
         task_id="drop_local_test_files",
-        bash_command="""rm -rf /tmp/transfer_file/* & rm -rf /tmp/dir_for_remote_transfer & ls /tmp"""
+        bash_command="""rm -rf /tmp/transfer_file/* & rm -rf /tmp/dir_for_remote_transfer & ls /tmp""",
     )
 
     # get file from remote to local
@@ -132,7 +134,7 @@ with DAG(
         local_filepath="/tmp/transfer_file/from_remote/put_file_file1.txt",
         remote_filepath="/tmp/transfer_file/remote/put_file_file1.txt",
         operation=SFTPOperation.GET,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # get 2 files from remote dir to local dir
@@ -140,10 +142,12 @@ with DAG(
         task_id="get_files",
         ssh_conn_id="ssh_default",
         local_filepath="/tmp/transfer_file/from_remote/",
-        remote_filepath=["/tmp/transfer_file/remote/put_files_file1.txt",
-                         "/tmp/transfer_file/remote/put_files_file2.txt"],
+        remote_filepath=[
+            "/tmp/transfer_file/remote/put_files_file1.txt",
+            "/tmp/transfer_file/remote/put_files_file2.txt",
+        ],
         operation=SFTPOperation.GET,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # get all remote files in dir to local dir
@@ -153,7 +157,7 @@ with DAG(
         local_folder="/tmp/dir_for_remote_transfer/from_remote/csv/",
         remote_folder="/tmp/dir_for_remote_transfer/remote/csv/",
         operation=SFTPOperation.GET,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     get_txt_dir = SFTPOperator(
@@ -162,32 +166,37 @@ with DAG(
         local_folder="/tmp/dir_for_remote_transfer/from_remote/txt/",
         remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
         operation=SFTPOperation.GET,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
     # drop all remote files
     drop_remote_files = SSHOperator(
         task_id="drop_remote_files",
         ssh_conn_id="ssh_default",
-        command="rm -rf /tmp/dir_for_remote_transfer & rm -rf /tmp/transfer_file & ls /tmp"
+        command="rm -rf /tmp/dir_for_remote_transfer & rm -rf /tmp/transfer_file & ls /tmp",
     )
 
-    check_transfer_file = PythonOperator(
-        task_id="check_transfer_file",
-        python_callable=all_files_exist
-    )
+    check_transfer_file = PythonOperator(task_id="check_transfer_file", python_callable=all_files_exist)
 
     bad_arguments = SFTPOperator(
         task_id="bad_arguments",
         ssh_conn_id="ssh_default",
         local_folder="/tmp/dir_for_remote_transfer/from_remote/csv/",
-        remote_filepath=["/tmp/transfer_file/remote/put_files_file1.txt",
-                         "/tmp/transfer_file/remote/put_files_file2.txt"],
+        remote_filepath=[
+            "/tmp/transfer_file/remote/put_files_file1.txt",
+            "/tmp/transfer_file/remote/put_files_file2.txt",
+        ],
         operation=SFTPOperation.GET,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
-    create_test_files >> Label("transfer data to remote server") >> \
-    [put_file, put_files, put_file_without_full_remote_path, put_dir_txt_files, put_dir_csv_files] >> \
-    drop_local_test_files >> Label("transfer data to local server") >> \
-    [get_file, get_files, get_csv_dir, get_txt_dir] >> drop_remote_files >> check_transfer_file
+    (
+        create_test_files
+        >> Label("transfer data to remote server")
+        >> [put_file, put_files, put_file_without_full_remote_path, put_dir_txt_files, put_dir_csv_files]
+        >> drop_local_test_files
+        >> Label("transfer data to local server")
+        >> [get_file, get_files, get_csv_dir, get_txt_dir]
+        >> drop_remote_files
+        >> check_transfer_file
+    )

--- a/airflow/providers/sftp/example_dags/example_sftp_operator.py
+++ b/airflow/providers/sftp/example_dags/example_sftp_operator.py
@@ -1,0 +1,193 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Example DAG demonstrating the usage of the SFTPOperator"""
+import os
+from datetime import timedelta
+
+from airflow.operators.python import PythonOperator
+
+from airflow import DAG
+from airflow.utils.edgemodifier import Label
+from airflow.operators.bash import BashOperator
+from airflow.providers.sftp.operators.sftp import SFTPOperator, SFTPOperation
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.utils.dates import days_ago
+
+
+def all_files_exist():
+    if os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/txt/file1.txt") and \
+        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/txt/file2.txt") and \
+        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/csv/file3.csv") and \
+        os.path.isfile("/tmp/dir_for_remote_transfer/from_remote/csv/file4.csv") and \
+        os.path.isfile("/tmp/transfer_file/from_remote/put_files_file1.txt") and \
+        os.path.isfile("/tmp/transfer_file/from_remote/put_files_file2.txt") and \
+        os.path.isfile("/tmp/transfer_file/from_remote/put_file_file1.txt"):
+        return True
+    else:
+        raise FileExistsError("Failed transfer")
+
+
+with DAG(
+    dag_id="example_sftp_operator",
+    schedule_interval="@once",
+    start_date=days_ago(1),
+    max_active_runs=1,
+    dagrun_timeout=timedelta(minutes=60),
+    concurrency=4,
+    tags=['example'],
+) as dag:
+    create_test_files = BashOperator(
+        task_id="create_test_files",
+        bash_command=f"""
+        mkdir /tmp/transfer_file & echo "transfer file from local" >> /tmp/transfer_file/put_file_file1.txt &
+            echo "transfer file from local" >> /tmp/transfer_file/put_file_without_full_remote_path_file2.txt &
+            echo "transfer file from local" >> /tmp/transfer_file/put_files_file1.txt &
+            echo "transfer file from local" >> /tmp/transfer_file/put_files_file2.txt &
+        mkdir /tmp/dir_for_remote_transfer &
+            touch /tmp/dir_for_remote_transfer/file1.txt &
+            touch /tmp/dir_for_remote_transfer/file2.txt &
+            touch /tmp/dir_for_remote_transfer/file3.csv &
+            touch /tmp/dir_for_remote_transfer/file4.csv &
+        ls /tmp/transfer_file & ls /tmp/transfer_file & ls /tmp/dir_for_remote_transfer"""
+    )
+
+    # transfer one file to remote server with full file_path
+    put_file = SFTPOperator(
+        task_id="put_file",
+        ssh_conn_id="ssh_default",
+        local_filepath="/tmp/transfer_file/put_file_file1.txt",
+        remote_filepath="/tmp/transfer_file/remote/put_file_file1.txt",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+    # transfer file without absolute remote file path
+    put_file_without_full_remote_path = SFTPOperator(
+        task_id="put_file_without_full_remote_path",
+        ssh_conn_id="ssh_default",
+        local_filepath="/tmp/transfer_file/put_file_without_full_remote_path_file2.txt",
+        remote_filepath="/tmp/transfer_file/remote/",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+    # transfer 2 files without absolute remote file path
+    put_files = SFTPOperator(
+        task_id="put_files",
+        ssh_conn_id="ssh_default",
+        local_filepath=["/tmp/transfer_file/put_files_file1.txt", "/tmp/transfer_file/put_files_file2.txt"],
+        remote_filepath="/tmp/transfer_file/remote/",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+    # transfer all files with match ".*.txt" pattern in directory to remote path
+    put_dir_txt_files = SFTPOperator(
+        task_id="put_dir_txt_files",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/",
+        remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
+        regexp_mask=".*.txt",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+    # transfer all files with match ".*.csv" pattern in directory to remote path
+    put_dir_csv_files = SFTPOperator(
+        task_id="put_dir_csv_files",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/",
+        remote_folder="/tmp/dir_for_remote_transfer/remote/csv/",
+        regexp_mask=".*.csv",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+    # drop all local tmp files
+    drop_local_test_files = BashOperator(
+        task_id="drop_local_test_files",
+        bash_command="""rm -rf /tmp/transfer_file/* & rm -rf /tmp/dir_for_remote_transfer & ls /tmp"""
+    )
+
+    # get file from remote to local
+    get_file = SFTPOperator(
+        task_id="get_file",
+        ssh_conn_id="ssh_default",
+        local_filepath="/tmp/transfer_file/from_remote/put_file_file1.txt",
+        remote_filepath="/tmp/transfer_file/remote/put_file_file1.txt",
+        operation=SFTPOperation.GET,
+        create_intermediate_dirs=True
+    )
+
+    # get 2 files from remote dir to local dir
+    get_files = SFTPOperator(
+        task_id="get_files",
+        ssh_conn_id="ssh_default",
+        local_filepath="/tmp/transfer_file/from_remote/",
+        remote_filepath=["/tmp/transfer_file/remote/put_files_file1.txt",
+                         "/tmp/transfer_file/remote/put_files_file2.txt"],
+        operation=SFTPOperation.GET,
+        create_intermediate_dirs=True
+    )
+
+    # get all remote files in dir to local dir
+    get_csv_dir = SFTPOperator(
+        task_id="get_csv_dir",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/from_remote/csv/",
+        remote_folder="/tmp/dir_for_remote_transfer/remote/csv/",
+        operation=SFTPOperation.GET,
+        create_intermediate_dirs=True
+    )
+
+    get_txt_dir = SFTPOperator(
+        task_id="get_txt_dir",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/from_remote/txt/",
+        remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
+        operation=SFTPOperation.GET,
+        create_intermediate_dirs=True
+    )
+
+    # drop all remote files
+    drop_remote_files = SSHOperator(
+        task_id="drop_remote_files",
+        ssh_conn_id="ssh_default",
+        command="rm -rf /tmp/dir_for_remote_transfer & rm -rf /tmp/transfer_file & ls /tmp"
+    )
+
+    check_transfer_file = PythonOperator(
+        task_id="check_transfer_file",
+        python_callable=all_files_exist
+    )
+
+    bad_arguments = SFTPOperator(
+        task_id="bad_arguments",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/from_remote/csv/",
+        remote_filepath=["/tmp/transfer_file/remote/put_files_file1.txt",
+                         "/tmp/transfer_file/remote/put_files_file2.txt"],
+        operation=SFTPOperation.GET,
+        create_intermediate_dirs=True
+    )
+
+    create_test_files >> Label("transfer data to remote server") >> \
+    [put_file, put_files, put_file_without_full_remote_path, put_dir_txt_files, put_dir_csv_files] >> \
+    drop_local_test_files >> Label("transfer data to local server") >> \
+    [get_file, get_files, get_csv_dir, get_txt_dir] >> drop_remote_files >> check_transfer_file

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """This module contains SFTP operator."""
-import ntpath
 import os
 import re
 from pathlib import Path
@@ -209,7 +208,7 @@ class SFTPOperator(BaseOperator):
                     elif self.operation.lower() == SFTPOperation.GET:
                         files_list = self._search_files(sftp_client.listdir(self.remote_folder))
                         for file in files_list:
-                            remote_file = ntpath.basename(file)
+                            remote_file = os.path.basename(file)
                             file_msg = file
                             self._transfer(sftp_client, self.local_folder, remote_file, self.remote_folder)
                 else:

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -181,23 +181,23 @@ class SFTPOperator(BaseOperator):
                         for file_path in self.local_filepath:
                             local_folder = os.path.dirname(file_path)
                             remote_folder = os.path.dirname(self.remote_filepath)
-                            local_file = ntpath.basename(file_path)
+                            local_file = os.path.basename(file_path)
                             self._transfer(sftp_client, local_folder, local_file, remote_folder)
                     elif isinstance(self.remote_filepath, list) and isinstance(self.local_filepath, str):
                         for file_path in self.remote_filepath:
                             remote_folder = os.path.dirname(file_path)
-                            remote_file = ntpath.basename(file_path)
+                            remote_file = os.path.basename(file_path)
                             self._transfer(sftp_client, self.local_filepath, remote_file, remote_folder)
                     elif isinstance(self.remote_filepath, str) and isinstance(self.local_filepath, str):
                         local_folder = os.path.dirname(self.local_filepath)
                         remote_folder = os.path.dirname(self.remote_filepath)
-                        local_file = ntpath.basename(self.local_filepath)
+                        local_file = os.path.basename(self.local_filepath)
                         self._transfer(sftp_client, local_folder, local_file, remote_folder)
                 elif self.local_folder and self.remote_folder:
                     if self.operation.lower() == SFTPOperation.PUT:
                         files_list = self._search_files(os.listdir(self.local_folder))
                         for file in files_list:
-                            local_file = ntpath.basename(file)
+                            local_file = os.path.basename(file)
                             self._transfer(sftp_client, self.local_folder, local_file, self.remote_folder)
                     elif self.operation.lower() == SFTPOperation.GET:
                         files_list = self._search_files(sftp_client.listdir(self.remote_folder))

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -74,7 +74,7 @@ class SFTPOperator(BaseOperator):
         at ``/tmp/tmp1/tmp2/`` while creating ``tmp``,``tmp1`` and ``tmp2`` if they
         don't exist. If the parameter is not passed it would error as the directory
         does not exist. ::
-
+            # for transfer only one file
             put_file = SFTPOperator(
                 task_id="put_file",
                 ssh_conn_id="ssh_default",
@@ -84,7 +84,7 @@ class SFTPOperator(BaseOperator):
                 create_intermediate_dirs=True,
                 dag=dag
             )
-
+            # for transfer more files
             put_files = SFTPOperator(
                 task_id="put_files",
                 ssh_conn_id="ssh_default",
@@ -93,7 +93,7 @@ class SFTPOperator(BaseOperator):
                 operation=SFTPOperation.PUT,
                 create_intermediate_dirs=True
             )
-
+            # for transfer all files in dir with pattern
             put_dir_txt_files = SFTPOperator(
                 task_id="put_dir_txt_files",
                 ssh_conn_id="ssh_default",
@@ -205,6 +205,8 @@ class SFTPOperator(BaseOperator):
                         for file in files_list:
                             remote_file = ntpath.basename(file)
                             self._transfer(sftp_client, self.local_folder, remote_file, self.remote_folder)
+                else:
+                    raise AirflowException(f"Argument mismatch, please read docs \n {SFTPOperator.__doc__}")
 
         except Exception as e:
             raise AirflowException(f"Error while transferring {file_msg}, error: {str(e)}")

--- a/airflow/providers/sftp/operators/sftp.py
+++ b/airflow/providers/sftp/operators/sftp.py
@@ -214,7 +214,7 @@ class SFTPOperator(BaseOperator):
     def _search_files(self, files) -> List:
         if self.regexp_mask:
             files = list(filter(re.compile(self.regexp_mask).match, files))
-        self.log.info(f"File for transfer: \n {files}")
+        self.log.info("File for transfer: \n %s", files)
         return files
 
     def _transfer(self, sftp_client: SFTPClient, local_folder, file, remote_path) -> None:

--- a/docs/apache-airflow-providers-sftp/operators/index.rst
+++ b/docs/apache-airflow-providers-sftp/operators/index.rst
@@ -23,7 +23,7 @@ Use the :class:`~airflow.providers.sftp.operators.sftp.py` to
 transfer data between servers under sftp.
 
 Using the Operator
-^^^^^^^^^^^^^^^^^^
+------------------
 To start working with an operator, you need to register an SFTP \ SSH connection in Airflow Connections.
 Use ssh_conn_id to specify the name of the connection.
 
@@ -62,7 +62,7 @@ You can use the operator for the following tasks:
 
 .. code-block:: python
 
-     put_dir_files = SFTPOperator(
+    put_dir_files = SFTPOperator(
         task_id="put_dir_files",
         ssh_conn_id="ssh_default",
         local_folder="/tmp/dir_for_remote_transfer/",

--- a/docs/apache-airflow-providers-sftp/operators/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/operators/sftp.rst
@@ -1,0 +1,87 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+.. _howto/operator:SFTPOperator:
+
+SFTPOperator
+==========================
+Use the :class:`~airflow.providers.sftp.operators.sftp.py` to
+transfer data between servers under sftp.
+
+Using the Operator
+^^^^^^^^^^^^^^^^^^
+To start working with an operator, you need to register an SFTP \ SSH connection in Airflow Connections.
+Use ssh_conn_id to specify the name of the connection.
+
+You can use the operator for the following tasks:
+1. Send one file to the server with the full path
+
+.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
+  :language: python
+    put_file = SFTPOperator(
+        task_id="put_file",
+        ssh_conn_id="ssh_default",
+        local_filepath="/tmp/transfer_file/put_file_file1.txt",
+        remote_filepath="/tmp/transfer_file/remote/put_file_file1.txt",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+2. Send multiple files to the specified directory on the remote server
+
+.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
+  :language: python
+    put_files = SFTPOperator(
+        task_id="put_files",
+        ssh_conn_id="ssh_default",
+        local_filepath=["/tmp/transfer_file/put_files_file1.txt", "/tmp/transfer_file/put_files_file2.txt"],
+        remote_filepath="/tmp/transfer_file/remote/",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+3. Send all files from local directory to remote server
+
+.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
+  :language: python
+     put_dir_files = SFTPOperator(
+        task_id="put_dir_files",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/",
+        remote_folder="/tmp/dir_for_remote_transfer/remote/",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+4. Send all files from the local directory that match the specified pattern to the remote server
+
+.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
+  :language: python
+    put_dir_txt_files = SFTPOperator(
+        task_id="put_dir_txt_files",
+        ssh_conn_id="ssh_default",
+        local_folder="/tmp/dir_for_remote_transfer/",
+        remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
+        regexp_mask=".*.txt",
+        operation=SFTPOperation.PUT,
+        create_intermediate_dirs=True
+    )
+
+The operator also supports transfer files from a remote server to a local,
+for this you need to change the parameter ``operation`` from ``SFTPOperation.PUT`` to ``SFTPOperation.GET``.
+Parameter ``create_intermediate_dirs`` needed for create missing intermediate directories when
+copying from remote to local and vice-versa. Default is False.

--- a/docs/apache-airflow-providers-sftp/operators/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/operators/sftp.rst
@@ -39,7 +39,7 @@ You can use the operator for the following tasks:
         local_filepath="/tmp/transfer_file/put_file_file1.txt",
         remote_filepath="/tmp/transfer_file/remote/put_file_file1.txt",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
 2. Send multiple files to the specified directory on the remote server
@@ -49,10 +49,13 @@ You can use the operator for the following tasks:
     put_files = SFTPOperator(
         task_id="put_files",
         ssh_conn_id="ssh_default",
-        local_filepath=["/tmp/transfer_file/put_files_file1.txt", "/tmp/transfer_file/put_files_file2.txt"],
+        local_filepath=[
+            "/tmp/transfer_file/put_files_file1.txt",
+            "/tmp/transfer_file/put_files_file2.txt",
+        ],
         remote_filepath="/tmp/transfer_file/remote/",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
 3. Send all files from local directory to remote server
@@ -65,7 +68,7 @@ You can use the operator for the following tasks:
         local_folder="/tmp/dir_for_remote_transfer/",
         remote_folder="/tmp/dir_for_remote_transfer/remote/",
         operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
+        create_intermediate_dirs=True,
     )
 
 4. Send all files from the local directory that match the specified pattern to the remote server
@@ -79,7 +82,7 @@ You can use the operator for the following tasks:
       remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
       regexp_mask=".*.txt",
       operation=SFTPOperation.PUT,
-      create_intermediate_dirs=True
+      create_intermediate_dirs=True,
   )
 
 The operator also supports transfer files from a remote server to a local,

--- a/docs/apache-airflow-providers-sftp/operators/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/operators/sftp.rst
@@ -28,10 +28,11 @@ To start working with an operator, you need to register an SFTP \ SSH connection
 Use ssh_conn_id to specify the name of the connection.
 
 You can use the operator for the following tasks:
+
 1. Send one file to the server with the full path
 
-.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
-  :language: python
+.. code-block:: python
+
     put_file = SFTPOperator(
         task_id="put_file",
         ssh_conn_id="ssh_default",
@@ -43,8 +44,8 @@ You can use the operator for the following tasks:
 
 2. Send multiple files to the specified directory on the remote server
 
-.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
-  :language: python
+.. code-block:: python
+
     put_files = SFTPOperator(
         task_id="put_files",
         ssh_conn_id="ssh_default",
@@ -56,8 +57,8 @@ You can use the operator for the following tasks:
 
 3. Send all files from local directory to remote server
 
-.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
-  :language: python
+.. code-block:: python
+
      put_dir_files = SFTPOperator(
         task_id="put_dir_files",
         ssh_conn_id="ssh_default",
@@ -69,17 +70,17 @@ You can use the operator for the following tasks:
 
 4. Send all files from the local directory that match the specified pattern to the remote server
 
-.. exampleinclude airflow/providers/sftp/example_dags/example_sftp_operator.py
-  :language: python
-    put_dir_txt_files = SFTPOperator(
-        task_id="put_dir_txt_files",
-        ssh_conn_id="ssh_default",
-        local_folder="/tmp/dir_for_remote_transfer/",
-        remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
-        regexp_mask=".*.txt",
-        operation=SFTPOperation.PUT,
-        create_intermediate_dirs=True
-    )
+.. code-block:: python
+
+  put_dir_txt_files = SFTPOperator(
+      task_id="put_dir_txt_files",
+      ssh_conn_id="ssh_default",
+      local_folder="/tmp/dir_for_remote_transfer/",
+      remote_folder="/tmp/dir_for_remote_transfer/remote/txt/",
+      regexp_mask=".*.txt",
+      operation=SFTPOperation.PUT,
+      create_intermediate_dirs=True
+  )
 
 The operator also supports transfer files from a remote server to a local,
 for this you need to change the parameter ``operation`` from ``SFTPOperation.PUT`` to ``SFTPOperation.GET``.

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -359,7 +359,9 @@ class TestSFTPOperator(unittest.TestCase):
         )
         ti2 = TaskInstance(task=show_files, execution_date=timezone.utcnow())
         ti2.run()
-        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == test_output.encode('utf8')
+        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == test_output.encode(
+            'utf8'
+        )
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_regexp_files(self):
@@ -416,8 +418,10 @@ class TestSFTPOperator(unittest.TestCase):
             task_id="get_files",
             ssh_hook=self.hook,
             local_filepath=self.test_local_dir,
-            remote_filepath=[f"{self.test_remote_dir}/{self.test_txt_file}",
-                             f"{self.test_remote_dir}/{self.test_csv_file}"],
+            remote_filepath=[
+                f"{self.test_remote_dir}/{self.test_txt_file}",
+                f"{self.test_remote_dir}/{self.test_csv_file}",
+            ],
             operation=SFTPOperation.GET,
             create_intermediate_dirs=True,
             dag=self.dag,
@@ -504,16 +508,13 @@ class TestSFTPOperator(unittest.TestCase):
         show_files = SSHOperator(
             task_id="show_files",
             ssh_hook=self.hook,
-            command=f"find {self.test_remote_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
+            command=fr"find {self.test_remote_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
             do_xcom_push=True,
             dag=self.dag,
         )
         ti2 = TaskInstance(task=show_files, execution_date=timezone.utcnow())
         ti2.run()
-        assert (
-            ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip()
-            == b"2"
-        )
+        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == b"2"
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_file_transfer_with_intermediate_dir_error_get(self):
@@ -665,6 +666,7 @@ class TestSFTPOperator(unittest.TestCase):
             os.remove(self.test_remote_filepath_int_dir)
         if os.path.exists(self.test_remote_dir):
             import shutil
+
             shutil.rmtree(self.test_remote_dir)
 
     def tearDown(self):

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -401,13 +401,21 @@ class TestSFTPOperator(unittest.TestCase):
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_many_files_to_local(self):
-        test_txt_file_content = b"is txt file"
-        test_csv_file_content = b"is csv file"
-        os.mkdir(self.test_remote_dir)
-        with open(f'{self.test_remote_dir}/{self.test_txt_file}', 'wb') as f:
-            f.write(test_txt_file_content)
-        with open(f'{self.test_remote_dir}/{self.test_csv_file}', 'wb') as f:
-            f.write(test_csv_file_content)
+        test_txt_file_content = "is txt file"
+        test_csv_file_content = "is csv file"
+        create_file_task = SSHOperator(
+            task_id="test_create_file",
+            ssh_hook=self.hook,
+            command=f"mkdir -p {self.test_remote_dir} |"
+                    f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
+                    f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
+            do_xcom_push=False,
+            dag=self.dag,
+        )
+        assert create_file_task is not None
+        ti0 = TaskInstance(task=create_file_task, execution_date=timezone.utcnow())
+        ti0.run()
+
         get_files = SFTPOperator(
             task_id="get_files",
             ssh_hook=self.hook,
@@ -438,13 +446,22 @@ class TestSFTPOperator(unittest.TestCase):
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_all_files_to_local(self):
-        test_txt_file_content = b"is txt file"
-        test_csv_file_content = b"is csv file"
-        os.mkdir(self.test_remote_dir)
-        with open(f'{self.test_remote_dir}/{self.test_txt_file}', 'wb') as f:
-            f.write(test_txt_file_content)
-        with open(f'{self.test_remote_dir}/{self.test_csv_file}', 'wb') as f:
-            f.write(test_csv_file_content)
+        test_txt_file_content = "is txt file"
+        test_csv_file_content = "is csv file"
+
+        create_file_task = SSHOperator(
+            task_id="test_create_file",
+            ssh_hook=self.hook,
+            command=f"mkdir -p {self.test_remote_dir} |"
+                    f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
+                    f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
+            do_xcom_push=False,
+            dag=self.dag,
+        )
+        assert create_file_task is not None
+        ti0 = TaskInstance(task=create_file_task, execution_date=timezone.utcnow())
+        ti0.run()
+
         get_files = SFTPOperator(
             task_id="get_files",
             ssh_hook=self.hook,

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -337,8 +337,10 @@ class TestSFTPOperator(unittest.TestCase):
         put_files = SFTPOperator(
             task_id="put_files",
             ssh_hook=self.hook,
-            local_filepath=[f"{self.test_local_dir}/{self.test_txt_file}",
-                            f"{self.test_local_dir}/{self.test_csv_file}"],
+            local_filepath=[
+                f"{self.test_local_dir}/{self.test_txt_file}",
+                f"{self.test_local_dir}/{self.test_csv_file}",
+            ],
             remote_filepath=self.test_remote_dir,
             operation=SFTPOperation.PUT,
             create_intermediate_dirs=True,
@@ -357,10 +359,7 @@ class TestSFTPOperator(unittest.TestCase):
         )
         ti2 = TaskInstance(task=show_files, execution_date=timezone.utcnow())
         ti2.run()
-        assert (
-            ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip()
-            == test_output.encode('utf8')
-        )
+        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == test_output.encode('utf8')
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_regexp_files(self):
@@ -388,16 +387,13 @@ class TestSFTPOperator(unittest.TestCase):
         show_files = SSHOperator(
             task_id="show_files",
             ssh_hook=self.hook,
-            command=f"find {self.test_remote_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
+            command=fr"find {self.test_remote_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
             do_xcom_push=True,
             dag=self.dag,
         )
         ti2 = TaskInstance(task=show_files, execution_date=timezone.utcnow())
         ti2.run()
-        assert (
-            ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip()
-            == b"1"
-        )
+        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == b"1"
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_many_files_to_local(self):
@@ -407,8 +403,8 @@ class TestSFTPOperator(unittest.TestCase):
             task_id="test_create_file",
             ssh_hook=self.hook,
             command=f"mkdir -p {self.test_remote_dir} |"
-                    f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
-                    f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
+            f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
+            f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
             do_xcom_push=False,
             dag=self.dag,
         )
@@ -433,16 +429,13 @@ class TestSFTPOperator(unittest.TestCase):
         show_files = SSHOperator(
             task_id="show_files",
             ssh_hook=self.hook,
-            command=f"find {self.test_local_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
+            command=fr"find {self.test_local_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
             do_xcom_push=True,
             dag=self.dag,
         )
         ti2 = TaskInstance(task=show_files, execution_date=timezone.utcnow())
         ti2.run()
-        assert (
-            ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip()
-            == b"2"
-        )
+        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == b"2"
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_all_files_to_local(self):
@@ -453,8 +446,8 @@ class TestSFTPOperator(unittest.TestCase):
             task_id="test_create_file",
             ssh_hook=self.hook,
             command=f"mkdir -p {self.test_remote_dir} |"
-                    f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
-                    f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
+            f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
+            f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
             do_xcom_push=False,
             dag=self.dag,
         )
@@ -478,16 +471,13 @@ class TestSFTPOperator(unittest.TestCase):
         show_files = SSHOperator(
             task_id="show_files",
             ssh_hook=self.hook,
-            command=f"find {self.test_local_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
+            command=fr"find {self.test_local_dir} -maxdepth 1 -type f -not -path '*/\.*' | wc -l",
             do_xcom_push=True,
             dag=self.dag,
         )
         ti2 = TaskInstance(task=show_files, execution_date=timezone.utcnow())
         ti2.run()
-        assert (
-            ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip()
-            == b"2"
-        )
+        assert ti2.xcom_pull(task_ids=show_files.task_id, key='return_value').strip() == b"2"
 
     @conf_vars({('core', 'enable_xcom_pickling'): 'True'})
     def test_transfer_all_files_to_remote(self):

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -665,7 +665,6 @@ class TestSFTPOperator(unittest.TestCase):
         if os.path.exists(self.test_remote_filepath_int_dir):
             os.remove(self.test_remote_filepath_int_dir)
         if os.path.exists(self.test_remote_dir):
-            import shutil
 
             shutil.rmtree(self.test_remote_dir)
 

--- a/tests/providers/sftp/operators/test_sftp.py
+++ b/tests/providers/sftp/operators/test_sftp.py
@@ -402,8 +402,8 @@ class TestSFTPOperator(unittest.TestCase):
         create_file_task = SSHOperator(
             task_id="test_create_file",
             ssh_hook=self.hook,
-            command=f"mkdir -p {self.test_remote_dir} |"
-            f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
+            command=f"mkdir -p {self.test_remote_dir} && "
+            f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} && "
             f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
             do_xcom_push=False,
             dag=self.dag,
@@ -445,8 +445,8 @@ class TestSFTPOperator(unittest.TestCase):
         create_file_task = SSHOperator(
             task_id="test_create_file",
             ssh_hook=self.hook,
-            command=f"mkdir -p {self.test_remote_dir} |"
-            f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} | "
+            command=f"mkdir -p {self.test_remote_dir} && "
+            f"echo '{test_txt_file_content}' >> {self.test_remote_dir}/{self.test_txt_file} && "
             f"echo '{test_csv_file_content}' >> {self.test_remote_dir}/{self.test_csv_file}",
             do_xcom_push=False,
             dag=self.dag,


### PR DESCRIPTION
Closes AIRFLOW-5703. Continuing previous work (for reference) in #16792.

Added next features:
1. transfer a list of files to a remote directory or a list of remote files to a local directory
2. transfer all files from a local or remote directory without specifying the files themselves
3. transfer files according to the pattern both to a remote directory and back

![image](https://user-images.githubusercontent.com/86562687/124365304-bd37a600-dc4f-11eb-8c50-9bea4d997a8f.png)