### PR TITLE
Fix docs about login for hdfs connections

### DIFF
--- a/docs/apache-airflow-providers-apache-hdfs/connections.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/connections.rst
@@ -36,11 +36,13 @@ Host
 Port
     Specify the port in case of host be an URL.
 
+Login
+    Effective user for HDFS operations (non-Kerberized).
+
 Extra (optional, connection parameters)
     Specify the extra parameters (as json dictionary) that can be used in HDFS connection. The following
     parameters out of the standard python parameters are supported:
 
-    * ``proxy_user`` - Effective user for HDFS operations.
     * ``autoconfig`` - Default value is bool: False. Use snakebite's automatically configured client. This HDFSHook implementation requires snakebite.
 
     The following extra parameters can be used to configure SSL for Web HDFS Hook:


### PR DESCRIPTION
Noticed a minor inaccuracy  in hdfs provider documentation - connections are using `login` field instead of `proxy_user` from `Extra` as is said in the documentation. See https://github.com/apache/airflow/blob/main/airflow/providers/apache/hdfs/hooks/webhdfs.py#L106 or https://github.com/apache/airflow/blob/main/airflow/providers/apache/hdfs/hooks/hdfs.py#L80 .