### PR TITLE
Fix ``docker-stack`` docs build

### DIFF
--- a/docs/docker-stack/build-arg-ref.rst
+++ b/docs/docker-stack/build-arg-ref.rst
@@ -70,6 +70,7 @@ Those are the most common arguments that you use when you want to build a custom
 List of default extras in the production Dockerfile:
 
 .. BEGINNING OF EXTRAS LIST UPDATED BY PRE COMMIT
+
 * amazon
 * async
 * celery
@@ -96,6 +97,7 @@ List of default extras in the production Dockerfile:
 * ssh
 * statsd
 * virtualenv
+
 .. END OF EXTRAS LIST UPDATED BY PRE COMMIT
 
 Image optimization options

--- a/scripts/ci/pre_commit/pre_commit_check_order_dockerfile_extras.py
+++ b/scripts/ci/pre_commit/pre_commit_check_order_dockerfile_extras.py
@@ -67,12 +67,12 @@ def check_dockerfile():
                 is_copying = True
                 for line in content:
                     if line.startswith(START_LINE):
-                        result.append(line)
+                        result.append(f"{line}\n")
                         is_copying = False
                         for extra in extras_list:
                             result.append(f'* {extra}')
                     elif line.startswith(END_LINE):
-                        result.append(line)
+                        result.append(f"\n{line}")
                         is_copying = True
                     elif is_copying:
                         result.append(line)


### PR DESCRIPTION
Missing newlines in the new pre-commit hook is causing the `docker-stack` docs build to fail:

e.g: https://github.com/apache/airflow/pull/18417/checks?check_run_id=3669346986
```
############################## Start docs build errors summary ##############################

============================== docker-stack ==============================
------------------------------ Error   1 --------------------
 WARNING: Explicit markup ends without a blank line; unexpected unindent.

File path: docker-stack/build-arg-ref.rst (73)

  68 | +------------------------------------------+------------------------------------------+---------------------------------------------+
  69 | 
  70 | List of default extras in the production Dockerfile:
  71 | 
  72 | .. BEGINNING OF EXTRAS LIST UPDATED BY PRE COMMIT
> 73 | * amazon
  74 | * async
  75 | * celery
  76 | * cncf.kubernetes
  77 | * dask
  78 | * docker
------------------------------ Error   2 --------------------
 WARNING: Bullet list ends without a blank line; unexpected unindent.

File path: docker-stack/build-arg-ref.rst (99)

  94 | * sftp
  95 | * slack
  96 | * ssh
  97 | * statsd
  98 | * virtualenv
> 99 | .. END OF EXTRAS LIST UPDATED BY PRE COMMIT
 100 | 
 101 | Image optimization options
 102 | ..........................
 103 | 
 104 | The main advantage of Customization method of building Airflow image, is that it allows to build highly optimized image because

############################## End docs build errors summary ##############################
```