### PR TITLE
Reduce number of lines in "monitoring job" parallel group

### DIFF
--- a/scripts/ci/libraries/_docker_engine_resources.sh
+++ b/scripts/ci/libraries/_docker_engine_resources.sh
@@ -18,18 +18,18 @@
 
 
 function docker_engine_resources::print_overall_stats() {
-    echo
-    echo "Docker statistics"
-    echo
-    docker stats --all --no-stream --no-trunc
-    echo
-    echo "Memory statistics"
+    docker stats --all --no-stream
     echo
     docker run --rm --entrypoint /bin/sh "alpine:latest" -c "free -m"
     echo
-    echo "Disk statistics"
-    echo
-    df -h || true
+    df -h \
+        --exclude-type devtmpfs \
+        --exclude-type overlay \
+        --exclude-type squashfs \
+        | grep -v " /run" \
+        | grep -v " /sys" \
+        | grep -v "/dev/shm" \
+    || true
 }
 
 function docker_engine_resources::get_available_cpus_in_docker() {

--- a/scripts/ci/libraries/_parallel.sh
+++ b/scripts/ci/libraries/_parallel.sh
@@ -73,7 +73,7 @@ function parallel::monitor_loop() {
     while true
     do
         echo
-        echo "${COLOR_YELLOW}########### Monitoring progress start: ${progress_report_number} #################${COLOR_RESET}"
+        echo "${COLOR_YELLOW}########## Monitoring progress start: ${progress_report_number}  ##########${COLOR_RESET}"
         echo
         echo "${COLOR_BLUE}########### STATISTICS #################"
         docker_engine_resources::print_overall_stats
@@ -87,31 +87,22 @@ function parallel::monitor_loop() {
             fi
 
             echo "${COLOR_BLUE}### The last ${PARALLEL_TAIL_LENGTH} lines for ${parallel_process} process: ${directory}/stdout ###${COLOR_RESET}"
-            echo
             tail "-${PARALLEL_TAIL_LENGTH}" "${directory}/stdout" || true
             echo
 
             if [[ -s "${directory}/status" ]]; then
               finished_jobs+=("$parallel_process")
-              status=$(cat "${directory}/status")
-
-              if [[ $status == 0 ]]; then
-                local color="$COLOR_GREEN"
-              else
-                local color="$COLOR_RED"
-              fi
-              echo "${color}### Test ${parallel_process} exited with ${status}${COLOR_RESET}"
+              # The last line of output (which we've already shown) will be a line about the success/failure
+              # of this job
             fi
 
             echo
 
         done
-        echo
-        echo "${COLOR_YELLOW}########### Monitoring progress end: ${progress_report_number} #################${COLOR_RESET}"
-        echo
+
         end_time=${SECONDS}
-        echo "${COLOR_YELLOW}############## $((end_time - start_time)) seconds passed since start ####################### ${COLOR_RESET}"
-        sleep 10
+        echo "${COLOR_YELLOW}########## $((end_time - start_time)) seconds passed since start ##########${COLOR_RESET}"
+        sleep 15
         progress_report_number=$((progress_report_number + 1))
     done
 }

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -176,11 +176,9 @@ function run_airflow_testing_in_docker() {
     if [[ ${exit_code} == 0 ]]; then
         echo
         echo "${COLOR_GREEN}Test type: ${TEST_TYPE} succeeded.${COLOR_RESET}"
-        echo
     else
         echo
         echo "${COLOR_RED}Test type: ${TEST_TYPE} failed.${COLOR_RESET}"
-        echo
     fi
     return "${exit_code}"
 }


### PR DESCRIPTION
Although this group is collapsed when the job is finished it it is large
it can cause the logs view in GitHub to bog down the browser, so this PR
does a few things:

- Stops showing disk information for "overlay" FS types -- i.e. docker
  containers as they share the same disk usage as the docker root
- Removes a few "duplicated" messages to further reduce output
-  Reduces the poll interval form 10s to 15s

This reduces this "hidden" output from around 4200 lines to around 2000.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).