### PR TITLE
Bugfix: dag_bag.get_dag should not raise exception

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -29,7 +29,7 @@ from airflow.api_connexion.schemas.dag_schema import (
     dag_schema,
     dags_collection_schema,
 )
-from airflow.exceptions import AirflowException, DagNotFound, SerializedDagNotFound
+from airflow.exceptions import AirflowException, DagNotFound
 from airflow.models.dag import DagModel, DagTag
 from airflow.security import permissions
 from airflow.settings import Session
@@ -51,9 +51,8 @@ def get_dag(dag_id, session):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 def get_dag_details(dag_id):
     """Get details of DAG."""
-    try:
-        dag: DAG = current_app.dag_bag.get_dag(dag_id)
-    except SerializedDagNotFound:
+    dag: DAG = current_app.dag_bag.get_dag(dag_id)
+    if not dag:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
     if dag is None:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")

--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -54,8 +54,6 @@ def get_dag_details(dag_id):
     dag: DAG = current_app.dag_bag.get_dag(dag_id)
     if not dag:
         raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
-    if dag is None:
-        raise NotFound("DAG not found", detail=f"The DAG with dag_id: {dag_id} was not found")
     return dag_detail_schema.dump(dag)
 
 

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -150,10 +150,6 @@ class DuplicateTaskIdFound(AirflowException):
     """Raise when a Task with duplicate task_id is defined in the same DAG"""
 
 
-class SerializedDagNotFound(DagNotFound):
-    """Raise when DAG is not found in the serialized_dags table in DB"""
-
-
 class SerializationError(AirflowException):
     """A problem occurred when trying to serialize a DAG"""
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -40,7 +40,6 @@ from airflow.exceptions import (
     AirflowDagCycleException,
     AirflowDagDuplicatedIdException,
     AirflowTimetableInvalid,
-    SerializedDagNotFound,
 )
 from airflow.stats import Stats
 from airflow.utils import timezone
@@ -256,7 +255,7 @@ class DagBag(LoggingMixin):
 
         row = SerializedDagModel.get(dag_id, session)
         if not row:
-            raise SerializedDagNotFound(f"DAG '{dag_id}' not found in serialized_dag table")
+            return None
 
         row.load_op_links = self.load_op_links
         dag = row.dag

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -95,7 +95,7 @@ from airflow.api.common.experimental.mark_tasks import (
     set_dag_run_state_to_success,
 )
 from airflow.configuration import AIRFLOW_CONFIG, conf
-from airflow.exceptions import AirflowException, SerializedDagNotFound
+from airflow.exceptions import AirflowException
 from airflow.executors.executor_loader import ExecutorLoader
 from airflow.jobs.base_job import BaseJob
 from airflow.jobs.scheduler_job import SchedulerJob
@@ -1871,10 +1871,7 @@ class Airflow(AirflowBaseView):
         payload = []
         for dag_id, active_dag_runs in dags:
             max_active_runs = 0
-            try:
-                dag = current_app.dag_bag.get_dag(dag_id)
-            except SerializedDagNotFound:
-                dag = None
+            dag = current_app.dag_bag.get_dag(dag_id)
             if dag:
                 # TODO: Make max_active_runs a column so we can query for it directly
                 max_active_runs = dag.max_active_runs
@@ -2026,9 +2023,8 @@ class Airflow(AirflowBaseView):
         future = to_boolean(args.get('future'))
         past = to_boolean(args.get('past'))
 
-        try:
-            dag = current_app.dag_bag.get_dag(dag_id)
-        except airflow.exceptions.SerializedDagNotFound:
+        dag = current_app.dag_bag.get_dag(dag_id)
+        if not dag:
             flash(f'DAG {dag_id} not found', "error")
             return redirect(request.referrer or url_for('Airflow.index'))
 
@@ -2503,11 +2499,7 @@ class Airflow(AirflowBaseView):
         dag_id = request.args.get('dag_id')
         dag_model = DagModel.get_dagmodel(dag_id)
 
-        try:
-            dag: Optional[DAG] = current_app.dag_bag.get_dag(dag_id)
-        except airflow.exceptions.SerializedDagNotFound:
-            dag = None
-
+        dag: Optional[DAG] = current_app.dag_bag.get_dag(dag_id)
         if dag is None:
             flash(f'DAG "{dag_id}" seems to be missing.', "error")
             return redirect(url_for('Airflow.index'))

--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -91,6 +91,15 @@ class TestDagBag:
         non_existing_dag_id = "non_existing_dag_id"
         assert dagbag.get_dag(non_existing_dag_id) is None
 
+    def test_serialized_dag_not_existing_doesnt_raise(self):
+        """
+        test that retrieving a non existing dag id returns None without crashing
+        """
+        dagbag = models.DagBag(dag_folder=self.empty_dir, include_examples=False, read_dags_from_db=True)
+
+        non_existing_dag_id = "non_existing_dag_id"
+        assert dagbag.get_dag(non_existing_dag_id) is None
+
     def test_dont_load_example(self):
         """
         test that the example are not loaded


### PR DESCRIPTION
get_dag raising exception is breaking many parts of the codebase.
The usage in code suggests that it should return None if a dag is not
found. There are about 30 usages expecting it to return None if a dag
is not found. A missing dag errors out in the UI instead of returning
a message that DAG is missing.

This PR returns None when a dag is not found in SerializedDagModel instead of raising exception


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
