### PR TITLE
Fix missing stroke color and tooltips of tasks in graph view

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -467,29 +467,28 @@ function groupTooltip(node, tis) {
 function updateNodesStates(tis) {
   g.nodes().forEach((nodeId) => {
     const { elem } = g.node(nodeId);
-    if (!elem) {
-      return;
-    }
-    const classes = `node enter ${getNodeState(nodeId, tis)}`;
-    elem.setAttribute('class', classes);
-    elem.setAttribute('data-toggle', 'tooltip');
+    if (elem) {
+      const classes = `node enter ${getNodeState(nodeId, tis)}`;
+      elem.setAttribute('class', classes);
+      elem.setAttribute('data-toggle', 'tooltip');
 
-    const taskId = nodeId;
-    const node = g.node(nodeId);
-    elem.onmouseover = (evt) => {
-      let tt;
-      if (taskId in tis) {
-        tt = tiTooltip(tis[taskId]);
-      } else if (node.children) {
-        tt = groupTooltip(node, tis);
-      } else if (taskId in tasks) {
-        tt = taskNoInstanceTooltip(taskId, tasks[taskId]);
-        elem.setAttribute('class', `${classes} not-allowed`);
-      }
-      if (tt) taskTip.show(tt, evt.target); // taskTip is defined in graph.html
-    };
-    elem.onmouseout = taskTip.hide;
-    elem.onclick = taskTip.hide;
+      const taskId = nodeId;
+      const node = g.node(nodeId);
+      elem.onmouseover = (evt) => {
+        let tt;
+        if (taskId in tis) {
+          tt = tiTooltip(tis[taskId]);
+        } else if (node.children) {
+          tt = groupTooltip(node, tis);
+        } else if (taskId in tasks) {
+          tt = taskNoInstanceTooltip(taskId, tasks[taskId]);
+          elem.setAttribute('class', `${classes} not-allowed`);
+        }
+        if (tt) taskTip.show(tt, evt.target); // taskTip is defined in graph.html
+      };
+      elem.onmouseout = taskTip.hide;
+      elem.onclick = taskTip.hide;
+    }
   });
 }
 


### PR DESCRIPTION
closes: #18369

In the graph view, the stroke color and tooltip would not work for some tasks, depending on the order of `g.nodes` in the d3 graph.

I wanted to simply change the `return` for a `continue` (I would have prefered this) but this eslint rule prevented me of doing so: https://eslint.org/docs/rules/no-continue