### PR TITLE
Switch to latest version of PGBouncer-Exporter

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -504,7 +504,7 @@
                         "tag": {
                             "description": "The PgBouncer exporter image tag.",
                             "type": "string",
-                            "default": "airflow-pgbouncer-exporter-2021.04.28-0.5.0"
+                            "default": "airflow-pgbouncer-exporter-2021.09.22-0.12.0"
                         },
                         "pullPolicy": {
                             "description": "The PgBouncer exporter image pull policy.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -78,7 +78,7 @@ images:
     pullPolicy: IfNotPresent
   pgbouncerExporter:
     repository: apache/airflow
-    tag: airflow-pgbouncer-exporter-2021.04.28-0.5.0
+    tag: airflow-pgbouncer-exporter-2021.09.22-0.12.0
     pullPolicy: IfNotPresent
   gitSync:
     repository: k8s.gcr.io/git-sync/git-sync


### PR DESCRIPTION
The latest version of pgbouncer exporter have been updated in
https://github.com/apache/airflow-pgbouncer-exporter/pull/3 and
pushed. This PR switches to this exporter version.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
