### PR TITLE
Restore 'filename' to template_fields of SlackAPIFileOperator

### DIFF
--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -195,7 +195,7 @@ class SlackAPIFileOperator(SlackAPIOperator):
     :type content: str
     """
 
-    template_fields = ('channel', 'initial_comment', 'filetype', 'content')
+    template_fields = ('channel', 'initial_comment', 'filename', 'filetype', 'content')
     ui_color = '#44BEDF'
 
     def __init__(


### PR DESCRIPTION
closes: #18465

`filename` was removed from `SlackAPIFileOperator.template_fields`, presumably by mistake.  This PR restores it.