### PR TITLE
enable setting of pod specific annotations

### DIFF
--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -54,9 +54,14 @@ spec:
 {{- with .Values.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-      {{- if .Values.airflowPodAnnotations }}
+      {{- if or .Values.airflowPodAnnotations .Values.flower.podAnnotations }}
       annotations:
+      {{- if .Values.airflowPodAnnotations }}
       {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.flower.podAnnotations }}
+      {{- toYaml .Values.flower.podAnnotations | nindent 8 }}
+      {{- end }}
       {{- end }}
     spec:
       nodeSelector:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -85,6 +85,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.scheduler.podAnnotations }}
+        {{- toYaml .Values.scheduler.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -68,6 +68,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.triggerer.podAnnotations }}
+        {{- toYaml .Values.triggerer.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
         {{- toYaml $nodeSelector | nindent 8 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -80,6 +80,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.webserver.podAnnotations }}
+        {{- toYaml .Values.webserver.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "webserver.serviceAccountName" . }}
       nodeSelector:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1287,10 +1287,10 @@
                     }
                 },
                 "podAnnotations": {
-                  "description": "Annotations specific to the scheduler pod.",
-                  "type": "object",
-                  "default": {},
-                  "x-docsSection": "Kubernetes"
+                    "description": "Annotations specific to the scheduler pod.",
+                    "type": "object",
+                    "default": {},
+                    "x-docsSection": "Kubernetes"
                 },
                 "resources": {
                     "description": "Resources for scheduler pods.",
@@ -1556,10 +1556,10 @@
                     "default": []
                 },
                 "podAnnotations": {
-                  "description": "Annotations specific to the triggerer pod.",
-                  "type": "object",
-                  "default": {},
-                  "x-docsSection": "Kubernetes"
+                    "description": "Annotations specific to the triggerer pod.",
+                    "type": "object",
+                    "default": {},
+                    "x-docsSection": "Kubernetes"
                 },
                 "nodeSelector": {
                     "description": "Select certain nodes for triggerer pods.",
@@ -2020,10 +2020,10 @@
                     }
                 },
                 "podAnnotations": {
-                  "description": "Annotations specific to the webserver pod.",
-                  "type": "object",
-                  "default": {},
-                  "x-docsSection": "Kubernetes"
+                    "description": "Annotations specific to the webserver pod.",
+                    "type": "object",
+                    "default": {},
+                    "x-docsSection": "Kubernetes"
                 },
                 "nodeSelector": {
                     "description": "Select certain nodes for webserver pods.",
@@ -2246,10 +2246,10 @@
                     "default": []
                 },
                 "podAnnotations": {
-                  "description": "Annotations specific to the flower pod.",
-                  "type": "object",
-                  "default": {},
-                  "x-docsSection": "Kubernetes"
+                    "description": "Annotations specific to the flower pod.",
+                    "type": "object",
+                    "default": {},
+                    "x-docsSection": "Kubernetes"
                 },
                 "nodeSelector": {
                     "description": "Select certain nodes for Flower pods.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1286,6 +1286,12 @@
                         }
                     }
                 },
+                "podAnnotations": {
+                  "description": "Annotations specific to the scheduler pod.",
+                  "type": "object",
+                  "default": {},
+                  "x-docsSection": "Kubernetes"
+                },
                 "resources": {
                     "description": "Resources for scheduler pods.",
                     "type": "object",
@@ -1548,6 +1554,12 @@
                     "description": "Mount additional volumes into triggerer.",
                     "type": "array",
                     "default": []
+                },
+                "podAnnotations": {
+                  "description": "Annotations specific to the triggerer pod.",
+                  "type": "object",
+                  "default": {},
+                  "x-docsSection": "Kubernetes"
                 },
                 "nodeSelector": {
                     "description": "Select certain nodes for triggerer pods.",
@@ -2007,6 +2019,12 @@
                         }
                     }
                 },
+                "podAnnotations": {
+                  "description": "Annotations specific to the webserver pod.",
+                  "type": "object",
+                  "default": {},
+                  "x-docsSection": "Kubernetes"
+                },
                 "nodeSelector": {
                     "description": "Select certain nodes for webserver pods.",
                     "type": "object",
@@ -2226,6 +2244,12 @@
                     "description": "Mount additional volumes into the flower pods.",
                     "type": "array",
                     "default": []
+                },
+                "podAnnotations": {
+                  "description": "Annotations specific to the flower pod.",
+                  "type": "object",
+                  "default": {},
+                  "x-docsSection": "Kubernetes"
                 },
                 "nodeSelector": {
                     "description": "Select certain nodes for Flower pods.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -528,6 +528,9 @@ scheduler:
   extraVolumes: []
   extraVolumeMounts: []
 
+  # scheduler specific pod annotations
+  podAnnotations: {}
+
   # Select certain nodes for airflow scheduler pods.
   nodeSelector: {}
   affinity:
@@ -675,6 +678,9 @@ webserver:
   extraVolumes: []
   extraVolumeMounts: []
 
+  # webserver specific pod annotations
+  podAnnotations: {}
+
   # This string (can be templated) will be mounted into the Airflow Webserver as a custom
   # webserver_config.py. You can bake a webserver_config.py in to your image instead.
   webserverConfig: ~
@@ -758,6 +764,9 @@ triggerer:
     # Annotations to add to triggerer kubernetes service account.
     annotations: {}
 
+  # triggerer specific pod annotations
+  podAnnotations: {}
+
   resources: {}
   #  limits:
   #   cpu: 100m
@@ -821,6 +830,9 @@ flower:
       # Ports for flower NetworkPolicy ingress (if ingressPeers is set)
       ports:
         - port: flower-ui
+
+  # flower specific pod annotations
+  podAnnotations: {}
 
   resources: {}
   #   limits:


### PR DESCRIPTION
Allow for pod specific annotations.

Our specific use case requires this for scraping additional openmetrics exposed via plugin by the airflow webserver.
The webserver pod requires annotations that are picked up by our datadog agents to enable and configure the scraping.

For consistency this PR also enables specific pod annotations for scheduler, triggerer and flower.

