### PR TITLE
Add banner indicating environment type

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1177,6 +1177,20 @@
       type: string
       example: ~
       default: "#fff"
+    - name: enable_environment_banner
+      description: |
+        Enable banner indicating environment type of the instance
+      version_added: ~
+      type: boolean
+      example: ~
+      default: "False"
+    - name: environment_type
+      description: |
+        Environment type of this Airflow instance. One of PROD, STAGING, TEST.
+      version_added: ~
+      type: string
+      example: ~
+      default: "STAGING"
     - name: default_dag_run_display_number
       description: |
         Default dagrun to show in UI

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -597,6 +597,12 @@ page_size = 100
 # Define the color of navigation bar
 navbar_color = #fff
 
+# Enable banner indicating environment type of the instance
+enable_environment_banner = False
+
+# Environment type of this Airflow instance. One of PROD, STAGING, TEST.
+environment_type = STAGING
+
 # Default dagrun to show in UI
 default_dag_run_display_number = 25
 

--- a/airflow/www/extensions/init_jinja_globals.py
+++ b/airflow/www/extensions/init_jinja_globals.py
@@ -67,6 +67,8 @@ def init_jinja_globals(app):
             'git_version': git_version,
             'k8s_or_k8scelery_executor': IS_K8S_OR_K8SCELERY_EXECUTOR,
             'rest_api_enabled': conf.get('api', 'auth_backend') != 'airflow.api.auth.backend.deny_all',
+            'environment_type': conf.get('webserver', 'environment_type'),
+            'enable_environment_banner': conf.getboolean('webserver', 'enable_environment_banner'),
         }
 
         if 'analytics_tool' in conf.getsection('webserver'):

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -21,14 +21,13 @@
   Adapted from: https://github.com/dpgaspar/Flask-AppBuilder/blob/master/flask_appbuilder/templates/appbuilder/flash.html
 -#}
 <link rel="stylesheet" type="text/css" href="{{ url_for_asset('flash.css') }}">
-
+<div style="padding-top: 40px">
 {#
   Split messages into two arrays: one for regular alerts, another for DAG import errors
 #}
 {% with messages = get_flashed_messages(with_categories=true) %}
   {% set dag_import_errors = [] %}
   {% set regular_alerts = [] %}
-
   {% if messages %}
     {% for category, m in messages %}
       {% if category == 'dag_import_error' %}
@@ -64,6 +63,7 @@
     </div>
   {% endif %}
 {% endwith %}
+</div>
 
 {% block tail %}
   <script>

--- a/airflow/www/templates/appbuilder/navbar.html
+++ b/airflow/www/templates/appbuilder/navbar.html
@@ -21,6 +21,14 @@
 {% set languages = appbuilder.languages %}
 
 <div class="navbar navbar-fixed-top" role="navigation" style="background-color: {{ navbar_color }};">
+  {% if enable_environment_banner %}
+  <div style="background-color: #008000;">
+    <div class="text-right">
+      <p class="mr1" style="color: #fff; padding-right: 1em">
+         Apache Airflow {% if airflow_version %}v{{ airflow_version }}{% else %} N/A{% endif %} ( {{environment_type}} )</p>
+    </div>
+  </div>
+  {% endif %}
   <div class="container">
     <div class="navbar-header">
       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">


### PR DESCRIPTION
This work was inspired by responses to this [linkedin comment](https://www.linkedin.com/feed/update/urn:li:activity:6848963597859618816?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A6848963597859618816%2C6848966678429138944%29). The aim is to add simple banner hovering at top of the Airflow webui and indicating what environment type it is (test, staging, production etc).

Example:
<img width="1680" alt="Screenshot 2021-09-30 at 21 13 05" src="https://user-images.githubusercontent.com/9528307/135516488-cd9a2249-c8ea-4e3a-93e7-1f93ec955659.png">


The banner is by default disabled. Personally I think we should provided users with predefined environment types with correlated colours (to keep the UI visually consistent). However, I'm extremely poor front developer so if someone would like to help with polishing the css and html I would be grateful ❤️ 

![](https://media.giphy.com/media/13FrpeVH09Zrb2/giphy.gif?cid=ecf05e47rtbejrchvsara8ohngjlm54av315fg6z5z8tyzoa&rid=giphy.gif&ct=g)