### PR TITLE
Serialize the template_ext attribute to show it in UI

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1572,6 +1572,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
                     'subdag',
                     'ui_color',
                     'ui_fgcolor',
+                    'template_ext',
                     'template_fields',
                     'template_fields_renderers',
                 }

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -434,6 +434,7 @@ class SerializedBaseOperator(BaseOperator, BaseSerialization):
         # Move class attributes into object attributes.
         self.ui_color = BaseOperator.ui_color
         self.ui_fgcolor = BaseOperator.ui_fgcolor
+        self.template_ext = BaseOperator.template_ext
         self.template_fields = BaseOperator.template_fields
         self.operator_extra_links = BaseOperator.operator_extra_links
 

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -99,6 +99,7 @@ serialized_simple_dag_ground_truth = {
                 "_outlets": [],
                 "ui_color": "#f0ede4",
                 "ui_fgcolor": "#000",
+                "template_ext": ['.sh', '.bash'],
                 "template_fields": ['bash_command', 'env'],
                 "template_fields_renderers": {'bash_command': 'bash', 'env': 'json'},
                 "bash_command": "echo {{ task.task_id }}",
@@ -130,6 +131,7 @@ serialized_simple_dag_ground_truth = {
                 "_operator_extra_links": [{"tests.test_utils.mock_operators.CustomOpLink": {}}],
                 "ui_color": "#fff",
                 "ui_fgcolor": "#000",
+                "template_ext": [],
                 "template_fields": ['bash_command'],
                 "template_fields_renderers": {},
                 "_task_type": "CustomOperator",
@@ -447,6 +449,7 @@ class TestStringifiedDAGs(unittest.TestCase):
             # Type is excluded, so don't check it
             '_log',
             # List vs tuple. Check separately
+            'template_ext',
             'template_fields',
             # We store the string, real dag has the actual code
             'on_failure_callback',
@@ -457,6 +460,8 @@ class TestStringifiedDAGs(unittest.TestCase):
         }
 
         assert serialized_task.task_type == task.task_type
+
+        assert set(serialized_task.template_ext) == set(task.template_ext)
         assert set(serialized_task.template_fields) == set(task.template_fields)
 
         assert serialized_task.upstream_task_ids == task.upstream_task_ids


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: https://github.com/apache/airflow/issues/17932

This PR includes `template_ext` as a serialized field. Because `template_ext` is currently not serialized, the task attributes view shows an empty tuple, which is incorrect. With this change, it shows correctly (tuple is converted to list):

![image](https://user-images.githubusercontent.com/6249654/131827393-54dbaddc-0678-46c8-a4e5-c3f552fa5039.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
