### PR TITLE
Add missing email type of connection

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3297,6 +3297,7 @@ def lazy_add_provider_discovered_options_to_connection_form():
         _connection_types = [
             ('fs', 'File (path)'),
             ('mesos_framework-id', 'Mesos Framework ID'),
+            ('email', 'Email'),
         ]
         providers_manager = ProvidersManager()
         for connection_type, provider_info in providers_manager.hooks.items():

--- a/docs/apache-airflow/howto/email-config.rst
+++ b/docs/apache-airflow/howto/email-config.rst
@@ -31,7 +31,7 @@ in the ``[email]`` section.
 
 To configure SMTP settings, checkout the :ref:`SMTP <config:smtp>` section in the standard configuration.
 If you do not want to store the SMTP credentials in the config or in the environment variables, you can create a
-connection called ``smtp_default``, or choose a custom connection name and set the ``email_conn_id`` with it's name in
+connection called ``smtp_default`` of ``Email`` type, or choose a custom connection name and set the ``email_conn_id`` with it's name in
 the configuration & store SMTP username-password in it. Other SMTP settings like host, port etc always gets picked up
 from the configuration only. The connection can be of any type (for example 'HTTP connection').
 
@@ -67,11 +67,17 @@ Airflow can be configured to send e-mail using `SendGrid <https://sendgrid.com/>
 
 Follow the steps below to enable it:
 
-1. Include ``sendgrid`` subpackage as part of your Airflow installation, e.g.,
+1. Include ``sendgrid`` provider as part of your Airflow installation, e.g.,
 
-  .. code-block:: ini
+  .. code-block:: bash
 
-     pip install 'apache-airflow[sendgrid]'
+     pip install 'apache-airflow[sendgrid]' --constraint ...
+
+or
+  .. code-block:: bash
+
+     pip install 'apache-airflow-providers-sendgrid' --constraint ...
+
 
 2. Update ``email_backend`` property in ``[email]`` section in ``airflow.cfg``, i.e.
 
@@ -82,7 +88,8 @@ Follow the steps below to enable it:
       email_conn_id = sendgrid_default
 
 3. Create a connection called ``sendgrid_default``, or choose a custom connection
-   name and set it in ``email_conn_id``.
+   name and set it in ``email_conn_id`` of  'Email' type. Only login and password
+   are used from the connection.
 
 .. _email-configuration-ses:
 
@@ -108,4 +115,4 @@ Follow the steps below to enable it:
       email_conn_id = aws_default
 
 3. Create a connection called ``aws_default``, or choose a custom connection
-   name and set it in ``email_conn_id``.
+   name and set it in ``email_conn_id``. The type of connection should be ``Amazon Web Services``.


### PR DESCRIPTION
The email configuration of Airflow became somwhat hybrid - part
of the configuration is in the config file and part (authentication)
in connection. However there is no dedicated connection type to
use for email, and user got confused - they did not realize they
could use any connection, and this was really not intuitive.

This PR adds email connection type as built-in and updates the
documentation of email configuration to use that connection
type for smtp/sendgrid (and use the aws one for aws email)

Fixes: #18495

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
