### PR TITLE
Add ODBC extra for the production image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -323,6 +323,13 @@ repos:
         language: python
         files: ^setup\.py$|^INSTALL$|^CONTRIBUTING\.rst$
         pass_filenames: false
+      - id: check-extras-order
+        name: Check order of extras in Dockerfile
+        entry: ./scripts/ci/pre_commit/pre_commit_check_order_dockerfile_extras.py
+        language: python
+        files: ^Dockerfile$
+        pass_filenames: false
+        additional_dependencies: ['rich']
       - id: update-version
         name: Update version to the latest version in the documentation
         entry: ./scripts/ci/pre_commit/pre_commit_update_versions.py

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1314,8 +1314,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  devel_ci
 
           Production image:
-                 async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,
-                 http,ldap,google,google_auth,microsoft.azure,mysql,pandas,postgres,redis,sendgrid,
+                 amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,google_auth,
+                 grpc,hashicorp,http,ldap,microsoft.azure,mysql,odbc,pandas,postgres,redis,sendgrid,
                  sftp,slack,ssh,statsd,virtualenv
 
   --image-tag TAG
@@ -1913,8 +1913,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  devel_ci
 
           Production image:
-                 async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,
-                 http,ldap,google,google_auth,microsoft.azure,mysql,pandas,postgres,redis,sendgrid,
+                 amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,google_auth,
+                 grpc,hashicorp,http,ldap,microsoft.azure,mysql,odbc,pandas,postgres,redis,sendgrid,
                  sftp,slack,ssh,statsd,virtualenv
 
   --image-tag TAG
@@ -2175,19 +2175,20 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  all airflow-config-yaml airflow-providers-available airflow-provider-yaml-files-ok
                  base-operator bats-tests bats-in-container-tests black blacken-docs boring-cyborg
                  build build-providers-dependencies check-apache-license check-builtin-literals
-                 check-executables-have-shebangs check-hooks-apply check-integrations
-                 check-merge-conflict check-xml daysago-import-check debug-statements
-                 detect-private-key doctoc dont-use-safe-filter end-of-file-fixer fix-encoding-pragma
-                 flake8 flynt forbid-tabs helm-lint identity incorrect-use-of-LoggingMixin
-                 insert-license isort json-schema language-matters lint-dockerfile lint-openapi
-                 markdownlint mermaid mixed-line-ending mypy mypy-helm no-providers-in-core-examples
-                 no-relative-imports pre-commit-descriptions pre-commit-hook-names pretty-format-json
-                 provide-create-sessions providers-changelogs providers-init-file
-                 providers-subpackages-init-file provider-yamls pydevd pydocstyle python-no-log-warn
-                 pyupgrade restrict-start_date rst-backticks setup-order setup-extra-packages
-                 shellcheck sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace
-                 ui-lint update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
-                 update-versions verify-db-migrations-documented version-sync www-lint yamllint yesqa
+                 check-executables-have-shebangs check-extras-order check-hooks-apply
+                 check-integrations check-merge-conflict check-xml daysago-import-check
+                 debug-statements detect-private-key doctoc dont-use-safe-filter end-of-file-fixer
+                 fix-encoding-pragma flake8 flynt forbid-tabs helm-lint identity
+                 incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
+                 lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
+                 no-providers-in-core-examples no-relative-imports pre-commit-descriptions
+                 pre-commit-hook-names pretty-format-json provide-create-sessions
+                 providers-changelogs providers-init-file providers-subpackages-init-file
+                 provider-yamls pydevd pydocstyle python-no-log-warn pyupgrade restrict-start_date
+                 rst-backticks setup-order setup-extra-packages shellcheck sort-in-the-wild
+                 sort-spelling-wordlist stylelint trailing-whitespace ui-lint update-breeze-file
+                 update-extras update-local-yml-file update-setup-cfg-file update-versions
+                 verify-db-migrations-documented version-sync www-lint yamllint yesqa
 
         You can pass extra arguments including options to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:
@@ -2500,8 +2501,8 @@ This is the current syntax for  `./breeze <./breeze>`_:
                  devel_ci
 
           Production image:
-                 async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,
-                 http,ldap,google,google_auth,microsoft.azure,mysql,pandas,postgres,redis,sendgrid,
+                 amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,google_auth,
+                 grpc,hashicorp,http,ldap,microsoft.azure,mysql,odbc,pandas,postgres,redis,sendgrid,
                  sftp,slack,ssh,statsd,virtualenv
 
   --image-tag TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@
 #                        much smaller.
 #
 ARG AIRFLOW_VERSION="2.2.0.dev0"
-ARG AIRFLOW_EXTRAS="async,amazon,celery,cncf.kubernetes,docker,dask,elasticsearch,ftp,grpc,hashicorp,http,ldap,google,google_auth,microsoft.azure,mysql,pandas,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
+ARG AIRFLOW_EXTRAS="amazon,async,celery,cncf.kubernetes,dask,docker,elasticsearch,ftp,google,google_auth,grpc,hashicorp,http,ldap,microsoft.azure,mysql,odbc,pandas,postgres,redis,sendgrid,sftp,slack,ssh,statsd,virtualenv"
 ARG ADDITIONAL_AIRFLOW_EXTRAS=""
 ARG ADDITIONAL_PYTHON_DEPS=""
 

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -154,6 +154,8 @@ require Breeze Docker images to be installed locally.
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``check-executables-have-shebangs``    Checks that executables have shebang
 ------------------------------------ ---------------------------------------------------------------- ------------
+``check-extras-order``                 Checks that extras in Dockerfile are sorted
+------------------------------------ ---------------------------------------------------------------- ------------
 ``check-hooks-apply``                  Checks which hooks are applicable to the repository
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``check-integrations``                 Checks if integration list is synchronized in code

--- a/breeze-complete
+++ b/breeze-complete
@@ -88,6 +88,7 @@ build-providers-dependencies
 check-apache-license
 check-builtin-literals
 check-executables-have-shebangs
+check-extras-order
 check-hooks-apply
 check-integrations
 check-merge-conflict

--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -34,7 +34,7 @@ Those are the most common arguments that you use when you want to build a custom
 +------------------------------------------+------------------------------------------+---------------------------------------------+
 | ``AIRFLOW_VERSION``                      | :subst-code:`|airflow-version|`          | version of Airflow.                         |
 +------------------------------------------+------------------------------------------+---------------------------------------------+
-| ``AIRFLOW_EXTRAS``                       | (see Dockerfile)                         | Default extras with which airflow is        |
+| ``AIRFLOW_EXTRAS``                       | (see below the table)                    | Default extras with which airflow is        |
 |                                          |                                          | installed.                                  |
 +------------------------------------------+------------------------------------------+---------------------------------------------+
 | ``ADDITIONAL_AIRFLOW_EXTRAS``            |                                          | Optional additional extras with which       |
@@ -66,6 +66,37 @@ Those are the most common arguments that you use when you want to build a custom
 |                                          |                                          | :subst-code:`constraints-|airflow-version|`.|
 |                                          |                                          | Auto-detected if empty.                     |
 +------------------------------------------+------------------------------------------+---------------------------------------------+
+
+List of default extras in the production Dockerfile:
+
+.. BEGINNING OF EXTRAS LIST UPDATED BY PRE COMMIT
+* amazon
+* async
+* celery
+* cncf.kubernetes
+* dask
+* docker
+* elasticsearch
+* ftp
+* google
+* google_auth
+* grpc
+* hashicorp
+* http
+* ldap
+* microsoft.azure
+* mysql
+* odbc
+* pandas
+* postgres
+* redis
+* sendgrid
+* sftp
+* slack
+* ssh
+* statsd
+* virtualenv
+.. END OF EXTRAS LIST UPDATED BY PRE COMMIT
 
 Image optimization options
 ..........................

--- a/scripts/ci/libraries/_verify_image.sh
+++ b/scripts/ci/libraries/_verify_image.sh
@@ -288,6 +288,7 @@ function verify_image::verify_production_image_python_modules() {
     verify_image::check_command "Import: slack" "python -c 'import slack_sdk'"
     verify_image::check_command "Import: statsd" "python -c 'import statsd'"
     verify_image::check_command "Import: virtualenv" "python -c 'import virtualenv'"
+    verify_image::check_command "Import: pyodbc" "python -c 'import pyodbc'"
 
     start_end::group_end
 }

--- a/scripts/ci/pre_commit/pre_commit_check_order_dockerfile_extras.py
+++ b/scripts/ci/pre_commit/pre_commit_check_order_dockerfile_extras.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Test for an order of dependencies in setup.py
+"""
+import os
+import sys
+from typing import List
+
+from rich import print
+
+errors = []
+
+MY_DIR_PATH = os.path.dirname(__file__)
+SOURCE_DIR_PATH = os.path.abspath(os.path.join(MY_DIR_PATH, os.pardir, os.pardir, os.pardir))
+BUILD_ARGS_REF_PATH = os.path.join(SOURCE_DIR_PATH, "docs", "docker-stack", "build-arg-ref.rst")
+
+START_LINE = ".. BEGINNING OF EXTRAS LIST UPDATED BY PRE COMMIT"
+END_LINE = ".. END OF EXTRAS LIST UPDATED BY PRE COMMIT"
+
+
+def _check_list_sorted(the_list: List[str], message: str) -> bool:
+    print(the_list)
+    sorted_list = sorted(the_list)
+    if the_list == sorted_list:
+        print(f"{message} is [green]ok[/]")
+        print()
+        return True
+    i = 0
+    while sorted_list[i] == the_list[i]:
+        i += 1
+    print(f"{message} [red]NOK[/]")
+    print()
+    errors.append(
+        f"ERROR in {message}. First wrongly sorted element {repr(the_list[i])}. Should "
+        f"be {repr(sorted_list[i])}"
+    )
+    return False
+
+
+def check_dockerfile():
+    with open(os.path.join(SOURCE_DIR_PATH, "Dockerfile")) as dockerfile:
+        file_contents = dockerfile.read()
+    for line in file_contents.splitlines():
+        if line.startswith("ARG AIRFLOW_EXTRAS="):
+            extras_list = line.split("=")[1].replace('"', '').split(",")
+            if _check_list_sorted(extras_list, "Dockerfile's AIRFLOW_EXTRAS"):
+                with open(BUILD_ARGS_REF_PATH) as build_args_file:
+                    content = build_args_file.read().splitlines(keepends=False)
+                result = []
+                is_copying = True
+                for line in content:
+                    if line.startswith(START_LINE):
+                        result.append(line)
+                        is_copying = False
+                        for extra in extras_list:
+                            result.append(f'* {extra}')
+                    elif line.startswith(END_LINE):
+                        result.append(line)
+                        is_copying = True
+                    elif is_copying:
+                        result.append(line)
+                with open(BUILD_ARGS_REF_PATH, "w") as build_args_file:
+                    build_args_file.write("\n".join(result))
+                    build_args_file.write("\n")
+                return
+    errors.append("Something is wrong. Dockerfile does not contain AIRFLOW_EXTRAS")
+
+
+if __name__ == '__main__':
+    check_dockerfile()
+    print()
+    print()
+    for error in errors:
+        print(error)
+
+    print()
+
+    if errors:
+        sys.exit(1)


### PR DESCRIPTION
The ODBC extra has been missing from #18382. This PR adds the
missing extra and verifies if pyodbc is importable in the PROD
image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
