### PR TITLE
Fix quarentine tests affected by AIP-39

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -26,7 +26,7 @@ import sys
 import time
 from collections import defaultdict
 from datetime import timedelta
-from typing import DefaultDict, Dict, Iterable, List, Optional, Tuple
+from typing import Collection, DefaultDict, Dict, List, Optional, Tuple
 
 from sqlalchemy import and_, func, not_, or_, tuple_
 from sqlalchemy.exc import OperationalError
@@ -795,7 +795,7 @@ class SchedulerJob(BaseJob):
         guard.commit()
         # END: create dagruns
 
-    def _create_dag_runs(self, dag_models: Iterable[DagModel], session: Session) -> None:
+    def _create_dag_runs(self, dag_models: Collection[DagModel], session: Session) -> None:
         """
         Unconditionally create a DAG run for the given DAG, and update the dag_model's fields to control
         if/when the next DAGRun should be created

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -954,7 +954,7 @@ class SchedulerJob(BaseJob):
             unfinished_task_instances = (
                 session.query(TI)
                 .filter(TI.dag_id == dag_run.dag_id)
-                .filter(TI.execution_date == dag_run.execution_date)
+                .filter(TI.run_id == dag_run.run_id)
                 .filter(TI.state.in_(State.unfinished))
             )
             for task_instance in unfinished_task_instances:

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -378,6 +378,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
     def setUp(self) -> None:
         self.dag_id = "test_logging_dag"
         self.task_id = "test_task"
+        self.run_id = "test_run"
         self.dag_path = os.path.join(ROOT_FOLDER, "dags", "test_logging_in_dag.py")
         reset(self.dag_id)
         self.execution_date = timezone.make_aware(datetime(2017, 1, 1))
@@ -387,6 +388,14 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         self.log_filename = f"{self.dag_id}/{self.task_id}/{self.execution_date_str}/1.log"
         self.ti_log_file_path = os.path.join(self.log_dir, self.log_filename)
         self.parser = cli_parser.get_parser()
+
+        DagBag().get_dag(self.dag_id).create_dagrun(
+            run_id=self.run_id,
+            execution_date=self.execution_date,
+            start_date=timezone.utcnow(),
+            state=State.RUNNING,
+            run_type=DagRunType.MANUAL,
+        )
 
         root = self.root_logger = logging.getLogger()
         self.root_handlers = root.handlers.copy()
@@ -491,20 +500,9 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         with mock.patch.object(task_command, "_run_task_by_selected_method"):
             with conf_vars({('core', 'dags_folder'): self.dag_path}):
                 # increment the try_number of the task to be run
-                dag = DagBag().get_dag(self.dag_id)
-                task = dag.get_task(self.task_id)
                 with create_session() as session:
-                    dag.create_dagrun(
-                        execution_date=self.execution_date,
-                        start_date=timezone.utcnow(),
-                        state=State.RUNNING,
-                        run_type=DagRunType.MANUAL,
-                        session=session,
-                    )
-                    ti = TaskInstance(task, self.execution_date)
-                    ti.refresh_from_db(session=session, lock_for_update=True)
-                    ti.try_number = 1  # not running, so starts at 0
-                    session.merge(ti)
+                    ti = session.query(TaskInstance).filter_by(run_id=self.run_id)
+                    ti.try_number = 1
 
                 log_file_path = os.path.join(os.path.dirname(self.ti_log_file_path), "2.log")
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -529,7 +529,7 @@ def test_send_tasks_to_celery_hang(register_signals):
     executor = celery_executor.CeleryExecutor()
 
     task = MockTask()
-    task_tuples_to_send = [(None, None, None, None, task) for _ in range(26)]
+    task_tuples_to_send = [(None, None, None, task) for _ in range(26)]
 
     for _ in range(500):
         # This loop can hang on Linux if celery_executor does something wrong with

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -1668,22 +1668,24 @@ class TestSchedulerJob:
         with dag_maker(
             dag_id='test_scheduler_keeps_scheduling_pool_full_d1',
             start_date=DEFAULT_DATE,
-        ) as dag_d1:
+        ):
             BashOperator(
                 task_id='test_scheduler_keeps_scheduling_pool_full_t1',
                 pool='test_scheduler_keeps_scheduling_pool_full_p1',
                 bash_command='echo hi',
             )
+        dag_d1 = dag_maker.dag
 
         with dag_maker(
             dag_id='test_scheduler_keeps_scheduling_pool_full_d2',
             start_date=DEFAULT_DATE,
-        ) as dag_d2:
+        ):
             BashOperator(
                 task_id='test_scheduler_keeps_scheduling_pool_full_t2',
                 pool='test_scheduler_keeps_scheduling_pool_full_p2',
                 bash_command='echo hi',
             )
+        dag_d2 = dag_maker.dag
 
         session = settings.Session()
         pool_p1 = Pool(pool='test_scheduler_keeps_scheduling_pool_full_p1', slots=1)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3269,25 +3269,25 @@ class TestSchedulerJobQueriesCount:
         dagbag = DagBag(dag_folder=dag_file, include_examples=False, read_dags_from_db=False)
         dagbag.sync_to_db()
 
-        self.scheduler_job_job = SchedulerJob(subdir=os.devnull)
-        self.scheduler_job_job.processor_agent = mock.MagicMock()
-        dag = self.scheduler_job_job.dagbag.get_dag("test_only_dummy_tasks")
+        self.scheduler_job = SchedulerJob(subdir=os.devnull)
+        self.scheduler_job.processor_agent = mock.MagicMock()
+        dag = self.scheduler_job.dagbag.get_dag("test_only_dummy_tasks")
 
         # Create DagRun
         session = settings.Session()
         orm_dag = session.query(DagModel).get(dag.dag_id)
-        self.scheduler_job_job._create_dag_runs([orm_dag], session)
+        self.scheduler_job._create_dag_runs([orm_dag], session)
 
         drs = DagRun.find(dag_id=dag.dag_id, session=session)
         assert len(drs) == 1
         dr = drs[0]
 
         # Schedule TaskInstances
-        self.scheduler_job_job._schedule_dag_run(dr, session)
+        self.scheduler_job._schedule_dag_run(dr, session)
         with create_session() as session:
             tis = session.query(TaskInstance).all()
 
-        dags = self.scheduler_job_job.dagbag.dags.values()
+        dags = self.scheduler_job.dagbag.dags.values()
         assert ['test_only_dummy_tasks'] == [dag.dag_id for dag in dags]
         assert 5 == len(tis)
         assert {
@@ -3309,7 +3309,7 @@ class TestSchedulerJobQueriesCount:
                 assert end_date is None
                 assert duration is None
 
-        self.scheduler_job_job._schedule_dag_run(dr, session)
+        self.scheduler_job._schedule_dag_run(dr, session)
         with create_session() as session:
             tis = session.query(TaskInstance).all()
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -28,7 +28,6 @@ from unittest.mock import MagicMock, patch
 import psutil
 import pytest
 from freezegun import freeze_time
-from parameterized import parameterized
 from sqlalchemy import func
 
 import airflow.example_dags
@@ -3113,16 +3112,13 @@ class TestSchedulerJobQueriesCount:
             self.scheduler_job = None
         self.clean_db()
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "expected_query_count, dag_count, task_count",
         [
-            # expected, dag_count, task_count
-            # One DAG with one task per DAG file
-            (24, 1, 1),
-            # One DAG with five tasks per DAG  file
-            (28, 1, 5),
-            # 10 DAGs with 10 tasks per DAG file
-            (195, 10, 10),
-        ]
+            (20, 1, 1),  # One DAG with one task per DAG file.
+            (20, 1, 5),  # One DAG with five tasks per DAG file.
+            (83, 10, 10),  # 10 DAGs with 10 tasks per DAG file.
+        ],
     )
     def test_execute_queries_count_with_harvested_dags(self, expected_query_count, dag_count, task_count):
         with mock.patch.dict(
@@ -3176,10 +3172,10 @@ class TestSchedulerJobQueriesCount:
 
                     self.scheduler_job._run_scheduler_loop()
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "expected_query_counts, dag_count, task_count, start_ago, schedule_interval, shape",
         [
-            # expected, dag_count, task_count, start_ago, schedule_interval, shape
-            # One DAG with one task per DAG file
+            # One DAG with one task per DAG file.
             ([9, 9, 9, 9], 1, 1, "1d", "None", "no_structure"),
             ([9, 9, 9, 9], 1, 1, "1d", "None", "linear"),
             ([21, 12, 12, 12], 1, 1, "1d", "@once", "no_structure"),
@@ -3189,7 +3185,7 @@ class TestSchedulerJobQueriesCount:
             ([21, 22, 24, 26], 1, 1, "1d", "30m", "binary_tree"),
             ([21, 22, 24, 26], 1, 1, "1d", "30m", "star"),
             ([21, 22, 24, 26], 1, 1, "1d", "30m", "grid"),
-            # One DAG with five tasks per DAG  file
+            # One DAG with five tasks per DAG file.
             ([9, 9, 9, 9], 1, 5, "1d", "None", "no_structure"),
             ([9, 9, 9, 9], 1, 5, "1d", "None", "linear"),
             ([21, 12, 12, 12], 1, 5, "1d", "@once", "no_structure"),
@@ -3199,7 +3195,7 @@ class TestSchedulerJobQueriesCount:
             ([22, 24, 27, 30], 1, 5, "1d", "30m", "binary_tree"),
             ([22, 24, 27, 30], 1, 5, "1d", "30m", "star"),
             ([22, 24, 27, 30], 1, 5, "1d", "30m", "grid"),
-            # 10 DAGs with 10 tasks per DAG file
+            # 10 DAGs with 10 tasks per DAG file.
             ([9, 9, 9, 9], 10, 10, "1d", "None", "no_structure"),
             ([9, 9, 9, 9], 10, 10, "1d", "None", "linear"),
             ([84, 27, 27, 27], 10, 10, "1d", "@once", "no_structure"),
@@ -3209,7 +3205,7 @@ class TestSchedulerJobQueriesCount:
             ([94, 108, 108, 108], 10, 10, "1d", "30m", "binary_tree"),
             ([94, 108, 108, 108], 10, 10, "1d", "30m", "star"),
             ([94, 108, 108, 108], 10, 10, "1d", "30m", "grid"),
-        ]
+        ],
     )
     def test_process_dags_queries_count(
         self, expected_query_counts, dag_count, task_count, start_ago, schedule_interval, shape

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -3176,35 +3176,35 @@ class TestSchedulerJobQueriesCount:
         "expected_query_counts, dag_count, task_count, start_ago, schedule_interval, shape",
         [
             # One DAG with one task per DAG file.
-            ([9, 9, 9, 9], 1, 1, "1d", "None", "no_structure"),
-            ([9, 9, 9, 9], 1, 1, "1d", "None", "linear"),
-            ([21, 12, 12, 12], 1, 1, "1d", "@once", "no_structure"),
-            ([21, 12, 12, 12], 1, 1, "1d", "@once", "linear"),
-            ([21, 22, 24, 26], 1, 1, "1d", "30m", "no_structure"),
-            ([21, 22, 24, 26], 1, 1, "1d", "30m", "linear"),
-            ([21, 22, 24, 26], 1, 1, "1d", "30m", "binary_tree"),
-            ([21, 22, 24, 26], 1, 1, "1d", "30m", "star"),
-            ([21, 22, 24, 26], 1, 1, "1d", "30m", "grid"),
+            ([10, 10, 10, 10], 1, 1, "1d", "None", "no_structure"),
+            ([10, 10, 10, 10], 1, 1, "1d", "None", "linear"),
+            ([23, 13, 13, 13], 1, 1, "1d", "@once", "no_structure"),
+            ([23, 13, 13, 13], 1, 1, "1d", "@once", "linear"),
+            ([23, 24, 26, 28], 1, 1, "1d", "30m", "no_structure"),
+            ([23, 24, 26, 28], 1, 1, "1d", "30m", "linear"),
+            ([23, 24, 26, 28], 1, 1, "1d", "30m", "binary_tree"),
+            ([23, 24, 26, 28], 1, 1, "1d", "30m", "star"),
+            ([23, 24, 26, 28], 1, 1, "1d", "30m", "grid"),
             # One DAG with five tasks per DAG file.
-            ([9, 9, 9, 9], 1, 5, "1d", "None", "no_structure"),
-            ([9, 9, 9, 9], 1, 5, "1d", "None", "linear"),
-            ([21, 12, 12, 12], 1, 5, "1d", "@once", "no_structure"),
-            ([22, 13, 13, 13], 1, 5, "1d", "@once", "linear"),
-            ([21, 22, 24, 26], 1, 5, "1d", "30m", "no_structure"),
-            ([22, 24, 27, 30], 1, 5, "1d", "30m", "linear"),
-            ([22, 24, 27, 30], 1, 5, "1d", "30m", "binary_tree"),
-            ([22, 24, 27, 30], 1, 5, "1d", "30m", "star"),
-            ([22, 24, 27, 30], 1, 5, "1d", "30m", "grid"),
+            ([10, 10, 10, 10], 1, 5, "1d", "None", "no_structure"),
+            ([10, 10, 10, 10], 1, 5, "1d", "None", "linear"),
+            ([23, 13, 13, 13], 1, 5, "1d", "@once", "no_structure"),
+            ([24, 14, 14, 14], 1, 5, "1d", "@once", "linear"),
+            ([23, 24, 26, 28], 1, 5, "1d", "30m", "no_structure"),
+            ([24, 26, 29, 32], 1, 5, "1d", "30m", "linear"),
+            ([24, 26, 29, 32], 1, 5, "1d", "30m", "binary_tree"),
+            ([24, 26, 29, 32], 1, 5, "1d", "30m", "star"),
+            ([24, 26, 29, 32], 1, 5, "1d", "30m", "grid"),
             # 10 DAGs with 10 tasks per DAG file.
-            ([9, 9, 9, 9], 10, 10, "1d", "None", "no_structure"),
-            ([9, 9, 9, 9], 10, 10, "1d", "None", "linear"),
-            ([84, 27, 27, 27], 10, 10, "1d", "@once", "no_structure"),
-            ([94, 40, 40, 40], 10, 10, "1d", "@once", "linear"),
-            ([84, 88, 88, 88], 10, 10, "1d", "30m", "no_structure"),
-            ([94, 114, 114, 114], 10, 10, "1d", "30m", "linear"),
-            ([94, 108, 108, 108], 10, 10, "1d", "30m", "binary_tree"),
-            ([94, 108, 108, 108], 10, 10, "1d", "30m", "star"),
-            ([94, 108, 108, 108], 10, 10, "1d", "30m", "grid"),
+            ([10, 10, 10, 10], 10, 10, "1d", "None", "no_structure"),
+            ([10, 10, 10, 10], 10, 10, "1d", "None", "linear"),
+            ([95, 28, 28, 28], 10, 10, "1d", "@once", "no_structure"),
+            ([105, 41, 41, 41], 10, 10, "1d", "@once", "linear"),
+            ([95, 99, 99, 99], 10, 10, "1d", "30m", "no_structure"),
+            ([105, 125, 125, 125], 10, 10, "1d", "30m", "linear"),
+            ([105, 119, 119, 119], 10, 10, "1d", "30m", "binary_tree"),
+            ([105, 119, 119, 119], 10, 10, "1d", "30m", "star"),
+            ([105, 119, 119, 119], 10, 10, "1d", "30m", "grid"),
         ],
     )
     def test_process_dags_queries_count(
@@ -3240,10 +3240,20 @@ class TestSchedulerJobQueriesCount:
             self.scheduler_job.executor = MockExecutor(do_update=False)
             self.scheduler_job.heartbeat = mock.MagicMock()
             self.scheduler_job.processor_agent = mock_agent
+
+            failures = []  # Collects assertion errors and report all of them at the end.
+            message = "Expected {expected_count} query, but got {current_count} located at:"
             for expected_query_count in expected_query_counts:
                 with create_session() as session:
-                    with assert_queries_count(expected_query_count):
-                        self.scheduler_job._do_scheduling(session)
+                    try:
+                        with assert_queries_count(expected_query_count, message):
+                            self.scheduler_job._do_scheduling(session)
+                    except AssertionError as e:
+                        failures.append(str(e))
+            if failures:
+                prefix = "Collected database query count mismatches:"
+                joined = "\n\n".join(failures)
+                raise AssertionError(f"{prefix}\n\n{joined}")
 
     def test_should_mark_dummy_task_as_success(self):
         dag_file = os.path.join(


### PR DESCRIPTION
When we did `TaskInstance`’s migration from `execution_date` to `run_id`, we forgot to check the quarentined tests. This fixes them.

Note that this does _not_ make the quarentined tests to pass (although some do pass now), only modify them to fit the test setup required by AIP-39, namely 1. `TaskInstance.execution_date` is now fetched via a `JOIN` to `DagRun`, and an associating `DagRun` is now requried for every `TaskInstance`.

This also fixes some of the tests to match reality, which I’ll comment inline.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
