### PR TITLE
Add config to warn public deployment exposure in UI

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1303,6 +1303,13 @@
       type: integer
       example: ~
       default: "3"
+    - name: warn_deployment_exposure
+      description: |
+        Boolean for displaying warning for publicly viewable deployment
+      version_added: 2.2.0
+      type: boolean
+      example: ~
+      default: "True"
 
 - name: email
   description: |

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1306,7 +1306,7 @@
     - name: warn_deployment_exposure
       description: |
         Boolean for displaying warning for publicly viewable deployment
-      version_added: 2.2.0
+      version_added: 2.3.0
       type: boolean
       example: ~
       default: "True"

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -655,6 +655,9 @@ session_lifetime_minutes = 43200
 # when auto-refresh is turned on
 auto_refresh_interval = 3
 
+# Boolean for displaying warning for publicly viewable deployment
+warn_deployment_exposure = True
+
 [email]
 
 # Configuration email backend and whether to

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3091,6 +3091,14 @@ class Airflow(AirflowBaseView):
         # avoid spaces to reduce payload size
         return htmlsafe_json_dumps(data, separators=(',', ':'))
 
+    def warn_deployment_exposure(self):
+        deployment_warning = "Deployment is exposed to public internet"
+        flash(
+            deployment_warning,
+            "warning",
+        )
+        logging.warning(deployment_warning)
+
     @expose('/robots.txt')
     @action_logging
     def robots(self):
@@ -3099,6 +3107,8 @@ class Airflow(AirflowBaseView):
         of the risk associated with exposing Airflow to the public internet, however it does not
         address the real security risks associated with such a deployment.
         """
+        if conf.getboolean("webserver", "warn_deployment_exposure"):
+            self.warn_deployment_exposure()
         return send_from_directory(current_app.static_folder, 'robots.txt')
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -120,8 +120,7 @@ from airflow.utils.log.log_reader import TaskLogReader
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.utils.strings import to_boolean
-from airflow.utils.timezone import td_format
-from airflow.utils.timezone import utcnow
+from airflow.utils.timezone import td_format, utcnow
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
 from airflow.www.decorators import action_logging, gzipped

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -806,7 +806,7 @@ class Airflow(AirflowBaseView):
                         'This indicates that this deployment may be accessible to the public internet. '
                         'This warning can be disabled by setting webserver.warn_deployment_exposure=False in '
                         'airflow.cfg. Read more about web deployment security <a href='
-                        '"https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html">'
+                        f'"{get_docs_url("security/webserver.html")}">'
                         'here</a>'
                     ),
                     "warning",

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -121,6 +121,7 @@ from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import State
 from airflow.utils.strings import to_boolean
 from airflow.utils.timezone import td_format
+from airflow.utils.timezone import utcnow
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
 from airflow.www.decorators import action_logging, gzipped
@@ -788,18 +789,21 @@ class Airflow(AirflowBaseView):
                 # Second segment is a version marker that we don't need to show.
                 yield segments[2], table_name
 
-        warn_deployment_query = session.query(Log).filter(Log.event == "robots").count()
+        robots_file_access_count = session.query(Log).filter(Log.event == "robots").filter(
+            Log.dttm > (utcnow() - timedelta(days=7))).count()
+
         if (
             permissions.ACTION_CAN_ACCESS_MENU,
             permissions.RESOURCE_ADMIN_MENU,
-        ) in user_permissions and warn_deployment_query > 0:
+        ) in user_permissions and robots_file_access_count > 0 \
+            and conf.getboolean("webserver", "warn_deployment_exposure"):
             flash(
                 Markup(
                     'Recent requests have been made to /robots.txt. '
                     'This indicates that this deployment may be accessible to the public internet. '
                     'This warning can be disabled by setting webserver.warn_deployment_exposure=False in '
                     'airflow.cfg. Read more about web deployment security <a href='
-                    '"https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html">here</a>'
+                    '"https://airflow.apache.org/docs/apache-airflow/stable/security/webserver.html">here</a> '
                 ),
                 "warning",
             )

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -34,7 +34,7 @@ set the below:
 Disable Deployment Exposure Warning
 ---------------------------------------
 
-Airflow warns when recent requests are made to `/robot.txt`. To disable this warning set ``warn_deployment_exposure`` to
+Airflow warns when recent requests are made to ``/robot.txt``. To disable this warning set ``warn_deployment_exposure`` to
 ``False`` as below:
 
 .. code-block:: ini

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -34,8 +34,8 @@ set the below:
 Disable Deployment Exposure Warning
 ---------------------------------------
 
-Airflow warns when recent requests are made to `/robot.txt`. To disable this warning set `warn_deployment_exposure` to
-`False` as below:
+Airflow warns when recent requests are made to `/robot.txt`. To disable this warning set ``warn_deployment_exposure`` to
+``False`` as below:
 
 .. code-block:: ini
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -34,7 +34,7 @@ set the below:
 Disable Deployment Exposure Warning
 ------------------------------------------------------
 
-Airflow warns when recent requests are made to /robot.txt. To disable this warning set the bewlow:
+Airflow warns when recent requests are made to /robot.txt. To disable this warning set the below:
 
 .. code-block:: ini
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -34,8 +34,8 @@ set the below:
 Disable Deployment Exposure Warning
 ---------------------------------------
 
-Airflow warns when recent requests are made to `/robot.txt`. To disable this warning set ``warn_deployment_exposure`` to
-``False`` as below:
+Airflow warns when recent requests are made to `/robot.txt`. To disable this warning set `warn_deployment_exposure` to
+`False` as below:
 
 .. code-block:: ini
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -31,6 +31,16 @@ set the below:
     [webserver]
     x_frame_enabled = False
 
+Disable Deployment Exposure Warning
+------------------------------------------------------
+
+Airflow warns when recent requests are made to /robot.txt. To disable this warning set the bewlow:
+
+.. code-block:: ini
+
+    [webserver]
+    warn_deployment_exposure = False
+
 Sensitive Variable fields
 -------------------------
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -32,9 +32,10 @@ set the below:
     x_frame_enabled = False
 
 Disable Deployment Exposure Warning
-------------------------------------------------------
+---------------------------------------
 
-Airflow warns when recent requests are made to /robot.txt. To disable this warning set the below:
+Airflow warns when recent requests are made to `/robot.txt`. To disable this warning set ``warn_deployment_exposure`` to
+``False`` as below:
 
 .. code-block:: ini
 

--- a/tests/www/views/test_views_base.py
+++ b/tests/www/views/test_views_base.py
@@ -30,7 +30,7 @@ from tests.test_utils.www import check_content_in_response, check_content_not_in
 
 
 def test_index(admin_client):
-    with assert_queries_count(49):
+    with assert_queries_count(50):
         resp = admin_client.get('/', follow_redirects=True)
     check_content_in_response('DAGs', resp)
 

--- a/tests/www/views/test_views_robots.py
+++ b/tests/www/views/test_views_robots.py
@@ -22,12 +22,13 @@ def test_robots(viewer_client):
     assert resp.data.decode('utf-8') == "User-agent: *\nDisallow: /\n"
 
 
-def test_deployment_warning_config(viewer_client):
-    viewer_client.get('/robots.txt', follow_redirects=True)
-    resp = viewer_client.get('', follow_redirects=True)
-    assert "exposed to public internet" in resp.data.decode('utf-8')
+def test_deployment_warning_config(admin_client):
+    warn_text = "webserver.warn_deployment_exposure"
+    admin_client.get('/robots.txt', follow_redirects=True)
+    resp = admin_client.get('', follow_redirects=True)
+    assert warn_text in resp.data.decode('utf-8')
 
     with conf_vars({('webserver', 'warn_deployment_exposure'): 'False'}):
-        viewer_client.get('/robots.txt', follow_redirects=True)
-        resp = viewer_client.get('/robots.txt', follow_redirects=True)
-        assert "exposed to public internet" not in resp.data.decode('utf-8')
+        admin_client.get('/robots.txt', follow_redirects=True)
+        resp = admin_client.get('/robots.txt', follow_redirects=True)
+        assert warn_text not in resp.data.decode('utf-8')

--- a/tests/www/views/test_views_robots.py
+++ b/tests/www/views/test_views_robots.py
@@ -14,8 +14,20 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from tests.test_utils.config import conf_vars
 
 
 def test_robots(viewer_client):
     resp = viewer_client.get('/robots.txt', follow_redirects=True)
     assert resp.data.decode('utf-8') == "User-agent: *\nDisallow: /\n"
+
+
+def test_deployment_warning_config(viewer_client):
+    viewer_client.get('/robots.txt', follow_redirects=True)
+    resp = viewer_client.get('', follow_redirects=True)
+    assert "exposed to public internet" in resp.data.decode('utf-8')
+
+    with conf_vars({('webserver', 'warn_deployment_exposure'): 'False'}):
+        viewer_client.get('/robots.txt', follow_redirects=True)
+        resp = viewer_client.get('/robots.txt', follow_redirects=True)
+        assert "exposed to public internet" not in resp.data.decode('utf-8')


### PR DESCRIPTION
closes:  #17962

Added warning banner message for when /robot.txt is hit with on/off config
