### PR TITLE
Improved log handling for zombie tasks

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1073,7 +1073,7 @@ class DagFileProcessorManager(LoggingMixin):
                 request = TaskCallbackRequest(
                     full_filepath=file_loc,
                     simple_task_instance=SimpleTaskInstance(ti),
-                    msg="Detected as zombie",
+                    msg=f"Detected {ti} as zombie",
                 )
                 self.log.info("Detected zombie job: %s", request)
                 self._add_callback_to_queue(request)

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -467,7 +467,7 @@ class TestDagFileProcessorManager:
             requests = manager._callback_to_execute[dag.fileloc]
             assert 1 == len(requests)
             assert requests[0].full_filepath == dag.fileloc
-            assert requests[0].msg == "Detected as zombie"
+            assert requests[0].msg == f"Detected {ti} as zombie"
             assert requests[0].is_failure_callback is True
             assert isinstance(requests[0].simple_task_instance, SimpleTaskInstance)
             assert ti.dag_id == requests[0].simple_task_instance.dag_id


### PR DESCRIPTION
When a task is detected as zombie, the log does not show the task details. It would be nice having having the task information inside the log. 
Example:
https://ibb.co/crsH9N4