### PR TITLE
Patch `utcnow` in retry delay test

### DIFF
--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -17,16 +17,15 @@
 # under the License.
 
 import datetime
-import math
 import os
 import signal
+import sys
 import urllib
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Union, cast
 from unittest import mock
 from unittest.mock import call, mock_open, patch
 
-import numpy as np
 import pendulum
 import pytest
 from freezegun import freeze_time
@@ -526,8 +525,11 @@ class TestTaskInstance:
         # third run -- failed
         frozen_time.tick(
             delta=datetime.timedelta(
-                # I think this is the smallest timedelta to create a different datetime
-                microseconds=np.nextafter(0.5, math.inf)
+                # Approximate the smallest timedelta needed to create a different datetime
+                # (In Python>=3.9, math.nextafter can be used for an even better approximation.
+                # np.nextafter was not used to avoid introducing numpy as a required dependency)
+                microseconds=0.5
+                + sys.float_info.epsilon
             )
         )
         run_with_error(ti)

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -19,7 +19,6 @@
 import datetime
 import os
 import signal
-import sys
 import urllib
 from tempfile import NamedTemporaryFile
 from typing import List, Optional, Union, cast
@@ -523,15 +522,7 @@ class TestTaskInstance:
         assert ti.state == State.UP_FOR_RETRY
 
         # third run -- failed
-        frozen_time.tick(
-            delta=datetime.timedelta(
-                # Approximate the smallest timedelta needed to create a different datetime
-                # (In Python>=3.9, math.nextafter can be used for an even better approximation.
-                # np.nextafter was not used to avoid introducing numpy as a required dependency)
-                microseconds=0.5
-                + sys.float_info.epsilon
-            )
-        )
+        frozen_time.tick(delta=datetime.datetime.resolution)
         run_with_error(ti)
         assert ti.state == State.FAILED
 


### PR DESCRIPTION
This test uses the current timestamp and sleep to test `retry_delay`. This is nondeterministic and fails on my local machine as it takes longer than 3 seconds to execute the first two runs. The `retry_delay` code was originally written using `datetime.datetime.now`, which is a built-in method and probably could not be easily patched without affecting other parts of the code that used `datetime.datetime`. However, now that `timezone.utcnow` is used, patching is possible. The logic of `timezone.utc` does need to be duplicated, though it is only two lines.
https://github.com/apache/airflow/blob/87e98652d58198e4ef7146bdc7e1e8d87a7d2bae/airflow/utils/timezone.py#L53-L65

---
Original commit that added these tests: https://github.com/apache/airflow/commit/8051aa988d315ab5c54bf5dd8f6e931356c07c2e#diff-969c0712020e8472d8d78ae32190692cc1e8a3e16dc17f6977c8f87a1328adb7R142

At that time, `retry_delay` logic was done using `datetime.datetime.now`: https://github.com/apache/airflow/blob/8051aa988d315ab5c54bf5dd8f6e931356c07c2e/airflow/models.py#L928-L934
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
