### PR TITLE
Move tags filter cookie to frontend

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -132,7 +132,6 @@ from airflow.www.forms import (
 from airflow.www.widgets import AirflowModelListWidget
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
-FILTER_TAGS_COOKIE = 'tags_filter'
 FILTER_STATUS_COOKIE = 'dag_status_filter'
 
 
@@ -573,18 +572,6 @@ class Airflow(AirflowBaseView):
         arg_search_query = request.args.get('search')
         arg_tags_filter = request.args.getlist('tags')
         arg_status_filter = request.args.get('status')
-
-        if request.args.get('reset_tags') is not None:
-            flask_session[FILTER_TAGS_COOKIE] = None
-            # Remove the reset_tags=reset from the URL
-            return redirect(url_for('Airflow.index'))
-
-        cookie_val = flask_session.get(FILTER_TAGS_COOKIE)
-        if arg_tags_filter:
-            flask_session[FILTER_TAGS_COOKIE] = ','.join(arg_tags_filter)
-        elif cookie_val:
-            # If tags exist in cookie, but not URL, add them to the URL
-            return redirect(url_for('Airflow.index', tags=cookie_val.split(',')))
 
         if arg_status_filter is None:
             cookie_val = flask_session.get(FILTER_STATUS_COOKIE)


### PR DESCRIPTION
It turns out that the filter_tags_cookie does not work as intended. It caused extra page loads with duplicated banner messages. Instead the cookie will now be managed by `localstorage` in the js frontend instead of the webserver and remove an extraneous UI - webserver trip.

Closes #17727

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
