### PR TITLE
Always draw borders if task instance state is null or undefined

### DIFF
--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -332,7 +332,15 @@ document.addEventListener('DOMContentLoaded', () => {
       .attr('ry', (d) => (isDagRun(d) ? '5' : '1'))
       .style('shape-rendering', (d) => (isDagRun(d) ? 'auto' : 'crispEdges'))
       .style('stroke-width', (d) => (isDagRun(d) ? '2' : '1'))
-      .style('stroke-opacity', (d) => (d.external_trigger ? '0' : '1'))
+      .style('stroke-opacity', (d) => {
+        if (!d.external_trigger) {
+          return 1;
+        }
+        if (d.state === null) {
+          return 0.5;
+        }
+        return 0;
+      })
       .on('mouseover', function (d) {
         // Calculate duration if it doesn't exist
         const tt = tiTooltip({

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -96,19 +96,21 @@ document.addEventListener('DOMContentLoaded', () => {
 
       // check that the dataInstance and the row are valid
       if (dataInstance && dataInstance.execution_date) {
-        if (row && row.length) {
-          const taskInstance = {
-            state: row[0],
-            try_number: row[1],
-            start_ts: row[2],
-            duration: row[3],
-          };
-          node.instances[j] = taskInstance;
+        const taskInstance = {
+          task_id: node.name,
+          operator: node.operator,
+          execution_date: dataInstance.execution_date,
+          external_trigger: dataInstance.external_trigger,
+        };
+        node.instances[j] = taskInstance;
 
-          taskInstance.task_id = node.name;
-          taskInstance.operator = node.operator;
-          taskInstance.execution_date = dataInstance.execution_date;
-          taskInstance.external_trigger = dataInstance.external_trigger;
+        if (row && row.length) {
+          [
+            taskInstance.state,
+            taskInstance.try_number,
+            taskInstance.start_ts,
+            taskInstance.duration,
+          ] = row;
 
           // compute start_date and end_date if applicable
           if (taskInstance.start_ts !== null) {
@@ -119,12 +121,6 @@ document.addEventListener('DOMContentLoaded', () => {
               taskInstance.end_date = toDateString(taskInstance.start_ts + taskInstance.duration);
             }
           }
-        } else {
-          node.instances[j] = {
-            task_id: node.name,
-            execution_date: dataInstance.execution_date,
-            external_trigger: dataInstance.external_trigger,
-          };
         }
       }
     }

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -337,7 +337,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!d.external_trigger) {
           return 1;
         }
-        if (d.state === null) {
+        if (!d.state) {
           return 0.5;
         }
         return 0;

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -352,7 +352,7 @@ document.addEventListener('DOMContentLoaded', () => {
         taskTip.direction('n');
         taskTip.show(tt, this);
         d3.select(this).transition().duration(duration)
-          .style('stroke-width', 3);
+          .style('stroke-width', (dd) => (dd.external_trigger ? '1' : '3'));
       })
       .on('mouseout', function (d) {
         taskTip.hide(d);

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -123,6 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
           node.instances[j] = {
             task_id: node.name,
             execution_date: dataInstance.execution_date,
+            external_trigger: dataInstance.external_trigger,
           };
         }
       }


### PR DESCRIPTION
Task instances of manual runs are usually drawn without borders. However, when a task instance has `null` state, it blends into the background without a border. In this case, drawing a border makes sense, but draw it at reduced opacity to distinguish it from scheduled runs.

Task instances with `undefined` state were previously always drawn with full-opacity borders because `external_trigger` for these task instances was `undefined`. This has been fixed, so these task instances are now drawn with borders and the proper opacity, depending on whether they are part of manual or scheduled runs.

Common task instance properties are now defined in a single place, and `external_trigger` is included as a common property so that it will not be `undefined` as described above.

Fixes #16877.

Screenshots:

1. DAG with one scheduled run and one manual run

![image](https://user-images.githubusercontent.com/40527812/133365149-4f0f6923-bc94-4412-aedd-89cdf6ab70f1.png)
2. Clear all task instances in manual run. This results in task instances with `null` state.
 - Before: 
 
![image](https://user-images.githubusercontent.com/40527812/133365635-c8c163e0-96f0-4790-997c-fe26cb5617c4.png)
 - After: 
 
![image](https://user-images.githubusercontent.com/40527812/133365824-7dc5d505-9db4-403f-8aef-6ecbaaff3519.png)
3. Clear all task instances in the scheduled run
- Before:

![image](https://user-images.githubusercontent.com/40527812/133374855-01baf549-65a6-4ff9-a32f-240fbc539836.png)

- After:
  - Still works as expected
  
![image](https://user-images.githubusercontent.com/40527812/133375125-9ad33387-547e-434d-b016-d909ad81e440.png)
4. Add new tasks to the DAG. This results in task instances with `undefined` state:
 - Before:
   - No difference in borders of manual vs. scheduled run
   
![image](https://user-images.githubusercontent.com/40527812/133366360-d44b3211-6410-434b-8308-9682956e6a26.png)
 - After
   - Notice difference in border opacity
   
![image](https://user-images.githubusercontent.com/40527812/133366521-af23e848-c018-47bb-83db-25880a2a0d8a.png)
5. Mouseover effect of the scheduled run
 
 - Before:
![image](https://user-images.githubusercontent.com/40527812/133371958-85dc4472-5593-40fa-88f1-d8ade565e24c.png)
![image](https://user-images.githubusercontent.com/40527812/133371218-26f3f140-4fe7-474f-bbfd-4ba1cd48557e.png)

 - After:
   - Still works as expected
   
![image](https://user-images.githubusercontent.com/40527812/133371750-1108fb6a-b1be-4ab4-b9af-34a45ecd2280.png)
![image](https://user-images.githubusercontent.com/40527812/133371471-ea4c9690-9732-45d4-912c-75612381db2b.png)
6. Mouseover effect of the manual run

 - Before:
   - The mouseover behavior is inconsistent: one has mouseover effect and the other does not
   
 ![image](https://user-images.githubusercontent.com/40527812/133372092-dc764181-103f-42b6-9258-0ac389136619.png)
![image](https://user-images.githubusercontent.com/40527812/133371143-3c2f3fec-a4af-4864-8b5c-a608b38d386b.png)

- After:
   - Both now have no mouseover effect
   
![image](https://user-images.githubusercontent.com/40527812/133371643-ddaf8aa1-b519-4f00-8c18-b4c4501f5d5f.png)
![image](https://user-images.githubusercontent.com/40527812/133371112-9c7e3d42-48b2-4e29-8e07-610f1b1d78bd.png)






<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
