### PR TITLE
Add example JSON for airflow pools import

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -357,7 +357,22 @@ ARG_EXEC_DATE = Arg(("-e", "--exec-date"), help="The execution date of the DAG",
 ARG_POOL_NAME = Arg(("pool",), metavar='NAME', help="Pool name")
 ARG_POOL_SLOTS = Arg(("slots",), type=int, help="Pool slots")
 ARG_POOL_DESCRIPTION = Arg(("description",), help="Pool description")
-ARG_POOL_IMPORT = Arg(("file",), metavar="FILEPATH", help="Import pools from JSON file")
+ARG_POOL_IMPORT = Arg(
+    ("file",),
+    metavar="FILEPATH",
+    help="Import pools from JSON file. Example format::\n"
+    + textwrap.indent(
+        textwrap.dedent(
+            '''
+            {
+                "pool_1": {"slots": 5, "description": ""},
+                "pool_2": {"slots": 10, "description": "test"}
+            }'''
+        ),
+        " " * 4,
+    ),
+)
+
 ARG_POOL_EXPORT = Arg(("file",), metavar="FILEPATH", help="Export all pools to JSON file")
 
 # variables


### PR DESCRIPTION
Had to dive into the source code to understand what format is expected for `airflow pools import`. This PR adds an example JSON to the docs.

### **Before:**
![image](https://user-images.githubusercontent.com/6249654/134022434-6f0ef00d-7bfe-4fd4-911e-41e7d54b5080.png)

### **After:**
![image](https://user-images.githubusercontent.com/6249654/134022502-104351d4-361e-42bf-9660-5e8bab740770.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
