### PR TITLE
Remove invalid option for docker-compose

### DIFF
--- a/scripts/ci/docker-compose/base.yml
+++ b/scripts/ci/docker-compose/base.yml
@@ -19,7 +19,6 @@ version: "3.7"
 services:
   airflow:
     image: ${AIRFLOW_CI_IMAGE}
-    pull_policy: never
     environment:
       - USER=root
       - ADDITIONAL_PATH=~/.local/bin


### PR DESCRIPTION
Breeze is failing to start and complaining about below unsupported option.

ERROR: The Compose file '...../airflow/scripts/ci/docker-compose/base.yml' is invalid because:
Unsupported config option for services.airflow: 'pull_policy'
ERROR: The previous step completed with error. Please take a look at output above 


This PR removes unsupported option by docker and makes Breeze work again

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
