### PR TITLE
Bring back version to docker-compose files

### DIFF
--- a/scripts/ci/docker-compose/backend-mssql-bind-volume.yml
+++ b/scripts/ci/docker-compose/backend-mssql-bind-volume.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   mssql:
     volumes:

--- a/scripts/ci/docker-compose/backend-mssql-docker-volume.yml
+++ b/scripts/ci/docker-compose/backend-mssql-docker-volume.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   mssql:
     volumes:

--- a/scripts/ci/docker-compose/backend-mssql-port.yml
+++ b/scripts/ci/docker-compose/backend-mssql-port.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   mssql:
     ports:

--- a/scripts/ci/docker-compose/backend-mssql.yml
+++ b/scripts/ci/docker-compose/backend-mssql.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/backend-mysql-port.yml
+++ b/scripts/ci/docker-compose/backend-mysql-port.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   mysql:
     ports:

--- a/scripts/ci/docker-compose/backend-mysql.yml
+++ b/scripts/ci/docker-compose/backend-mysql.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/backend-postgres-port.yml
+++ b/scripts/ci/docker-compose/backend-postgres-port.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   postgres:
     ports:

--- a/scripts/ci/docker-compose/backend-postgres.yml
+++ b/scripts/ci/docker-compose/backend-postgres.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/backend-sqlite-port.yml
+++ b/scripts/ci/docker-compose/backend-sqlite-port.yml
@@ -15,6 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-services:
-  sqlite:
-    ports: []
+version: "3.7"

--- a/scripts/ci/docker-compose/backend-sqlite.yml
+++ b/scripts/ci/docker-compose/backend-sqlite.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     image: ${AIRFLOW_CI_IMAGE}

--- a/scripts/ci/docker-compose/files.yml
+++ b/scripts/ci/docker-compose/files.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     volumes:

--- a/scripts/ci/docker-compose/forward-credentials.yml
+++ b/scripts/ci/docker-compose/forward-credentials.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     # Forwards local credentials to docker image

--- a/scripts/ci/docker-compose/ga.yml
+++ b/scripts/ci/docker-compose/ga.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     environment:

--- a/scripts/ci/docker-compose/integration-cassandra.yml
+++ b/scripts/ci/docker-compose/integration-cassandra.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   cassandra:
     image: cassandra:3.0

--- a/scripts/ci/docker-compose/integration-kerberos.yml
+++ b/scripts/ci/docker-compose/integration-kerberos.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   kdc-server-example-com:
     image: ghcr.io/apache/airflow-krb5-kdc-server:2021.07.04

--- a/scripts/ci/docker-compose/integration-mongo.yml
+++ b/scripts/ci/docker-compose/integration-mongo.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   mongo:
     image: mongo:3

--- a/scripts/ci/docker-compose/integration-openldap.yml
+++ b/scripts/ci/docker-compose/integration-openldap.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   openldap:
     image: ghcr.io/apache/airflow-openldap:2.4.50-2021.07.04

--- a/scripts/ci/docker-compose/integration-pinot.yml
+++ b/scripts/ci/docker-compose/integration-pinot.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   pinot:
     image: apachepinot/pinot:latest

--- a/scripts/ci/docker-compose/integration-rabbitmq.yml
+++ b/scripts/ci/docker-compose/integration-rabbitmq.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   rabbitmq:
     image: rabbitmq:3.7

--- a/scripts/ci/docker-compose/integration-redis.yml
+++ b/scripts/ci/docker-compose/integration-redis.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   redis:
     image: redis:5.0.1

--- a/scripts/ci/docker-compose/integration-statsd.yml
+++ b/scripts/ci/docker-compose/integration-statsd.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   statsd-exporter:
     image: apache/airflow:airflow-statsd-exporter-2020.09.05-v0.17.0

--- a/scripts/ci/docker-compose/integration-trino.yml
+++ b/scripts/ci/docker-compose/integration-trino.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   trino:
     image: ghcr.io/apache/airflow-trino:359-2021.07.04

--- a/scripts/ci/docker-compose/local-all-sources.yml
+++ b/scripts/ci/docker-compose/local-all-sources.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     stdin_open: true  # docker run -i

--- a/scripts/ci/docker-compose/local.yml
+++ b/scripts/ci/docker-compose/local.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     stdin_open: true  # docker run -i

--- a/scripts/ci/docker-compose/remove-sources.yml
+++ b/scripts/ci/docker-compose/remove-sources.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
+version: "3.7"
 services:
   airflow:
     # Forwards local credentials to docker image


### PR DESCRIPTION
Even if version is only for information and should not be
used, apparently it's removal causes some problems with different
docker versions.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
