### PR TITLE
Fix passing Jinja templates in ``DateTimeSensor``

### DIFF
--- a/tests/sensors/test_date_time.py
+++ b/tests/sensors/test_date_time.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import datetime
+
 from unittest.mock import patch
 
 import pytest
@@ -39,16 +39,22 @@ class TestDateTimeSensor:
             (
                 "valid_datetime",
                 timezone.datetime(2020, 7, 6, 13, tzinfo=timezone.utc),
-                timezone.datetime(2020, 7, 6, 13, tzinfo=timezone.utc),
+                "2020-07-06T13:00:00+00:00",
             ),
             (
                 "valid_str",
                 "20200706T210000+8",
-                timezone.datetime(2020, 7, 6, 21, tzinfo=datetime.timezone(datetime.timedelta(hours=8))),
+                "20200706T210000+8",
+            ),
+            (
+                "jinja_str_is_accepted",
+                "{{ ds }}",
+                "{{ ds }}",
             ),
         ]
     )
     def test_valid_input(self, task_id, target_time, expected):
+        """target_time should be a string as it is a template field"""
         op = DateTimeSensor(
             task_id=task_id,
             target_time=target_time,


### PR DESCRIPTION
While fixing ``DateTimeSensorAsync`` in https://github.com/apache/airflow/pull/17747 -- I broke ``DateTimeSensor``.

As `target_time` is a template_field for `DateTimeSensor`, Jinja tries to render it which does not work if the input is a datetime object or if someone passes just a template field like ``{{ execution_date }} `` it throws an error:

```
    DateTimeSensor(task_id="foo",
                   target_time="{{ execution_time }}"
    )
    '
        Traceback (most recent call last):
          File "/usr/local/lib/python3.9/site-packages/pendulum/parsing/__init__.py", line 131, in _parse
            dt = parser.parse(
          File "/usr/local/lib/python3.9/site-packages/dateutil/parser/_parser.py", line 1368, in parse
            return DEFAULTPARSER.parse(timestr, **kwargs)
          File "/usr/local/lib/python3.9/site-packages/dateutil/parser/_parser.py", line 643, in parse
            raise ParserError("Unknown string format: %s", timestr)
        dateutil.parser._parser.ParserError: Unknown string format: {{ execution_time }}

        During handling of the above exception, another exception occurred:

        Traceback (most recent call last):
          File "<string>", line 3, in <module>
          File "/usr/local/lib/python3.9/site-packages/airflow/models/baseoperator.py", line 186, in apply_defaults
            result = func(self, *args, **kwargs)
          File "/usr/local/lib/python3.9/site-packages/airflow/sensors/date_time.py", line 66, in __init__
            self.target_time = timezone.parse(target_time)
          File "/usr/local/lib/python3.9/site-packages/airflow/utils/timezone.py", line 175, in parse
            return pendulum.parse(string, tz=timezone or TIMEZONE, strict=False)  # type: ignore
          File "/usr/local/lib/python3.9/site-packages/pendulum/parser.py", line 29, in parse
            return _parse(text, **options)
          File "/usr/local/lib/python3.9/site-packages/pendulum/parser.py", line 45, in _parse
            parsed = base_parse(text, **options)
          File "/usr/local/lib/python3.9/site-packages/pendulum/parsing/__init__.py", line 74, in parse
            return _normalize(_parse(text, **_options), **_options)
          File "/usr/local/lib/python3.9/site-packages/pendulum/parsing/__init__.py", line 135, in _parse
            raise ParserError("Invalid date string: {}".format(text))
        pendulum.parsing.exceptions.ParserError: Invalid date string: {{ execution_time }}
```

This PR fixes it by reverting change in `DateTimeSensor` and parses the string to datetime in `DateTimeSensorAsync.execute`

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
