### PR TITLE
Fix some UI datetimes

### DIFF
--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -91,12 +91,6 @@ export function updateAllDateTimes() {
   $('.datetime input').each((_, el) => {
     el.value = moment(el.value).format();
   });
-
-  $('.js-format-date').each((_, el) => {
-    el.innerHTML = moment(el.innerHTML, 'YYYY-MM-DD').isValid()
-      ? formatDateTime(el.innerHTML)
-      : el.innerHTML;
-  });
 }
 
 export function setDisplayedTimezone(tz) {

--- a/airflow/www/static/js/task.js
+++ b/airflow/www/static/js/task.js
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const value = attr.innerHTML;
     if (value.length === 32 && moment(value, 'YYYY-MM-DD').isValid()) {
       // 32 is the length of our timestamps
-      attr.className = 'js-format-date';
+      attr.innerHTML = `<time datetime="${value}">${value}</time>`;
     } else if (value.includes('http')) {
       // very basic url detection
       attr.innerHTML = `<a href=${value}>${value}</a>`;

--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -18,7 +18,6 @@
  */
 
 /* global document, window, $, */
-import { formatDateTime } from './datetime_utils';
 import { escapeHtml } from './main';
 import getMetaValue from './meta_value';
 
@@ -117,7 +116,7 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
         const escapedMessage = escapeHtml(item[1]);
         const linkifiedMessage = escapedMessage
           .replace(urlRegex, (url) => `<a href="${url}" target="_blank">${url}</a>`)
-          .replaceAll(dateRegex, (date) => `<span class="js-format-date">${formatDateTime(`${date}+00:00`)}</span>`);
+          .replaceAll(dateRegex, (date) => `<time datetime="${date}+00:00">${date}+00:00</time>`);
         logBlock.innerHTML += `${linkifiedMessage}\n`;
       });
 

--- a/airflow/www/templates/airflow/dag_details.html
+++ b/airflow/www/templates/airflow/dag_details.html
@@ -55,7 +55,7 @@
     {% if dag.catchup %}
       <tr>
         <th>Start Date</th>
-        <td class="js-format-date">{{ dag.start_date }}</td>
+        <td><time datetime="{{ dag.start_date }}">{{ dag.start_date }}</time></td>
       </tr>
     {% else %}
       <tr>
@@ -65,7 +65,7 @@
     {% endif %}
     <tr>
       <th>End Date</th>
-      <td class="js-format-date">{{ dag.end_date }}</td>
+      <td><time datetime="{{ dag.end_date }}">{{ dag.end_date }}</time></td>
     </tr>
     <tr>
       <th>Max Active Runs</th>

--- a/airflow/www/templates/airflow/task_instance.html
+++ b/airflow/www/templates/airflow/task_instance.html
@@ -26,7 +26,7 @@
   <br>
   <h4>
     <span class="text-muted">Task Instance:</span> <span>{{ task_id }}</span>
-    <span class="text-muted">at</span> <span class="js-format-date">{{ execution_date }}</span>
+    <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
   </h4>
   <ul class="nav nav-pills">
     <li><a href="{{ url_for('Airflow.task', dag_id=dag.dag_id, task_id=task_id, execution_date=execution_date) }}">

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3926,6 +3926,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'state': wwwutils.state_f,
         'start_date': wwwutils.datetime_f('start_date'),
         'end_date': wwwutils.datetime_f('end_date'),
+        'queued_at': wwwutils.datetime_f('queued_at'),
         'dag_id': wwwutils.dag_link,
         'run_id': wwwutils.dag_run_link,
         'conf': wwwutils.json_f('conf'),


### PR DESCRIPTION
Make `Queued At` in `/dagrun/list` to be formatted like other dates

Also, decided to improve consistency and move all `js-format-date`s to proper `<time>` html elements. This helped to solve some appearances of `invalid_date` on task instance logs

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
