### PR TITLE
Adds LoggingMixins to BaseTrigger

### DIFF
--- a/airflow/triggers/base.py
+++ b/airflow/triggers/base.py
@@ -18,8 +18,10 @@
 import abc
 from typing import Any, AsyncIterator, Dict, Tuple
 
+from airflow.utils.log.logging_mixin import LoggingMixin
 
-class BaseTrigger(abc.ABC):
+
+class BaseTrigger(abc.ABC, LoggingMixin):
     """
     Base class for all triggers.
 


### PR DESCRIPTION
This is a simple change to add logging to BaseTrigger, making it consistent with other classes like BaseOperator.
No issue to link to.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
