### PR TITLE
Add fixing of ownership also for sources in Breeze

### DIFF
--- a/scripts/in_container/_in_container_utils.sh
+++ b/scripts/in_container/_in_container_utils.sh
@@ -120,6 +120,8 @@ function in_container_fix_ownership() {
             "/root/.docker"
             "/opt/airflow/logs"
             "/opt/airflow/docs"
+            "/opt/airflow/dags"
+            "${AIRFLOW_SOURCES}"
         )
         find "${DIRECTORIES_TO_FIX[@]}" -print0 -user root 2>/dev/null |
             xargs --null chown "${HOST_USER_ID}.${HOST_GROUP_ID}" --no-dereference || true >/dev/null 2>&1


### PR DESCRIPTION
In some cases files created inside the container on linux in
sources are owned by root - so far we cleaned only some directories
that we knew were touched by Airflow, but in case of branch
switching some folders/files might also got created as owned
by root.

This PR adds AIRFLOW_SOURCES and "dags" folders to the list
of folders to fix ownership of.

This might lead to slightly longer exit time when exiting
from Breeze, but since we are running it only when the host is
Linux and the fixung is rather performant - with explicitly finding
files and dirs owned by root, this should not be a problem.

It would be much bigger problem on MacOS,Windows due to slow filesystem,
but on MacOS it is not needed as there ownership mapping is done
using the filesystem itself.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
