### PR TITLE
Fix building docs in `main` builds

### DIFF
--- a/docs/build_docs.py
+++ b/docs/build_docs.py
@@ -54,6 +54,7 @@ ERRORS_ELIGIBLE_TO_REBUILD = [
     'failed to reach any of the inventories with the following issues',
     'undefined label:',
     'unknown document:',
+    'Error loading airflow.providers',
 ]
 
 ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS', 'false') == "true"


### PR DESCRIPTION
The builds run from `main` branch perform eager upgrade of
constraints. For some reason (the root cause is still not known)
importing google provider docs fails for autoapi. The import
fails with "TypeError("unsupported operand type(s) for +:
'SSL_VERIFY_PEER' and 'SSL_VERIFY_FAIL_IF_NO_PEER_CERT'",))"

This problem is gone however when generate google docs for the
second time - apparently the first pass generates cache in
the inventory that unblocks the real import.

This is similar error to those that we already handle by
making them eligible for rebuilding. Adding the type of
error to the list of eligible errors fixes the problem, and
likely when the new sphinx iventory for google provider
will be pushed, it will disappear completely.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
