### PR TITLE
Silence warnings in tests from using SubDagOperator

### DIFF
--- a/airflow/operators/subdag.py
+++ b/airflow/operators/subdag.py
@@ -90,7 +90,7 @@ class SubDagOperator(BaseSensorOperator):
         warnings.warn(
             """This class is deprecated. Please use `airflow.utils.task_group.TaskGroup`.""",
             DeprecationWarning,
-            stacklevel=2,
+            stacklevel=4,
         )
 
     def _validate_dag(self, kwargs):

--- a/tests/dags/test_clear_subdag.py
+++ b/tests/dags/test_clear_subdag.py
@@ -18,6 +18,7 @@
 #
 
 import datetime
+import warnings
 
 from airflow.models import DAG
 from airflow.operators.bash import BashOperator
@@ -33,11 +34,12 @@ def create_subdag_opt(main_dag):
         max_active_tasks=2,
     )
     BashOperator(bash_command="echo 1", task_id="daily_job_subdag_task", dag=subdag)
-    return SubDagOperator(
-        task_id=subdag_name,
-        subdag=subdag,
-        dag=main_dag,
-    )
+    with warnings.catch_warnings(record=True):
+        return SubDagOperator(
+            task_id=subdag_name,
+            subdag=subdag,
+            dag=main_dag,
+        )
 
 
 dag_name = "clear_subdag_test_dag"

--- a/tests/dags/test_impersonation_subdag.py
+++ b/tests/dags/test_impersonation_subdag.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import warnings
 from datetime import datetime
 
 from airflow.models import DAG
@@ -43,6 +43,7 @@ PythonOperator(python_callable=print_today, task_id='exec_python_fn', dag=subdag
 BashOperator(task_id='exec_bash_operator', bash_command='echo "Running within SubDag"', dag=subdag)
 
 
-subdag_operator = SubDagOperator(
-    task_id='test_subdag_operation', subdag=subdag, mode='reschedule', poke_interval=1, dag=dag
-)
+with warnings.catch_warnings(record=True):
+    subdag_operator = SubDagOperator(
+        task_id='test_subdag_operation', subdag=subdag, mode='reschedule', poke_interval=1, dag=dag
+    )

--- a/tests/dags/test_subdag.py
+++ b/tests/dags/test_subdag.py
@@ -21,6 +21,7 @@
 A DAG with subdag for testing purpose.
 """
 
+import warnings
 from datetime import datetime, timedelta
 
 from airflow.models.dag import DAG
@@ -68,11 +69,12 @@ with DAG(
         task_id='start',
     )
 
-    section_1 = SubDagOperator(
-        task_id='section-1',
-        subdag=subdag(DAG_NAME, 'section-1', DEFAULT_TASK_ARGS),
-        default_args=DEFAULT_TASK_ARGS,
-    )
+    with warnings.catch_warnings(record=True):
+        section_1 = SubDagOperator(
+            task_id='section-1',
+            subdag=subdag(DAG_NAME, 'section-1', DEFAULT_TASK_ARGS),
+            default_args=DEFAULT_TASK_ARGS,
+        )
 
     some_other_task = DummyOperator(
         task_id='some-other-task',


### PR DESCRIPTION
And in order to track these down I had to correct the stacklevel -- +1 for the provide_session, and +1 for the BaseOperator metaclass.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).