### PR TITLE
Allow ingress multiple hostnames w/diff secrets

### DIFF
--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -43,6 +43,13 @@ Default Airflow image is updated to ``2.2.2``
 
 The default Airflow image that is used with the Chart is now ``2.2.2``, previously it was ``2.2.1``.
 
+``ingress.web.hosts`` and ``ingress.flower.hosts`` parameters data type has changed and ``ingress.web.tls`` and ``ingress.flower.tls`` have moved
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+``ingress.web.hosts`` and ``ingress.flower.hosts`` have had their types have been changed from an array of strings to an array of objects. ``ingress.web.tls`` and ``ingress.flower.tls`` can now be specified per host in ``ingress.web.hosts`` and ``ingress.flower.hosts`` respectively.
+
+The old parameter names will continue to work, however support for them will be removed in a future release so please update your values file.
+
 Airflow Helm Chart 1.3.0
 ------------------------
 

--- a/chart/templates/NOTES.txt
+++ b/chart/templates/NOTES.txt
@@ -34,6 +34,14 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+{{- if .Values.ingress.web.tls }}
+
+DEPRECATION WARNING:
+   `ingress.web.tls` has been renamed to `ingress.web.hosts[*].tls` and can be set per host.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 {{- if .Values.ingress.flower.host }}
 
 DEPRECATION WARNING:
@@ -42,14 +50,39 @@ DEPRECATION WARNING:
 
 {{- end }}
 
+
+{{- if .Values.ingress.flower.tls }}
+
+DEPRECATION WARNING:
+   `ingress.flower.tls` has been renamed to `ingress.flower.hosts[*].tls` and can be set per host.
+   Please change your values as support for the old name will be dropped in a future release.
+
+{{- end }}
+
 Airflow Webserver:
 {{- range .Values.ingress.web.hosts | default (list .Values.ingress.web.host) }}
-      http{{ if $.Values.ingress.web.tls.enabled }}s{{ end }}://{{ . }}{{ $.Values.ingress.web.path }}/
+      {{- $tlsEnabled := $.Values.ingress.web.tls.enabled -}}
+      {{- $hostname := $.Values.ingress.web.host -}}
+      {{- if . | kindIs "string" | not }}
+      {{- if .tls }}
+      {{- $tlsEnabled := .tls.enabled -}}
+      {{- $hostname := $.name -}}
+      {{- end }}
+      {{- end }}
+      http{{ if $tlsEnabled }}s{{ end }}://{{ $hostname }}{{ $.Values.ingress.web.path }}/
 {{- end }}
 {{- if or (eq .Values.executor "CeleryExecutor") (eq .Values.executor "CeleryKubernetesExecutor") }}
 Flower dashboard:
-{{- range .Values.ingress.flower.hosts }}
-      http{{ if $.Values.ingress.flower.tls.enabled }}s{{ end }}://{{ . }}{{ $.Values.ingress.flower.path }}/
+{{- range .Values.ingress.flower.hosts | default (list .Values.ingress.flower.host) }}
+      {{- $tlsEnabled := $.Values.ingress.flower.tls.enabled -}}
+      {{- $hostname := $.Values.ingress.flower.host -}}
+      {{- if . | kindIs "string" | not }}
+      {{- if .tls }}
+      {{- $tlsEnabled := .tls.enabled -}}
+      {{- $hostname := $.name -}}
+      {{- end }}
+      {{- end }}
+      http{{ if $tlsEnabled }}s{{ end }}://{{ $hostname }}{{ $.Values.ingress.flower.path }}/
 {{- end }}
 {{- end }}
 {{- else }}

--- a/chart/templates/flower/flower-ingress.yaml
+++ b/chart/templates/flower/flower-ingress.yaml
@@ -40,12 +40,31 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.flower.tls.enabled }}
+  {{- if and .Values.ingress.flower.hosts (.Values.ingress.flower.hosts | first | kindIs "string" | not) }}
+  {{- $anyTlsHosts := false -}}
+  {{- range .Values.ingress.flower.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+  {{- $anyTlsHosts = true -}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if $anyTlsHosts }}
+  tls:
+  {{- range .Values.ingress.flower.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+    - hosts:
+        - {{ .name | quote }}
+      secretName: {{ .tls.secretName }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- else if .Values.ingress.flower.tls.enabled }}
   tls:
     - hosts:
-{{- if .Values.ingress.flower.tls.enabled }}
         {{- .Values.ingress.flower.hosts | default (list .Values.ingress.flower.host) | toYaml | nindent 8 }}
-{{- end }}
       secretName: {{ .Values.ingress.flower.tls.secretName }}
   {{- end }}
   rules:
@@ -68,8 +87,12 @@ spec:
             pathType: {{ $.Values.ingress.flower.pathType }}
             {{- end }}
             {{- end }}
-      {{- if . }}
-      host: {{ . | quote }}
+      {{- $hostname := . -}}
+      {{- if . | kindIs "string" | not }}
+      {{- $hostname = .name -}}
+      {{- end }}
+      {{- if $hostname }}
+      host: {{ $hostname | quote }}
       {{- end }}
     {{- end }}
   {{- if and .Values.ingress.flower.ingressClassName $apiIsStable }}

--- a/chart/templates/webserver/webserver-ingress.yaml
+++ b/chart/templates/webserver/webserver-ingress.yaml
@@ -39,12 +39,31 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.ingress.web.tls.enabled }}
+  {{- if and .Values.ingress.web.hosts (.Values.ingress.web.hosts | first | kindIs "string" | not) }}
+  {{- $anyTlsHosts := false -}}
+  {{- range .Values.ingress.web.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+  {{- $anyTlsHosts = true -}}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if $anyTlsHosts }}
+  tls:
+  {{- range .Values.ingress.web.hosts }}
+  {{- if .tls }}
+  {{- if .tls.enabled }}
+    - hosts:
+        - {{ .name | quote }}
+      secretName: {{ .tls.secretName }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- else if .Values.ingress.web.tls.enabled }}
   tls:
     - hosts:
-{{- if .Values.ingress.web.tls.enabled }}
         {{- .Values.ingress.web.hosts | default (list .Values.ingress.web.host) | toYaml | nindent 8 }}
-{{- end }}
       secretName: {{ .Values.ingress.web.tls.secretName }}
   {{- end }}
   rules:
@@ -99,8 +118,12 @@ spec:
               servicePort: {{ .servicePort }}
               {{- end }}
           {{- end }}
-      {{- if . }}
-      host: {{ . | quote }}
+      {{- $hostname := . -}}
+      {{- if . | kindIs "string" | not }}
+      {{- $hostname = .name -}}
+      {{- end }}
+      {{- if $hostname }}
+      host: {{ $hostname | quote }}
       {{- end }}
     {{- end }}
   {{- if and .Values.ingress.web.ingressClassName $apiIsStable }}

--- a/chart/tests/test_ingress_flower.py
+++ b/chart/tests/test_ingress_flower.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import itertools
 import unittest
 
 import jmespath
@@ -56,27 +57,56 @@ class IngressFlowerTest(unittest.TestCase):
         )
         assert "foo" == jmespath.search("spec.ingressClassName", docs[0])
 
-    def test_should_ingress_hosts_have_priority_over_host(self):
+    def test_should_ingress_hosts_objs_have_priority_over_host(self):
         docs = render_chart(
             values={
                 "ingress": {
                     "enabled": True,
                     "flower": {
-                        "tls": {"enabled": True, "secretName": "supersecret"},
-                        "hosts": ["*.a-host", "b-host"],
+                        "tls": {"enabled": True, "secretName": "oldsecret"},
+                        "hosts": [
+                            {"name": "*.a-host", "tls": {"enabled": True, "secretName": "newsecret1"}},
+                            {"name": "b-host", "tls": {"enabled": True, "secretName": "newsecret2"}},
+                            {"name": "c-host", "tls": {"enabled": True, "secretName": "newsecret1"}},
+                            {"name": "d-host", "tls": {"enabled": False, "secretName": ""}},
+                            {"name": "e-host"},
+                        ],
                         "host": "old-host",
                     },
                 }
             },
             show_only=["templates/flower/flower-ingress.yaml"],
         )
-        assert (
-            ["*.a-host", "b-host"]
-            == jmespath.search("spec.rules[*].host", docs[0])
-            == jmespath.search("spec.tls[0].hosts", docs[0])
+        assert ["*.a-host", "b-host", "c-host", "d-host", "e-host"] == jmespath.search(
+            "spec.rules[*].host", docs[0]
+        )
+        assert [
+            {"hosts": ["*.a-host"], "secretName": "newsecret1"},
+            {"hosts": ["b-host"], "secretName": "newsecret2"},
+            {"hosts": ["c-host"], "secretName": "newsecret1"},
+        ] == jmespath.search("spec.tls[*]", docs[0])
+
+    def test_should_ingress_hosts_strs_have_priority_over_host(self):
+        docs = render_chart(
+            values={
+                "ingress": {
+                    "enabled": True,
+                    "flower": {
+                        "tls": {"enabled": True, "secretName": "secret"},
+                        "hosts": ["*.a-host", "b-host", "c-host", "d-host"],
+                        "host": "old-host",
+                    },
+                }
+            },
+            show_only=["templates/flower/flower-ingress.yaml"],
         )
 
-    def test_should_ingress_host_still_work(self):
+        assert ["*.a-host", "b-host", "c-host", "d-host"] == jmespath.search("spec.rules[*].host", docs[0])
+        assert [
+            {"hosts": ["*.a-host", "b-host", "c-host", "d-host"], "secretName": "secret"}
+        ] == jmespath.search("spec.tls[*]", docs[0])
+
+    def test_should_ingress_deprecated_host_and_top_level_tls_still_work(self):
         docs = render_chart(
             values={
                 "ingress": {
@@ -92,7 +122,7 @@ class IngressFlowerTest(unittest.TestCase):
         assert (
             ["old-host"]
             == jmespath.search("spec.rules[*].host", docs[0])
-            == jmespath.search("spec.tls[0].hosts", docs[0])
+            == list(itertools.chain.from_iterable(jmespath.search("spec.tls[*].hosts", docs[0])))
         )
 
     def test_should_ingress_host_entry_not_exist(self):

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -142,11 +142,48 @@
                             "default": ""
                         },
                         "hosts": {
-                            "description": "The hostnames for the web Ingress.",
+                            "description": "The hostnames or hosts configuration for the web Ingress.",
                             "type": "array",
                             "default": [],
                             "items": {
-                                "type": "string"
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "description": "The hostname for the web Ingress.",
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "tls": {
+                                                "description": "Configuration for web Ingress TLS.",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "enabled": {
+                                                        "description": "Enable TLS termination for the web Ingress.",
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "secretName": {
+                                                        "description": "The name of a pre-created Secret containing a TLS private key and certificate.",
+                                                        "type": "string",
+                                                        "default": ""
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "default": "",
+                                        "$comment": "Deprecated by object above"
+                                    }
+                                ]
                             }
                         },
                         "ingressClassName": {
@@ -155,7 +192,7 @@
                             "default": ""
                         },
                         "tls": {
-                            "description": "Configuration for web Ingress TLS.",
+                            "description": "Configuration for web Ingress TLS. (Deprecated - renamed to `ingress.web.hosts[*].tls`)",
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {
@@ -209,11 +246,48 @@
                             "default": ""
                         },
                         "hosts": {
-                            "description": "The hostnames for the flower Ingress.",
+                            "description": "The hostnames or hosts configuration for the flower Ingress.",
                             "type": "array",
                             "default": [],
                             "items": {
-                                "type": "string"
+                                "oneOf": [
+                                    {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "name": {
+                                                "description": "The hostname for the web Ingress.",
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "tls": {
+                                                "description": "Configuration for web Ingress TLS.",
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "enabled": {
+                                                        "description": "Enable TLS termination for the web Ingress.",
+                                                        "type": "boolean",
+                                                        "default": false
+                                                    },
+                                                    "secretName": {
+                                                        "description": "The name of a pre-created Secret containing a TLS private key and certificate.",
+                                                        "type": "string",
+                                                        "default": ""
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    },
+                                    {
+                                        "type": "string",
+                                        "default": "",
+                                        "$comment": "Deprecated by object above"
+                                    }
+                                ]
                             }
                         },
                         "ingressClassName": {
@@ -222,7 +296,7 @@
                             "default": ""
                         },
                         "tls": {
-                            "description": "Configuration for flower Ingress TLS.",
+                            "description": "Configuration for flower Ingress TLS. (Deprecated - renamed to `ingress.flower.hosts[*].tls`)",
                             "type": "object",
                             "additionalProperties": false,
                             "properties": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -112,13 +112,20 @@ ingress:
     # The hostname for the web Ingress (Deprecated - renamed to `ingress.web.hosts`)
     host: ""
 
-    # The hostnames for the web Ingress
+    # The hostnames or hosts configuration for the web Ingress
     hosts: []
+    # - name: ""
+    #   # configs for web Ingress TLS
+    #   tls:
+    #     # Enable TLS termination for the web Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
 
     # The Ingress Class for the web Ingress (used only with Kubernetes v1.19 and above)
     ingressClassName: ""
 
-    # configs for web Ingress TLS
+    # configs for web Ingress TLS (Deprecated - renamed to `ingress.web.hosts[*].tls`)
     tls:
       # Enable TLS termination for the web Ingress
       enabled: false
@@ -145,13 +152,19 @@ ingress:
     # The hostname for the flower Ingress (Deprecated - renamed to `ingress.flower.hosts`)
     host: ""
 
-    # The hostnames for the flower Ingress
+    # The hostnames or hosts configuration for the flower Ingress
     hosts: []
+    # - name: ""
+    #   tls:
+    #     # Enable TLS termination for the flower Ingress
+    #     enabled: false
+    #     # the name of a pre-created Secret containing a TLS private key and certificate
+    #     secretName: ""
 
     # The Ingress Class for the flower Ingress (used only with Kubernetes v1.19 and above)
     ingressClassName: ""
 
-    # configs for web Ingress TLS
+    # configs for flower Ingress TLS (Deprecated - renamed to `ingress.flower.hosts[*].tls`)
     tls:
       # Enable TLS termination for the flower Ingress
       enabled: false


### PR DESCRIPTION
This allows the ingress to specify multiple hosts with multiple
different secrets, rather than being contrainted to one secret for all
hosts specified.  Doing this now avoids what is likely some painful
backwards compatability work to resolve this later.

@jedcunningham apologizes for messing up your cadence.  I know the 1.2.0 helm chart release will be going out soon, and looking back on some issues with TLS certs I noticed after #18257 was merged, I wondered if this change would be considered before that release goes out.  If so, I can clean up these failures.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
