### PR TITLE
Graceful scheduler shutdown on error

### DIFF
--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -38,13 +38,9 @@ def _create_scheduler_job(args):
     return job
 
 
-def _run_scheduler_job(args, is_daemon):
+def _run_scheduler_job(args):
     skip_serve_logs = args.skip_serve_logs
     job = _create_scheduler_job(args)
-    if not is_daemon:
-        signal.signal(signal.SIGINT, sigint_handler)
-        signal.signal(signal.SIGTERM, sigint_handler)
-        signal.signal(signal.SIGQUIT, sigquit_handler)
     sub_proc = _serve_logs(skip_serve_logs)
     try:
         job.run()
@@ -71,9 +67,12 @@ def scheduler(args):
                 stderr=stderr_handle,
             )
             with ctx:
-                _run_scheduler_job(args=args, is_daemon=True)
+                _run_scheduler_job(args=args)
     else:
-        _run_scheduler_job(args=args, is_daemon=False)
+        signal.signal(signal.SIGINT, sigint_handler)
+        signal.signal(signal.SIGTERM, sigint_handler)
+        signal.signal(signal.SIGQUIT, sigquit_handler)
+        _run_scheduler_job(args=args)
 
 
 def _serve_logs(skip_serve_logs: bool = False) -> Optional[Process]:

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -38,11 +38,24 @@ def _create_scheduler_job(args):
     return job
 
 
+def _run_scheduler_job(args, is_daemon):
+    skip_serve_logs = args.skip_serve_logs
+    job = _create_scheduler_job(args)
+    if not is_daemon:
+        signal.signal(signal.SIGINT, sigint_handler)
+        signal.signal(signal.SIGTERM, sigint_handler)
+        signal.signal(signal.SIGQUIT, sigquit_handler)
+    sub_proc = _serve_logs(skip_serve_logs)
+    try:
+        job.run()
+    finally:
+        if sub_proc:
+            sub_proc.terminate()
+
+
 @cli_utils.action_logging
 def scheduler(args):
     """Starts Airflow Scheduler"""
-    skip_serve_logs = args.skip_serve_logs
-
     print(settings.HEADER)
 
     if args.daemon:
@@ -58,19 +71,9 @@ def scheduler(args):
                 stderr=stderr_handle,
             )
             with ctx:
-                job = _create_scheduler_job(args)
-                sub_proc = _serve_logs(skip_serve_logs)
-                job.run()
+                _run_scheduler_job(args=args, is_daemon=True)
     else:
-        job = _create_scheduler_job(args)
-        signal.signal(signal.SIGINT, sigint_handler)
-        signal.signal(signal.SIGTERM, sigint_handler)
-        signal.signal(signal.SIGQUIT, sigquit_handler)
-        sub_proc = _serve_logs(skip_serve_logs)
-        job.run()
-
-    if sub_proc:
-        sub_proc.terminate()
+        _run_scheduler_job(args=args, is_daemon=False)
 
 
 def _serve_logs(skip_serve_logs: bool = False) -> Optional[Process]:


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/18096

This solves a potential rare occurrence of a process deadlock when using logs serving.
If the scheduler, for any reason, were to encounter an unrecoverable error (such as a loss of connectivity to the database, or anything forcing the process to exit), the serve_logs subprocess would not be properly terminated.

Thus, the process hangs instead of gracefully shutting down, thus requiring external restart.

By ensuring the `.terminate()` function is _always_ called in case of a failure, the parent process can properly shut itself down.