### PR TITLE
Set default branch in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -16,6 +16,7 @@
 # under the License.
 ---
 codecov:
+  branch: main
   max_report_age: off  # yamllint disable-line rule:truthy
   require_ci_to_pass: true
   notify:


### PR DESCRIPTION
The codecov uses master as default branch, See: https://docs.codecov.com/docs/codecov-yaml#master-copy

Hopefully this will solve the codecov stats missing problem.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
