### PR TITLE
Adding a default conn ID value for Apache Cassandra sensors

### DIFF
--- a/airflow/providers/apache/cassandra/sensors/record.py
+++ b/airflow/providers/apache/cassandra/sensors/record.py
@@ -55,7 +55,14 @@ class CassandraRecordSensor(BaseSensorOperator):
 
     template_fields = ('table', 'keys')
 
-    def __init__(self, *, table: str, keys: Dict[str, str], cassandra_conn_id: str, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        table: str,
+        keys: Dict[str, str],
+        cassandra_conn_id: str = CassandraHook.default_conn_name,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(**kwargs)
         self.cassandra_conn_id = cassandra_conn_id
         self.table = table

--- a/airflow/providers/apache/cassandra/sensors/table.py
+++ b/airflow/providers/apache/cassandra/sensors/table.py
@@ -53,7 +53,9 @@ class CassandraTableSensor(BaseSensorOperator):
 
     template_fields = ('table',)
 
-    def __init__(self, *, table: str, cassandra_conn_id: str, **kwargs: Any) -> None:
+    def __init__(
+        self, *, table: str, cassandra_conn_id: str = CassandraHook.default_conn_name, **kwargs: Any
+    ) -> None:
         super().__init__(**kwargs)
         self.cassandra_conn_id = cassandra_conn_id
         self.table = table

--- a/tests/providers/apache/cassandra/sensors/test_record.py
+++ b/tests/providers/apache/cassandra/sensors/test_record.py
@@ -73,3 +73,13 @@ class TestCassandraRecordSensor(unittest.TestCase):
 
         mock_hook.return_value.record_exists.assert_called_once_with(TEST_CASSANDRA_TABLE, TEST_CASSANDRA_KEY)
         mock_hook.assert_called_once_with(TEST_CASSANDRA_CONN_ID)
+
+    @patch("airflow.providers.apache.cassandra.sensors.record.CassandraHook")
+    def test_init_with_default_conn(self, mock_hook):
+        sensor = CassandraRecordSensor(
+            task_id='test_task',
+            table=TEST_CASSANDRA_TABLE,
+            keys=TEST_CASSANDRA_KEY,
+        )
+
+        assert sensor.cassandra_conn_id == TEST_CASSANDRA_CONN_ID

--- a/tests/providers/apache/cassandra/sensors/test_table.py
+++ b/tests/providers/apache/cassandra/sensors/test_table.py
@@ -70,3 +70,9 @@ class TestCassandraTableSensor(unittest.TestCase):
 
         mock_hook.return_value.table_exists.assert_called_once_with(TEST_CASSANDRA_TABLE_WITH_KEYSPACE)
         mock_hook.assert_called_once_with(TEST_CASSANDRA_CONN_ID)
+
+    @patch("airflow.providers.apache.cassandra.sensors.table.CassandraHook")
+    def test_init_with_default_conn(self, mock_hook):
+        sensor = CassandraTableSensor(task_id='test_task', table=TEST_CASSANDRA_TABLE)
+
+        assert sensor.cassandra_conn_id == TEST_CASSANDRA_CONN_ID


### PR DESCRIPTION
Currently the Cassandra sensors, `CassandraRecordSensor` and `CassandraTableSensor`, do not have a default value for the `cassandra_conn_id` parameter even though one is set within the `CassandraHook`.  Because of this, users are required to explicitly pass in an arg for the `cassandra_conn_id` when using the sensors in pipelines.  The missing default value for the connection ID does not follow the typical pattern for developing operators/sensors.  

This PR adds this default value for the sensor modules.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
