### PR TITLE
Add information about differences of deps in eager-upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn) }}
       BACKEND: postgres
+      UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgradeToNewerDependencies }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       POSTGRES_VERSION: ${{ matrix.postgres-version }}
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
@@ -687,6 +688,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn) }}
       BACKEND: mysql
+      UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgradeToNewerDependencies }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       MYSQL_VERSION: ${{ matrix.mysql-version }}
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
@@ -742,6 +744,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn) }}
       BACKEND: mssql
+      UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgradeToNewerDependencies }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       MSSQL_VERSION: ${{ matrix.mssql-version }}
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
@@ -796,6 +799,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
     env:
       RUNS_ON: ${{ fromJson(needs.build-info.outputs.runsOn) }}
       BACKEND: sqlite
+      UPGRADE_TO_NEWER_DEPENDENCIES: ${{ needs.build-info.outputs.upgradeToNewerDependencies }}
       PYTHON_MAJOR_MINOR_VERSION: ${{ matrix.python-version }}
       TEST_TYPES: "${{needs.build-info.outputs.testTypes}}"
     if: needs.build-info.outputs.run-tests == 'true'

--- a/docs/docker-stack/docker-examples/customizing/github-v2-1-test.sh
+++ b/docs/docker-stack/docker-examples/customizing/github-v2-1-test.sh
@@ -25,7 +25,7 @@ cd "${AIRFLOW_SOURCES}"
 docker build . \
     --build-arg PYTHON_BASE_IMAGE="python:3.8-slim-buster" \
     --build-arg AIRFLOW_INSTALLATION_METHOD="https://github.com/apache/airflow/archive/v2-1-test.tar.gz#egg=apache-airflow" \
-    --build-arg AIRFLOW_CONSTRAINTS_REFERENCE="constraints-2-0" \
+    --build-arg AIRFLOW_CONSTRAINTS_REFERENCE="constraints-2-1" \
     --tag "my-github-v2-1:0.0.1"
 # [END build]
 docker rmi --force "my-github-v2-1:0.0.1"

--- a/scripts/ci/constraints/ci_branch_constraints.sh
+++ b/scripts/ci/constraints/ci_branch_constraints.sh
@@ -22,10 +22,8 @@ if [[ ${GITHUB_REF} == 'refs/heads/main' ]]; then
   echo "::set-output name=branch::constraints-main"
 elif [[ ${GITHUB_REF} == 'refs/heads/main' ]]; then
   echo "::set-output name=branch::constraints-main"
-elif [[ ${GITHUB_REF} == 'refs/heads/v2-0-test' ]]; then
-  echo "::set-output name=branch::constraints-2-0"
-elif [[ ${GITHUB_REF} == 'refs/heads/v2-1-test' ]]; then
-  echo "::set-output name=branch::constraints-2-1"
+elif [[ ${GITHUB_REF} =~ refs/heads/v([0-9\-]*)\-(test|stable) ]]; then
+  echo "::set-output name=branch::constraints-${BASH_REMATCH[1]}"
 else
   echo
   echo "Unexpected ref ${GITHUB_REF}. Exiting!"

--- a/setup.py
+++ b/setup.py
@@ -1037,4 +1037,4 @@ def do_setup() -> None:
 
 
 if __name__ == "__main__":
-    do_setup()
+    do_setup()  # comment


### PR DESCRIPTION
Whenever tests fail in case of eager-upgrade we print now the diff
of the dependencies used in the build versus stable set of constraints

This helps in cases when new dependency released cause test failures
- this way you can immediately see which dependencies were upgraded
and what might be the possible cause. Also additional information
is printed in order to guide the PR owners to understand where
the test failures could came from.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
