### PR TITLE
LineageBackend is notified on pre_execute and post fail

### DIFF
--- a/airflow/lineage/backend.py
+++ b/airflow/lineage/backend.py
@@ -25,6 +25,27 @@ if TYPE_CHECKING:
 class LineageBackend:
     """Sends lineage metadata to a backend"""
 
+    def on_task_instance_start(
+        self,
+        operator: 'BaseOperator',
+        inlets: Optional[list] = None,
+        outlets: Optional[list] = None,
+        context: Optional[dict] = None,
+    ):
+        """
+        Notifies lineage backend of an execution start.
+
+        :param operator: the operator executing a transformation on the inlets and outlets
+        :type operator: airflow.models.baseoperator.BaseOperator
+        :param inlets: the inlets to this operator
+        :type inlets: list
+        :param outlets: the outlets from this operator
+        :type outlets: list
+        :param context: the current context of the task instance
+        :type context: dict
+        """
+        pass
+
     def send_lineage(
         self,
         operator: 'BaseOperator',
@@ -45,3 +66,24 @@ class LineageBackend:
         :type context: dict
         """
         raise NotImplementedError()
+
+    def on_task_instance_fail(
+        self,
+        operator: 'BaseOperator',
+        inlets: Optional[list] = None,
+        outlets: Optional[list] = None,
+        context: Optional[dict] = None,
+    ):
+        """
+        Sends lineage metadata to a backend in case of a failed job.
+
+        :param operator: the operator executing a transformation on the inlets and outlets
+        :type operator: airflow.models.baseoperator.BaseOperator
+        :param inlets: the inlets to this operator
+        :type inlets: list
+        :param outlets: the outlets from this operator
+        :type outlets: list
+        :param context: the current context of the task instance
+        :type context: dict
+        """
+        pass

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -54,7 +54,7 @@ import airflow.templates
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.exceptions import AirflowException, TaskDeferred
-from airflow.lineage import apply_lineage, prepare_lineage
+from airflow.lineage import apply_lineage, fail_lineage, prepare_lineage
 from airflow.models.base import Operator
 from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
@@ -1004,6 +1004,11 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         """
         if self._post_execute_hook is not None:
             self._post_execute_hook(context, result)
+
+    @fail_lineage
+    def on_failure(self, context: Any):
+        if self.on_failure_callback is not None:
+            self.on_failure_callback(context)
 
     def on_kill(self) -> None:
         """

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1555,13 +1555,16 @@ class TaskInstance(Base, LoggingMixin):
         """
         if self.state == State.FAILED:
             task = self.task
+            context = {}
             if task.on_failure_callback is not None:
                 context = self.get_template_context()
                 context["exception"] = error
-                try:
-                    task.on_failure_callback(context)
-                except Exception:
-                    self.log.exception("Error when executing on_failure_callback")
+
+            # Always call on_failure to handle case where LineageBackend is defined
+            try:
+                task.on_failure(context)
+            except Exception:
+                self.log.exception("Error when executing on_failure_callback")
         elif self.state == State.SUCCESS:
             task = self.task
             if task.on_success_callback is not None:


### PR DESCRIPTION
Motivation for this PR is [OpenLineage's](https://openlineage.io/) [Airflow integration.](https://github.com/OpenLineage/OpenLineage/tree/main/integration/airflow)

Currently, LineageBackend is notified only when task succesfully completes.
This PR implements support for two additional methods for `LineageBackend` - to become notified when task starts and when it fails. Those methods are optional, and any implementations of `LineageBackend` should work exactly the same if they won't implement it.

With addition to adding those methods, they are hooked with (AFAIK) appropriate places to do so. 
Also, changed loading lineage backend to be lazy.  

Now, I think few things are incomplete. 
I have no idea what behavior should be for lineage inlets and outlets in context of a failed job - so I just ignored them.

Implements https://github.com/apache/airflow/issues/17984

Signed-off-by: Maciej Obuchowski <maciej.obuchowski@getindata.com>
