### PR TITLE
Resync DAG during next parse if error in ``sync_to_db``

### DIFF
--- a/tests/models/test_dagbag.py
+++ b/tests/models/test_dagbag.py
@@ -721,6 +721,7 @@ class TestDagBag:
 
             caplog.set_level(logging.ERROR)
             dagbag.sync_to_db(session=session)
+            assert "Failed to write serialized DAG 'test_example_bash_operator'" in caplog.text
             assert "SerializationError" in caplog.text
 
             assert path in dagbag.import_errors
@@ -821,6 +822,7 @@ class TestDagBag:
                 )
                 caplog.set_level(logging.ERROR)
                 dagbag.sync_to_db(session=session)
+                assert "Failed to sync DAG permissions for 'access_control_test'" in caplog.text
                 assert "FakeRole" in caplog.text
                 assert f.name in dagbag.import_errors
                 err = dagbag.import_errors[f.name]


### PR DESCRIPTION
If there is an issue syncing DAG specific permissions, force syncing to
happen again the next time the DAG is parsed so errors will be added to
``import_errors`` and shown in the UI.

The easiest example of this is the use of a non-existent role in
``access_control``.

Related #17166