### PR TITLE
18400 chart custom pod annotations

### DIFF
--- a/chart/templates/flower/flower-deployment.yaml
+++ b/chart/templates/flower/flower-deployment.yaml
@@ -54,9 +54,9 @@ spec:
 {{- with .Values.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-      {{- if .Values.airflowPodAnnotations }}
+      {{- if or (.Values.airflowPodAnnotations) (.Values.flower.podAnnotations) }}
       annotations:
-      {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
+      {{- mustMerge .Values.flower.podAnnotations .Values.airflowPodAnnotations | toYaml | nindent 8 }}
       {{- end }}
     spec:
       nodeSelector:

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -85,6 +85,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.scheduler.podAnnotations }}
+        {{- toYaml .Values.scheduler.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -67,6 +67,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.triggerer.podAnnotations }}
+        {{- toYaml .Values.triggerer.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
         {{- toYaml $nodeSelector | nindent 8 }}

--- a/chart/templates/webserver/webserver-deployment.yaml
+++ b/chart/templates/webserver/webserver-deployment.yaml
@@ -81,6 +81,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.webserver.podAnnotations }}
+        {{- toYaml .Values.webserver.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "webserver.serviceAccountName" . }}
       nodeSelector:

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -77,6 +77,9 @@ spec:
         {{- if .Values.airflowPodAnnotations }}
         {{- toYaml .Values.airflowPodAnnotations | nindent 8 }}
         {{- end }}
+        {{- if .Values.workers.podAnnotations }}
+        {{- toYaml .Values.workers.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       nodeSelector:
 {{ toYaml $nodeSelector | indent 8 }}

--- a/chart/tests/test_airflow_common.py
+++ b/chart/tests/test_airflow_common.py
@@ -74,16 +74,20 @@ class TestAirflowCommon:
         release_name = "TEST-BASIC"
         k8s_objects = render_chart(
             name=release_name,
-            values={"airflowPodAnnotations": {"test-annotation/safe-to-evict": "true"}},
+            values={
+                "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
+                "airflowPodAnnotations": {"test-annotation/safe-to-evict": "true"},
+            },
             show_only=[
                 "templates/scheduler/scheduler-deployment.yaml",
                 "templates/workers/worker-deployment.yaml",
                 "templates/webserver/webserver-deployment.yaml",
                 "templates/flower/flower-deployment.yaml",
+                "templates/triggerer/triggerer-deployment.yaml",
             ],
         )
 
-        assert 4 == len(k8s_objects)
+        assert 5 == len(k8s_objects)
 
         for k8s_object in k8s_objects:
             annotations = k8s_object["spec"]["template"]["metadata"]["annotations"]

--- a/chart/tests/test_annotations.py
+++ b/chart/tests/test_annotations.py
@@ -45,6 +45,14 @@ CUSTOM_ANNOTATION_VALUES = (
     "redis",
 )
 
+COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS = (
+    "scheduler",
+    "webserver",
+    "worker",
+    "flower",
+    "triggerer",
+)
+
 
 class AnnotationsTest(unittest.TestCase):
     def test_service_account_annotations(self):
@@ -136,3 +144,112 @@ class AnnotationsTest(unittest.TestCase):
             list_of_annotation_values_in_objects,
             CUSTOM_ANNOTATION_VALUES,
         )
+
+    def test_per_component_custom_annotations(self):
+        release_name = "RELEASE_NAME"
+
+        k8s_objects = render_chart(
+            name=release_name,
+            values={
+                "scheduler": {
+                    "podAnnotations": {
+                        "example": "scheduler",
+                    },
+                },
+                "webserver": {
+                    "podAnnotations": {
+                        "example": "webserver",
+                    },
+                },
+                "workers": {
+                    "podAnnotations": {
+                        "example": "worker",
+                    },
+                },
+                "flower": {
+                    "podAnnotations": {
+                        "example": "flower",
+                    },
+                },
+                "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
+                "triggerer": {
+                    "podAnnotations": {
+                        "example": "triggerer",
+                    },
+                },
+            },
+            show_only=[
+                "templates/scheduler/scheduler-deployment.yaml",
+                "templates/workers/worker-deployment.yaml",
+                "templates/webserver/webserver-deployment.yaml",
+                "templates/flower/flower-deployment.yaml",
+                "templates/triggerer/triggerer-deployment.yaml",
+            ],
+        )
+
+        # The test relies on the convention that the Deployment name
+        # is always `{ Release.Name }-<component_name>`.
+        obj_by_component_name = {
+            obj["metadata"]["name"].replace(release_name + "-", ""): obj for obj in k8s_objects
+        }
+
+        self.assertCountEqual(obj_by_component_name, COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS)
+
+        for component_name, obj in obj_by_component_name.items():
+            self.assertIn("example", obj["spec"]["template"]["metadata"]["annotations"])
+            self.assertEqual(component_name, obj["spec"]["template"]["metadata"]["annotations"]["example"])
+
+    def test_per_component_custom_annotations_precedence(self):
+        release_name = "RELEASE_NAME"
+
+        k8s_objects = render_chart(
+            name=release_name,
+            values={
+                "airflowPodAnnotations": {"example": "GLOBAL"},
+                "scheduler": {
+                    "podAnnotations": {
+                        "example": "scheduler",
+                    },
+                },
+                "webserver": {
+                    "podAnnotations": {
+                        "example": "webserver",
+                    },
+                },
+                "workers": {
+                    "podAnnotations": {
+                        "example": "worker",
+                    },
+                },
+                "flower": {
+                    "podAnnotations": {
+                        "example": "flower",
+                    },
+                },
+                "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
+                "triggerer": {
+                    "podAnnotations": {
+                        "example": "triggerer",
+                    },
+                },
+            },
+            show_only=[
+                "templates/scheduler/scheduler-deployment.yaml",
+                "templates/workers/worker-deployment.yaml",
+                "templates/webserver/webserver-deployment.yaml",
+                "templates/flower/flower-deployment.yaml",
+                "templates/triggerer/triggerer-deployment.yaml",
+            ],
+        )
+
+        # The test relies on the convention that the Deployment name
+        # is always `{ Release.Name }-<component_name>`.
+        obj_by_component_name = {
+            obj["metadata"]["name"].replace(release_name + "-", ""): obj for obj in k8s_objects
+        }
+
+        self.assertCountEqual(obj_by_component_name, COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS)
+
+        for component_name, obj in obj_by_component_name.items():
+            self.assertIn("example", obj["spec"]["template"]["metadata"]["annotations"])
+            self.assertEqual(component_name, obj["spec"]["template"]["metadata"]["annotations"]["example"])

--- a/chart/tests/test_annotations.py
+++ b/chart/tests/test_annotations.py
@@ -15,158 +15,260 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
+import pytest
 
 from tests.helm_template_generator import render_chart
 
-COMPONENTS_SUPPORTING_CUSTOM_SERVICEACCOUNT_ANNOTATIONS = (
-    "scheduler",
-    "webserver",
-    "worker",
-    "cleanup",
-    "flower",
-    "pgbouncer",
-    "statsd",
-    "createuser",
-    "migratedb",
-    "redis",
-    "triggerer",
-)
 
-COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS = (
-    "scheduler",
-    "webserver",
-    "worker",
-    "flower",
-    "triggerer",
-)
-
-
-class AnnotationsTest(unittest.TestCase):
-    def test_service_account_annotations(self):
+class TestServiceAccountAnnotations:
+    @pytest.mark.parametrize(
+        "values,show_only,expected_annotations",
+        [
+            (
+                {
+                    "cleanup": {
+                        "enabled": True,
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "cleanup",
+                            },
+                        },
+                    },
+                },
+                "templates/cleanup/cleanup-serviceaccount.yaml",
+                {
+                    "example": "cleanup",
+                },
+            ),
+            (
+                {
+                    "scheduler": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "scheduler",
+                            },
+                        },
+                    },
+                },
+                "templates/scheduler/scheduler-serviceaccount.yaml",
+                {
+                    "example": "scheduler",
+                },
+            ),
+            (
+                {
+                    "webserver": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "webserver",
+                            },
+                        },
+                    },
+                },
+                "templates/webserver/webserver-serviceaccount.yaml",
+                {
+                    "example": "webserver",
+                },
+            ),
+            (
+                {
+                    "workers": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "worker",
+                            },
+                        },
+                    },
+                },
+                "templates/workers/worker-serviceaccount.yaml",
+                {
+                    "example": "worker",
+                },
+            ),
+            (
+                {
+                    "flower": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "flower",
+                            },
+                        },
+                    },
+                },
+                "templates/flower/flower-serviceaccount.yaml",
+                {
+                    "example": "flower",
+                },
+            ),
+            (
+                {
+                    "statsd": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "statsd",
+                            },
+                        },
+                    },
+                },
+                "templates/statsd/statsd-serviceaccount.yaml",
+                {
+                    "example": "statsd",
+                },
+            ),
+            (
+                {
+                    "redis": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "redis",
+                            },
+                        },
+                    },
+                },
+                "templates/redis/redis-serviceaccount.yaml",
+                {
+                    "example": "redis",
+                },
+            ),
+            (
+                {
+                    "pgbouncer": {
+                        "enabled": True,
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "pgbouncer",
+                            },
+                        },
+                    },
+                },
+                "templates/pgbouncer/pgbouncer-serviceaccount.yaml",
+                {
+                    "example": "pgbouncer",
+                },
+            ),
+            (
+                {
+                    "createUserJob": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "createuser",
+                            },
+                        },
+                    },
+                },
+                "templates/jobs/create-user-job-serviceaccount.yaml",
+                {
+                    "example": "createuser",
+                },
+            ),
+            (
+                {
+                    "migrateDatabaseJob": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "migratedb",
+                            },
+                        },
+                    },
+                },
+                "templates/jobs/migrate-database-job-serviceaccount.yaml",
+                {
+                    "example": "migratedb",
+                },
+            ),
+            (
+                {
+                    "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
+                    "triggerer": {
+                        "serviceAccount": {
+                            "annotations": {
+                                "example": "triggerer",
+                            },
+                        },
+                    },
+                },
+                "templates/triggerer/triggerer-serviceaccount.yaml",
+                {
+                    "example": "triggerer",
+                },
+            ),
+        ],
+    )
+    def test_annotations_are_added(self, values, show_only, expected_annotations):
         k8s_objects = render_chart(
-            values={
-                "cleanup": {
-                    "enabled": True,
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "cleanup",
-                        },
-                    },
-                },
-                "scheduler": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "scheduler",
-                        },
-                    },
-                },
-                "webserver": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "webserver",
-                        },
-                    },
-                },
-                "workers": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "worker",
-                        },
-                    },
-                },
-                "flower": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "flower",
-                        },
-                    },
-                },
-                "statsd": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "statsd",
-                        },
-                    },
-                },
-                "redis": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "redis",
-                        },
-                    },
-                },
-                "pgbouncer": {
-                    "enabled": True,
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "pgbouncer",
-                        },
-                    },
-                },
-                "createUserJob": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "createuser",
-                        },
-                    },
-                },
-                "migrateDatabaseJob": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "migratedb",
-                        },
-                    },
-                },
-                "executor": "CeleryExecutor",  # create worker deployment
-                "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
-                "triggerer": {
-                    "serviceAccount": {
-                        "annotations": {
-                            "example": "triggerer",
-                        },
-                    },
-                },
-            },
+            values=values,
+            show_only=[show_only],
         )
 
-        list_of_annotation_values_in_objects = [
-            k8s_object['metadata']['annotations']['example']
-            for k8s_object in k8s_objects
-            if k8s_object['kind'] == "ServiceAccount"
-        ]
+        # This test relies on the convention that the helm chart puts a single
+        # ServiceAccount in its own .yaml file, so by specifying `show_only`,
+        # we should only get a single k8s_object here - the target object that
+        # we hope to test on.
+        assert len(k8s_objects) == 1
+        obj = k8s_objects[0]
 
-        self.assertCountEqual(
-            list_of_annotation_values_in_objects,
-            COMPONENTS_SUPPORTING_CUSTOM_SERVICEACCOUNT_ANNOTATIONS,
-        )
+        for k, v in expected_annotations.items():
+            assert k in obj["metadata"]["annotations"]
+            assert v == obj["metadata"]["annotations"][k]
 
-    def test_per_component_custom_annotations(self):
-        release_name = "RELEASE_NAME"
 
-        k8s_objects = render_chart(
-            name=release_name,
-            values={
+@pytest.mark.parametrize(
+    "values,show_only,expected_annotations",
+    [
+        (
+            {
                 "scheduler": {
                     "podAnnotations": {
                         "example": "scheduler",
                     },
                 },
+            },
+            "templates/scheduler/scheduler-deployment.yaml",
+            {
+                "example": "scheduler",
+            },
+        ),
+        (
+            {
                 "webserver": {
                     "podAnnotations": {
                         "example": "webserver",
                     },
                 },
+            },
+            "templates/webserver/webserver-deployment.yaml",
+            {
+                "example": "webserver",
+            },
+        ),
+        (
+            {
                 "workers": {
                     "podAnnotations": {
                         "example": "worker",
                     },
                 },
+            },
+            "templates/workers/worker-deployment.yaml",
+            {
+                "example": "worker",
+            },
+        ),
+        (
+            {
                 "flower": {
                     "podAnnotations": {
                         "example": "flower",
                     },
                 },
+            },
+            "templates/flower/flower-deployment.yaml",
+            {
+                "example": "flower",
+            },
+        ),
+        (
+            {
                 "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
                 "triggerer": {
                     "podAnnotations": {
@@ -174,78 +276,48 @@ class AnnotationsTest(unittest.TestCase):
                     },
                 },
             },
-            show_only=[
-                "templates/scheduler/scheduler-deployment.yaml",
-                "templates/workers/worker-deployment.yaml",
-                "templates/webserver/webserver-deployment.yaml",
-                "templates/flower/flower-deployment.yaml",
-                "templates/triggerer/triggerer-deployment.yaml",
-            ],
+            "templates/triggerer/triggerer-deployment.yaml",
+            {
+                "example": "triggerer",
+            },
+        ),
+    ],
+)
+class TestPerComponentPodAnnotations:
+    def test_annotations_are_added(self, values, show_only, expected_annotations):
+        k8s_objects = render_chart(
+            values=values,
+            show_only=[show_only],
         )
 
-        # The test relies on the convention that the Deployment name
-        # is always `{ Release.Name }-<component_name>`.
-        obj_by_component_name = {
-            obj["metadata"]["name"].replace(release_name + "-", ""): obj for obj in k8s_objects
-        }
+        # This test relies on the convention that the helm chart puts a single
+        # Deployment in its own .yaml file, so by specifying `show_only`,
+        # we should only get a single k8s_object here - the target object that
+        # we hope to test on.
+        assert len(k8s_objects) == 1
+        obj = k8s_objects[0]
 
-        self.assertCountEqual(obj_by_component_name, COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS)
+        for k, v in expected_annotations.items():
+            assert k in obj["spec"]["template"]["metadata"]["annotations"]
+            assert v == obj["spec"]["template"]["metadata"]["annotations"][k]
 
-        for component_name, obj in obj_by_component_name.items():
-            self.assertIn("example", obj["spec"]["template"]["metadata"]["annotations"])
-            self.assertEqual(component_name, obj["spec"]["template"]["metadata"]["annotations"]["example"])
+    def test_precedence(self, values, show_only, expected_annotations):
+        values_global_annotations = {"airflowPodAnnotations": {k: "GLOBAL" for k in expected_annotations}}
 
-    def test_per_component_custom_annotations_precedence(self):
-        release_name = "RELEASE_NAME"
+        values_merged = {**values, **values_global_annotations}
 
         k8s_objects = render_chart(
-            name=release_name,
-            values={
-                "airflowPodAnnotations": {"example": "GLOBAL"},
-                "scheduler": {
-                    "podAnnotations": {
-                        "example": "scheduler",
-                    },
-                },
-                "webserver": {
-                    "podAnnotations": {
-                        "example": "webserver",
-                    },
-                },
-                "workers": {
-                    "podAnnotations": {
-                        "example": "worker",
-                    },
-                },
-                "flower": {
-                    "podAnnotations": {
-                        "example": "flower",
-                    },
-                },
-                "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
-                "triggerer": {
-                    "podAnnotations": {
-                        "example": "triggerer",
-                    },
-                },
-            },
-            show_only=[
-                "templates/scheduler/scheduler-deployment.yaml",
-                "templates/workers/worker-deployment.yaml",
-                "templates/webserver/webserver-deployment.yaml",
-                "templates/flower/flower-deployment.yaml",
-                "templates/triggerer/triggerer-deployment.yaml",
-            ],
+            values=values_merged,
+            show_only=[show_only],
         )
 
-        # The test relies on the convention that the Deployment name
-        # is always `{ Release.Name }-<component_name>`.
-        obj_by_component_name = {
-            obj["metadata"]["name"].replace(release_name + "-", ""): obj for obj in k8s_objects
-        }
+        # This test relies on the convention that the helm chart puts a single
+        # Deployment in its own .yaml file, so by specifying `show_only`,
+        # we should only get a single k8s_object here - the target object that
+        # we hope to test on.
+        assert len(k8s_objects) == 1
+        obj = k8s_objects[0]
 
-        self.assertCountEqual(obj_by_component_name, COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS)
-
-        for component_name, obj in obj_by_component_name.items():
-            self.assertIn("example", obj["spec"]["template"]["metadata"]["annotations"])
-            self.assertEqual(component_name, obj["spec"]["template"]["metadata"]["annotations"]["example"])
+        for k, v in expected_annotations.items():
+            assert k in obj["spec"]["template"]["metadata"]["annotations"]
+            assert v == obj["spec"]["template"]["metadata"]["annotations"][k]

--- a/chart/tests/test_annotations.py
+++ b/chart/tests/test_annotations.py
@@ -19,20 +19,7 @@ import unittest
 
 from tests.helm_template_generator import render_chart
 
-# Values for each service mapped to the 'example'
-# key annotation
-CUSTOM_ANNOTATION_VALUES = (
-    CUSTOM_SCHEDULER_ANNOTATION,
-    CUSTOM_WEBSERVER_ANNOTATION,
-    CUSTOM_WORKER_ANNOTATION,
-    CUSTOM_CLEANUP_ANNOTATION,
-    CUSTOM_FLOWER_ANNOTATION,
-    CUSTOM_PGBOUNCER_ANNOTATION,
-    CUSTOM_STATSD_ANNOTATION,
-    CUSTOM_CREATE_USER_JOB_ANNOTATION,
-    CUSTOM_MIGRATE_DATABASE_JOB_ANNOTATION,
-    CUSTOM_REDIS_ANNOTATION,
-) = (
+COMPONENTS_SUPPORTING_CUSTOM_SERVICEACCOUNT_ANNOTATIONS = (
     "scheduler",
     "webserver",
     "worker",
@@ -43,6 +30,7 @@ CUSTOM_ANNOTATION_VALUES = (
     "createuser",
     "migratedb",
     "redis",
+    "triggerer",
 )
 
 COMPONENTS_SUPPORTING_CUSTOM_POD_ANNOTATIONS = (
@@ -62,49 +50,49 @@ class AnnotationsTest(unittest.TestCase):
                     "enabled": True,
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_CLEANUP_ANNOTATION,
+                            "example": "cleanup",
                         },
                     },
                 },
                 "scheduler": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_SCHEDULER_ANNOTATION,
+                            "example": "scheduler",
                         },
                     },
                 },
                 "webserver": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_WEBSERVER_ANNOTATION,
+                            "example": "webserver",
                         },
                     },
                 },
                 "workers": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_WORKER_ANNOTATION,
+                            "example": "worker",
                         },
                     },
                 },
                 "flower": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_FLOWER_ANNOTATION,
+                            "example": "flower",
                         },
                     },
                 },
                 "statsd": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_STATSD_ANNOTATION,
+                            "example": "statsd",
                         },
                     },
                 },
                 "redis": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_REDIS_ANNOTATION,
+                            "example": "redis",
                         },
                     },
                 },
@@ -112,25 +100,33 @@ class AnnotationsTest(unittest.TestCase):
                     "enabled": True,
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_PGBOUNCER_ANNOTATION,
+                            "example": "pgbouncer",
                         },
                     },
                 },
                 "createUserJob": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_CREATE_USER_JOB_ANNOTATION,
+                            "example": "createuser",
                         },
                     },
                 },
                 "migrateDatabaseJob": {
                     "serviceAccount": {
                         "annotations": {
-                            "example": CUSTOM_MIGRATE_DATABASE_JOB_ANNOTATION,
+                            "example": "migratedb",
                         },
                     },
                 },
                 "executor": "CeleryExecutor",  # create worker deployment
+                "airflowVersion": "2.2.0",  # Needed for triggerer to be enabled.
+                "triggerer": {
+                    "serviceAccount": {
+                        "annotations": {
+                            "example": "triggerer",
+                        },
+                    },
+                },
             },
         )
 
@@ -142,7 +138,7 @@ class AnnotationsTest(unittest.TestCase):
 
         self.assertCountEqual(
             list_of_annotation_values_in_objects,
-            CUSTOM_ANNOTATION_VALUES,
+            COMPONENTS_SUPPORTING_CUSTOM_SERVICEACCOUNT_ANNOTATIONS,
         )
 
     def test_per_component_custom_annotations(self):

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1141,6 +1141,11 @@
                         }
                     ]
                 },
+                "podAnnotations": {
+                    "description": "Annotations to add to the worker pods.",
+                    "type": "object",
+                    "default": {}
+                },
                 "logGroomerSidecar": {
                     "description": "Configuration for worker log groomer sidecar",
                     "type": "object",
@@ -1384,6 +1389,11 @@
                     "type": "array",
                     "default": []
                 },
+                "podAnnotations": {
+                    "description": "Annotations to add to the scheduler pods.",
+                    "type": "object",
+                    "default": {}
+                },
                 "logGroomerSidecar": {
                     "description": "Configuration for the schedulers log groomer sidecar.",
                     "type": "object",
@@ -1609,6 +1619,11 @@
                     "description": "Grace period for tasks to finish after SIGTERM is sent from Kubernetes.",
                     "type": "integer",
                     "default": 60
+                },
+                "podAnnotations": {
+                    "description": "Annotations to add to the triggerer pods.",
+                    "type": "object",
+                    "default": {}
                 }
             }
         },
@@ -2067,6 +2082,11 @@
                     "description": "Specify Tolerations for webserver pods.",
                     "type": "array",
                     "default": []
+                },
+                "podAnnotations": {
+                    "description": "Annotations to add to the webserver pods.",
+                    "type": "object",
+                    "default": {}
                 }
             }
         },
@@ -2287,6 +2307,11 @@
                     "description": "Specify Tolerations for Flower pods.",
                     "type": "array",
                     "default": []
+                },
+                "podAnnotations": {
+                    "description": "Annotations to add to the Flower pods.",
+                    "type": "object",
+                    "default": {}
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -485,6 +485,8 @@ workers:
   #   hostnames:
   #   - "test.hostname.two"
 
+  podAnnotations: {}
+
   logGroomerSidecar:
     # Command to use when running the Airflow worker log groomer sidecar (templated).
     command: ~
@@ -578,6 +580,8 @@ scheduler:
             topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
+  podAnnotations: {}
+
   logGroomerSidecar:
     # Whether to deploy the Airflow scheduler log groomer sidecar.
     enabled: true
@@ -594,6 +598,7 @@ scheduler:
     #  requests:
     #   cpu: 100m
     #   memory: 128Mi
+
 # Airflow create user job settings
 createUserJob:
   # Annotations on the create user job pod
@@ -762,6 +767,8 @@ webserver:
             topologyKey: "kubernetes.io/hostname"
   tolerations: []
 
+  podAnnotations: {}
+
 # Airflow Triggerer Config
 triggerer:
   # Number of airflow triggerers in the deployment
@@ -833,6 +840,8 @@ triggerer:
                 component: triggerer
             topologyKey: "kubernetes.io/hostname"
   tolerations: []
+
+  podAnnotations: {}
 
 # Flower settings
 flower:
@@ -914,6 +923,8 @@ flower:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+
+  podAnnotations: {}
 
 # Statsd settings
 statsd:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #18400 

The change allows adding different custom pod annotations to the different airflow components (whereas the current chart can only add the same set of custom pod annotations to all airflow components).

Some notes:
- The per-component pod annotations take precedence over the global pod annotations injected via `.Values.airflowPodAnnotations`
- I've only added it to components that already currently support `airflowPodAnnotations`, which excludes `redis` etc. I don't know why we have `airflowPodAnnotations` in some components but not in others, but I want to just continue to convention to keep things clean.
- Added annotations test for `triggerer` as well.
- Added 2 new test cases, one to test the basic functionality, and one to test the precedence. There are some copy-paste between the two tests but I think there is no need for further abstraction or code-reuse because YAGNI.
-  Also refactored the existing ServiceAccount annotations test to make it IMO simpler and more readable.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
