### PR TITLE
Update non-working example in documentation

### DIFF
--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -85,6 +85,9 @@ And if you want to chain together dependencies, you can use ``chain``::
 
     # Replaces op1 >> op2 >> op3 >> op4
     chain(op1, op2, op3, op4)
+    
+    # You can also do it dynamically
+    chain(*[DummyOperator(task_id='op' + i) for i in range(1, 6)])
 
 Chain can also do *pairwise* dependencies for lists the same size (this is different to the *cross dependencies* done by ``cross_downstream``!)::
 
@@ -95,12 +98,7 @@ Chain can also do *pairwise* dependencies for lists the same size (this is diffe
     # op1 >> op3 >> op5 >> op6
     chain(op1, [op2, op3], [op4, op5], op6)
     
-And if you want to chain together dependencies dyamically::
-
-   tasks=[DummyOperator(task_id=f'op_{task}') for task in range(7)]
-   for task_ind in range(1,len(tasks)):
-       tasks[task_ind-1]>>tasks[task_ind]
-
+    
 .. _concepts:dag-loading:
 
 Loading DAGs

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -86,9 +86,6 @@ And if you want to chain together dependencies, you can use ``chain``::
     # Replaces op1 >> op2 >> op3 >> op4
     chain(op1, op2, op3, op4)
 
-    # You can also do it dynamically
-    chain([DummyOperator(task_id='op' + i) for i in range(1, 6)])
-
 Chain can also do *pairwise* dependencies for lists the same size (this is different to the *cross dependencies* done by ``cross_downstream``!)::
 
     from airflow.models.baseoperator import chain
@@ -97,7 +94,12 @@ Chain can also do *pairwise* dependencies for lists the same size (this is diffe
     # op1 >> op2 >> op4 >> op6
     # op1 >> op3 >> op5 >> op6
     chain(op1, [op2, op3], [op4, op5], op6)
+    
+And if you want to chain together dependencies dyamically::
 
+   tasks=[DummyOperator(task_id=f'op_{task}') for task in range(7)]
+   for task_ind in range(1,len(tasks)):
+       tasks[task_ind-1]>>tasks[task_ind]
 
 .. _concepts:dag-loading:
 

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -85,7 +85,7 @@ And if you want to chain together dependencies, you can use ``chain``::
 
     # Replaces op1 >> op2 >> op3 >> op4
     chain(op1, op2, op3, op4)
-    
+
     # You can also do it dynamically
     chain(*[DummyOperator(task_id='op' + i) for i in range(1, 6)])
 
@@ -97,8 +97,8 @@ Chain can also do *pairwise* dependencies for lists the same size (this is diffe
     # op1 >> op2 >> op4 >> op6
     # op1 >> op3 >> op5 >> op6
     chain(op1, [op2, op3], [op4, op5], op6)
-    
-    
+
+
 .. _concepts:dag-loading:
 
 Loading DAGs


### PR DESCRIPTION
Chain function cannot accept a list, but the example provided supplies with a list. Supplied example did not create chain dependencies as expected 
Replaced non-working example with working example, but does not use the chain function. I do not think you are able to use chain function dynamically.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
