### PR TITLE
Fix error when create external table using table resource

### DIFF
--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1119,6 +1119,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         # BQ config
         kwargs_passed = any(
             [
+                destination_project_dataset_table
                 schema_fields,
                 source_format,
                 compression,

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1119,7 +1119,6 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         # BQ config
         kwargs_passed = any(
             [
-                destination_project_dataset_table,
                 schema_fields,
                 source_format,
                 compression,

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -29,7 +29,6 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, SupportsA
 
 import attr
 from google.api_core.exceptions import Conflict
-from google.cloud.bigquery import TableReference
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator, BaseOperatorLink

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1198,12 +1198,8 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             self.table_resource["externalDataConfiguration"]["schema"] = schema_fields
 
         if self.table_resource:
-            tab_ref = TableReference.from_string(self.destination_project_dataset_table)
             bq_hook.create_empty_table(
                 table_resource=self.table_resource,
-                project_id=tab_ref.project,
-                table_id=tab_ref.table_id,
-                dataset_id=tab_ref.dataset_id,
             )
         else:
             source_uris = [f"gs://{self.bucket}/{source_object}" for source_object in self.source_objects]

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1119,7 +1119,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
         # BQ config
         kwargs_passed = any(
             [
-                destination_project_dataset_table
+                destination_project_dataset_table,
                 schema_fields,
                 source_format,
                 compression,

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1187,6 +1187,7 @@ class BigQueryCreateExternalTableOperator(BaseOperator):
             bq_hook.create_empty_table(
                 table_resource=self.table_resource,
             )
+            return
 
         if not self.schema_fields and self.schema_object and self.source_format != 'DATASTORE_BACKUP':
             gcs_hook = GCSHook(


### PR DESCRIPTION
affected operator: class BigQueryCreateExternalTableOperator(BaseOperator):
root cause: destination_project_dataset_table is being used in l1201 but cannot pass init check at 1154 where  ValueError(“You provided both `table_resource` and exclusive keywords arguments.“) is returned

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
