### PR TITLE
 Implement before stm and after stm 

### DIFF
--- a/airflow/providers/mysql/hooks/mysql.py
+++ b/airflow/providers/mysql/hooks/mysql.py
@@ -282,3 +282,25 @@ class MySqlHook(DbApiHook):
 
         cursor.close()
         conn.commit()
+
+    @staticmethod
+    def insert_ignore() -> str:
+        return "INSERT IGNORE"
+
+    @staticmethod
+    def on_duplicate_key_update(columns: Dict[str, str]):
+        """Implement ON DUPLICATE KEY UPDATE statement in mysql
+
+        :param columns: a dictionary that map columns to their update value
+
+            .. seealso:: https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html
+        :type  columns: Dict[str, str]
+
+         >>> print(MySqlHook.on_duplicate_key_update({"updated_at": "now()"}))
+         ON DUPLICATE KEY UPDATE updated_at=now()
+
+         >>> print(MySqlHook.on_duplicate_key_update({"col1": "VALUES(col1)"}))
+         ON DUPLICATE KEY UPDATE updated_at=VALUES(col1)
+        """
+        update_columns_list = [f"{key}={value}" for key, value in columns.items()]
+        return f"ON DUPLICATE KEY UPDATE {', '.join(update_columns_list)}"

--- a/tests/hooks/test_dbapi.py
+++ b/tests/hooks/test_dbapi.py
@@ -232,3 +232,69 @@ class TestDbApiHook(unittest.TestCase):
         assert called == 2
         assert self.conn.commit.called
         assert result == [obj, obj]
+
+    def test__generate_insert_sql(self):
+        actual_sql = self.db_hook._generate_insert_sql(
+            table="test-table",
+            values=(("col1_value", "col2_value")),
+            target_fields=("col1", "col2"),
+            replace=False,
+        )
+
+        expected_sql = "INSERT INTO test-table (col1, col2) VALUES (%s,%s)"
+
+        assert expected_sql == actual_sql
+
+    def test__generate_insert_sql_with_replace(self):
+        actual_sql = self.db_hook._generate_insert_sql(
+            table="test-table",
+            values=("col1_value", "col2_value"),
+            target_fields=("col1", "col2"),
+            replace=True,
+        )
+
+        expected_sql = "REPLACE INTO test-table (col1, col2) VALUES (%s,%s)"
+
+        assert expected_sql == actual_sql
+
+    def test__generate_insert_sql_with_before_statement(self):
+        actual_sql = self.db_hook._generate_insert_sql(
+            table="test-table",
+            values=("col1_value", "col2_value"),
+            target_fields=("col1", "col2"),
+            replace=False,
+            before_statement="INSERT IGNORE",
+        )
+
+        expected_sql = "INSERT IGNORE test-table (col1, col2) VALUES (%s,%s)"
+
+        assert expected_sql == actual_sql
+
+    def test__generate_insert_sql_with_after_statement(self):
+        actual_sql = self.db_hook._generate_insert_sql(
+            table="test-table",
+            values=("col1_value", "col2_value"),
+            target_fields=("pkey", "col1", "col2"),
+            replace=False,
+            after_statement="ON CONFLICT DO NOTHING",
+        )
+
+        expected_sql = "INSERT INTO test-table (pkey, col1, col2) VALUES (%s,%s) ON CONFLICT DO NOTHING"
+
+        assert expected_sql == actual_sql
+
+    def test_test__generate_insert_sql_with_before_and_after_statement(self):
+        actual_sql = self.db_hook._generate_insert_sql(
+            table="test-table",
+            values=("pdate_value", "col1_value", "col2_value"),
+            target_fields=("pkey", "pdate", "col1", "col2"),
+            replace=False,
+            before_statement="INSERT HIGH_PRIORITY",
+            after_statement="ON DUPLICATE KEY UPDATE col1=VALUE(col1)",
+        )
+
+        expected_sql = (
+            "INSERT HIGH_PRIORITY test-table (pkey, pdate, col1, col2) VALUES (%s,%s,%s) "
+            "ON DUPLICATE KEY UPDATE col1=VALUE(col1)"
+        )
+        assert expected_sql == actual_sql

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -348,6 +348,32 @@ class TestMySqlHook(unittest.TestCase):
             """
         )
 
+    def test_insert_ignore(self):
+        actual = self.db_hook._generate_insert_sql(
+            table="test",
+            values=(1, 2),
+            target_fields=("col1", "col2"),
+            replace=False,
+            before_statement=MySqlHook.insert_ignore(),
+        )
+
+        expected = "INSERT IGNORE test (col1, col2) VALUES (%s,%s)"
+
+        assert actual == expected
+
+    def test_on_duplicate_key_update(self):
+        actual = self.db_hook._generate_insert_sql(
+            table="test",
+            values=(1, 2),
+            target_fields=("col1", "col2"),
+            replace=False,
+            after_statement=MySqlHook.on_duplicate_key_update({"col1": "VALUES(col1)"}),
+        )
+
+        expected = "INSERT INTO test (col1, col2) VALUES (%s,%s) ON DUPLICATE KEY UPDATE col1=VALUES(col1)"
+
+        assert actual == expected
+
 
 DEFAULT_DATE = timezone.datetime(2015, 1, 1)
 DEFAULT_DATE_ISO = DEFAULT_DATE.isoformat()


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This new feature  on top of `insert_rows` method gives more flexibility to the users to control type of `INSERT` statement and  also after statement. it can help users to implement more complex insert statements such as `partitioning`, `update`, `conflicts`, etc.

---
**^ Add meaningful description above**

related: #17938

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
