### PR TITLE
Declared readonly variable and added double quote in variables containing strings

### DIFF
--- a/scripts/in_container/run_generate_constraints.sh
+++ b/scripts/in_container/run_generate_constraints.sh
@@ -19,12 +19,14 @@
 . "$( dirname "${BASH_SOURCE[0]}" )/_in_container_script_init.sh"
 
 CONSTRAINTS_DIR="/files/constraints-${PYTHON_MAJOR_MINOR_VERSION}"
+readonly CONSTRAINTS_DIR
 
 LATEST_CONSTRAINT_FILE="${CONSTRAINTS_DIR}/original-${AIRFLOW_CONSTRAINTS}-${PYTHON_MAJOR_MINOR_VERSION}.txt"
+readonly LATEST_CONSTRAINT_FILE
 mkdir -pv "${CONSTRAINTS_DIR}"
 
 
-if [[ ${GENERATE_CONSTRAINTS_MODE} == "no-providers" ]]; then
+if [[ "${GENERATE_CONSTRAINTS_MODE}" == "no-providers" ]]; then
     AIRFLOW_CONSTRAINTS="constraints-no-providers"
     NO_PROVIDERS_EXTRAS=$(python -c 'import setup; print(",".join(setup.CORE_EXTRAS_REQUIREMENTS.keys()))')
     CURRENT_CONSTRAINT_FILE="${CONSTRAINTS_DIR}/${AIRFLOW_CONSTRAINTS}-${PYTHON_MAJOR_MINOR_VERSION}.txt"
@@ -47,7 +49,7 @@ if [[ ${GENERATE_CONSTRAINTS_MODE} == "no-providers" ]]; then
 # Airflow in any way.
 #
 EOF
-elif [[ ${GENERATE_CONSTRAINTS_MODE} == "source-providers" ]]; then
+elif [[ "${GENERATE_CONSTRAINTS_MODE}" == "source-providers" ]]; then
     AIRFLOW_CONSTRAINTS="constraints-source-providers"
     CURRENT_CONSTRAINT_FILE="${CONSTRAINTS_DIR}/${AIRFLOW_CONSTRAINTS}-${PYTHON_MAJOR_MINOR_VERSION}.txt"
     echo
@@ -65,7 +67,7 @@ elif [[ ${GENERATE_CONSTRAINTS_MODE} == "source-providers" ]]; then
 # Install with "HEAD" of providers. Those are the only constraints that are used by our CI builds.
 #
 EOF
-elif [[ ${GENERATE_CONSTRAINTS_MODE} == "pypi-providers" ]]; then
+elif [[ "${GENERATE_CONSTRAINTS_MODE}" == "pypi-providers" ]]; then
     AIRFLOW_CONSTRAINTS="constraints"
     CURRENT_CONSTRAINT_FILE="${CONSTRAINTS_DIR}/${AIRFLOW_CONSTRAINTS}-${PYTHON_MAJOR_MINOR_VERSION}.txt"
     echo


### PR DESCRIPTION
Declared readonly variable.
Added double quote in variables containing strings.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
