### PR TITLE
Add example of TaskFlow to declare task dependencies

### DIFF
--- a/docs/apache-airflow/concepts/tasks.rst
+++ b/docs/apache-airflow/concepts/tasks.rst
@@ -56,10 +56,10 @@ Option 3: The @task decorator provided by TaskFlow API, see :ref:`concepts:taskf
     def first_task():
         ...
         
-    second_task(first_task()))
+    second_task(first_task())
     
 
-The former two do exactly the same thing and work on any type of Operator, but in general we recommend you use the bitshift operators, as they are easier to read in most cases. The TaskFlow API likewise connects dependencies between tasks, but is tailored to python functions written with the @task-decorator, note that the functions here are not executed inline, rather they are converted to tasks to be scheduled and sent to Executors, for more information see see :ref:`concepts:taskflow`.
+The former two do exactly the same thing and work on any type of Operator, but in general we recommend you use the bitshift operators, as they are easier to read in most cases. The TaskFlow API likewise connects dependencies between tasks, but is tailored to python functions written with the @task-decorator, note that the functions here are not executed inline, rather they are converted to tasks to be scheduled and sent to Executors, for more information see see :ref:`TaskFlow <concepts:taskflow>`.
 
 By default, a Task will run when all of its upstream (parent) tasks have succeeded, but there are many ways of modifying this behaviour to add branching, only wait for some upstream tasks, or change behaviour based on where the current run is in history. For more, see :ref:`concepts:control-flow`.
 

--- a/docs/apache-airflow/concepts/tasks.rst
+++ b/docs/apache-airflow/concepts/tasks.rst
@@ -47,7 +47,7 @@ Option 2: The more explicit ``set_upstream`` and ``set_downstream`` methods::
     first_task.set_downstream(second_task)
     third_task.set_upstream(second_task)
     
-Option 3: The @task decorator provided by TaskFlow API, see :ref:`concepts:taskflow`::
+Option 3: The @task decorator provided by TaskFlow API, see :ref:`TaskFlow <concepts:taskflow>`::
 
     @task
     def second_task(some_parameter):
@@ -59,7 +59,7 @@ Option 3: The @task decorator provided by TaskFlow API, see :ref:`concepts:taskf
     second_task(first_task())
     
 
-The former two do exactly the same thing and work on any type of Operator, but in general we recommend you use the bitshift operators, as they are easier to read in most cases. The TaskFlow API likewise connects dependencies between tasks, but is tailored to python functions written with the @task-decorator, note that the functions here are not executed inline, rather they are converted to tasks to be scheduled and sent to Executors, for more information see see :ref:`TaskFlow <concepts:taskflow>`.
+The former two do exactly the same thing and work on any type of Operator, but in general we recommend you use the bitshift operators, as they are easier to read in most cases. The TaskFlow API likewise connects dependencies between tasks, but is tailored to python functions written with the @task-decorator, note that the functions here are not executed inline, rather they are converted to tasks to be scheduled and sent to Executors, for more information see :ref:`TaskFlow <concepts:taskflow>`.
 
 By default, a Task will run when all of its upstream (parent) tasks have succeeded, but there are many ways of modifying this behaviour to add branching, only wait for some upstream tasks, or change behaviour based on where the current run is in history. For more, see :ref:`concepts:control-flow`.
 

--- a/docs/apache-airflow/concepts/tasks.rst
+++ b/docs/apache-airflow/concepts/tasks.rst
@@ -36,16 +36,30 @@ Relationships
 
 The key part of using Tasks is defining how they relate to each other - their *dependencies*, or as we say in Airflow, their *upstream* and *downstream* tasks. You declare your Tasks first, and then you declare their dependencies second.
 
-There are two ways of declaring dependencies - using the ``>>`` and ``<<`` (bitshift) operators::
+There are three ways of declaring dependencies:
+
+Option 1: using the ``>>`` and ``<<`` (bitshift) operators::
 
     first_task >> second_task >> [third_task, fourth_task]
 
-Or the more explicit ``set_upstream`` and ``set_downstream`` methods::
+Option 2: The more explicit ``set_upstream`` and ``set_downstream`` methods::
 
     first_task.set_downstream(second_task)
     third_task.set_upstream(second_task)
+    
+Option 3: The @task decorator provided by TaskFlow API, see :ref:`concepts:taskflow`::
 
-These both do exactly the same thing, but in general we recommend you use the bitshift operators, as they are easier to read in most cases.
+    @task
+    def second_task(some_parameter):
+        ...
+    @task 
+    def first_task():
+        ...
+        
+    second_task(first_task()))
+    
+
+The former two do exactly the same thing and work on any type of Operator, but in general we recommend you use the bitshift operators, as they are easier to read in most cases. The TaskFlow API likewise connects dependencies between tasks, but is tailored to python functions written with the @task-decorator, note that the functions here are not executed inline, rather they are converted to tasks to be scheduled and sent to Executors, for more information see see :ref:`concepts:taskflow`.
 
 By default, a Task will run when all of its upstream (parent) tasks have succeeded, but there are many ways of modifying this behaviour to add branching, only wait for some upstream tasks, or change behaviour based on where the current run is in history. For more, see :ref:`concepts:control-flow`.
 

--- a/docs/apache-airflow/concepts/tasks.rst
+++ b/docs/apache-airflow/concepts/tasks.rst
@@ -46,18 +46,18 @@ Option 2: The more explicit ``set_upstream`` and ``set_downstream`` methods::
 
     first_task.set_downstream(second_task)
     third_task.set_upstream(second_task)
-    
+
 Option 3: The @task decorator provided by TaskFlow API, see :ref:`TaskFlow <concepts:taskflow>`::
 
     @task
     def second_task(some_parameter):
         ...
-    @task 
+    @task
     def first_task():
         ...
-        
+
     second_task(first_task())
-    
+
 
 The former two do exactly the same thing and work on any type of Operator, but in general we recommend you use the bitshift operators, as they are easier to read in most cases. The TaskFlow API likewise connects dependencies between tasks, but is tailored to python functions written with the @task-decorator, note that the functions here are not executed inline, rather they are converted to tasks to be scheduled and sent to Executors, for more information see :ref:`TaskFlow <concepts:taskflow>`.
 


### PR DESCRIPTION
As a new user of Airflow it is not obvious to realize TaskFlow exists and 
one might think declaring dependencies between tasks is very verbose.
Having more examples of such would help in promoting this style of 
writing DAGs and speed up on-boarding.