### PR TITLE
Cleanup of start_date and default arg use for Apache example DAGs

### DIFF
--- a/airflow/providers/apache/beam/example_dags/example_beam.py
+++ b/airflow/providers/apache/beam/example_dags/example_beam.py
@@ -20,6 +20,7 @@
 Example Airflow DAG for Apache Beam operators
 """
 import os
+from datetime import datetime
 from urllib.parse import urlparse
 
 from airflow import models
@@ -31,7 +32,7 @@ from airflow.providers.google.cloud.hooks.dataflow import DataflowJobStatus
 from airflow.providers.google.cloud.operators.dataflow import DataflowConfiguration
 from airflow.providers.google.cloud.sensors.dataflow import DataflowJobStatusSensor
 from airflow.providers.google.cloud.transfers.gcs_to_local import GCSToLocalFilesystemOperator
-from airflow.utils.dates import days_ago
+from airflow.utils.trigger_rule import TriggerRule
 
 GCP_PROJECT_ID = os.environ.get('GCP_PROJECT_ID', 'example-project')
 GCS_INPUT = os.environ.get('APACHE_BEAM_PYTHON', 'gs://INVALID BUCKET NAME/shakespeare/kinglear.txt')
@@ -72,19 +73,13 @@ GCS_JAR_FLINK_RUNNER_PARTS = urlparse(GCS_JAR_FLINK_RUNNER)
 GCS_JAR_FLINK_RUNNER_BUCKET_NAME = GCS_JAR_FLINK_RUNNER_PARTS.netloc
 GCS_JAR_FLINK_RUNNER_OBJECT_NAME = GCS_JAR_FLINK_RUNNER_PARTS.path[1:]
 
-
-default_args = {
-    'default_pipeline_options': {
-        'output': '/tmp/example_beam',
-    },
-    "trigger_rule": "all_done",
-}
+START_DATE = datetime(2021, 1, 1)
 
 
 with models.DAG(
     "example_beam_native_java_direct_runner",
     schedule_interval=None,  # Override to match your needs
-    start_date=days_ago(1),
+    start_date=START_DATE,
     tags=['example'],
 ) as dag_native_java_direct_runner:
 
@@ -112,7 +107,7 @@ with models.DAG(
 with models.DAG(
     "example_beam_native_java_dataflow_runner",
     schedule_interval=None,  # Override to match your needs
-    start_date=days_ago(1),
+    start_date=START_DATE,
     tags=['example'],
 ) as dag_native_java_dataflow_runner:
     # [START howto_operator_start_java_dataflow_runner_pipeline]
@@ -142,7 +137,7 @@ with models.DAG(
 with models.DAG(
     "example_beam_native_java_spark_runner",
     schedule_interval=None,  # Override to match your needs
-    start_date=days_ago(1),
+    start_date=START_DATE,
     tags=['example'],
 ) as dag_native_java_spark_runner:
 
@@ -169,7 +164,7 @@ with models.DAG(
 with models.DAG(
     "example_beam_native_java_flink_runner",
     schedule_interval=None,  # Override to match your needs
-    start_date=days_ago(1),
+    start_date=START_DATE,
     tags=['example'],
 ) as dag_native_java_flink_runner:
 
@@ -196,9 +191,15 @@ with models.DAG(
 
 with models.DAG(
     "example_beam_native_python",
-    default_args=default_args,
-    start_date=days_ago(1),
+    start_date=START_DATE,
     schedule_interval=None,  # Override to match your needs
+    default_args={
+        'default_pipeline_options': {'output': '/tmp/example_beam'},
+        'trigger_rule': TriggerRule.ALL_DONE,
+        'py_requirements': ['apache-beam[gcp]==2.26.0'],
+        'py_interpreter': 'python3',
+        'py_system_site_packages': False,
+    },
     tags=['example'],
 ) as dag_native_python:
 
@@ -207,7 +208,6 @@ with models.DAG(
         task_id="start_python_pipeline_local_direct_runner",
         py_file='apache_beam.examples.wordcount',
         py_options=['-m'],
-        py_requirements=['apache-beam[gcp]==2.26.0'],
         py_interpreter='python3',
         py_system_site_packages=False,
     )
@@ -219,9 +219,6 @@ with models.DAG(
         py_file=GCS_PYTHON,
         py_options=[],
         pipeline_options={"output": GCS_OUTPUT},
-        py_requirements=['apache-beam[gcp]==2.26.0'],
-        py_interpreter='python3',
-        py_system_site_packages=False,
     )
     # [END howto_operator_start_python_direct_runner_pipeline_gcs_file]
 
@@ -236,9 +233,6 @@ with models.DAG(
             'output': GCS_OUTPUT,
         },
         py_options=[],
-        py_requirements=['apache-beam[gcp]==2.26.0'],
-        py_interpreter='python3',
-        py_system_site_packages=False,
         dataflow_config=DataflowConfiguration(
             job_name='{{task.task_id}}', project_id=GCP_PROJECT_ID, location="us-central1"
         ),
@@ -250,9 +244,6 @@ with models.DAG(
         py_file='apache_beam.examples.wordcount',
         runner="SparkRunner",
         py_options=['-m'],
-        py_requirements=['apache-beam[gcp]==2.26.0'],
-        py_interpreter='python3',
-        py_system_site_packages=False,
     )
 
     start_python_pipeline_local_flink_runner = BeamRunPythonPipelineOperator(
@@ -263,9 +254,6 @@ with models.DAG(
         pipeline_options={
             'output': '/tmp/start_python_pipeline_local_flink_runner',
         },
-        py_requirements=['apache-beam[gcp]==2.26.0'],
-        py_interpreter='python3',
-        py_system_site_packages=False,
     )
 
     (
@@ -280,8 +268,11 @@ with models.DAG(
 
 with models.DAG(
     "example_beam_native_python_dataflow_async",
-    default_args=default_args,
-    start_date=days_ago(1),
+    default_args={
+        'default_pipeline_options': {'output': '/tmp/example_beam'},
+        'trigger_rule': TriggerRule.ALL_DONE,
+    },
+    start_date=START_DATE,
     schedule_interval=None,  # Override to match your needs
     tags=['example'],
 ) as dag_native_python_dataflow_async:

--- a/airflow/providers/apache/beam/example_dags/example_beam.py
+++ b/airflow/providers/apache/beam/example_dags/example_beam.py
@@ -73,6 +73,11 @@ GCS_JAR_FLINK_RUNNER_PARTS = urlparse(GCS_JAR_FLINK_RUNNER)
 GCS_JAR_FLINK_RUNNER_BUCKET_NAME = GCS_JAR_FLINK_RUNNER_PARTS.netloc
 GCS_JAR_FLINK_RUNNER_OBJECT_NAME = GCS_JAR_FLINK_RUNNER_PARTS.path[1:]
 
+
+DEFAULT_ARGS = {
+    'default_pipeline_options': {'output': '/tmp/example_beam'},
+    'trigger_rule': TriggerRule.ALL_DONE,
+}
 START_DATE = datetime(2021, 1, 1)
 
 
@@ -193,13 +198,7 @@ with models.DAG(
     "example_beam_native_python",
     start_date=START_DATE,
     schedule_interval=None,  # Override to match your needs
-    default_args={
-        'default_pipeline_options': {'output': '/tmp/example_beam'},
-        'trigger_rule': TriggerRule.ALL_DONE,
-        'py_requirements': ['apache-beam[gcp]==2.26.0'],
-        'py_interpreter': 'python3',
-        'py_system_site_packages': False,
-    },
+    default_args=DEFAULT_ARGS,
     tags=['example'],
 ) as dag_native_python:
 
@@ -208,6 +207,7 @@ with models.DAG(
         task_id="start_python_pipeline_local_direct_runner",
         py_file='apache_beam.examples.wordcount',
         py_options=['-m'],
+        py_requirements=['apache-beam[gcp]==2.26.0'],
         py_interpreter='python3',
         py_system_site_packages=False,
     )
@@ -219,6 +219,9 @@ with models.DAG(
         py_file=GCS_PYTHON,
         py_options=[],
         pipeline_options={"output": GCS_OUTPUT},
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
     )
     # [END howto_operator_start_python_direct_runner_pipeline_gcs_file]
 
@@ -233,6 +236,9 @@ with models.DAG(
             'output': GCS_OUTPUT,
         },
         py_options=[],
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
         dataflow_config=DataflowConfiguration(
             job_name='{{task.task_id}}', project_id=GCP_PROJECT_ID, location="us-central1"
         ),
@@ -244,6 +250,9 @@ with models.DAG(
         py_file='apache_beam.examples.wordcount',
         runner="SparkRunner",
         py_options=['-m'],
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
     )
 
     start_python_pipeline_local_flink_runner = BeamRunPythonPipelineOperator(
@@ -254,6 +263,9 @@ with models.DAG(
         pipeline_options={
             'output': '/tmp/start_python_pipeline_local_flink_runner',
         },
+        py_requirements=['apache-beam[gcp]==2.26.0'],
+        py_interpreter='python3',
+        py_system_site_packages=False,
     )
 
     (
@@ -268,10 +280,7 @@ with models.DAG(
 
 with models.DAG(
     "example_beam_native_python_dataflow_async",
-    default_args={
-        'default_pipeline_options': {'output': '/tmp/example_beam'},
-        'trigger_rule': TriggerRule.ALL_DONE,
-    },
+    default_args=DEFAULT_ARGS,
     start_date=START_DATE,
     schedule_interval=None,  # Override to match your needs
     tags=['example'],

--- a/airflow/providers/apache/beam/example_dags/example_beam.py
+++ b/airflow/providers/apache/beam/example_dags/example_beam.py
@@ -85,6 +85,7 @@ with models.DAG(
     "example_beam_native_java_direct_runner",
     schedule_interval=None,  # Override to match your needs
     start_date=START_DATE,
+    catchup=False,
     tags=['example'],
 ) as dag_native_java_direct_runner:
 
@@ -113,6 +114,7 @@ with models.DAG(
     "example_beam_native_java_dataflow_runner",
     schedule_interval=None,  # Override to match your needs
     start_date=START_DATE,
+    catchup=False,
     tags=['example'],
 ) as dag_native_java_dataflow_runner:
     # [START howto_operator_start_java_dataflow_runner_pipeline]
@@ -143,6 +145,7 @@ with models.DAG(
     "example_beam_native_java_spark_runner",
     schedule_interval=None,  # Override to match your needs
     start_date=START_DATE,
+    catchup=False,
     tags=['example'],
 ) as dag_native_java_spark_runner:
 
@@ -170,6 +173,7 @@ with models.DAG(
     "example_beam_native_java_flink_runner",
     schedule_interval=None,  # Override to match your needs
     start_date=START_DATE,
+    catchup=False,
     tags=['example'],
 ) as dag_native_java_flink_runner:
 
@@ -198,6 +202,7 @@ with models.DAG(
     "example_beam_native_python",
     start_date=START_DATE,
     schedule_interval=None,  # Override to match your needs
+    catchup=False,
     default_args=DEFAULT_ARGS,
     tags=['example'],
 ) as dag_native_python:
@@ -283,6 +288,7 @@ with models.DAG(
     default_args=DEFAULT_ARGS,
     start_date=START_DATE,
     schedule_interval=None,  # Override to match your needs
+    catchup=False,
     tags=['example'],
 ) as dag_native_python_dataflow_async:
     # [START howto_operator_start_python_dataflow_runner_pipeline_async_gcs_file]

--- a/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
+++ b/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
@@ -37,4 +37,4 @@ with DAG(
     table_sensor = CassandraTableSensor(task_id="cassandra_table_sensor")
 
     record_sensor = CassandraRecordSensor(task_id="cassandra_record_sensor", keys={"p1": "v1", "p2": "v2"})
-    # [END howto_operator_cassandra_sensors]
+# [END howto_operator_cassandra_sensors]

--- a/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
+++ b/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
@@ -20,30 +20,21 @@
 Example Airflow DAG to check if a Cassandra Table and a Records exists
 or not using `CassandraTableSensor` and `CassandraRecordSensor`.
 """
+from datetime import datetime
+
 from airflow.models import DAG
 from airflow.providers.apache.cassandra.sensors.record import CassandraRecordSensor
 from airflow.providers.apache.cassandra.sensors.table import CassandraTableSensor
-from airflow.utils.dates import days_ago
 
+# [START howto_operator_cassandra_sensors]
 with DAG(
     dag_id='example_cassandra_operator',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
+    default_args={'table': 'keyspace_name.table_name'},
     tags=['example'],
 ) as dag:
-    # [START howto_operator_cassandra_table_sensor]
-    table_sensor = CassandraTableSensor(
-        task_id="cassandra_table_sensor",
-        cassandra_conn_id="cassandra_default",
-        table="keyspace_name.table_name",
-    )
-    # [END howto_operator_cassandra_table_sensor]
+    table_sensor = CassandraTableSensor(task_id="cassandra_table_sensor")
 
-    # [START howto_operator_cassandra_record_sensor]
-    record_sensor = CassandraRecordSensor(
-        task_id="cassandra_record_sensor",
-        cassandra_conn_id="cassandra_default",
-        table="keyspace_name.table_name",
-        keys={"p1": "v1", "p2": "v2"},
-    )
-    # [END howto_operator_cassandra_record_sensor]
+    record_sensor = CassandraRecordSensor(task_id="cassandra_record_sensor", keys={"p1": "v1", "p2": "v2"})
+    # [END howto_operator_cassandra_sensors]

--- a/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
+++ b/airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
@@ -32,6 +32,7 @@ with DAG(
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
     default_args={'table': 'keyspace_name.table_name'},
+    catchup=False,
     tags=['example'],
 ) as dag:
     table_sensor = CassandraTableSensor(task_id="cassandra_table_sensor")

--- a/airflow/providers/apache/drill/example_dags/example_drill_dag.py
+++ b/airflow/providers/apache/drill/example_dags/example_drill_dag.py
@@ -19,14 +19,15 @@
 """
 Example Airflow DAG to execute SQL in an Apache Drill environment using the `DrillOperator`.
 """
+from datetime import datetime
+
 from airflow.models import DAG
 from airflow.providers.apache.drill.operators.drill import DrillOperator
-from airflow.utils.dates import days_ago
 
 with DAG(
     dag_id='example_drill_dag',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
     # [START howto_operator_drill]

--- a/airflow/providers/apache/drill/example_dags/example_drill_dag.py
+++ b/airflow/providers/apache/drill/example_dags/example_drill_dag.py
@@ -28,6 +28,7 @@ with DAG(
     dag_id='example_drill_dag',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_drill]

--- a/airflow/providers/apache/druid/example_dags/example_druid_dag.py
+++ b/airflow/providers/apache/druid/example_dags/example_druid_dag.py
@@ -19,22 +19,19 @@
 """
 Example Airflow DAG to submit Apache Druid json index file using `DruidOperator`
 """
+from datetime import datetime
+
 from airflow.models import DAG
 from airflow.providers.apache.druid.operators.druid import DruidOperator
-from airflow.utils.dates import days_ago
 
 with DAG(
     dag_id='example_druid_operator',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
     # [START howto_operator_druid_submit]
-    submit_job = DruidOperator(
-        task_id='spark_submit_job',
-        json_index_file='json_index.json',
-        druid_ingest_conn_id='druid_ingest_default',
-    )
+    submit_job = DruidOperator(task_id='spark_submit_job', json_index_file='json_index.json')
     # Example content of json_index.json:
     JSON_INDEX_STR = """
         {

--- a/airflow/providers/apache/druid/example_dags/example_druid_dag.py
+++ b/airflow/providers/apache/druid/example_dags/example_druid_dag.py
@@ -28,6 +28,7 @@ with DAG(
     dag_id='example_druid_operator',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_druid_submit]

--- a/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
+++ b/airflow/providers/apache/hive/example_dags/example_twitter_dag.py
@@ -28,13 +28,12 @@
 """
 This is an example dag for managing twitter data.
 """
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from airflow import DAG
 from airflow.decorators import task
 from airflow.operators.bash import BashOperator
 from airflow.providers.apache.hive.operators.hive import HiveOperator
-from airflow.utils.dates import days_ago
 
 
 @task
@@ -77,8 +76,9 @@ with DAG(
         'retries': 1,
     },
     schedule_interval="@daily",
-    start_date=days_ago(5),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
+    catchup=False,
 ) as dag:
     fetch_tweets = fetch_tweets()
     clean_tweets = clean_tweets()

--- a/airflow/providers/apache/kylin/example_dags/example_kylin_dag.py
+++ b/airflow/providers/apache/kylin/example_dags/example_kylin_dag.py
@@ -29,7 +29,7 @@ dag = DAG(
     dag_id='example_kylin_operator',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
-    default_args={'kylin_conn_id': 'kylin_default', 'project': 'learn_kylin', 'cube': 'kylin_sales_cube'},
+    default_args={'project': 'learn_kylin', 'cube': 'kylin_sales_cube'},
     tags=['example'],
 )
 

--- a/airflow/providers/apache/kylin/example_dags/example_kylin_dag.py
+++ b/airflow/providers/apache/kylin/example_dags/example_kylin_dag.py
@@ -20,14 +20,15 @@
 This is an example DAG which uses the KylinCubeOperator.
 The tasks below include kylin build, refresh, merge operation.
 """
+from datetime import datetime
+
 from airflow import DAG
 from airflow.providers.apache.kylin.operators.kylin_cube import KylinCubeOperator
-from airflow.utils.dates import days_ago
 
 dag = DAG(
     dag_id='example_kylin_operator',
     schedule_interval=None,
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     default_args={'kylin_conn_id': 'kylin_default', 'project': 'learn_kylin', 'cube': 'kylin_sales_cube'},
     tags=['example'],
 )

--- a/airflow/providers/apache/kylin/example_dags/example_kylin_dag.py
+++ b/airflow/providers/apache/kylin/example_dags/example_kylin_dag.py
@@ -29,6 +29,7 @@ dag = DAG(
     dag_id='example_kylin_operator',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     default_args={'project': 'learn_kylin', 'cube': 'kylin_sales_cube'},
     tags=['example'],
 )

--- a/airflow/providers/apache/pig/example_dags/example_pig.py
+++ b/airflow/providers/apache/pig/example_dags/example_pig.py
@@ -17,15 +17,15 @@
 # under the License.
 
 """Example DAG demonstrating the usage of the PigOperator."""
+from datetime import datetime
 
 from airflow import DAG
 from airflow.providers.apache.pig.operators.pig import PigOperator
-from airflow.utils.dates import days_ago
 
 dag = DAG(
     dag_id='example_pig_operator',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 )
 

--- a/airflow/providers/apache/pig/example_dags/example_pig.py
+++ b/airflow/providers/apache/pig/example_dags/example_pig.py
@@ -26,6 +26,7 @@ dag = DAG(
     dag_id='example_pig_operator',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 )
 

--- a/airflow/providers/apache/spark/example_dags/example_spark_dag.py
+++ b/airflow/providers/apache/spark/example_dags/example_spark_dag.py
@@ -20,16 +20,17 @@
 Example Airflow DAG to submit Apache Spark applications using
 `SparkSubmitOperator`, `SparkJDBCOperator` and `SparkSqlOperator`.
 """
+from datetime import datetime
+
 from airflow.models import DAG
 from airflow.providers.apache.spark.operators.spark_jdbc import SparkJDBCOperator
 from airflow.providers.apache.spark.operators.spark_sql import SparkSqlOperator
 from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
-from airflow.utils.dates import days_ago
 
 with DAG(
     dag_id='example_spark_operator',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
     # [START howto_operator_spark_submit]

--- a/airflow/providers/apache/spark/example_dags/example_spark_dag.py
+++ b/airflow/providers/apache/spark/example_dags/example_spark_dag.py
@@ -31,6 +31,7 @@ with DAG(
     dag_id='example_spark_operator',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_spark_submit]

--- a/docs/apache-airflow-providers-apache-cassandra/operators.rst
+++ b/docs/apache-airflow-providers-apache-cassandra/operators.rst
@@ -52,7 +52,6 @@ Example use of these sensors
 
 .. exampleinclude:: /../../airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
     :language: python
-    :dedent: 4
     :start-after: [START howto_operator_cassandra_sensors]
     :end-before: [END howto_operator_cassandra_sensors]
 

--- a/docs/apache-airflow-providers-apache-cassandra/operators.rst
+++ b/docs/apache-airflow-providers-apache-cassandra/operators.rst
@@ -34,14 +34,7 @@ Waiting for a Table to be created
 
 The :class:`~airflow.providers.apache.cassandra.sensors.table.CassandraTableSensor` operator is used to check for the existence of a table in a Cassandra cluster.
 
-Use the ``table`` parameter to poke until the provided table is found. Use dot notation to target a specific keyspace.
-
-.. exampleinclude:: /../../airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
-    :language: python
-    :dedent: 4
-    :start-after: [START howto_operator_cassandra_table_sensor]
-    :end-before: [END howto_operator_cassandra_table_sensor]
-
+Use the ``table`` parameter (set in ``default_args`` in the example below) to poke until the provided table is found. Use dot notation to target a specific keyspace.
 
 .. _howto/operator:CassandraRecordSensor:
 
@@ -50,15 +43,18 @@ Waiting for a Record to be created
 
 The :class:`~airflow.providers.apache.cassandra.sensors.record.CassandraRecordSensor` operator is used to check for the existence of a record of a table in the Cassandra cluster.
 
-Use the ``table`` parameter to mention the keyspace and table for the record. Use dot notation to target a specific keyspace.
+Use the ``table`` parameter (set in ``default_args`` in the example below) to mention the keyspace and table for the record. Use dot notation to target a specific keyspace.
 
 Use the ``keys`` parameter to poke until the provided record is found. The existence of record is identified using key value pairs. In the given example, we're are looking for value ``v1`` in column ``p1`` and ``v2`` in column ``p2``.
+
+Example use of these sensors
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. exampleinclude:: /../../airflow/providers/apache/cassandra/example_dags/example_cassandra_dag.py
     :language: python
     :dedent: 4
-    :start-after: [START howto_operator_cassandra_record_sensor]
-    :end-before: [END howto_operator_cassandra_record_sensor]
+    :start-after: [START howto_operator_cassandra_sensors]
+    :end-before: [END howto_operator_cassandra_sensors]
 
 Reference
 ^^^^^^^^^


### PR DESCRIPTION
There is an ongoing effort to enhance example DAGs by setting static values for `start_date` (already complete for core example DAGs), cleaning up and/or implementing useful `default_args`, and removing/limiting the use of redundant, default connection ID values.

This PR mainly addresses these 3 cleanup areas in example DAGs across Apache providers.  There are other small docs updates and use of the `TriggerRule` attr rather than the literal string where applicable.

> Note: In the `example_beam` DAG, there was an opportunity to consolidate task args to `default_args` for a couple of DAGs, however, this was not implemented as the changes would have conflicted too much with the operator documentation that references the example DAG.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
