### PR TITLE
Fix building documentation broken by upgrade of dnspython

### DIFF
--- a/docs/exts/exampleinclude.py
+++ b/docs/exts/exampleinclude.py
@@ -20,6 +20,7 @@
 
 
 """Nice formatted include for examples"""
+import traceback
 from os import path
 
 from docutils import nodes
@@ -150,6 +151,11 @@ def register_source(app, env, modname):
             logger.info(
                 "Module \"%s\" could not be loaded. Full source will not be available. \"%s\"", modname, ex
             )
+            # We cannot use regular warnings or exception methods because those warnings are interpreted
+            # by running python process and converted into "real" warnings, so we need to print the
+            # traceback here at info level
+            tb = traceback.format_exc()
+            logger.info("%s", tb)
             env._viewcode_modules[modname] = False
             return False
 

--- a/setup.py
+++ b/setup.py
@@ -192,6 +192,12 @@ apache_beam = [
 ]
 asana = ['asana>=0.10']
 async_packages = [
+    # DNS Python 2.0.0 and above breaks building documentation on Sphinx. When dnspython 2.0.0 is installed
+    # building documentation fails with trying to import google packages with
+    # TypeError("unsupported operand type(s) for +: 'SSL_VERIFY_PEER' and
+    # 'SSL_VERIFY_FAIL_IF_NO_PEER_CERT'")
+    # The issue is opened for it https://github.com/rthalley/dnspython/issues/681
+    'dnspython<2.0.0',
     'eventlet>= 0.9.7',
     'gevent>=0.13',
     'greenlet>=0.4.9',


### PR DESCRIPTION
The automated upgrade of dependencies in main broken building of
Airflow documentation in main build.

After a lot of experimentation, It has been narrowed down
to upgrade of dnspython from 1.16.0 to 2.+ which was brought
by upgrading eventlet to 0.32.0.

This PR limits the dnspython library to < 2.0.0. An issue
has been opened:
https://github.com/rthalley/dnspython/issues/681

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
