### PR TITLE
fix triggerer liveness probe syntax

### DIFF
--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -150,7 +150,7 @@ spec:
                 os.environ['AIRFLOW__CORE__LOGGING_LEVEL'] = 'ERROR'
                 os.environ['AIRFLOW__LOGGING__LOGGING_LEVEL'] = 'ERROR'
 
-                from airflow.jobs.triggerer_job. import TriggererJob
+                from airflow.jobs.triggerer_job import TriggererJob
                 from airflow.utils.db import create_session
                 from airflow.utils.net import get_hostname
                 import sys


### PR DESCRIPTION
The syntax error caused the liveness probe to always fail.  This fixes it so that k8s will let the triggerer live long enough to be useful.

Hopefully this will one day be a cli command so that it can be tested without k8s in the loop.