### PR TITLE
task logs for dummy operators

### DIFF
--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -23,7 +23,9 @@ from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.utils.helpers import render_log_filename
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
+from airflow.operators.dummy import DummyOperator
 
+DUMMY_TASK_LOG_MESSAGE = f"tasks of type {DummyOperator.__class__.__name__} do not have task logs \n"
 
 class TaskLogReader:
     """Task log reader"""
@@ -54,6 +56,8 @@ class TaskLogReader:
         contain information about the task log which can enable you read logs to the
         end.
         """
+        if ti.operator == DummyOpeartor.__class__.__name__:
+            return [(('', DUMMY_TASK_LOG_MESSAGE))], {'end_of_log': True}
         logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
         metadata = metadatas[0]
         return logs, metadata
@@ -70,6 +74,8 @@ class TaskLogReader:
         :type metadata: dict
         :rtype: Iterator[str]
         """
+        if ti.operator == DummyOpeartor.__class__.__name__:
+            yield DUMMY_TASK_LOG_MESSAGE
         if try_number is None:
             next_try = ti.next_try_number
             try_numbers = list(range(1, next_try))

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -26,11 +26,11 @@ from airflow.sensors.external_task import ExternalTaskMarker
 from airflow.utils.helpers import render_log_filename
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 
-DUMMY_TASK_LOG_MESSAGE = f"Tasks of type {DummyOperator.__class__.__name__} do not have task logs.\n"
 OPERATORS_WITHOUT_LOGS = {
     DummyOperator.__class__.__name__,
     ExternalTaskMarker.__class__.__name__,
 }
+DUMMY_TASK_LOG_MESSAGE = f"Tasks of types: {OPERATORS_WITHOUT_LOGS} do not have task logs.\n"
 
 
 def has_logs(ti: TaskInstance) -> bool:

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -21,11 +21,12 @@ from typing import Dict, Iterator, List, Optional, Tuple
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.models import TaskInstance
+from airflow.operators.dummy import DummyOperator
 from airflow.utils.helpers import render_log_filename
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
-from airflow.operators.dummy import DummyOperator
 
 DUMMY_TASK_LOG_MESSAGE = f"tasks of type {DummyOperator.__class__.__name__} do not have task logs \n"
+
 
 class TaskLogReader:
     """Task log reader"""

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -16,7 +16,7 @@
 # under the License.
 
 import logging
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
@@ -42,7 +42,7 @@ class TaskLogReader:
 
     def read_log_chunks(
         self, ti: TaskInstance, try_number: Optional[int], metadata
-    ) -> Tuple[List[Tuple[Tuple[str, str]]], Dict[str, str]]:
+    ) -> Tuple[List[Tuple[Tuple[str, str]]], Dict[str, Union[str, bool]]]:
         """
         Reads chunks of Task Instance logs.
 
@@ -53,7 +53,7 @@ class TaskLogReader:
         :type try_number: Optional[int]
         :param metadata: A dictionary containing information about how to read the task log
         :type metadata: dict
-        :rtype: Tuple[List[Tuple[Tuple[str, str]]], Dict[str, str]]
+        :rtype: Tuple[List[Tuple[Tuple[str, str]]], Dict[str, Union[str,bool]]
 
         The following is an example of how to use this method to read log:
 
@@ -70,7 +70,7 @@ class TaskLogReader:
             logs, metadatas = self.log_handler.read(ti, try_number, metadata=metadata)
             metadata = metadatas[0]
             return logs, metadata
-        return [(('', DUMMY_TASK_LOG_MESSAGE))], {'end_of_log': True}
+        return ([(('', DUMMY_TASK_LOG_MESSAGE),)]), {'end_of_log': True}
 
     def read_log_stream(self, ti: TaskInstance, try_number: Optional[int], metadata: dict) -> Iterator[str]:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -722,6 +722,8 @@ def create_task_instance_of_operator(dag_maker):
         dag_id,
         execution_date=None,
         session=None,
+        run_type=None,
+        state=None,
         **operator_kwargs,
     ):
         with dag_maker(dag_id=dag_id, session=session):
@@ -730,7 +732,10 @@ def create_task_instance_of_operator(dag_maker):
             dagrun_kwargs = {}
         else:
             dagrun_kwargs = {"execution_date": execution_date}
+        if run_type is not None:
+            dagrun_kwargs["run_type"] = run_type
         (ti,) = dag_maker.create_dagrun(**dagrun_kwargs).task_instances
+        ti.state = state
         return ti
 
     return _create_task_instance

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -27,7 +27,7 @@ import pytest
 from airflow import settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.utils import timezone
-from airflow.utils.log.log_reader import TaskLogReader, DUMMY_TASK_LOG_MESSAGE
+from airflow.utils.log.log_reader import DUMMY_TASK_LOG_MESSAGE, TaskLogReader
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 from airflow.utils.state import TaskInstanceState
 from airflow.utils.types import DagRunType
@@ -256,7 +256,7 @@ class TestLogView:
         assert [
             (
                 '',
-		DUMMY_TASK_LOG_MESSAGE,
+                DUMMY_TASK_LOG_MESSAGE,
             )
         ] == logs[0]
         assert {"end_of_log": True} == metadatas

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -37,9 +37,9 @@ from tests.test_utils.db import clear_db_dags, clear_db_runs
 
 class TestLogView:
     DAG_ID = "dag_log_reader"
+    DUMMY_DAG_ID = "dag_dummy_log_reader"
+    EXTERNAL_TASK_MARKER_DAG_ID = "dag_external_task_marker_log_reader"
     TASK_ID = "task_log_reader"
-    DUMMY_TASK_ID = "dummy_task_log_reader"
-    EXTERNAL_TASK_MARKER = "external_task_marker_log_reader"
     DEFAULT_DATE = timezone.datetime(2017, 9, 1)
 
     @pytest.fixture(autouse=True)
@@ -81,12 +81,13 @@ class TestLogView:
 
     @pytest.fixture(autouse=True)
     def prepare_log_files(self, log_dir):
-        dir_path = f"{log_dir}/{self.DAG_ID}/{self.TASK_ID}/2017-09-01T00.00.00+00.00/"
-        os.makedirs(dir_path)
-        for try_number in range(1, 4):
-            with open(f"{dir_path}/{try_number}.log", "w+") as f:
-                f.write(f"try_number={try_number}.\n")
-                f.flush()
+        for dag_id in {self.DAG_ID, self.DUMMY_DAG_ID, self.EXTERNAL_TASK_MARKER_DAG_ID}:
+            dir_path = f"{log_dir}/{dag_id}/{self.TASK_ID}/2017-09-01T00.00.00+00.00/"
+            os.makedirs(dir_path)
+            for try_number in range(1, 4):
+                with open(f"{dir_path}/{try_number}.log", "w+") as f:
+                    f.write(f"try_number={try_number}.\n")
+                    f.flush()
 
     @pytest.fixture(autouse=True)
     def prepare_db(self, session, create_task_instance_of_operator):
@@ -110,11 +111,9 @@ class TestLogView:
 
     @pytest.fixture(scope="function")
     def dummy_ti(self, session, create_task_instance):
-        clear_db_runs()
-        clear_db_dags()
         dummy_ti = create_task_instance(
-            dag_id=self.DAG_ID,
-            task_id=self.DUMMY_TASK_ID,
+            dag_id=self.DUMMY_DAG_ID,
+            task_id=self.TASK_ID,
             start_date=self.DEFAULT_DATE,
             run_type=DagRunType.SCHEDULED,
             execution_date=self.DEFAULT_DATE,
@@ -128,11 +127,9 @@ class TestLogView:
 
     @pytest.fixture(scope="function")
     def external_task_marker_ti(self, session, create_task_instance):
-        clear_db_runs()
-        clear_db_dags()
         external_task_marker_ti = create_task_instance(
-            dag_id=self.DAG_ID,
-            task_id=self.EXTERNAL_TASK_MARKER,
+            dag_id=self.EXTERNAL_TASK_MARKER_DAG_ID,
+            task_id=self.TASK_ID,
             start_date=self.DEFAULT_DATE,
             run_type=DagRunType.SCHEDULED,
             execution_date=self.DEFAULT_DATE,

--- a/tests/utils/log/test_log_reader.py
+++ b/tests/utils/log/test_log_reader.py
@@ -282,7 +282,7 @@ class TestLogView:
         task_log_reader = TaskLogReader()
         logs, metadatas = task_log_reader.read_log_chunks(ti=self.dummy_ti, try_number=1, metadata={})
 
-        assert [('', DUMMY_TASK_LOG_MESSAGE)] == logs
+        assert [(('', DUMMY_TASK_LOG_MESSAGE),)] == logs[0]
         assert {"end_of_log": True} == metadatas
 
     def test_read_log_stream_should_read_one_try_dummy_operator(self, dummy_ti):


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

add dummy task logs for dummy operators
---
**^ Add meaningful description above**

Currently if a user clicks in the webserver on a node that is a `DummyOperator` and tries to read the logs they will get a blank Log by Attempts screen. This is expected but confusing for new users of airflow.

This PR suggests maybe we cloud populate a message on this page to let the user know that no task logs are expected.

cc @jhtimmins 



Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
