### PR TITLE
Proper handling of Account URL custom conn field in AzureBatchHook

### DIFF
--- a/docs/apache-airflow-providers-microsoft-azure/connections/azure_batch.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/azure_batch.rst
@@ -19,10 +19,10 @@
 
 .. _howto/connection:azure_batch:
 
-Microsoft Azure Batch Connection
-====================================
+Microsoft Azure Batch
+=====================
 
-The Microsoft Azure Batch connection type enables the Azure Batch Integrations.
+The Microsoft Azure Batch connection type enables the Azure Batch integrations.
 
 Authenticating to Azure Batch
 ------------------------------------------
@@ -41,20 +41,16 @@ All hooks and operators related to Microsoft Azure Batch use ``azure_batch_defau
 Configuring the Connection
 --------------------------
 
-Login
+Batch Account Name
     Specify the Azure Batch Account Name used for the initial connection.
 
-Password
-    Specify the Azure Batch Key used for the initial connection.
+Batch Account Access Key
+    Specify the access key used for the initial connection.
 
-Extra
-    Specify the extra parameters (as json dictionary) that can be used in Azure Batch connection.
-    The following parameters are all optional:
+Batch Account URL
+    Specify the batch account URL you would like to use.
 
-    * ``account_url``: Specify the batch account url you would like to use.
-
-When specifying the connection in environment variable you should specify
-it using URI syntax.
+When specifying the connection in environment variable you should specify it using URI syntax.
 
 Note that all components of the URI should be URL-encoded.
 

--- a/tests/providers/microsoft/azure/hooks/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_batch.py
@@ -49,17 +49,7 @@ class TestAzureBatchHook(unittest.TestCase):
             Connection(
                 conn_id=self.test_vm_conn_id,
                 conn_type="azure_batch",
-                extra=json.dumps(
-                    {
-                        "account_name": self.test_account_name,
-                        "account_key": self.test_account_key,
-                        "account_url": self.test_account_url,
-                        "vm_publisher": self.test_vm_publisher,
-                        "vm_offer": self.test_vm_offer,
-                        "vm_sku": self.test_vm_sku,
-                        "node_agent_sku_id": self.test_node_agent_sku,
-                    }
-                ),
+                extra=json.dumps({"extra__azure_batch__account_url": self.test_account_url}),
             )
         )
         # connect with cloud service
@@ -67,16 +57,7 @@ class TestAzureBatchHook(unittest.TestCase):
             Connection(
                 conn_id=self.test_cloud_conn_id,
                 conn_type="azure_batch",
-                extra=json.dumps(
-                    {
-                        "account_name": self.test_account_name,
-                        "account_key": self.test_account_key,
-                        "account_url": self.test_account_url,
-                        "os_family": self.test_cloud_os_family,
-                        "os_version": self.test_cloud_os_version,
-                        "node_agent_sku_id": self.test_node_agent_sku,
-                    }
-                ),
+                extra=json.dumps({"extra__azure_batch__account_url": self.test_account_url}),
             )
         )
 

--- a/tests/providers/microsoft/azure/operators/test_azure_batch.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_batch.py
@@ -64,17 +64,7 @@ class TestAzureBatchOperator(unittest.TestCase):
             Connection(
                 conn_id=self.test_vm_conn_id,
                 conn_type="azure_batch",
-                extra=json.dumps(
-                    {
-                        "account_name": self.test_account_name,
-                        "account_key": self.test_account_key,
-                        "account_url": self.test_account_url,
-                        "vm_publisher": self.test_vm_publisher,
-                        "vm_offer": self.test_vm_offer,
-                        "vm_sku": self.test_vm_sku,
-                        "node_agent_sku_id": self.test_node_agent_sku,
-                    }
-                ),
+                extra=json.dumps({"extra__azure_batch__account_url": self.test_account_url}),
             )
         )
         # connect with cloud service
@@ -82,16 +72,7 @@ class TestAzureBatchOperator(unittest.TestCase):
             Connection(
                 conn_id=self.test_cloud_conn_id,
                 conn_type="azure_batch",
-                extra=json.dumps(
-                    {
-                        "account_name": self.test_account_name,
-                        "account_key": self.test_account_key,
-                        "account_url": self.test_account_url,
-                        "os_family": self.test_cloud_os_family,
-                        "os_version": self.test_cloud_os_version,
-                        "node_agent_sku_id": self.test_node_agent_sku,
-                    }
-                ),
+                extra=json.dumps({"extra__azure_batch__account_url": self.test_account_url}),
             )
         )
         self.operator = AzureBatchOperator(


### PR DESCRIPTION
Closes: #18442

The existing `_get_required_params()` method is passed an invalid value for the Batch Account URL and will always raise an exception for this missing required parameter. This value comes from the classic `Extra` field in the connection form which is no longer exposed in the Azure Batch Service connection type.

Additionally there are minor updates made to the hook's docstring for information accuracy, small spelling/grammar changes in the `AzureBatchHook`, updated the corresponding connection doc, and cleaned up the relevant unit tests.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
