### PR TITLE
Implement API endpoint for DAG deletion

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -20,7 +20,7 @@ from marshmallow import ValidationError
 from airflow import DAG
 from airflow._vendor.connexion import NoContent
 from airflow.api_connexion import security
-from airflow.api_connexion.exceptions import BadRequest, NotFound
+from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
 from airflow.api_connexion.schemas.dag_schema import (
     DAGCollection,
@@ -28,7 +28,7 @@ from airflow.api_connexion.schemas.dag_schema import (
     dag_schema,
     dags_collection_schema,
 )
-from airflow.exceptions import DagNotFound, SerializedDagNotFound
+from airflow.exceptions import AirflowException, DagNotFound, SerializedDagNotFound
 from airflow.models.dag import DagModel
 from airflow.security import permissions
 from airflow.settings import Session
@@ -117,5 +117,7 @@ def delete_dag(dag_id: str, session: Session):
         delete_dag.delete_dag(dag_id, session=session)
     except DagNotFound:
         raise NotFound(f"Dag with id: '{dag_id}' not found")
+    except AirflowException:
+        raise AlreadyExists(detail=f"Task instances of fag with id: '{dag_id}' are still running")
 
     return NoContent, 204

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -118,6 +118,6 @@ def delete_dag(dag_id: str, session: Session):
     except DagNotFound:
         raise NotFound(f"Dag with id: '{dag_id}' not found")
     except AirflowException:
-        raise AlreadyExists(detail=f"Task instances of fag with id: '{dag_id}' are still running")
+        raise AlreadyExists(detail=f"Task instances of dag with id: '{dag_id}' are still running")
 
     return NoContent, 204

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -18,6 +18,7 @@ from flask import current_app, g, request
 from marshmallow import ValidationError
 
 from airflow import DAG
+from airflow._vendor.connexion import NoContent
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound
 from airflow.api_connexion.parameters import check_limit, format_parameters
@@ -27,9 +28,10 @@ from airflow.api_connexion.schemas.dag_schema import (
     dag_schema,
     dags_collection_schema,
 )
-from airflow.exceptions import SerializedDagNotFound
+from airflow.exceptions import DagNotFound, SerializedDagNotFound
 from airflow.models.dag import DagModel
 from airflow.security import permissions
+from airflow.settings import Session
 from airflow.utils.session import provide_session
 
 
@@ -100,3 +102,20 @@ def patch_dag(session, dag_id, update_mask=None):
     setattr(dag, 'is_paused', patch_body['is_paused'])
     session.commit()
     return dag_schema.dump(dag)
+
+
+@security.requires_access([(permissions.ACTION_CAN_DELETE, permissions.RESOURCE_DAG)])
+@provide_session
+def delete_dag(dag_id: str, session: Session):
+    """Delete the specific DAG."""
+    # TODO: This function is shared with the /delete endpoint used by the web
+    # UI, so we're reusing it to simplify maintenance. Refactor the function to
+    # another place when the experimental/legacy API is removed.
+    from airflow.api.common.experimental import delete_dag
+
+    try:
+        delete_dag.delete_dag(dag_id, session=session)
+    except DagNotFound:
+        raise NotFound(f"Dag with id: '{dag_id}' not found")
+
+    return NoContent, 204

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -230,7 +230,7 @@ info:
     ## AlreadyExists
 
     The request could not be completed due to a conflict with the current state of the target
-    resource, meaning that the resource already exists
+    resource, e.g. the resource it tries to create already exists.
 
     ## Unknown
 
@@ -480,6 +480,9 @@ paths:
 
     delete:
       summary: Delete a DAG
+      description: >
+        Deletes all metadata related to the DAG, including finished DAG Runs and Tasks.
+        Logs are not deleted. This action cannot be undone.
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint
       operationId: delete_dag
       tags: [DAG]
@@ -494,6 +497,8 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/AlreadyExists'
 
   /dags/{dag_id}/clearTaskInstances:
     parameters:
@@ -3539,7 +3544,7 @@ components:
             $ref: '#/components/schemas/Error'
     # 409
     'AlreadyExists':
-      description: The resource that a client tried to create already exists.
+      description: An existing resource conflicts with the request.
       content:
         application/json:
           schema:

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -478,6 +478,23 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+    delete:
+      summary: Delete a DAG
+      x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint
+      operationId: delete_dag
+      tags: [DAG]
+      responses:
+        '204':
+          description: Success.
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /dags/{dag_id}/clearTaskInstances:
     parameters:
       - $ref: '#/components/parameters/DAGID'

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -20,6 +20,7 @@
 #       to be marked in an ERROR state
 """Exceptions used by Airflow"""
 import datetime
+import warnings
 from typing import Any, Dict, List, NamedTuple, Optional
 
 from airflow.utils.code_utils import prepare_code_snippet
@@ -138,6 +139,10 @@ class DagRunAlreadyExists(AirflowBadRequest):
 
 class DagFileExists(AirflowBadRequest):
     """Raise when a DAG ID is still in DagBag i.e., DAG file is in DAG folder"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn("DagFileExists is deprecated and will be removed.", DeprecationWarning, stacklevel=2)
 
 
 class DuplicateTaskIdFound(AirflowException):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1556,7 +1556,7 @@ class Airflow(AirflowBaseView):
     def delete(self):
         """Deletes DAG."""
         from airflow.api.common.experimental import delete_dag
-        from airflow.exceptions import DagFileExists, DagNotFound
+        from airflow.exceptions import DagNotFound
 
         dag_id = request.values.get('dag_id')
         origin = get_safe_url(request.values.get('origin'))
@@ -1565,9 +1565,6 @@ class Airflow(AirflowBaseView):
             delete_dag.delete_dag(dag_id)
         except DagNotFound:
             flash(f"DAG with id {dag_id} not found. Cannot delete", 'error')
-            return redirect(request.referrer)
-        except DagFileExists:
-            flash(f"Dag id {dag_id} is still in DagBag. Remove the DAG file first.", 'error')
             return redirect(request.referrer)
         except AirflowException:
             flash(


### PR DESCRIPTION
Close #17969.

I’m not sure about the error returned for `DagFileExists`. I was considering 409 Conflict, but Airflow (and Connexion) seems to define that to only represent conflicts on POST. I’m settling for 400 Bad Request, but I feel the current definition is too narrow. The definition in RFC 7231 is much broader and IMO applies here:

> The 409 (Conflict) status code indicates that the request could not be completed due to a conflict with the current state of the target resource.  This code is used in situations where the user might be able to resolve the conflict and resubmit the request.

https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.8