### PR TITLE
Check and run migration in commands if necessary

### DIFF
--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -37,7 +37,7 @@ from airflow.utils.serve_logs import serve_logs
 WORKER_PROCESS_NAME = "worker"
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def flower(args):
     """Starts Flower, Celery monitoring tool"""
     options = [
@@ -97,7 +97,7 @@ def _run_worker(options, skip_serve_logs):
             sub_proc.terminate()
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def worker(args):
     """Starts Airflow Celery worker"""
     if not settings.validate_session():
@@ -188,7 +188,7 @@ def worker(args):
         _run_worker(options=options, skip_serve_logs=skip_serve_logs)
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def stop_worker(args):
     """Sends SIGTERM to Celery worker"""
     # Read PID from file

--- a/airflow/cli/commands/celery_command.py
+++ b/airflow/cli/commands/celery_command.py
@@ -37,7 +37,7 @@ from airflow.utils.serve_logs import serve_logs
 WORKER_PROCESS_NAME = "worker"
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def flower(args):
     """Starts Flower, Celery monitoring tool"""
     options = [
@@ -97,7 +97,7 @@ def _run_worker(options, skip_serve_logs):
             sub_proc.terminate()
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def worker(args):
     """Starts Airflow Celery worker"""
     if not settings.validate_session():
@@ -188,7 +188,7 @@ def worker(args):
         _run_worker(options=options, skip_serve_logs=skip_serve_logs)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def stop_worker(args):
     """Sends SIGTERM to Celery worker"""
     # Read PID from file

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -154,7 +154,7 @@ def connections_export(args):
 alternative_conn_specs = ['conn_type', 'conn_host', 'conn_login', 'conn_password', 'conn_schema', 'conn_port']
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def connections_add(args):
     """Adds new connection"""
     # Check that the conn_id and conn_uri args were passed to the command:
@@ -221,7 +221,7 @@ def connections_add(args):
             raise SystemExit(msg)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def connections_delete(args):
     """Deletes connection from DB"""
     with create_session() as session:
@@ -236,7 +236,7 @@ def connections_delete(args):
             print(f"Successfully deleted connection with `conn_id`={to_delete.conn_id}")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def connections_import(args):
     """Imports connections from a file"""
     if os.path.exists(args.file):

--- a/airflow/cli/commands/connection_command.py
+++ b/airflow/cli/commands/connection_command.py
@@ -154,7 +154,7 @@ def connections_export(args):
 alternative_conn_specs = ['conn_type', 'conn_host', 'conn_login', 'conn_password', 'conn_schema', 'conn_port']
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def connections_add(args):
     """Adds new connection"""
     # Check that the conn_id and conn_uri args were passed to the command:
@@ -221,7 +221,7 @@ def connections_add(args):
             raise SystemExit(msg)
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def connections_delete(args):
     """Deletes connection from DB"""
     with create_session() as session:

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -51,7 +51,7 @@ from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_backfill(args, dag=None):
     """Creates backfill job or dry run for a DAG"""
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
@@ -130,7 +130,7 @@ def dag_backfill(args, dag=None):
             sys.exit(1)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_trigger(args):
     """Creates a dag run for the specified dag"""
     api_client = get_current_api_client()
@@ -143,7 +143,7 @@ def dag_trigger(args):
         raise AirflowException(err)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_delete(args):
     """Deletes all DB records related to the specified dag"""
     api_client = get_current_api_client()
@@ -161,13 +161,13 @@ def dag_delete(args):
         print("Cancelled")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_pause(args):
     """Pauses a DAG"""
     set_is_paused(True, args)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_unpause(args):
     """Unpauses a DAG"""
     set_is_paused(False, args)
@@ -248,7 +248,7 @@ def _save_dot_to_file(dot: Dot, filename: str):
     print(f"File {filename} saved")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_state(args):
     """
     Returns the state (and conf if exists) of a DagRun at the command line.
@@ -269,7 +269,7 @@ def dag_state(args):
     print(str(out) + conf_out)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_next_execution(args):
     """
     Returns the next execution datetime of a DAG at the command line.
@@ -314,7 +314,7 @@ def dag_next_execution(args):
         print(next_info.logical_date.isoformat())
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def dag_list_dags(args):
     """Displays dags with or without stats at the command line"""
@@ -331,7 +331,7 @@ def dag_list_dags(args):
     )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def dag_report(args):
     """Displays dagbag stats at the command line"""
@@ -349,7 +349,7 @@ def dag_report(args):
     )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def dag_list_jobs(args, dag=None):
     """Lists latest n jobs"""
@@ -384,7 +384,7 @@ def dag_list_jobs(args, dag=None):
     )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def dag_list_dag_runs(args, dag=None):
     """Lists dag runs for a given DAG"""
@@ -422,7 +422,7 @@ def dag_list_dag_runs(args, dag=None):
 
 
 @provide_session
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_test(args, session=None):
     """Execute one single DagRun for a given DAG and execution date, using the DebugExecutor."""
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -51,7 +51,7 @@ from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_backfill(args, dag=None):
     """Creates backfill job or dry run for a DAG"""
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)
@@ -130,7 +130,7 @@ def dag_backfill(args, dag=None):
             sys.exit(1)
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_trigger(args):
     """Creates a dag run for the specified dag"""
     api_client = get_current_api_client()
@@ -143,7 +143,7 @@ def dag_trigger(args):
         raise AirflowException(err)
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_delete(args):
     """Deletes all DB records related to the specified dag"""
     api_client = get_current_api_client()
@@ -161,13 +161,13 @@ def dag_delete(args):
         print("Cancelled")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_pause(args):
     """Pauses a DAG"""
     set_is_paused(True, args)
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_unpause(args):
     """Unpauses a DAG"""
     set_is_paused(False, args)
@@ -248,7 +248,7 @@ def _save_dot_to_file(dot: Dot, filename: str):
     print(f"File {filename} saved")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_state(args):
     """
     Returns the state (and conf if exists) of a DagRun at the command line.
@@ -269,7 +269,7 @@ def dag_state(args):
     print(str(out) + conf_out)
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_next_execution(args):
     """
     Returns the next execution datetime of a DAG at the command line.
@@ -314,7 +314,7 @@ def dag_next_execution(args):
         print(next_info.logical_date.isoformat())
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def dag_list_dags(args):
     """Displays dags with or without stats at the command line"""
@@ -331,7 +331,7 @@ def dag_list_dags(args):
     )
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def dag_report(args):
     """Displays dagbag stats at the command line"""
@@ -349,7 +349,7 @@ def dag_report(args):
     )
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def dag_list_jobs(args, dag=None):
     """Lists latest n jobs"""
@@ -384,7 +384,7 @@ def dag_list_jobs(args, dag=None):
     )
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def dag_list_dag_runs(args, dag=None):
     """Lists dag runs for a given DAG"""
@@ -422,7 +422,7 @@ def dag_list_dag_runs(args, dag=None):
 
 
 @provide_session
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_test(args, session=None):
     """Execute one single DagRun for a given DAG and execution date, using the DebugExecutor."""
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
@@ -464,7 +464,7 @@ def dag_test(args, session=None):
 
 
 @provide_session
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def dag_reserialize(args, session=None):
     session.query(SerializedDagModel).delete(synchronize_session=False)
 

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -464,7 +464,7 @@ def dag_test(args, session=None):
 
 
 @provide_session
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def dag_reserialize(args, session=None):
     session.query(SerializedDagModel).delete(synchronize_session=False)
 

--- a/airflow/cli/commands/db_command.py
+++ b/airflow/cli/commands/db_command.py
@@ -41,7 +41,7 @@ def resetdb(args):
         print("Cancelled")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def upgradedb(args):
     """Upgrades the metadata database"""
     print("DB: " + repr(settings.engine.url))
@@ -54,7 +54,7 @@ def check_migrations(args):
     db.check_migrations(timeout=args.migration_wait_timeout)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def shell(args):
     """Run a shell that allows to access metadata database"""
     url = settings.engine.url
@@ -90,7 +90,7 @@ def shell(args):
         raise AirflowException(f"Unknown driver: {url.drivername}")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def check(_):
     """Runs a check command that checks if db is available."""
     db.check()

--- a/airflow/cli/commands/kerberos_command.py
+++ b/airflow/cli/commands/kerberos_command.py
@@ -25,7 +25,7 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def kerberos(args):
     """Start a kerberos ticket renewer"""
     print(settings.HEADER)

--- a/airflow/cli/commands/kerberos_command.py
+++ b/airflow/cli/commands/kerberos_command.py
@@ -25,7 +25,7 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def kerberos(args):
     """Start a kerberos ticket renewer"""
     print(settings.HEADER)

--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -32,7 +32,7 @@ from airflow.utils import cli as cli_utils, yaml
 from airflow.utils.cli import get_dag
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def generate_pod_yaml(args):
     """Generates yaml files for each task in the DAG. Used for testing output of KubernetesExecutor"""
     execution_date = args.execution_date
@@ -67,7 +67,7 @@ def generate_pod_yaml(args):
     print(f"YAML output can be found at {yaml_output_path}/airflow_yaml_output/")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def cleanup_pods(args):
     """Clean up k8s pods in evicted/failed/succeeded states"""
     namespace = args.namespace

--- a/airflow/cli/commands/kubernetes_command.py
+++ b/airflow/cli/commands/kubernetes_command.py
@@ -32,7 +32,7 @@ from airflow.utils import cli as cli_utils, yaml
 from airflow.utils.cli import get_dag
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def generate_pod_yaml(args):
     """Generates yaml files for each task in the DAG. Used for testing output of KubernetesExecutor"""
     execution_date = args.execution_date
@@ -67,7 +67,7 @@ def generate_pod_yaml(args):
     print(f"YAML output can be found at {yaml_output_path}/airflow_yaml_output/")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def cleanup_pods(args):
     """Clean up k8s pods in evicted/failed/succeeded states"""
     namespace = args.namespace

--- a/airflow/cli/commands/pool_command.py
+++ b/airflow/cli/commands/pool_command.py
@@ -58,7 +58,7 @@ def pool_get(args):
         raise SystemExit(f"Pool {args.pool} does not exist")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def pool_set(args):
     """Creates new pool with a given name and slots"""
@@ -67,7 +67,7 @@ def pool_set(args):
     print("Pool created")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def pool_delete(args):
     """Deletes pool by a given name"""
@@ -79,7 +79,7 @@ def pool_delete(args):
         raise SystemExit(f"Pool {args.pool} does not exist")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def pool_import(args):
     """Imports pools from the file"""

--- a/airflow/cli/commands/pool_command.py
+++ b/airflow/cli/commands/pool_command.py
@@ -58,7 +58,7 @@ def pool_get(args):
         raise SystemExit(f"Pool {args.pool} does not exist")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def pool_set(args):
     """Creates new pool with a given name and slots"""
@@ -67,7 +67,7 @@ def pool_set(args):
     print("Pool created")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def pool_delete(args):
     """Deletes pool by a given name"""
@@ -79,7 +79,7 @@ def pool_delete(args):
         raise SystemExit(f"Pool {args.pool} does not exist")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def pool_import(args):
     """Imports pools from the file"""

--- a/airflow/cli/commands/role_command.py
+++ b/airflow/cli/commands/role_command.py
@@ -37,7 +37,7 @@ def roles_list(args):
     )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def roles_create(args):
     """Creates new empty role in DB"""
@@ -64,7 +64,7 @@ def roles_export(args):
     print(f"{len(exporting_roles)} roles successfully exported to {filename}")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 @suppress_logs_and_warning
 def roles_import(args):
     """

--- a/airflow/cli/commands/role_command.py
+++ b/airflow/cli/commands/role_command.py
@@ -37,7 +37,7 @@ def roles_list(args):
     )
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def roles_create(args):
     """Creates new empty role in DB"""
@@ -64,7 +64,7 @@ def roles_export(args):
     print(f"{len(exporting_roles)} roles successfully exported to {filename}")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 @suppress_logs_and_warning
 def roles_import(args):
     """

--- a/airflow/cli/commands/rotate_fernet_key_command.py
+++ b/airflow/cli/commands/rotate_fernet_key_command.py
@@ -20,7 +20,7 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.session import create_session
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def rotate_fernet_key(args):
     """Rotates all encrypted connection credentials and variables"""
     with create_session() as session:

--- a/airflow/cli/commands/rotate_fernet_key_command.py
+++ b/airflow/cli/commands/rotate_fernet_key_command.py
@@ -20,7 +20,7 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.session import create_session
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def rotate_fernet_key(args):
     """Rotates all encrypted connection credentials and variables"""
     with create_session() as session:

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -49,7 +49,7 @@ def _run_scheduler_job(args):
             sub_proc.terminate()
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def scheduler(args):
     """Starts Airflow Scheduler"""
     print(settings.HEADER)

--- a/airflow/cli/commands/scheduler_command.py
+++ b/airflow/cli/commands/scheduler_command.py
@@ -49,7 +49,7 @@ def _run_scheduler_job(args):
             sub_proc.terminate()
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def scheduler(args):
     """Starts Airflow Scheduler"""
     print(settings.HEADER)

--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -20,7 +20,7 @@ from airflow.utils import cli as cli_utils
 from airflow.www.app import cached_app
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def sync_perm(args):
     """Updates permissions for existing roles and DAGs"""
     appbuilder = cached_app().appbuilder

--- a/airflow/cli/commands/sync_perm_command.py
+++ b/airflow/cli/commands/sync_perm_command.py
@@ -20,7 +20,7 @@ from airflow.utils import cli as cli_utils
 from airflow.www.app import cached_app
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def sync_perm(args):
     """Updates permissions for existing roles and DAGs"""
     appbuilder = cached_app().appbuilder

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -226,7 +226,7 @@ def _capture_task_logs(ti):
             root_logger.handlers[:] = orig_handlers
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def task_run(args, dag=None):
     """Run a single task instance.
 
@@ -299,7 +299,7 @@ def task_run(args, dag=None):
             _run_task_by_selected_method(args, dag, ti)
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def task_failed_deps(args):
     """
     Returns the unmet dependencies for a task instance from the perspective of the
@@ -326,7 +326,7 @@ def task_failed_deps(args):
         print("Task instance dependencies are all met.")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
 def task_state(args):
     """
@@ -340,7 +340,7 @@ def task_state(args):
     print(ti.current_state())
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
 def task_list(args, dag=None):
     """Lists the tasks within a DAG at the command line"""
@@ -380,7 +380,7 @@ def _guess_debugger():
     return importlib.import_module("pdb")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
 @provide_session
 def task_states_for_dag_run(args, session=None):
@@ -421,7 +421,7 @@ def task_states_for_dag_run(args, session=None):
     )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def task_test(args, dag=None):
     """Tests task for a given dag_id"""
     # We want to log output from operators etc to show up here. Normally
@@ -475,7 +475,7 @@ def task_test(args, dag=None):
             logging.getLogger('airflow.task').propagate = False
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 @suppress_logs_and_warning
 def task_render(args):
     """Renders and displays templated fields for a given task"""
@@ -495,7 +495,7 @@ def task_render(args):
         )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=False)
 def task_clear(args):
     """Clears all task instances or only those matched by regex for a DAG(s)"""
     logging.basicConfig(level=settings.LOGGING_LEVEL, format=settings.SIMPLE_LOG_FORMAT)

--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -27,7 +27,7 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, sigquit_handler
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def triggerer(args):
     """Starts Airflow Triggerer"""
     print(settings.HEADER)

--- a/airflow/cli/commands/triggerer_command.py
+++ b/airflow/cli/commands/triggerer_command.py
@@ -27,7 +27,7 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, sigquit_handler
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def triggerer(args):
     """Starts Airflow Triggerer"""
     print(settings.HEADER)

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -85,7 +85,7 @@ def _find_user(args):
     return user
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def users_delete(args):
     """Deletes user from DB"""
     user = _find_user(args)
@@ -98,7 +98,7 @@ def users_delete(args):
         raise SystemExit('Failed to delete user')
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def users_manage_role(args, remove=False):
     """Deletes or appends user roles"""
     user = _find_user(args)
@@ -152,7 +152,7 @@ def users_export(args):
         print(f"{len(users)} users successfully exported to {file.name}")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def users_import(args):
     """Imports users from the json file"""
     json_file = getattr(args, 'import')

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -41,7 +41,7 @@ def users_list(args):
     )
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli(check_db=True)
 def users_create(args):
     """Creates new user in the DB"""
     appbuilder = cached_app().appbuilder
@@ -85,7 +85,7 @@ def _find_user(args):
     return user
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def users_delete(args):
     """Deletes user from DB"""
     user = _find_user(args)
@@ -98,7 +98,7 @@ def users_delete(args):
         raise SystemExit('Failed to delete user')
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def users_manage_role(args, remove=False):
     """Deletes or appends user roles"""
     user = _find_user(args)
@@ -152,7 +152,7 @@ def users_export(args):
         print(f"{len(users)} users successfully exported to {file.name}")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def users_import(args):
     """Imports users from the json file"""
     json_file = getattr(args, 'import')

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -49,21 +49,21 @@ def variables_get(args):
         raise SystemExit(str(e).strip("'\""))
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def variables_set(args):
     """Creates new variable with a given name and value"""
     Variable.set(args.key, args.value, serialize_json=args.json)
     print(f"Variable {args.key} created")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def variables_delete(args):
     """Deletes variable by a given name"""
     Variable.delete(args.key)
     print(f"Variable {args.key} deleted")
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def variables_import(args):
     """Imports variables from a given file"""
     if os.path.exists(args.file):

--- a/airflow/cli/commands/variable_command.py
+++ b/airflow/cli/commands/variable_command.py
@@ -49,21 +49,21 @@ def variables_get(args):
         raise SystemExit(str(e).strip("'\""))
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def variables_set(args):
     """Creates new variable with a given name and value"""
     Variable.set(args.key, args.value, serialize_json=args.json)
     print(f"Variable {args.key} created")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def variables_delete(args):
     """Deletes variable by a given name"""
     Variable.delete(args.key)
     print(f"Variable {args.key} deleted")
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def variables_import(args):
     """Imports variables from a given file"""
     if os.path.exists(args.file):

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -313,7 +313,7 @@ class GunicornMonitor(LoggingMixin):
                 self._reload_gunicorn()
 
 
-@cli_utils.action_logging
+@cli_utils.action_cli()
 def webserver(args):
     """Starts Airflow Webserver"""
     print(settings.HEADER)

--- a/airflow/cli/commands/webserver_command.py
+++ b/airflow/cli/commands/webserver_command.py
@@ -313,7 +313,7 @@ class GunicornMonitor(LoggingMixin):
                 self._reload_gunicorn()
 
 
-@cli_utils.action_cli()
+@cli_utils.action_cli
 def webserver(args):
     """Starts Airflow Webserver"""
     print(settings.HEADER)

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -104,6 +104,8 @@ def action_cli(check_db=True):
 
         return cast(T, wrapper)
 
+    if func:
+        return action_logging(func)
     return action_logging
 
 

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Callable, Optional, TypeVar, cast
 from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.utils import cli_action_loggers
+from airflow.utils.db import check_and_run_migrations
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 from airflow.utils.platform import getuser, is_terminal_support_colors
 from airflow.utils.session import provide_session
@@ -53,51 +54,57 @@ def _check_cli_args(args):
         )
 
 
-def action_logging(f: T) -> T:
-    """
-    Decorates function to execute function at the same time submitting action_logging
-    but in CLI context. It will call action logger callbacks twice,
-    one for pre-execution and the other one for post-execution.
-
-    Action logger will be called with below keyword parameters:
-        sub_command : name of sub-command
-        start_datetime : start datetime instance by utc
-        end_datetime : end datetime instance by utc
-        full_command : full command line arguments
-        user : current user
-        log : airflow.models.log.Log ORM instance
-        dag_id : dag id (optional)
-        task_id : task_id (optional)
-        execution_date : execution date (optional)
-        error : exception instance if there's an exception
-
-    :param f: function instance
-    :return: wrapped function
-    """
-
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
+def action_cli(check_db=True):
+    def action_logging(f: T) -> T:
         """
-        An wrapper for cli functions. It assumes to have Namespace instance
-        at 1st positional argument
+        Decorates function to execute function at the same time submitting action_logging
+        but in CLI context. It will call action logger callbacks twice,
+        one for pre-execution and the other one for post-execution.
 
-        :param args: Positional argument. It assumes to have Namespace instance
+        Action logger will be called with below keyword parameters:
+            sub_command : name of sub-command
+            start_datetime : start datetime instance by utc
+            end_datetime : end datetime instance by utc
+            full_command : full command line arguments
+            user : current user
+            log : airflow.models.log.Log ORM instance
+            dag_id : dag id (optional)
+            task_id : task_id (optional)
+            execution_date : execution date (optional)
+            error : exception instance if there's an exception
+
+        :param f: function instance
+        :return: wrapped function
+        """
+
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            """
+            An wrapper for cli functions. It assumes to have Namespace instance
             at 1st positional argument
-        :param kwargs: A passthrough keyword argument
-        """
-        _check_cli_args(args)
-        metrics = _build_metrics(f.__name__, args[0])
-        cli_action_loggers.on_pre_execution(**metrics)
-        try:
-            return f(*args, **kwargs)
-        except Exception as e:
-            metrics['error'] = e
-            raise
-        finally:
-            metrics['end_datetime'] = datetime.utcnow()
-            cli_action_loggers.on_post_execution(**metrics)
 
-    return cast(T, wrapper)
+            :param args: Positional argument. It assumes to have Namespace instance
+                at 1st positional argument
+            :param kwargs: A passthrough keyword argument
+            """
+            _check_cli_args(args)
+            metrics = _build_metrics(f.__name__, args[0])
+            cli_action_loggers.on_pre_execution(**metrics)
+            try:
+                # Check and run migrations if necessary
+                if check_db:
+                    check_and_run_migrations()
+                return f(*args, **kwargs)
+            except Exception as e:
+                metrics['error'] = e
+                raise
+            finally:
+                metrics['end_datetime'] = datetime.utcnow()
+                cli_action_loggers.on_post_execution(**metrics)
+
+        return cast(T, wrapper)
+
+    return action_logging
 
 
 def _build_metrics(func_name, namespace):

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -54,7 +54,7 @@ def _check_cli_args(args):
         )
 
 
-def action_cli(check_db=True):
+def action_cli(func=None, check_db=True):
     def action_logging(f: T) -> T:
         """
         Decorates function to execute function at the same time submitting action_logging

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -656,7 +656,6 @@ def check_migrations(timeout):
         )
 
 
-
 def _get_script_dir_and_config():
     """Get config and script directory"""
     from alembic.script import ScriptDirectory
@@ -704,7 +703,7 @@ def check_and_run_migrations():
                     print(error)
                     print(
                         "You still have unapplied migrations. "
-                        "You may need to reset the database by running `airflow db reset`",
+                        "You may need to {verb} the database by running `airflow db {command_name}`",
                         f"Make sure the command is run using airflow version {version}.",
                         file=sys.stderr,
                     )

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -19,6 +19,7 @@ import contextlib
 import enum
 import logging
 import os
+import sys
 import time
 from tempfile import gettempdir
 from typing import Iterable
@@ -27,6 +28,7 @@ from sqlalchemy import Table, exc, func, inspect, or_, text
 
 from airflow import settings
 from airflow.configuration import conf
+from airflow.exceptions import AirflowException
 from airflow.jobs.base_job import BaseJob  # noqa: F401
 from airflow.models import (  # noqa: F401
     DAG,
@@ -52,9 +54,11 @@ from airflow.models import (  # noqa: F401
 
 # We need to add this model manually to get reset working well
 from airflow.models.serialized_dag import SerializedDagModel  # noqa: F401
+from airflow.utils import helpers
 
 # TODO: remove create_session once we decide to break backward compatibility
 from airflow.utils.session import create_session, provide_session  # noqa: F401
+from airflow.version import version
 
 log = logging.getLogger(__name__)
 
@@ -625,35 +629,95 @@ def _get_alembic_config():
 def check_migrations(timeout):
     """
     Function to wait for all airflow migrations to complete.
-
     :param timeout: Timeout for the migration in seconds
     :return: None
     """
     from alembic.runtime.environment import EnvironmentContext
-    from alembic.script import ScriptDirectory
 
-    config = _get_alembic_config()
-    script_ = ScriptDirectory.from_config(config)
+    script_, config = _get_script_dir_and_config()
     with EnvironmentContext(
         config,
         script_,
     ) as env, settings.engine.connect() as connection:
         env.configure(connection)
         context = env.get_context()
-        ticker = 0
-        while True:
+        source_heads = None
+        db_heads = None
+        for ticker in range(timeout):
             source_heads = set(script_.get_heads())
             db_heads = set(context.get_current_heads())
             if source_heads == db_heads:
-                break
-            if ticker >= timeout:
-                raise TimeoutError(
-                    f"There are still unapplied migrations after {ticker} seconds. Migration"
-                    f"Head(s) in DB: {db_heads} | Migration Head(s) in Source Code: {source_heads}"
-                )
-            ticker += 1
+                return
             time.sleep(1)
             log.info('Waiting for migrations... %s second(s)', ticker)
+        raise TimeoutError(
+            f"There are still unapplied migrations after {timeout} seconds. Migration"
+            f"Head(s) in DB: {db_heads} | Migration Head(s) in Source Code: {source_heads}"
+        )
+
+
+
+def _get_script_dir_and_config():
+    """Get config and script directory"""
+    from alembic.script import ScriptDirectory
+
+    config = _get_alembic_config()
+    script_ = ScriptDirectory.from_config(config)
+    return script_, config
+
+
+def check_and_run_migrations():
+    """Check and run migrations if necessary. Only use in a tty"""
+    from alembic.runtime.environment import EnvironmentContext
+
+    script_, config = _get_script_dir_and_config()
+    with EnvironmentContext(
+        config,
+        script_,
+    ) as env, settings.engine.connect() as connection:
+        env.configure(connection)
+        context = env.get_context()
+        source_heads = set(script_.get_heads())
+        db_heads = set(context.get_current_heads())
+        db_command = None
+        command_name = None
+        verb = None
+    if len(db_heads) < 1:
+        db_command = initdb
+        command_name = "init"
+        verb = "initialization"
+    elif source_heads != db_heads:
+        db_command = upgradedb
+        command_name = "upgrade"
+        verb = "upgrade"
+
+    if sys.stdout.isatty() and verb:
+        print()
+        question = f"Please confirm database {verb} (or wait 4 seconds to skip it). Are you sure?"
+        try:
+            answer = helpers.prompt_with_timeout(question, timeout=4)
+            if answer:
+                try:
+                    db_command()
+                    print(f"DB {verb} done")
+                except Exception as error:
+                    print(error)
+                    print(
+                        "You still have unapplied migrations. "
+                        "You may need to reset the database by running `airflow db reset`",
+                        f"Make sure the command is run using airflow version {version}.",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
+        except AirflowException:
+            pass
+    elif source_heads != db_heads:
+        print(
+            f"ERROR: You need to {verb} the database. Please run `airflow db {command_name}` ."
+            f"Make sure the command is run using airflow version {version}.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 def check_conn_id_duplicates(session=None) -> Iterable[str]:

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -15,8 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 import re
+import signal
 import warnings
 from datetime import datetime
 from functools import reduce
@@ -95,6 +95,20 @@ def ask_yesno(question: str) -> bool:
             return False
         else:
             print("Please respond by yes or no.")
+
+
+def prompt_with_timeout(question: str, timeout: int):
+    """Ask user a question and timeout after timeout"""
+
+    def handler(signum, frame):
+        raise AirflowException(f"Timeout {timeout}s reached")
+
+    signal.signal(signal.SIGALRM, handler)
+    signal.alarm(timeout)
+    try:
+        return ask_yesno(question)
+    finally:
+        signal.alarm(0)
 
 
 def is_container(obj: Any) -> bool:

--- a/tests/utils/test_cli_util.py
+++ b/tests/utils/test_cli_util.py
@@ -176,11 +176,11 @@ def fail_action_logger_callback():
     cli_action_loggers.__pre_exec_callbacks = tmp
 
 
-@cli.action_logging
+@cli.action_cli(check_db=False)
 def fail_func(_):
     raise NotImplementedError
 
 
-@cli.action_logging
+@cli.action_cli(check_db=False)
 def success_func(_):
     pass


### PR DESCRIPTION
This PR proposes to add db initialization and upgrade in webserver startup.

When the webserver is started, we check the migrations and decide whether
to initialize the database or upgrade it.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
