### PR TITLE
Remove local in-page ToCs from most docs

### DIFF
--- a/docs/apache-airflow-providers-alibaba/operators/oss.rst
+++ b/docs/apache-airflow-providers-alibaba/operators/oss.rst
@@ -18,10 +18,6 @@
 Alibaba Cloud OSS Operators
 ===========================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Overview
 --------
 

--- a/docs/apache-airflow-providers-amazon/operators/datasync.rst
+++ b/docs/apache-airflow-providers-amazon/operators/datasync.rst
@@ -21,10 +21,6 @@
 AWS DataSync Operator
 =====================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Overview
 --------
 

--- a/docs/apache-airflow-providers-amazon/operators/dms.rst
+++ b/docs/apache-airflow-providers-amazon/operators/dms.rst
@@ -19,10 +19,6 @@
 AWS Database Migration Service Operators
 ========================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-amazon/operators/ecs.rst
+++ b/docs/apache-airflow-providers-amazon/operators/ecs.rst
@@ -21,10 +21,6 @@
 ECS Operator
 ============
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-amazon/operators/eks.rst
+++ b/docs/apache-airflow-providers-amazon/operators/eks.rst
@@ -26,15 +26,10 @@ and management of containerized applications.
 
 Airflow provides operators to create and interact with the EKS clusters and compute infrastructure.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
 .. include::/operators/_partials/prerequisite_tasks.rst
-
 
 Manage Amazon EKS Clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/apache-airflow-providers-amazon/operators/emr.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr.rst
@@ -21,10 +21,6 @@
 Amazon EMR Operators
 ====================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-amazon/operators/emr_eks.rst
+++ b/docs/apache-airflow-providers-amazon/operators/emr_eks.rst
@@ -25,10 +25,6 @@ Amazon EMR on EKS Operators
 
 Airflow provides the :class:`~airflow.providers.amazon.aws.operators.emr_containers.EMRContainerOperator` to submit Spark jobs to your EMR on EKS virtual cluster.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-amazon/operators/google_api_to_s3_transfer.rst
+++ b/docs/apache-airflow-providers-amazon/operators/google_api_to_s3_transfer.rst
@@ -21,10 +21,6 @@
 Google API To S3 Transfer
 =========================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Overview
 --------
 

--- a/docs/apache-airflow-providers-amazon/operators/imap_attachment_to_s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/imap_attachment_to_s3.rst
@@ -21,10 +21,6 @@
 Imap Attachment To S3 Operator
 ==============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Overview
 --------
 

--- a/docs/apache-airflow-providers-amazon/operators/s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/s3.rst
@@ -19,10 +19,6 @@
 Amazon S3 Operators
 ====================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-amazon/operators/s3_to_redshift.rst
+++ b/docs/apache-airflow-providers-amazon/operators/s3_to_redshift.rst
@@ -21,10 +21,6 @@
 S3 To Redshift Transfer Operator
 ================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Overview
 --------
 

--- a/docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst
+++ b/docs/apache-airflow-providers-amazon/operators/salesforce_to_s3.rst
@@ -18,10 +18,6 @@
 Salesforce To S3 Operator
 ==============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 .. _howto/operator:SalesforceToS3Operator:
 
 Overview

--- a/docs/apache-airflow-providers-apache-cassandra/operators.rst
+++ b/docs/apache-airflow-providers-apache-cassandra/operators.rst
@@ -22,10 +22,6 @@ Apache Cassandra Operators
 
 `Apache Cassandra <https://cassandra.apache.org/>`__ is an open source distributed NoSQL database that can be used when you need scalability and high availability without compromising performance. It offers linear scalability and fault-tolerance on commodity hardware or cloud infrastructure which makes it the perfect platform for mission-critical data. It supports multi-datacenter replication with lower latencies.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite
 ------------
 

--- a/docs/apache-airflow-providers-apache-drill/operators.rst
+++ b/docs/apache-airflow-providers-apache-drill/operators.rst
@@ -19,15 +19,10 @@
 Apache Drill Operators
 ======================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite
 ------------
 
 To use ``DrillOperator``, you must configure a :doc:`Drill Connection <connections/drill>`.
-
 
 .. _howto/operator:DrillOperator:
 

--- a/docs/apache-airflow-providers-apache-druid/operators.rst
+++ b/docs/apache-airflow-providers-apache-druid/operators.rst
@@ -19,10 +19,6 @@
 Apache Druid Operators
 ======================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite
 ------------
 

--- a/docs/apache-airflow-providers-apache-hdfs/operators.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/operators.rst
@@ -20,7 +20,6 @@
 Apache Hadoop HDFS Operators
 ============================
 
-
 `Apache Hadoop HDFS <https://hadoop.apache.org/docs/r1.2.1/hdfs_design.html>`__ is a distributed file system
 designed to run on commodity hardware. It has many similarities with existing distributed file systems.
 However, the differences from other distributed file systems are significant.
@@ -28,10 +27,6 @@ HDFS is highly fault-tolerant and is designed to be deployed on low-cost hardwar
 HDFS provides high throughput access to application data and is suitable for applications that have
 large data sets. HDFS relaxes a few POSIX requirements to enable streaming access to file
 system data. HDFS is now an Apache Hadoop sub project.
-
-.. contents::
-  :depth: 1
-  :local:
 
 Prerequisite
 ------------

--- a/docs/apache-airflow-providers-apache-spark/operators.rst
+++ b/docs/apache-airflow-providers-apache-spark/operators.rst
@@ -19,10 +19,6 @@
 Apache Spark Operators
 ======================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite
 ------------
 

--- a/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
+++ b/docs/apache-airflow-providers-cncf-kubernetes/operators.rst
@@ -25,10 +25,6 @@ KubernetesPodOperator
 The :class:`~airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator` allows
 you to create and run Pods on a Kubernetes cluster.
 
-.. contents::
-  :depth: 1
-  :local:
-
 .. note::
   If you use `Google Kubernetes Engine <https://cloud.google.com/kubernetes-engine/>`__, consider
   using the

--- a/docs/apache-airflow-providers-google/operators/ads.rst
+++ b/docs/apache-airflow-providers-google/operators/ads.rst
@@ -20,10 +20,6 @@ Google Ads Operators
 `Google Ads <https://ads.google.com/home/>`__, formerly Google AdWords and Google AdWords Express, is a platform which allows
 businesses to advertise on Google Search, YouTube and other sites across the web.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/automl.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/automl.rst
@@ -24,19 +24,12 @@ of machine learning. You can use AutoML to build on Google's machine learning ca
 to create your own custom machine learning models that are tailored to your business needs,
 and then integrate those models into your applications and web sites.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
 .. include::/operators/_partials/prerequisite_tasks.rst
 
-
 .. _howto/operator:CloudAutoMLDocuments:
-
-
 .. _howto/operator:AutoMLCreateDatasetOperator:
 .. _howto/operator:AutoMLImportDataOperator:
 .. _howto/operator:AutoMLTablesUpdateDatasetOperator:

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery.rst
@@ -26,10 +26,6 @@ analyzing data to find meaningful insights using familiar SQL.
 Airflow provides operators to manage datasets and tables, run queries and validate
 data.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/bigquery_dts.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigquery_dts.rst
@@ -25,16 +25,10 @@ BigQuery Data Transfer Service initially supports Google application sources lik
 Campaign Manager, Google Ad Manager and YouTube. Through BigQuery Data Transfer Service, users also
 gain access to data connectors that allow you to easily transfer data from Teradata and Amazon S3 to BigQuery.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 
 .. include::/operators/_partials/prerequisite_tasks.rst
-
 
 .. _howto/operator:BigQueryDTSDocuments:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/bigtable.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/bigtable.rst
@@ -20,15 +20,10 @@
 Google Cloud Bigtable Operators
 ===============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 
 .. include::/operators/_partials/prerequisite_tasks.rst
-
 
 .. _howto/operator:BigtableCreateInstanceOperator:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_build.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_build.rst
@@ -25,11 +25,6 @@ infrastructure. Cloud Build can import source code from Google Cloud Storage,
 Cloud Source Repositories, execute a build to your specifications, and produce
 artifacts such as Docker containers or Java archives.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_memorystore.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_memorystore.rst
@@ -25,10 +25,6 @@ Redis service for the Google Cloud. Applications running on Google Cloud can ach
 extreme performance by leveraging the highly scalable, available, secure Redis service without the burden
 of managing complex Redis deployments.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_memorystore_memcached.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_memorystore_memcached.rst
@@ -25,10 +25,6 @@ Memcached service for Google Cloud. Applications running on Google Cloud can ach
 leveraging the highly scalable, available, secure Memcached service without the burden of managing complex
 Memcached deployments.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_sql.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_sql.rst
@@ -20,10 +20,6 @@
 Google Cloud SQL Operators
 ==========================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/cloud_storage_transfer_service.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/cloud_storage_transfer_service.rst
@@ -20,10 +20,6 @@
 Google Cloud Transfer Service Operators
 =======================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/compute.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/compute.rst
@@ -20,10 +20,6 @@
 Google Compute Engine Operators
 ===============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/compute_ssh.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/compute_ssh.rst
@@ -20,10 +20,6 @@
 Google Compute Engine SSH Operators
 ===================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/data_loss_prevention.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/data_loss_prevention.rst
@@ -20,10 +20,6 @@ Google Cloud Data Loss Prevention Operator
 `Google Cloud DLP <https://cloud.google.com/dlp>`__, provides tools to classify, mask, tokenize, and transform sensitive
 elements to help you better manage the data that you collect, store, or use for business or analytics.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/datacatalog.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/datacatalog.rst
@@ -29,10 +29,6 @@ Google Cloud. It offers:
 * A flexible and powerful cataloging system for capturing technical and business metadata
 * An auto-tagging mechanism for sensitive data with DLP API integration
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/dataflow.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataflow.rst
@@ -22,10 +22,6 @@ Google Cloud Dataflow Operators
 executing a wide variety of data processing patterns. These pipelines are created
 using the Apache Beam programming model which allows for both batch and streaming processing.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/datafusion.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/datafusion.rst
@@ -26,10 +26,6 @@ and a broad open source library of preconfigured connectors and transformations,
 Data Fusion shifts an organization’s focus away from code and integration to insights
 and action.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/dataprep.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataprep.rst
@@ -42,10 +42,6 @@ Set values for these fields:
   Extra: {"extra__dataprep__token": "TOKEN",
           "extra__dataprep__base_url": "https://api.clouddataprep.com"}
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -25,10 +25,6 @@ save money by turning clusters off when you don't need them.
 
 For more information about the service visit `Dataproc production documentation <Product documentation <https://cloud.google.com/dataproc/docs/reference>`__
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/datastore.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/datastore.rst
@@ -24,10 +24,6 @@ high performance, and ease of application development.
 For more information about the service visit
 `Datastore product documentation <https://cloud.google.com/datastore/docs>`__
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/functions.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/functions.rst
@@ -20,10 +20,6 @@
 Google Cloud Functions Operators
 ================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/gcs.rst
@@ -24,10 +24,6 @@ Cloud Storage allows world-wide storage and retrieval of any amount of data at a
 You can use Cloud Storage for a range of scenarios including serving website content,
 storing data for archival and disaster recovery, or distributing large data objects to users via direct download.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
@@ -24,10 +24,6 @@ Google Kubernetes Engine Operators
 deploying, managing, and scaling your containerized applications using Google infrastructure. The GKE environment
 consists of multiple machines (specifically, Compute Engine instances) grouped together to form a cluster.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/life_sciences.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/life_sciences.rst
@@ -23,11 +23,6 @@ The `Google Cloud Life Sciences <https://cloud.google.com/life-sciences/>`__ is 
 series of compute engine containers on the Google Cloud. It is used to process, analyze and annotate genomics
 and biomedical data at scale.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/mlengine.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/mlengine.rst
@@ -26,10 +26,6 @@ in the cloud, and use models to make predictions for new data. AI Platform is a 
 of tools for training, evaluating, and tuning machine learning models. AI Platform can also
 be used to deploy a trained model, make predictions, and manage various model versions.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/natural_language.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/natural_language.rst
@@ -28,10 +28,6 @@ You can use it to understand sentiment about your product on social media or
 parse intent from customer conversations happening in a call center or a
 messaging app.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/pubsub.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/pubsub.rst
@@ -28,10 +28,6 @@ on Google Cloud or elsewhere on the Internet.
 Publisher applications can send messages to a topic and other applications can subscribe to that topic to receive the messages.
 By decoupling senders and receivers Google Cloud PubSub allows developers to communicate between independently written applications.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/spanner.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/spanner.rst
@@ -20,10 +20,6 @@
 Google Cloud Spanner Operators
 ==============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/stackdriver.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/stackdriver.rst
@@ -20,10 +20,6 @@
 Google Cloud Stackdriver Operators
 ==================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/translate.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/translate.rst
@@ -20,10 +20,6 @@
 Google Cloud Translate Operators
 --------------------------------
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/cloud/translate_speech.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/translate_speech.rst
@@ -18,10 +18,6 @@
 Google Cloud Speech Translate Operators
 =======================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/video_intelligence.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/video_intelligence.rst
@@ -18,10 +18,6 @@
 Google Cloud Video Intelligence Operators
 =========================================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/vision.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/vision.rst
@@ -20,10 +20,6 @@
 Google Cloud Vision Operators
 =============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/cloud/workflows.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/workflows.rst
@@ -25,10 +25,6 @@ Functions and Cloud Run, and calls to external APIs to create flexible serverles
 For more information about the service visit
 `Workflows production documentation <Product documentation <https://cloud.google.com/workflows/docs/overview>`__.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ------------------
 

--- a/docs/apache-airflow-providers-google/operators/firebase/firestore.rst
+++ b/docs/apache-airflow-providers-google/operators/firebase/firestore.rst
@@ -27,10 +27,6 @@ so you can build responsive apps that work regardless of network latency or Inte
 Firestore also offers seamless integration with other Firebase and Google Cloud products, including
 Cloud Functions.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/leveldb/leveldb.rst
+++ b/docs/apache-airflow-providers-google/operators/leveldb/leveldb.rst
@@ -25,10 +25,6 @@ Google LevelDB Operator
 `LevelDB <https://github.com/google/leveldb>`__ is a fast key-value storage library written at Google that provides
 an ordered mapping from string keys to string values.
 
-.. contents::
-  :depth: 1
-  :local:
-
 .. note::
 
     To use LevelDB hooks and operators you must requires installation of ``plyvel``.  It will be

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/analytics.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/analytics.rst
@@ -22,11 +22,6 @@ Google Analytics 360 operators allow you to lists all accounts to which the user
 For more information about the Google Analytics 360 API check
 `official documentation <https://developers.google.com/analytics/devguides/config/mgmt/v3>`__.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/campaign_manager.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/campaign_manager.rst
@@ -22,11 +22,6 @@ Google Campaign Manager operators allow you to insert, run, get or delete
 reports. For more information about the Campaign Manager API check
 `official documentation <https://developers.google.com/doubleclick-advertisers/v3.3/reports>`__.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/display_video.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/display_video.rst
@@ -20,10 +20,6 @@ Google Display & Video 360 Operators
 `Google Display & Video 360 <https://marketingplatform.google.com/about/display-video-360/>`__ has the end-to-end
 campaign management features you need.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/marketing_platform/search_ads.rst
+++ b/docs/apache-airflow-providers-google/operators/marketing_platform/search_ads.rst
@@ -21,10 +21,6 @@ Google Search Ads Operators
 Create, manage, and track high-impact campaigns across multiple search engines with one centralized tool.
 For more information check `Google Search Ads <https://developers.google.com/search-ads/>`__.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/suite/sheets.rst
+++ b/docs/apache-airflow-providers-google/operators/suite/sheets.rst
@@ -31,11 +31,6 @@ The latest version of the Sheets API lets developers programmatically:
 
 For more information check `official documentation <https://developers.google.com/sheets/api>`__.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/facebook_ads_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/facebook_ads_to_gcs.rst
@@ -20,10 +20,6 @@
 Facebook Ads To GCS Operators
 ==============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gdrive.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_gdrive.rst
@@ -25,11 +25,6 @@ used to store daily use data, including documents and photos. Google Cloud Stora
 with Google Cloud services. Google Drive has built-in mechanisms to facilitate group work e.g.
 document editor, file sharing mechanisms.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_local.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_local.rst
@@ -21,11 +21,6 @@ Downloads data from Google Cloud Storage to Local Filesystem
 The `Google Cloud Storage <https://cloud.google.com/storage/>`__  (GCS) is used to store large data from various applications.
 This page shows how to download data from GCS to local filesystem.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sftp.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sftp.rst
@@ -24,11 +24,6 @@ This service is used to store large data from various applications.
 SFTP (SSH File Transfer Protocol) is a secure file transfer protocol.
 It runs over the SSH protocol. It supports the full security and authentication functionality of SSH.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sheets.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gcs_to_sheets.rst
@@ -25,10 +25,6 @@ With `Google Sheets <https://www.google.pl/intl/en/sheets/about/>`__, everyone c
 spreadsheet at the same time. Use formulas functions, and formatting options to save time and simplify
 common spreadsheet tasks.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gdrive_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gdrive_to_gcs.rst
@@ -25,11 +25,6 @@ used to store daily use data, including documents and photos. Google Cloud Stora
 with Google Cloud services. Google Drive has built-in mechanisms to facilitate group work e.g.
 document editor, file sharing mechanisms.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/gdrive_to_local.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/gdrive_to_local.rst
@@ -22,11 +22,6 @@ The `Google Drive <https://www.google.com/drive/>`__ is
 used to store daily use data, including documents and photos. Google Drive has built-in mechanisms to facilitate group work e.g.
 document editor, file sharing mechanisms.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/local_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/local_to_gcs.rst
@@ -21,11 +21,6 @@ Upload data from Local Filesystem to Google Cloud Storage
 The `Google Cloud Storage <https://cloud.google.com/storage/>`__  (GCS) is used to store large data from various applications.
 This page shows how to upload data from local filesystem to GCS.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/mysql_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/mysql_to_gcs.rst
@@ -21,11 +21,6 @@ The `Google Cloud Storage <https://cloud.google.com/storage/>`__ (GCS) service i
 used to store large data from various applications. This page shows how to copy
 data from MySQL to GCS.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/oracle_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/oracle_to_gcs.rst
@@ -21,11 +21,6 @@ The `Google Cloud Storage <https://cloud.google.com/storage/>`__ (GCS) service i
 used to store large data from various applications. This page shows how to copy
 data from Oracle to GCS.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/s3_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/s3_to_gcs.rst
@@ -24,10 +24,6 @@ The `Google Cloud Storage <https://cloud.google.com/storage/>`__  (GCS) is used 
 data from various applications. This is also the same with `Amazon Simple Storage Service <https://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html>`__.
 This page shows how to transfer data from Amazon S3 to GCS.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/salesforce_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/salesforce_to_gcs.rst
@@ -18,10 +18,6 @@
 Salesforce To GCS Operators
 ==============================
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/sftp_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/sftp_to_gcs.rst
@@ -24,11 +24,6 @@ used to store large data from various applications.
 SFTP (SSH File Transfer Protocol) is a secure file transfer protocol.
 It runs over the SSH protocol. It supports the full security and authentication functionality of the SSH.
 
-
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/sheets_to_gcs.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/sheets_to_gcs.rst
@@ -25,10 +25,6 @@ With `Google Sheets <https://www.google.pl/intl/en/sheets/about/>`__, everyone c
 spreadsheet at the same time. Use formulas functions, and formatting options to save time and simplify
 common spreadsheet tasks.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-google/operators/transfer/sql_to_sheets.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/sql_to_sheets.rst
@@ -22,10 +22,6 @@ With `Google Sheets <https://www.google.pl/intl/en/sheets/about/>`__, everyone c
 spreadsheet at the same time. Use formulas functions, and formatting options to save time and simplify
 common spreadsheet tasks.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-jdbc/operators.rst
+++ b/docs/apache-airflow-providers-jdbc/operators.rst
@@ -24,10 +24,6 @@ Java Database Connectivity (JDBC) is an application programming interface
 (API) for the programming language Java, which defines how a client may
 access a database.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-microsoft-azure/operators/adf_run_pipeline.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/adf_run_pipeline.rst
@@ -21,10 +21,6 @@ Azure Data Factory Operators
 Azure Data Factory is Azure's cloud ETL service for scale-out serverless data integration and data transformation.
 It offers a code-free UI for intuitive authoring and single-pane-of-glass monitoring and management.
 
-.. contents::
-  :depth: 1
-  :local:
-
 .. _howto/operator:AzureDataFactoryRunPipelineOperator:
 
 AzureDataFactoryRunPipelineOperator

--- a/docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/adls.rst
@@ -19,11 +19,6 @@
 Azure DataLake Storage Operators
 =================================
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
@@ -43,10 +43,6 @@ Set values for these fields:
   Password: KEY1
   Extra: {"sas_token": "TOKEN"}
 
-.. contents::
-  :depth: 1
-  :local:
-
 .. _howto/operator:AzureBlobStorageToGCSOperator:
 
 Transfer Data from Blob Storage to Google Cloud Storage

--- a/docs/apache-airflow-providers-microsoft-azure/operators/local_to_adls.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/local_to_adls.rst
@@ -22,11 +22,6 @@ The `Azure Data Lake <https://azure.microsoft.com/en-us/solutions/data-lake/>`__
 any size, shape, and speed.
 This page shows how to upload data from local filesystem to ADL.
 
-.. contents::
-  :depth: 1
-  :local:
-
-
 Prerequisite Tasks
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/apache-airflow-providers/howto/create-update-providers.rst
+++ b/docs/apache-airflow-providers/howto/create-update-providers.rst
@@ -19,8 +19,6 @@
 Community Providers
 ===================
 
-.. contents:: :local:
-
 How-to creating a new community provider
 ----------------------------------------
 

--- a/docs/apache-airflow-providers/installing-from-pypi.rst
+++ b/docs/apache-airflow-providers/installing-from-pypi.rst
@@ -18,9 +18,6 @@
 Installation from PyPI
 ----------------------
 
-.. contents:: :local:
-
-
 This page describes installations using the ``apache-airflow-providers`` package `published in
 PyPI <https://pypi.org/search/?q=apache-airflow-providers>`__.
 

--- a/docs/apache-airflow-providers/installing-from-sources.rst
+++ b/docs/apache-airflow-providers/installing-from-sources.rst
@@ -19,9 +19,6 @@
 Installing Providers from Sources
 ---------------------------------
 
-.. contents:: :local:
-
-
 Released packages
 '''''''''''''''''
 

--- a/docs/apache-airflow/concepts/scheduler.rst
+++ b/docs/apache-airflow/concepts/scheduler.rst
@@ -20,9 +20,6 @@
 Scheduler
 ==========
 
-.. contents:: :local:
-
-
 The Airflow scheduler monitors all tasks and DAGs, then triggers the
 task instances once their dependencies are complete. Behind the scenes,
 the scheduler spins up a subprocess, which monitors and stays in sync with all

--- a/docs/apache-airflow/installation/installing-from-pypi.rst
+++ b/docs/apache-airflow/installation/installing-from-pypi.rst
@@ -18,9 +18,6 @@
 Installation from PyPI
 ----------------------
 
-.. contents:: :local:
-
-
 This page describes installations using the ``apache-airflow`` package `published in
 PyPI <https://pypi.org/project/apache-airflow/>`__.
 

--- a/docs/apache-airflow/installation/installing-from-sources.rst
+++ b/docs/apache-airflow/installation/installing-from-sources.rst
@@ -18,9 +18,6 @@
 Installing from Sources
 -----------------------
 
-.. contents:: :local:
-
-
 Released packages
 '''''''''''''''''
 

--- a/docs/apache-airflow/security/access-control.rst
+++ b/docs/apache-airflow/security/access-control.rst
@@ -22,10 +22,6 @@ Access Control of Airflow Webserver UI is handled by Flask AppBuilder (FAB).
 Please read its related `security document <http://flask-appbuilder.readthedocs.io/en/latest/security.html>`_
 regarding its security model.
 
-.. contents::
-  :depth: 1
-  :local:
-
 .. spelling::
     clearTaskInstances
     dagRuns

--- a/docs/apache-airflow/security/api.rst
+++ b/docs/apache-airflow/security/api.rst
@@ -18,10 +18,6 @@
 API
 ===
 
-.. contents::
-  :depth: 1
-  :local:
-
 API Authentication
 ------------------
 

--- a/docs/apache-airflow/security/flower.rst
+++ b/docs/apache-airflow/security/flower.rst
@@ -21,10 +21,6 @@ Flower
 Flower is a web based tool for monitoring and administrating Celery clusters. This topic describes how
 to configure Airflow to secure your flower instance.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Flower Authentication
 ---------------------
 

--- a/docs/apache-airflow/security/kerberos.rst
+++ b/docs/apache-airflow/security/kerberos.rst
@@ -22,10 +22,6 @@ Airflow has initial support for Kerberos. This means that Airflow can renew kerb
 tickets for itself and store it in the ticket cache. The hooks and dags can make use of ticket
 to authenticate against kerberized services.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Limitations
 '''''''''''
 

--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -20,10 +20,6 @@ Webserver
 
 This topic describes how to configure Airflow to secure your webserver.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Rendering Airflow UI in a Web Frame from another site
 ------------------------------------------------------
 

--- a/docs/apache-airflow/security/workload.rst
+++ b/docs/apache-airflow/security/workload.rst
@@ -20,10 +20,6 @@ Workload
 
 This topic describes how to configure Airflow to secure your workload.
 
-.. contents::
-  :depth: 1
-  :local:
-
 Impersonation
 -------------
 

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -24,8 +24,6 @@ Upgrading from 1.10 to 2
 
     upgrade-check
 
-.. contents:: :local:
-
 Apache Airflow 2 is a major release and the purpose of this document is to assist
 users to migrate from Airflow 1.10.x to Airflow 2
 

--- a/docs/apache-airflow/upgrading-from-1-10/upgrade-check.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/upgrade-check.rst
@@ -19,8 +19,6 @@
 Upgrade Check Script
 --------------------
 
-.. contents:: :local:
-
 .. _upgrade-check:
 
 Getting the Airflow Upgrade Check Package

--- a/docs/helm-chart/installing-helm-chart-from-sources.rst
+++ b/docs/helm-chart/installing-helm-chart-from-sources.rst
@@ -18,9 +18,6 @@
 Installing Helm Chart from sources
 ----------------------------------
 
-.. contents:: :local:
-
-
 Released packages
 '''''''''''''''''
 

--- a/docs/helm-chart/parameters-ref.rst
+++ b/docs/helm-chart/parameters-ref.rst
@@ -20,10 +20,6 @@ Parameters reference
 
 The following tables lists the configurable parameters of the Airflow chart and their default values.
 
-.. contents:: Sections:
-   :local:
-   :depth: 1
-
 .. jinja:: params_ctx
 
     {% for section in sections %}

--- a/docs/installing-providers-from-sources.rst
+++ b/docs/installing-providers-from-sources.rst
@@ -18,9 +18,6 @@
 Installing from sources
 -----------------------
 
-.. contents:: :local:
-
-
 Released packages
 '''''''''''''''''
 


### PR DESCRIPTION
This pattern of having a local table of contents seems to have been cargo-culted to all of the providers, and other pages, but our Sphinx theme already has the page contents on the right hand side -- this is just leading to duplication.

(Not to mention that for the majority of cases the page is so short that you can easily see everytine at once anyway.)

I have left it in a few places -- for instance the main configurations-ref.rst I have kept it.

One such example:


![image](https://user-images.githubusercontent.com/34150/135614462-6969c116-9a44-4183-9880-50e3de44fb95.png)


Local ToCs that I kept (non exhaustive list):


- http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/cli-and-env-variables-ref.html
- http://apache-airflow-docs.s3-website.eu-central-1.amazonaws.com/docs/apache-airflow/latest/configurations-ref.html
