### PR TITLE
Hide variable import form if user lacks permission

### DIFF
--- a/airflow/www/templates/airflow/variable_list.html
+++ b/airflow/www/templates/airflow/variable_list.html
@@ -20,6 +20,7 @@
 {% extends 'appbuilder/general/model/list.html' %}
 
 {% block content %}
+  {% if can_create_variable() %}
   <div class="well well-sm pull-left">
     <form class="form-inline" action="{{ url_for('VariableModelView.varimport') }}" method="post" enctype="multipart/form-data">
       {% if csrf_token %}
@@ -35,5 +36,6 @@
     </form>
   </div>
   <div class="clearfix"></div>
+  {% endif %}
   {{ super() }}
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3570,7 +3570,7 @@ class PoolModelView(AirflowModelView):
     validators_columns = {'pool': [validators.DataRequired()], 'slots': [validators.NumberRange(min=-1)]}
 
 
-def _can_create_variable():
+def _can_create_variable() -> bool:
     return current_app.appbuilder.sm.has_access(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3570,6 +3570,10 @@ class PoolModelView(AirflowModelView):
     validators_columns = {'pool': [validators.DataRequired()], 'slots': [validators.NumberRange(min=-1)]}
 
 
+def _can_create_variable():
+    return current_app.appbuilder.sm.has_access(permissions.ACTION_CAN_CREATE, permissions.RESOURCE_VARIABLE)
+
+
 class VariableModelView(AirflowModelView):
     """View to show records from Variable table"""
 
@@ -3624,6 +3628,8 @@ class VariableModelView(AirflowModelView):
     def prefill_form(self, form, request_id):
         if secrets_masker.should_hide_value_for_key(form.key.data):
             form.val.data = '*' * 8
+
+    extra_args = {"can_create_variable": _can_create_variable}
 
     @action('muldelete', 'Delete', 'Are you sure you want to delete selected records?', single=False)
     def action_muldelete(self, items):


### PR DESCRIPTION
This hides the variable import form if the user does not have the "can
create on variable" permission.

Before or if the user has "can create on variable":

![Screen Shot 2021-09-02 at 6 04 58 PM](https://user-images.githubusercontent.com/66968678/131931038-ab97c324-11c7-4a76-b5a4-8ae8c9f3c69e.png)

After for users without "can create on variable":
![Screen Shot 2021-09-02 at 6 05 06 PM](https://user-images.githubusercontent.com/66968678/131931071-b27edba7-d43c-447a-94a1-0194683cdb2a.png)
