### PR TITLE
Adds CeleryKubernetesExecutor check to AirflowBaseView.run

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1538,6 +1538,7 @@ class Airflow(AirflowBaseView):
         executor = ExecutorLoader.get_default_executor()
         valid_celery_config = False
         valid_kubernetes_config = False
+        valid_celery_kubernetes_config = False
 
         try:
             from airflow.executors.celery_executor import CeleryExecutor
@@ -1552,9 +1553,16 @@ class Airflow(AirflowBaseView):
             valid_kubernetes_config = isinstance(executor, KubernetesExecutor)
         except ImportError:
             pass
+        
+        try:
+            airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
 
-        if not valid_celery_config and not valid_kubernetes_config:
-            flash("Only works with the Celery or Kubernetes executors, sorry", "error")
+            valid_celery_kubernetes_config = isinstance(executor, CeleryKubernetesExecutor)
+        except ImportError:
+            pass
+
+        if not valid_celery_config and not valid_kubernetes_config and not valid_celery_kubernetes_config:
+            flash("Only works with the Celery, CeleryKubernetes or Kubernetes executors, sorry", "error")
             return redirect(origin)
 
         dag_run = dag.get_dagrun(execution_date=execution_date)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1555,7 +1555,7 @@ class Airflow(AirflowBaseView):
             pass
         
         try:
-            airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
+            from airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
 
             valid_celery_kubernetes_config = isinstance(executor, CeleryKubernetesExecutor)
         except ImportError:

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1553,7 +1553,6 @@ class Airflow(AirflowBaseView):
             valid_kubernetes_config = isinstance(executor, KubernetesExecutor)
         except ImportError:
             pass
-        
         try:
             from airflow.executors.celery_kubernetes_executor import CeleryKubernetesExecutor
 


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/18440
Without this fix an Airflow Instance using CeleryKubernetesExecutor will fail to Run a Task Instance with error "Only works with the Celery or Kubernetes executors, sorry".

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #18440
related: #18440

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
