### PR TITLE
Update webserver secret key reference configuration

### DIFF
--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -95,7 +95,7 @@ Alternatively, create a kubernetes Secret and use ``webserverSecretKeySecretName
 
 .. code-block:: yaml
 
-    webserverSecretKey: my-webserver-secret
+    webserverSecretKeySecretName: my-webserver-secret
     # where the random key is under `webserver-secret-key` in the k8s Secret
 
 Extending and customizing Airflow Image

--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -98,6 +98,12 @@ Alternatively, create a kubernetes Secret and use ``webserverSecretKeySecretName
     webserverSecretKeySecretName: my-webserver-secret
     # where the random key is under `webserver-secret-key` in the k8s Secret
 
+Example to create a kubernetes Secret from ``kubectl``:
+
+.. code-block:: bash
+
+    kubectl create secret generic my-webserver-secret --from-literal="webserver-secret-key=$(python3 -c 'import secrets; print(secrets.token_hex(16))')"
+
 Extending and customizing Airflow Image
 ---------------------------------------
 


### PR DESCRIPTION
Update values file example to reference a kubernetes secret name for the webserver secret key.

The second commit is nice to have, to include some guidance on how to create the K8s secret with kubectl.

