### PR TITLE
Delete extra space in adding connections doc

### DIFF
--- a/docs/helm-chart/adding-connections-and-variables.rst
+++ b/docs/helm-chart/adding-connections-and-variables.rst
@@ -35,11 +35,11 @@ to override values under these sections of the ``values.yaml`` file.
 
    secret:
      - envName: "AIRFLOW_CONN_GCP"
-        secretName: "my-airflow-connections"
-        secretKey: "AIRFLOW_CONN_GCP"
-      - envName: "my-env"
-        secretName: "my-secret-name"
-        secretKey: "my-secret-key"
+       secretName: "my-airflow-connections"
+       secretKey: "AIRFLOW_CONN_GCP"
+     - envName: "my-env"
+       secretName: "my-secret-name"
+       secretKey: "my-secret-key"
 
    extraSecrets:
      my-airflow-connections:


### PR DESCRIPTION
Extra space in secret keys was causing an error while parsing values.yaml

Before this change, copying and pasting the example from the docs was causing:
```bash
Error: failed to parse values.yaml: error converting YAML to JSON: yaml: line 19: did not find expected key
```
