### PR TITLE
Make auto refresh interval configurable

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1293,6 +1293,14 @@
       type: string
       example: ~
       default:
+    - name: auto_refresh_interval
+      description: |
+        How frequently, in seconds, the DAG data will auto-refresh in graph or tree view
+        when auto-refresh is turned on
+      version_added: 2.2.0
+      type: integer
+      example: ~
+      default: "3"
 
 - name: email
   description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -649,6 +649,10 @@ session_lifetime_minutes = 43200
 # Sets a custom page title for the DAGs overview page and site title for all pages
 # instance_name =
 
+# How frequently, in seconds, the DAG data will auto-refresh in graph or tree view
+# when auto-refresh is turned on
+auto_refresh_interval = 3
+
 [email]
 
 # Configuration email backend and whether to

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -20,7 +20,8 @@
  */
 
 /*
-  global d3, document, nodes, taskInstances, tasks, edges, dagreD3, localStorage, $
+  global d3, document, nodes, taskInstances, tasks, edges, dagreD3, localStorage, $,
+  autoRefreshInterval
 */
 
 import getMetaValue from './meta_value';
@@ -408,7 +409,7 @@ function startOrStopRefresh() {
   if ($('#auto_refresh').is(':checked')) {
     refreshInterval = setInterval(() => {
       handleRefresh();
-    }, 3000); // run refresh every 3 seconds
+    }, autoRefreshInterval * 1000);
   } else {
     clearInterval(refreshInterval);
   }

--- a/airflow/www/static/js/tree.js
+++ b/airflow/www/static/js/tree.js
@@ -19,7 +19,7 @@
  * under the License.
  */
 
-/* global treeData, document, window, $, d3, moment, localStorage */
+/* global treeData, document, window, $, d3, moment, localStorage, autoRefreshInterval */
 import { escapeHtml } from './main';
 import tiTooltip from './task_instances';
 import { callModal, callModalDag } from './dag';
@@ -460,7 +460,7 @@ document.addEventListener('DOMContentLoaded', () => {
         } else {
           $('#auto_refresh').prop('checked', false);
         }
-      }, 3000); // run refresh every 3 seconds
+      }, autoRefreshInterval * 1000);
     } else {
       clearInterval(refreshInterval);
     }

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -128,6 +128,7 @@
     const edges = {{ edges|tojson }};
     const tasks = {{ tasks|tojson }};
     let taskInstances = {{ task_instances|tojson }};
+    const autoRefreshInterval = {{ auto_refresh_interval }};
   </script>
   <script src="{{ url_for_asset('d3.min.js') }}"></script>
   <script src="{{ url_for_asset('dagre-d3.min.js') }}"></script>

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -107,6 +107,7 @@
   <script src="{{ url_for_asset('d3-tip.js') }}"></script>
   <script src="{{ url_for_asset('tree.js') }}"></script>
   <script>
-    const treeData = {{ data|tojson }}
+    const treeData = {{ data|tojson }};
+    const autoRefreshInterval = {{ auto_refresh_interval }};
   </script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2292,6 +2292,7 @@ class Airflow(AirflowBaseView):
             show_external_log_redirect=task_log_reader.supports_external_link,
             external_log_name=external_log_name,
             dag_model=dag_model,
+            auto_refresh_interval=conf.getint('webserver', 'auto_refresh_interval'),
         )
 
     @expose('/calendar')
@@ -2459,6 +2460,7 @@ class Airflow(AirflowBaseView):
             external_log_name=external_log_name,
             dag_run_state=dt_nr_dr_data['dr_state'],
             dag_model=dag_model,
+            auto_refresh_interval=conf.getint('webserver', 'auto_refresh_interval'),
         )
 
     @expose('/duration')


### PR DESCRIPTION
closes: #18069

We accidentally DDOS'd our own webserver yesterday :smile: More details in the issue on how exactly this happened, but the gist is that auto-refresh can be a significant strain if there are many active tasks whose statuses must be polled. Auto-refresh is a wonderful feature but we wanted to be able to lengthen the interval to protect against this.

On main, the interval is hard-coded to 3 seconds. I'm proposing we add a new webserver config variable that will allow this interval to be customized.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
