### PR TITLE
Added dag_concurrency default value to airflow config file

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -196,6 +196,10 @@ enable_xcom_pickling = False
 # it has to cleanup after it is sent a SIGTERM, before it is SIGKILLED
 killed_task_cleanup_time = 60
 
+# The maximum number of task instances allowed to run concurrently in each DAG. 
+# To calculate the number of tasks that is running concurrently for a DAG, add up the number of running tasks for all DAG runs of the DAG. 
+dag_concurrency = 16
+
 # Whether to override params with dag_run.conf. If you pass some key-value pairs
 # through ``airflow dags backfill -c`` or
 # ``airflow dags trigger -c``, the key-value pairs will override the existing ones in params.


### PR DESCRIPTION
Added the default value of the airflow dag_concurrency  variable to the default_airflow.cfg configuration file so people are aware this variable still can be used and updated in the current version of Airflow.