### PR TITLE
Fix usage of ``range(len())`` to ``enumerate``

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1172,12 +1172,10 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
                         self.log.exception(e)
                 elif isinstance(content, list):
                     env = self.dag.get_template_env()
-                    for i in range(len(content)):
-                        if isinstance(content[i], str) and any(
-                            content[i].endswith(ext) for ext in self.template_ext
-                        ):
+                    for i, item in enumerate(content):
+                        if isinstance(item, str) and any(item.endswith(ext) for ext in self.template_ext):
                             try:
-                                content[i] = env.loader.get_source(env, content[i])[0]
+                                content[i] = env.loader.get_source(env, item)[0]
                             except Exception as e:
                                 self.log.exception(e)
         self.prepare_template()

--- a/airflow/providers/papermill/operators/papermill.py
+++ b/airflow/providers/papermill/operators/papermill.py
@@ -67,11 +67,11 @@ class PapermillOperator(BaseOperator):
         if not self.inlets or not self.outlets:
             raise ValueError("Input notebook or output notebook is not specified")
 
-        for i in range(len(self.inlets)):
+        for i, item in enumerate(self.inlets):
             pm.execute_notebook(
-                self.inlets[i].url,
+                item.url,
                 self.outlets[i].url,
-                parameters=self.inlets[i].parameters,
+                parameters=item.parameters,
                 progress_bar=False,
                 report_mode=True,
             )

--- a/tests/providers/apache/drill/hooks/test_drill.py
+++ b/tests/providers/apache/drill/hooks/test_drill.py
@@ -77,8 +77,8 @@ class TestDrillHook(unittest.TestCase):
         df = self.db_hook().get_pandas_df(statement)
 
         assert column == df.columns[0]
-        for i in range(len(result_sets)):  # pylint: disable=consider-using-enumerate
-            assert result_sets[i][0] == df.values.tolist()[i][0]
+        for i, item in enumerate(result_sets):
+            assert item[0] == df.values.tolist()[i][0]
         assert self.conn.close.call_count == 1
         assert self.cur.close.call_count == 1
         self.cur.execute.assert_called_once_with(statement)

--- a/tests/providers/apache/druid/hooks/test_druid.py
+++ b/tests/providers/apache/druid/hooks/test_druid.py
@@ -242,8 +242,8 @@ class TestDruidDbApiHook(unittest.TestCase):
         df = self.db_hook().get_pandas_df(statement)
 
         assert column == df.columns[0]
-        for i in range(len(result_sets)):
-            assert result_sets[i][0] == df.values.tolist()[i][0]
+        for i, item in enumerate(result_sets):
+            assert item[0] == df.values.tolist()[i][0]
         assert self.conn.close.call_count == 1
         assert self.cur.close.call_count == 1
         self.cur.execute.assert_called_once_with(statement)

--- a/tests/providers/apache/pinot/hooks/test_pinot.py
+++ b/tests/providers/apache/pinot/hooks/test_pinot.py
@@ -263,8 +263,8 @@ class TestPinotDbApiHook(unittest.TestCase):
         self.cur.fetchall.return_value = result_sets
         df = self.db_hook().get_pandas_df(statement)
         assert column == df.columns[0]
-        for i in range(len(result_sets)):
-            assert result_sets[i][0] == df.values.tolist()[i][0]
+        for i, item in enumerate(result_sets):
+            assert item[0] == df.values.tolist()[i][0]
 
 
 class TestPinotDbApiHookIntegration(unittest.TestCase):

--- a/tests/providers/exasol/hooks/test_exasol.py
+++ b/tests/providers/exasol/hooks/test_exasol.py
@@ -124,8 +124,8 @@ class TestExasolHook(unittest.TestCase):
         sql = ['SQL1', 'SQL2']
         self.db_hook.run(sql, autocommit=True)
         self.conn.set_autocommit.assert_called_once_with(True)
-        for i in range(len(self.conn.execute.call_args_list)):
-            args, kwargs = self.conn.execute.call_args_list[i]
+        for i, item in enumerate(self.conn.execute.call_args_list):
+            args, kwargs = item
             assert len(args) == 2
             assert args[0] == sql[i]
             assert kwargs == {}

--- a/tests/providers/mysql/hooks/test_mysql.py
+++ b/tests/providers/mysql/hooks/test_mysql.py
@@ -298,8 +298,8 @@ class TestMySqlHook(unittest.TestCase):
         sql = ['SQL1', 'SQL2']
         self.db_hook.run(sql, autocommit=True)
         self.conn.autocommit.assert_called_once_with(True)
-        for i in range(len(self.cur.execute.call_args_list)):
-            args, kwargs = self.cur.execute.call_args_list[i]
+        for i, item in enumerate(self.cur.execute.call_args_list):
+            args, kwargs = item
             assert len(args) == 1
             assert args[0] == sql[i]
             assert kwargs == {}


### PR DESCRIPTION
https://www.reddit.com/r/learnpython/comments/4af432/who_is_teaching_beginners_to_use_rangeleniterable/ has good reasons :)

Also https://www.reddit.com/r/learnpython/comments/nn0il2/rangelens_vs_enumerate/ has more details and we had pylint disables at few places which are fixed

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
