### PR TITLE
Refactor usage of SecurityManager.add_user to add multiple roles at once

### DIFF
--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -99,19 +99,14 @@ def post_user():
         detail = f"Unknown roles: {', '.join(repr(n) for n in missing_role_names)}"
         raise BadRequest(detail=detail)
 
-    if roles_to_add:
-        default_role = roles_to_add.pop()
-    else:  # No roles provided, use the F.A.B's default registered user role.
-        default_role = security_manager.find_role(security_manager.auth_user_registration_role)
+    if not roles_to_add:  # No roles provided, use the F.A.B's default registered user role.
+        roles_to_add.append(security_manager.find_role(security_manager.auth_user_registration_role))
 
-    user = security_manager.add_user(role=default_role, **data)
+    user = security_manager.add_user(role=roles_to_add, **data)
     if not user:
         detail = f"Failed to add user `{username}`."
         return Unknown(detail=detail)
 
-    if roles_to_add:
-        user.roles.extend(roles_to_add)
-        security_manager.update_user(user)
     return user_schema.dump(user)
 
 

--- a/airflow/cli/commands/user_command.py
+++ b/airflow/cli/commands/user_command.py
@@ -216,13 +216,8 @@ def _import_users(users_list):
                 first_name=user['firstname'],
                 last_name=user['lastname'],
                 email=user['email'],
-                role=roles[0],  # add_user() requires exactly 1 role
+                role=roles,
             )
-
-            if len(roles) > 1:
-                new_user = appbuilder.sm.find_user(email=user['email'])
-                new_user.roles = roles
-                appbuilder.sm.update_user(new_user)
 
             users_created.append(user['email'])
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In flask-appbuilder 3.2.0 the `SecurityManager.add_user()` method was extended to accept a list of roles rather than a single role:
https://github.com/apache/airflow/blob/8a1437e55ed50bcb9301c55c1217e9e66532f6ed/airflow/www/fab_security/sqla/manager.py#L189-L219

This means we can remove some of the unnecessary logic when creating a user with multiple roles. 

I don't think I need to add any additional tests as there's already coverage for these cases.
