### PR TITLE
Mark passing pre/post execute callbacks to operators as experimental.

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -353,10 +353,14 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     :param pre_execute: a function to be called immediately before task
         execution, receiving a context dictionary; raising an exception will
         prevent the task from being executed.
+
+        |experimental|
     :type pre_execute: TaskPreExecuteHook
     :param post_execute: a function to be called immediately after task
         execution, receiving a context dictionary and task result; raising an
         exception will prevent the task from succeeding.
+
+        |experimental|
     :type post_execute: TaskPostExecuteHook
     :param trigger_rule: defines the rule by which dependencies are applied
         for the task to get triggered. Options are:

--- a/docs/apache-airflow/release-process.rst
+++ b/docs/apache-airflow/release-process.rst
@@ -82,6 +82,8 @@ So, for example, if we decided to start the deprecation of a function in Airflow
 
 The exception to this deprecation policy is any feature which is marked as "experimental", which *may* suffer breaking changes or complete removal in a Feature release.
 
+.. _experimental:
+
 Experimental features
 =====================
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,6 +112,7 @@ release = PACKAGE_VERSION
 rst_epilog = f"""
 .. |version| replace:: {version}
 .. |airflow-version| replace:: {airflow.__version__}
+.. |experimental| replace:: This is an :ref:`experimental feature <experimental>`.
 """
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
My primary concern here is that by being able to arbitrarily "change"
what an operator does will greatly increase the "accidental complexity"
of both Airflow (for us as developers) and of the DAG itself (for our
users).

By marking this features as experimental we reserve the right to delete
it at any point (for instance once we add better methods of doing what
the OP wanted with these hooks.)

See discussion starting https://github.com/apache/airflow/pull/17576#issuecomment-916361093

![image](https://user-images.githubusercontent.com/34150/132848445-b32f3375-5bc9-462c-ac77-62f7e90b34e3.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
