### PR TITLE
Don't check for `__init__.py` under pycache folders.

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_check_providers_subpackages_all_have_init.py
+++ b/scripts/ci/pre_commit/pre_commit_check_providers_subpackages_all_have_init.py
@@ -26,9 +26,11 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os
 
 def check_dir_init_file(provider_files: List[str]) -> None:
     missing_init_dirs = []
-    for dags_file in provider_files:
-        if os.path.isdir(dags_file) and not os.path.exists(os.path.join(dags_file, "__init__.py")):
-            missing_init_dirs.append(dags_file)
+    for path in provider_files:
+        if path.endswith("/__pycache__"):
+            continue
+        if os.path.isdir(path) and not os.path.exists(os.path.join(path, "__init__.py")):
+            missing_init_dirs.append(path)
 
     if missing_init_dirs:
         with open(os.path.join(ROOT_DIR, "license-templates/LICENSE.txt")) as license:


### PR DESCRIPTION
Otherwise we end up with errors like this from pre-commit:

```
No __init__.py file was found in the following provider directories:
/home/ash/code/airflow/airflow/airflow/providers/airbyte/__pycache__
/home/ash/code/airflow/airflow/airflow/providers/airbyte/hooks/__pycache__
/home/ash/code/airflow/airflow/airflow/providers/airbyte/operators/__pycache__
```


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).