### PR TITLE
Change location of bucket creation for Datastore

### DIFF
--- a/tests/providers/google/cloud/operators/test_datastore_system.py
+++ b/tests/providers/google/cloud/operators/test_datastore_system.py
@@ -31,7 +31,7 @@ class GcpDatastoreSystemTest(GoogleSystemTest):
     @provide_gcp_context(GCP_DATASTORE_KEY)
     def setUp(self):
         super().setUp()
-        self.create_gcs_bucket(BUCKET, location="europe-north1")
+        self.create_gcs_bucket(BUCKET, location="europe-central2")
 
     @provide_gcp_context(GCP_DATASTORE_KEY)
     def tearDown(self):


### PR DESCRIPTION
Due to the error `This project can only operate on buckets spanning location europe-central2 or eu`, passed location to the **create_gcs_bucket** method was changed to the **europe-central2**