### PR TITLE
Add "packaging" to core requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -126,6 +126,7 @@ install_requires =
     marshmallow-oneofschema>=2.0.1
     # Required by vendored-in connexion
     openapi-spec-validator>=0.2.4
+    packaging~=21.0
     pendulum~=2.0
     pep562~=1.0;python_version<"3.7"
     psutil>=4.2.0, <6.0.0


### PR DESCRIPTION
This adds a dependency for core airflow on the `packaging` package, which was first used by https://github.com/apache/airflow/commit/b486a0ed86ca4bda2f05105e6d30f470d540daed but not added to the core requirements (presumably as most development environments have it via `pytest` - but a fresh non-dev install of Airflow will not work without this)