### PR TITLE
Add in before_send config option to sentry integration

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1435,7 +1435,7 @@
       default: ""
     - name: before_send
       description: Dotted path to a before_send function that the sentry SDK should be configured to use.
-      version_added: 2.1.4
+      version_added: 2.2
       type: string
       example: ~
       default: ~

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1437,6 +1437,7 @@
       description: Dotted path to a before_send function that the sentry SDK should be configured to use.
       version_added: 2.1.4
       type: string
+      example: ~
       default: ""
 - name: celery_kubernetes_executor
   description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1419,7 +1419,7 @@
     additional configuration options based on the Python platform. See:
     https://docs.sentry.io/error-reporting/configuration/?platform=python.
     Unsupported options: ``integrations``, ``in_app_include``, ``in_app_exclude``,
-    ``ignore_errors``, ``before_breadcrumb``, ``before_send``, ``transport``.
+    ``ignore_errors``, ``before_breadcrumb``, ``transport``.
   options:
     - name: sentry_on
       description: Enable error reporting to Sentry
@@ -1432,6 +1432,11 @@
       version_added: 1.10.6
       type: string
       example: ~
+      default: ""
+    - name: before_send
+      description: Dotted path to a before_send function that the sentry SDK should be configured to use.
+      version_added: 2.1.4
+      type: string
       default: ""
 - name: celery_kubernetes_executor
   description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1438,7 +1438,7 @@
       version_added: 2.1.4
       type: string
       example: ~
-      default: ""
+      default: ~
 - name: celery_kubernetes_executor
   description: |
     This section only applies if you are using the ``CeleryKubernetesExecutor`` in

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1435,7 +1435,7 @@
       default: ""
     - name: before_send
       description: Dotted path to a before_send function that the sentry SDK should be configured to use.
-      version_added: 2.2
+      version_added: 2.2.0
       type: string
       example: ~
       default: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -706,6 +706,8 @@ smtp_retry_limit = 5
 # Enable error reporting to Sentry
 sentry_on = false
 sentry_dsn =
+
+# Dotted path to a before_send function that the sentry SDK should be configured to use.
 before_send =
 
 [celery_kubernetes_executor]

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -708,7 +708,7 @@ sentry_on = false
 sentry_dsn =
 
 # Dotted path to a before_send function that the sentry SDK should be configured to use.
-before_send =
+# before_send =
 
 [celery_kubernetes_executor]
 

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -702,10 +702,11 @@ smtp_retry_limit = 5
 # additional configuration options based on the Python platform. See:
 # https://docs.sentry.io/error-reporting/configuration/?platform=python.
 # Unsupported options: ``integrations``, ``in_app_include``, ``in_app_exclude``,
-# ``ignore_errors``, ``before_breadcrumb``, ``before_send``, ``transport``.
+# ``ignore_errors``, ``before_breadcrumb``, ``transport``.
 # Enable error reporting to Sentry
 sentry_on = false
 sentry_dsn =
+before_send =
 
 [celery_kubernetes_executor]
 

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -21,7 +21,6 @@ import logging
 from functools import wraps
 
 from airflow.configuration import conf
-from airflow.utils.module_loading import import_string
 from airflow.utils.session import find_session_idx, provide_session
 from airflow.utils.state import State
 
@@ -110,8 +109,7 @@ if conf.getboolean("sentry", 'sentry_on', fallback=False):
                         ", ".join(unsupported_options),
                     )
 
-                if sentry_config_opts.get('before_send'):
-                    sentry_config_opts['before_send'] = import_string(sentry_config_opts['before_send'])
+                sentry_config_opts['before_send'] = conf.getimport('sentry', 'before_send')
 
             if dsn:
                 sentry_sdk.init(dsn=dsn, integrations=integrations, **sentry_config_opts)

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -21,9 +21,9 @@ import logging
 from functools import wraps
 
 from airflow.configuration import conf
+from airflow.utils.module_loading import import_string
 from airflow.utils.session import find_session_idx, provide_session
 from airflow.utils.state import State
-from airflow.utils.module_loading import import_string
 
 log = logging.getLogger(__name__)
 

--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -23,6 +23,7 @@ from functools import wraps
 from airflow.configuration import conf
 from airflow.utils.session import find_session_idx, provide_session
 from airflow.utils.state import State
+from airflow.utils.module_loading import import_string
 
 log = logging.getLogger(__name__)
 
@@ -72,7 +73,6 @@ if conf.getboolean("sentry", 'sentry_on', fallback=False):
                 "in_app_exclude",
                 "ignore_errors",
                 "before_breadcrumb",
-                "before_send",
                 "transport",
             )
         )
@@ -109,6 +109,9 @@ if conf.getboolean("sentry", 'sentry_on', fallback=False):
                         "There are unsupported options in [sentry] section: %s",
                         ", ".join(unsupported_options),
                     )
+
+                if sentry_config_opts.get('before_send'):
+                    sentry_config_opts['before_send'] = import_string(sentry_config_opts['before_send'])
 
             if dsn:
                 sentry_sdk.init(dsn=dsn, integrations=integrations, **sentry_config_opts)

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -28,7 +28,6 @@ from airflow.operators.python import PythonOperator
 from airflow.utils import timezone
 from airflow.utils.module_loading import import_string
 from airflow.utils.state import State
-
 from tests.test_utils.config import conf_vars
 
 EXECUTION_DATE = timezone.utcnow()

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -122,7 +122,7 @@ class TestSentryHook:
             assert CRUMB == test_crumb
 
     @mock.patch('airflow.sentry.sentry_sdk.init')
-    def test_before_send(self, sentry, init):
+    def test_before_send(self, init, sentry):
         """
         Test before send callable gets passed to the sentry SDK.
         """

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -121,7 +121,7 @@ class TestSentryHook:
             test_crumb = scope._breadcrumbs.pop()
             assert CRUMB == test_crumb
 
-    @mock.patch('airflow.sentry.sentry_sdk.init')
+    @mock.patch('sentry_sdk.init')
     def test_before_send(self, init, sentry):
         """
         Test before send callable gets passed to the sentry SDK.

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -86,11 +86,13 @@ class TestSentryHook:
 
     @pytest.fixture
     def sentry(self):
-        with conf_vars({
-            ('sentry', 'sentry_on'): 'True',
-            ('sentry', 'default_integrations'): 'False',
-            ('sentry', 'before_send'): 'tests.core.test_sentry.before_send',
-        }):
+        with conf_vars(
+            {
+                ('sentry', 'sentry_on'): 'True',
+                ('sentry', 'default_integrations'): 'False',
+                ('sentry', 'before_send'): 'tests.core.test_sentry.before_send',
+            },
+        ):
             from airflow import sentry
 
             importlib.reload(sentry)

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -132,6 +132,6 @@ class TestSentryHook:
         Test before send callable gets passed to the sentry SDK.
         """
         assert sentry
-        called = sentry_sdk.call_args.kwargs['before_send']
+        called = sentry_sdk.call_args[1]['before_send']
         expected = import_string('tests.core.test_sentry.before_send')
         assert called == expected


### PR DESCRIPTION
Adds in the ability to define a before_send callback to the sentry SDK

https://docs.sentry.io/platforms/python/configuration/filtering/