### PR TITLE
Make sure create_user arguments are keyword-ed

### DIFF
--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -18,7 +18,7 @@ from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.www.security import EXISTING_ROLES
 
 
-def create_user(app, username, role_name, email=None, permissions=None):
+def create_user(app, *, username, role_name, email=None, permissions=None):
     appbuilder = app.appbuilder
 
     # Removes user and role so each test has isolated test data.

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -336,8 +336,8 @@ class TestSecurity(unittest.TestCase):
         with self.app.app_context():
             user = api_connexion_utils.create_user(
                 self.app,
-                username,
-                role_name,
+                username=username,
+                role_name=role_name,
                 permissions=[
                     (role_perm, role_vm),
                 ],
@@ -355,8 +355,8 @@ class TestSecurity(unittest.TestCase):
         with self.app.app_context():
             user = api_connexion_utils.create_user(
                 self.app,
-                "current_user_has_permissions",
-                "current_user_has_permissions",
+                username="current_user_has_permissions",
+                role_name="current_user_has_permissions",
                 permissions=[("can_some_action", "SomeBaseView")],
             )
             role = user.roles[0]
@@ -379,8 +379,8 @@ class TestSecurity(unittest.TestCase):
 
         user = api_connexion_utils.create_user(
             self.app,
-            username,
-            role_name,
+            username=username,
+            role_name=role_name,
             permissions=[
                 (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
                 (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
@@ -407,8 +407,8 @@ class TestSecurity(unittest.TestCase):
 
         user = api_connexion_utils.create_user(
             self.app,
-            username,
-            role_name,
+            username=username,
+            role_name=role_name,
             permissions=[
                 (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG),
             ],
@@ -473,8 +473,8 @@ class TestSecurity(unittest.TestCase):
         with self.app.app_context():
             user = api_connexion_utils.create_user(
                 self.app,
-                username,
-                role_name,
+                username=username,
+                role_name=role_name,
                 permissions=[
                     (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
                     (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
@@ -512,8 +512,8 @@ class TestSecurity(unittest.TestCase):
         with self.app.app_context():
             user = api_connexion_utils.create_user(
                 self.app,
-                username,
-                role_name,
+                username=username,
+                role_name=role_name,
                 permissions=[],
             )
             self.expect_user_is_in_role(user, rolename='team-a')
@@ -540,8 +540,8 @@ class TestSecurity(unittest.TestCase):
         with self.app.app_context():
             user = api_connexion_utils.create_user(
                 self.app,
-                username,
-                role_name,
+                username=username,
+                role_name=role_name,
                 permissions=[],
             )
             self.expect_user_is_in_role(user, rolename='team-a')
@@ -692,8 +692,8 @@ class TestSecurity(unittest.TestCase):
             ]
             user = api_connexion_utils.create_user(
                 self.app,
-                username,
-                role_name,
+                username=username,
+                role_name=role_name,
             )
             self.security_manager.bulk_sync_roles(mock_roles)
             self.security_manager._sync_dag_view_permissions(

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -117,7 +117,7 @@ def user_client(app):
 @pytest.fixture(scope="module")
 def client_factory(app):
     def factory(name, role_name, permissions):
-        create_user(app, name, role_name, permissions)
+        create_user(app, username=name, role_name=role_name, permissions=permissions)
         client = app.test_client()
         resp = client.post("/login/", data={"username": name, "password": name})
         assert resp.status_code == 302


### PR DESCRIPTION
This fixes the failure in main

```
tests/www/views/test_views_trigger_dag.py::test_viewer_cant_trigger_dag
```

(There’s another failure in main on 3.6 so those failures are expected.)

Turns out there’s one usage of the `create_user` helper that does not correctly call with keyword arguments. This fixes the issue and makes `create_user` take keyword-only arguments instead to prevent future breakage.