### PR TITLE
AwsBaseHook make `client_type` & `resource_type` optional params for `get_client_type` & `get_resource_type`

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -452,13 +452,15 @@ class AwsBaseHook(BaseHook):
 
     def get_resource_type(
         self,
-        resource_type: str,
+        resource_type: Optional[str] = None,
         region_name: Optional[str] = None,
         config: Optional[Config] = None,
     ) -> boto3.resource:
         """Get the underlying boto3 resource using boto3 session"""
         session, endpoint_url = self._get_credentials(region_name)
 
+        if resource_type is None:
+            resource_type = self.resource_type
         # No AWS Operators use the config argument to this method.
         # Keep backward compatibility with other users who might use it
         if config is None:

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -433,12 +433,15 @@ class AwsBaseHook(BaseHook):
 
     def get_client_type(
         self,
-        client_type: str,
+        client_type: Optional[str] = None,
         region_name: Optional[str] = None,
         config: Optional[Config] = None,
     ) -> boto3.client:
         """Get the underlying boto3 client using boto3 session"""
         session, endpoint_url = self._get_credentials(region_name)
+
+        if client_type is None:
+            client_type = self.client_type
 
         # No AWS Operators use the config argument to this method.
         # Keep backward compatibility with other users who might use it

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -27,6 +27,7 @@ This module contains Base AWS Hook.
 import configparser
 import datetime
 import logging
+import warnings
 from functools import wraps
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
@@ -440,7 +441,13 @@ class AwsBaseHook(BaseHook):
         """Get the underlying boto3 client using boto3 session"""
         session, endpoint_url = self._get_credentials(region_name)
 
-        if client_type is None:
+        if client_type:
+            warnings.warn(
+                "client_type is deprecated. Set client_type from class attribute.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
             client_type = self.client_type
 
         # No AWS Operators use the config argument to this method.
@@ -459,8 +466,15 @@ class AwsBaseHook(BaseHook):
         """Get the underlying boto3 resource using boto3 session"""
         session, endpoint_url = self._get_credentials(region_name)
 
-        if resource_type is None:
+        if resource_type:
+            warnings.warn(
+                "resource_type is deprecated. Set resource_type from class attribute.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        else:
             resource_type = self.resource_type
+
         # No AWS Operators use the config argument to this method.
         # Keep backward compatibility with other users who might use it
         if config is None:

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -137,6 +137,18 @@ class TestAwsBaseHook(unittest.TestCase):
         client_from_hook = hook.get_client_type(client_type='emr')
         assert client_from_hook.list_clusters()['Clusters'] == []
 
+    @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
+    @mock_emr
+    def test_get_client_type_deprecation_warning(self):
+        client = boto3.client('emr', region_name='us-east-1')
+        if client.list_clusters()['Clusters']:
+            raise ValueError('AWS not properly mocked')
+        hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
+        warning_message = """client_type is deprecated. Set client_type from class attribute."""
+        with pytest.warns(DeprecationWarning) as warnings:
+            hook.get_client_type(client_type='emr')
+            assert warning_message == str(warnings[0].message)
+
     @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
     @mock_dynamodb2
     def test_get_resource_type_returns_a_boto3_resource_of_the_requested_type(self):
@@ -196,6 +208,15 @@ class TestAwsBaseHook(unittest.TestCase):
         table.meta.client.get_waiter('table_exists').wait(TableName='test_airflow')
 
         assert table.item_count == 0
+
+    @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
+    @mock_dynamodb2
+    def test_get_resource_deprecation_warning(self):
+        hook = AwsBaseHook(aws_conn_id='aws_default', resource_type='dynamodb')
+        warning_message = """resource_type is deprecated. Set resource_type from class attribute."""
+        with pytest.warns(DeprecationWarning) as warnings:
+            hook.get_resource_type('dynamodb')
+            assert warning_message == str(warnings[0].message)
 
     @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
     @mock_dynamodb2

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -112,10 +112,20 @@ class TestAwsBaseHook(unittest.TestCase):
         if client.list_clusters()['Clusters']:
             raise ValueError('AWS not properly mocked')
 
-        hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
-        client_from_hook = hook.get_client_type('emr')
+        with self.subTest("client_type set in both class and function"):
+            hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
+            client_from_hook = hook.get_client_type(client_type='emr')
+            assert client_from_hook.list_clusters()['Clusters'] == []
 
-        assert client_from_hook.list_clusters()['Clusters'] == []
+        with self.subTest("client_type set only in class"):
+            hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
+            client_from_hook = hook.get_client_type()
+            assert client_from_hook.list_clusters()['Clusters'] == []
+
+        with self.subTest("client_type overwrite by function"):
+            hook = AwsBaseHook(aws_conn_id='aws_default', client_type='dynamodb')
+            client_from_hook = hook.get_client_type(client_type='emr')
+            assert client_from_hook.list_clusters()['Clusters'] == []
 
     @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
     @mock_dynamodb2

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -140,9 +140,6 @@ class TestAwsBaseHook(unittest.TestCase):
     @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
     @mock_emr
     def test_get_client_type_deprecation_warning(self):
-        client = boto3.client('emr', region_name='us-east-1')
-        if client.list_clusters()['Clusters']:
-            raise ValueError('AWS not properly mocked')
         hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
         warning_message = """client_type is deprecated. Set client_type from class attribute."""
         with pytest.warns(DeprecationWarning) as warnings:

--- a/tests/providers/amazon/aws/hooks/test_base_aws.py
+++ b/tests/providers/amazon/aws/hooks/test_base_aws.py
@@ -111,21 +111,31 @@ class TestAwsBaseHook(unittest.TestCase):
         client = boto3.client('emr', region_name='us-east-1')
         if client.list_clusters()['Clusters']:
             raise ValueError('AWS not properly mocked')
+        hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
+        client_from_hook = hook.get_client_type('emr')
 
-        with self.subTest("client_type set in both class and function"):
-            hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
-            client_from_hook = hook.get_client_type(client_type='emr')
-            assert client_from_hook.list_clusters()['Clusters'] == []
+        assert client_from_hook.list_clusters()['Clusters'] == []
 
-        with self.subTest("client_type set only in class"):
-            hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
-            client_from_hook = hook.get_client_type()
-            assert client_from_hook.list_clusters()['Clusters'] == []
+    @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
+    @mock_emr
+    def test_get_client_type_set_in_class_attribute(self):
+        client = boto3.client('emr', region_name='us-east-1')
+        if client.list_clusters()['Clusters']:
+            raise ValueError('AWS not properly mocked')
+        hook = AwsBaseHook(aws_conn_id='aws_default', client_type='emr')
+        client_from_hook = hook.get_client_type()
 
-        with self.subTest("client_type overwrite by function"):
-            hook = AwsBaseHook(aws_conn_id='aws_default', client_type='dynamodb')
-            client_from_hook = hook.get_client_type(client_type='emr')
-            assert client_from_hook.list_clusters()['Clusters'] == []
+        assert client_from_hook.list_clusters()['Clusters'] == []
+
+    @unittest.skipIf(mock_emr is None, 'mock_emr package not present')
+    @mock_emr
+    def test_get_client_type_overwrite(self):
+        client = boto3.client('emr', region_name='us-east-1')
+        if client.list_clusters()['Clusters']:
+            raise ValueError('AWS not properly mocked')
+        hook = AwsBaseHook(aws_conn_id='aws_default', client_type='dynamodb')
+        client_from_hook = hook.get_client_type(client_type='emr')
+        assert client_from_hook.list_clusters()['Clusters'] == []
 
     @unittest.skipIf(mock_dynamodb2 is None, 'mock_dynamo2 package not present')
     @mock_dynamodb2


### PR DESCRIPTION
Currently user must specify `client_type` to for `get_client_type` so an example usage is:

`emr_client = AwsBaseHook(self.aws_conn_id, client_type='emr', region_name='us-east-1').get_client_type('emr')`

however we already have `client_type` as class attribute so we can simplify it to:

`emr_client = AwsBaseHook(self.aws_conn_id, client_type='emr', region_name='us-east-1').get_client_type()`

**EDIT**:
Same applied for `resource_type` with `get_resource_type`

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
