### PR TITLE
Fix spelling on chart docs

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1044,6 +1044,7 @@ parameterizing
 paramiko
 params
 passwd
+pathType
 pem
 performant
 personalizations


### PR DESCRIPTION
There is a spelling error in the chart docs on main (my bad, #18307 should prevent it in the future).