### PR TITLE
Upgrade importlib-resources version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -111,7 +111,7 @@ install_requires =
     gunicorn>=20.1.0
     httpx
     importlib_metadata>=1.7;python_version<"3.9"
-    importlib_resources~=1.4
+    importlib_resources~=5.0
     # Required by vendored-in connexion
     inflection>=0.3.1
     iso8601>=0.1.12

--- a/setup.py
+++ b/setup.py
@@ -512,7 +512,7 @@ devel = [
     'freezegun',
     'github3.py',
     'gitpython',
-    'importlib-resources~=1.4',
+    'importlib-resources~=5.0',
     'ipdb',
     'jira',
     'jsondiff',


### PR DESCRIPTION
Closes #18155

Update `importlib-resources` version as the current selected version is over a year old. Fixes compatibility issues with other packages.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
