### PR TITLE
Allow using default celery commands for custom Celery executors subclassed from existing 

### DIFF
--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -16,10 +16,23 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+import sys
+
 import pytest
 
 from airflow import models
 from airflow.cli import cli_parser
+from airflow.executors import celery_executor, celery_kubernetes_executor
+
+# Create custom executors here because conftest is imported first
+custom_executor_module = type(sys)('custom_executor')
+custom_executor_module.CustomCeleryExecutor = type(
+    'CustomCeleryExecutor', (celery_executor.CeleryExecutor,), {}
+)
+custom_executor_module.CustomCeleryKubernetesExecutor = type(
+    'CustomCeleryKubernetesExecutor', (celery_kubernetes_executor.CeleryKubernetesExecutor,), {}
+)
+sys.modules['custom_executor'] = custom_executor_module
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_parser.py
+++ b/tests/cli/test_cli_parser.py
@@ -206,10 +206,18 @@ class TestCli(TestCase):
             stderr = stderr.getvalue()
         assert (
             "airflow command error: argument GROUP_OR_COMMAND: celery subcommand "
-            "works only with CeleryExecutor, your current executor: SequentialExecutor, see help above."
+            "works only with CeleryExecutor, CeleryKubernetesExecutor and executors derived from them, "
+            "your current executor: SequentialExecutor, subclassed from: BaseExecutor, see help above."
         ) in stderr
 
-    @parameterized.expand(["CeleryExecutor", "CeleryKubernetesExecutor"])
+    @parameterized.expand(
+        [
+            "CeleryExecutor",
+            "CeleryKubernetesExecutor",
+            "custom_executor.CustomCeleryExecutor",
+            "custom_executor.CustomCeleryKubernetesExecutor",
+        ]
+    )
     def test_dag_parser_celery_command_accept_celery_executor(self, executor):
         with conf_vars({('core', 'executor'): executor}), contextlib.redirect_stderr(io.StringIO()) as stderr:
             parser = cli_parser.get_parser()


### PR DESCRIPTION
Currently Airflow CLI does not allow using Celery commands for custom executors subclassed from CeleryExecutor or CeleryKubernetesExecutor. With this PR, additional check is run to determine whether custom executor is subclassed from pre-existing Celery executors, which means that it supports CLI Celery commands.  

(This PR was reopened from #17426 due to an issue with merging existing changes which led to >250 commits being referenced in PR)

Fixes: #17373 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
