### PR TITLE
Add more informative messages when rebuilding the image

### DIFF
--- a/scripts/ci/pre_commit/pre_commit_ci_build.sh
+++ b/scripts/ci/pre_commit/pre_commit_ci_build.sh
@@ -18,7 +18,6 @@
 export PYTHON_MAJOR_MINOR_VERSION="${1}"
 export REMEMBER_LAST_ANSWER="${2}"
 export PRINT_INFO_FROM_SCRIPTS="false"
-export SKIP_CHECK_REMOTE_IMAGE="true"
 
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"

--- a/scripts/ci/pre_commit/pre_commit_flake8.sh
+++ b/scripts/ci/pre_commit/pre_commit_flake8.sh
@@ -19,8 +19,6 @@ export PYTHON_MAJOR_MINOR_VERSION="3.6"
 export FORCE_ANSWER_TO_QUESTIONS=${FORCE_ANSWER_TO_QUESTIONS:="quit"}
 export REMEMBER_LAST_ANSWER="true"
 export PRINT_INFO_FROM_SCRIPTS="false"
-export SKIP_CHECK_REMOTE_IMAGE="true"
-
 
 # shellcheck source=scripts/ci/static_checks/flake8.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../static_checks/flake8.sh" "${@}"

--- a/scripts/ci/pre_commit/pre_commit_mypy.sh
+++ b/scripts/ci/pre_commit/pre_commit_mypy.sh
@@ -19,8 +19,6 @@ export PYTHON_MAJOR_MINOR_VERSION="3.6"
 export FORCE_ANSWER_TO_QUESTIONS=${FORCE_ANSWER_TO_QUESTIONS:="quit"}
 export REMEMBER_LAST_ANSWER="true"
 export PRINT_INFO_FROM_SCRIPTS="false"
-export SKIP_CHECK_REMOTE_IMAGE="true"
-
 
 # shellcheck source=scripts/ci/static_checks/mypy.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../static_checks/mypy.sh" "${@}"


### PR DESCRIPTION
Reviewed and updated the messages printed when image needed to
be rebuild. Some messages were unclear or duplicatd. I removed
all the ambiguities and added some colors. Also there was
apparently the case that automated rebuild on commit did not take
into account the check of whethere image needs to be pulled, that
could lead to longer rebuild times in this case.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
