### PR TITLE
Chart: Allow running and waiting for DB Migrations using default image

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -233,6 +233,14 @@ If release name contains chart name it will be used as a full name.
 {{ printf "%s:%s" .Values.defaultAirflowRepository .Values.defaultAirflowTag }}
 {{- end }}
 
+{{ define "airflow_image_for_migrations" -}}
+{{- if .Values.useDefaultImageForMigration -}}
+{{ template "default_airflow_image" . }}
+{{- else -}}
+{{ template "airflow_image" . }}
+{{- end -}}
+{{- end }}
+
 {{ define "flower_image" -}}
 {{ printf "%s:%s" (.Values.images.flower.repository | default .Values.defaultAirflowRepository) (.Values.images.flower.tag | default .Values.defaultAirflowTag) }}
 {{- end }}

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -234,7 +234,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{ define "airflow_image_for_migrations" -}}
-{{- if .Values.useDefaultImageForMigration -}}
+{{- if .Values.images.useDefaultImageForMigration -}}
 {{ template "default_airflow_image" . }}
 {{- else -}}
 {{ template "airflow_image" . }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       containers:
         - name: run-airflow-migrations
-          image: {{ template "airflow_image" . }}
+          image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           # Support running against 1.10.x and 2.x
           {{- if semverCompare ">=2.0.0" .Values.airflowVersion }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -106,7 +106,7 @@ spec:
         - name: wait-for-airflow-migrations
           resources:
 {{ toYaml .Values.scheduler.resources | indent 12 }}
-          image: {{ template "airflow_image" . }}
+          image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
           {{- include "wait-for-migrations-command" . | indent 10 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - name: wait-for-airflow-migrations
           resources:
             {{- toYaml .Values.triggerer.resources | nindent 12 }}
-          image: {{ template "airflow_image" . }}
+          image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
           {{- include "wait-for-migrations-command" . | nindent 10 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -101,7 +101,7 @@ spec:
         - name: wait-for-airflow-migrations
           resources:
 {{ toYaml .Values.webserver.resources | indent 12 }}
-          image: {{ template "airflow_image" . }}
+          image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
           {{- include "wait-for-migrations-command" . | indent 10 }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -119,7 +119,7 @@ spec:
         - name: wait-for-airflow-migrations
           resources:
 {{ toYaml .Values.workers.resources | indent 12 }}
-          image: {{ template "airflow_image" . }}
+          image: {{ template "airflow_image_for_migrations" . }}
           imagePullPolicy: {{ .Values.images.airflow.pullPolicy }}
           args:
           {{- include "wait-for-migrations-command" . | indent 10 }}

--- a/chart/tests/test_migrate_database_job.py
+++ b/chart/tests/test_migrate_database_job.py
@@ -94,14 +94,14 @@ class TestMigrateDatabaseJob:
     def test_should_use_correct_image(self, use_default_image, expected_image):
         docs = render_chart(
             values={
-                "useDefaultImageForMigration": use_default_image,
                 "defaultAirflowRepository": "apache/airflow",
                 "defaultAirflowTag": "2.1.0",
                 "images": {
                     "airflow": {
                         "repository": "apache/airflow",
                         "tag": "user-image",
-                    }
+                    },
+                    "useDefaultImageForMigration": use_default_image,
                 },
             },
             show_only=["templates/jobs/migrate-database-job.yaml"],

--- a/chart/tests/test_migrate_database_job.py
+++ b/chart/tests/test_migrate_database_job.py
@@ -15,14 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
-
 import jmespath
+import pytest
 
 from tests.helm_template_generator import render_chart
 
 
-class MigrateDatabaseJobTest(unittest.TestCase):
+class TestMigrateDatabaseJob:
     def test_should_run_by_default(self):
         docs = render_chart(show_only=["templates/jobs/migrate-database-job.yaml"])
         assert "Job" == docs[0]["kind"]
@@ -84,3 +83,28 @@ class MigrateDatabaseJobTest(unittest.TestCase):
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    @pytest.mark.parametrize(
+        "use_default_image,expected_image",
+        [
+            (True, "apache/airflow:2.1.0"),
+            (False, "apache/airflow:user-image"),
+        ],
+    )
+    def test_should_use_correct_image(self, use_default_image, expected_image):
+        docs = render_chart(
+            values={
+                "useDefaultImageForMigration": use_default_image,
+                "defaultAirflowRepository": "apache/airflow",
+                "defaultAirflowTag": "2.1.0",
+                "images": {
+                    "airflow": {
+                        "repository": "apache/airflow",
+                        "tag": "user-image",
+                    }
+                },
+            },
+            show_only=["templates/jobs/migrate-database-job.yaml"],
+        )
+
+        assert expected_image == jmespath.search("spec.template.spec.containers[0].image", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -613,6 +613,12 @@
                 }
             ]
         },
+        "useDefaultImageForMigration": {
+            "description": "To avoid images with user code for running and waiting for DB migrations set this to ``true``. ",
+            "type": "boolean",
+            "x-docsSection": "Airflow",
+            "default": false
+        },
         "data": {
             "description": "Airflow database & redis configuration.",
             "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -312,6 +312,12 @@
                         }
                     }
                 },
+                "useDefaultImageForMigration": {
+                    "description": "To avoid images with user code for running and waiting for DB migrations set this to ``true``. ",
+                    "type": "boolean",
+                    "x-docsSection": "Images",
+                    "default": false
+                },
                 "pod_template": {
                     "description": "Configuration of the pod_template image.",
                     "type": "object",
@@ -612,12 +618,6 @@
                     }
                 }
             ]
-        },
-        "useDefaultImageForMigration": {
-            "description": "To avoid images with user code for running and waiting for DB migrations set this to ``true``. ",
-            "type": "boolean",
-            "x-docsSection": "Airflow",
-            "default": false
         },
         "data": {
             "description": "Airflow database & redis configuration.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -232,6 +232,12 @@ extraEnvFrom: ~
 #   - configMapRef:
 #       name: '{{ .Release.Name }}-airflow-variables'
 
+# To avoid images with user code, you can turn this to 'true' and
+# all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' containers/jobs
+# will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
+# to run and wait for DB migrations .
+useDefaultImageForMigration: false
+
 # Airflow database & redis config
 data:
   # If secret names are provided, use those secrets

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,6 +48,11 @@ images:
     repository: ~
     tag: ~
     pullPolicy: IfNotPresent
+  # To avoid images with user code, you can turn this to 'true' and
+  # all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' containers/jobs
+  # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
+  # to run and wait for DB migrations .
+  useDefaultImageForMigration: false
   pod_template:
     repository: ~
     tag: ~
@@ -231,12 +236,6 @@ extraEnvFrom: ~
 #       name: '{{ .Release.Name }}-airflow-connections'
 #   - configMapRef:
 #       name: '{{ .Release.Name }}-airflow-variables'
-
-# To avoid images with user code, you can turn this to 'true' and
-# all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' containers/jobs
-# will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
-# to run and wait for DB migrations .
-useDefaultImageForMigration: false
 
 # Airflow database & redis config
 data:


### PR DESCRIPTION
This keeps the same behaviour but allows setting `useDefaultImageForMigration` to `true` which will then use the default image (set by `.Values.defaultAirflowRepository` and `.Values.defaultAirflowTag`) to run and wait for DB migration.

This safeguards issues with dependency and other user codes like badly written dags, etc

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
