### PR TITLE
Fix DetachedInstanceError when dag_run attrs are accessed from ti

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -400,7 +400,7 @@ class TaskInstance(Base, LoggingMixin):
         innerjoin=True,
     )
 
-    dag_run = relationship("DagRun", back_populates="task_instances", lazy='selectin')
+    dag_run = relationship("DagRun", back_populates="task_instances", lazy='joined', innerjoin=True)
 
     execution_date = association_proxy("dag_run", "execution_date")
 

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -400,7 +400,7 @@ class TaskInstance(Base, LoggingMixin):
         innerjoin=True,
     )
 
-    dag_run = relationship("DagRun", back_populates="task_instances")
+    dag_run = relationship("DagRun", back_populates="task_instances", lazy='selectin')
 
     execution_date = association_proxy("dag_run", "execution_date")
 
@@ -1693,9 +1693,6 @@ class TaskInstance(Base, LoggingMixin):
         Stats.incr(f'operator_failures_{task.task_type}', 1, 1)
         Stats.incr('ti_failures')
         if not test_mode:
-            # This is needed as dag_run is lazily loaded. Without it, sqlalchemy errors with
-            # DetachedInstanceError error.
-            self.dag_run = self.get_dagrun(session=session)
             session.add(Log(State.FAILED, self))
 
             # Log failure duration

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -878,5 +878,5 @@ def test_number_of_queries_single_loop(mock_get_task_runner, return_codes, dag_m
     ti.refresh_from_task(task)
 
     job = LocalTaskJob(task_instance=ti, executor=MockExecutor())
-    with assert_queries_count(25):
+    with assert_queries_count(20):
         job.run()

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2063,8 +2063,8 @@ class TestRunRawTaskQueriesCount:
         "expected_query_count, mark_success",
         [
             # Expected queries, mark_success
-            (12, False),
-            (5, True),
+            (13, False),
+            (7, True),
         ],
     )
     @provide_session
@@ -2094,7 +2094,7 @@ class TestRunRawTaskQueriesCount:
 
         # an extra query is fired in RenderedTaskInstanceFields.delete_old_records
         # for other DBs
-        expected_query_count_based_on_db = 5
+        expected_query_count_based_on_db = 7
 
         session.flush()
 

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2063,8 +2063,8 @@ class TestRunRawTaskQueriesCount:
         "expected_query_count, mark_success",
         [
             # Expected queries, mark_success
-            (13, False),
-            (7, True),
+            (10, False),
+            (5, True),
         ],
     )
     @provide_session
@@ -2094,7 +2094,7 @@ class TestRunRawTaskQueriesCount:
 
         # an extra query is fired in RenderedTaskInstanceFields.delete_old_records
         # for other DBs
-        expected_query_count_based_on_db = 7
+        expected_query_count_based_on_db = 5
 
         session.flush()
 


### PR DESCRIPTION
Fix DetachedInstanceError when dag_run attrs are accessed from ti
    
Loading a taskinstance doesn't load the corresponding dag_run with
the effect that when the dag_run attr is accessed from the ti it gives
a DetachedInstanceError, dag_run is not bound to a session.
    
This PR fixes it by making an extra query to get the dagrun using the
relationship between the two objects

cc: @ash @uranusjr 
I think with this, we can also get rid of `ti.get_dagrun` method?


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
