### PR TITLE
Fixing bug when roles list is empty

### DIFF
--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -197,7 +197,13 @@ def _import_users(users_list: List[Dict[str, Any]]):
     try:
         UserSchema(many=True).load(users_list)
     except ValidationError as e:
-        raise SystemExit(f"Error: Input file didn't pass validation. See below:\n{e}")
+        msg = []
+        failures = e.messages
+        for row_num in failures:
+            msg.append(f'[Item {row_num}]')
+            for key in failures[row_num]:
+                msg.append(f'\t{key}: {failures[row_num][key]}')
+        raise SystemExit("Error: Input file didn't pass validation. See below:\n{}".format('\n'.join(msg)))
 
     for user in users_list:
 

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -175,12 +175,12 @@ def users_import(args):
         print("Updated the following users:\n\t{}".format("\n\t".join(users_updated)))
 
 
-def _import_users(users_list_: List[Dict[str, Any]]):
+def _import_users(users_list: List[Dict[str, Any]]):
     appbuilder = cached_app().appbuilder
     users_created = []
     users_updated = []
 
-    for user in users_list_:
+    for user in users_list:
         required_fields = ['username', 'firstname', 'lastname', 'email', 'roles']
         for field in required_fields:
             if field not in user:

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -174,12 +174,20 @@ def users_import(args):
         print("Updated the following users:\n\t{}".format("\n\t".join(users_updated)))
 
 
-def _import_users(users_list):
+def _import_users(users_list_):
     appbuilder = cached_app().appbuilder
     users_created = []
     users_updated = []
 
-    for user in users_list:
+    for user in users_list_:
+        required_fields = ['username', 'firstname', 'lastname', 'email', 'roles']
+        for field in required_fields:
+            if field not in user:
+                raise SystemExit(f"Error: '{field}' is a required field, but was not specified")
+
+        if isinstance(user['roles'], list) and not user['roles']:
+            raise SystemExit('Error: User "{}" must have at lest one role'.format(user['username']))
+
         roles = []
         for rolename in user['roles']:
             role = appbuilder.sm.find_role(rolename)

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -200,8 +200,8 @@ def _import_users(users_list: List[Dict[str, Any]]):
         msg = []
         for row_num, failure in e.messages.items():
             msg.append(f'[Item {row_num}]')
-            for key in failure:
-                msg.append(f'\t{key}: {failure[key]}')
+            for key, value in failure.items():
+                msg.append(f'\t{key}: {value}')
         raise SystemExit("Error: Input file didn't pass validation. See below:\n{}".format('\n'.join(msg)))
 
     for user in users_list:

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+    # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -22,6 +22,7 @@ import os
 import random
 import re
 import string
+from typing import Any, Dict, List
 
 from airflow.cli.simple_table import AirflowConsole
 from airflow.utils import cli as cli_utils
@@ -174,7 +175,7 @@ def users_import(args):
         print("Updated the following users:\n\t{}".format("\n\t".join(users_updated)))
 
 
-def _import_users(users_list_):
+def _import_users(users_list_: List[Dict[str, Any]]):
     appbuilder = cached_app().appbuilder
     users_created = []
     users_updated = []
@@ -183,9 +184,12 @@ def _import_users(users_list_):
         required_fields = ['username', 'firstname', 'lastname', 'email', 'roles']
         for field in required_fields:
             if field not in user:
-                raise SystemExit(f"Error: '{field}' is a required field, but was not specified")
+                raise SystemExit(f'Error: "{field}" is a required field, but was not specified')
 
-        if isinstance(user['roles'], list) and not user['roles']:
+        if not isinstance(user['roles'], list):
+            raise SystemExit('Error: Incorrect list of roles specified for user "{}"'.format(user['username']))
+
+        if not user['roles']:
             raise SystemExit('Error: User "{}" must have at lest one role'.format(user['username']))
 
         roles = []
@@ -196,11 +200,6 @@ def _import_users(users_list_):
                 raise SystemExit(f'Error: "{rolename}" is not a valid role. Valid roles are: {valid_roles}')
 
             roles.append(role)
-
-        required_fields = ['username', 'firstname', 'lastname', 'email', 'roles']
-        for field in required_fields:
-            if not user.get(field):
-                raise SystemExit(f"Error: '{field}' is a required field, but was not specified")
 
         existing_user = appbuilder.sm.find_user(email=user['email'])
         if existing_user:

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -198,11 +198,10 @@ def _import_users(users_list: List[Dict[str, Any]]):
         UserSchema(many=True).load(users_list)
     except ValidationError as e:
         msg = []
-        failures = e.messages
-        for row_num in failures:
+        for row_num, failure in e.messages.items():
             msg.append(f'[Item {row_num}]')
-            for key in failures[row_num]:
-                msg.append(f'\t{key}: {failures[row_num][key]}')
+            for key in failure:
+                msg.append(f'\t{key}: {failure[key]}')
         raise SystemExit("Error: Input file didn't pass validation. See below:\n{}".format('\n'.join(msg)))
 
     for user in users_list:

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -194,13 +194,12 @@ def _import_users(users_list: List[Dict[str, Any]]):
     users_created = []
     users_updated = []
 
-    for user in users_list:
+    try:
+        UserSchema(many=True).load(users_list)
+    except ValidationError as e:
+        raise SystemExit(f"Error: Input file didn't pass validation. See below:\n{e}")
 
-        try:
-            # Validate structure
-            UserSchema().load(user)
-        except ValidationError as e:
-            raise SystemExit(f"Error: Can't load user \"{user}\". \nDetails:{e}")
+    for user in users_list:
 
         roles = []
         for rolename in user['roles']:

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -1,4 +1,4 @@
-    # Licensed to the Apache Software Foundation (ASF) under one
+# Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -187,10 +187,10 @@ def _import_users(users_list_: List[Dict[str, Any]]):
                 raise SystemExit(f'Error: "{field}" is a required field, but was not specified')
 
         if not isinstance(user['roles'], list):
-            raise SystemExit('Error: Incorrect list of roles specified for user "{}"'.format(user['username']))
+            raise SystemExit(f"Error: Incorrect list of roles specified for user \"{user['username']}\"")
 
         if not user['roles']:
-            raise SystemExit('Error: User "{}" must have at lest one role'.format(user['username']))
+            raise SystemExit(f"Error: User \"{user['username']}\" must have at lest one role")
 
         roles = []
         for rolename in user['roles']:

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -418,7 +418,8 @@ class TestCliUsers:
                     "roles": "This is not a list",
                 },
                 "Error: Input file didn't pass validation. See below:\n"
-                "{0: {'roles': ['Not a valid list.']}}",
+                "[Item 0]\n"
+                "\troles: ['Not a valid list.']",
             ],
             [
                 {
@@ -429,7 +430,8 @@ class TestCliUsers:
                     "roles": [],
                 },
                 "Error: Input file didn't pass validation. See below:\n"
-                "{0: {'roles': ['Shorter than minimum length 1.']}}",
+                "[Item 0]\n"
+                "\troles: ['Shorter than minimum length 1.']",
             ],
             [
                 {
@@ -437,14 +439,21 @@ class TestCliUsers:
                     "lastname": "doe3",
                     "firstname": "jon",
                     "email": TEST_USER3_EMAIL,
+                    "roles": ["Test"],
                 },
                 "Error: Input file didn't pass validation. See below:\n"
-                "{0: {'username': ['Missing data for required field.'], "
-                "'roles': ['Missing data for required field.'], "
-                "'username1': ['Unknown field.']}}",
+                "[Item 0]\n"
+                "\tusername: ['Missing data for required field.']\n"
+                "\tusername1: ['Unknown field.']",
+            ],
+            [
+                "Wrong input",
+                "Error: Input file didn't pass validation. See below:\n"
+                "[Item 0]\n"
+                "\t_schema: ['Invalid input type.']",
             ],
         ],
-        ids=["Incorrect roles argument", "Empty roles", "Roles is missing"],
+        ids=["Incorrect roles", "Empty roles", "Required field is missing", "Wrong input"],
     )
     def test_cli_import_users_exceptions(self, user, message):
         with pytest.raises(SystemExit, match=re.escape(message)):

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -28,6 +28,7 @@ from tests.test_utils.api_connexion_utils import delete_users
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
 TEST_USER2_EMAIL = 'test-user2@example.com'
+TEST_USER3_EMAIL = 'test-user3@example.com'
 
 
 def _does_user_belong_to_role(appbuilder, email, rolename):
@@ -432,7 +433,7 @@ class TestCliUsers:
                     "username": "imported_user3",
                     "lastname": "doe3",
                     "firstname": "jon",
-                    "email": TEST_USER2_EMAIL,
+                    "email": TEST_USER3_EMAIL,
                 },
                 'Error: "roles" is a required field, but was not specified',
             ],

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -18,6 +18,7 @@
 import io
 import json
 import os
+import re
 import tempfile
 from contextlib import redirect_stdout
 
@@ -416,7 +417,9 @@ class TestCliUsers:
                     "email": TEST_USER1_EMAIL,
                     "roles": "This is not a list",
                 },
-                'Error: Incorrect list of roles specified for user "imported_user1"',
+                "Error: Can't load user \"{'username': 'imported_user1', 'lastname': 'doe1',"
+                " 'firstname': 'john', 'email': 'test-user1@example.com', 'roles': 'This is not a list'}\". "
+                "\nDetails:{'roles': ['Not a valid list.']}",
             ],
             [
                 {
@@ -426,7 +429,9 @@ class TestCliUsers:
                     "email": TEST_USER2_EMAIL,
                     "roles": [],
                 },
-                'Error: User "imported_user2" must have at lest one role',
+                "Error: Can't load user \"{'username': 'imported_user2', 'lastname': 'doe2', "
+                "'firstname': 'jon', 'email': 'test-user2@example.com', 'roles': []}\". \nDetails:{'roles': "
+                "['Shorter than minimum length 1.']}",
             ],
             [
                 {
@@ -435,11 +440,13 @@ class TestCliUsers:
                     "firstname": "jon",
                     "email": TEST_USER3_EMAIL,
                 },
-                'Error: "roles" is a required field, but was not specified',
+                "Error: Can't load user \"{'username': 'imported_user3', 'lastname': 'doe3', "
+                "'firstname': 'jon', 'email': 'test-user3@example.com'}\". \nDetails:{'roles': "
+                "['Missing data for required field.']}",
             ],
         ],
         ids=["Incorrect roles argument", "Empty roles", "Roles is missing"],
     )
     def test_cli_import_users_exceptions(self, user, message):
-        with pytest.raises(SystemExit, match=message):
+        with pytest.raises(SystemExit, match=re.escape(message)):
             self._import_users_from_file([user])

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -407,29 +407,37 @@ class TestCliUsers:
     @pytest.mark.parametrize(
         "user, message",
         [
-            [{
-                "username": "imported_user1",
-                "lastname": "doe1",
-                "firstname": "jon",
-                "email": TEST_USER1_EMAIL,
-                "roles": "This is not a list",
-            },
-                'Error: Incorrect list of roles specified for user "imported_user1"'],
-            [{
-                "username": "imported_user2",
-                "lastname": "doe2",
-                "firstname": "jon",
-                "email": TEST_USER2_EMAIL,
-                "roles": [],
-            }, 'Error: User "imported_user2" must have at lest one role'],
-            [{
-                "username": "imported_user3",
-                "lastname": "doe3",
-                "firstname": "jon",
-                "email": TEST_USER2_EMAIL,
-            }, 'Error: "roles" is a required field, but was not specified'],
+            [
+                {
+                    "username": "imported_user1",
+                    "lastname": "doe1",
+                    "firstname": "john",
+                    "email": TEST_USER1_EMAIL,
+                    "roles": "This is not a list",
+                },
+                'Error: Incorrect list of roles specified for user "imported_user1"',
+            ],
+            [
+                {
+                    "username": "imported_user2",
+                    "lastname": "doe2",
+                    "firstname": "jon",
+                    "email": TEST_USER2_EMAIL,
+                    "roles": [],
+                },
+                'Error: User "imported_user2" must have at lest one role',
+            ],
+            [
+                {
+                    "username": "imported_user3",
+                    "lastname": "doe3",
+                    "firstname": "jon",
+                    "email": TEST_USER2_EMAIL,
+                },
+                'Error: "roles" is a required field, but was not specified',
+            ],
         ],
-        ids=["Incorrect roles argument", "Empty roles", "Roles is missing"]
+        ids=["Incorrect roles argument", "Empty roles", "Roles is missing"],
     )
     def test_cli_import_users_exceptions(self, user, message):
         with pytest.raises(SystemExit, match=message):

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -417,9 +417,8 @@ class TestCliUsers:
                     "email": TEST_USER1_EMAIL,
                     "roles": "This is not a list",
                 },
-                "Error: Can't load user \"{'username': 'imported_user1', 'lastname': 'doe1',"
-                " 'firstname': 'john', 'email': 'test-user1@example.com', 'roles': 'This is not a list'}\". "
-                "\nDetails:{'roles': ['Not a valid list.']}",
+                "Error: Input file didn't pass validation. See below:\n"
+                "{0: {'roles': ['Not a valid list.']}}",
             ],
             [
                 {
@@ -429,20 +428,20 @@ class TestCliUsers:
                     "email": TEST_USER2_EMAIL,
                     "roles": [],
                 },
-                "Error: Can't load user \"{'username': 'imported_user2', 'lastname': 'doe2', "
-                "'firstname': 'jon', 'email': 'test-user2@example.com', 'roles': []}\". \nDetails:{'roles': "
-                "['Shorter than minimum length 1.']}",
+                "Error: Input file didn't pass validation. See below:\n"
+                "{0: {'roles': ['Shorter than minimum length 1.']}}",
             ],
             [
                 {
-                    "username": "imported_user3",
+                    "username1": "imported_user3",
                     "lastname": "doe3",
                     "firstname": "jon",
                     "email": TEST_USER3_EMAIL,
                 },
-                "Error: Can't load user \"{'username': 'imported_user3', 'lastname': 'doe3', "
-                "'firstname': 'jon', 'email': 'test-user3@example.com'}\". \nDetails:{'roles': "
-                "['Missing data for required field.']}",
+                "Error: Input file didn't pass validation. See below:\n"
+                "{0: {'username': ['Missing data for required field.'], "
+                "'roles': ['Missing data for required field.'], "
+                "'username1': ['Unknown field.']}}",
             ],
         ],
         ids=["Incorrect roles argument", "Empty roles", "Roles is missing"],

--- a/tests/cli/commands/test_user_command.py
+++ b/tests/cli/commands/test_user_command.py
@@ -24,6 +24,7 @@ from contextlib import redirect_stdout
 import pytest
 
 from airflow.cli.commands import user_command
+from tests.test_utils.api_connexion_utils import delete_users
 
 TEST_USER1_EMAIL = 'test-user1@example.com'
 TEST_USER2_EMAIL = 'test-user2@example.com'
@@ -45,18 +46,9 @@ class TestCliUsers:
         self.dagbag = dagbag
         self.parser = parser
         self.appbuilder = self.app.appbuilder
-        self.clear_roles_and_roles()
+        delete_users(app)
         yield
-        self.clear_roles_and_roles()
-
-    def clear_roles_and_roles(self):
-        for email in [TEST_USER1_EMAIL, TEST_USER2_EMAIL]:
-            test_user = self.appbuilder.sm.find_user(email=email)
-            if test_user:
-                self.appbuilder.sm.del_register_user(test_user)
-        for role_name in ['FakeTeamA', 'FakeTeamB']:
-            if self.appbuilder.sm.find_role(role_name):
-                self.appbuilder.sm.delete_role(role_name)
+        delete_users(app)
 
     def test_cli_create_user_random_password(self):
         args = self.parser.parse_args(
@@ -411,3 +403,34 @@ class TestCliUsers:
                 user_command.add_role(args)
             else:
                 user_command.remove_role(args)
+
+    @pytest.mark.parametrize(
+        "user, message",
+        [
+            [{
+                "username": "imported_user1",
+                "lastname": "doe1",
+                "firstname": "jon",
+                "email": TEST_USER1_EMAIL,
+                "roles": "This is not a list",
+            },
+                'Error: Incorrect list of roles specified for user "imported_user1"'],
+            [{
+                "username": "imported_user2",
+                "lastname": "doe2",
+                "firstname": "jon",
+                "email": TEST_USER2_EMAIL,
+                "roles": [],
+            }, 'Error: User "imported_user2" must have at lest one role'],
+            [{
+                "username": "imported_user3",
+                "lastname": "doe3",
+                "firstname": "jon",
+                "email": TEST_USER2_EMAIL,
+            }, 'Error: "roles" is a required field, but was not specified'],
+        ],
+        ids=["Incorrect roles argument", "Empty roles", "Roles is missing"]
+    )
+    def test_cli_import_users_exceptions(self, user, message):
+        with pytest.raises(SystemExit, match=message):
+            self._import_users_from_file([user])

--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -110,6 +110,11 @@ def delete_user(app, username):
             break
 
 
+def delete_users(app):
+    for user in app.appbuilder.sm.get_all_users():
+        delete_user(app, user.username)
+
+
 def assert_401(response):
     assert response.status_code == 401, f"Current code: {response.status_code}"
     assert response.json == {


### PR DESCRIPTION
This PR fixes a bug when "roles" dictionary key is checked for none existence and provides false positive when field does exist and is an empty array.

e.g. given below dictionary
```
d=dict(role=[])
if d.get('role'): # will yield False!!!
    do_something
```
but 
```
if 'role' in d: # is True
    do_something
``` 
will provide true


I also renamed **users_list** variable names to **users_list_** as there is a function with the same name **users_list** in the module. This can help to avoid possible future issues.

This PR also fixes below flaky test:
tests/cli/commands/test_user_command.py::TestCliUsers::test_find_user_exceptions   

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
