### PR TITLE
Fix unexpected bug in exiting PSRPHook.client context manager

### DIFF
--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -57,7 +57,7 @@ class PSRPHook(BaseHook):
 
     def __exit__(self, exc_type, exc_value, traceback):
         try:
-            self._client.__exit__()
+            self._client.__exit__(exc_type, exc_value, traceback)
         finally:
             self._client = None
 

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -64,6 +64,8 @@ class TestPSRPHook(unittest.TestCase):
 
             hook.invoke_powershell("foo")
 
+        assert ws_man().__exit__.mock_calls == [call(None, None, None)]
+
         assert call('%s', '<output>') in log_info.mock_calls
         assert call('Information: %s', '<message>') in log_info.mock_calls
         assert call('Invocation state: %s', 'Completed') in log_info.mock_calls


### PR DESCRIPTION
This fixes a minor code issue (which rendered the hook unusable).