### PR TITLE
Make `AirflowDateTimePickerWidget` a required field

### DIFF
--- a/airflow/www/widgets.py
+++ b/airflow/www/widgets.py
@@ -42,10 +42,12 @@ class AirflowDateTimePickerWidget:
         kwargs.setdefault("id", field.id)
         kwargs.setdefault("name", field.name)
         if not field.data:
-            field.data = ""
+            field.data = ''
         template = self.data_template
 
-        return Markup(template % {"text": html_params(type="text", value=field.data, **kwargs)})
+        return Markup(
+            template % {"text": html_params(type="text", value=field.data, required=True, **kwargs)}
+        )
 
 
 class AirflowDateTimePickerROWidget(AirflowDateTimePickerWidget):


### PR DESCRIPTION
The UI breaks when a search field sends a null datetime. This fixes it.

Closes #15976