### PR TITLE
Add Slack operators how-to guide

### DIFF
--- a/airflow/providers/slack/example_dags/example_slack.py
+++ b/airflow/providers/slack/example_dags/example_slack.py
@@ -26,6 +26,7 @@ with DAG(
     max_active_runs=1,
     tags=['example'],
 ) as dag:
+    # [START slack_operator_howto_guide_send_file]
     # Send file with filename and filetype
     slack_operator_file = SlackAPIFileOperator(
         task_id="slack_file_upload_1",
@@ -36,7 +37,9 @@ with DAG(
         filename="/files/dags/test.txt",
         filetype="txt",
     )
+    # [END slack_operator_howto_guide_send_file]
 
+    # [START slack_operator_howto_guide_send_file_content]
     # Send file content
     slack_operator_file_content = SlackAPIFileOperator(
         task_id="slack_file_upload_2",
@@ -46,5 +49,6 @@ with DAG(
         initial_comment="Hello World!",
         content="file content in txt",
     )
+    # [END slack_operator_howto_guide_send_file_content]
 
     slack_operator_file >> slack_operator_file_content

--- a/airflow/providers/slack/operators/slack.py
+++ b/airflow/providers/slack/operators/slack.py
@@ -161,20 +161,19 @@ class SlackAPIFileOperator(SlackAPIOperator):
     .. code-block:: python
 
         # Send file with filename and filetype
-        with open("test.txt", "rb") as file:
-            slack = SlackAPIFileOperator(
-                task_id="slack_file_upload",
-                dag=dag,
-                slack_conn_id="slack",
-                channel="#general",
-                initial_comment="Hello World!",
-                file="/files/dags/test.txt",
-                filetype="txt",
-            )
+        slack_operator_file = SlackAPIFileOperator(
+            task_id="slack_file_upload_1",
+            dag=dag,
+            slack_conn_id="slack",
+            channel="#general",
+            initial_comment="Hello World!",
+            filename="/files/dags/test.txt",
+            filetype="txt",
+        )
 
         # Send file content
-        slack = SlackAPIFileOperator(
-            task_id="slack_file_upload",
+        slack_operator_file_content = SlackAPIFileOperator(
+            task_id="slack_file_upload_2",
             dag=dag,
             slack_conn_id="slack",
             channel="#general",

--- a/airflow/providers/slack/provider.yaml
+++ b/airflow/providers/slack/provider.yaml
@@ -34,6 +34,8 @@ additional-dependencies:
 integrations:
   - integration-name: Slack
     external-doc-url: https://slack.com/
+    how-to-guide:
+      - /docs/apache-airflow-providers-slack/operators/slack_operator_howto_guide.rst
     logo: /integration-logos/slack/Slack.png
     tags: [service]
 

--- a/docs/apache-airflow-providers-slack/index.rst
+++ b/docs/apache-airflow-providers-slack/index.rst
@@ -24,6 +24,12 @@ Content
 
 .. toctree::
     :maxdepth: 1
+    :caption: Guides
+
+    How-to Guide <operators/slack_operator_howto_guide>
+
+.. toctree::
+    :maxdepth: 1
     :caption: References
 
     Connection Types <connections/slack>

--- a/docs/apache-airflow-providers-slack/operators/slack_operator_howto_guide.rst
+++ b/docs/apache-airflow-providers-slack/operators/slack_operator_howto_guide.rst
@@ -1,0 +1,44 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+How-to Guide for Slack Operators
+================================
+
+Introduction
+------------
+
+Slack operators can send text messages (:class:`~airflow.providers.slack.operators.slack.SlackAPIFileOperator`)
+or files (:class:`~airflow.providers.slack.operators.slack.SlackAPIPostOperator`) to specified Slack channels.
+Provide either ``slack_conn_id`` or ``token`` for the connection, and specify ``channel`` (name or ID).
+
+Example Codes for Sending Files
+-------------------------------
+
+Sending files by specifying file names
+
+.. exampleinclude:: /../../airflow/providers/slack/example_dags/example_slack.py
+    :language: python
+    :start-after: [START slack_operator_howto_guide_send_file]
+    :end-before: [END slack_operator_howto_guide_send_file]
+
+
+Sending files by directly providing file contents
+
+.. exampleinclude:: /../../airflow/providers/slack/example_dags/example_slack.py
+    :language: python
+    :start-after: [START slack_operator_howto_guide_send_file_content]
+    :end-before: [END slack_operator_howto_guide_send_file_content]


### PR DESCRIPTION
- Solve #11919 
- Generate a how-to guide for Slack operators (currently only SlackAPIFileOperator; could add SlackAPIPostOperator later)
- Fix and unify the code sample in API page
