### PR TITLE
Fix image retagging when pulling the images

### DIFF
--- a/scripts/ci/images/ci_prepare_ci_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_ci_image_on_ci.sh
@@ -33,6 +33,7 @@ function build_ci_image_on_ci() {
         md5sum::calculate_md5sum_for_all_files
         local image_name_with_tag="${AIRFLOW_CI_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
         push_pull_remove_images::wait_for_image "${image_name_with_tag}"
+        docker_v tag  "${image_name_with_tag}" "${AIRFLOW_CI_IMAGE}"
         md5sum::update_all_md5_with_group
     else
         build_images::rebuild_ci_image_if_needed

--- a/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
+++ b/scripts/ci/images/ci_prepare_prod_image_on_ci.sh
@@ -34,6 +34,7 @@ function build_prod_images_on_ci() {
     if [[ ${GITHUB_REGISTRY_WAIT_FOR_IMAGE} == "true" ]]; then
         local image_name_with_tag="${AIRFLOW_PROD_IMAGE}:${GITHUB_REGISTRY_PULL_IMAGE_TAG}"
         push_pull_remove_images::wait_for_image "${image_name_with_tag}"
+        docker_v tag  "${image_name_with_tag}" "${AIRFLOW_PROD_IMAGE}"
     else
         build_images::build_prod_images_from_locally_built_airflow_packages
     fi

--- a/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_ci_image.sh
@@ -37,3 +37,5 @@ push_pull_remove_images::wait_for_image "${image_name_with_tag}"
 if [[ ${VERIFY_IMAGE=} != "false" ]]; then
     verify_image::verify_ci_image "${image_name_with_tag}"
 fi
+
+docker_v tag  "${image_name_with_tag}" "${AIRFLOW_CI_IMAGE}"

--- a/scripts/ci/images/ci_wait_for_and_verify_prod_image.sh
+++ b/scripts/ci/images/ci_wait_for_and_verify_prod_image.sh
@@ -36,3 +36,5 @@ push_pull_remove_images::wait_for_image "${image_name_with_tag}"
 if [[ ${VERIFY_IMAGE=} != "false" ]]; then
     verify_image::verify_prod_image "${image_name_with_tag}"
 fi
+
+docker_v tag  "${image_name_with_tag}" "${AIRFLOW_PROD_IMAGE}"


### PR DESCRIPTION
The change #17883 missed re-tagging images after downloading
which caused unnecessary image rebuilding for PRs as well as using
wrong image for doc building - previous version of docs were used
when building docs!

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
