### PR TITLE
Fix blank dag dependencies view

### DIFF
--- a/airflow/www/templates/airflow/dag_dependencies.html
+++ b/airflow/www/templates/airflow/dag_dependencies.html
@@ -44,7 +44,7 @@ under the License.
     <span class="legend-item trigger">trigger</span>
     <span class="legend-item sensor">sensor</span>
   </div>
-  <div style="float:right">Last refresh: {{ last_refresh }}</div>
+  <div style="float:right">Last refresh: <time datetime="{{ last_refresh }}">{{ last_refresh }}</time></div>
 </div>
 <div id="error" style="display: none; margin-top: 10px;" class="alert alert-danger" role="alert">
   <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4295,9 +4295,7 @@ class DagDependenciesView(AirflowBaseView):
         title = "DAG Dependencies"
 
         if timezone.utcnow() > self.last_refresh + self.refresh_interval:
-            max_last_updated = SerializedDagModel.get_max_last_updated_datetime()
-            if max_last_updated is None or max_last_updated > self.last_refresh:
-                self._calculate_graph()
+            self._calculate_graph()
             self.last_refresh = timezone.utcnow()
 
         return self.render_template(
@@ -4305,7 +4303,7 @@ class DagDependenciesView(AirflowBaseView):
             title=title,
             nodes=self.nodes,
             edges=self.edges,
-            last_refresh=self.last_refresh.strftime("%Y-%m-%d %H:%M:%S"),
+            last_refresh=self.last_refresh,
             arrange=conf.get("webserver", "dag_orientation"),
             width=request.args.get("width", "100%"),
             height=request.args.get("height", "800"),

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4294,8 +4294,13 @@ class DagDependenciesView(AirflowBaseView):
         """Display DAG dependencies"""
         title = "DAG Dependencies"
 
-        if timezone.utcnow() > self.last_refresh + self.refresh_interval:
+        if not self.nodes or not self.edges:
             self._calculate_graph()
+            self.last_refresh = timezone.utcnow()
+        elif timezone.utcnow() > self.last_refresh + self.refresh_interval:
+            max_last_updated = SerializedDagModel.get_max_last_updated_datetime()
+            if max_last_updated is None or max_last_updated > self.last_refresh:
+                self._calculate_graph()
             self.last_refresh = timezone.utcnow()
 
         return self.render_template(


### PR DESCRIPTION
When there is an issue with the scheduler `max_last_updated` may be older than `last_refresh` and therefore `calculate_graph` was never being called leaving the `nodes` and `edges` to be blank. ~~Removing it allows us to calculate the nodes and edges even in that circumstance.~~

Update: I added a check to calculate the graph when there isn't already node or edge data.

Bonus: Make the `last_refresh` change with the app's timezone like all other dates.

Closes #16610

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
