### PR TITLE
Fix task instance url in webserver utils

### DIFF
--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -228,7 +228,7 @@ def task_instance_link(attr):
     dag_id = attr.get('dag_id')
     task_id = attr.get('task_id')
     execution_date = attr.get('dag_run.execution_date') or attr.get('execution_date') or timezone.utcnow()
-    url = url_for('Airflow.task', dag_id=dag_id, task_id=task_id)
+    url = url_for('Airflow.task', dag_id=dag_id, task_id=task_id, execution_date=execution_date)
     url_root = url_for(
         'Airflow.graph', dag_id=dag_id, root=task_id, execution_date=execution_date.isoformat()
     )


### PR DESCRIPTION
`execution_date` was omitted when generating the task instance URL.
This PR fixes it


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
