### PR TITLE
Add muldelete action to TaskInstanceModelView and tests. Change permissions for TaskInstanceModelView.action_clear to "delete"

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3896,7 +3896,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     class_permission_name = permissions.RESOURCE_DAG_RUN
     method_permission_name = {
         'list': 'read',
-        'action_clear': 'delete',
+        'action_clear': 'edit',
         'action_muldelete': 'delete',
         'action_set_running': 'edit',
         'action_set_failed': 'edit',
@@ -4204,6 +4204,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     method_permission_name = {
         'list': 'read',
         'action_clear': 'edit',
+        'action_muldelete': 'delete',
         'action_set_running': 'edit',
         'action_set_failed': 'edit',
         'action_set_success': 'edit',
@@ -4335,6 +4336,13 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
             flash(f"{len(task_instances)} task instances have been cleared")
         except Exception as e:
             flash(f'Failed to clear task instances: "{e}"', 'error')
+        self.update_redirect()
+        return redirect(self.get_redirect())
+
+    @action('muldelete', 'Delete', "Are you sure you want to delete selected records?", single=False)
+    @action_has_dag_edit_access
+    def action_muldelete(self, items):
+        self.datamodel.delete_all(items)
         self.update_redirect()
         return redirect(self.get_redirect())
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Closes #18333.  Adds a Delete option in `TaskInstanceModelView` and deletes multiple `TaskInstance`s based on which options are checked in the model view.  Added unit tests for this as well.  Tests that the right tasks get deleted and also tests that deletes get cascaded to `TaskReschedule`s in the meta DB.

Also, changed permissions for `DagRunModelView`'s `action_clear` to be `edit` instead of `delete`.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
