### PR TITLE
Fix kinesis test

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -511,7 +511,7 @@ devel = [
     'jira',
     'jsondiff',
     'mongomock',
-    'moto~=2.2, >=2.2.1',
+    'moto~=2.2, >=2.2.1, <2.2.7',
     'mypy==0.770',
     'parameterized',
     'paramiko',

--- a/setup.py
+++ b/setup.py
@@ -511,7 +511,7 @@ devel = [
     'jira',
     'jsondiff',
     'mongomock',
-    'moto~=2.2, >=2.2.1, <2.2.7',
+    'moto~=2.2, >=2.2.7',
     'mypy==0.770',
     'parameterized',
     'paramiko',


### PR DESCRIPTION
`moto==2.2.7` broke a test in main.

e.g:

https://github.com/apache/airflow/runs/3635791248

```
tests/providers/amazon/aws/hooks/test_kinesis.py::TestAwsFirehoseHook::test_insert_batch_records_kinesis_firehose: botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException) when calling the CreateDeliveryStream operation: The security token included in the request is invalid.
```