### PR TITLE
[ISSUE-18468] add container option for SparkKubernetesSensor

### DIFF
--- a/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/sensors/spark_kubernetes.py
@@ -60,6 +60,7 @@ class SparkKubernetesSensor(BaseSensorOperator):
         kubernetes_conn_id: str = "kubernetes_default",
         api_group: str = 'sparkoperator.k8s.io',
         api_version: str = 'v1beta2',
+        driver_container: str = 'spark-kubernetes-driver',
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -70,6 +71,7 @@ class SparkKubernetesSensor(BaseSensorOperator):
         self.hook = KubernetesHook(conn_id=self.kubernetes_conn_id)
         self.api_group = api_group
         self.api_version = api_version
+        self.driver_container = driver_container
 
     def _log_driver(self, application_state: str, response: dict) -> None:
         if not self.attach_log:
@@ -85,7 +87,7 @@ class SparkKubernetesSensor(BaseSensorOperator):
         log_method = self.log.error if application_state in self.FAILURE_STATES else self.log.info
         try:
             log = ""
-            for line in self.hook.get_pod_logs(driver_pod_name, namespace=namespace):
+            for line in self.hook.get_pod_logs(driver_pod_name, namespace=namespace, container=self.driver_container):
                 log += line.decode()
             log_method(log)
         except client.rest.ApiException as e:


### PR DESCRIPTION
…configure which container to retrieve logs

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: 18468
related: 18468

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

The problem with the current `SparkKubernetesSensor` is that, if the spark is running with sidecar containers for instance `istio-proxy` or `vault-sidecar`, which is rather common is some cases, the previous version cannot retrieve logs correctly and will run into errors.

A quick fix would be to add an option that allows developers to configure which container is the driver and can retrieve logs from driver container correctly.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
