### PR TITLE
Rename LocalToAzureDataLakeStorageOperator to LocalFilesystemToADLSOperator

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
@@ -19,7 +19,7 @@ import os
 
 from airflow import models
 from airflow.providers.microsoft.azure.operators.adls_delete import AzureDataLakeStorageDeleteOperator
-from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalToAzureDataLakeStorageOperator
+from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalFilesystemToADLSOperator
 from airflow.utils.dates import days_ago
 
 LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", 'localfile.txt')
@@ -33,7 +33,7 @@ with models.DAG(
     tags=['example'],
 ) as dag:
 
-    upload_file = LocalToAzureDataLakeStorageOperator(
+    upload_file = LocalFilesystemToADLSOperator(
         task_id='upload_task',
         local_path=LOCAL_FILE_PATH,
         remote_path=REMOTE_FILE_PATH,

--- a/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.py
@@ -19,7 +19,7 @@ import os
 
 from airflow import models
 from airflow.providers.microsoft.azure.operators.adls_delete import AzureDataLakeStorageDeleteOperator
-from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalToAzureDataLakeStorageOperator
+from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalFilesystemToADLSOperator
 from airflow.utils.dates import days_ago
 
 LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", 'localfile.txt')
@@ -32,7 +32,7 @@ with models.DAG(
     tags=['example'],
 ) as dag:
     # [START howto_operator_local_to_adls]
-    upload_file = LocalToAzureDataLakeStorageOperator(
+    upload_file = LocalFilesystemToADLSOperator(
         task_id='upload_task',
         local_path=LOCAL_FILE_PATH,
         remote_path=REMOTE_FILE_PATH,

--- a/airflow/providers/microsoft/azure/transfers/local_to_adls.py
+++ b/airflow/providers/microsoft/azure/transfers/local_to_adls.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import warnings
 from typing import Any, Dict, Optional
 
 from airflow.exceptions import AirflowException
@@ -22,13 +22,13 @@ from airflow.models import BaseOperator
 from airflow.providers.microsoft.azure.hooks.azure_data_lake import AzureDataLakeHook
 
 
-class LocalToAzureDataLakeStorageOperator(BaseOperator):
+class LocalFilesystemToADLSOperator(BaseOperator):
     """
     Upload file(s) to Azure Data Lake
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:LocalToAzureDataLakeStorageOperator`
+        :ref:`howto/operator:LocalFilesystemToADLSOperator`
 
     :param local_path: local path. Can be single file, directory (in which case,
             upload recursively) or glob pattern. Recursive glob patterns using `**`
@@ -100,3 +100,20 @@ class LocalToAzureDataLakeStorageOperator(BaseOperator):
             blocksize=self.blocksize,
             **self.extra_upload_options,
         )
+
+
+class LocalToAzureDataLakeStorageOperator(LocalFilesystemToADLSOperator):
+    """
+    This class is deprecated.
+    Please use `airflow.providers.microsoft.azure.transfers.local_to_adls.LocalFilesystemToADLSOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            """This class is deprecated.
+            Please use
+            `airflow.providers.microsoft.azure.transfers.local_to_adls.LocalFilesystemToADLSOperator`.""",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        super().__init__(*args, **kwargs)

--- a/docs/apache-airflow-providers-microsoft-azure/operators/local_to_adls.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/local_to_adls.rst
@@ -32,12 +32,12 @@ Prerequisite Tasks
 
 .. include::/operators/_partials/prerequisite_tasks.rst
 
-.. _howto/operator:LocalToAzureDataLakeStorageOperator:
+.. _howto/operator:LocalFilesystemToADLSOperator:
 
-LocalToAzureDataLakeStorageOperator
+LocalFilesystemToADLSOperator
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:class:`~airflow.providers.microsoft.azure.transfers.local_to_adls.LocalToAzureDataLakeStorageOperator` allows you to
+:class:`~airflow.providers.microsoft.azure.transfers.local_to_adls.LocalFilesystemToADLSOperator` allows you to
 upload data from local filesystem to ADL.
 
 

--- a/tests/providers/microsoft/azure/transfers/test_local_to_adls.py
+++ b/tests/providers/microsoft/azure/transfers/test_local_to_adls.py
@@ -22,7 +22,7 @@ from unittest import mock
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalToAzureDataLakeStorageOperator
+from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalFilesystemToADLSOperator
 
 TASK_ID = 'test-adls-upload-operator'
 LOCAL_PATH = 'test/*'
@@ -33,7 +33,7 @@ REMOTE_PATH = 'TEST-DIR'
 class TestAzureDataLakeStorageUploadOperator(unittest.TestCase):
     @mock.patch('airflow.providers.microsoft.azure.transfers.local_to_adls.AzureDataLakeHook')
     def test_execute_success(self, mock_hook):
-        operator = LocalToAzureDataLakeStorageOperator(
+        operator = LocalFilesystemToADLSOperator(
             task_id=TASK_ID, local_path=LOCAL_PATH, remote_path=REMOTE_PATH
         )
         operator.execute(None)
@@ -48,7 +48,7 @@ class TestAzureDataLakeStorageUploadOperator(unittest.TestCase):
 
     @mock.patch('airflow.providers.microsoft.azure.transfers.local_to_adls.AzureDataLakeHook')
     def test_execute_raises_for_bad_glob_val(self, mock_hook):
-        operator = LocalToAzureDataLakeStorageOperator(
+        operator = LocalFilesystemToADLSOperator(
             task_id=TASK_ID, local_path=BAD_LOCAL_PATH, remote_path=REMOTE_PATH
         )
         with pytest.raises(AirflowException) as ctx:
@@ -57,7 +57,7 @@ class TestAzureDataLakeStorageUploadOperator(unittest.TestCase):
 
     @mock.patch('airflow.providers.microsoft.azure.transfers.local_to_adls.AzureDataLakeHook')
     def test_extra_options_is_passed(self, mock_hook):
-        operator = LocalToAzureDataLakeStorageOperator(
+        operator = LocalFilesystemToADLSOperator(
             task_id=TASK_ID,
             local_path=LOCAL_PATH,
             remote_path=REMOTE_PATH,


### PR DESCRIPTION
Renaming for consistency:.

Local -> LocalFilesystem based on: `LocalFilesystemToS3Operator`, `LocalFilesystemToGCSOperator`
shorting AzureDataLakeStorage to ADLS based on: `ADLSToGCSOperator`.

Noting that we have other operators that use the full service name like: `AzureDataLakeStorageDeleteOperator`, `AzureDataLakeStorageListOperator` but I think the ADLS is preferred just like we use GCS rather than GoogleCloudStorage - This falls within [case 6 Isolated cases of AIP-21](https://cwiki.apache.org/confluence/display/AIRFLOW/AIP-21%3A+Changes+in+import+paths#AIP21:Changesinimportpaths-Case#6Otherisolatedcases) I will create PRs to handle them as well if we go with the shorter ADLS version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
