### PR TITLE
Optional method name in task deferred

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -238,6 +238,14 @@ class TaskDeferred(BaseException):
     """
     Special exception raised to signal that the operator it was raised from
     wishes to defer until a trigger fires.
+
+    :param trigger: The asynchronous workload object that represents the trigger condition.
+    :param method_name:
+        The operator method that is invoked when the task resumes. The method must accept
+        a context dictionary as argument in addition to keyword arguments provided in the
+        deferred exception (see below).
+    :param kwargs: Keyword arguments passed on to the operator method on resume.
+    :param timeout: A timeout after which the deferred is cancelled.
     """
 
     def __init__(

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1645,8 +1645,10 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         Marks this Operator as being "deferred" - that is, suspending its
         execution until the provided trigger fires an event.
 
-        This is achieved by raising a special exception (TaskDeferred)
-        which is caught in the main _execute_task wrapper.
+        This is achieved by raising a special exception which is processed internally
+        in the task execution logic.
+
+        For a description of the arguments, see :class:`~airflow.exceptions.TaskDeferred`.
         """
         raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
 


### PR DESCRIPTION
Currently, a `TaskDeferred` takes a `method_name` parameter such as "execute_complete" and this method must then exist on the operator.
```python
class MyOperator(BaseOperator):
    def execute_complete(self, context, event=None):
        """Callback for when the trigger fires."""
```

But in some cases, it makes sense to simply restart the operator – essentially calling its "execute" method. There is however an inconvenience or compatibility issue here in that the resume method receives an "event" keyword argument with the trigger event payload – and "execute" takes no such argument.

To appreciate why this is a problem, consider the problem of having to delay the execution of an existing operator component, for example deferring its execution for 10 minutes. We would like to avoid having to extend the implementation of this operator in order to accomplish this.

In #17576, support for `pre_execute` was added – a hook that runs before the operator's `execute` method. The change proposal presented here builds upon this functionality to allow an implementation such as:
```python
class PreExecuteDefer:
    def __init__(self, timedelta):
        self._timedelta = timedelta

    def __call__(self, context):
        moment = context["data_interval_end"] + self._timedelta

        # We must verify the trigger condition since upon re-entry, this will be called again.
        if moment < timezone.utcnow():
            return

        trigger = DateTimeTrigger(moment=moment)
        raise TaskDeferred(trigger=trigger, kwargs={})
```
This can be used as the `pre_execute` hook to the effect of delaying the execution.