### PR TITLE
Fixed broken URL

### DIFF
--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -84,7 +84,7 @@ principal exists in the keytab file.
 Basic authentication
 ''''''''''''''''''''
 
-`Basic username password authentication <https://tools.ietf.org/html/rfc7617
+`Basic username password authentication <https://tools.ietf.org/html/rfc7617?
 https://en.wikipedia.org/wiki/Basic_access_authentication>`_ is currently
 supported for the API. This works for users created through LDAP login or
 within Airflow Metadata DB using password.

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -84,8 +84,8 @@ principal exists in the keytab file.
 Basic authentication
 ''''''''''''''''''''
 
-`Basic username password authentication <https://tools.ietf.org/html/rfc7617?
-https://en.wikipedia.org/wiki/Basic_access_authentication>`_ is currently
+`Basic username password authentication <https://tools.ietf.org/html/rfc7617`_
+`https://en.wikipedia.org/wiki/Basic_access_authentication>`_ is currently
 supported for the API. This works for users created through LDAP login or
 within Airflow Metadata DB using password.
 


### PR DESCRIPTION
URL for "Basic username password authentication" in this readme was broken

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
