### PR TITLE
Fix bad repository name in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -250,7 +250,7 @@ repos:
         exclude: |
           (?x)
           ^airflow/_vendor/
-  - repo: https://github.com/ikamensh/flynt/
+  - repo: https://github.com/ikamensh/flynt
     rev: '0.66'
     hooks:
       - id: flynt


### PR DESCRIPTION
Having a trailing slash on the `flynt` repo makes some versions of Git (in my case, the one under Ubuntu 20.04) unwilling to clone it. Removing the trailing slash to match the other entries fixes the problem.