### PR TITLE
Fixes incorrect parameter passed to views (#18083)

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -88,7 +88,7 @@ const encodedDagIds = new URLSearchParams();
 $.each($('[id^=toggle]'), function toggleId() {
   const $input = $(this);
   const dagId = $input.data('dag-id');
-  encodedDagIds.append('dagIds', dagId);
+  encodedDagIds.append('dag_ids', dagId);
 
   $input.on('change', () => {
     const isPaused = $input.is(':checked');
@@ -318,7 +318,7 @@ function taskStatsHandler(error, json) {
   });
 }
 
-if (encodedDagIds.has('dagIds')) {
+if (encodedDagIds.has('dag_ids')) {
   // dags on page fetch stats
   d3.json(blockedUrl)
     .header('X-CSRFToken', csrfToken)


### PR DESCRIPTION
The task_stats, last_dagruns, blocked etc expect dag_ids not dagIds.

This caused the endpoint to return all dags the user had access to by default

closes: #18083