### PR TITLE
Fix errors upgrading from Airflow 1.10.15

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -661,6 +661,7 @@ def check_conn_id_duplicates(session=None) -> Iterable[str]:
         dups = session.query(Connection.conn_id).group_by(Connection.conn_id).having(func.count() > 1).all()
     except (exc.OperationalError, exc.ProgrammingError):
         # fallback if tables hasn't been created yet
+        session.rollback()
         pass
     if dups:
         yield (
@@ -680,9 +681,10 @@ def check_conn_type_null(session=None) -> Iterable[str]:
     """
     n_nulls = []
     try:
-        n_nulls = session.query(Connection).filter(Connection.conn_type.is_(None)).all()
+        n_nulls = session.query(Connection.conn_id).filter(Connection.conn_type.is_(None)).all()
     except (exc.OperationalError, exc.ProgrammingError, exc.InternalError):
         # fallback if tables hasn't been created yet
+        session.rollback()
         pass
 
     if n_nulls:


### PR DESCRIPTION
If either of those checks failed the session was left in a transaction
with a failure so couldn't be used for future tests.

And the second check (conn_type_null) _always_ failed on 1.10.15,
because even thought the table existed, the `description` column which
the model expects hasn't yet been added (because we are running this pre
migration!) so the fix there is to just select `conn_id` column.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).