### PR TITLE
Fixed log view for deferred tasks

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1280,7 +1280,7 @@ class Airflow(AirflowBaseView):
         num_logs = 0
         if ti is not None:
             num_logs = ti.next_try_number - 1
-            if ti.state == State.UP_FOR_RESCHEDULE:
+            if ti.state in (State.UP_FOR_RESCHEDULE, State.DEFERRED):
                 # Tasks in reschedule state decremented the try number
                 num_logs += 1
         logs = [''] * num_logs


### PR DESCRIPTION
Deferred tasks were not showing up in the log view while they were
deferred, as they decrement the try_number on the way into deferral
status much like rescheduling sensors. This applies the same fix that
rescheduling sensors have to make their log appear.
