### PR TITLE
Use try/except when closing temporary file in task_runner

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -183,4 +183,9 @@ class BaseTaskRunner(LoggingMixin):
                 subprocess.call(['sudo', 'rm', self._cfg_path], close_fds=True)
             else:
                 os.remove(self._cfg_path)
-        self._error_file.close()
+        try:
+            self._error_file.close()
+        except FileNotFoundError:
+            # The subprocess has deleted this file before we do
+            # so we ignore
+            pass


### PR DESCRIPTION
Occasionally we get FileNotFoundError when calling close on the named temporary file,
the reason I believe is that the file has been removed by the subprocess before we call
close on it.

When NamedTemporary file is instantiated  with delete=True, calling close on the file deletes the file

This PR adds a try/except when calling the close method to capture the error


Related: https://github.com/apache/airflow/issues/16020 , https://github.com/apache/airflow/pull/18208/checks?check_run_id=3608932176



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
