### PR TITLE
fix(CloudSqlProxyRunner): don't query connections from Airflow DB

### DIFF
--- a/airflow/providers/google/cloud/hooks/cloud_sql.py
+++ b/airflow/providers/google/cloud/hooks/cloud_sql.py
@@ -39,7 +39,6 @@ from urllib.parse import quote_plus
 import httpx
 from googleapiclient.discovery import Resource, build
 from googleapiclient.errors import HttpError
-from sqlalchemy.orm import Session
 
 from airflow.exceptions import AirflowException
 
@@ -51,7 +50,6 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 from airflow.providers.mysql.hooks.mysql import MySqlHook
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.session import provide_session
 
 UNIX_PATH_MAX = 108
 
@@ -516,10 +514,9 @@ class CloudSqlProxyRunner(LoggingMixin):
         os.chmod(self.sql_proxy_path, 0o744)  # Set executable bit
         self.sql_proxy_was_downloaded = True
 
-    @provide_session
-    def _get_credential_parameters(self, session: Session) -> List[str]:
-        connection = session.query(Connection).filter(Connection.conn_id == self.gcp_conn_id).first()
-        session.expunge_all()
+    def _get_credential_parameters(self) -> List[str]:
+        connection = GoogleBaseHook.get_connection(conn_id=self.gcp_conn_id)
+
         if connection.extra_dejson.get(GCP_CREDENTIALS_KEY_PATH):
             credential_params = ['-credential_file', connection.extra_dejson[GCP_CREDENTIALS_KEY_PATH]]
         elif connection.extra_dejson.get(GCP_CREDENTIALS_KEYFILE_DICT):


### PR DESCRIPTION
Instead of directly querying connections from Airflow DB we use
`get_connection()` which also supports external secrets backends.

closes: #18003

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #18003
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
