### PR TITLE
When calling `dr.get_task_instance` automatically set `dag_run` relationship

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import joinedload, relationship, synonym
+from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql import expression
 
@@ -381,11 +382,14 @@ class DagRun(Base, LoggingMixin):
         :param session: Sqlalchemy ORM Session
         :type session: Session
         """
-        return (
+        ti = (
             session.query(TI)
             .filter(TI.dag_id == self.dag_id, TI.run_id == self.run_id, TI.task_id == task_id)
             .one_or_none()
         )
+        if ti:
+            set_committed_value(ti, 'dag_run', self)
+        return ti
 
     def get_dag(self) -> "DAG":
         """


### PR DESCRIPTION
We know that this TI belongs to this relationship, so setting this
avoids a lookup in a few places.

This somehow feels like we are fighting SQLAlchemy a bit, but from what
I can work out the only way to do this would either be an eager load of
one form or another (which would make a more complex query or an extra
query) or to look at `self.task_instances` -- which means the filtering
would be done in python space -- which we want to avoid for large dags
(it's not totally unheard of to have dags with 10 or 20k tasks in them!)


Relates to #18359 (but is in addition to that PR)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).