### PR TITLE
Don't use flash for "same-page" UI messages.

### DIFF
--- a/airflow/www/templates/airflow/_messages.html
+++ b/airflow/www/templates/airflow/_messages.html
@@ -1,0 +1,30 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+{%- macro message(content, category='info', dismissable=true) -%}
+  <div class="alert alert-{{ category }}">
+    {%- if dismissable -%}
+    <button type="button" class="close" data-dismiss="alert">&times;</button>
+    {%- endif -%}
+    {%- if caller is defined -%}
+      {{ caller() }}
+    {%- else -%}
+      {{ content }}
+    {%- endif -%}
+  </div>
+{%- endmacro -%}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -19,6 +19,7 @@
 
 {% extends base_template %}
 {% from 'appbuilder/loading_dots.html' import loading_dots %}
+{% from 'airflow/_messages.html' import message %}
 
 {% block page_title %}
   {% if search_query %}"{{ search_query }}" - {% endif %}DAGs - {{ appbuilder.app_name }}
@@ -44,6 +45,26 @@
   {{ super() }}
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('switch.css') }}">
   <link rel="stylesheet" type="text/css" href="{{ url_for_asset('dags.css') }}">
+{% endblock %}
+
+{% block messages %}
+  {% for m in dashboard_alerts %}
+    {{ message(m.message, m.category) }}
+  {% endfor %}
+  {{ super() }}
+  {% if sqlite_warning | default(true) %}
+    {% call message(category='warning', dismissable=false)  %}
+      Do not use <b>SQLite</b> as metadata DB in production &#8211; it should only be used for dev/testing
+      We recommend using Postgres or MySQL.
+      <a href={{ get_docs_url("howto/set-up-database.html") }}><b>Click here</b></a> for more information.
+    {% endcall %}
+  {% endif %}
+  {% if sequential_executor_warning | default(false) %}
+    {% call message(category='warning', dismissable=false)  %}
+      Do not use <b>SequentialExecutor</b> in production.
+      <a href={{ get_docs_url("executor/index.html") }}><b>Click here</b></a> for more information.
+    {% endcall %}
+  {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -18,6 +18,7 @@
 #}
 
 {% extends 'appbuilder/baselayout.html' %}
+{% from 'airflow/_messages.html' import message %}
 
 {% block page_title -%}
   {% if title is defined -%}
@@ -51,7 +52,7 @@
 {% block messages %}
   {% include 'appbuilder/flash.html' %}
   {% if scheduler_job is defined and (not scheduler_job or not scheduler_job.is_alive()) %}
-    <div class="alert alert-warning">
+    {% call message(category='warning', dismissable=false) %}
       <p>The scheduler does not appear to be running.
       {% if scheduler_job %}
       Last heartbeat was received
@@ -63,10 +64,10 @@
       {% endif %}
       </p>
       <p>The DAGs list may not update, and new tasks will not be scheduled.</p>
-    </div>
+    {% endcall %}
   {% endif %}
   {% if triggerer_job is defined and (not triggerer_job or not triggerer_job.is_alive()) %}
-    <div class="alert alert-warning">
+    {% call message(category='warning', dismissable=false) %}
       <p>The triggerer does not appear to be running.
       {% if triggerer_job %}
       Last heartbeat was received
@@ -78,7 +79,7 @@
       {% endif %}
       </p>
       <p>Triggers will not run, and any deferred operator will remain deferred until it times out and fails.</p>
-    </div>
+    {% endcall %}
   {% endif %}
 {% endblock %}
 

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -17,9 +17,9 @@
  under the License.
 #}
 
-{#
+{#-
   Adapted from: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/templates/appbuilder/flash.html
-#}
+-#}
 <link rel="stylesheet" type="text/css" href="{{ url_for_asset('flash.css') }}">
 
 {#
@@ -33,20 +33,9 @@
     {% for category, m in messages %}
       {% if category == 'dag_import_error' %}
         {{ dag_import_errors.append((category, m)) if dag_import_errors.append((category, m)) != None else '' }}
-      {% else %}
-        {{ regular_alerts.append((category, m)) if regular_alerts.append((category, m)) != None else '' }}
-      {% endif %}
-    {% endfor %}
-  {% endif %}
-
-  {% if regular_alerts %}
-    {% for category, m in regular_alerts %}
-      {% if not (request.path == appbuilder.get_url_for_login and 'access is denied' in m.lower()) %}
+      {% elif not (request.path == appbuilder.get_url_for_login and 'access is denied' in m.lower()) %}
       {# Don't show 'Access is Denied' alert if user is logged out and on the login page. #}
-        <div class="alert alert-{{ category if category else 'info' }}">
-          <button type="button" class="close" data-dismiss="alert">&times;</button>
-          {{ m }}
-        </div>
+        {{ message(m, category) }}
       {% endif %}
     {% endfor %}
   {% endif %}

--- a/tests/www/views/test_views.py
+++ b/tests/www/views/test_views.py
@@ -52,6 +52,8 @@ def test_configuration_expose_config(admin_client):
 
 
 def test_redoc_should_render_template(capture_templates, admin_client):
+    from airflow.utils.docs import get_docs_url
+
     with capture_templates() as templates:
         resp = admin_client.get('redoc')
         check_content_in_response('Redoc', resp)
@@ -61,6 +63,7 @@ def test_redoc_should_render_template(capture_templates, admin_client):
     assert templates[0].local_context == {
         'openapi_spec_url': '/api/v1/openapi.yaml',
         'rest_api_enabled': True,
+        'get_docs_url': get_docs_url,
     }
 
 


### PR DESCRIPTION
The flash is designed for setting a message on one page and then showing
it after a redirect, so in the case of these UI warnings they were being
shown twice due to an early redirect.

I could have chosen to fix this by moving the checks to after the
`reset_tags` redirect, but it _also_ felt wrong to me to have HTML in
the view, so I have chosen to move it in to the template where it
belongs.

To (marginally) reduce boilerplate I have created `message()` "macro"
(Jinja macro, a.k.a. function; not to be confused with what Airflow
templates call a macro, but is in fact just a template global) that
handles the formatting for messages.

Closes https://github.com/apache/airflow/issues/17727