### PR TITLE
change label from area:docs to kind:documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_doc_issue_report.yml
@@ -1,7 +1,7 @@
 ---
 name: Airflow Doc issue report
 description: Problems and issues with docs of Apache Airflow
-labels: ["kind:bug", "area:docs"]
+labels: ["kind:bug", "kind:documentation"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
We should not use `area:docs` label.
https://github.com/apache/airflow/blob/main/ISSUE_TRIAGE_PROCESS.rst#labels

I'll remove the label in the upcoming days.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
