### PR TITLE
Only show the task modal if it is a valid instance

### DIFF
--- a/airflow/www/static/css/graph.css
+++ b/airflow/www/static/css/graph.css
@@ -78,6 +78,11 @@ svg {
   fill: #017cee;
 }
 
+.not-allowed rect,
+.not-allowed text {
+  cursor: not-allowed !important;
+}
+
 g.cluster rect {
   stroke: #fff;
   stroke-dasharray: 5;

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -470,7 +470,8 @@ function updateNodesStates(tis) {
     if (!elem) {
       return;
     }
-    elem.setAttribute('class', `node enter ${getNodeState(nodeId, tis)}`);
+    const classes = `node enter ${getNodeState(nodeId, tis)}`;
+    elem.setAttribute('class', classes);
     elem.setAttribute('data-toggle', 'tooltip');
 
     const taskId = nodeId;
@@ -483,6 +484,7 @@ function updateNodesStates(tis) {
         tt = groupTooltip(node, tis);
       } else if (taskId in tasks) {
         tt = taskNoInstanceTooltip(taskId, tasks[taskId]);
+        elem.setAttribute('class', `${classes} not-allowed`);
       }
       if (tt) taskTip.show(tt, evt.target); // taskTip is defined in graph.html
     };

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -144,9 +144,7 @@ function draw() {
     } else if (nodeId in taskInstances) {
       // A task node
       const task = tasks[nodeId];
-      let tryNumber;
-      if (nodeId in taskInstances) tryNumber = taskInstances[nodeId].try_number;
-      else tryNumber = 0;
+      const tryNumber = taskInstances[nodeId].try_number || 0;
 
       if (task.task_type === 'SubDagOperator') callModal(nodeId, executionDate, task.extra_links, tryNumber, true);
       else callModal(nodeId, executionDate, task.extra_links, tryNumber, undefined);

--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -141,7 +141,7 @@ function draw() {
       expandGroup(nodeId, node);
       draw();
       focusGroup(nodeId);
-    } else if (nodeId in tasks) {
+    } else if (nodeId in taskInstances) {
       // A task node
       const task = tasks[nodeId];
       let tryNumber;


### PR DESCRIPTION
We were allowing users to click on a task to open the task instance modal even if it wasn't connected to a dag run. Many of the actions would then break the UI with a stacktrace from the webserver. In this PR we simply only show the modal if there is a valid task instance.

Ideally, we should also update the webserver to handle those errors more gracefully as well. But this at least prevents users from getting there from the UI.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
