### PR TITLE
Remove loading dots even when last run data is empty

### DIFF
--- a/airflow/www/static/js/dags.js
+++ b/airflow/www/static/js/dags.js
@@ -151,6 +151,7 @@ function blockedHandler(error, json) {
 }
 
 function lastDagRunsHandler(error, json) {
+  $('.js-loading-last-run').remove();
   Object.keys(json).forEach((safeDagId) => {
     const dagId = json[safeDagId].dag_id;
     const executionDate = json[safeDagId].execution_date;
@@ -165,9 +166,6 @@ function lastDagRunsHandler(error, json) {
     g.selectAll('span')
       .style('display', null)
       .attr('data-lastrun', JSON.stringify(json[safeDagId]));
-
-    g.selectAll('.js-loading-last-run').remove();
-    $('.js-loading-last-run').remove();
   });
 }
 


### PR DESCRIPTION
Loading dots are displayed on the last run column while we get the last run data for each dag.
But the dots are only removed if there actually is data. But if you haven't had any dag runs yet it would always appear to be loading. Instead the loading dots should be removed even when the response is empty.

Before: https://share.getcloudapp.com/12uvLy8N

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
