### PR TITLE
update sshtunnel version

### DIFF
--- a/airflow/providers/ssh/hooks/ssh.py
+++ b/airflow/providers/ssh/hooks/ssh.py
@@ -361,7 +361,7 @@ class SSHHook(BaseHook):
             )
         else:
             tunnel_kwargs.update(
-                host_pkey_directories=[],
+                host_pkey_directories=None,
             )
 
         client = SSHTunnelForwarder(self.remote_host, **tunnel_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -465,7 +465,7 @@ spark = [
 ssh = [
     'paramiko>=2.6.0',
     'pysftp>=0.2.9',
-    'sshtunnel>=0.1.4,<0.2',
+    'sshtunnel>=0.3.2,<0.5',
 ]
 statsd = [
     'statsd>=3.3.0, <4.0',

--- a/tests/providers/ssh/hooks/test_ssh.py
+++ b/tests/providers/ssh/hooks/test_ssh.py
@@ -317,7 +317,7 @@ class TestSSHHook(unittest.TestCase):
                 ssh_proxy=None,
                 local_bind_address=('localhost',),
                 remote_bind_address=('localhost', 1234),
-                host_pkey_directories=[],
+                host_pkey_directories=None,
                 logger=hook.log,
             )
 
@@ -351,7 +351,7 @@ class TestSSHHook(unittest.TestCase):
                 ssh_proxy=None,
                 local_bind_address=('localhost',),
                 remote_bind_address=('localhost', 1234),
-                host_pkey_directories=[],
+                host_pkey_directories=None,
                 logger=hook.log,
             )
 
@@ -374,7 +374,7 @@ class TestSSHHook(unittest.TestCase):
                 ssh_proxy=None,
                 local_bind_address=('localhost',),
                 remote_bind_address=('localhost', 1234),
-                host_pkey_directories=[],
+                host_pkey_directories=None,
                 logger=hook.log,
             )
 
@@ -397,7 +397,7 @@ class TestSSHHook(unittest.TestCase):
                 ssh_proxy=None,
                 local_bind_address=('localhost',),
                 remote_bind_address=('localhost', 1234),
-                host_pkey_directories=[],
+                host_pkey_directories=None,
                 logger=hook.log,
             )
 
@@ -430,7 +430,9 @@ class TestSSHHook(unittest.TestCase):
             args=["python", "-c", HELLO_SERVER_CMD],
             stdout=subprocess.PIPE,
         )
-        with subprocess.Popen(**subprocess_kwargs) as server_handle, hook.create_tunnel(2135, 2134):
+        with subprocess.Popen(**subprocess_kwargs) as server_handle, hook.get_tunnel(
+            local_port=2135, remote_port=2134
+        ):
             server_output = server_handle.stdout.read(5)
             assert b"ready" == server_output
             socket = socket.socket()


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/16699

update `sshtunnel` to latest version.
1. min version needs to be 0.3.2 due to PR https://github.com/pahaz/sshtunnel/pull/216/files which changed the behavior around `host_pkey_directories`. The relevant change is in these [code lines](https://github.com/pahaz/sshtunnel/pull/216/files#diff-11ccf18bb1618a9e107ff29db859eb1aaaa63d3aba94770f78de58deae467689L1088-R1085).

2. [`create_tunnel`](https://github.com/apache/airflow/blob/68d99bc5582b52106f876ccc22cc1e115a42b252/airflow/providers/ssh/hooks/ssh.py#L371-L388) is deprecated. replaced with `get_tunnel`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
