### PR TITLE
Properly fix dagrun update state endpoint

### DIFF
--- a/airflow/api/common/experimental/mark_tasks.py
+++ b/airflow/api/common/experimental/mark_tasks.py
@@ -131,7 +131,6 @@ def set_state(
         if sub_dag_run_ids:
             qry_sub_dag = all_subdag_tasks_query(sub_dag_run_ids, session, state, confirmed_dates)
             tis_altered += qry_sub_dag.all()
-
     return tis_altered
 
 

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -21,6 +21,10 @@ from marshmallow import ValidationError
 from sqlalchemy import or_
 
 from airflow._vendor.connexion import NoContent
+from airflow.api.common.experimental.mark_tasks import (
+    set_dag_run_state_to_failed,
+    set_dag_run_state_to_success,
+)
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import AlreadyExists, BadRequest, NotFound
 from airflow.api_connexion.parameters import apply_sorting, check_limit, format_datetime, format_parameters
@@ -34,7 +38,7 @@ from airflow.api_connexion.schemas.dag_run_schema import (
 from airflow.models import DagModel, DagRun
 from airflow.security import permissions
 from airflow.utils.session import provide_session
-from airflow.utils.state import DagRunState, State
+from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 
@@ -302,6 +306,10 @@ def update_dag_run_state(dag_id: str, dag_run_id: str, session) -> dict:
         raise BadRequest(detail=str(err))
 
     state = post_body['state']
-    dag_run.set_state(state=DagRunState(state))
-    session.merge(dag_run)
+    dag = current_app.dag_bag.get_dag(dag_id)
+    if state == State.SUCCESS:
+        set_dag_run_state_to_success(dag, dag_run.execution_date, commit=True)
+    else:
+        set_dag_run_state_to_failed(dag, dag_run.execution_date, commit=True)
+    dag_run = session.query(DagRun).get(dag_run.id)
     return dagrun_schema.dump(dag_run)


### PR DESCRIPTION
The dagrun update state endpoint was recently added but is not working
as expected. This PR fixes it to work exactly like the UI mark dagrun state API

Closes: https://github.com/apache/airflow/issues/18363

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
