### PR TITLE
Fix mini scheduler not respecting `wait_for_downstream` dependency

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -226,6 +226,18 @@ class LocalTaskJob(BaseJob):
     @Sentry.enrich_errors
     def _run_mini_scheduler_on_child_tasks(self, session=None) -> None:
         try:
+
+            if (
+                self.task_instance.task.wait_for_downstream
+                and self.task_instance.get_previous_ti()
+                and not self.task_instance.are_dependents_done()
+            ):
+                self.log.info(
+                    "No downstream tasks scheduled because task instance "
+                    "dependents have not completed yet and wait_for_downstream is true"
+                )
+                return
+
             # Re-select the row with a lock
             dag_run = with_row_locks(
                 session.query(DagRun).filter_by(


### PR DESCRIPTION
When wait_for_downstream is set on a task, mini scheduler doesn't respect it
and goes ahead to schedule unrunnable task instances.

This PR fixes it by checking the dependency in mini scheduler

Closes: https://github.com/apache/airflow/issues/18229


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
