### PR TITLE
Remove workaround for docker-compose-failures

### DIFF
--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -110,42 +110,24 @@ function run_airflow_testing_in_docker() {
             backend_docker_compose+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/backend-mssql-docker-volume.yml")
         fi
     fi
-
-    for try_num in {1..5}
-    do
-        echo
-        echo "Starting try number ${try_num}"
-        echo
-        echo
-        echo "Making sure docker-compose is down and remnants removed"
-        echo
-
-        docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
-            --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
-            down --remove-orphans \
-            --volumes --timeout 10
-        docker-compose --log-level INFO \
-          -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
-          "${backend_docker_compose[@]}" \
-          "${INTEGRATIONS[@]}" \
-          "${DOCKER_COMPOSE_LOCAL[@]}" \
-          --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
-             run airflow "${@}"
-        exit_code=$?
-        docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
-            --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
-            down --remove-orphans \
-            --volumes --timeout 10
-        if [[ ${exit_code} == "254" && ${try_num} != "5" ]]; then
-            echo
-            echo "Failed try num ${try_num}. Sleeping 5 seconds for retry"
-            echo
-            sleep 5
-            continue
-        else
-            break
-        fi
-    done
+    echo "Making sure docker-compose is down and remnants removed"
+    echo
+    docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
+        --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
+        down --remove-orphans \
+        --volumes --timeout 10
+    docker-compose --log-level INFO \
+      -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
+      "${backend_docker_compose[@]}" \
+      "${INTEGRATIONS[@]}" \
+      "${DOCKER_COMPOSE_LOCAL[@]}" \
+      --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
+         run airflow "${@}"
+    exit_code=$?
+    docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
+        --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
+        down --remove-orphans \
+        --volumes --timeout 10
     set -u
     set -e
     if [[ ${exit_code} != "0" ]]; then


### PR DESCRIPTION
Long time ago we had unknown docker-compose failures that returned
254 exit code. This has long been improved by decreasing memory
pressure for CI dockers and healthiness checks and is no
longer needed.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
