### PR TITLE
Add region to Snowflake URI.

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -212,7 +212,7 @@ class SnowflakeHook(DbApiHook):
         """Override DbApiHook get_uri method for get_sqlalchemy_engine()"""
         conn_config = self._get_conn_params()
         uri = (
-            'snowflake://{user}:{password}@{account}/{database}/{schema}'
+            'snowflake://{user}:{password}@{account}.{region}/{database}/{schema}'
             '?warehouse={warehouse}&role={role}&authenticator={authenticator}'
         )
         return uri.format(**conn_config)

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -86,7 +86,8 @@ class TestSnowflakeHook(unittest.TestCase):
 
     def test_get_uri(self):
         uri_shouldbe = (
-            'snowflake://user:pw@airflow/db/public?warehouse=af_wh&role=af_role&authenticator=snowflake'
+            'snowflake://user:pw@airflow.af_region/db/public?'
+            'warehouse=af_wh&role=af_role&authenticator=snowflake'
         )
         assert uri_shouldbe == self.db_hook.get_uri()
 
@@ -243,7 +244,8 @@ class TestSnowflakeHookExtra(unittest.TestCase):
 
     def test_get_uri_extra(self):
         uri_shouldbe = (
-            'snowflake://user:pw@airflow/db/public?warehouse=af_wh&role=af_role&authenticator=snowflake'
+            'snowflake://user:pw@airflow.af_region/db/public?'
+            'warehouse=af_wh&role=af_role&authenticator=snowflake'
         )
         assert uri_shouldbe == self.db_hook_extra.get_uri()
 


### PR DESCRIPTION
Without adding the AWS region to the URL, SQLAlchemy engines created by
Airflow can't write dataframes to snowflake using pd_writer. This PR
fixes this.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
