### PR TITLE
Make next_dagrun_info take a data interval

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -257,10 +257,12 @@ def post_dag_run(dag_id, session):
         .first()
     )
     if not dagrun_instance:
-        dag_run = current_app.dag_bag.get_dag(dag_id).create_dagrun(
+        dag = current_app.dag_bag.get_dag(dag_id)
+        dag_run = dag.create_dagrun(
             run_type=DagRunType.MANUAL,
             run_id=run_id,
             execution_date=logical_date,
+            data_interval=dag.timetable.infer_manual_data_interval(run_after=logical_date),
             state=State.QUEUED,
             conf=post_body.get("conf"),
             external_trigger=True,

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -92,10 +92,14 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
 def ts_function(context):
     """
     Default callback for the GoogleCloudStorageObjectUpdatedSensor. The default
-    behaviour is check for the object being updated after execution_date +
-    schedule_interval.
+    behaviour is check for the object being updated after the data interval's
+    end, or execution_date + interval on Airflow versions prior to 2.2 (before
+    AIP-39 implementation).
     """
-    return context['dag'].following_schedule(context['execution_date'])
+    try:
+        return context["data_interval_end"]
+    except KeyError:
+        return context["dag"].following_schedule(context["execution_date"])
 
 
 class GCSObjectUpdateSensor(BaseSensorOperator):

--- a/airflow/sensors/time_delta.py
+++ b/airflow/sensors/time_delta.py
@@ -23,12 +23,9 @@ from airflow.utils import timezone
 
 class TimeDeltaSensor(BaseSensorOperator):
     """
-    Waits for a timedelta after the task's execution_date + schedule_interval.
-    In Airflow, the daily task stamped with ``execution_date``
-    2016-01-01 can only start running on 2016-01-02. The timedelta here
-    represents the time after the execution period has closed.
+    Waits for a timedelta after the run's data interval.
 
-    :param delta: time length to wait after execution_date before succeeding
+    :param delta: time length to wait after the data interval before succeeding.
     :type delta: datetime.timedelta
     """
 
@@ -37,8 +34,7 @@ class TimeDeltaSensor(BaseSensorOperator):
         self.delta = delta
 
     def poke(self, context):
-        dag = context['dag']
-        target_dttm = dag.following_schedule(context['execution_date'])
+        target_dttm = context['data_interval_end']
         target_dttm += self.delta
         self.log.info('Checking if the time (%s) has come', target_dttm)
         return timezone.utcnow() > target_dttm
@@ -49,13 +45,12 @@ class TimeDeltaSensorAsync(TimeDeltaSensor):
     A drop-in replacement for TimeDeltaSensor that defers itself to avoid
     taking up a worker slot while it is waiting.
 
-    :param delta: time length to wait after execution_date before succeeding
+    :param delta: time length to wait after the data interval before succeeding.
     :type delta: datetime.timedelta
     """
 
     def execute(self, context):
-        dag = context['dag']
-        target_dttm = dag.following_schedule(context['execution_date'])
+        target_dttm = context['data_interval_end']
         target_dttm += self.delta
         self.defer(trigger=DateTimeTrigger(moment=target_dttm), method_name="execute_complete")
 

--- a/airflow/timetables/base.py
+++ b/airflow/timetables/base.py
@@ -148,7 +148,7 @@ class Timetable(Protocol):
         """
         return type(self).__name__
 
-    def infer_data_interval(self, *, run_after: DateTime) -> DataInterval:
+    def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
         """When a DAG run is manually triggered, infer a data interval for it.
 
         This is used for e.g. manually-triggered runs, where ``run_after`` would
@@ -160,14 +160,14 @@ class Timetable(Protocol):
     def next_dagrun_info(
         self,
         *,
-        last_automated_dagrun: Optional[DateTime],
+        last_automated_data_interval: Optional[DataInterval],
         restriction: TimeRestriction,
     ) -> Optional[DagRunInfo]:
         """Provide information to schedule the next DagRun.
 
         The default implementation raises ``NotImplementedError``.
 
-        :param last_automated_dagrun: The ``execution_date`` of the associated
+        :param last_automated_data_interval: The data interval of the associated
             DAG's last scheduled or backfilled run (manual runs not considered).
         :param restriction: Restriction to apply when scheduling the DAG run.
             See documentation of :class:`TimeRestriction` for details.

--- a/airflow/timetables/simple.py
+++ b/airflow/timetables/simple.py
@@ -44,7 +44,7 @@ class _TrivialTimetable(Timetable):
     def serialize(self) -> Dict[str, Any]:
         return {}
 
-    def infer_data_interval(self, *, run_after: DateTime) -> DataInterval:
+    def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
         return DataInterval.exact(run_after)
 
 
@@ -61,7 +61,7 @@ class NullTimetable(_TrivialTimetable):
     def next_dagrun_info(
         self,
         *,
-        last_automated_dagrun: Optional[DateTime],
+        last_automated_data_interval: Optional[DataInterval],
         restriction: TimeRestriction,
     ) -> Optional[DagRunInfo]:
         return None
@@ -80,10 +80,10 @@ class OnceTimetable(_TrivialTimetable):
     def next_dagrun_info(
         self,
         *,
-        last_automated_dagrun: Optional[DateTime],
+        last_automated_data_interval: Optional[DataInterval],
         restriction: TimeRestriction,
     ) -> Optional[DagRunInfo]:
-        if last_automated_dagrun is not None:
+        if last_automated_data_interval is not None:
             return None  # Already run, no more scheduling.
         if restriction.earliest is None:  # No start date, won't run.
             return None

--- a/airflow/utils/session.py
+++ b/airflow/utils/session.py
@@ -18,15 +18,15 @@
 import contextlib
 from functools import wraps
 from inspect import signature
-from typing import Callable, TypeVar
+from typing import Callable, Iterator, TypeVar
 
 from airflow import settings
 
 
 @contextlib.contextmanager
-def create_session():
+def create_session() -> Iterator[settings.SASession]:
     """Contextmanager that will create and teardown a session."""
-    session = settings.Session()
+    session: settings.SASession = settings.Session()
     try:
         yield session
         session.commit()

--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -36,8 +36,8 @@ in all templates
 ==========================================  ====================================
 Variable                                    Description
 ==========================================  ====================================
-``{{ data_interval_start }}``               Start of the data interval (`pendulum.Pendulum`_ or ``None``).
-``{{ data_interval_end }}``                 End of the data interval (`pendulum.Pendulum`_ or ``None``).
+``{{ data_interval_start }}``               Start of the data interval (`pendulum.Pendulum`_).
+``{{ data_interval_end }}``                 End of the data interval (`pendulum.Pendulum`_).
 ``{{ ds }}``                                Start of the data interval as ``YYYY-MM-DD``.
                                             Same as ``{{ data_interval_start | ds }}``.
 ``{{ ds_nodash }}``                         Start of the data interval as ``YYYYMMDD``.

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -74,7 +74,7 @@ class TestGetLog:
             DummyOperator(task_id=self.TASK_ID)
         dr = dag_maker.create_dagrun(
             run_id='TEST_DAG_RUN_ID',
-            run_type=DagRunType.MANUAL,
+            run_type=DagRunType.SCHEDULED,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
         )
@@ -111,7 +111,7 @@ class TestGetLog:
     def teardown_method(self):
         clear_db_runs()
 
-    def test_should_respond_200_json(self, session):
+    def test_should_respond_200_json(self):
         key = self.app.config["SECRET_KEY"]
         serializer = URLSafeSerializer(key)
         token = serializer.dumps({"download_logs": False})
@@ -132,7 +132,7 @@ class TestGetLog:
         assert info == {'end_of_log': True}
         assert 200 == response.status_code
 
-    def test_should_respond_200_text_plain(self, session):
+    def test_should_respond_200_text_plain(self):
         key = self.app.config["SECRET_KEY"]
         serializer = URLSafeSerializer(key)
         token = serializer.dumps({"download_logs": True})
@@ -152,7 +152,7 @@ class TestGetLog:
             == f"\n*** Reading local file: {expected_filename}\nLog for testing.\n"
         )
 
-    def test_get_logs_of_removed_task(self, session):
+    def test_get_logs_of_removed_task(self):
         # Recreate DAG without tasks
         dagbag = self.app.dag_bag
         dag = DAG(self.DAG_ID, start_date=timezone.parse(self.default_time))
@@ -178,7 +178,7 @@ class TestGetLog:
             == f"\n*** Reading local file: {expected_filename}\nLog for testing.\n"
         )
 
-    def test_get_logs_response_with_ti_equal_to_none(self, session):
+    def test_get_logs_response_with_ti_equal_to_none(self):
         key = self.app.config["SECRET_KEY"]
         serializer = URLSafeSerializer(key)
         token = serializer.dumps({"download_logs": True})
@@ -196,7 +196,7 @@ class TestGetLog:
             'type': EXCEPTIONS_LINK_MAP[404],
         }
 
-    def test_get_logs_with_metadata_as_download_large_file(self, session):
+    def test_get_logs_with_metadata_as_download_large_file(self):
         with mock.patch("airflow.utils.log.file_task_handler.FileTaskHandler.read") as read_mock:
             first_return = ([[('', '1st line')]], [{}])
             second_return = ([[('', '2nd line')]], [{'end_of_log': False}])
@@ -234,7 +234,7 @@ class TestGetLog:
         assert 400 == response.status_code
         assert 'Task log handler does not support read logs.' in response.data.decode('utf-8')
 
-    def test_bad_signature_raises(self, session):
+    def test_bad_signature_raises(self):
         token = {"download_logs": False}
 
         response = self.client.get(

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -315,7 +315,10 @@ class TestCliDags(unittest.TestCase):
             dag = self.dagbag.dags[dag_id]
             # Create a DagRun for each DAG, to prepare for next step
             dag.create_dagrun(
-                run_type=DagRunType.MANUAL, execution_date=now, start_date=now, state=State.FAILED
+                run_type=DagRunType.SCHEDULED,
+                execution_date=now,
+                start_date=now,
+                state=State.FAILED,
             )
 
             # Test num-executions = 1 (default)

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import datetime
 import os
 import signal
 import time
@@ -782,12 +783,13 @@ class TestLocalTaskJob:
 
     def test_task_exit_should_update_state_of_finished_dagruns_with_dag_paused(self, dag_maker):
         """Test that with DAG paused, DagRun state will update when the tasks finishes the run"""
-        with dag_maker(dag_id='test_dags') as dag:
+        schedule_interval = datetime.timedelta(days=1)
+        with dag_maker(dag_id='test_dags', schedule_interval=schedule_interval) as dag:
             op1 = PythonOperator(task_id='dummy', python_callable=lambda: True)
 
         session = settings.Session()
         dagmodel = dag_maker.dag_model
-        dagmodel.next_dagrun_create_after = dag.following_schedule(DEFAULT_DATE)
+        dagmodel.next_dagrun_create_after = DEFAULT_DATE + schedule_interval
         dagmodel.is_paused = True
         session.merge(dagmodel)
         session.flush()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1588,11 +1588,18 @@ class TestTaskInstance:
             schedule_interval=None,
             start_date=start_date,
             task_id="test_handle_failure_on_failure",
+            with_dagrun_type=DagRunType.MANUAL,
             on_failure_callback=mock_on_failure_1,
             on_retry_callback=mock_on_retry_1,
             session=session,
         )
-        dr = dag.create_dagrun(run_id="test2", execution_date=timezone.utcnow(), state=None, session=session)
+        dr = dag.create_dagrun(
+            run_id="test2",
+            run_type=DagRunType.MANUAL,
+            execution_date=timezone.utcnow(),
+            state=None,
+            session=session,
+        )
 
         ti1 = dr.get_task_instance(task1.task_id, session=session)
         ti1.task = task1

--- a/tests/providers/apache/druid/operators/test_druid.py
+++ b/tests/providers/apache/druid/operators/test_druid.py
@@ -20,6 +20,7 @@ import json
 
 from airflow.providers.apache.druid.operators.druid import DruidOperator
 from airflow.utils import timezone
+from airflow.utils.types import DagRunType
 
 DEFAULT_DATE = timezone.datetime(2017, 1, 1)
 
@@ -52,7 +53,7 @@ def test_render_template(dag_maker):
             params={"index_type": "index_hadoop", "datasource": "datasource_prd"},
         )
 
-    dag_maker.create_dagrun().task_instances[0].render_templates()
+    dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0].render_templates()
     assert RENDERED_INDEX == json.loads(operator.json_index_file)
 
 
@@ -71,5 +72,5 @@ def test_render_template_from_file(tmp_path, dag_maker):
             params={"index_type": "index_hadoop", "datasource": "datasource_prd"},
         )
 
-    dag_maker.create_dagrun().task_instances[0].render_templates()
+    dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED).task_instances[0].render_templates()
     assert RENDERED_INDEX == json.loads(operator.json_index_file)

--- a/tests/providers/apache/kylin/operators/test_kylin_cube.py
+++ b/tests/providers/apache/kylin/operators/test_kylin_cube.py
@@ -167,7 +167,7 @@ class TestKylinCubeOperator(unittest.TestCase):
             },
         )
         ti = TaskInstance(operator, run_id="kylin_test")
-        ti.dag_run = DagRun(run_id="kylin_test", execution_date=DEFAULT_DATE)
+        ti.dag_run = DagRun(dag_id=self.dag.dag_id, run_id="kylin_test", execution_date=DEFAULT_DATE)
         ti.render_templates()
         assert 'learn_kylin' == getattr(operator, 'project')
         assert 'kylin_sales_cube' == getattr(operator, 'cube')

--- a/tests/providers/apache/spark/operators/test_spark_submit.py
+++ b/tests/providers/apache/spark/operators/test_spark_submit.py
@@ -148,7 +148,7 @@ class TestSparkSubmitOperator(unittest.TestCase):
         # Given
         operator = SparkSubmitOperator(task_id='spark_submit_job', dag=self.dag, **self._config)
         ti = TaskInstance(operator, run_id="spark_test")
-        ti.dag_run = DagRun(run_id="spark_test", execution_date=DEFAULT_DATE)
+        ti.dag_run = DagRun(dag_id=self.dag.dag_id, run_id="spark_test", execution_date=DEFAULT_DATE)
 
         # When
         ti.render_templates()

--- a/tests/sensors/test_external_task_sensor.py
+++ b/tests/sensors/test_external_task_sensor.py
@@ -415,7 +415,8 @@ def test_external_task_sensor_templated(dag_maker):
             external_task_id='task_{{ ds }}',
         )
 
-    (instance,) = dag_maker.create_dagrun(execution_date=DEFAULT_DATE).task_instances
+    dagrun = dag_maker.create_dagrun(run_type=DagRunType.SCHEDULED, execution_date=DEFAULT_DATE)
+    (instance,) = dagrun.task_instances
     instance.render_templates()
 
     assert instance.task.external_dag_id == f"dag_{DEFAULT_DATE.date()}"

--- a/tests/ti_deps/deps/test_runnable_exec_date_dep.py
+++ b/tests/ti_deps/deps/test_runnable_exec_date_dep.py
@@ -26,6 +26,7 @@ from airflow import settings
 from airflow.models import DagRun, TaskInstance
 from airflow.ti_deps.deps.runnable_exec_date_dep import RunnableExecDateDep
 from airflow.utils.timezone import datetime
+from airflow.utils.types import DagRunType
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -66,6 +67,7 @@ def test_exec_date_dep(
             start_date=datetime(2015, 1, 1),
             end_date=datetime(2016, 11, 5),
             schedule_interval=schedule_interval,
+            with_dagrun_type=DagRunType.MANUAL,
             session=session,
         )
         (ti,) = dag_maker.create_dagrun(execution_date=execution_date).task_instances
@@ -82,6 +84,7 @@ def test_exec_date_after_end_date(session, dag_maker, create_dummy_dag):
         start_date=datetime(2015, 1, 1),
         end_date=datetime(2016, 11, 5),
         schedule_interval=None,
+        with_dagrun_type=DagRunType.MANUAL,
         session=session,
     )
     (ti,) = dag_maker.create_dagrun(execution_date=datetime(2016, 11, 2)).task_instances

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -30,6 +30,7 @@ from airflow.utils import timezone
 from airflow.utils.log.log_reader import TaskLogReader
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 from airflow.utils.state import TaskInstanceState
+from airflow.utils.types import DagRunType
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs
 
@@ -91,6 +92,7 @@ class TestLogView:
             dag_id=self.DAG_ID,
             task_id=self.TASK_ID,
             start_date=self.DEFAULT_DATE,
+            run_type=DagRunType.SCHEDULED,
             execution_date=self.DEFAULT_DATE,
             state=TaskInstanceState.RUNNING,
         )

--- a/tests/utils/test_log_handlers.py
+++ b/tests/utils/test_log_handlers.py
@@ -223,6 +223,7 @@ def filename_rendering_ti(session, create_task_instance):
     return create_task_instance(
         dag_id='dag_for_testing_filename_rendering',
         task_id='task_for_testing_filename_rendering',
+        run_type=DagRunType.SCHEDULED,
         execution_date=DEFAULT_DATE,
         session=session,
     )

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -108,14 +108,14 @@ def dags(log_app, create_dummy_dag, session):
         dag_id=DAG_ID,
         task_id=TASK_ID,
         start_date=DEFAULT_DATE,
-        with_dagrun=False,
+        with_dagrun_type=None,
         session=session,
     )
     dag_removed, _ = create_dummy_dag(
         dag_id=DAG_ID_REMOVED,
         task_id=TASK_ID,
         start_date=DEFAULT_DATE,
-        with_dagrun=False,
+        with_dagrun_type=None,
         session=session,
     )
 


### PR DESCRIPTION
From https://github.com/apache/airflow/pull/17552#discussion_r697817943

This modifies the `Timetable.next_dagrun_info()` to take the previous run's data interval instead of logical date. `DAG.next_dagrun_info()` is modified to accept `datetime | DataInterval | None` for compatibility, but the datetime form is deprecated. When receiving a datetime, a compatibility method `DAG.infer_automated_data_interval()` is called to reverse-infer the data interval from the logical date, which should work for all DAGs prior to AIP-39 implementation.

All code paths that need `DAG.infer_automated_data_interval()` become deprecated:

* `DAG.following_schedule()`
* `DAG.next_dagrun_info()` with a datetime argument
* `DAG.create_dagrun()` without passing in a data interval
* `DagModel.calculate_dagrun_date_fields()` with a datetime argument

All existing usages of the newly deprecated code paths are rewritten to avoid triggering the deprecation warning, the most significant one being `DAG.following_schedule()`. Most of its usages are to calculate the end of the interval, replaced by `data_interval.end` instead (except those already deprecated, which continue to use `DAG.following_schedule()` to avoid any unintended change).

For clarity, `Timetable.infer_data_interval()` is renamed to `Timetable.infer_manual_data_interval()`.

Hopefully this is the last big thing we need to do before 2.2.
