### PR TITLE
Add missing "be" in documentation

### DIFF
--- a/docs/apache-airflow/howto/custom-operator.rst
+++ b/docs/apache-airflow/howto/custom-operator.rst
@@ -37,7 +37,7 @@ There are two methods that you need to override in a derived class:
 .. note::
 
     When implementing custom operators, do not make any expensive operations in the ``__init__`` method. The operators
-    will instantiated once per scheduler cycle per task using them, and making database calls can significantly slow
+    will be instantiated once per scheduler cycle per task using them, and making database calls can significantly slow
     down scheduling and waste resources.
 
 Let's implement an example ``HelloOperator`` in a new file ``hello_operator.py``:


### PR DESCRIPTION
Fix typo: "The operators will be instantiated." Add missing "be"

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
