### PR TITLE
Give MSSQL container more time to start up

### DIFF
--- a/scripts/ci/docker-compose/backend-mssql.yml
+++ b/scripts/ci/docker-compose/backend-mssql.yml
@@ -39,6 +39,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 10
+      start_period: 2m
     restart: always
   mssqlsetup:
     image: mcr.microsoft.com/mssql/server:${MSSQL_VERSION}


### PR DESCRIPTION
The MSSQL jobs on CI fail from time-to-time with a message from docker
compose saying "the container is unhealthy" -- this should give us more
time to start up before failing.

Thankfully for the way docker healthchecks work if the container does
start up and pass healthcheck while still in the start_period we don't
have to wait for the full period to elapse before continuing


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).