### PR TITLE
Cleaning roles and users for tests cases after completion

### DIFF
--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -87,7 +87,7 @@ class TestSecurity(unittest.TestCase):
         cls.appbuilder = cls.app.appbuilder
         cls.app.config['WTF_CSRF_ENABLED'] = False
         cls.security_manager = cls.appbuilder.sm
-        cls.delete_roles()
+        cls.delete_test_roles()
 
     def setUp(self):
         clear_db_runs()
@@ -99,7 +99,25 @@ class TestSecurity(unittest.TestCase):
         log.debug("Complete setup!")
 
     @classmethod
-    def delete_roles(cls):
+    def tearDownClass(cls):
+        cls.delete_test_roles()
+        cls.delete_test_users()
+
+    @classmethod
+    def delete_test_users(cls):
+        method_users = [attr[5:] for attr in cls.__dict__ if attr[:4] == 'test']
+        adhoc_users = [
+            'ElUser',
+            'Monsieur User',
+            'dag_access_user',
+            'LaUser',
+            'dag_permission_user'
+        ]
+        for user_name in method_users + adhoc_users:
+            api_connexion_utils.delete_user(cls.app, user_name)
+
+    @classmethod
+    def delete_test_roles(cls):
         for role_name in [
             'team-a',
             'MyRole1',
@@ -107,6 +125,7 @@ class TestSecurity(unittest.TestCase):
             'Test_Role',
             'MyRole3',
             'MyRole2',
+            'MyRole7',
             'dag_permission_role',
         ]:
             api_connexion_utils.delete_role(cls.app, role_name)


### PR DESCRIPTION
This is to clean up test database once tests are completed as some test create users and roles and don't delete them. This affects other test suites when run in different scenarios like `pytest tests` to test all. For example one test adds a user 'test' and doesn't delete it. Then some other test author creates a 'test' user as well. This causes issues.


This PR fixes these issues in this file only and I'll file some more PRs to fix them all so they "leave the house tidy once leave"

This PR linked to  #18653 and #18586 I have been working on

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
