### PR TITLE
Coerce datetime to pendulum for timetable

### DIFF
--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -280,7 +280,10 @@ def post_dag_run(dag_id, session):
 
     if dagrun_instance.execution_date == logical_date:
         raise AlreadyExists(
-            detail=f"DAGRun with DAG ID: '{dag_id}' and DAGRun logical date: '{logical_date}' already exists"
+            detail=(
+                f"DAGRun with DAG ID: '{dag_id}' and "
+                f"DAGRun logical date: '{logical_date.isoformat(sep=' ')}' already exists"
+            ),
         )
 
     raise AlreadyExists(detail=f"DAGRun with DAG ID: '{dag_id}' and DAGRun ID: '{run_id}' already exists")

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -16,6 +16,7 @@
 # under the License.
 from typing import Optional
 
+import pendulum
 from flask import current_app, g, request
 from marshmallow import ValidationError
 from sqlalchemy import or_
@@ -250,7 +251,7 @@ def post_dag_run(dag_id, session):
     except ValidationError as err:
         raise BadRequest(detail=str(err))
 
-    logical_date = post_body["execution_date"]
+    logical_date = pendulum.instance(post_body["execution_date"])
     run_id = post_body["run_id"]
     dagrun_instance = (
         session.query(DagRun)


### PR DESCRIPTION
`Timetable.infer_manual_data_interval()` expects a `pendulum.DateTime`, but `marshmallow_sqlalchemy.auto_field()` only automatically decodes to `datetime.datetime`. So we perform one additional coersion before passing the value on.