### PR TITLE
Support all Unix wildcards in S3KeySensor

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -453,7 +453,7 @@ class S3Hook(AwsBaseHook):
         :return: the key object from the bucket or None if none has been found.
         :rtype: boto3.s3.Object
         """
-        prefix = re.split(r'[*]', wildcard_key, 1)[0]
+        prefix = re.split(r'[\[\*\?]', wildcard_key, 1)[0]
         key_list = self.list_keys(bucket_name, prefix=prefix, delimiter=delimiter)
         key_matches = [k for k in key_list if fnmatch.fnmatch(k, wildcard_key)]
         if key_matches:

--- a/airflow/providers/amazon/aws/sensors/s3_key.py
+++ b/airflow/providers/amazon/aws/sensors/s3_key.py
@@ -176,7 +176,7 @@ class S3KeySizeSensor(S3KeySensor):
             'MaxItems': None,
         }
         if self.wildcard_match:
-            prefix = re.split(r'[*]', self.bucket_key, 1)[0]
+            prefix = re.split(r'[\[\*\?]', self.bucket_key, 1)[0]
 
         paginator = s3_hook.get_conn().get_paginator('list_objects_v2')
         response = paginator.paginate(

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -202,6 +202,7 @@ class TestAwsS3Hook:
         bucket = hook.get_bucket(s3_bucket)
         bucket.put_object(Key='abc', Body=b'a')
         bucket.put_object(Key='a/b', Body=b'a')
+        bucket.put_object(Key='foo_5.txt', Body=b'a')
 
         assert hook.check_for_wildcard_key('a*', s3_bucket) is True
         assert hook.check_for_wildcard_key('abc', s3_bucket) is True
@@ -213,11 +214,17 @@ class TestAwsS3Hook:
         assert hook.check_for_wildcard_key(f's3://{s3_bucket}//a') is False
         assert hook.check_for_wildcard_key(f's3://{s3_bucket}//b') is False
 
+        assert hook.get_wildcard_key('a?b', s3_bucket).key == 'a/b'
+        assert hook.get_wildcard_key('a?c', s3_bucket, delimiter='/').key == 'abc'
+        assert hook.get_wildcard_key('foo_[0-9].txt', s3_bucket, delimiter='/').key == 'foo_5.txt'
+        assert hook.get_wildcard_key(f's3://{s3_bucket}/foo_[0-9].txt', delimiter='/').key == 'foo_5.txt'
+
     def test_get_wildcard_key(self, s3_bucket):
         hook = S3Hook()
         bucket = hook.get_bucket(s3_bucket)
         bucket.put_object(Key='abc', Body=b'a')
         bucket.put_object(Key='a/b', Body=b'a')
+        bucket.put_object(Key='foo_5.txt', Body=b'a')
 
         # The boto3 Class API is _odd_, and we can't do an isinstance check as
         # each instance is a different class, so lets just check one property
@@ -233,6 +240,11 @@ class TestAwsS3Hook:
         assert hook.get_wildcard_key('b', s3_bucket) is None
         assert hook.get_wildcard_key(f's3://{s3_bucket}/a') is None
         assert hook.get_wildcard_key(f's3://{s3_bucket}/b') is None
+
+        assert hook.get_wildcard_key('a?b', s3_bucket).key == 'a/b'
+        assert hook.get_wildcard_key('a?c', s3_bucket, delimiter='/').key == 'abc'
+        assert hook.get_wildcard_key('foo_[0-9].txt', s3_bucket, delimiter='/').key == 'foo_5.txt'
+        assert hook.get_wildcard_key(f's3://{s3_bucket}/foo_[0-9].txt', delimiter='/').key == 'foo_5.txt'
 
     def test_load_string(self, s3_bucket):
         hook = S3Hook()

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -165,3 +165,13 @@ class TestS3KeySizeSensor(unittest.TestCase):
         mock_paginator.paginate.return_value = [paginate_return_value]
         assert op.poke(None) is poke_return_value
         mock_check_for_key.assert_called_once_with(op.bucket_key, op.bucket_name)
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3KeySizeSensor.get_files', return_value=[])
+    @mock.patch('airflow.providers.amazon.aws.sensors.s3_key.S3Hook')
+    def test_poke_wildcard(self, mock_hook, mock_get_files):
+        op = S3KeySizeSensor(task_id='s3_key_sensor', bucket_key='s3://test_bucket/file', wildcard_match=True)
+
+        mock_check_for_wildcard_key = mock_hook.return_value.check_for_wildcard_key
+        mock_check_for_wildcard_key.return_value = False
+        assert not op.poke(None)
+        mock_check_for_wildcard_key.assert_called_once_with(op.bucket_key, op.bucket_name)


### PR DESCRIPTION
Support all Unix wildcards in S3KeySensor

This addresses issue 15538 by expanding the regular expression to include all possible wildcard input to fnmatch:

previously: re.split(r'[*]'
now: re.split(r'[\[\*\?]'

closes: #15538
