### PR TITLE
logs task launch exception in standard task runner

### DIFF
--- a/airflow/task/task_runner/standard_task_runner.py
+++ b/airflow/task/task_runner/standard_task_runner.py
@@ -85,6 +85,11 @@ class StandardTaskRunner(BaseTaskRunner):
                 args.func(args, dag=self.dag)
                 return_code = 0
             except Exception:
+                self.log.exception(
+                    "Failed to execute job %s fo task %s",
+                    self._task_instance.job_id,
+                    self._task_instance.task_id,
+                )
                 return_code = 1
             finally:
                 # Explicitly flush any pending exception to Sentry if enabled


### PR DESCRIPTION

closes: #17966 

Adds an error log message to task runner when task launch fails with error code 1
