### PR TITLE
Update spark_submit.py to work with Kubernetes in client mode

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -439,7 +439,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.
-        if returncode or (self._is_kubernetes and self._spark_exit_code != 0):
+        if returncode or (self._is_kubernetes and self._connection['deploy_mode']!='client' and self._spark_exit_code != 0):
             if self._is_kubernetes:
                 raise AirflowException(
                     "Cannot execute: {}. Error code is: {}. Kubernetes spark exit code is: {}".format(

--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -418,6 +418,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         :type application: str
         :param kwargs: extra arguments to Popen (see subprocess.Popen)
         """
+        deploy_mode_launch = self._connection['deploy_mode'] 
+
         spark_submit_cmd = self._build_spark_submit_command(application)
 
         if self._env:
@@ -439,7 +441,8 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
         # Check spark-submit return code. In Kubernetes mode, also check the value
         # of exit code in the log, as it may differ.
-        if returncode or (self._is_kubernetes and self._connection['deploy_mode']!='client' and self._spark_exit_code != 0):
+        if returncode or (self._is_kubernetes and deploy_mode_launch=='cluster' and self._spark_exit_code != 0):
+            self.log.debug(f"detected kubernetes mode: {self._is_kubernetes} and deploy mode: {deploy_mode_launch} and exit code: {self._spark_exit_code}")
             if self._is_kubernetes:
                 raise AirflowException(
                     "Cannot execute: {}. Error code is: {}. Kubernetes spark exit code is: {}".format(


### PR DESCRIPTION
This change is needed, because we can launch spark on kubernetes without a separate kubernetes pod for the driver if we run in client mode. It was an oversight not to check if running in client mode before also checking for the pod return code.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
