### PR TITLE
Fetch PR labels from API for Build Images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -61,7 +61,6 @@ jobs:
     runs-on: ${{ github.repository == 'apache/airflow' && 'self-hosted' || 'ubuntu-20.04' }}
     env:
       targetBranch: ${{ github.event.pull_request.base.ref }}
-      pullRequestLabels: "${{ toJSON(github.event.pull_request.labels.*.name) }}"
     outputs:
       runsOn: ${{ github.repository == 'apache/airflow' && '["self-hosted"]' || '["ubuntu-20.04"]' }}
       pythonVersions: "${{ steps.selective-checks.python-versions }}"
@@ -86,6 +85,24 @@ jobs:
           echo "TARGET_COMMIT_SHA=$TARGET_COMMIT_SHA" >> $GITHUB_ENV
           echo "::set-output name=targetCommitSha::${TARGET_COMMIT_SHA}"
         if: github.event_name == 'pull_request_target'
+      # The labels in the event aren't updated when re-triggering the job, So lets hit the API to get
+      # up-to-date values
+      - name: Get latest PR labels
+        id: get-latest-pr-labels
+        run: |
+          echo -n "::set-output name=pullRequestLabels::"
+          gh api graphql --paginate -F node_id=${{github.event.pull_request.node_id}} -f query='
+            query($node_id: ID!, $endCursor: String) {
+              node(id:$node_id) {
+                ... on PullRequest {
+                  labels(first: 100, after: $endCursor) {
+                    nodes { name }
+                    pageInfo { hasNextPage endCursor }
+                  }
+                }
+              }
+            }' --jq '.data.node.labels.nodes[]' | jq --slurp -c '[.[].name]'
+        if: github.event_name == 'pull_request_target'
       # Retrieve it to be able to determine which files has changed in the incoming commit of the PR
       # we checkout the target commit and it's parent to be able to compare them
       - uses: actions/checkout@v2
@@ -102,11 +119,12 @@ jobs:
         run: printenv
         env:
           dynamicOutputs: ${{ toJSON(steps.dynamic-outputs.outputs) }}
+          PR_LABELS: ${{ steps.get-latest-pr-labels.outputs.pullRequestLabels }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
       - name: Selective checks
         id: selective-checks
         env:
-          PR_LABELS: ${{ env.pullRequestLabels }}
+          PR_LABELS: ${{ steps.get-latest-pr-labels.outputs.pullRequestLabels }}
         run: |
           if [[ ${GITHUB_EVENT_NAME} == "pull_request_target" ]]; then
             # Run selective checks


### PR DESCRIPTION
The event payload in GitHub does contain PR labels, but they are "fixed"
at the time the original event is triggered, meaning that if you re-run
the Build Image job at a later date (say after the "full tests needed"
label has been automatically applies) it will still see the same values.


Tested on my fork: https://github.com/ashb/airflow/runs/3732997192
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).