### PR TITLE
Fix helm chart unittests on public runners

### DIFF
--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -30,6 +30,7 @@ OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 38
 
 class TestBaseChartTest(unittest.TestCase):
     def test_basic_deployments(self):
+        assert 1 == 1
         k8s_objects = render_chart(
             "TEST-BASIC",
             values={

--- a/chart/tests/test_basic_helm_chart.py
+++ b/chart/tests/test_basic_helm_chart.py
@@ -30,7 +30,6 @@ OBJECT_COUNT_IN_BASIC_DEPLOYMENT = 38
 
 class TestBaseChartTest(unittest.TestCase):
     def test_basic_deployments(self):
-        assert 1 == 1
         k8s_objects = render_chart(
             "TEST-BASIC",
             values={

--- a/scripts/ci/libraries/_parallel.sh
+++ b/scripts/ci/libraries/_parallel.sh
@@ -173,7 +173,7 @@ function parallel::print_job_summary_and_return_status_code() {
         if [[ -s "${status_file}"  ]]; then
             status=$(cat "${status_file}")
         else
-            echo "${COLOR_RED}Missing ${status_file}  file"
+            echo "${COLOR_RED}Missing ${status_file} file"
             status="1"
         fi
         if [[ ${status} == "0" ]]; then

--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -45,10 +45,10 @@ function run_test_types_in_parallel() {
         mkdir -p "${PARALLEL_MONITORED_DIR}/${SEMAPHORE_NAME}/${TEST_TYPE}"
         export JOB_LOG="${PARALLEL_MONITORED_DIR}/${SEMAPHORE_NAME}/${TEST_TYPE}/stdout"
         export PARALLEL_JOB_STATUS="${PARALLEL_MONITORED_DIR}/${SEMAPHORE_NAME}/${TEST_TYPE}/status"
-        # Each test job will get SIGTERM followed by SIGTERM 200ms later and SIGKILL 200ms later after 25 mins
+        # Each test job will get SIGTERM followed by SIGTERM 200ms later and SIGKILL 200ms later after 35 mins
         # shellcheck disable=SC2086
         parallel --ungroup --bg --semaphore --semaphorename "${SEMAPHORE_NAME}" \
-            --jobs "${MAX_PARALLEL_TEST_JOBS}" --timeout 1500 \
+            --jobs "${MAX_PARALLEL_TEST_JOBS}" --timeout 2100 \
             "$( dirname "${BASH_SOURCE[0]}" )/ci_run_single_airflow_test_in_docker.sh" "${@}" >"${JOB_LOG}" 2>&1
     done
     parallel --semaphore --semaphorename "${SEMAPHORE_NAME}" --wait


### PR DESCRIPTION
The helm tests are now regularly taking longer than 25 minutes on public
GitHub Actions workers, so we will increase the timeout.