### PR TITLE
update azure cosmos version

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
+++ b/airflow/providers/microsoft/azure/hooks/azure_cosmos.py
@@ -27,7 +27,7 @@ import uuid
 from typing import Any, Dict, Optional
 
 from azure.cosmos.cosmos_client import CosmosClient
-from azure.cosmos.errors import HTTPFailure
+from azure.cosmos.exceptions import CosmosHttpResponseError
 
 from airflow.exceptions import AirflowBadRequest
 from airflow.hooks.base import BaseHook
@@ -307,7 +307,7 @@ class AzureCosmosDBHook(BaseHook):
                     document_id,
                 )
             )
-        except HTTPFailure:
+        except CosmosHttpResponseError:
             return None
 
     def get_documents(
@@ -334,7 +334,7 @@ class AzureCosmosDBHook(BaseHook):
             )
 
             return list(result_iterable)
-        except HTTPFailure:
+        except CosmosHttpResponseError:
             return None
 
 

--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,7 @@ atlas = [
 ]
 azure = [
     'azure-batch>=8.0.0',
-    'azure-cosmos>=3.0.1,<4',
+    'azure-cosmos>=4.0.0,<5',
     'azure-datalake-store>=0.0.45',
     'azure-identity>=1.3.1',
     'azure-keyvault>=4.1.0',


### PR DESCRIPTION
Update azure-cosmos version.
Relevant changes from [cosmos change log](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/cosmos/azure-cosmos/CHANGELOG.md) are:
1. azure.cosmos.errors module deprecated and replaced by azure.cosmos.exceptions
2. HTTPFailure has been renamed to CosmosHttpResponseError


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
