### PR TITLE
Updating the InfluxDB example DAG to use the TaskFlow API

### DIFF
--- a/airflow/providers/influxdb/example_dags/example_influxdb.py
+++ b/airflow/providers/influxdb/example_dags/example_influxdb.py
@@ -15,15 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime
+
+from airflow.decorators import task
 from airflow.models.dag import DAG
-from airflow.operators.python import PythonOperator
 from airflow.providers.influxdb.hooks.influxdb import InfluxDBHook
-from airflow.utils.dates import days_ago
 
 
+@task(task_id="influxdb_task")
 def test_influxdb_hook():
     bucket_name = 'test-influx'
-    influxdb_hook = InfluxDBHook("influxdb_default")
+    influxdb_hook = InfluxDBHook()
     client = influxdb_hook.get_conn()
     print(client)
     print(f"Organization name {influxdb_hook.org_name}")
@@ -48,10 +50,8 @@ def test_influxdb_hook():
 with DAG(
     dag_id='influxdb_example_dag',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     max_active_runs=1,
     tags=['example'],
 ) as dag:
-    influxdb_task = PythonOperator(task_id="influxdb_task", python_callable=test_influxdb_hook)
-
-    influxdb_task
+    test_influxdb_hook()


### PR DESCRIPTION
Related: #9415

This PR updates the example DAG for InfluxDB to use the TaskFlow API. Also setting a static `start_date` as best practice and removing default connection ID values (which will align with soon-to-be-raised PRs handling `start_date`, `default_args`, and default connection ID cleanup for provider example DAGs).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
