### PR TITLE
Update error message to guide the user into self-help mostly

### DIFF
--- a/airflow/www/templates/airflow/traceback.html
+++ b/airflow/www/templates/airflow/traceback.html
@@ -28,7 +28,24 @@
       <div>
           <pre>
 Something bad has happened.
-Please consider letting us know by creating a <b><a href="https://github.com/apache/airflow/issues/new/choose">bug report using GitHub</a></b>.
+
+Airflow is used by many users, and it is very likely that others had similar problems and you can easily find
+a solution to your problem.
+
+Consider following those steps:
+
+  * gather the relevant information (detailed logs with errors, reproduction steps, details of your deployment)
+
+  * find similar issues using:
+     * <b><a href="https://github.com/apache/airflow/discussions">GitHub Discussions</a></b>
+     * <b><a href="https://github.com/apache/airflow/issues">GitHub Issues</a></b>
+     * <b><a href="https://stackoverflow.com/questions/tagged/airflow">Stack Overflow</a></b>
+     * the usual search engine you use on a daily basis
+
+  * if you run Airflow on a Managed Service, consider opening an issue using the service support channels
+
+  * if you tried and have difficulty with diagnosing and fixing the problem yourself, consider creating a <b><a href="https://github.com/apache/airflow/issues/new/choose">bug report</a></b>.
+    Make sure however, to include all relevant details and results of your investigation so far.
 
 Python version: {{ python_version }}
 Airflow version: {{ airflow_version }}


### PR DESCRIPTION
The error report generated, when there is a crash on webserver,
directed the user to open an issue in Apache Airflow without any
extra explanation or suggesting other actions. This is not a good
idea because it might lead people to thinking that they can
just follow the link, open issue and it will be solved, However,
more often than not such issue can be caused by misconfiguration,
networking or other actions that the user should - in many cases -
be able to fix or workaround on their own, with a little effort
of gathering logs/information and searching for relevant problems.

This PR changes the message as folows:

* explains that user should gather more information (the link
  and bug report does not contain any information)
* search for similar problem (we provide links to the places which
  can be searched and suggest using regular search engine as well
* direct the managed services users to open the issue using
  relevant channels
* only as the last resort, opening an issue in Airflow GitHub,
  providing sufficient information.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
