### PR TITLE
Fix DB session handling in XCom.set.

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -96,8 +96,6 @@ class BaseXCom(Base, LoggingMixin):
 
             execution_date = dag_run.execution_date
 
-        session.expunge_all()
-
         value = XCom.serialize_value(value)
 
         # remove any duplicate XComs
@@ -105,12 +103,12 @@ class BaseXCom(Base, LoggingMixin):
             cls.key == key, cls.execution_date == execution_date, cls.task_id == task_id, cls.dag_id == dag_id
         ).delete()
 
-        session.commit()
+        session.flush()
 
         # insert new XCom
         session.add(XCom(key=key, value=value, execution_date=execution_date, task_id=task_id, dag_id=dag_id))
 
-        session.commit()
+        session.flush()
 
     @classmethod
     @provide_session


### PR DESCRIPTION
Since the function has the `@provide_session` decorator it should not be
committing the session (the decorator handles that if it's not passed a
session) and nor should it be calling expunge_all -- that detaches all
objects from the session which is just not needed (or right) behaviour
form setting an XCom value.

By using the `session` fixture we get the transaction automatically
rolled back, so we don't need any setup/teardown methods.

(This is a prep PR for fixing the deserialize behavoiur of XCom.get_one)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
