### PR TITLE
Fix section formatting in the "Customizing the UI" docs page

### DIFF
--- a/docs/apache-airflow/howto/customize-ui.rst
+++ b/docs/apache-airflow/howto/customize-ui.rst
@@ -88,7 +88,7 @@ Note: the custom title will be applied to both the page header and the page titl
 
 To make this change, simply:
 
-1.  Add the configuration option of ``instance_name`` under ``webserver`` inside ``airflow.cfg``:
+1.  Add the configuration option of ``instance_name`` under the ``[webserver]`` section inside ``airflow.cfg``:
 
 .. code-block::
 


### PR DESCRIPTION
Make the reference to the config section consistent with other docs pages.