### PR TITLE
Always upgrade to newer dependencies in main

### DIFF
--- a/scripts/ci/selective_ci_checks.sh
+++ b/scripts/ci/selective_ci_checks.sh
@@ -691,6 +691,7 @@ if (($# < 1)); then
     FULL_TESTS_NEEDED_LABEL="true"
     readonly FULL_TESTS_NEEDED_LABEL
     output_all_basic_variables
+    check_upgrade_to_newer_dependencies_needed
     set_outputs_run_everything_and_exit
 else
     INCOMING_COMMIT_SHA="${1}"


### PR DESCRIPTION
When we want to run the "push" or "schedule" build, we want
to always "upgrade to newer dependencies" because we want to
attempt to generate latest constraints.

There was a mistake that caused failures like celery
incompatibilities because successfull main build pushed downgraded
constraints because the released image did not contain latest
celery libraries and it has not been rebuilt with latest
constraints yet.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
