### PR TITLE
Add cascade to DagRun/TaskInstance relationship

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -124,7 +124,7 @@ class DagRun(Base, LoggingMixin):
         ),
     )
 
-    task_instances = relationship(TI, back_populates="dag_run")
+    task_instances = relationship(TI, back_populates="dag_run", cascade='all, delete, delete-orphan')
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(
         'scheduler',

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -124,7 +124,9 @@ class DagRun(Base, LoggingMixin):
         ),
     )
 
-    task_instances = relationship(TI, back_populates="dag_run", cascade='all, delete, delete-orphan')
+    task_instances = relationship(
+        TI, back_populates="dag_run", cascade='save-update, merge, delete, delete-orphan'
+    )
 
     DEFAULT_DAGRUNS_TO_EXAMINE = airflow_conf.getint(
         'scheduler',


### PR DESCRIPTION
We currently have an issue where deleting dagruns causes a dependency error in Sqlalchemy because
the session doesn't know what to do with the related taskinstances.
    
This PR adds cascade so that when a dagrun is marked for deletion, the related taskinstances
are also deleted

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask_appbuilder/models/sqla/interface.py", line 698, in delete
    self.session.commit()
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/scoping.py", line 163, in do
    return getattr(self.registry(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 1046, in commit
    self.transaction.commit()
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 504, in commit
    self._prepare_impl()
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 483, in _prepare_impl
    self.session.flush()
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 2540, in flush
    self._flush(objects)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 2682, in _flush
    transaction.rollback(_capture_exception=True)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    with_traceback=exc_tb,
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py", line 2642, in _flush
    flush_context.execute()
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/unitofwork.py", line 422, in execute
    rec.execute(self)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/unitofwork.py", line 538, in execute
    self.dependency_processor.process_deletes(uow, states)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/dependency.py", line 547, in process_deletes
    state, child, None, True, uowcommit, False
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/dependency.py", line 604, in _synchronize
    sync.clear(dest, self.mapper, self.prop.synchronize_pairs)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/sync.py", line 88, in clear
    "column '%s' on instance '%s'" % (r, orm_util.state_str(dest))
AssertionError: Dependency rule tried to blank-out primary key column 'task_instance.dag_id' on instance '<TaskInstance at 0x7fbdca3bc3c8>
```


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
