### PR TITLE
sets encoding to utf-8 by default while reading task logs

### DIFF
--- a/airflow/utils/log/file_task_handler.py
+++ b/airflow/utils/log/file_task_handler.py
@@ -116,7 +116,7 @@ class FileTaskHandler(logging.Handler):
 
         if os.path.exists(location):
             try:
-                with open(location) as file:
+                with open(location, encoding="utf-8", errors="surrogateescape") as file:
                     log += f"*** Reading local file: {location}\n"
                     log += "".join(file.readlines())
             except Exception as e:


### PR DESCRIPTION
closes: #16834 

Airflow task log rendering fails when there are characters out of ascii range in the log. Since writing the log doesn't generate this (logs are accessible from backend), the task log reading part needs to be fixed.