### PR TITLE
Check docker-compose version in breeze

### DIFF
--- a/breeze
+++ b/breeze
@@ -592,20 +592,27 @@ function breeze::prepare_command_file() {
     local compose_file="${3}"
     cat <<EOF >"${file}"
 #!/usr/bin/env bash
-docker_compose_version=\$(docker-compose --version)
-if [[ \${docker_compose_version} =~ .*version\ v2.* ]]; then
-  echo
-  echo "${COLOR_RED}Docker Compose Beta version v2 has a bug that prevents breeze from running.${COLOR_RESET}"
-  echo "${COLOR_RED}You have: \${docker_compose_version}.${COLOR_RESET}"
-  echo
-  echo "${COLOR_YELLOW}Please switch to stable version via Docker Desktop -> Experimental or by running:${COLOR_RESET}"
-  echo
-  echo "${COLOR_CYAN}docker-compose disable-v2${COLOR_RESET}"
-  echo
-  echo "${COLOR_YELLOW}Also please upvote https://github.com/docker/compose-cli/issues/1917${COLOR_RESET}"
-  echo
-  echo "${COLOR_RED}Exiting until you disable v2 version.${COLOR_RESET}"
-  exit 1
+docker_compose_version=\$(docker-compose --version || true)
+if [[ \${docker_compose_version} =~ .*([0-9]+)\.([0-9]+)\.([0-9]+).+ ]]; then
+    major=\${BASH_REMATCH[1]}
+    minor=\${BASH_REMATCH[2]}
+    patch=\${BASH_REMATCH[3]}
+    if [[ \${major} == "1" ]]; then
+        if (( minor < 29 )); then
+            echo
+            echo "${COLOR_RED}You have too old version of docker-compose: \${major}.\${minor}.\${patch}! At least 1.29 is needed! Please upgrade!${COLOR_RESET}"
+            echo "${COLOR_RED}See https://docs.docker.com/compose/install/ for instructions. Make sure docker-compose you install is first on the PATH variable of yours.${COLOR_RESET}"
+            echo
+            exit 1
+        fi
+    fi
+    echo
+    echo "${COLOR_GREEN}Good version of docker-compose: \${major}.\${minor}.\${patch}${COLOR_RESET}"
+    echo
+else
+    echo
+    echo "${COLOR_YELLOW}Unknown docker-compose version. At least 1.29 is needed! If Breeze fails - upgrade to latest available docker-compose version${COLOR_RESET}"
+    echo
 fi
 
 if [[ \${VERBOSE} == "true" ]]; then
@@ -3579,7 +3586,6 @@ function breeze::determine_python_version_to_use_in_breeze() {
     PYTHON_MAJOR_MINOR_VERSION="${PYTHON_MAJOR_MINOR_VERSION:=$(parameters::read_from_file PYTHON_MAJOR_MINOR_VERSION)}"
     export PYTHON_MAJOR_MINOR_VERSION
 }
-
 
 breeze::setup_default_breeze_constants
 

--- a/confirm
+++ b/confirm
@@ -35,7 +35,7 @@ else
     read -t 4 -r RESPONSE
 fi
 
-case "${RESPONSE}" in
+case "${RESPONSE="N"}" in
     [yY][eE][sS]|[yY])
         echo "The answer is 'yes'. ${1}. This can take some time!"
         exit 0

--- a/scripts/ci/libraries/_build_images.sh
+++ b/scripts/ci/libraries/_build_images.sh
@@ -282,7 +282,7 @@ function build_images::get_local_build_cache_hash() {
         return
 
     fi
-    docker_v create --name "local-airflow-ci-container" "${AIRFLOW_CI_IMAGE}" 2>/dev/null
+    docker_v create --name "local-airflow-ci-container" "${AIRFLOW_CI_IMAGE}" 2>/dev/null >/dev/null
     docker_v cp "local-airflow-ci-container:/build-cache-hash" \
         "${local_image_build_cache_file}" 2>/dev/null ||
         touch "${local_image_build_cache_file}"


### PR DESCRIPTION
We started to use some newer features in docker-compose of breeze.
They are new enough (May 2020) that older versions of
docker-compose do not work with them.

This PR checks if the docker-compose is >= 1.29

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
