### PR TITLE
Create CMDExecutor for raising an exception in case of error during cmd execution

### DIFF
--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -261,3 +261,7 @@ class TaskDeferred(BaseException):
 
 class TaskDeferralError(AirflowException):
     """Raised when a task failed during deferral for some reason."""
+
+
+class CMDExecutionError(AirflowException):
+    """Raise in case of error during cmd execution"""

--- a/tests/providers/google/cloud/operators/test_cloud_build_system_helper.py
+++ b/tests/providers/google/cloud/operators/test_cloud_build_system_helper.py
@@ -25,7 +25,7 @@ from tempfile import TemporaryDirectory
 from urllib.parse import urlparse
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUD_BUILD_KEY, GcpAuthenticator
-from tests.test_utils.logging_command_executor import LoggingCommandExecutor
+from tests.test_utils.logging_command_executor import CMDExecutor
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-project")
 GCP_ARCHIVE_URL = os.environ.get("GCP_CLOUD_BUILD_ARCHIVE_URL", "gs://example-bucket/source-code.tar.gz")
@@ -36,7 +36,7 @@ GCP_OBJECT_NAME = GCP_ARCHIVE_URL_PARTS.path[1:]
 GCP_REPOSITORY_NAME = os.environ.get("GCP_CLOUD_BUILD_REPOSITORY_NAME", "repository-name")
 
 
-class GCPCloudBuildTestHelper(LoggingCommandExecutor):
+class GCPCloudBuildTestHelper(CMDExecutor):
     """
     Helper class to perform system tests for the Google Cloud Build service.
     """

--- a/tests/providers/google/cloud/operators/test_cloud_sql_system_helper.py
+++ b/tests/providers/google/cloud/operators/test_cloud_sql_system_helper.py
@@ -27,7 +27,7 @@ from typing import Optional
 from urllib.parse import urlsplit
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_CLOUDSQL_KEY, GcpAuthenticator
-from tests.test_utils.logging_command_executor import LoggingCommandExecutor
+from tests.test_utils.logging_command_executor import CMDExecutor
 
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCP_LOCATION = os.environ.get('GCP_LOCATION', 'europe-west1')
@@ -89,7 +89,7 @@ def get_mysql_instance_name(instance_suffix=''):
     return os.environ.get('GCSQL_MYSQL_INSTANCE_NAME', 'testmysql') + instance_suffix
 
 
-class CloudSqlQueryTestHelper(LoggingCommandExecutor):
+class CloudSqlQueryTestHelper(CMDExecutor):
     def create_instances(
         self, instance_suffix='', failover_instance_suffix=None, master_instance_suffix=None
     ):
@@ -153,30 +153,21 @@ class CloudSqlQueryTestHelper(LoggingCommandExecutor):
         )
 
     def check_if_instances_are_up(self, instance_suffix=''):
-        res_postgres = self.execute_cmd(
-            [
-                'gcloud',
-                'sql',
-                'instances',
-                'describe',
-                get_postgres_instance_name(instance_suffix),
-                f"--project={GCP_PROJECT_ID}",
-            ]
-        )
-        if res_postgres != 0:
-            self.raise_database_exception('postgres')
-        res_postgres = self.execute_cmd(
-            [
-                'gcloud',
-                'sql',
-                'instances',
-                'describe',
-                get_postgres_instance_name(instance_suffix),
-                f"--project={GCP_PROJECT_ID}",
-            ]
-        )
-        if res_postgres != 0:
-            self.raise_database_exception('mysql')
+        def check_db(db_instance_name, db_name):
+            retcode_db = self.execute_cmd(
+                [
+                    'gcloud',
+                    'sql',
+                    'instances',
+                    'describe',
+                    db_instance_name,
+                    f"--project={GCP_PROJECT_ID}",
+                ]
+            )
+            if retcode_db:
+                self.raise_database_exception(db_name)
+        check_db(db_instance_name=get_postgres_instance_name(instance_suffix), db_name='postgres')
+        check_db(db_instance_name=get_mysql_instance_name(instance_suffix), db_name='mysql')
 
     def authorize_address(self, instance_suffix=''):
         ip_address = self.__get_my_public_ip()

--- a/tests/providers/google/cloud/operators/test_compute_system_helper.py
+++ b/tests/providers/google/cloud/operators/test_compute_system_helper.py
@@ -20,7 +20,7 @@ import argparse
 import os
 
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_COMPUTE_KEY, GcpAuthenticator
-from tests.test_utils.logging_command_executor import LoggingCommandExecutor
+from tests.test_utils.logging_command_executor import CMDExecutor
 
 GCE_INSTANCE = os.environ.get('GCE_INSTANCE', 'testinstance')
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
@@ -30,7 +30,7 @@ GCE_TEMPLATE_NAME = os.environ.get('GCE_TEMPLATE_NAME', 'instance-template-test'
 GCE_NEW_TEMPLATE_NAME = os.environ.get('GCE_NEW_TEMPLATE_NAME', 'instance-template-test-new')
 
 
-class GCPComputeTestHelper(LoggingCommandExecutor):
+class GCPComputeTestHelper(CMDExecutor):
     def delete_instance(self):
         self.execute_cmd(
             [

--- a/tests/providers/google/cloud/operators/test_gcs_system_helper.py
+++ b/tests/providers/google/cloud/operators/test_gcs_system_helper.py
@@ -25,10 +25,10 @@ from airflow.providers.google.cloud.example_dags.example_gcs import (
     PATH_TO_TRANSFORM_SCRIPT,
     PATH_TO_UPLOAD_FILE,
 )
-from tests.test_utils.logging_command_executor import LoggingCommandExecutor
+from tests.test_utils.logging_command_executor import CMDExecutor
 
 
-class GcsSystemTestHelper(LoggingCommandExecutor):
+class GcsSystemTestHelper(CMDExecutor):
     @staticmethod
     def create_test_file():
         # Create test file for upload

--- a/tests/providers/google/cloud/utils/gcp_authenticator.py
+++ b/tests/providers/google/cloud/utils/gcp_authenticator.py
@@ -26,7 +26,7 @@ from airflow.models import Connection
 
 # Please keep these variables in alphabetical order.
 from tests.test_utils import AIRFLOW_MAIN_FOLDER
-from tests.test_utils.logging_command_executor import LoggingCommandExecutor
+from tests.test_utils.logging_command_executor import CMDExecutor
 
 GCP_AI_KEY = 'gcp_ai.json'
 GCP_AUTOML_KEY = 'gcp_automl.json'
@@ -65,7 +65,7 @@ SCOPE_EXTRA = 'extra__google_cloud_platform__scope'
 PROJECT_EXTRA = 'extra__google_cloud_platform__project'
 
 
-class GcpAuthenticator(LoggingCommandExecutor):
+class GcpAuthenticator(CMDExecutor):
     """
     Initialises the authenticator.
 

--- a/tests/test_utils/gcp_system_helpers.py
+++ b/tests/test_utils/gcp_system_helpers.py
@@ -28,7 +28,7 @@ from google.auth.environment_vars import CLOUD_SDK_CONFIG_DIR, CREDENTIALS
 from airflow.providers.google.cloud.utils.credentials_provider import provide_gcp_conn_and_credentials
 from tests.providers.google.cloud.utils.gcp_authenticator import GCP_GCS_KEY, GCP_SECRET_MANAGER_KEY
 from tests.test_utils import AIRFLOW_MAIN_FOLDER
-from tests.test_utils.logging_command_executor import get_executor
+from tests.test_utils.logging_command_executor import CMDExecutor
 from tests.test_utils.system_tests_class import SystemTest
 
 CLOUD_DAG_FOLDER = os.path.join(
@@ -97,7 +97,7 @@ def provide_gcp_context(
     ), tempfile.TemporaryDirectory() as gcloud_config_tmp, mock.patch.dict(
         'os.environ', {CLOUD_SDK_CONFIG_DIR: gcloud_config_tmp}
     ):
-        executor = get_executor()
+        executor = CMDExecutor()
 
         if project_id:
             executor.execute_cmd(["gcloud", "config", "set", "core/project", project_id])
@@ -124,6 +124,11 @@ def provide_gcs_bucket(bucket_name: str):
 @pytest.mark.system("google")
 class GoogleSystemTest(SystemTest):
     @staticmethod
+    def execute_cmd(*args, **kwargs):
+        executor = CMDExecutor()
+        return executor.execute_cmd(*args, **kwargs)
+
+    @staticmethod
     def _project_id():
         return os.environ.get("GCP_PROJECT_ID")
 
@@ -139,10 +144,9 @@ class GoogleSystemTest(SystemTest):
         Executes command with context created by provide_gcp_context and activated
         service key.
         """
-        executor = get_executor()
         current_project_id = project_id or cls._project_id()
         with provide_gcp_context(key, project_id=current_project_id, scopes=scopes):
-            executor.execute_cmd(cmd=cmd, silent=silent)
+            cls.execute_cmd(cmd=cmd, silent=silent)
 
     @classmethod
     def create_gcs_bucket(cls, name: str, location: Optional[str] = None) -> None:

--- a/tests/test_utils/logging_command_executor.py
+++ b/tests/test_utils/logging_command_executor.py
@@ -19,7 +19,7 @@ import os
 import shlex
 import subprocess
 
-from airflow.exceptions import AirflowException
+from airflow.exceptions import AirflowException, CMDExecutionError
 from airflow.utils.log.logging_mixin import LoggingMixin
 
 
@@ -60,6 +60,39 @@ class LoggingCommandExecutor(LoggingMixin):
                     f"Retcode {retcode} on {' '.join(cmd)} with stdout: {output}, stderr: {err}"
                 )
             return output
+
+
+class CMDExecutor(LoggingCommandExecutor):
+    """
+    Due to 'LoggingCommandExecutor' class just returns the status code of command execution ('execute_cmd' method)
+    and continues to perform code with possible errors, separate inherited 'CMDExecutor' class was created to use it
+    if you need to break code performing and immediately raise an exception in case of error during command execution,
+    so re-written 'execute_cmd' method will raise 'CMDExecutionError' exception.
+     """
+
+    def execute_cmd(self, cmd, silent=False, cwd=None, env=None):
+        if silent:
+            self.log.info("Executing in silent mode: '%s'", " ".join(shlex.quote(c) for c in cmd))
+            with open(os.devnull, 'w') as dev_null:
+                return subprocess.call(args=cmd, stdout=dev_null, stderr=subprocess.STDOUT, env=env, cwd=cwd)
+        else:
+            self.log.info("Executing: '%s'", " ".join(shlex.quote(c) for c in cmd))
+            with subprocess.Popen(
+                args=cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
+                cwd=cwd,
+                env=env,
+            ) as process:
+                output, err = process.communicate()
+                retcode = process.poll()
+                if retcode:
+                    raise CMDExecutionError(
+                        f"Error when executing '{' '.join(cmd)}' with stdout: {output}, stderr: {err}"
+                    )
+                self.log.info("Stdout: %s", output)
+                self.log.info("Stderr: %s", err)
 
 
 def get_executor() -> LoggingCommandExecutor:


### PR DESCRIPTION
This is not specific to Google, but for now is used only in Google because we need to raise an exception in case of any errors during command execution (original logic in the parent class just returns the status code of command execution). That's why we decided to leave the original logic and create the separate class which raises the exception in case of error during command execution, so if someone in future requires such behavior too, they will be able to use this class.