### PR TITLE
Optimize the providers tests when running subsets of them

### DIFF
--- a/tests/providers/apache/drill/operators/test_drill.py
+++ b/tests/providers/apache/drill/operators/test_drill.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
 import pytest
 
@@ -52,7 +53,7 @@ class TestDrillOperator(unittest.TestCase):
         select * from cp.`employee.json` limit 10
         """
         op = DrillOperator(task_id='drill_operator_test_single', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
     def test_drill_operator_multi(self):
         sql = [
@@ -60,4 +61,4 @@ class TestDrillOperator(unittest.TestCase):
             "select sum(employee_id), any_value(full_name)" "from dfs.tmp.test_airflow",
         ]
         op = DrillOperator(task_id='drill_operator_test_multi', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/apache/hive/operators/test_hive.py
+++ b/tests/providers/apache/hive/operators/test_hive.py
@@ -24,7 +24,7 @@ from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.providers.apache.hive.operators.hive import HiveOperator
 from airflow.utils import timezone
-from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
+from tests.providers.apache.hive import TestHiveEnvironment
 from tests.test_utils.mock_operators import MockHiveOperator
 from tests.test_utils.mock_process import MockSubProcess
 
@@ -108,7 +108,7 @@ class TestHivePresto(TestHiveEnvironment):
         mock_temp_dir.return_value = "tst"
         op = HiveOperator(task_id='basic_hql', hql=self.hql, dag=self.dag, mapred_job_name="test_job_name")
 
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
         hive_cmd = [
             'beeline',
             '-u',
@@ -190,7 +190,7 @@ class TestHivePresto(TestHiveEnvironment):
             mapred_job_name='airflow.test_hive_queues',
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
         mock_popen.assert_called_with(
             hive_cmd,
@@ -287,7 +287,7 @@ class TestHivePresto(TestHiveEnvironment):
             dag=self.dag,
             mapred_job_name="test_job_name",
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
         mock_popen.assert_called_with(
             hive_cmd,
             stdout=mock_subprocess.PIPE,

--- a/tests/providers/apache/hive/sensors/test_hdfs.py
+++ b/tests/providers/apache/hive/sensors/test_hdfs.py
@@ -18,9 +18,10 @@
 
 import os
 import unittest
+from unittest import mock
 
 from airflow.providers.apache.hdfs.sensors.hdfs import HdfsSensor
-from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
+from tests.providers.apache.hive import TestHiveEnvironment
 
 
 @unittest.skipIf('AIRFLOW_RUNALL_TESTS' not in os.environ, "Skipped because AIRFLOW_RUNALL_TESTS is not set")
@@ -31,4 +32,4 @@ class TestHdfsSensor(TestHiveEnvironment):
             filepath='hdfs://user/hive/warehouse/airflow.db/static_babynames',
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/apache/hive/sensors/test_hive_partition.py
+++ b/tests/providers/apache/hive/sensors/test_hive_partition.py
@@ -18,10 +18,11 @@
 
 import os
 import unittest
+from unittest import mock
 from unittest.mock import patch
 
 from airflow.providers.apache.hive.sensors.hive_partition import HivePartitionSensor
-from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
+from tests.providers.apache.hive import TestHiveEnvironment
 from tests.test_utils.mock_hooks import MockHiveMetastoreHook
 
 
@@ -35,4 +36,4 @@ class TestHivePartitionSensor(TestHiveEnvironment):
         op = HivePartitionSensor(
             task_id='hive_partition_check', table='airflow.static_babynames_partitioned', dag=self.dag
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/apache/hive/sensors/test_metastore_partition.py
+++ b/tests/providers/apache/hive/sensors/test_metastore_partition.py
@@ -21,7 +21,7 @@ import unittest
 from unittest import mock
 
 from airflow.providers.apache.hive.sensors.metastore_partition import MetastorePartitionSensor
-from tests.providers.apache.hive import DEFAULT_DATE, DEFAULT_DATE_DS, TestHiveEnvironment
+from tests.providers.apache.hive import DEFAULT_DATE_DS, TestHiveEnvironment
 from tests.test_utils.mock_process import MockDBConnection
 
 
@@ -37,4 +37,4 @@ class TestHivePartitionSensor(TestHiveEnvironment):
             dag=self.dag,
         )
         op._get_hook = mock.MagicMock(return_value=MockDBConnection({}))
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/apache/hive/sensors/test_named_hive_partition.py
+++ b/tests/providers/apache/hive/sensors/test_named_hive_partition.py
@@ -66,7 +66,7 @@ class TestNamedHivePartitionSensor(unittest.TestCase):
             hql=self.hql,
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
     def test_parse_partition_name_correct(self):
         schema = 'default'
@@ -136,7 +136,7 @@ class TestPartitions(TestHiveEnvironment):
             hook=mock_hive_metastore_hook,
         )
 
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
         mock_hive_metastore_hook.check_for_named_partition.assert_called_once_with(
             'airflow', 'static_babynames_partitioned', 'ds=2015-01-01'
@@ -155,7 +155,7 @@ class TestPartitions(TestHiveEnvironment):
             dag=self.dag,
             hook=mock_hive_metastore_hook,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
         mock_hive_metastore_hook.check_for_named_partition.assert_any_call(
             'airflow', 'static_babynames_partitioned', 'ds=2015-01-01'
         )
@@ -187,4 +187,4 @@ class TestPartitions(TestHiveEnvironment):
                 dag=self.dag,
                 hook=mock_hive_metastore_hook,
             )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            op.execute(mock.MagicMock())

--- a/tests/providers/apache/hive/transfers/test_hive_to_samba.py
+++ b/tests/providers/apache/hive/transfers/test_hive_to_samba.py
@@ -17,6 +17,7 @@
 # under the License.
 import os
 import unittest
+from unittest import mock
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 import pytest
@@ -24,7 +25,7 @@ import pytest
 from airflow import PY39
 from airflow.providers.apache.hive.transfers.hive_to_samba import HiveToSambaOperator
 from airflow.utils.operator_helpers import context_to_airflow_vars
-from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
+from tests.providers.apache.hive import TestHiveEnvironment
 from tests.test_utils.mock_hooks import MockHiveServer2Hook, MockSambaHook
 
 
@@ -92,6 +93,6 @@ class TestHive2SambaOperator(TestHiveEnvironment):
                 destination_filepath='test_airflow.csv',
                 dag=self.dag,
             )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            op.execute(mock.MagicMock())
 
         samba_hook.conn.upload.assert_called_with('/tmp/tmptst', 'test_airflow.csv')

--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -35,10 +35,6 @@ TEST_DAG_ID = 'unit_test_dag'
 
 
 class TestHttpSensor(unittest.TestCase):
-    def setUp(self):
-        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
-        self.dag = DAG(TEST_DAG_ID, default_args=args)
-
     @patch("airflow.providers.http.hooks.http.requests.Session.send")
     def test_poke_exception(self, mock_session_send):
         """
@@ -75,7 +71,6 @@ class TestHttpSensor(unittest.TestCase):
         mock_session_send.return_value = response
 
         task = HttpSensor(
-            dag=self.dag,
             task_id='http_sensor_poke_for_code_500',
             http_conn_id='http_default',
             endpoint='',
@@ -96,7 +91,6 @@ class TestHttpSensor(unittest.TestCase):
             return True
 
         task = HttpSensor(
-            dag=self.dag,
             task_id='http_sensor_head_method',
             http_conn_id='http_default',
             endpoint='',
@@ -136,7 +130,6 @@ class TestHttpSensor(unittest.TestCase):
             response_check=resp_check,
             timeout=5,
             poke_interval=1,
-            dag=self.dag,
         )
 
         task_instance = TaskInstance(task=task, execution_date=DEFAULT_DATE)
@@ -154,7 +147,6 @@ class TestHttpSensor(unittest.TestCase):
         mock_session_send.return_value = response
 
         task = HttpSensor(
-            dag=self.dag,
             task_id='http_sensor_head_method',
             http_conn_id='http_default',
             endpoint='',
@@ -221,7 +213,7 @@ class TestHttpOpSensor(unittest.TestCase):
             headers={},
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
     @mock.patch('requests.Session', FakeSession)
     def test_get_response_check(self):
@@ -234,11 +226,11 @@ class TestHttpOpSensor(unittest.TestCase):
             headers={},
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
     @mock.patch('requests.Session', FakeSession)
     def test_sensor(self):
-        sensor = HttpSensor(
+        op = HttpSensor(
             task_id='http_sensor_check',
             http_conn_id='http_default',
             endpoint='/search',
@@ -251,4 +243,4 @@ class TestHttpOpSensor(unittest.TestCase):
             timeout=15,
             dag=self.dag,
         )
-        sensor.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/mysql/operators/test_mysql.py
+++ b/tests/providers/mysql/operators/test_mysql.py
@@ -19,6 +19,7 @@ import os
 import unittest
 from contextlib import closing
 from tempfile import NamedTemporaryFile
+from unittest import mock
 
 import pytest
 from parameterized import parameterized
@@ -63,7 +64,7 @@ class TestMySql(unittest.TestCase):
             );
             """
             op = MySqlOperator(task_id='basic_mysql', sql=sql, dag=self.dag)
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            op.execute(mock.MagicMock())
 
     @parameterized.expand(
         [
@@ -83,7 +84,7 @@ class TestMySql(unittest.TestCase):
                 sql=sql,
                 dag=self.dag,
             )
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+            op.execute(mock.MagicMock())
 
     @parameterized.expand(
         [
@@ -106,10 +107,8 @@ class TestMySql(unittest.TestCase):
 
             from MySQLdb import OperationalError
 
-            try:
-                op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-            except OperationalError as e:
-                assert "Unknown database 'foobar'" in str(e)
+            with pytest.raises(OperationalError, match=r".+Unknown database 'foobar'.+"):
+                op.execute(mock.MagicMock())
 
     def test_mysql_operator_resolve_parameters_template_json_file(self):
 

--- a/tests/providers/mysql/transfers/test_presto_to_mysql.py
+++ b/tests/providers/mysql/transfers/test_presto_to_mysql.py
@@ -17,10 +17,11 @@
 # under the License.
 import os
 import unittest
+from unittest import mock
 from unittest.mock import patch
 
 from airflow.providers.mysql.transfers.presto_to_mysql import PrestoToMySqlOperator
-from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
+from tests.providers.apache.hive import TestHiveEnvironment
 
 
 class TestPrestoToMySqlTransfer(TestHiveEnvironment):
@@ -70,4 +71,4 @@ class TestPrestoToMySqlTransfer(TestHiveEnvironment):
             mysql_preoperator='TRUNCATE TABLE test_static_babynames;',
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/mysql/transfers/test_trino_to_mysql.py
+++ b/tests/providers/mysql/transfers/test_trino_to_mysql.py
@@ -17,10 +17,11 @@
 # under the License.
 import os
 import unittest
+from unittest import mock
 from unittest.mock import patch
 
 from airflow.providers.mysql.transfers.trino_to_mysql import TrinoToMySqlOperator
-from tests.providers.apache.hive import DEFAULT_DATE, TestHiveEnvironment
+from tests.providers.apache.hive import TestHiveEnvironment
 
 
 class TestTrinoToMySqlTransfer(TestHiveEnvironment):
@@ -70,4 +71,4 @@ class TestTrinoToMySqlTransfer(TestHiveEnvironment):
             mysql_preoperator='TRUNCATE TABLE test_static_babynames;',
             dag=self.dag,
         )
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/neo4j/operators/test_neo4j.py
+++ b/tests/providers/neo4j/operators/test_neo4j.py
@@ -58,4 +58,4 @@ class TestNeo4jOperator(unittest.TestCase):
             MATCH (tom {name: "Tom Hanks"}) RETURN tom
             """
         op = Neo4jOperator(task_id='basic_neo4j', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())

--- a/tests/providers/postgres/operators/test_postgres.py
+++ b/tests/providers/postgres/operators/test_postgres.py
@@ -17,10 +17,10 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
 import pytest
 
-from airflow.models.dag import DAG
 from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils import timezone
 
@@ -32,11 +32,6 @@ TEST_DAG_ID = 'unit_test_dag'
 
 @pytest.mark.backend("postgres")
 class TestPostgres(unittest.TestCase):
-    def setUp(self):
-        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
-        dag = DAG(TEST_DAG_ID, default_args=args)
-        self.dag = dag
-
     def tearDown(self):
         tables_to_drop = ['test_postgres_to_postgres', 'test_airflow']
         from airflow.providers.postgres.hooks.postgres import PostgresHook
@@ -52,13 +47,11 @@ class TestPostgres(unittest.TestCase):
             dummy VARCHAR(50)
         );
         """
-        op = PostgresOperator(task_id='basic_postgres', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op = PostgresOperator(task_id='basic_postgres', sql=sql)
+        op.execute(mock.MagicMock())
 
-        autocommit_task = PostgresOperator(
-            task_id='basic_postgres_with_autocommit', sql=sql, dag=self.dag, autocommit=True
-        )
-        autocommit_task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        autocommit_task = PostgresOperator(task_id='basic_postgres_with_autocommit', sql=sql, autocommit=True)
+        autocommit_task.execute(mock.MagicMock())
 
     def test_postgres_operator_test_multi(self):
         sql = [
@@ -66,8 +59,8 @@ class TestPostgres(unittest.TestCase):
             "TRUNCATE TABLE test_airflow",
             "INSERT INTO test_airflow VALUES ('X')",
         ]
-        op = PostgresOperator(task_id='postgres_operator_test_multi', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op = PostgresOperator(task_id='postgres_operator_test_multi', sql=sql)
+        op.execute(mock.MagicMock())
 
     def test_vacuum(self):
         """
@@ -75,8 +68,8 @@ class TestPostgres(unittest.TestCase):
         """
 
         sql = "VACUUM ANALYZE;"
-        op = PostgresOperator(task_id='postgres_operator_test_vacuum', sql=sql, dag=self.dag, autocommit=True)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op = PostgresOperator(task_id='postgres_operator_test_vacuum', sql=sql, autocommit=True)
+        op.execute(mock.MagicMock())
 
     def test_overwrite_schema(self):
         """
@@ -94,7 +87,5 @@ class TestPostgres(unittest.TestCase):
 
         from psycopg2 import OperationalError
 
-        try:
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-        except OperationalError as e:
-            assert 'database "foobar" does not exist' in str(e)
+        with pytest.raises(OperationalError, match=r'.+database "foobar" does not exist.+'):
+            op.execute(mock.MagicMock)

--- a/tests/providers/sqlite/operators/test_sqlite.py
+++ b/tests/providers/sqlite/operators/test_sqlite.py
@@ -17,6 +17,7 @@
 # under the License.
 
 import unittest
+from unittest import mock
 
 import pytest
 
@@ -53,7 +54,7 @@ class TestSqliteOperator(unittest.TestCase):
         );
         """
         op = SqliteOperator(task_id='basic_sqlite', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
     def test_sqlite_operator_with_multiple_statements(self):
         sql = [
@@ -61,7 +62,7 @@ class TestSqliteOperator(unittest.TestCase):
             "INSERT INTO test_airflow VALUES ('X')",
         ]
         op = SqliteOperator(task_id='sqlite_operator_with_multiple_statements', sql=sql, dag=self.dag)
-        op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
+        op.execute(mock.MagicMock())
 
     def test_sqlite_operator_with_invalid_sql(self):
         sql = [
@@ -71,9 +72,6 @@ class TestSqliteOperator(unittest.TestCase):
 
         from sqlite3 import OperationalError
 
-        try:
+        with pytest.raises(OperationalError, match=r"no such table: test_airflow2"):
             op = SqliteOperator(task_id='sqlite_operator_with_multiple_statements', sql=sql, dag=self.dag)
-            op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE, ignore_ti_state=True)
-            pytest.fail("An exception should have been thrown")
-        except OperationalError as e:
-            assert 'no such table: test_airflow2' in str(e)
+            op.execute(mock.MagicMock())


### PR DESCRIPTION
Some tests take an excessively long time to run when you run a subset of the tests locally. This is because they use BaseOperator.run () which loads a lot of classes. In many cases, we can call the BaseOperator.execute method directly, which speeds up these tests.
For example:
Before:
```
$  pytest tests/providers/sqlite/ | tail -n 1
================================== 11 passed, 6 warnings in 9.18s ===================================
$ pytest tests/providers/neo4j/ | tail -n 1
======================== 5 passed, 6 warnings in 9.55s =========================
```

After:
```
$  pytest tests/providers/sqlite/ | tail -n 1
======================================== 11 passed in 1.99s =========================================
pytest tests/providers/neo4j/ | tail -n 1
============================== 5 passed in 1.55s ===============================
```
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
