### PR TITLE
Add task information to logs about k8s pods

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -195,19 +195,23 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         """Process status response"""
         if status == 'Pending':
             if event['type'] == 'DELETED':
-                self.log.info('Event: Failed to start pod %s', pod_id)
+                self.log.info('Event: Failed to start pod_id: %s, annotations: %s', pod_id, annotations)
                 self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
             else:
-                self.log.info('Event: %s Pending', pod_id)
+                self.log.info('Event: Pending pod_id: %s, annotations: %s', pod_id, annotations)
         elif status == 'Failed':
-            self.log.error('Event: %s Failed', pod_id)
+            self.log.error('Event: Failed pod_id: %s, annotations: %s', pod_id, annotations)
             self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
         elif status == 'Succeeded':
-            self.log.info('Event: %s Succeeded', pod_id)
+            self.log.info('Event: Succeeded pod_id: %s, annotations: %s', pod_id, annotations)
             self.watcher_queue.put((pod_id, namespace, None, annotations, resource_version))
         elif status == 'Running':
             if event['type'] == 'DELETED':
-                self.log.info('Event: Pod %s deleted before it could complete', pod_id)
+                self.log.info(
+                    'Event: Pod deleted before it could complete pod_id: %s, annotations: %s',
+                    pod_id,
+                    annotations,
+                )
                 self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
             else:
                 self.log.info('Event: %s is Running', pod_id)

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -193,24 +193,26 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         event: Any,
     ) -> None:
         """Process status response"""
+        annotations_condensed: str = force_single_line(annotations)
+
         if status == 'Pending':
             if event['type'] == 'DELETED':
-                self.log.info('Event: Failed to start pod_id: %s, annotations: %s', pod_id, annotations)
+                self.log.info('Event: Failed to start pod_id: %s, annotations: %s', pod_id, annotations_condensed)
                 self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
             else:
-                self.log.info('Event: Pending pod_id: %s, annotations: %s', pod_id, annotations)
+                self.log.info('Event: Pending pod_id: %s, annotations: %s', pod_id, annotations_condensed)
         elif status == 'Failed':
-            self.log.error('Event: Failed pod_id: %s, annotations: %s', pod_id, annotations)
+            self.log.error('Event: Failed pod_id: %s, annotations: %s', pod_id, annotations_condensed)
             self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
         elif status == 'Succeeded':
-            self.log.info('Event: Succeeded pod_id: %s, annotations: %s', pod_id, annotations)
+            self.log.info('Event: Succeeded pod_id: %s, annotations: %s', pod_id, annotations_condensed)
             self.watcher_queue.put((pod_id, namespace, None, annotations, resource_version))
         elif status == 'Running':
             if event['type'] == 'DELETED':
                 self.log.info(
                     'Event: Pod deleted before it could complete pod_id: %s, annotations: %s',
                     pod_id,
-                    annotations,
+                    annotations_condensed,
                 )
                 self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
             else:

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -40,7 +40,11 @@ from airflow.executors.base_executor import NOT_STARTED_MESSAGE, BaseExecutor, C
 from airflow.kubernetes import pod_generator
 from airflow.kubernetes.kube_client import get_kube_client
 from airflow.kubernetes.kube_config import KubeConfig
-from airflow.kubernetes.kubernetes_helper_functions import annotations_to_key, create_pod_id, force_single_line
+from airflow.kubernetes.kubernetes_helper_functions import (
+    annotations_to_key,
+    create_pod_id,
+    force_single_line
+)
 from airflow.kubernetes.pod_generator import PodGenerator
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.settings import pod_mutation_hook
@@ -197,7 +201,9 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
 
         if status == 'Pending':
             if event['type'] == 'DELETED':
-                self.log.info('Event: Failed to start pod_id: %s, annotations: %s', pod_id, annotations_condensed)
+                self.log.info(
+                    'Event: Failed to start pod_id: %s, annotations: %s', pod_id, annotations_condensed
+                )
                 self.watcher_queue.put((pod_id, namespace, State.FAILED, annotations, resource_version))
             else:
                 self.log.info('Event: Pending pod_id: %s, annotations: %s', pod_id, annotations_condensed)
@@ -260,16 +266,15 @@ class AirflowKubernetesScheduler(LoggingMixin):
         sanitized_pod = self.kube_client.api_client.sanitize_for_serialization(pod)
         json_pod = json.dumps(sanitized_pod, indent=2)
 
-        self.log.debug('Pod Creation Request: \n%s',
-                       force_single_line(json_pod))
+        self.log.debug('Pod Creation Request: \n%s', force_single_line(json_pod))
         try:
             resp = self.kube_client.create_namespaced_pod(
                 body=sanitized_pod, namespace=pod.metadata.namespace, **kwargs
             )
             self.log.debug('Pod Creation Response: %s', resp)
         except Exception as e:
-            self.log.exception('Exception when attempting to create Namespaced Pod: %s',
-                               force_single_line(json_pod)
+            self.log.exception(
+                'Exception when attempting to create Namespaced Pod: %s', force_single_line(json_pod)
                                )
             raise e
         return resp
@@ -657,7 +662,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                     ),
                     pod.metadata.name,
                     timeout,
-                    force_single_line(pod.metadata.annotations)
+                    force_single_line(pod.metadata.annotations),
                 )
                 self.kube_scheduler.delete_pod(pod.metadata.name, pod.metadata.namespace)
 

--- a/airflow/kubernetes/kubernetes_helper_functions.py
+++ b/airflow/kubernetes/kubernetes_helper_functions.py
@@ -85,3 +85,7 @@ def annotations_to_key(annotations: Dict[str, str]) -> Optional[TaskInstanceKey]
         )
 
     return TaskInstanceKey(dag_id, task_id, run_id, try_number)
+
+
+def force_single_line(log_element):
+    return str(log_element).replace("\n", " ")


### PR DESCRIPTION
Add annotations, which contain the task information, to log lines that reference a specific pod so that logs can be searched by task or DAG id. Also condenses a few more log elements into a single line to play better with Elastic.

I did not have the confidence/time to go through every log line that references a pod name to add annotations, as some of them would require passing the annotations through several layers that I do not understand and do not want to break. I think I got the most common and critical log lines though.

closes: #18329 
