### PR TITLE
Add robots.txt and X-Robots-Tag header

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -34,6 +34,7 @@ from airflow.www.extensions.init_appbuilder_links import init_appbuilder_links
 from airflow.www.extensions.init_dagbag import init_dagbag
 from airflow.www.extensions.init_jinja_globals import init_jinja_globals
 from airflow.www.extensions.init_manifest_files import configure_manifest_files
+from airflow.www.extensions.init_robots import init_robots
 from airflow.www.extensions.init_security import init_api_experimental_auth, init_xframe_protection
 from airflow.www.extensions.init_session import init_airflow_session_interface, init_permanent_session
 from airflow.www.extensions.init_views import (
@@ -109,6 +110,8 @@ def create_app(config=None, testing=False):
     init_dagbag(flask_app)
 
     init_api_experimental_auth(flask_app)
+
+    init_robots(flask_app)
 
     Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
 

--- a/airflow/www/extensions/init_robots.py
+++ b/airflow/www/extensions/init_robots.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def init_robots(app):
+    """
+    Add X-Robots-Tag header. Use it to avoid search engines indexing airflow. This mitigates some
+    of the risk associated with exposing Airflow to the public internet, however it does not
+    address the real security risks associated with such a deployment.
+
+    See also: https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#xrobotstag
+    """
+
+    def apply_robot_tag(response):
+        response.headers['X-Robots-Tag'] = 'noindex, nofollow'
+        return response
+
+    app.after_request(apply_robot_tag)

--- a/airflow/www/static/robots.txt
+++ b/airflow/www/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -51,6 +51,7 @@ from flask import (
     redirect,
     render_template,
     request,
+    send_from_directory,
     session as flask_session,
     url_for,
 )
@@ -2923,6 +2924,16 @@ class Airflow(AirflowBaseView):
 
         # avoid spaces to reduce payload size
         return htmlsafe_json_dumps(tree_data, separators=(',', ':'))
+
+    @expose('/robots.txt')
+    @action_logging
+    def robots(self):
+        """
+        Returns a robots.txt file for blocking certain search engine crawlers. This mitigates some
+        of the risk associated with exposing Airflow to the public internet, however it does not
+        address the real security risks associated with such a deployment.
+        """
+        return send_from_directory(current_app.static_folder, 'robots.txt')
 
 
 class ConfigurationView(AirflowBaseView):

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -178,3 +178,9 @@ def test_home_dag_list_filtered_singledag_user(working_dags, client_single_dag):
     # But not the rest
     for dag_id in TEST_FILTER_DAG_IDS[1:]:
         check_content_not_in_response(f"dag_id={dag_id}", resp)
+
+
+def test_home_robots_header_in_response(user_client):
+    # Responses should include X-Robots-Tag header
+    resp = user_client.get('home', follow_redirects=True)
+    assert resp.headers['X-Robots-Tag'] == 'noindex, nofollow'

--- a/tests/www/views/test_views_robots.py
+++ b/tests/www/views/test_views_robots.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+def test_robots(viewer_client):
+    resp = viewer_client.get('/robots.txt', follow_redirects=True)
+    assert resp.data.decode('utf-8') == "User-agent: *\nDisallow: /\n"


### PR DESCRIPTION
Added a robots.txt file and X-Robots-Tag header to limit some of the damage caused when accidentally exposing airflow to the public internet. 