### PR TITLE
Remove limits for dnspython

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -192,12 +192,6 @@ apache_beam = [
 ]
 asana = ['asana>=0.10']
 async_packages = [
-    # DNS Python 2.0.0 and above breaks building documentation on Sphinx. When dnspython 2.0.0 is installed
-    # building documentation fails with trying to import google packages with
-    # TypeError("unsupported operand type(s) for +: 'SSL_VERIFY_PEER' and
-    # 'SSL_VERIFY_FAIL_IF_NO_PEER_CERT'")
-    # The issue is opened for it https://github.com/rthalley/dnspython/issues/681
-    'dnspython<2.0.0',
     'eventlet>= 0.9.7',
     'gevent>=0.13',
     'greenlet>=0.4.9',


### PR DESCRIPTION
I believe, while the root cause of the problem is still not solved,
the optimisation in providers's manager imports implemented
in #18052 might not trigger the SSL error when examples are
highlighted. The only way the SSL error was triggered was inside
import done by sphinx and currently that import should not
import wtforms (and email/dns transitively).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
