### PR TITLE
Fix example dag of PostgresOperator

### DIFF
--- a/airflow/providers/postgres/example_dags/example_postgres.py
+++ b/airflow/providers/postgres/example_dags/example_postgres.py
@@ -49,10 +49,14 @@ with DAG(
         task_id="populate_pet_table",
         postgres_conn_id="postgres_default",
         sql="""
-            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Max', 'Dog', '2018-07-05', 'Jane');
-            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Susie', 'Cat', '2019-05-01', 'Phil');
-            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Lester', 'Hamster', '2020-06-23', 'Lily');
-            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Quincy', 'Parrot', '2013-08-11', 'Anne');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER)
+            VALUES ( 'Max', 'Dog', '2018-07-05', 'Jane');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER)
+            VALUES ( 'Susie', 'Cat', '2019-05-01', 'Phil');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER)
+            VALUES ( 'Lester', 'Hamster', '2020-06-23', 'Lily');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER)
+            VALUES ( 'Quincy', 'Parrot', '2013-08-11', 'Anne');
             """,
     )
     # [END postgres_operator_howto_guide_populate_pet_table]

--- a/airflow/providers/postgres/example_dags/example_postgres.py
+++ b/airflow/providers/postgres/example_dags/example_postgres.py
@@ -49,10 +49,10 @@ with DAG(
         task_id="populate_pet_table",
         postgres_conn_id="postgres_default",
         sql="""
-            INSERT INTO pet VALUES ( 'Max', 'Dog', '2018-07-05', 'Jane');
-            INSERT INTO pet VALUES ( 'Susie', 'Cat', '2019-05-01', 'Phil');
-            INSERT INTO pet VALUES ( 'Lester', 'Hamster', '2020-06-23', 'Lily');
-            INSERT INTO pet VALUES ( 'Quincy', 'Parrot', '2013-08-11', 'Anne');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Max', 'Dog', '2018-07-05', 'Jane');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Susie', 'Cat', '2019-05-01', 'Phil');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Lester', 'Hamster', '2020-06-23', 'Lily');
+            INSERT INTO pet (name, pet_type, birth_date, OWNER) VALUES ( 'Quincy', 'Parrot', '2013-08-11', 'Anne');
             """,
     )
     # [END postgres_operator_howto_guide_populate_pet_table]
@@ -68,7 +68,7 @@ with DAG(
         sql="""
             SELECT * FROM pet
             WHERE birth_date
-            BETWEEN SYMMETRIC {{ params.begin_date }} AND {{ params.end_date }};
+            BETWEEN SYMMETRIC DATE '{{ params.begin_date }}' AND DATE '{{ params.end_date }}';
             """,
         params={'begin_date': '2020-01-01', 'end_date': '2020-12-31'},
     )


### PR DESCRIPTION
Currently the example dag produce error ([sqlfiddle](http://sqlfiddle.com/#!17/b0052/1)):

`ERROR: invalid input syntax for integer: "Max" Position: 26`

This PR changes the sql code to execute successfully ([sqlfiddle](http://sqlfiddle.com/#!17/4eb282/1)):
![Screen Shot 2021-09-14 at 13 17 23](https://user-images.githubusercontent.com/45845474/133240160-cfe49e83-c950-4896-854c-dc9b4a1a0641.png)

![Screen Shot 2021-09-14 at 13 17 14](https://user-images.githubusercontent.com/45845474/133240181-5371aede-7054-4950-96f6-ae42873148fe.png)





<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
