### PR TITLE
Fixing flaky test that fails when run with other test that leave a trace

### DIFF
--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -176,7 +176,7 @@ class TestCliUsers:
                     'users',
                     'delete',
                     '--username',
-                    'test',
+                    'test_user_name99',
                     '--email',
                     'jdoe2@example.com',
                 ],
@@ -187,9 +187,9 @@ class TestCliUsers:
                     'users',
                     'delete',
                     '--username',
-                    'test',
+                    'test_user_name99',
                 ],
-                'User "test" does not exist',
+                'User "test_user_name99" does not exist',
             ),
             (
                 [


### PR DESCRIPTION
This PR fixes flaky test which is failing when run in conjunction with other tests in the pack which leaves traces, in this case other tests leave trace for a user with a username "test" in the db which this test tries to check against for non-existence.
This small fix should make username unique so test works all scenarios.
 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
