### PR TITLE
Expanding docs on client auth for AzureKeyVaultBackend

### DIFF
--- a/airflow/providers/microsoft/azure/secrets/azure_key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/azure_key_vault.py
@@ -46,6 +46,16 @@ class AzureKeyVaultBackend(BaseSecretsBackend, LoggingMixin):
     And if variables prefix is ``airflow-variables-hello``, this would be accessible
     if you provide ``{"variables_prefix": "airflow-variables"}`` and request variable key ``hello``.
 
+    For client authentication, the ``DefaultAzureCredential`` from the Azure Python SDK is used as
+    credential provider, which supports service principal, managed identity and user credentials
+
+    For example, to specify a service principal with secret you can set the environment variables
+    ``AZURE_TENANT_ID``, ``AZURE_CLIENT_ID`` and ``AZURE_CLIENT_SECRET``.
+
+    .. seealso::
+        For more details on client authentication refer to the ``DefaultAzureCredential`` Class reference:
+        https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python
+
     :param connections_prefix: Specifies the prefix of the secret to read to get Connections
         If set to None (null), requests for connections will not be sent to Azure Key Vault
     :type connections_prefix: str

--- a/docs/apache-airflow-providers-microsoft-azure/secrets-backends/azure-key-vault.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/secrets-backends/azure-key-vault.rst
@@ -34,6 +34,8 @@ Here is a sample configuration:
 For client authentication, the ``DefaultAzureCredential`` from the Azure Python SDK is used as credential provider,
 which supports service principal, managed identity and user credentials.
 
+For example, to specify a service principal with secret you can set the environment variables ``AZURE_TENANT_ID``, ``AZURE_CLIENT_ID`` and ``AZURE_CLIENT_SECRET``.
+
 Optional lookup
 """""""""""""""
 
@@ -64,3 +66,8 @@ Storing and Retrieving Variables
 
 If you have set ``variables_prefix`` as ``airflow-variables``, then for an Variable key of ``hello``,
 you would want to store your Variable at ``airflow-variables-hello``.
+
+Reference
+"""""""""
+
+For more details on client authentication refer to the `DefaultAzureCredential Class reference <https://docs.microsoft.com/en-us/python/api/azure-identity/azure.identity.defaultazurecredential?view=azure-python>`_.


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Expanded the documentation on client authentication for `AzureKeyVaultBackend` using Azure Python SDK's `DefaultAzureCredential` class. Added an example of adding environment variables to use the service principal with secret.

Also, carried over the note about client authentication form the docs page into the python file's docstring (this is what is used to populate Astronomer' Registry site, so without this change their soccumentation is missing notes about client authentication).

Also included a link to the `DefaultAzureCredential` class reference page.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
