### PR TITLE
Update max_tis_per_query docs to better render on the webpage

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1800,11 +1800,8 @@
     - name: max_tis_per_query
       description: |
         This changes the batch size of queries in the scheduling main loop.
-        If this is too high, SQL query performance may be impacted by one
-        or more of the following:
-        - reversion to full table scan
-        - complexity of query predicate
-        - excessive locking
+        If this is too high, SQL query performance may be impacted by
+        reversion to full table scan, complexity of query predicate, and/or excessive locking.
         Additionally, you may hit the maximum allowable query length for your db.
         Set this to 0 for no limit (not advised)
       version_added: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -897,11 +897,8 @@ scheduler_zombie_task_threshold = 300
 catchup_by_default = True
 
 # This changes the batch size of queries in the scheduling main loop.
-# If this is too high, SQL query performance may be impacted by one
-# or more of the following:
-# - reversion to full table scan
-# - complexity of query predicate
-# - excessive locking
+# If this is too high, SQL query performance may be impacted by
+# reversion to full table scan, complexity of query predicate, and/or excessive locking.
 # Additionally, you may hit the maximum allowable query length for your db.
 # Set this to 0 for no limit (not advised)
 max_tis_per_query = 512


### PR DESCRIPTION
The bullet point format looks good in the code, but [doesn't actually render in the webpage](https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#max-tis-per-query). Since I found no other instances of bullet format in the Configuration Reference page and there are only three items in the list, I simply change it to a normal English sentence.