### PR TITLE
Fix deleting of zipped Dags in Serialized Dag Table

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -661,6 +661,7 @@ class DagFileProcessorManager(LoggingMixin):
                 self.clear_nonexistent_import_errors()
             except Exception:
                 self.log.exception("Error removing old import errors")
+
             # Check if file path is a zipfile and get the full path of the python file.
             # Without this, SerializedDagModel.remove_deleted_files would delete zipped dags.
             # Likewise DagCode.remove_deleted_code

--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -26,6 +26,7 @@ import random
 import signal
 import sys
 import time
+import zipfile
 from collections import defaultdict
 from datetime import datetime, timedelta
 from importlib import import_module
@@ -45,7 +46,7 @@ from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.stats import Stats
 from airflow.utils import timezone
 from airflow.utils.callback_requests import CallbackRequest, SlaCallbackRequest, TaskCallbackRequest
-from airflow.utils.file import list_py_file_paths
+from airflow.utils.file import list_py_file_paths, might_contain_dag
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.mixins import MultiprocessingStartMethodMixin
 from airflow.utils.net import get_hostname
@@ -660,13 +661,29 @@ class DagFileProcessorManager(LoggingMixin):
                 self.clear_nonexistent_import_errors()
             except Exception:
                 self.log.exception("Error removing old import errors")
+            # Check if file path is a zipfile and get the full path of the python file.
+            # Without this, SerializedDagModel.remove_deleted_files would delete zipped dags.
+            # Likewise DagCode.remove_deleted_code
+            dag_filelocs = []
+            for fileloc in self._file_paths:
+                if zipfile.is_zipfile(fileloc):
+                    with zipfile.ZipFile(fileloc) as z:
+                        dag_filelocs.extend(
+                            [
+                                os.path.join(fileloc, info.filename)
+                                for info in z.infolist()
+                                if might_contain_dag(info.filename, True, z)
+                            ]
+                        )
+                else:
+                    dag_filelocs.append(fileloc)
 
-            SerializedDagModel.remove_deleted_dags(self._file_paths)
+            SerializedDagModel.remove_deleted_dags(dag_filelocs)
             DagModel.deactivate_deleted_dags(self._file_paths)
 
             from airflow.models.dagcode import DagCode
 
-            DagCode.remove_deleted_code(self._file_paths)
+            DagCode.remove_deleted_code(dag_filelocs)
 
     def _print_stat(self):
         """Occasionally print out stats about how fast the files are getting processed"""


### PR DESCRIPTION
The file locations of DAGs in zipped folders are not correctly listed when removing deleted dags from serialized dag table thus the delete query for deleting deleted dags from serialized DAGs is deleting dags in zipped folders. Likewise DagCode.remove_deleted_code

Related: https://github.com/apache/airflow/issues/18114#issuecomment-918090551



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
