### PR TITLE
Improve MySqlToHiveOperator tests

### DIFF
--- a/tests/providers/apache/hive/transfers/test_mysql_to_hive.py
+++ b/tests/providers/apache/hive/transfers/test_mysql_to_hive.py
@@ -16,47 +16,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
+import textwrap
 from collections import OrderedDict
 from contextlib import closing
-from os import path
 from unittest import mock
 
 import pytest
 
 from airflow import PY39
-from airflow.models.dag import DAG
+from airflow.providers.apache.hive.hooks.hive import HiveCliHook
 from airflow.providers.apache.hive.transfers.mysql_to_hive import MySqlToHiveOperator
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.utils import timezone
-from tests.test_utils.mock_hooks import MockHiveServer2Hook
-from tests.test_utils.mock_process import MockConnectionCursor, MockSubProcess
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()
 DEFAULT_DATE_DS = DEFAULT_DATE_ISO[:10]
-TEST_DAG_ID = 'unit_test_dag'
-
-
-class HiveopTempFile:
-    """
-    Make sure temp file path is in the format of "/tmp/airflow_hiveop_t_78lpye/tmpour2_kig",
-    """
-
-    def __eq__(self, other: str) -> bool:
-        (head, tail) = path.split(other)
-        (head, tail) = path.split(head)
-        return tail.startswith("airflow_hiveop_")
-
-
-class HiveopTempDir:
-    """
-    Make sure temp dir path is in the format of "/tmp/airflow_hiveop_t_78lpye",
-    """
-
-    def __eq__(self, other: str) -> bool:
-        (_, tail) = path.split(other)
-        return tail.startswith("airflow_hiveop_")
 
 
 @pytest.mark.skipif(
@@ -66,76 +41,45 @@ class HiveopTempDir:
     " is solved",
 )
 @pytest.mark.backend("mysql")
-class TestTransfer(unittest.TestCase):
-    def setUp(self):
-        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
-        dag = DAG(TEST_DAG_ID, default_args=args)
-        self.dag = dag
+class TestTransfer:
+    env_vars = {
+        'AIRFLOW_CTX_DAG_ID': 'test_dag_id',
+        'AIRFLOW_CTX_TASK_ID': 'test_task_id',
+        'AIRFLOW_CTX_EXECUTION_DATE': '2015-01-01T00:00:00+00:00',
+        'AIRFLOW_CTX_DAG_RUN_ID': '55',
+        'AIRFLOW_CTX_DAG_OWNER': 'airflow',
+        'AIRFLOW_CTX_DAG_EMAIL': 'test@airflow.com',
+    }
 
+    @pytest.fixture
+    def spy_on_hive(self):
+        """Patch HiveCliHook.load_file and capture the contents of the CSV file"""
+
+        class Capturer:
+            def __enter__(self):
+                self._patch = mock.patch.object(HiveCliHook, 'load_file', side_effect=self.capture_file)
+                self.load_file = self._patch.start()
+                return self
+
+            def __exit__(self, *args):
+                self._patch.stop()
+
+            def capture_file(self, file, *args, **kwargs):
+                with open(file) as fh:
+                    self.csv_contents = fh.read()
+
+        with Capturer() as c:
+            yield c
+
+    @pytest.fixture
+    def baby_names_table(self):
         rows = [
             (1880, "John", 0.081541, "boy"),
             (1880, "William", 0.080511, "boy"),
             (1880, "James", 0.050057, "boy"),
             (1880, "Charles", 0.045167, "boy"),
             (1880, "George", 0.043292, "boy"),
-            (1880, "Frank", 0.02738, "boy"),
-            (1880, "Joseph", 0.022229, "boy"),
-            (1880, "Thomas", 0.021401, "boy"),
-            (1880, "Henry", 0.020641, "boy"),
-            (1880, "Robert", 0.020404, "boy"),
-            (1880, "Edward", 0.019965, "boy"),
-            (1880, "Harry", 0.018175, "boy"),
-            (1880, "Walter", 0.014822, "boy"),
-            (1880, "Arthur", 0.013504, "boy"),
-            (1880, "Fred", 0.013251, "boy"),
-            (1880, "Albert", 0.012609, "boy"),
-            (1880, "Samuel", 0.008648, "boy"),
-            (1880, "David", 0.007339, "boy"),
-            (1880, "Louis", 0.006993, "boy"),
-            (1880, "Joe", 0.006174, "boy"),
-            (1880, "Charlie", 0.006165, "boy"),
-            (1880, "Clarence", 0.006165, "boy"),
-            (1880, "Richard", 0.006148, "boy"),
-            (1880, "Andrew", 0.005439, "boy"),
-            (1880, "Daniel", 0.00543, "boy"),
-            (1880, "Ernest", 0.005194, "boy"),
-            (1880, "Will", 0.004966, "boy"),
-            (1880, "Jesse", 0.004805, "boy"),
-            (1880, "Oscar", 0.004594, "boy"),
-            (1880, "Lewis", 0.004366, "boy"),
-            (1880, "Peter", 0.004189, "boy"),
-            (1880, "Benjamin", 0.004138, "boy"),
-            (1880, "Frederick", 0.004079, "boy"),
-            (1880, "Willie", 0.00402, "boy"),
-            (1880, "Alfred", 0.003961, "boy"),
-            (1880, "Sam", 0.00386, "boy"),
-            (1880, "Roy", 0.003716, "boy"),
-            (1880, "Herbert", 0.003581, "boy"),
-            (1880, "Jacob", 0.003412, "boy"),
-            (1880, "Tom", 0.00337, "boy"),
-            (1880, "Elmer", 0.00315, "boy"),
-            (1880, "Carl", 0.003142, "boy"),
-            (1880, "Lee", 0.003049, "boy"),
-            (1880, "Howard", 0.003015, "boy"),
-            (1880, "Martin", 0.003015, "boy"),
-            (1880, "Michael", 0.00299, "boy"),
-            (1880, "Bert", 0.002939, "boy"),
-            (1880, "Herman", 0.002931, "boy"),
-            (1880, "Jim", 0.002914, "boy"),
-            (1880, "Francis", 0.002905, "boy"),
-            (1880, "Harvey", 0.002905, "boy"),
-            (1880, "Earl", 0.002829, "boy"),
-            (1880, "Eugene", 0.00277, "boy"),
         ]
-
-        self.env_vars = {
-            'AIRFLOW_CTX_DAG_ID': 'test_dag_id',
-            'AIRFLOW_CTX_TASK_ID': 'test_task_id',
-            'AIRFLOW_CTX_EXECUTION_DATE': '2015-01-01T00:00:00+00:00',
-            'AIRFLOW_CTX_DAG_RUN_ID': '55',
-            'AIRFLOW_CTX_DAG_OWNER': 'airflow',
-            'AIRFLOW_CTX_DAG_EMAIL': 'test@airflow.com',
-        }
 
         with closing(MySqlHook().get_conn()) as conn:
             with closing(conn.cursor()) as cur:
@@ -152,172 +96,115 @@ class TestTransfer(unittest.TestCase):
                 for row in rows:
                     cur.execute("INSERT INTO baby_names VALUES(%s, %s, %s, %s);", row)
 
-    def tearDown(self):
+                conn.commit()
+
+        yield
+
         with closing(MySqlHook().get_conn()) as conn:
             with closing(conn.cursor()) as cur:
                 cur.execute("DROP TABLE IF EXISTS baby_names CASCADE;")
 
-    @mock.patch('subprocess.Popen')
-    def test_mysql_to_hive(self, mock_popen):
-        mock_subprocess = MockSubProcess()
-        mock_popen.return_value = mock_subprocess
+    @pytest.mark.parametrize(
+        ('params', 'expected', 'csv'),
+        [
+            pytest.param(
+                {'recreate': True, 'delimiter': ','},
+                {
+                    'field_dict': {
+                        'org_year': 'BIGINT',
+                        'baby_name': 'STRING',
+                        'rate': 'DOUBLE',
+                        'sex': 'STRING',
+                    },
+                    'create': True,
+                    'partition': {},
+                    'delimiter': ',',
+                    'recreate': True,
+                    'tblproperties': None,
+                },
+                textwrap.dedent(
+                    """\
+                    1880,John,0.081541,boy
+                    1880,William,0.080511,boy
+                    1880,James,0.050057,boy
+                    1880,Charles,0.045167,boy
+                    1880,George,0.043292,boy
+                    """
+                ),
+                id="recreate-delimiter",
+            ),
+            pytest.param(
+                {'partition': {'ds': DEFAULT_DATE_DS}},
+                {
+                    'field_dict': {
+                        'org_year': 'BIGINT',
+                        'baby_name': 'STRING',
+                        'rate': 'DOUBLE',
+                        'sex': 'STRING',
+                    },
+                    'create': True,
+                    'partition': {'ds': DEFAULT_DATE_DS},
+                    'delimiter': '\x01',
+                    'recreate': False,
+                    'tblproperties': None,
+                },
+                textwrap.dedent(
+                    """\
+                    1880\x01John\x010.081541\x01boy
+                    1880\x01William\x010.080511\x01boy
+                    1880\x01James\x010.050057\x01boy
+                    1880\x01Charles\x010.045167\x01boy
+                    1880\x01George\x010.043292\x01boy
+                    """
+                ),
+                id="partition",
+            ),
+            pytest.param(
+                {'tblproperties': {'test_property': 'test_value'}},
+                {
+                    'field_dict': {
+                        'org_year': 'BIGINT',
+                        'baby_name': 'STRING',
+                        'rate': 'DOUBLE',
+                        'sex': 'STRING',
+                    },
+                    'create': True,
+                    'partition': {},
+                    'delimiter': '\x01',
+                    'recreate': False,
+                    'tblproperties': {'test_property': 'test_value'},
+                },
+                textwrap.dedent(
+                    """\
+                    1880\x01John\x010.081541\x01boy
+                    1880\x01William\x010.080511\x01boy
+                    1880\x01James\x010.050057\x01boy
+                    1880\x01Charles\x010.045167\x01boy
+                    1880\x01George\x010.043292\x01boy
+                    """
+                ),
+                id="tblproperties",
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures('baby_names_table')
+    def test_mysql_to_hive(self, spy_on_hive, params, expected, csv):
 
-        with mock.patch.dict('os.environ', self.env_vars):
-            sql = "SELECT * FROM baby_names LIMIT 1000;"
-            op = MySqlToHiveOperator(
-                task_id='test_m2h',
-                hive_cli_conn_id='hive_cli_default',
-                sql=sql,
-                hive_table='test_mysql_to_hive',
-                recreate=True,
-                delimiter=",",
-                dag=self.dag,
-            )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-        hive_cmd = [
-            'beeline',
-            '-u',
-            '"jdbc:hive2://localhost:10000/default"',
-            '-hiveconf',
-            'airflow.ctx.dag_id=unit_test_dag',
-            '-hiveconf',
-            'airflow.ctx.task_id=test_m2h',
-            '-hiveconf',
-            'airflow.ctx.execution_date=2015-01-01T00:00:00+00:00',
-            '-hiveconf',
-            'airflow.ctx.dag_run_id=55',
-            '-hiveconf',
-            'airflow.ctx.dag_owner=airflow',
-            '-hiveconf',
-            'airflow.ctx.dag_email=test@airflow.com',
-            '-hiveconf',
-            'mapreduce.job.queuename=airflow',
-            '-hiveconf',
-            'mapred.job.queue.name=airflow',
-            '-hiveconf',
-            'tez.queue.name=airflow',
-            '-f',
-            HiveopTempFile(),
-        ]
-
-        mock_popen.assert_called_with(
-            hive_cmd,
-            stdout=mock_subprocess.PIPE,
-            stderr=mock_subprocess.STDOUT,
-            cwd=HiveopTempDir(),
-            close_fds=True,
+        sql = "SELECT * FROM baby_names LIMIT 1000;"
+        op = MySqlToHiveOperator(
+            task_id='test_m2h',
+            hive_cli_conn_id='hive_cli_default',
+            sql=sql,
+            hive_table='test_mysql_to_hive',
+            **params,
         )
+        op.execute({})
 
-    @mock.patch('subprocess.Popen')
-    def test_mysql_to_hive_partition(self, mock_popen):
-        mock_subprocess = MockSubProcess()
-        mock_popen.return_value = mock_subprocess
+        spy_on_hive.load_file.assert_called_with(mock.ANY, 'test_mysql_to_hive', **expected)
 
-        with mock.patch.dict('os.environ', self.env_vars):
-            sql = "SELECT * FROM baby_names LIMIT 1000;"
-            op = MySqlToHiveOperator(
-                task_id='test_m2h',
-                hive_cli_conn_id='hive_cli_default',
-                sql=sql,
-                hive_table='test_mysql_to_hive_part',
-                partition={'ds': DEFAULT_DATE_DS},
-                recreate=False,
-                create=True,
-                delimiter=",",
-                dag=self.dag,
-            )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        assert spy_on_hive.csv_contents == csv
 
-        hive_cmd = [
-            'beeline',
-            '-u',
-            '"jdbc:hive2://localhost:10000/default"',
-            '-hiveconf',
-            'airflow.ctx.dag_id=unit_test_dag',
-            '-hiveconf',
-            'airflow.ctx.task_id=test_m2h',
-            '-hiveconf',
-            'airflow.ctx.execution_date=2015-01-01T00:00:00+00:00',
-            '-hiveconf',
-            'airflow.ctx.dag_run_id=55',
-            '-hiveconf',
-            'airflow.ctx.dag_owner=airflow',
-            '-hiveconf',
-            'airflow.ctx.dag_email=test@airflow.com',
-            '-hiveconf',
-            'mapreduce.job.queuename=airflow',
-            '-hiveconf',
-            'mapred.job.queue.name=airflow',
-            '-hiveconf',
-            'tez.queue.name=airflow',
-            '-f',
-            HiveopTempFile(),
-        ]
-
-        mock_popen.assert_called_with(
-            hive_cmd,
-            stdout=mock_subprocess.PIPE,
-            stderr=mock_subprocess.STDOUT,
-            cwd=HiveopTempDir(),
-            close_fds=True,
-        )
-
-    @mock.patch('subprocess.Popen')
-    def test_mysql_to_hive_tblproperties(self, mock_popen):
-        mock_subprocess = MockSubProcess()
-        mock_popen.return_value = mock_subprocess
-
-        with mock.patch.dict('os.environ', self.env_vars):
-            sql = "SELECT * FROM baby_names LIMIT 1000;"
-            op = MySqlToHiveOperator(
-                task_id='test_m2h',
-                hive_cli_conn_id='hive_cli_default',
-                sql=sql,
-                hive_table='test_mysql_to_hive',
-                recreate=True,
-                delimiter=",",
-                tblproperties={'test_property': 'test_value'},
-                dag=self.dag,
-            )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-        hive_cmd = [
-            'beeline',
-            '-u',
-            '"jdbc:hive2://localhost:10000/default"',
-            '-hiveconf',
-            'airflow.ctx.dag_id=unit_test_dag',
-            '-hiveconf',
-            'airflow.ctx.task_id=test_m2h',
-            '-hiveconf',
-            'airflow.ctx.execution_date=2015-01-01T00:00:00+00:00',
-            '-hiveconf',
-            'airflow.ctx.dag_run_id=55',
-            '-hiveconf',
-            'airflow.ctx.dag_owner=airflow',
-            '-hiveconf',
-            'airflow.ctx.dag_email=test@airflow.com',
-            '-hiveconf',
-            'mapreduce.job.queuename=airflow',
-            '-hiveconf',
-            'mapred.job.queue.name=airflow',
-            '-hiveconf',
-            'tez.queue.name=airflow',
-            '-f',
-            HiveopTempFile(),
-        ]
-
-        mock_popen.assert_called_with(
-            hive_cmd,
-            stdout=mock_subprocess.PIPE,
-            stderr=mock_subprocess.STDOUT,
-            cwd=HiveopTempDir(),
-            close_fds=True,
-        )
-
-    @mock.patch('airflow.providers.apache.hive.hooks.hive.HiveCliHook.load_file')
-    def test_mysql_to_hive_type_conversion(self, mock_load_file):
+    def test_mysql_to_hive_type_conversion(self, spy_on_hive):
         mysql_table = 'test_mysql_to_hive'
 
         hook = MySqlHook()
@@ -344,11 +231,10 @@ class TestTransfer(unittest.TestCase):
                 hive_cli_conn_id='hive_cli_default',
                 sql=f"SELECT * FROM {mysql_table}",
                 hive_table='test_mysql_to_hive',
-                dag=self.dag,
             )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            op.execute({})
 
-            assert mock_load_file.call_count == 1
+            assert spy_on_hive.load_file.call_count == 1
             ordered_dict = OrderedDict()
             ordered_dict["c0"] = "SMALLINT"
             ordered_dict["c1"] = "INT"
@@ -356,16 +242,13 @@ class TestTransfer(unittest.TestCase):
             ordered_dict["c3"] = "BIGINT"
             ordered_dict["c4"] = "DECIMAL(38,0)"
             ordered_dict["c5"] = "TIMESTAMP"
-            assert mock_load_file.call_args[1]["field_dict"] == ordered_dict
+            assert spy_on_hive.load_file.call_args[1]["field_dict"] == ordered_dict
         finally:
             with closing(hook.get_conn()) as conn:
                 with closing(conn.cursor()) as cursor:
                     cursor.execute(f"DROP TABLE IF EXISTS {mysql_table}")
 
-    @mock.patch('subprocess.Popen')
-    def test_mysql_to_hive_verify_csv_special_char(self, mock_popen):
-        mock_subprocess = MockSubProcess()
-        mock_popen.return_value = mock_subprocess
+    def test_mysql_to_hive_verify_csv_special_char(self, spy_on_hive):
 
         mysql_table = 'test_mysql_to_hive'
         hive_table = 'test_mysql_to_hive'
@@ -373,7 +256,7 @@ class TestTransfer(unittest.TestCase):
         hook = MySqlHook()
 
         try:
-            db_record = ('c0', '["true"]')
+            db_record = ('c0', '["true",1]')
             with closing(hook.get_conn()) as conn:
                 with closing(conn.cursor()) as cursor:
                     cursor.execute(f"DROP TABLE IF EXISTS {mysql_table}")
@@ -394,175 +277,26 @@ class TestTransfer(unittest.TestCase):
                             mysql_table, *db_record
                         )
                     )
+                    conn.commit()
 
-            with mock.patch.dict('os.environ', self.env_vars):
-                import unicodecsv as csv
+            import unicodecsv as csv
 
-                op = MySqlToHiveOperator(
-                    task_id='test_m2h',
-                    hive_cli_conn_id='hive_cli_default',
-                    sql=f"SELECT * FROM {mysql_table}",
-                    hive_table=hive_table,
-                    recreate=True,
-                    delimiter=",",
-                    quoting=csv.QUOTE_NONE,
-                    quotechar='',
-                    escapechar='@',
-                    dag=self.dag,
-                )
-                op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-                mock_cursor = MockConnectionCursor()
-                mock_cursor.iterable = [('c0', '["true"]'), (2, 2)]
-                hive_hook = MockHiveServer2Hook(connection_cursor=mock_cursor)
-
-                result = hive_hook.get_records(f"SELECT * FROM {hive_table}")
-            assert result[0] == db_record
-
-            hive_cmd = [
-                'beeline',
-                '-u',
-                '"jdbc:hive2://localhost:10000/default"',
-                '-hiveconf',
-                'airflow.ctx.dag_id=unit_test_dag',
-                '-hiveconf',
-                'airflow.ctx.task_id=test_m2h',
-                '-hiveconf',
-                'airflow.ctx.execution_date=2015-01-01T00:00:00+00:00',
-                '-hiveconf',
-                'airflow.ctx.dag_run_id=55',
-                '-hiveconf',
-                'airflow.ctx.dag_owner=airflow',
-                '-hiveconf',
-                'airflow.ctx.dag_email=test@airflow.com',
-                '-hiveconf',
-                'mapreduce.job.queuename=airflow',
-                '-hiveconf',
-                'mapred.job.queue.name=airflow',
-                '-hiveconf',
-                'tez.queue.name=airflow',
-                '-f',
-                HiveopTempFile(),
-            ]
-
-            mock_popen.assert_called_with(
-                hive_cmd,
-                stdout=mock_subprocess.PIPE,
-                stderr=mock_subprocess.STDOUT,
-                cwd=HiveopTempDir(),
-                close_fds=True,
-            )
-        finally:
-            with closing(hook.get_conn()) as conn:
-                with closing(conn.cursor()) as cursor:
-                    cursor.execute(f"DROP TABLE IF EXISTS {mysql_table}")
-
-    @mock.patch('subprocess.Popen')
-    def test_mysql_to_hive_verify_loaded_values(self, mock_popen):
-        mock_subprocess = MockSubProcess()
-        mock_popen.return_value = mock_subprocess
-
-        mysql_table = 'test_mysql_to_hive'
-        hive_table = 'test_mysql_to_hive'
-
-        hook = MySqlHook()
-
-        try:
-            minmax = (
-                255,
-                65535,
-                16777215,
-                4294967295,
-                18446744073709551615,
-                -128,
-                -32768,
-                -8388608,
-                -2147483648,
-                -9223372036854775808,
+            op = MySqlToHiveOperator(
+                task_id='test_m2h',
+                hive_cli_conn_id='hive_cli_default',
+                sql=f"SELECT * FROM {mysql_table}",
+                hive_table=hive_table,
+                recreate=True,
+                delimiter=",",
+                quoting=csv.QUOTE_NONE,
+                quotechar='',
+                escapechar='@',
             )
 
-            with closing(hook.get_conn()) as conn:
-                with closing(conn.cursor()) as cursor:
-                    cursor.execute(f"DROP TABLE IF EXISTS {mysql_table}")
-                    cursor.execute(
-                        f"""
-                        CREATE TABLE {mysql_table} (
-                            c0 TINYINT   UNSIGNED,
-                            c1 SMALLINT  UNSIGNED,
-                            c2 MEDIUMINT UNSIGNED,
-                            c3 INT       UNSIGNED,
-                            c4 BIGINT    UNSIGNED,
-                            c5 TINYINT,
-                            c6 SMALLINT,
-                            c7 MEDIUMINT,
-                            c8 INT,
-                            c9 BIGINT
-                        )
-                    """
-                    )
-                    cursor.execute(
-                        """
-                        INSERT INTO {} VALUES (
-                            {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
-                        )
-                    """.format(
-                            mysql_table, *minmax
-                        )
-                    )
+            op.execute({})
 
-            with mock.patch.dict('os.environ', self.env_vars):
-                op = MySqlToHiveOperator(
-                    task_id='test_m2h',
-                    hive_cli_conn_id='hive_cli_default',
-                    sql=f"SELECT * FROM {mysql_table}",
-                    hive_table=hive_table,
-                    recreate=True,
-                    delimiter=",",
-                    dag=self.dag,
-                )
-                op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-
-                mock_cursor = MockConnectionCursor()
-                mock_cursor.iterable = [minmax]
-                hive_hook = MockHiveServer2Hook(connection_cursor=mock_cursor)
-
-                result = hive_hook.get_records(f"SELECT * FROM {hive_table}")
-                assert result[0] == minmax
-
-                hive_cmd = [
-                    'beeline',
-                    '-u',
-                    '"jdbc:hive2://localhost:10000/default"',
-                    '-hiveconf',
-                    'airflow.ctx.dag_id=unit_test_dag',
-                    '-hiveconf',
-                    'airflow.ctx.task_id=test_m2h',
-                    '-hiveconf',
-                    'airflow.ctx.execution_date=2015-01-01T00:00:00+00:00',
-                    '-hiveconf',
-                    'airflow.ctx.dag_run_id=55',
-                    '-hiveconf',
-                    'airflow.ctx.dag_owner=airflow',
-                    '-hiveconf',
-                    'airflow.ctx.dag_email=test@airflow.com',
-                    '-hiveconf',
-                    'mapreduce.job.queuename=airflow',
-                    '-hiveconf',
-                    'mapred.job.queue.name=airflow',
-                    '-hiveconf',
-                    'tez.queue.name=airflow',
-                    '-f',
-                    HiveopTempFile(),
-                ]
-
-                mock_popen.assert_called_with(
-                    hive_cmd,
-                    stdout=mock_subprocess.PIPE,
-                    stderr=mock_subprocess.STDOUT,
-                    cwd=HiveopTempDir(),
-                    close_fds=True,
-                )
-
+            spy_on_hive.load_file.assert_called()
+            assert spy_on_hive.csv_contents == 'c0,["true"@,1]\n'
         finally:
             with closing(hook.get_conn()) as conn:
                 with closing(conn.cursor()) as cursor:


### PR DESCRIPTION
These tests were actually just testing the hook again (by checking the
command executed) but were asserting nothing about the CSV passed to the
hook.

This change makes the operator tests check the logic in the operator and
no longer tests the hook code again.

`test_mysql_to_hive_verify_loaded_values` was removed as since we
removed Java/a real hive CLI from our tests this has only been testing
our mock, not the real code.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).