### PR TITLE
🚧 Is this the broken `test_scheduler_job` test?

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -169,6 +169,7 @@ class TestSchedulerJob:
         self.scheduler_job.heartrate = 0
         self.scheduler_job.run()
 
+    @pytest.mark.quarantined
     @pytest.mark.skipif(
         conf.get('core', 'sql_alchemy_conn').lower().startswith("mssql"),
         reason="MSSQL does not like os._exit()",

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -169,7 +169,7 @@ class TestSchedulerJob:
         self.scheduler_job.heartrate = 0
         self.scheduler_job.run()
 
-    @pytest.mark.quarantined
+    # @pytest.mark.quarantined
     @pytest.mark.skipif(
         conf.get('core', 'sql_alchemy_conn').lower().startswith("mssql"),
         reason="MSSQL does not like os._exit()",


### PR DESCRIPTION
I'm hunting for the broken test in `test_scheduler_job.py`.

e.g:
```
  tests/jobs/test_scheduler_job.py ..Timeout (0:08:00)!
  Thread 0x00007f9054ff4700 (most recent call first):
    File "/usr/local/lib/python3.8/selectors.py", line 468 in select
    File "/usr/local/lib/python3.8/asyncio/base_events.py", line 1823 in _run_once
    File "/usr/local/lib/python3.8/asyncio/base_events.py", line 570 in run_forever
    File "/usr/local/lib/python3.8/site-packages/tornado/platform/asyncio.py", line 199 in start
    File "/usr/local/lib/python3.8/site-packages/distributed/utils.py", line 418 in run_loop
    File "/usr/local/lib/python3.8/threading.py", line 870 in run
    File "/usr/local/lib/python3.8/threading.py", line 932 in _bootstrap_inner
    File "/usr/local/lib/python3.8/threading.py", line 890 in _bootstrap
  
  Thread 0x00007f905bffb700 (most recent call first):
    File "/usr/local/lib/python3.8/site-packages/distributed/profile.py", line 269 in _watch
    File "/usr/local/lib/python3.8/threading.py", line 870 in run
    File "/usr/local/lib/python3.8/threading.py", line 932 in _bootstrap_inner
    File "/usr/local/lib/python3.8/threading.py", line 890 in _bootstrap

(and on and on)
```
