### PR TITLE
Protect agains images not being pulled properly

### DIFF
--- a/scripts/ci/docker-compose/backend-mssql-bind-volume.yml
+++ b/scripts/ci/docker-compose/backend-mssql-bind-volume.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   mssql:
     volumes:

--- a/scripts/ci/docker-compose/backend-mssql-docker-volume.yml
+++ b/scripts/ci/docker-compose/backend-mssql-docker-volume.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   mssql:
     volumes:

--- a/scripts/ci/docker-compose/backend-mssql-port.yml
+++ b/scripts/ci/docker-compose/backend-mssql-port.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   mssql:
     ports:

--- a/scripts/ci/docker-compose/backend-mssql.yml
+++ b/scripts/ci/docker-compose/backend-mssql.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/backend-mysql-port.yml
+++ b/scripts/ci/docker-compose/backend-mysql-port.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   mysql:
     ports:

--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     environment:
@@ -26,7 +25,6 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-
   mysql:
     image: mysql:${MYSQL_VERSION}
     environment:

--- a/scripts/ci/docker-compose/backend-postgres-port.yml
+++ b/scripts/ci/docker-compose/backend-postgres-port.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   postgres:
     ports:

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/backend-sqlite-port.yml
+++ b/scripts/ci/docker-compose/backend-sqlite-port.yml
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
+services:
+  sqlite:
+    ports: []

--- a/scripts/ci/docker-compose/backend-sqlite.yml
+++ b/scripts/ci/docker-compose/backend-sqlite.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     image: ${AIRFLOW_CI_IMAGE}
+    pull_policy: never
     environment:
       - USER=root
       - ADDITIONAL_PATH=~/.local/bin

--- a/scripts/ci/docker-compose/files.yml
+++ b/scripts/ci/docker-compose/files.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     volumes:

--- a/scripts/ci/docker-compose/forward-credentials.yml
+++ b/scripts/ci/docker-compose/forward-credentials.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     # Forwards local credentials to docker image

--- a/scripts/ci/docker-compose/ga.yml
+++ b/scripts/ci/docker-compose/ga.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   cassandra:
     image: cassandra:3.0

--- a/scripts/ci/docker-compose/integration-kerberos.yml
+++ b/scripts/ci/docker-compose/integration-kerberos.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   kdc-server-example-com:
     image: ghcr.io/apache/airflow-krb5-kdc-server:2021.07.04

--- a/scripts/ci/docker-compose/integration-mongo.yml
+++ b/scripts/ci/docker-compose/integration-mongo.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   mongo:
     image: mongo:3

--- a/scripts/ci/docker-compose/integration-openldap.yml
+++ b/scripts/ci/docker-compose/integration-openldap.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   openldap:
     image: ghcr.io/apache/airflow-openldap:2.4.50-2021.07.04

--- a/scripts/ci/docker-compose/integration-pinot.yml
+++ b/scripts/ci/docker-compose/integration-pinot.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   pinot:
     image: apachepinot/pinot:latest

--- a/scripts/ci/docker-compose/integration-rabbitmq.yml
+++ b/scripts/ci/docker-compose/integration-rabbitmq.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   rabbitmq:
     image: rabbitmq:3.7

--- a/scripts/ci/docker-compose/integration-redis.yml
+++ b/scripts/ci/docker-compose/integration-redis.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   redis:
     image: redis:5.0.1

--- a/scripts/ci/docker-compose/integration-statsd.yml
+++ b/scripts/ci/docker-compose/integration-statsd.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   statsd-exporter:
     image: apache/airflow:airflow-statsd-exporter-2020.09.05-v0.17.0

--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   trino:
     image: ghcr.io/apache/airflow-trino:359-2021.07.04

--- a/scripts/ci/docker-compose/local-all-sources.yml
+++ b/scripts/ci/docker-compose/local-all-sources.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     stdin_open: true  # docker run -i

--- a/scripts/ci/docker-compose/local.yml
+++ b/scripts/ci/docker-compose/local.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     stdin_open: true  # docker run -i

--- a/scripts/ci/docker-compose/remove-sources.yml
+++ b/scripts/ci/docker-compose/remove-sources.yml
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.2"
 services:
   airflow:
     # Forwards local credentials to docker image

--- a/scripts/ci/libraries/_runs.sh
+++ b/scripts/ci/libraries/_runs.sh
@@ -22,6 +22,7 @@ function runs::run_docs() {
     docker_v run "${EXTRA_DOCKER_FLAGS[@]}" -t \
         -e "GITHUB_ACTIONS=${GITHUB_ACTIONS="false"}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
+        --pull never \
         "${AIRFLOW_CI_IMAGE}" \
         "--" "/opt/airflow/scripts/in_container/run_docs_build.sh" "${@}"
     start_end::group_end
@@ -32,6 +33,7 @@ function runs::run_generate_constraints() {
     start_end::group_start "Run generate constraints"
     docker_v run "${EXTRA_DOCKER_FLAGS[@]}" \
         --entrypoint "/usr/local/bin/dumb-init"  \
+        --pull never \
         "${AIRFLOW_CI_IMAGE}" \
         "--" "/opt/airflow/scripts/in_container/run_generate_constraints.sh"
     start_end::group_end
@@ -44,6 +46,7 @@ function runs::run_prepare_airflow_packages() {
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
         -v "${AIRFLOW_SOURCES}:/opt/airflow" \
+        --pull never \
         "${AIRFLOW_CI_IMAGE}" \
         "--" "/opt/airflow/scripts/in_container/run_prepare_airflow_packages.sh"
     start_end::group_end
@@ -57,6 +60,7 @@ function runs::run_prepare_provider_packages() {
         --entrypoint "/usr/local/bin/dumb-init"  \
         -t \
         -v "${AIRFLOW_SOURCES}:/opt/airflow" \
+        --pull never \
         "${AIRFLOW_CI_IMAGE}" \
         "--" "/opt/airflow/scripts/in_container/run_prepare_provider_packages.sh" "${@}"
 }
@@ -75,6 +79,7 @@ function runs::run_prepare_provider_documentation() {
         -e "NON_INTERACTIVE" \
         -e "GENERATE_PROVIDERS_ISSUE" \
         -e "GITHUB_TOKEN" \
+        --pull never \
         "${AIRFLOW_CI_IMAGE}" \
         "--" "/opt/airflow/scripts/in_container/run_prepare_provider_documentation.sh" "${@}"
 }


### PR DESCRIPTION
Recently we had a problem that our CI got broken because
pulled images were not tagged properly after #17883 missed image
tagging. This has been fixed in #18433 but the problem is that this
might happen in the future and mignt not get noticed on time.

This PR prevents from similar situations happnening. Whenever we
try to run doc building or tests we set --pull policy to never
for both docker and docker compose which should simply fail if
the images were not pulled and tagged properly rather than
fail over to pulling latest `main` image.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
