### PR TITLE
Fixing Vault AppRole authentication with CONN_URI

### DIFF
--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -84,7 +84,7 @@ class VaultHook(BaseHook):
     :param kv_engine_version: Select the version of the engine to run (``1`` or ``2``). Defaults to
           version defined in connection or ``2`` if not defined in connection.
     :type kv_engine_version: int
-    :param role_id: Role ID for Authentication (for ``approle``, ``aws_iam`` auth_types)
+    :param role_id: Role ID for ``aws_iam`` Authentication.
     :type role_id: str
     :param kubernetes_role: Role for Authentication (for ``kubernetes`` auth_type)
     :type kubernetes_role: str
@@ -157,8 +157,8 @@ class VaultHook(BaseHook):
                     role_id = self.connection.login
             else:
                 warnings.warn(
-                    """The usage of role_id has been deprecated.
-                    Please use either the connection login or extras.""",
+                    """The usage of role_id via AppRole authentication has been deprecated.
+                    Please use connection login.""",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -166,12 +166,6 @@ class VaultHook(BaseHook):
         if auth_type == "aws_iam":
             if not role_id:
                 role_id = self.connection.extra_dejson.get('role_id')
-            else:
-                warnings.warn(
-                    "The usage of role_id has been deprecated.  Please specify this in connection extras.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
 
         azure_resource, azure_tenant_id = (
             self._get_azure_parameters_from_connection(azure_resource, azure_tenant_id)

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -150,10 +150,10 @@ class VaultHook(BaseHook):
 
         if auth_type in ["approle", "aws_iam"]:
             if not role_id:
-                if self.connection.login:
-                    role_id = self.connection.login
-                else:
+                if self.connection.extra_dejson.get('role_id'):
                     role_id = self.connection.extra_dejson.get('role_id')
+                else:
+                    role_id = self.connection.login
 
         azure_resource, azure_tenant_id = (
             self._get_azure_parameters_from_connection(azure_resource, azure_tenant_id)

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -150,7 +150,10 @@ class VaultHook(BaseHook):
 
         if auth_type in ["approle", "aws_iam"]:
             if not role_id:
-                role_id = self.connection.extra_dejson.get('role_id')
+                if self.connection.login:
+                    role_id = self.connection.login
+                else:
+                    role_id = self.connection.extra_dejson.get('role_id')
 
         azure_resource, azure_tenant_id = (
             self._get_azure_parameters_from_connection(azure_resource, azure_tenant_id)

--- a/airflow/providers/hashicorp/hooks/vault.py
+++ b/airflow/providers/hashicorp/hooks/vault.py
@@ -150,18 +150,23 @@ class VaultHook(BaseHook):
                 raise VaultError(f"The version is not an int: {conn_version}. ")
 
         if auth_type == "approle":
-            if not role_id:
-                if self.connection.extra_dejson.get('role_id'):
-                    role_id = self.connection.extra_dejson.get('role_id')
-                else:
-                    role_id = self.connection.login
-            else:
+            if role_id:
                 warnings.warn(
-                    """The usage of role_id via AppRole authentication has been deprecated.
+                    """The usage of role_id for AppRole authentication has been deprecated.
                     Please use connection login.""",
                     DeprecationWarning,
                     stacklevel=2,
                 )
+            elif self.connection.extra_dejson.get('role_id'):
+                role_id = self.connection.extra_dejson.get('role_id')
+                warnings.warn(
+                    """The usage of role_id in connection extra for AppRole authentication has been
+                    deprecated. Please use connection login.""",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            elif self.connection.login:
+                role_id = self.connection.login
 
         if auth_type == "aws_iam":
             if not role_id:

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -220,10 +220,7 @@ class TestVaultHook(TestCase):
         mock_connection = self.get_mock_connection()
         mock_get_connection.return_value = mock_connection
 
-        connection_dict = {
-            "auth_type": "approle",
-            'role_id': "role",
-        }
+        connection_dict = {"auth_type": "approle"}
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
         kwargs = {
@@ -234,7 +231,7 @@ class TestVaultHook(TestCase):
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url='http://localhost:8180')
-        test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
+        test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -176,7 +176,6 @@ class TestVaultHook(TestCase):
         kwargs = {
             "vault_conn_id": "vault_conn_id",
             "auth_type": "approle",
-            "role_id": "role",
             "kv_engine_version": 2,
         }
 
@@ -184,7 +183,7 @@ class TestVaultHook(TestCase):
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url=expected_url)
-        test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
+        test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 
@@ -202,7 +201,6 @@ class TestVaultHook(TestCase):
         kwargs = {
             "vault_conn_id": "vault_conn_id",
             "auth_type": "approle",
-            "role_id": "role",
             "kv_engine_version": 2,
         }
 
@@ -210,7 +208,7 @@ class TestVaultHook(TestCase):
         mock_get_connection.assert_called_with("vault_conn_id")
         test_client = test_hook.get_conn()
         mock_hvac.Client.assert_called_with(url='http://localhost:8180')
-        test_client.auth.approle.login.assert_called_with(role_id="role", secret_id="pass")
+        test_client.auth.approle.login.assert_called_with(role_id="user", secret_id="pass")
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 
@@ -256,10 +254,13 @@ class TestVaultHook(TestCase):
         mock_connection = self.get_mock_connection()
         mock_get_connection.return_value = mock_connection
 
-        connection_dict = {}
+        connection_dict = {
+            "auth_type": "aws_iam",
+            'role_id': "role",
+        }
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
-        kwargs = {"vault_conn_id": "vault_conn_id", "auth_type": "aws_iam", "role_id": "role"}
+        kwargs = {"vault_conn_id": "vault_conn_id"}
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -259,13 +259,10 @@ class TestVaultHook(TestCase):
         mock_connection = self.get_mock_connection()
         mock_get_connection.return_value = mock_connection
 
-        connection_dict = {
-            "auth_type": "aws_iam",
-            'role_id': "role",
-        }
+        connection_dict = {}
 
         mock_connection.extra_dejson.get.side_effect = connection_dict.get
-        kwargs = {"vault_conn_id": "vault_conn_id"}
+        kwargs = {"vault_conn_id": "vault_conn_id", "auth_type": "aws_iam", "role_id": "role"}
 
         test_hook = VaultHook(**kwargs)
         mock_get_connection.assert_called_with("vault_conn_id")

--- a/tests/providers/hashicorp/hooks/test_vault.py
+++ b/tests/providers/hashicorp/hooks/test_vault.py
@@ -240,6 +240,14 @@ class TestVaultHook(TestCase):
         test_client.is_authenticated.assert_called_with()
         assert 2 == test_hook.vault_client.kv_engine_version
 
+    @mock.patch.dict(
+        'os.environ',
+        AIRFLOW_CONN_VAULT_CONN_ID='http://role:secret@https://vault.example.com?auth_type=approle',
+    )
+    def test_approle_uri(self):
+        test_hook = VaultHook(vault_conn_id='vault_conn_id')
+        assert test_hook.vault_client.role_id == 'role'
+
     @mock.patch("airflow.providers.hashicorp.hooks.vault.VaultHook.get_connection")
     @mock.patch("airflow.providers.hashicorp._internal_client.vault_client.hvac")
     def test_aws_iam_init_params(self, mock_hvac, mock_get_connection):


### PR DESCRIPTION
This PR adds some additional logic to the VaultHook to ensure that if a connection to Vault defined as a `CONN_URI` using AppRole authentication is used that the `role_id` is retrieved from `connection.login`.

closes: #18053 

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
