### PR TITLE
Fix BigQuery data extraction in BigQueryToMySqlOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mysql.py
@@ -129,21 +129,17 @@ class BigQueryToMySqlOperator(BaseOperator):
             impersonation_chain=self.impersonation_chain,
         )
 
-        conn = hook.get_conn()
-        cursor = conn.cursor()
         i = 0
         while True:
-            response = cursor.get_tabledata(
+            response = hook.list_rows(
                 dataset_id=self.dataset_id,
                 table_id=self.table_id,
                 max_results=self.batch_size,
                 selected_fields=self.selected_fields,
                 start_index=i * self.batch_size,
             )
-
-            if 'rows' in response:
-                rows = response['rows']
-            else:
+            rows = [dict(r) for r in response]
+            if len(rows) == 0:
                 self.log.info('Job Finished')
                 return
 

--- a/tests/providers/google/cloud/transfers/test_bigquery_to_mysql.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_mysql.py
@@ -39,12 +39,11 @@ class TestBigQueryToMySqlOperator(unittest.TestCase):
 
         operator.execute(None)
         # fmt: off
-        mock_hook.return_value.get_conn.return_value.cursor.return_value.get_tabledata\
-            .assert_called_once_with(
-                dataset_id=TEST_DATASET,
-                table_id=TEST_TABLE_ID,
-                max_results=1000,
-                selected_fields=None,
-                start_index=0,
-            )
+        mock_hook.return_value.list_rows.assert_called_once_with(
+            dataset_id=TEST_DATASET,
+            table_id=TEST_TABLE_ID,
+            max_results=1000,
+            selected_fields=None,
+            start_index=0,
+        )
         # fmt: on


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #17198

Uses the list_rows function from BigQueryHook to query data.

If there no more rows, job is finished.