### PR TITLE
Suppress stat stderr output when we have fallback

### DIFF
--- a/breeze
+++ b/breeze
@@ -668,7 +668,7 @@ function breeze::prepare_command_files() {
 
     if [[ ${BACKEND} == "mssql" ]]; then
         local docker_filesystem
-        docker_filesystem=$(stat "-f" "-c" "%T" /var/lib/docker || echo "unknown")
+        docker_filesystem=$(stat "-f" "-c" "%T" /var/lib/docker 2>/dev/null || echo "unknown")
         if [[ ${docker_filesystem} == "tmpfs" ]]; then
             # In case of tmpfs backend for docker, mssql fails because TMPFS does not support
             # O_DIRECT parameter for direct writing to the filesystem

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -85,7 +85,7 @@ function run_airflow_testing_in_docker() {
     local backend_docker_compose=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-${BACKEND}.yml")
     if [[ ${BACKEND} == "mssql" ]]; then
         local docker_filesystem
-        docker_filesystem=$(stat "-f" "-c" "%T" /var/lib/docker || echo "unknown")
+        docker_filesystem=$(stat "-f" "-c" "%T" /var/lib/docker 2>/dev/null || echo "unknown")
         if [[ ${docker_filesystem} == "tmpfs" ]]; then
             # In case of tmpfs backend for docker, mssql fails because TMPFS does not support
             # O_DIRECT parameter for direct writing to the filesystem


### PR DESCRIPTION
Without this, the `stat` would emit

```
stat: cannot read file system information for '/var/lib/docker': No such file or directory
```

when breeze is running against a remote Docker setup. Since we already just default to `unknown`, suppress the stderr line.