### PR TITLE
Fix providers tests in main branch with eager upgrades

### DIFF
--- a/airflow/providers/google/cloud/hooks/datacatalog.py
+++ b/airflow/providers/google/cloud/hooks/datacatalog.py
@@ -19,7 +19,7 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core.retry import Retry
 from google.cloud import datacatalog
-from google.cloud.datacatalog_v1beta1 import (
+from google.cloud.datacatalog import (
     CreateTagRequest,
     DataCatalogClient,
     Entry,

--- a/tests/providers/amazon/aws/operators/test_sqs.py
+++ b/tests/providers/amazon/aws/operators/test_sqs.py
@@ -29,6 +29,9 @@ from airflow.utils import timezone
 
 DEFAULT_DATE = timezone.datetime(2019, 1, 1)
 
+QUEUE_NAME = 'test-queue'
+QUEUE_URL = f'https://{QUEUE_NAME}'
+
 
 class TestSQSPublishOperator(unittest.TestCase):
     def setUp(self):
@@ -38,7 +41,7 @@ class TestSQSPublishOperator(unittest.TestCase):
         self.operator = SQSPublishOperator(
             task_id='test_task',
             dag=self.dag,
-            sqs_queue='test',
+            sqs_queue=QUEUE_URL,
             message_content='hello',
             aws_conn_id='aws_default',
         )
@@ -48,13 +51,13 @@ class TestSQSPublishOperator(unittest.TestCase):
 
     @mock_sqs
     def test_execute_success(self):
-        self.sqs_hook.create_queue('test')
+        self.sqs_hook.create_queue(QUEUE_NAME)
 
         result = self.operator.execute(self.mock_context)
         assert 'MD5OfMessageBody' in result
         assert 'MessageId' in result
 
-        message = self.sqs_hook.get_conn().receive_message(QueueUrl='test')
+        message = self.sqs_hook.get_conn().receive_message(QueueUrl=QUEUE_URL)
 
         assert len(message['Messages']) == 1
         assert message['Messages'][0]['MessageId'] == result['MessageId']

--- a/tests/providers/google/cloud/hooks/test_datacatalog.py
+++ b/tests/providers/google/cloud/hooks/test_datacatalog.py
@@ -22,8 +22,7 @@ from unittest import TestCase, mock
 
 import pytest
 from google.api_core.retry import Retry
-from google.cloud.datacatalog_v1beta1 import CreateTagRequest, CreateTagTemplateRequest
-from google.cloud.datacatalog_v1beta1.types import Entry, Tag, TagTemplate
+from google.cloud.datacatalog import CreateTagRequest, CreateTagTemplateRequest, Entry, Tag, TagTemplate
 
 from airflow import AirflowException
 from airflow.providers.google.cloud.hooks.datacatalog import CloudDataCatalogHook


### PR DESCRIPTION
The SQS and DataCatalog were failing tests in main branch because
some recent release of dependencies broke them:

1) SQS moto 2.2.6 broke SQS tests - the queue url in the 2.2.6+
   version has to start with http:// or https://

2) DataCatalog part of Google Provider incorrectly imported
   types and broke tests (used beta instad of datacatalog path)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
