### PR TITLE
Configuration lookup in environment wil ignore empty env var

### DIFF
--- a/airflow/configuration.py
+++ b/airflow/configuration.py
@@ -309,17 +309,17 @@ class AirflowConfigParser(ConfigParser):
     def _get_env_var_option(self, section, key):
         # must have format AIRFLOW__{SECTION}__{KEY} (note double underscore)
         env_var = self._env_var_name(section, key)
-        if env_var in os.environ:
+        if os.environ.get(env_var):
             return expand_env_var(os.environ[env_var])
         # alternatively AIRFLOW__{SECTION}__{KEY}_CMD (for a command)
         env_var_cmd = env_var + '_CMD'
-        if env_var_cmd in os.environ:
+        if os.environ.get(env_var_cmd):
             # if this is a valid command key...
             if (section, key) in self.sensitive_config_values:
                 return run_command(os.environ[env_var_cmd])
         # alternatively AIRFLOW__{SECTION}__{KEY}_SECRET (to get from Secrets Backend)
         env_var_secret_path = env_var + '_SECRET'
-        if env_var_secret_path in os.environ:
+        if os.environ.get(env_var_secret_path):
             # if this is a valid secret path...
             if (section, key) in self.sensitive_config_values:
                 return _get_config_value_from_secret_backend(os.environ[env_var_secret_path])


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

If environment variables are empty strings, but still set, then airflow will not try other environment variables (such as the `_CMD` env vars). This patch fixes that.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
