### PR TITLE
Add support for templated fields in PapermillOperator

### DIFF
--- a/airflow/providers/papermill/operators/papermill.py
+++ b/airflow/providers/papermill/operators/papermill.py
@@ -48,6 +48,8 @@ class PapermillOperator(BaseOperator):
 
     supports_lineage = True
 
+    template_fields = ('input_nb', 'output_nb', 'parameters')
+
     def __init__(
         self,
         *,
@@ -58,8 +60,11 @@ class PapermillOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
 
+        self.input_nb = input_nb
+        self.output_nb = output_nb
+        self.parameters = parameters
         if input_nb:
-            self.inlets.append(NoteBook(url=input_nb, parameters=parameters))
+            self.inlets.append(NoteBook(url=input_nb, parameters=self.parameters))
         if output_nb:
             self.outlets.append(NoteBook(url=output_nb))
 

--- a/tests/providers/papermill/operators/test_papermill.py
+++ b/tests/providers/papermill/operators/test_papermill.py
@@ -16,9 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
+from datetime import datetime
 from unittest.mock import patch
 
+from airflow.models import DAG, DagRun, TaskInstance
 from airflow.providers.papermill.operators.papermill import PapermillOperator
+
+DEFAULT_DATE = datetime(2021, 1, 1)
 
 
 class TestPapermillOperator(unittest.TestCase):
@@ -42,3 +46,23 @@ class TestPapermillOperator(unittest.TestCase):
         mock_papermill.execute_notebook.assert_called_once_with(
             in_nb, out_nb, parameters=parameters, progress_bar=False, report_mode=True
         )
+
+    def test_render_template(self):
+        args = {'owner': 'airflow', 'start_date': DEFAULT_DATE}
+        dag = DAG('test_render_template', default_args=args)
+
+        operator = PapermillOperator(
+            task_id="render_dag_test",
+            input_nb="/tmp/{{ dag.dag_id }}.ipynb",
+            output_nb="/tmp/out-{{ dag.dag_id }}.ipynb",
+            parameters={"msgs": "dag id is {{ dag.dag_id }}!"},
+            dag=dag,
+        )
+
+        ti = TaskInstance(operator, run_id="papermill_test")
+        ti.dag_run = DagRun(execution_date=DEFAULT_DATE)
+        ti.render_templates()
+
+        assert "/tmp/test_render_template.ipynb" == getattr(operator, 'input_nb')
+        assert '/tmp/out-test_render_template.ipynb' == getattr(operator, 'output_nb')
+        assert {"msgs": "dag id is test_render_template!"} == getattr(operator, 'parameters')


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/12081

Traceback from reproducing the issue reported by the user:
```
Traceback (most recent call last):
  File "/opt/airflow/airflow/task/task_runner/standard_task_runner.py", line 85, in _start_by_fork
    args.func(args, dag=self.dag)
  File "/opt/airflow/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/opt/airflow/airflow/utils/cli.py", line 92, in wrapper
    return f(*args, **kwargs)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 292, in task_run
    _run_task_by_selected_method(args, dag, ti)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 107, in _run_task_by_selected_method
    _run_raw_task(args, ti)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 184, in _run_raw_task
    error_file=args.error_file,
  File "/opt/airflow/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1315, in _run_raw_task
    self._prepare_and_execute_task_with_callbacks(context, task)
  File "/opt/airflow/airflow/models/taskinstance.py", line 1414, in _prepare_and_execute_task_with_callbacks
    task_copy.pre_execute(context=context)
  File "/opt/airflow/airflow/lineage/__init__.py", line 186, in wrapper
    self.inlets = [_render_object(i, context) for i in self.inlets if attr.has(i)]
  File "/opt/airflow/airflow/lineage/__init__.py", line 186, in <listcomp>
    self.inlets = [_render_object(i, context) for i in self.inlets if attr.has(i)]
  File "/opt/airflow/airflow/lineage/__init__.py", line 77, in _render_object
    .render(**context)
  File "/usr/local/lib/python3.6/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.6/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/usr/local/lib/python3.6/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 1, in top-level template code
jinja2.exceptions.UndefinedError: 'seoul_date' is undefined
```

The issue is because the fields aren't templated as the [example dag suggested](https://github.com/apache/airflow/blob/11e34535e8cda2f22b26eb3f951a952e3acfe333/airflow/providers/papermill/example_dags/example_papermill.py#L45-L46).
This PR solves it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
