### PR TITLE
Retry deadlocked transactions on deleting old rendered task fields

### DIFF
--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -162,7 +162,7 @@ class RenderedTaskInstanceFields(Base):
                 tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq1),
             ).delete(synchronize_session=False)
         elif session.bind.dialect.name in ["mysql"]:
-            cls.remove_old_rendered_ti_fields_mysql(dag_id, session, task_id, tis_to_keep_query)
+            cls._remove_old_rendered_ti_fields_mysql(dag_id, session, task_id, tis_to_keep_query)
         else:
             # Fetch Top X records given dag_id & task_id ordered by Execution Date
             tis_to_keep = tis_to_keep_query.all()
@@ -182,7 +182,7 @@ class RenderedTaskInstanceFields(Base):
 
     @classmethod
     @retry_db_transaction
-    def remove_old_rendered_ti_fields_mysql(cls, dag_id, session, task_id, tis_to_keep_query):
+    def _remove_old_rendered_ti_fields_mysql(cls, dag_id, session, task_id, tis_to_keep_query):
         # Fetch Top X records given dag_id & task_id ordered by Execution Date
         subq1 = tis_to_keep_query.subquery('subq1')
         # Second Subquery
@@ -196,3 +196,4 @@ class RenderedTaskInstanceFields(Base):
             cls.task_id == task_id,
             tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq2),
         ).delete(synchronize_session=False)
+        session.flush()

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -28,6 +28,7 @@ from airflow.models.base import ID_LEN, Base
 from airflow.models.taskinstance import TaskInstance
 from airflow.serialization.helpers import serialize_template_field
 from airflow.settings import json
+from airflow.utils.retries import retry_db_transaction
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
@@ -161,20 +162,7 @@ class RenderedTaskInstanceFields(Base):
                 tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq1),
             ).delete(synchronize_session=False)
         elif session.bind.dialect.name in ["mysql"]:
-            # Fetch Top X records given dag_id & task_id ordered by Execution Date
-            subq1 = tis_to_keep_query.subquery('subq1')
-
-            # Second Subquery
-            # Workaround for MySQL Limitation (https://stackoverflow.com/a/19344141/5691525)
-            # Limitation: This version of MySQL does not yet support
-            # LIMIT & IN/ALL/ANY/SOME subquery
-            subq2 = session.query(subq1.c.dag_id, subq1.c.task_id, subq1.c.execution_date).subquery('subq2')
-
-            session.query(cls).filter(
-                cls.dag_id == dag_id,
-                cls.task_id == task_id,
-                tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq2),
-            ).delete(synchronize_session=False)
+            cls.remove_old_rendered_ti_fields_mysql(dag_id, session, task_id, tis_to_keep_query)
         else:
             # Fetch Top X records given dag_id & task_id ordered by Execution Date
             tis_to_keep = tis_to_keep_query.all()
@@ -191,3 +179,20 @@ class RenderedTaskInstanceFields(Base):
             ]
 
             session.query(cls).filter(and_(*filter_tis)).delete(synchronize_session=False)
+
+    @retry_db_transaction
+    @classmethod
+    def remove_old_rendered_ti_fields_mysql(cls, dag_id, session, task_id, tis_to_keep_query):
+        # Fetch Top X records given dag_id & task_id ordered by Execution Date
+        subq1 = tis_to_keep_query.subquery('subq1')
+        # Second Subquery
+        # Workaround for MySQL Limitation (https://stackoverflow.com/a/19344141/5691525)
+        # Limitation: This version of MySQL does not yet support
+        # LIMIT & IN/ALL/ANY/SOME subquery
+        subq2 = session.query(subq1.c.dag_id, subq1.c.task_id, subq1.c.execution_date).subquery('subq2')
+        # This query might deadlock occasionally and it should be retried if fails (see decorator)
+        session.query(cls).filter(
+            cls.dag_id == dag_id,
+            cls.task_id == task_id,
+            tuple_(cls.dag_id, cls.task_id, cls.execution_date).notin_(subq2),
+        ).delete(synchronize_session=False)

--- a/airflow/models/renderedtifields.py
+++ b/airflow/models/renderedtifields.py
@@ -180,8 +180,8 @@ class RenderedTaskInstanceFields(Base):
 
             session.query(cls).filter(and_(*filter_tis)).delete(synchronize_session=False)
 
-    @retry_db_transaction
     @classmethod
+    @retry_db_transaction
     def remove_old_rendered_ti_fields_mysql(cls, dag_id, session, task_id, tis_to_keep_query):
         # Fetch Top X records given dag_id & task_id ordered by Execution Date
         subq1 = tis_to_keep_query.subquery('subq1')


### PR DESCRIPTION
The query that deletes rendered old rendered task fields for MySQL
can occasionally deadlock because it is unncesssary complex with
a subquery (due to features missing in MySQL). This change
adds DB retries to get rid of the deadlock (as is the
recommended practice for MySQL).

Fixes: #18512

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
