### PR TITLE
Increase timeouts for setup/teardown in pytest

### DIFF
--- a/scripts/in_container/entrypoint_ci.sh
+++ b/scripts/in_container/entrypoint_ci.sh
@@ -215,9 +215,9 @@ EXTRA_PYTEST_ARGS=(
     # timeouts in seconds for individual tests
     "--timeouts-order"
     "moi"
-    "--setup-timeout=20"
+    "--setup-timeout=60"
     "--execution-timeout=60"
-    "--teardown-timeout=20"
+    "--teardown-timeout=60"
     # Only display summary for non-expected case
     # f - failed
     # E - error


### PR DESCRIPTION
For some unknown reason recently some tests started to fail
on setup timout exceeding 20 seconds. Those tests have NO setup
so it likely a side-effect of other tests (for example with some
process cleanup that takes more time/CPU.

This change attempts to fix it by simply increasing the timeout
to 60 seconds. If it works - fine, but if not, it will be indication
that we have a deeper problem to fix.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
