### PR TITLE
Chart: Fix applying labels on Triggerer

### DIFF
--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -33,7 +33,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     {{- with .Values.labels }}
-    {{- toYaml . | indent 4 }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.triggerer.replicas }}

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -25,7 +25,7 @@ from parameterized import parameterized
 
 from tests.helm_template_generator import render_chart
 
-OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 36
+OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 38
 
 
 class TestBaseChartTest(unittest.TestCase):
@@ -38,6 +38,7 @@ class TestBaseChartTest(unittest.TestCase):
                 },
                 'labels': {"TEST-LABEL": "TEST-VALUE"},
                 "fullnameOverride": "TEST-BASIC",
+                "airflowVersion": "2.2.0",
             },
         )
         list_of_kind_names_tuples = {
@@ -50,6 +51,7 @@ class TestBaseChartTest(unittest.TestCase):
             ('ServiceAccount', 'TEST-BASIC-redis'),
             ('ServiceAccount', 'TEST-BASIC-scheduler'),
             ('ServiceAccount', 'TEST-BASIC-statsd'),
+            ('ServiceAccount', 'TEST-BASIC-triggerer'),
             ('ServiceAccount', 'TEST-BASIC-webserver'),
             ('ServiceAccount', 'TEST-BASIC-worker'),
             ('Secret', 'TEST-BASIC-airflow-metadata'),
@@ -74,6 +76,7 @@ class TestBaseChartTest(unittest.TestCase):
             ('Deployment', 'TEST-BASIC-flower'),
             ('Deployment', 'TEST-BASIC-scheduler'),
             ('Deployment', 'TEST-BASIC-statsd'),
+            ('Deployment', 'TEST-BASIC-triggerer'),
             ('Deployment', 'TEST-BASIC-webserver'),
             ('StatefulSet', 'TEST-BASIC-postgresql'),
             ('StatefulSet', 'TEST-BASIC-redis'),

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -99,7 +99,13 @@ class TestBaseChartTest(unittest.TestCase):
             ), f"Missing label TEST-LABEL on {k8s_name}. Current labels: {labels}"
 
     def test_basic_deployment_without_default_users(self):
-        k8s_objects = render_chart("TEST-BASIC", {"webserver": {'defaultUser': {'enabled': False}}})
+        k8s_objects = render_chart(
+            "TEST-BASIC",
+            values={
+                "webserver": {"defaultUser": {'enabled': False}},
+                "airflowVersion": "2.2.0",
+            },
+        )
         list_of_kind_names_tuples = [
             (k8s_object['kind'], k8s_object['metadata']['name']) for k8s_object in k8s_objects
         ]

--- a/chart/tests/test_triggerer.py
+++ b/chart/tests/test_triggerer.py
@@ -24,6 +24,21 @@ from tests.helm_template_generator import render_chart
 
 
 class TriggererTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("2.1.0", 0),
+            ("2.2.0", 1),
+        ]
+    )
+    def test_only_exists_on_new_airflow_versions(self, airflow_version, num_docs):
+        """Trigger was only added from Airflow 2.2 onwards"""
+        docs = render_chart(
+            values={"airflowVersion": airflow_version},
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert num_docs == len(docs)
+
     def test_should_add_extra_containers(self):
         docs = render_chart(
             values={


### PR DESCRIPTION
Currently it errors with:

```
{"result":{"message":"YAML parse error on airflow/charts/airflow/templates/triggerer/triggerer-deployment.yaml: error converting YAML to JSON: yaml: line 30: mapping values are not allowed in this context"},"deployment":{}}
```

This PR fixes that and adds unit tests around it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
