### PR TITLE
Fix mini scheduler not respecting ``wait_for_downstream`` dep

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -226,18 +226,6 @@ class LocalTaskJob(BaseJob):
     @Sentry.enrich_errors
     def _run_mini_scheduler_on_child_tasks(self, session=None) -> None:
         try:
-
-            if (
-                self.task_instance.task.wait_for_downstream
-                and self.task_instance.get_previous_ti()
-                and not self.task_instance.are_dependents_done()
-            ):
-                self.log.info(
-                    "No downstream tasks scheduled because task instance "
-                    "dependents have not completed yet and wait_for_downstream is true"
-                )
-                return
-
             # Re-select the row with a lock
             dag_run = with_row_locks(
                 session.query(DagRun).filter_by(
@@ -255,7 +243,7 @@ class LocalTaskJob(BaseJob):
 
             partial_dag = task.dag.partial_subset(
                 task.downstream_task_ids,
-                include_downstream=False,
+                include_downstream=True,
                 include_upstream=False,
                 include_direct_upstream=True,
             )

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -740,13 +740,17 @@ class TestLocalTaskJob:
         job1 = LocalTaskJob(task_instance=ti2_a, ignore_ti_state=True, executor=SequentialExecutor())
         job1.task_runner = StandardTaskRunner(job1)
         job1.run()
-        ti2_a.refresh_from_db()
+
+        ti2_a.refresh_from_db(session)
+        ti2_b.refresh_from_db(session)
         assert ti2_a.state == State.SUCCESS
         assert ti2_b.state == State.NONE
-        assert (
-            "No downstream tasks scheduled because task instance "
-            "dependents have not completed yet and wait_for_downstream is true"
-        ) in caplog.text
+        assert "0 downstream tasks scheduled from follow-on schedule" in caplog.text
+
+        failed_deps = list(ti2_b.get_failed_dep_statuses(session=session))
+        assert len(failed_deps) == 1
+        assert failed_deps[0].dep_name == "Previous Dagrun State"
+        assert not failed_deps[0].passed
 
     @patch('airflow.utils.process_utils.subprocess.check_call')
     def test_task_sigkill_works_with_retries(self, _check_call, caplog, dag_maker):


### PR DESCRIPTION
When ``wait_for_downstream`` is set on a task, mini scheduler doesn't respect it
and goes ahead to schedule unrunnable task instances.

This PR fixes it by including all direct downstream tasks so that ``wait_for_downstream`` check works correctly.

Resolves https://github.com/apache/airflow/pull/18310#discussion_r711101901

Closes: #18229

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
