### PR TITLE
Deprecate default pod name in EKSPodOperator

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_eks_templated.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_templated.py
@@ -85,6 +85,7 @@ with DAG(
 
     start_pod = EKSPodOperator(
         task_id="run_pod",
+        pod_name="start_pod",
         cluster_name="{{ dag_run.conf['cluster_name'] }}",
         image="amazon/aws-cli:latest",
         cmds=["sh", "-c", "ls"],

--- a/airflow/providers/amazon/aws/example_dags/example_eks_using_defaults.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_using_defaults.py
@@ -71,6 +71,7 @@ with DAG(
 
     start_pod = EKSPodOperator(
         task_id="run_pod",
+        pod_name="run_pod",
         cluster_name=CLUSTER_NAME,
         image="amazon/aws-cli:latest",
         cmds=["sh", "-c", "ls"],

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
@@ -86,6 +86,7 @@ with DAG(
     # [START howto_operator_eks_pod_operator]
     start_pod = EKSPodOperator(
         task_id="run_pod",
+        pod_name="run_pod",
         cluster_name=CLUSTER_NAME,
         image="amazon/aws-cli:latest",
         cmds=["sh", "-c", "ls"],

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from time import sleep
 from typing import Dict, Iterable, List, Optional
 
+from airflow import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EKSHook
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
@@ -455,6 +456,10 @@ class EKSPodOperator(KubernetesPodOperator):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        # There is no need to manage the kube_config file, as it will be generated automatically.
+        # All Kubernetes parameters (except config_file) are also valid for the EKSPodOperator.
+        if self.config_file:
+            raise AirflowException("The config_file is not an allowed parameter for the EKSPodOperator.")
 
     def execute(self, context):
         eks_hook = EKSHook(

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -414,12 +414,21 @@ class EKSPodOperator(KubernetesPodOperator):
         in_cluster: bool = False,
         namespace: str = DEFAULT_NAMESPACE_NAME,
         pod_context: str = None,
-        pod_name: str = DEFAULT_POD_NAME,
+        pod_name: str = None,
         pod_username: str = None,
         aws_conn_id: str = DEFAULT_CONN_ID,
         region: Optional[str] = None,
         **kwargs,
     ) -> None:
+        if pod_name is None:
+            warnings.warn(
+                "Default value of pod name is deprecated. "
+                "We recommend that you pass pod name explicitly. ",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            pod_name = DEFAULT_POD_NAME
+
         self.cluster_name = cluster_name
         self.in_cluster = in_cluster
         self.namespace = namespace

--- a/tests/providers/amazon/aws/operators/test_eks.py
+++ b/tests/providers/amazon/aws/operators/test_eks.py
@@ -174,6 +174,7 @@ class TestEKSPodOperator(unittest.TestCase):
 
         op = EKSPodOperator(
             task_id="run_pod",
+            pod_name="run_pod",
             cluster_name=CLUSTER_NAME,
             image="amazon/aws-cli:latest",
             cmds=["sh", "-c", "ls"],


### PR DESCRIPTION
This operator should behave similar to `GKEStartPodOperator`, `KubernettesPodOperator`, but we accidentally added a default name for pod. This is not expected, so i added a warning about that
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
