### PR TITLE
Inherit `AirflowNotFound` from `connextion.NotFound` for better readability

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -34,7 +34,6 @@ from airflow.api_connexion.schemas.task_instance_schema import (
     task_instance_reference_collection_schema,
     task_instance_schema,
 )
-from airflow.exceptions import SerializedDagNotFound
 from airflow.models import SlaMiss
 from airflow.models.dagrun import DagRun as DR
 from airflow.models.taskinstance import TaskInstance as TI, clear_task_instances
@@ -276,12 +275,8 @@ def post_set_task_instances_state(dag_id, session):
         raise BadRequest(detail=str(err.messages))
 
     error_message = f"Dag ID {dag_id} not found"
-    try:
-        dag = current_app.dag_bag.get_dag(dag_id)
-        if not dag:
-            raise NotFound(error_message)
-    except SerializedDagNotFound:
-        # If DAG is not found in serialized_dag table
+    dag = current_app.dag_bag.get_dag(dag_id)
+    if not dag:
         raise NotFound(error_message)
 
     task_id = data['task_id']

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -23,6 +23,7 @@ import datetime
 import warnings
 from typing import Any, Dict, List, NamedTuple, Optional
 
+from airflow.api_connexion.exceptions import NotFound as ApiConnextionNotFound
 from airflow.utils.code_utils import prepare_code_snippet
 from airflow.utils.platform import is_tty
 
@@ -42,7 +43,7 @@ class AirflowBadRequest(AirflowException):
     status_code = 400
 
 
-class AirflowNotFoundException(AirflowException):
+class AirflowNotFoundException(AirflowException, ApiConnextionNotFound):
     """Raise when the requested object/resource is not available in the system"""
 
     status_code = 404


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

[These lines in `post_set_task_instances_state()`](https://github.com/apache/airflow/blob/690e80b82b12ab1d7232d6f02ea6bddd1d71750c/airflow/api_connexion/endpoints/task_instance_endpoint.py#L290-L297) tends to 
1. raise `NotFound` if no dag return based on the given `dag_id`
2. catch exception `SerializedDagNotFound` and raise `NotFound`

but raising exception in a try-catch clause lowers the readability. 

This PR makes `AirflowNotFoundException` inherited from `connextion.NotFound` and thus the try-catch can be removed and make `post_set_task_instances_state()` simpler.


Fixes: #11851