### PR TITLE
Remove check for at least one schema in GCSToBigquery

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -274,10 +274,6 @@ class GCSToBigQueryOperator(BaseOperator):
                     object_name=self.schema_object,
                 )
                 schema_fields = json.loads(blob.decode("utf-8"))
-            elif self.schema_object is None and self.autodetect is False:
-                raise AirflowException(
-                    'At least one of `schema_fields`, `schema_object`, or `autodetect` must be passed.'
-                )
             else:
                 schema_fields = None
 

--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -20,7 +20,6 @@
 import json
 from typing import Optional, Sequence, Union
 
-from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook


### PR DESCRIPTION
For the case when updating an existing table or insert data to a particular partition, no schema is needed.
Autodetect doesn't always work, e.g. cannot distinguish partition correctly. Other options requires forking the schema to airflow.
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
