### PR TITLE
Update version added field in config after 2.1.4 release

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -199,7 +199,7 @@
       description: |
         The maximum number of queued dagruns for a single DAG. The scheduler will not create more DAG runs
         if it reaches the limit. This is not configurable at the DAG level.
-      version_added: ~
+      version_added: 2.1.4
       type: string
       example: ~
       default: "16"


### PR DESCRIPTION
We added new config options in Airflow 2.1.4.  This information was added to the released documentation but is not included in the main branch.
http://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html?highlight=max_queued_runs_per_dag#max-queued-runs-per-dag.

Detected by [dev/validate_version_added_fields_in_config.py](https://github.com/apache/airflow/blob/c0fbe3ad12eae4dc408a0ef103f2a359762f73e3/dev/validate_version_added_fields_in_config.py)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
