### PR TITLE
Don't permanently add zip DAGs to ``sys.path``

### DIFF
--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -377,6 +377,9 @@ class DagBag(LoggingMixin):
                         )
                     else:
                         self.import_errors[fileloc] = str(e)
+                finally:
+                    if sys.path[0] == filepath:
+                        del sys.path[0]
         return mods
 
     def _process_modules(self, filepath, mods, file_last_changed_on_disk):

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -18,7 +18,9 @@ import inspect
 import logging
 import os
 import shutil
+import sys
 import textwrap
+from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 from tempfile import NamedTemporaryFile, mkdtemp
 from unittest import mock
@@ -191,9 +193,11 @@ class TestDagBag:
         """
         test the loading of a DAG within a zip file that includes dependencies
         """
+        syspath_before = deepcopy(sys.path)
         dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False)
         dagbag.process_file(os.path.join(TEST_DAGS_FOLDER, "test_zip.zip"))
         assert dagbag.get_dag("test_zip_dag")
+        assert sys.path == syspath_before  # sys.path doesn't change
 
     def test_process_file_cron_validity_check(self):
         """


### PR DESCRIPTION
Only leave the zip on `sys.path` while parsing that zip file, as we
shouldn't assume parsing only happens in separate processes. For
example, `resetdb` is used to run migrations, some of which parse
the DAGs.