### PR TITLE
Make Kubernetes job description fit on one log line

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -294,7 +294,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         and store relevant info in the current_jobs map so we can track the job's
         status
         """
-        self.log.info('Kubernetes job is %s', str(next_job))
+        self.log.info('Kubernetes job is %s', str(next_job).replace("\n", " "))
         key, command, kube_executor_config, pod_template_file = next_job
         dag_id, task_id, run_id, try_number = key
 

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -92,7 +92,9 @@ class PodLauncher(LoggingMixin):
             )
             self.log.debug('Pod Creation Response: %s', resp)
         except Exception as e:
-            self.log.exception('Exception when attempting to create Namespaced Pod: %s', json_pod)
+            self.log.exception(
+                'Exception when attempting to create Namespaced Pod: %s', str(json_pod).replace("\n", " ")
+            )
             raise e
         return resp
 


### PR DESCRIPTION
Currently, when the Kubernetes executor creates a pod it prints a dictionary description of the pod across many lines (can easily be 20+ lines). This is fine if you're reading the log in a stream in a text file, but throws off log search tools like Kibana. A better practice would be to print the whole pod description on a single line. It is quite easy to prettify a dictionary if one wants to see it back in a more human-friendly form with the newlines.

This update simply forces the log from this command into a single line.