### PR TITLE
Add Python2 to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -339,6 +339,9 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# As of August 2021, Debian buster-slim does not include Python2 by default and we need it
+# as we still support running Python2 via PythonVirtualenvOperator
+# TODO: Remove python2 when we stop supporting it
 ARG RUNTIME_APT_DEPS="\
        apt-transport-https \
        apt-utils \
@@ -360,6 +363,7 @@ ARG RUNTIME_APT_DEPS="\
        netcat \
        openssh-client \
        postgresql-client \
+       python2 \
        rsync \
        sasl2-bin \
        sqlite3 \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -57,6 +57,10 @@ ENV DEV_APT_COMMAND=${DEV_APT_COMMAND} \
     ADDITIONAL_DEV_APT_DEPS=${ADDITIONAL_DEV_APT_DEPS} \
     ADDITIONAL_DEV_APT_COMMAND=${ADDITIONAL_DEV_APT_COMMAND}
 
+# As of August 2021, Debian buster-slim does not include Python2 by default and we need it
+# as we still support running Python2 via PythonVirtualenvOperator
+# TODO: Remove python2 when we stop supporting it
+
 # Install basic and additional apt dependencies
 RUN mkdir -pv /usr/share/man/man1 \
     && mkdir -pv /usr/share/man/man7 \
@@ -86,6 +90,7 @@ RUN mkdir -pv /usr/share/man/man1 \
            locales  \
            netcat \
            nodejs \
+           python2 \
            rsync \
            sasl2-bin \
            sudo \


### PR DESCRIPTION
As of August 2021, the buster-slim python images, no longer
contain python2 packages. We still support running Python2 via
PythonVirtualenvOperator and our tests started to fail when
we run the tests in `main` - those tests always pull and build
the images using latest-available buster-slim images.

Our system to prevent PR failures in this case has proven to be
useful - the main tests failed to succeed so the base images
we have are still using previous buster-slim images which still
contain Python 2.

This PR adds python2 to installed packages - on both CI images
and PROD images. For CI images it is needed to pass tests, for
PROD images, it is needed for backwards-compatibility.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
