### PR TITLE
Add driver parameter for MsSQL URL for production image in docs

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -265,7 +265,15 @@ We recommend using the ``mssql+pyodbc`` driver and specifying it in your SqlAlch
 
 .. code-block:: text
 
-    mssql+pyodbc://<user>:<password>@<host>/<db>
+    mssql+pyodbc://<user>:<password>@<host>[:port]/<db>?[driver=<driver>]
+
+
+You do not need to specify the Driver if you have default driver configured in your system. For the
+Official Docker image we have ODBC driver installed, so you need to specify the ODBC driver to use:
+
+.. code-block:: text
+
+    mssql+pyodbc://<user>:<password>@<host>[:port]/<db>[?driver=ODBC+Driver+17+for+SQL+Server]
 
 
 Other configuration options


### PR DESCRIPTION
The production image uses ODBC Driver to connect to mssql, and you
need to specify the driver explicitely to make it works.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
