### PR TITLE
remove all reference to date in dropdown tests

### DIFF
--- a/airflow/ui/test/TimezoneDropdown.test.tsx
+++ b/airflow/ui/test/TimezoneDropdown.test.tsx
@@ -21,39 +21,34 @@ import React from 'react';
 import '@testing-library/jest-dom';
 import { render, fireEvent } from '@testing-library/react';
 
-import dayjs from 'dayjs';
-import timezone from 'dayjs/plugin/timezone';
-import utc from 'dayjs/plugin/utc';
-
 import TimezoneDropdown from 'components/AppContainer/TimezoneDropdown';
-import DateProvider, { HOURS_24 } from 'providers/DateProvider';
+import DateProvider from 'providers/DateProvider';
 import { ChakraWrapper } from './utils';
-
-dayjs.extend(utc);
-dayjs.extend(timezone);
 
 describe('test timezone dropdown', () => {
   test('Can search for a new timezone and the date changes', () => {
-    const { getByText } = render(
+    const { getByText, queryByText } = render(
       <DateProvider>
         <TimezoneDropdown />
       </DateProvider>,
       { wrapper: ChakraWrapper },
     );
 
-    const initialTime = dayjs().tz('UTC').format(HOURS_24);
+    const initialTime = '+00:00';
 
-    expect(getByText(initialTime)).toBeInTheDocument();
-    const button = getByText(initialTime);
+    expect(getByText(initialTime, { exact: false })).toBeInTheDocument();
+    const button = getByText(initialTime, { exact: false });
     fireEvent.click(button);
     const focusedElement = document.activeElement;
     if (focusedElement) {
       fireEvent.change(focusedElement, { target: { value: 'Anch' } });
     }
-    const option = getByText('-08:00 America/Anchorage');
+    const optionText = '-08:00 America/Anchorage';
+    const option = getByText(optionText);
     expect(option).toBeInTheDocument();
     fireEvent.click(option);
 
-    expect(getByText(dayjs().tz('America/Anchorage').format(HOURS_24))).toBeInTheDocument();
+    expect(queryByText(optionText)).toBeNull();
+    expect(getByText('-08:00', { exact: false })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Sometimes there can be a race condition between the date calculated by the test and the one made by the test renderer.
To prevent this possibility, the test is no rewritten to test the same logic but only checking the timezone tags instead of the full date.

See error here: https://apache-airflow.slack.com/archives/CCPRP7943/p1631718438251300 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
