### PR TITLE
Apply parent dag permissions to subdags.

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -487,10 +487,13 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         # FAB built-in view access method. Won't work for AllDag access.
 
         if self.is_dag_resource(resource_name):
+            root_dag_resource_name = resource_name.split(".")[0]
             if action_name == permissions.ACTION_CAN_READ:
                 has_access |= self.can_read_dag(resource_name, user)
+                has_access |= self.can_read_dag(root_dag_resource_name, user)
             elif action_name == permissions.ACTION_CAN_EDIT:
                 has_access |= self.can_edit_dag(resource_name, user)
+                has_access |= self.can_edit_dag(root_dag_resource_name, user)
 
         return has_access
 

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -485,7 +485,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         has_access = self._has_access(user, action_name, resource_name)
         # FAB built-in view access method. Won't work for AllDag access.
-
+        # breakpoint()
         if self.is_dag_resource(resource_name):
             root_dag_resource_name = resource_name.split(".")[0]
             if action_name == permissions.ACTION_CAN_READ:

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -424,7 +424,9 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """Determines whether a user has DAG read access."""
         if not user:
             user = g.user
-        dag_resource_name = permissions.resource_name_for_dag(dag_id)
+        # To account for SubDags
+        root_dag_id = dag_id.split(".")[0]
+        dag_resource_name = permissions.resource_name_for_dag(root_dag_id)
         return self._has_access(
             user, permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG
         ) or self._has_access(user, permissions.ACTION_CAN_READ, dag_resource_name)
@@ -433,7 +435,9 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """Determines whether a user has DAG edit access."""
         if not user:
             user = g.user
-        dag_resource_name = permissions.resource_name_for_dag(dag_id)
+        # To account for SubDags
+        root_dag_id = dag_id.split(".")[0]
+        dag_resource_name = permissions.resource_name_for_dag(root_dag_id)
 
         return self._has_access(
             user, permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG
@@ -485,15 +489,11 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         has_access = self._has_access(user, action_name, resource_name)
         # FAB built-in view access method. Won't work for AllDag access.
-        # breakpoint()
         if self.is_dag_resource(resource_name):
-            root_dag_resource_name = resource_name.split(".")[0]
             if action_name == permissions.ACTION_CAN_READ:
                 has_access |= self.can_read_dag(resource_name, user)
-                has_access |= self.can_read_dag(root_dag_resource_name, user)
             elif action_name == permissions.ACTION_CAN_EDIT:
                 has_access |= self.can_edit_dag(resource_name, user)
-                has_access |= self.can_edit_dag(root_dag_resource_name, user)
 
         return has_access
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -100,7 +100,15 @@ class TestSecurity(unittest.TestCase):
 
     @classmethod
     def delete_roles(cls):
-        for role_name in ['team-a', 'MyRole1', 'MyRole5', 'Test_Role', 'MyRole3', 'MyRole2', 'dag_permission_role']:
+        for role_name in [
+            'team-a',
+            'MyRole1',
+            'MyRole5',
+            'Test_Role',
+            'MyRole3',
+            'MyRole2',
+            'dag_permission_role',
+        ]:
             api_connexion_utils.delete_role(cls.app, role_name)
 
     def expect_user_is_in_role(self, user, rolename):
@@ -673,10 +681,15 @@ class TestSecurity(unittest.TestCase):
         role_name = 'dag_permission_role'
         parent_dag_name = "parent_dag"
         with self.app.app_context():
-            mock_roles = [{'role': role_name, 'perms': [
-                    (permissions.ACTION_CAN_READ, f"DAG:{parent_dag_name}"),
-                    (permissions.ACTION_CAN_EDIT, f"DAG:{parent_dag_name}"),
-                ]}]
+            mock_roles = [
+                {
+                    'role': role_name,
+                    'perms': [
+                        (permissions.ACTION_CAN_READ, f"DAG:{parent_dag_name}"),
+                        (permissions.ACTION_CAN_EDIT, f"DAG:{parent_dag_name}"),
+                    ],
+                }
+            ]
             user = api_connexion_utils.create_user(
                 self.app,
                 username,
@@ -688,4 +701,6 @@ class TestSecurity(unittest.TestCase):
             )
             self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id=parent_dag_name, user=user)
             self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id=parent_dag_name + ".subdag", user=user)
-            self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id=parent_dag_name + ".subdag.subsubdag", user=user)
+            self.assert_user_has_dag_perms(
+                perms=READ_WRITE, dag_id=parent_dag_name + ".subdag.subsubdag", user=user
+            )

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -100,7 +100,7 @@ class TestSecurity(unittest.TestCase):
 
     @classmethod
     def delete_roles(cls):
-        for role_name in ['team-a', 'MyRole1', 'MyRole5', 'Test_Role', 'MyRole3', 'MyRole2']:
+        for role_name in ['team-a', 'MyRole1', 'MyRole5', 'Test_Role', 'MyRole3', 'MyRole2', 'dag_permission_role']:
             api_connexion_utils.delete_role(cls.app, role_name)
 
     def expect_user_is_in_role(self, user, rolename):
@@ -677,12 +677,12 @@ class TestSecurity(unittest.TestCase):
                     (permissions.ACTION_CAN_READ, f"DAG:{parent_dag_name}"),
                     (permissions.ACTION_CAN_EDIT, f"DAG:{parent_dag_name}"),
                 ]}]
-            self.security_manager.bulk_sync_roles(mock_roles)
             user = api_connexion_utils.create_user(
                 self.app,
                 username,
                 role_name,
             )
+            self.security_manager.bulk_sync_roles(mock_roles)
             self.security_manager._sync_dag_view_permissions(
                 parent_dag_name, access_control={role_name: READ_WRITE}
             )

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -123,8 +123,6 @@ class TestSecurity(unittest.TestCase):
             ), f"User should not have '{perm}' on DAG '{dag_id}'"
 
     def _has_dag_perm(self, perm, dag_id, user):
-        # if not user:
-        #     user = self.user
         return self.security_manager.has_access(perm, permissions.resource_name_for_dag(dag_id), user)
 
     def _create_dag(self, dag_id):
@@ -669,3 +667,25 @@ class TestSecurity(unittest.TestCase):
             ),
         ):
             self.security_manager.prefixed_dag_id("hello")
+
+    def test_parent_dag_access_applies_to_subdag(self):
+        username = 'dag_permission_user'
+        role_name = 'dag_permission_role'
+        parent_dag_name = "parent_dag"
+        with self.app.app_context():
+            mock_roles = [{'role': role_name, 'perms': [
+                    (permissions.ACTION_CAN_READ, f"DAG:{parent_dag_name}"),
+                    (permissions.ACTION_CAN_EDIT, f"DAG:{parent_dag_name}"),
+                ]}]
+            self.security_manager.bulk_sync_roles(mock_roles)
+            user = api_connexion_utils.create_user(
+                self.app,
+                username,
+                role_name,
+            )
+            self.security_manager._sync_dag_view_permissions(
+                parent_dag_name, access_control={role_name: READ_WRITE}
+            )
+            self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id=parent_dag_name, user=user)
+            self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id=parent_dag_name + ".subdag", user=user)
+            self.assert_user_has_dag_perms(perms=READ_WRITE, dag_id=parent_dag_name + ".subdag.subsubdag", user=user)


### PR DESCRIPTION
This fixes a bug where users can't access a subdag even when they have access to the parent dag.

closes: #17652
related: https://github.com/apache/airflow/pull/7752