### PR TITLE
Fix running helm tests in parallel

### DIFF
--- a/scripts/ci/kubernetes/ci_setup_cluster_and_run_kubernetes_tests_single_job.sh
+++ b/scripts/ci/kubernetes/ci_setup_cluster_and_run_kubernetes_tests_single_job.sh
@@ -51,6 +51,13 @@ echo "PYTHON_MAJOR_MINOR_VERSION: ${PYTHON_MAJOR_MINOR_VERSION}"
 echo "EXECUTOR:                   ${EXECUTOR}"
 echo
 
+# For parallel tests - each helm test should have a different cache to avoid tests verriding each-other's cache
+HELM_CACHE_HOME=$(mktemp -d)
+export HELM_CACHE_HOME
+
+# shellcheck disable=SC2154
+trap 'rc=$?; rm -rf "${HELM_CACHE_HOME}" || true; exit "${rc}"' EXIT HUP INT TERM
+
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 

--- a/scripts/ci/kubernetes/ci_upgrade_cluster_with_different_executors_single_job.sh
+++ b/scripts/ci/kubernetes/ci_upgrade_cluster_with_different_executors_single_job.sh
@@ -51,6 +51,13 @@ echo "PYTHON_MAJOR_MINOR_VERSION: ${PYTHON_MAJOR_MINOR_VERSION}"
 echo "EXECUTOR:                   ${EXECUTOR}"
 echo
 
+# For parallel tests - each helm test should have a different cache to avoid tests verriding each-other's cache
+HELM_CACHE_HOME=$(mktemp -d)
+export HELM_CACHE_HOME
+
+# shellcheck disable=SC2154
+trap 'rc=$?; rm -rf "${HELM_CACHE_HOME}" || true; exit "${rc}"' EXIT HUP INT TERM
+
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 


### PR DESCRIPTION
When Helm tests are run in parallel in one machine they might
override each-other's cache if they are run at exactly the same
time (and one of the caches might be gone)

This led to an intermittent failures of those tests.

This PR sets different temporary directory for each helm test run

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
