### PR TITLE
Fix error on triggering a dag that doesn't exist using dagrun_conf

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1623,6 +1623,10 @@ class Airflow(AirflowBaseView):
         request_execution_date = request.values.get('execution_date', default=timezone.utcnow().isoformat())
         is_dag_run_conf_overrides_params = conf.getboolean('core', 'dag_run_conf_overrides_params')
         dag = current_app.dag_bag.get_dag(dag_id)
+        dag_orm = session.query(models.DagModel).filter(models.DagModel.dag_id == dag_id).first()
+        if not dag_orm:
+            flash(f"Cannot find dag {dag_id}")
+            return redirect(origin)
 
         if request.method == 'GET':
             # Populate conf textarea with conf requests parameter, or dag.params
@@ -1649,11 +1653,6 @@ class Airflow(AirflowBaseView):
                 form=form,
                 is_dag_run_conf_overrides_params=is_dag_run_conf_overrides_params,
             )
-
-        dag_orm = session.query(models.DagModel).filter(models.DagModel.dag_id == dag_id).first()
-        if not dag_orm:
-            flash(f"Cannot find dag {dag_id}")
-            return redirect(origin)
 
         try:
             execution_date = timezone.parse(request_execution_date)


### PR DESCRIPTION
We currently show a nice error message when the trigger button is clicked
but clicking on trigger DAG w/conf for a dag that doesn't exist anymore,
takes us to enter configuration. When you eventually trigger, you get error
messages.

This PR fixes it 



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
