### PR TITLE
Explain sentry default environment variable for subprocess hook

### DIFF
--- a/airflow/hooks/subprocess.py
+++ b/airflow/hooks/subprocess.py
@@ -50,6 +50,9 @@ class SubprocessHook(BaseHook):
         :param command: the command to run
         :param env: Optional dict containing environment variables to be made available to the shell
             environment in which ``command`` will be executed.  If omitted, ``os.environ`` will be used.
+            Note, that in case you have Sentry configured, original variables from the environment
+            will also be passed to the subprocess with ``SUBPROCESS_`` prefix. See
+            :doc:`/logging-monitoring/errors` for details.
         :param output_encoding: encoding to use for decoding stdout
         :param cwd: Working directory to run the command in.
             If None (default), the command is run in a temporary directory.

--- a/docs/apache-airflow/logging-monitoring/errors.rst
+++ b/docs/apache-airflow/logging-monitoring/errors.rst
@@ -70,3 +70,24 @@ Name                                    Description
 ``completed_tasks[operator]``           Task operator of task that executed before failed task
 ``completed_tasks[duration]``           Duration in seconds of task that executed before failed task
 ======================================= ==============================================================
+
+
+Impact os Sentry on Environment variables passed to Subprocess Hook
+-------------------------------------------------------------------
+
+When Sentry is enabled, by default it changes standard library to pass all environment variables to
+subprocesses opened by Airflow. This changes the default behaviour of
+:class:`airflow.hooks.subprocess.SubprocessHook` - always all environment variables are passed to the
+subprocess executed with specific set of environment variables. In this case not only the specified
+environment variables are passed but also all existing environment variables are passed with
+``SUBPROCESS_`` prefix added. This happens also for all other subprocesses.
+
+This behaviour can be disabled by setting ``default_integrations`` sentry configuration parameter to
+``False`` which disables ``StdlibIntegration``. This however also disables other default integrations
+and you need to enable them manually if you want to get them enabled,
+see `Sentry Default Integrations <https://docs.sentry.io/platforms/python/guides/wsgi/configuration/integrations/default-integrations/>`_
+
+.. code-block:: ini
+
+    [sentry]
+    default_integrations = False

--- a/docs/apache-airflow/logging-monitoring/errors.rst
+++ b/docs/apache-airflow/logging-monitoring/errors.rst
@@ -72,7 +72,7 @@ Name                                    Description
 ======================================= ==============================================================
 
 
-Impact os Sentry on Environment variables passed to Subprocess Hook
+Impact of Sentry on Environment variables passed to Subprocess Hook
 -------------------------------------------------------------------
 
 When Sentry is enabled, by default it changes standard library to pass all environment variables to

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -77,7 +77,7 @@ class TestSentryHook:
 
     @pytest.fixture
     def sentry(self):
-        with conf_vars({('sentry', 'sentry_on'): 'True'}):
+        with conf_vars({('sentry', 'sentry_on'): 'True', ('sentry', 'default_integrations'): 'False'}):
             from airflow import sentry
 
             importlib.reload(sentry)


### PR DESCRIPTION
Sentry by default monkey-patches standard library POpen function
to capture and pass current process' environment to subprocess
with `SUBPROCESS_` prefix. This break SubprocessHook tests
when sentry tests are run before SubprocessHook tests, and also
it modifies SubprocessHook behaviour (and promise) in production
environment as well.

This PR:

* adds documentation to both sentry documentation and the
  SubprocessHook documentation explaining the interaction between
  the two
* Adds documentation explaining how to disable this default
  Sentry behaviour
* disables default integrations in the Sentry tests to avoid
  side-effects

Fixes: #18268

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
