### PR TITLE
Celery: Sort adopted tasks in _check_for_stalled_adopted_tasks method

### DIFF
--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -341,11 +341,13 @@ class CeleryExecutor(BaseExecutor):
         just resend them. We do that by clearing the state and letting the
         normal scheduler loop deal with that
         """
-        now = utcnow()
+        sorted_adopted_task_timeouts = OrderedDict(
+            sorted(self.adopted_task_timeouts.items(), key=lambda k: k[1])
+        )
 
         timedout_keys = []
-        for key, stalled_after in self.adopted_task_timeouts.items():
-            if stalled_after > now:
+        for key, stalled_after in sorted_adopted_task_timeouts.items():
+            if stalled_after > utcnow():
                 # Since items are stored sorted, if we get to a stalled_after
                 # in the future then we can stop
                 break

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -341,13 +341,13 @@ class CeleryExecutor(BaseExecutor):
         just resend them. We do that by clearing the state and letting the
         normal scheduler loop deal with that
         """
-        sorted_adopted_task_timeouts = OrderedDict(
-            sorted(self.adopted_task_timeouts.items(), key=lambda k: k[1])
-        )
+        now = utcnow()
+
+        sorted_adopted_task_timeouts = sorted(self.adopted_task_timeouts.items(), key=lambda k: k[1])
 
         timedout_keys = []
-        for key, stalled_after in sorted_adopted_task_timeouts.items():
-            if stalled_after > utcnow():
+        for key, stalled_after in sorted_adopted_task_timeouts:
+            if stalled_after > now:
                 # Since items are stored sorted, if we get to a stalled_after
                 # in the future then we can stop
                 break

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -376,6 +376,34 @@ class TestCeleryExecutor(unittest.TestCase):
         assert executor.running == set()
         assert executor.adopted_task_timeouts == {}
 
+    @pytest.mark.backend("mysql", "postgres")
+    def test_check_for_stalled_adopted_tasks_goes_in_ordered_fashion(self):
+        start_date = timezone.utcnow() - timedelta(days=2)
+        queued_dttm = timezone.utcnow() - timedelta(minutes=30)
+        queued_dttm_2 = timezone.utcnow() - timedelta(minutes=4)
+
+        try_number = 1
+
+        with DAG("test_check_for_stalled_adopted_tasks") as dag:
+            task_1 = BaseOperator(task_id="task_1", start_date=start_date)
+            task_2 = BaseOperator(task_id="task_2", start_date=start_date)
+
+        key_1 = TaskInstanceKey(dag.dag_id, task_1.task_id, "runid", try_number)
+        key_2 = TaskInstanceKey(dag.dag_id, task_2.task_id, "runid", try_number)
+
+        executor = celery_executor.CeleryExecutor()
+        executor.adopted_task_timeouts = {
+            key_2: queued_dttm_2 + executor.task_adoption_timeout,
+            key_1: queued_dttm + executor.task_adoption_timeout,
+        }
+        executor.running = {key_1, key_2}
+        executor.tasks = {key_1: AsyncResult("231"), key_2: AsyncResult("232")}
+        executor.sync()
+        assert executor.event_buffer == {key_1: (State.FAILED, None)}
+        assert executor.tasks == {key_2: AsyncResult('232')}
+        assert executor.running == {key_2}
+        assert executor.adopted_task_timeouts == {key_2: queued_dttm_2 + executor.task_adoption_timeout}
+
 
 def test_operation_timeout_config():
     assert celery_executor.OPERATION_TIMEOUT == 1


### PR DESCRIPTION
This PR adds sorting in adopted_tasks_timeout to ensure we correctly
clear stalled adopted tasks

Closes: https://github.com/apache/airflow/issues/17381

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
