### PR TITLE
remove redundant css state colors

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -116,58 +116,6 @@ g.node text {
   cursor: pointer;
 }
 
-g.node.success rect {
-  stroke: green;
-}
-
-g.node.up_for_retry rect {
-  stroke: gold;
-}
-
-g.node.up_for_reschedule rect {
-  stroke: turquoise;
-}
-
-g.node.sensing rect {
-  stroke: lightseagreen;
-}
-
-g.node.deferred rect {
-  stroke: lightseagreen;
-}
-
-g.node.queued rect {
-  stroke: grey;
-}
-
-g.node.running rect {
-  stroke: lime;
-}
-
-g.node.failed rect {
-  stroke: red;
-}
-
-g.node.shutdown rect {
-  stroke: blue;
-}
-
-g.node.restarting rect {
-  stroke: violet;
-}
-
-g.node.upstream_failed rect {
-  stroke: orange;
-}
-
-g.node.skipped rect {
-  stroke: pink;
-}
-
-g.node.removed rect {
-  stroke: black;
-}
-
 .svg-wrapper {
   border-radius: 4px;
   background-color: #f0f0f0;

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -127,42 +127,6 @@ div.squares {
   font-size: 1;
 }
 
-span.success {
-  background-color: #1b8e49;
-}
-
-span.up_for_retry {
-  background-color: gold;
-}
-
-span.up_for_reschedule {
-  background-color: #00c7d4;
-}
-
-span.started {
-  background-color: #04d659;
-}
-
-span.error {
-  background-color: #e43921;
-}
-
-span.queued {
-  background-color: #cbcbcb;
-}
-
-span.upstream_failed {
-  background-color: orange;
-}
-
-span.skipped {
-  background-color: #f8cec8;
-}
-
-span.deferred {
-  background-color: lightseagreen;
-}
-
 .d3-tip {
   background: rgba(0, 0, 0, 0.85);
   color: #fff;

--- a/airflow/www/static/css/tree.css
+++ b/airflow/www/static/css/tree.css
@@ -41,60 +41,6 @@ rect.state {
   cursor: pointer;
 }
 
-rect.null,
-rect.scheduled,
-rect.undefined {
-  fill: #fff;
-}
-
-rect.success {
-  fill: green;
-}
-
-rect.running {
-  fill: lime;
-}
-
-rect.failed {
-  fill: red;
-}
-
-rect.queued {
-  fill: gray;
-}
-
-rect.shutdown {
-  fill: blue;
-}
-
-rect.restarting {
-  fill: violet;
-}
-
-rect.upstream_failed {
-  fill: orange;
-}
-
-rect.up_for_retry {
-  fill: gold;
-}
-
-rect.up_for_reschedule {
-  fill: turquoise;
-}
-
-rect.skipped {
-  fill: pink;
-}
-
-rect.sensing {
-  fill: lightseagreen;
-}
-
-rect.deferred {
-  fill: lightseagreen;
-}
-
 .tooltip.in {
   opacity: 1;
   filter: alpha(opacity=100);
@@ -104,6 +50,11 @@ rect.deferred {
 .axis line {
   fill: none;
   stroke: #51504f;
+}
+
+rect.null,
+rect.undefined {
+  fill: #fff;
 }
 
 .axis text {

--- a/airflow/www/templates/airflow/graph.html
+++ b/airflow/www/templates/airflow/graph.html
@@ -92,8 +92,14 @@
         {{ op.task_type }}</span>{% endfor %}
     </div>
     <div>
-      {% for state, state_color in state_color_mapping.items() %}<span class="legend-item legend-item--interactive js-state-legend-item" data-state="{{state}}" style="border-color: {{state_color}};">
-        {{state}}</span>{% endfor %}<span class="legend-item legend-item--interactive legend-item--no-border js-state-legend-item" data-state="no_status" style="border-color:white;">no_status</span>
+      {% for state, state_color in state_color_mapping.items() %}
+        <span class="legend-item legend-item--interactive js-state-legend-item" data-state="{{state}}" style="border-color: {{state_color}};">
+          {{state}}
+        </span>
+      {% endfor %}
+      <span class="legend-item legend-item--interactive legend-item--no-border js-state-legend-item" data-state="no_status" style="border-color:white;">
+        no_status
+      </span>
     </div>
   </div>
   <div id="error" style="display: none; margin-top: 10px;" class="alert alert-danger" role="alert">

--- a/airflow/www/templates/airflow/tree.html
+++ b/airflow/www/templates/airflow/tree.html
@@ -73,10 +73,16 @@
       </span>{% endfor %}
     </div>
     <div>
-      {% for state, state_color in state_color_mapping.items() %}<span class="legend-item legend-item--no-border">
-        <span class="legend-item__swatch legend-item__swatch--no-border" style="background: {{ state_color }};"></span>
-        {{state}}</span>{% endfor %}<span class="legend-item legend-item--no-border">
-        <span class="legend-item__swatch"></span>no_status</span>
+      {% for state, state_color in state_color_mapping.items() %}
+        <span class="legend-item legend-item--no-border">
+          <span class="legend-item__swatch legend-item__swatch--no-border" style="background: {{ state_color }};"></span>
+          {{state}}
+        </span>
+      {% endfor %}
+      <span class="legend-item legend-item--no-border">
+        <span class="legend-item__swatch"></span>
+        no_status
+      </span>
     </div>
   </div>
   <hr>


### PR DESCRIPTION
The true source of truth for state colors somes from `settings.py` and is exposed to the frontend through the webserver. The css  state colors are redundant and cause confusion on the source of truth. Really, they are left over from when colors were not defined by `settings.py` (going back to the first airflow commit).

Also, cleaned up some indentation for making the legends in the tree and graph html files

Closes #17303

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
