### PR TITLE
Limit colorlog version (6.x is incompatible)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ install_requires =
     cattrs~=1.1, <1.7.0;python_version>"3.6"
     # Required by vendored-in connexion
     clickclick>=1.2
-    colorlog>=4.0.2
+    colorlog>=4.0.2, <6.0
     croniter>=0.3.17, <1.1
     cryptography>=0.9.3
     dataclasses;python_version<"3.7"


### PR DESCRIPTION
The "color" method seems to have been removed:
```python
  File "/airflow/airflow/utils/log/colored_log.py", line 86, in _color_record_traceback
    self.color(self.log_colors, record.levelname) + record.exc_text + escape_codes['reset']
AttributeError: 'CustomTTYColoredFormatter' object has no attribute 'color'
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
