### PR TITLE
De-dup and reorganize render template tests

### DIFF
--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -31,6 +31,7 @@ from typing import Optional
 from unittest import mock
 from unittest.mock import patch
 
+import jinja2
 import pendulum
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -506,15 +507,34 @@ class TestDag(unittest.TestCase):
         )
         session.close()
 
-    def test_user_defined_filters(self):
+    def test_user_defined_filters_macros(self):
         def jinja_udf(name):
             return f'Hello {name}'
 
-        dag = models.DAG('test-dag', start_date=DEFAULT_DATE, user_defined_filters={"hello": jinja_udf})
+        dag = models.DAG(
+            'test-dag',
+            start_date=DEFAULT_DATE,
+            user_defined_filters={"hello": jinja_udf},
+            user_defined_macros={"foo": "bar"},
+        )
         jinja_env = dag.get_template_env()
 
         assert 'hello' in jinja_env.filters
         assert jinja_env.filters['hello'] == jinja_udf
+        assert jinja_env.globals['foo'] == 'bar'
+
+    def test_set_jinja_env_additional_option(self):
+        dag = DAG("test-dag", jinja_environment_kwargs={'keep_trailing_newline': True, 'cache_size': 50})
+        jinja_env = dag.get_template_env()
+        assert jinja_env.keep_trailing_newline is True
+        assert jinja_env.cache.capacity == 50
+
+        assert jinja_env.undefined is jinja2.StrictUndefined
+
+    def test_template_undefined(self):
+        dag = DAG("test-dag", template_undefined=jinja2.Undefined)
+        jinja_env = dag.get_template_env()
+        assert jinja_env.undefined is jinja2.Undefined
 
     def test_resolve_template_files_value(self):
 


### PR DESCRIPTION
- test_render_template_fields_native_envs duplicated the existing
  test_retest_render_template_with_native_envs
- Testing dag settings (user_defined_*) was testing the behaviour of
  Jinja2. The test has bee streamlined and moved to test_dag (where the
  jinija env is created)
- Tests of the undefined behaviour have been removed as it is just
  testing Jinja behaviour, moved to just testing property of env in
  test_dag.
- Removed neededless DAG creation
- Used BaseOperator instead of DummyOperator
- Used existing MockOperator class instead of file-local CustomOp


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).