### PR TITLE
Only show Pause/Unpause tooltip on hover

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -265,6 +265,8 @@ $('#pause_resume').on('change', function onChange() {
   const id = $input.data('dag-id');
   const isPaused = $input.is(':checked');
   const url = `${pausedUrl}?is_paused=${isPaused}&dag_id=${encodeURIComponent(id)}`;
+  // Remove focus on element so the tooltip will go away
+  $input.trigger('blur');
   $input.removeClass('switch-input--error');
   $.post(url).fail(() => {
     setTimeout(() => {

--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -94,6 +94,8 @@ $.each($('[id^=toggle]'), function toggleId() {
     const isPaused = $input.is(':checked');
     const url = `${pausedUrl}?is_paused=${isPaused}&dag_id=${encodeURIComponent(dagId)}`;
     $input.removeClass('switch-input--error');
+    // Remove focus on element so the tooltip will go away
+    $input.trigger('blur');
     $.post(url).fail(() => {
       setTimeout(() => {
         $input.prop('checked', !isPaused);


### PR DESCRIPTION
After clicking on the Pause/Unpause toggle, the element remained in focus and therefore the toggle wouldn't go away. After a change event we will also trigger a blur event to remove the focus so the tooltip will only appear on hover.

Fixes: #16500

![Sep-01-2021 12-30-09](https://user-images.githubusercontent.com/4600967/131656400-a7c16160-a80a-4ba8-905f-8b57e944c172.gif)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
