### PR TITLE
Removing redundant relabeling of ADX conn field

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/adx.py
+++ b/airflow/providers/microsoft/azure/hooks/adx.py
@@ -97,7 +97,6 @@ class AzureDataExplorerHook(BaseHook):
             "hidden_fields": ['schema', 'port', 'extra'],
             "relabeling": {
                 'login': 'Username',
-                'password': 'Password',
                 'host': 'Data Explorer Cluster URL',
             },
             "placeholders": {


### PR DESCRIPTION
In a previous PR (#18203) there was a change made to the relabeling of the `password` connection field from "Auth Password" to "Password". This relabeling should have been removed rather than updated as it is redundant.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
