### PR TITLE
Switch CI builds to use Python 3.7 by default

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1259,7 +1259,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
   -a, --install-airflow-version INSTALL_AIRFLOW_VERSION
           Uses different version of Airflow when building PROD image.
@@ -1458,7 +1458,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
   -I, --production-image
           Use production image for entering the environment and builds (not for tests).
@@ -1525,7 +1525,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
   -v, --verbose
           Show verbose information about executed docker, kind, kubectl, helm commands. Useful for
@@ -1616,7 +1616,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
 
   ####################################################################################################
@@ -1811,7 +1811,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
   -b, --backend BACKEND
           Backend to use for tests - it determines which database is used.
@@ -1880,7 +1880,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
   -F, --force-build-images
           Forces building of the local docker images. The images are rebuilt
@@ -2282,7 +2282,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
           One of:
 
-                 3.6 3.7 3.8 3.9
+                 3.7 3.8 3.9 3.6
 
   ****************************************************************************************************
    Choose backend to run for Airflow

--- a/IMAGES.rst
+++ b/IMAGES.rst
@@ -603,7 +603,7 @@ which checks if the image has been released and will pull it and rebuild it if n
     export FORCE_ANSWER_TO_QUESTIONS="true"
     export CI="true"
 
-    for python_version in "3.6" "3.7" "3.8"
+    for python_version in "3.6" "3.7" "3.8" "3.9"
     do
             ./breeze build-image --python ${python_version} --build-cache-local \
                     --check-if-python-base-image-updated --verbose

--- a/breeze-complete
+++ b/breeze-complete
@@ -23,7 +23,7 @@
 # by the BATS tests automatically during pre-commit and CI
 # Those cannot be made read-only as the breeze-complete must be re-sourceable
 
-_breeze_allowed_python_major_minor_versions="3.6 3.7 3.8 3.9"
+_breeze_allowed_python_major_minor_versions="3.7 3.8 3.9 3.6"
 _breeze_allowed_backends="sqlite mysql postgres mssql"
 _breeze_allowed_integrations="cassandra kerberos mongo openldap pinot rabbitmq redis statsd trino all"
 _breeze_allowed_generate_constraints_modes="source-providers pypi-providers no-providers"

--- a/dev/REFRESHING_CI_CACHE.md
+++ b/dev/REFRESHING_CI_CACHE.md
@@ -48,7 +48,7 @@ manual refresh might be needed.
 # Manually generating constraint files
 
 ```bash
-export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING="3.6 3.7 3.8 3.9"
+export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING="3.7 3.8 3.9 3.6"
 for python_version in $(echo "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS_AS_STRING}")
 do
   ./breeze build-image --upgrade-to-newer-dependencies --python ${python_version} --build-cache-local
@@ -90,5 +90,5 @@ If you have fast network and powerful computer, you can refresh the images in pa
 or with gnu parallel:
 
 ```bash
-parallel -j 4 --linebuffer --tagstring '{}' ./dev/refresh_images.sh ::: 3.6 3.7 3.8 3.9
+parallel -j 4 --linebuffer --tagstring '{}' ./dev/refresh_images.sh ::: 3.7 3.8 3.9 3.6
 ```

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2072,8 +2072,18 @@ KNOWN_DEPRECATED_MESSAGES: Set[Tuple[str, str]] = {
     ),
     (
         "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since"
+        " Python 3.3,and in 3.9 it will stop working",
+        "apache_beam",
+    ),
+    (
+        "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since"
         " Python 3.3, and in 3.10 it will stop working",
         "apache_beam",
+    ),
+    (
+        "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since"
+        " Python 3.3,and in 3.9 it will stop working",
+        "dns",
     ),
     (
         "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since"

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -107,11 +107,11 @@ function initialization::initialize_base_variables() {
     export PRODUCTION_IMAGE="false"
 
     # All supported major/minor versions of python in all versions of Airflow
-    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.6" "3.7" "3.8" "3.9")
+    ALL_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9" "3.6")
     export ALL_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported major/minor versions of python
-    CURRENT_PYTHON_MAJOR_MINOR_VERSIONS+=("3.6" "3.7" "3.8" "3.9")
+    CURRENT_PYTHON_MAJOR_MINOR_VERSIONS+=("3.7" "3.8" "3.9" "3.6")
     export CURRENT_PYTHON_MAJOR_MINOR_VERSIONS
 
     # Currently supported versions of Postgres
@@ -618,8 +618,8 @@ function initialization::initialize_common_environment() {
 }
 
 function initialization::set_default_python_version_if_empty() {
-    # default version of python used to tag the "main" and "latest" images in DockerHub
-    export DEFAULT_PYTHON_MAJOR_MINOR_VERSION=3.6
+    # default version of python used to run CI test with
+    export DEFAULT_PYTHON_MAJOR_MINOR_VERSION=3.7
 
     # default python Major/Minor version
     export PYTHON_MAJOR_MINOR_VERSION=${PYTHON_MAJOR_MINOR_VERSION:=${DEFAULT_PYTHON_MAJOR_MINOR_VERSION}}

--- a/scripts/ci/tools/build_dockerhub.sh
+++ b/scripts/ci/tools/build_dockerhub.sh
@@ -50,7 +50,9 @@ echo
 # Re-tag the image to be published in "apache/airflow"
 docker tag "${AIRFLOW_PROD_IMAGE}" "${RELEASE_IMAGE}"
 docker push "${RELEASE_IMAGE}"
-if [[ ${PYTHON_MAJOR_MINOR_VERSION} == "${DEFAULT_PYTHON_MAJOR_MINOR_VERSION}" ]]; then
+
+# For DockerHub, the default image is still 3.6 - From 2.2 we will change it to 3.7 if everyone agrees to
+if [[ ${PYTHON_MAJOR_MINOR_VERSION} == "3.6" ]]; then
     export DEFAULT_VERSION_IMAGE="apache/airflow:${INSTALL_AIRFLOW_VERSION}"
     echo
     echo "Pushing default airflow image as ${DEFAULT_VERSION_IMAGE}"

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,8 @@ deprecated_api = [
 ]
 doc = [
     'click>=7.1,<9',
-    # Sphinx is limited to < 3.5.0 because of https://github.com/sphinx-doc/sphinx/issues/8880
+    # Sphinx is limited to < 3.5.0 because of
+    # https://github.com/sphinx-doc/sphinx/issues/8880
     'sphinx>=2.1.2, <3.5.0',
     'sphinx-airflow-theme',
     'sphinx-argparse>=0.1.13',

--- a/tests/bats/breeze/test_breeze_complete.bats
+++ b/tests/bats/breeze/test_breeze_complete.bats
@@ -25,7 +25,7 @@
   source "${AIRFLOW_SOURCES}/breeze-complete"
 
   breeze_complete::get_known_values_breeze "-p"
-  assert_equal "${_breeze_known_values}" "3.6 3.7 3.8 3.9"
+  assert_equal "${_breeze_known_values}" "3.7 3.8 3.9 3.6"
 }
 
 @test "Test get_known_values long" {
@@ -34,7 +34,7 @@
   source "${AIRFLOW_SOURCES}/breeze-complete"
 
   breeze_complete::get_known_values_breeze "--python"
-  assert_equal "${_breeze_known_values}" "3.6 3.7 3.8 3.9"
+  assert_equal "${_breeze_known_values}" "3.7 3.8 3.9 3.6"
 }
 
 @test "Test wrong get_known_values" {
@@ -125,7 +125,7 @@
   COMP_WORDS=("--python" "")
   breeze_complete::_comp_breeze
 
-  assert_equal "${COMPREPLY[*]}" "3.6 3.7 3.8 3.9"
+  assert_equal "${COMPREPLY[*]}" "3.7 3.8 3.9 3.6"
 }
 
 @test "Test autocomplete --python with prefix" {
@@ -136,7 +136,7 @@
   COMP_WORDS=("--python" "3")
   breeze_complete::_comp_breeze
 
-  assert_equal "${COMPREPLY[*]}" "3.6 3.7 3.8 3.9"
+  assert_equal "${COMPREPLY[*]}" "3.7 3.8 3.9 3.6"
 }
 
 @test "Test autocomplete build-" {


### PR DESCRIPTION
Recent 3.6 image had a problem with building documentation with
eager upgrade and updating to the latest python images.
TypeError("unsupported operand type(s) for +: 'SSL_VERIFY_PEER' and
'SSL_VERIFY_FAIL_IF_NO_PEER_CERT'")

We are trying to diagnose and solve the problem properly but this
PR attempts to check if the problem is solved (seems so) if we
use Python 3.7 to build documentation (this requires changing the
default version used on CI to be Python 3.7 for all CI tests,
because in most cases we are building only one image for PR
and run all tests and docs building using the same image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
