### PR TITLE
Only show next run if not none

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -176,7 +176,9 @@
                   </span>
                 </td>
                 <td class="text-nowrap">
-                  <time datetime="{{ dag.next_dagrun }}">{{ dag.next_dagrun }}</time>
+                  {% if dag.next_dagrun is not none %}
+                    <time datetime="{{ dag.next_dagrun }}">{{ dag.next_dagrun }}</time>
+                  {% endif %}
                   {% if dag.next_dagrun_create_after %}
                     {# data-nextrun is being used to pass next_dagrun dates to js to build the full tooltip #}
                     <span


### PR DESCRIPTION
Instead of `none` which can sometimes end up as `invalid date` We will only show the next run if it exists and otherwise leave the place blank, which is a cleaner UI anyway.


Before:
<img width="219" alt="Screen Shot 2021-09-15 at 6 04 55 PM" src="https://user-images.githubusercontent.com/4600967/133468895-f36faeba-d88d-4451-9d74-98a5864d02d5.png">


After:
<img width="552" alt="Screen Shot 2021-09-15 at 6 01 19 PM" src="https://user-images.githubusercontent.com/4600967/133468365-104461dc-fbcb-4223-aaf8-879c2b50ce4a.png">



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
