### PR TITLE
Avoid importing DAGs during clean DB installation

### DIFF
--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -70,6 +70,9 @@ def upgrade():
         # Get current session
         sessionmaker = sa.orm.sessionmaker()
         session = sessionmaker(bind=connection)
+        if not bool(session.query(TaskInstance).first()):
+            session.commit()
+            return
         dagbag = DagBag(settings.DAGS_FOLDER)
         query = session.query(sa.func.count(TaskInstance.max_tries)).filter(TaskInstance.max_tries == -1)
         # Separate db query in batch to prevent loading entire table


### PR DESCRIPTION
One of our migration (adding max_tries) creates the DagBag and
effectively parses all the DAGS while performing the migraiions.

While this is needed in case you migrate from an older version of
the DB where you have some TaskInstances requiring migration, for
an empty database, there are no TaskInstance entities in the DB
and parsing of all the DAGs is not needed.

Actually it can even be harmful. If you attempt to run Airflow
Migration on an empty dataase and your DAGs will be erroneous,
your migration will break in the middle and you have no
clue what caused it = see #18408 for an example of such failure.

This PR skips DagBag import when there are no TaskInstance in
the database to migrate.

Fixes: #18449

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
