### PR TITLE
Fix config default

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1258,7 +1258,7 @@
       version_added: ~
       type: string
       example: "21600"
-      default: ~
+      default: "21600"
 - name: dask
   description: |
     This section only applies if you are using the DaskExecutor in


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Updating documentation regarding `visibility_timeout` property of `celery_broker_transport_options` section to correctly specify current default value for it **21600** as it's hardcoded in source right now: https://github.com/apache/airflow/blob/d3b066931191b82880d216af103517ea941c74ba/airflow/config_templates/default_celery.py#L38

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
