### PR TITLE
Fix intermittent orphan test

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -18,6 +18,7 @@
 #
 
 import datetime
+import logging
 import os
 import shutil
 from datetime import timedelta
@@ -33,6 +34,7 @@ from sqlalchemy import func
 import airflow.example_dags
 import airflow.smart_sensor_dags
 from airflow import settings
+from airflow.configuration import conf
 from airflow.dag_processing.manager import DagFileProcessorAgent
 from airflow.exceptions import AirflowException
 from airflow.executors.base_executor import BaseExecutor
@@ -75,6 +77,8 @@ ELASTIC_DAG_FILE = os.path.join(PERF_DAGS_FOLDER, "elastic_dag.py")
 TEST_DAG_FOLDER = os.environ['AIRFLOW__CORE__DAGS_FOLDER']
 DEFAULT_DATE = timezone.datetime(2016, 1, 1)
 TRY_NUMBER = 1
+
+log = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
@@ -165,19 +169,38 @@ class TestSchedulerJob:
         self.scheduler_job.heartrate = 0
         self.scheduler_job.run()
 
+    @pytest.mark.skipif(
+        conf.get('core', 'sql_alchemy_conn').lower().startswith("mssql"),
+        reason="MSSQL does not like os._exit()",
+    )
+    @pytest.mark.skipif(not hasattr(os, 'fork'), reason="Forking not available")
     def test_no_orphan_process_will_be_left(self):
         empty_dir = mkdtemp()
         current_process = psutil.Process()
-        old_children = current_process.children(recursive=True)
-        self.scheduler_job = SchedulerJob(
-            subdir=empty_dir, num_runs=1, executor=MockExecutor(do_update=False)
-        )
-        self.scheduler_job.run()
-        shutil.rmtree(empty_dir)
+        pid = os.fork()
+        # Running the test in a fork to avoid side effects from other tests - those side-effects migh
+        # Cause some processes to be running as children
+        if pid == 0:
+            old_children = current_process.children(recursive=True)
+            self.scheduler_job = SchedulerJob(
+                subdir=empty_dir, num_runs=1, executor=MockExecutor(do_update=False)
+            )
+            self.scheduler_job.run()
+            shutil.rmtree(empty_dir)
 
-        # Remove potential noise created by previous tests.
-        current_children = set(current_process.children(recursive=True)) - set(old_children)
-        assert not current_children
+            # Remove potential noise created by previous tests.
+            current_children = set(current_process.children(recursive=True)) - set(old_children)
+            if current_children:
+                log.error(f"Current children: {current_children}")
+                # Exit immediately from the fork without cleanup (avoid Pytest atexit)
+                os._exit(1)
+            # Exit immediately from the fork without cleanup (avoid Pytest atexit)
+            os._exit(0)
+        else:
+            pid, ret_val = os.wait()
+            assert (
+                not ret_val
+            ), "The return value entered from process was non-zero. See error log above for details."
 
     @mock.patch('airflow.jobs.scheduler_job.TaskCallbackRequest')
     @mock.patch('airflow.jobs.scheduler_job.Stats.incr')


### PR DESCRIPTION
The orphan scheduler test fails intermittently likely due to
the way how pytest runs child processes. The fix is to run this
test in a fork and pass the result of the test back to the
parent process. This way we can be pretty sure that the process
has no extra children.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
