### PR TITLE
Fix stop_airflow typos in CONTRIBUTORS_QUICK_START.rst

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -443,7 +443,7 @@ Using Breeze
 
 .. code-block:: bash
 
-  root@f3619b74c59a:/opt/airflow# stop_airflow.sh
+  root@f3619b74c59a:/opt/airflow# stop_airflow
   root@f3619b74c59a:/opt/airflow# exit
   $ breeze stop
 
@@ -1267,7 +1267,7 @@ Using Breeze
 
 .. code-block:: bash
 
-  root@f3619b74c59a:/opt/airflow# stop_airflow.sh
+  root@f3619b74c59a:/opt/airflow# stop_airflow
   root@f3619b74c59a:/opt/airflow# exit
   $ breeze stop
 


### PR DESCRIPTION
`CONTRIBUTORS_QUICK_START.rst` mentions that the following stops Airflow in `breeze`: 
```
root@f3619b74c59a:/opt/airflow# stop_airflow.sh
```
I think the correct command is `stop_airflow` and there exists no file `stop_airflow.sh`.