### PR TITLE
Swap dag import error dropdown icons

### DIFF
--- a/airflow/www/static/css/flash.css
+++ b/airflow/www/static/css/flash.css
@@ -53,7 +53,7 @@
 .dag-import-error::after {
   /* symbol for "opening" panels */
   font-family: FontAwesome;/* stylelint-disable-line font-family-no-missing-generic-family-keyword */
-  content: "\f078";
+  content: "\f054";
   float: right;
   color: #e43921;
   position: absolute;
@@ -63,5 +63,5 @@
 
 .dag-import-error.expanded-error::after {
   /* symbol for "closing" panels */
-  content: "\f054";
+  content: "\f078";
 }


### PR DESCRIPTION
Open/Close icons were backwards. This swaps them to be consistent with the expand/contract the whole dag error banner

Closes #18100

Now:
<img width="683" alt="Screen Shot 2021-09-13 at 5 52 18 PM" src="https://user-images.githubusercontent.com/4600967/133116846-d73ba110-3d62-4740-ac1c-71750914cfe0.png">
<img width="682" alt="Screen Shot 2021-09-13 at 5 52 22 PM" src="https://user-images.githubusercontent.com/4600967/133116850-232322d3-aee7-4ef2-8790-468acb5c1958.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
