### PR TITLE
Refresh credentials for long-running pods on EKS

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_eks_using_defaults.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_using_defaults.py
@@ -26,9 +26,8 @@ from airflow.providers.amazon.aws.operators.eks import (
 from airflow.providers.amazon.aws.sensors.eks import EKSClusterStateSensor, EKSNodegroupStateSensor
 from airflow.utils.dates import days_ago
 
-CLUSTER_NAME = 'eks-demo'
-NODEGROUP_SUFFIX = '-nodegroup'
-NODEGROUP_NAME = CLUSTER_NAME + NODEGROUP_SUFFIX
+CLUSTER_NAME = environ.get('EKS_CLUSTER_NAME', 'eks-demo')
+NODEGROUP_NAME = f'{CLUSTER_NAME}-nodegroup'
 ROLE_ARN = environ.get('EKS_DEMO_ROLE_ARN', 'arn:aws:iam::123456789012:role/role_name')
 SUBNETS = environ.get('EKS_DEMO_SUBNETS', 'subnet-12345ab subnet-67890cd').split(' ')
 VPC_CONFIG = {
@@ -73,7 +72,7 @@ with DAG(
         task_id="run_pod",
         cluster_name=CLUSTER_NAME,
         image="amazon/aws-cli:latest",
-        cmds=["sh", "-c", "ls"],
+        cmds=["sh", "-c", "echo Test Airflow; date"],
         labels={"demo": "hello_world"},
         get_logs=True,
         # Delete the pod when it reaches its final state, or the execution is interrupted.

--- a/airflow/providers/amazon/aws/utils/eks_get_token.py
+++ b/airflow/providers/amazon/aws/utils/eks_get_token.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import argparse
+import json
+from datetime import datetime, timedelta
+
+from airflow.providers.amazon.aws.hooks.eks import EKSHook
+
+# Presigned STS urls are valid for 15 minutes, set token expiration to 1 minute before it expires for
+# some cushion
+TOKEN_EXPIRATION_MINUTES = 14
+
+
+def get_expiration_time():
+    token_expiration = datetime.utcnow() + timedelta(minutes=TOKEN_EXPIRATION_MINUTES)
+    return token_expiration.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description='Get a token for authentication with an Amazon EKS cluster.')
+    parser.add_argument(
+        '--cluster-name', help='The name of the cluster to generate kubeconfig file for.', required=True
+    )
+    parser.add_argument(
+        '--aws-conn-id',
+        help=(
+            'The Airflow connection used for AWS credentials. '
+            'If not specified or empty then the default boto3 behaviour is used.'
+        ),
+    )
+    parser.add_argument(
+        '--region-name', help='AWS region_name. If not specified then the default boto3 behaviour is used.'
+    )
+
+    return parser
+
+
+def main():
+    parser = get_parser()
+    args = parser.parse_args()
+    eks_hook = EKSHook(aws_conn_id=args.aws_conn_id, region_name=args.region_name)
+    access_token = eks_hook.fetch_access_token_for_cluster(args.cluster_name)
+    access_token_expiration = get_expiration_time()
+    exec_credential_object = {
+        "kind": "ExecCredential",
+        "apiVersion": "client.authentication.k8s.io/v1alpha1",
+        "spec": {},
+        "status": {"expirationTimestamp": access_token_expiration, "token": access_token},
+    }
+    print(json.dumps(exec_credential_object))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/providers/amazon/aws/utils/test_eks_get_token.py
+++ b/tests/providers/amazon/aws/utils/test_eks_get_token.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import io
+import json
+import runpy
+from unittest import mock
+
+import pytest
+from freezegun import freeze_time
+
+
+class TestGetEksTtoken:
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook')
+    @freeze_time("1995-02-14")
+    @pytest.mark.parametrize(
+        "args, expected_aws_conn_id, expected_region_name",
+        [
+            [
+                [
+                    'airflow.providers.amazon.aws.utils.eks_get_token',
+                    '--region-name',
+                    'test-region',
+                    '--aws-conn-id',
+                    'test-id',
+                    '--cluster-name',
+                    'test-cluster',
+                ],
+                'test-id',
+                'test-region',
+            ],
+            [
+                [
+                    'airflow.providers.amazon.aws.utils.eks_get_token',
+                    '--region-name',
+                    'test-region',
+                    '--cluster-name',
+                    'test-cluster',
+                ],
+                None,
+                'test-region',
+            ],
+            [
+                ['airflow.providers.amazon.aws.utils.eks_get_token', '--cluster-name', 'test-cluster'],
+                None,
+                None,
+            ],
+        ],
+    )
+    def test_run(self, mock_eks_hook, args, expected_aws_conn_id, expected_region_name):
+        (
+            mock_eks_hook.return_value.fetch_access_token_for_cluster.return_value
+        ) = 'k8s-aws-v1.aHR0cDovL2V4YW1wbGUuY29t'
+
+        with mock.patch('sys.argv', args), contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
+            runpy.run_module('airflow.providers.amazon.aws.utils.eks_get_token', run_name='__main__')
+
+        assert {
+            'apiVersion': 'client.authentication.k8s.io/v1alpha1',
+            'kind': 'ExecCredential',
+            'spec': {},
+            'status': {
+                'expirationTimestamp': '1995-02-14T00:14:00Z',
+                'token': 'k8s-aws-v1.aHR0cDovL2V4YW1wbGUuY29t',
+            },
+        } == json.loads(temp_stdout.getvalue())
+        mock_eks_hook.assert_called_once_with(
+            aws_conn_id=expected_aws_conn_id, region_name=expected_region_name
+        )
+        mock_eks_hook.return_value.fetch_access_token_for_cluster.assert_called_once_with('test-cluster')


### PR DESCRIPTION
The currently generated token is generated only once and is valid for 15 minutes, so when the task is longer, the operation will fail. 
I added support for refreshing credentials with [client-go credential plugins](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins), so a new token is fetched every time it expires. I wrote an `airflow/providers/amazon/aws/utils/eks_get_token.py` script for this, which is similar to `aws eks get-token`, but all supports authentication protocols natively supported by Airflow including Secret backend, Google Credential using Web Identity Federation, HTTP SPEGO, SAML.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
