### PR TITLE
Ability to access http k8s via multiple hostnames

### DIFF
--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -38,7 +38,14 @@ Run ``helm repo update`` before upgrading the chart to the latest version.
 Airflow Helm Chart 1.2.0 (dev)
 ------------------------------
 
-Default Airflow version is updated to ``2.1.2``
+``ingress.web.host`` and ``ingress.flower.host`` parameters have been renamed and data type changed
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+``ingress.web.host`` and ``ingress.flower.host`` parameters have been renamed to ``ingress.web.hosts`` and ``ingress.flower.hosts``, respectively. Their types have been changed from a string to an array of strings.
+
+The old parameter names will continue to work, however support for them will be removed in a future release so please update your values file.
+
+Default Airflow version is updated to ``2.1.3``
 """""""""""""""""""""""""""""""""""""""""""""""
 
 The default Airflow version that is installed with the Chart is now ``2.1.3``, previously it was ``2.1.2``.

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -26,9 +26,31 @@ Your release is named {{ .Release.Name }}.
 {{- if .Values.ingress.enabled }}
 You can now access your service(s) by following defined Ingress urls:
 
-Airflow Webserver:     http{{ if .Values.ingress.web.tls.enabled }}s{{ end }}://{{ .Values.ingress.web.host }}{{ .Values.ingress.web.path }}/
+{{- if .Values.ingress.web.host }}
+
+DEPRECATION WARNING:
+   `ingress.web.host` has been renamed to `ingress.web.hosts` and is now an array.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+{{- if .Values.ingress.flower.host }}
+
+DEPRECATION WARNING:
+   `ingress.flower.host` has been renamed to `ingress.flower.hosts` and is now an array.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
+Airflow Webserver:
+{{- range .Values.ingress.web.hosts | default (list .Values.ingress.web.host) }}
+      http{{ if $.Values.ingress.web.tls.enabled }}s{{ end }}://{{ . }}{{ $.Values.ingress.web.path }}/
+{{- end }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
-Flower dashboard:      http{{ if .Values.ingress.flower.tls.enabled }}s{{ end }}://{{ .Values.ingress.flower.host }}{{ .Values.ingress.flower.path }}/
+Flower dashboard:
+{{- range .Values.ingress.flower.hosts }}
+      http{{ if $.Values.ingress.flower.tls.enabled }}s{{ end }}://{{ . }}{{ $.Values.ingress.flower.path }}/
+{{- end }}
 {{- end }}
 {{- else }}
 You can now access your dashboard(s) by executing the following command(s) and visiting the corresponding port at localhost in your browser:

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -43,31 +43,35 @@ spec:
   {{- if .Values.ingress.flower.tls.enabled }}
   tls:
     - hosts:
-        - {{ .Values.ingress.flower.host }}
+{{- if .Values.ingress.flower.tls.enabled }}
+        {{- .Values.ingress.flower.hosts | default (list .Values.ingress.flower.host) | toYaml | nindent 8 }}
+{{- end }}
       secretName: {{ .Values.ingress.flower.tls.secretName }}
   {{- end }}
   rules:
+    {{- range .Values.ingress.flower.hosts | default (list .Values.ingress.flower.host) }}
     - http:
         paths:
           - backend:
               {{- if $apiIsStable }}
               service:
-                name: {{ .Release.Name }}-flower
+                name: {{ $.Release.Name }}-flower
                 port:
                   name: flower-ui
               {{- else }}
-              serviceName: {{ .Release.Name }}-flower
+              serviceName: {{ $.Release.Name }}-flower
               servicePort: flower-ui
               {{- end }}
-            {{- if .Values.ingress.flower.path }}
-            path: {{ .Values.ingress.flower.path }}
+            {{- if $.Values.ingress.flower.path }}
+            path: {{ $.Values.ingress.flower.path }}
             {{- if $apiIsStable }}
-            pathType: {{ .Values.ingress.flower.pathType }}
+            pathType: {{ $.Values.ingress.flower.pathType }}
             {{- end }}
             {{- end }}
-      {{- if .Values.ingress.flower.host }}
-      host: {{ .Values.ingress.flower.host }}
+      {{- if . }}
+      host: {{ . | quote }}
       {{- end }}
+    {{- end }}
   {{- if and .Values.ingress.flower.ingressClassName $apiIsStable }}
   ingressClassName: {{ .Values.ingress.flower.ingressClassName }}
   {{- end }}

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -42,13 +42,16 @@ spec:
   {{- if .Values.ingress.web.tls.enabled }}
   tls:
     - hosts:
-        - {{ .Values.ingress.web.host }}
+{{- if .Values.ingress.web.tls.enabled }}
+        {{- .Values.ingress.web.hosts | default (list .Values.ingress.web.host) | toYaml | nindent 8 }}
+{{- end }}
       secretName: {{ .Values.ingress.web.tls.secretName }}
   {{- end }}
   rules:
+    {{- range .Values.ingress.web.hosts | default (list .Values.ingress.web.host) }}
     - http:
         paths:
-          {{- range .Values.ingress.web.precedingPaths }}
+          {{- range $.Values.ingress.web.precedingPaths }}
           - path: {{ .path }}
             {{- if $apiIsStable }}
             pathType: {{ .pathType }}
@@ -67,20 +70,20 @@ spec:
           - backend:
               {{- if $apiIsStable }}
               service:
-                name: {{ .Release.Name }}-webserver
+                name: {{ $.Release.Name }}-webserver
                 port:
                   name: airflow-ui
               {{- else }}
-              serviceName: {{ .Release.Name }}-webserver
+              serviceName: {{ $.Release.Name }}-webserver
               servicePort: airflow-ui
               {{- end }}
-            {{- if .Values.ingress.web.path }}
-            path: {{ .Values.ingress.web.path }}
+            {{- if $.Values.ingress.web.path }}
+            path: {{ $.Values.ingress.web.path }}
             {{- if $apiIsStable }}
-            pathType: {{ .Values.ingress.web.pathType }}
+            pathType: {{ $.Values.ingress.web.pathType }}
             {{- end }}
             {{- end }}
-          {{- range .Values.ingress.web.succeedingPaths }}
+          {{- range $.Values.ingress.web.succeedingPaths }}
           - path: {{ .path }}
             {{- if $apiIsStable }}
             pathType: {{ .pathType }}
@@ -96,9 +99,10 @@ spec:
               servicePort: {{ .servicePort }}
               {{- end }}
           {{- end }}
-      {{- if .Values.ingress.web.host }}
-      host: {{ .Values.ingress.web.host }}
+      {{- if . }}
+      host: {{ . | quote }}
       {{- end }}
+    {{- end }}
   {{- if and .Values.ingress.web.ingressClassName $apiIsStable }}
   ingressClassName: {{ .Values.ingress.web.ingressClassName }}
   {{- end }}

--- a/chart/tests/test_ingress_flower.py
+++ b/chart/tests/test_ingress_flower.py
@@ -55,3 +55,53 @@ class IngressFlowerTest(unittest.TestCase):
             show_only=["templates/flower/flower-ingress.yaml"],
         )
         assert "foo" == jmespath.search("spec.ingressClassName", docs[0])
+
+    def test_should_ingress_hosts_have_priority_over_host(self):
+        docs = render_chart(
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "flower": {
+                        "tls": {"enabled": True, "secretName": "supersecret"},
+                        "hosts": ["*.a-host", "b-host"],
+                        "host": "old-host",
+                    },
+                }
+            },
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )
+        assert (
+            ["*.a-host", "b-host"]
+            == jmespath.search("spec.rules[*].host", docs[0])
+            == jmespath.search("spec.tls[0].hosts", docs[0])
+        )
+
+    def test_should_ingress_host_still_work(self):
+        docs = render_chart(
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "flower": {
+                        "tls": {"enabled": True, "secretName": "supersecret"},
+                        "host": "old-host",
+                    },
+                }
+            },
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )
+        assert (
+            ["old-host"]
+            == jmespath.search("spec.rules[*].host", docs[0])
+            == jmespath.search("spec.tls[0].hosts", docs[0])
+        )
+
+    def test_should_ingress_host_entry_not_exist(self):
+        docs = render_chart(
+            values={
+                "ingress": {
+                    "enabled": True,
+                }
+            },
+            show_only=["templates/flower/flower-ingress.yaml"],
+        )
+        assert not jmespath.search("spec.rules[*].host", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -137,9 +137,17 @@
                             "default": "ImplementationSpecific"
                         },
                         "host": {
-                            "description": "The hostname for the web Ingress.",
+                            "description": "The hostname for the web Ingress. (Deprecated - renamed to `ingress.web.hosts`)",
                             "type": "string",
                             "default": ""
+                        },
+                        "hosts": {
+                            "description": "The hostnames for the web Ingress.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "ingressClassName": {
                             "description": "The Ingress Class for the web Ingress.",
@@ -196,9 +204,17 @@
                             "default": "ImplementationSpecific"
                         },
                         "host": {
-                            "description": "The hostname for the flower Ingress.",
+                            "description": "The hostname for the flower Ingress. (Deprecated - renamed to `ingress.flower.hosts`)",
                             "type": "string",
                             "default": ""
+                        },
+                        "hosts": {
+                            "description": "The hostnames for the flower Ingress.",
+                            "type": "array",
+                            "default": [],
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "ingressClassName": {
                             "description": "The Ingress Class for the flower Ingress.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -109,8 +109,11 @@ ingress:
     # The pathType for the above path (used only with Kubernetes v1.19 and above)
     pathType: "ImplementationSpecific"
 
-    # The hostname for the web Ingress
+    # The hostname for the web Ingress (Deprecated - renamed to `ingress.web.hosts`)
     host: ""
+
+    # The hostnames for the web Ingress
+    hosts: []
 
     # The Ingress Class for the web Ingress (used only with Kubernetes v1.19 and above)
     ingressClassName: ""
@@ -139,8 +142,11 @@ ingress:
     # The pathType for the above path (used only with Kubernetes v1.19 and above)
     pathType: "ImplementationSpecific"
 
-    # The hostname for the flower Ingress
+    # The hostname for the flower Ingress (Deprecated - renamed to `ingress.flower.hosts`)
     host: ""
+
+    # The hostnames for the flower Ingress
+    hosts: []
 
     # The Ingress Class for the flower Ingress (used only with Kubernetes v1.19 and above)
     ingressClassName: ""


### PR DESCRIPTION
Template the airflow ui and flower ingress in the helm chart to enable them
to be accessed via multiple hostnames.  Also quote hostnames so that
wildcard hostnames can be used.

The old field specifying a single hostname has been marked as deprecated, but can still be used maintaining backwards compatibility.  This does not allow different paths to be associated with different hosts.  I was concerned about increasing the complexity too much here while trying to keep backwards compatability.

closes: #18216.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
