### PR TITLE
Broken links on documentation site for Official Helm Chart

### DIFF
--- a/docs/apache-airflow/installation/setting-up-the-database.rst
+++ b/docs/apache-airflow/installation/setting-up-the-database.rst
@@ -28,5 +28,5 @@ Similarly, upgrading Airflow usually requires an extra step of upgrading the dat
 with ``airflow db upgrade`` CLI command. You should make sure that Airflow components are
 not running while the upgrade is being executed.
 
-In some deployments, such as :doc:`helm-chart:index`, both initializing and running the database migration
+In some deployments, such as :doc:`helm-chart:index.rst`, both initializing and running the database migration
 is executed automatically when Airflow is upgraded.


### PR DESCRIPTION
The broken link shown is https://airflow.apache.org/docs/helm-chart/latest/index.html which results in a 404 Not Found in the browser when clicked on from this page:
https://airflow.apache.org/docs/apache-airflow/stable/installation/index.html#using-official-airflow-helm-chart
(NOTE: there maybe other locations pointing to the official helm chart in the docs such as on this page: https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html#production-readiness )

Not sure what the exact fix needs to be throughout, but here's the file I saw that is the likely generator (.rst restructured text) for the index.html
https://github.com/apache/airflow/blob/main/docs/helm-chart/index.rst

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
