### PR TITLE
Session propagation for task_failed_deps command

### DIFF
--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -52,7 +52,7 @@ from airflow.utils.net import get_hostname
 from airflow.utils.session import create_session, provide_session
 
 
-def _get_dag_run(dag, exec_date_or_run_id, create_if_necssary, session):
+def _get_dag_run(dag, exec_date_or_run_id, create_if_necessary, session):
     dag_run = dag.get_dagrun(run_id=exec_date_or_run_id, session=session)
     if dag_run:
         return dag_run
@@ -61,7 +61,7 @@ def _get_dag_run(dag, exec_date_or_run_id, create_if_necssary, session):
     with suppress(ParserError, TypeError):
         execution_date = timezone.parse(exec_date_or_run_id)
 
-    if create_if_necssary and not execution_date:
+    if create_if_necessary and not execution_date:
         return DagRun(dag_id=dag.dag_id, run_id=exec_date_or_run_id)
     try:
         return (
@@ -73,7 +73,7 @@ def _get_dag_run(dag, exec_date_or_run_id, create_if_necssary, session):
             .one()
         )
     except NoResultFound:
-        if create_if_necssary:
+        if create_if_necessary:
             return DagRun(dag.dag_id, execution_date=execution_date)
         raise DagRunNotFound(
             f"DagRun for {dag.dag_id} with run_id or execution_date of {exec_date_or_run_id!r} not found"
@@ -81,12 +81,12 @@ def _get_dag_run(dag, exec_date_or_run_id, create_if_necssary, session):
 
 
 @provide_session
-def _get_ti(task, exec_date_or_run_id, create_if_necssary=False, session=None):
+def _get_ti(task, exec_date_or_run_id, create_if_necessary=False, session=None):
     """Get the task instance through DagRun.run_id, if that fails, get the TI the old way"""
-    dag_run = _get_dag_run(task.dag, exec_date_or_run_id, create_if_necssary, session)
+    dag_run = _get_dag_run(task.dag, exec_date_or_run_id, create_if_necessary, session)
 
-    ti = dag_run.get_task_instance(task.task_id)
-    if not ti and create_if_necssary:
+    ti = dag_run.get_task_instance(task.task_id, session)
+    if not ti and create_if_necessary:
         ti = TaskInstance(task, run_id=None)
         ti.dag_run = dag_run
     ti.refresh_from_task(task)
@@ -293,7 +293,8 @@ def task_run(args, dag=None):
 
 
 @cli_utils.action_logging
-def task_failed_deps(args):
+@provide_session
+def task_failed_deps(args, session=None):
     """
     Returns the unmet dependencies for a task instance from the perspective of the
     scheduler (i.e. why a task instance doesn't get scheduled and then queued by the
@@ -306,10 +307,10 @@ def task_failed_deps(args):
     """
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(task, args.execution_date_or_run_id)
+    ti = _get_ti(task, args.execution_date_or_run_id, session=session)
 
     dep_context = DepContext(deps=SCHEDULER_QUEUED_DEPS)
-    failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
+    failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context, session=session))
     # TODO, Do we want to print or log this
     if failed_deps:
         print("Task instance dependencies not met:")
@@ -448,7 +449,7 @@ def task_test(args, dag=None):
     if task.params:
         task.params.validate()
 
-    ti = _get_ti(task, args.execution_date_or_run_id, create_if_necssary=True)
+    ti = _get_ti(task, args.execution_date_or_run_id, create_if_necessary=True)
 
     try:
         if args.dry_run:
@@ -474,7 +475,7 @@ def task_render(args):
     """Renders and displays templated fields for a given task"""
     dag = get_dag(args.subdir, args.dag_id)
     task = dag.get_task(task_id=args.task_id)
-    ti = _get_ti(task, args.execution_date_or_run_id, create_if_necssary=True)
+    ti = _get_ti(task, args.execution_date_or_run_id, create_if_necessary=True)
     ti.render_templates()
     for attr in task.__class__.template_fields:
         print(


### PR DESCRIPTION
When failed dependencies checked as in below example, the command fails most of the time and some time succeeds. This is due to race condition for the session object.
It happens as dependency checker tries to access **ti.execution_date** attribute which is **lazily** loaded and when load is required the session is not available anymore as it was created temporarily for the duration _get_ti call. 

This PR fixes it by creating session beforehand and propagating to downstream. This helps avoiding of creating multiple sessions and making sure session is available when this lazy attribute is accessed.

I have also took opportunity to fix a typo for  "**create_if_necssary**" -> "**create_if_necessary**"

Thanks for reviewing!

```
root@c10237c871db:/opt/airflow/airflow/cli/commands# airflow tasks failed-deps my_dag print_date manual__2021-09-11T00:00:00+00:00
[2021-09-19 13:16:44,512] {dagbag.py:492} INFO - Filling up the DagBag from /files/dags
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 33, in <module>
    sys.exit(load_entry_point('apache-airflow', 'console_scripts', 'airflow')())
  File "/opt/airflow/airflow/__main__.py", line 40, in main
    args.func(args)
  File "/opt/airflow/airflow/cli/cli_parser.py", line 48, in command
    return func(*args, **kwargs)
  File "/opt/airflow/airflow/utils/cli.py", line 92, in wrapper
    return f(*args, **kwargs)
  File "/opt/airflow/airflow/cli/commands/task_command.py", line 312, in task_failed_deps
    failed_deps = list(ti.get_failed_dep_statuses(dep_context=dep_context))
  File "/opt/airflow/airflow/models/taskinstance.py", line 1042, in get_failed_dep_statuses
    for dep_status in dep.get_dep_statuses(self, session, dep_context):
  File "/opt/airflow/airflow/ti_deps/deps/base_ti_dep.py", line 101, in get_dep_statuses
    yield from self._get_dep_statuses(ti, session, dep_context)
  File "/opt/airflow/airflow/ti_deps/deps/exec_date_after_start_date_dep.py", line 31, in _get_dep_statuses
    if ti.task.start_date and ti.execution_date < ti.task.start_date:
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/ext/associationproxy.py", line 193, in __get__
    return inst.get(obj)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/ext/associationproxy.py", line 546, in get
    target = getattr(obj, self.target_collection)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/attributes.py", line 294, in __get__
    return self.impl.get(instance_state(instance), dict_)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/attributes.py", line 730, in get
    value = self.callable_(state, passive)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/strategies.py", line 720, in _load_for_state
    % (orm_util.state_str(state), self.key)
sqlalchemy.orm.exc.DetachedInstanceError: Parent instance <TaskInstance at 0x7fad6e3acc88> is not bound to a Session; lazy load operation of attribute 'dag_run' cannot proceed (Background on this error at: http://sqlalche.me/e/13/bhk3)
```