### PR TITLE
Change the color for deferred status to mediumpurple

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -93,7 +93,7 @@ STATE_COLORS = {
     "upstream_failed": "orange",
     "skipped": "pink",
     "scheduled": "tan",
-    "deferred": "lightseagreen",
+    "deferred": "blueviolet",
 }
 
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -93,7 +93,7 @@ STATE_COLORS = {
     "upstream_failed": "orange",
     "skipped": "pink",
     "scheduled": "tan",
-    "deferred": "blueviolet",
+    "deferred": "mediumpurple",
 }
 
 

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -121,7 +121,7 @@ class State:
         TaskInstanceState.REMOVED: 'lightgrey',
         TaskInstanceState.SCHEDULED: 'tan',
         TaskInstanceState.SENSING: 'lightseagreen',
-        TaskInstanceState.DEFERRED: 'lightseagreen',
+        TaskInstanceState.DEFERRED: 'blueviolet',
     }
     state_color.update(STATE_COLORS)  # type: ignore
 

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -112,7 +112,7 @@ class State:
         TaskInstanceState.RUNNING: 'lime',
         TaskInstanceState.SUCCESS: 'green',
         TaskInstanceState.SHUTDOWN: 'blue',
-        TaskInstanceState.RESTARTING: 'violet',
+        TaskInstanceState.RESTARTING: 'mediumpurple',
         TaskInstanceState.FAILED: 'red',
         TaskInstanceState.UP_FOR_RETRY: 'gold',
         TaskInstanceState.UP_FOR_RESCHEDULE: 'turquoise',
@@ -120,7 +120,7 @@ class State:
         TaskInstanceState.SKIPPED: 'pink',
         TaskInstanceState.REMOVED: 'lightgrey',
         TaskInstanceState.SCHEDULED: 'tan',
-        TaskInstanceState.DEFERRED: 'blueviolet',
+        TaskInstanceState.DEFERRED: 'mediumpurple',
     }
     state_color[TaskInstanceState.SENSING] = state_color[TaskInstanceState.DEFERRED]
     state_color.update(STATE_COLORS)  # type: ignore

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -120,9 +120,9 @@ class State:
         TaskInstanceState.SKIPPED: 'pink',
         TaskInstanceState.REMOVED: 'lightgrey',
         TaskInstanceState.SCHEDULED: 'tan',
-        TaskInstanceState.SENSING: 'lightseagreen',
         TaskInstanceState.DEFERRED: 'blueviolet',
     }
+    state_color[TaskInstanceState.SENSING] = state_color[TaskInstanceState.DEFERRED]
     state_color.update(STATE_COLORS)  # type: ignore
 
     @classmethod

--- a/airflow/utils/state.py
+++ b/airflow/utils/state.py
@@ -112,7 +112,7 @@ class State:
         TaskInstanceState.RUNNING: 'lime',
         TaskInstanceState.SUCCESS: 'green',
         TaskInstanceState.SHUTDOWN: 'blue',
-        TaskInstanceState.RESTARTING: 'mediumpurple',
+        TaskInstanceState.RESTARTING: 'violet',
         TaskInstanceState.FAILED: 'red',
         TaskInstanceState.UP_FOR_RETRY: 'gold',
         TaskInstanceState.UP_FOR_RESCHEDULE: 'turquoise',

--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -45,7 +45,7 @@ following steps:
           "upstream_failed": "orange",
           "skipped": "darkorchid",
           "scheduled": "tan",
-          "deferred": "blueviolet",
+          "deferred": "mediumpurple",
       }
 
 

--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -45,7 +45,7 @@ following steps:
           "upstream_failed": "orange",
           "skipped": "darkorchid",
           "scheduled": "tan",
-          "deferred": "lightseagreen",
+          "deferred": "blueviolet",
       }
 
 

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -51,10 +51,10 @@ def test_home(capture_templates, admin_client):
         check_content_in_response('DAGs', resp)
         val_state_color_mapping = (
             'const STATE_COLOR = {'
-            '"deferred": "blueviolet", "failed": "red", '
+            '"deferred": "mediumpurple", "failed": "red", '
             '"null": "lightblue", "queued": "gray", '
             '"removed": "lightgrey", "restarting": "violet", "running": "lime", '
-            '"scheduled": "tan", "sensing": "blueviolet", '
+            '"scheduled": "tan", "sensing": "mediumpurple", '
             '"shutdown": "blue", "skipped": "pink", '
             '"success": "green", "up_for_reschedule": "turquoise", '
             '"up_for_retry": "gold", "upstream_failed": "orange"};'

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -51,10 +51,10 @@ def test_home(capture_templates, admin_client):
         check_content_in_response('DAGs', resp)
         val_state_color_mapping = (
             'const STATE_COLOR = {'
-            '"deferred": "lightseagreen", "failed": "red", '
+            '"deferred": "blueviolet", "failed": "red", '
             '"null": "lightblue", "queued": "gray", '
             '"removed": "lightgrey", "restarting": "violet", "running": "lime", '
-            '"scheduled": "tan", "sensing": "lightseagreen", '
+            '"scheduled": "tan", "sensing": "blueviolet", '
             '"shutdown": "blue", "skipped": "pink", '
             '"success": "green", "up_for_reschedule": "turquoise", '
             '"up_for_retry": "gold", "upstream_failed": "orange"};'


### PR DESCRIPTION
Changes the color for the deferred status to something more distinct, mediumpurple.

![image](https://user-images.githubusercontent.com/13177948/134234580-11d1cec0-d9ad-45e4-9577-e9066b829363.png)

![image](https://user-images.githubusercontent.com/13177948/134234619-04851b97-5a26-4ecb-baa8-dbf3cd7270b0.png)


closes: #18245 