### PR TITLE
Renaming variables to be consistent with code logic

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -77,10 +77,10 @@ def _trigger_dag(
     if conf:
         run_conf = conf if isinstance(conf, dict) else json.loads(conf)
 
-    triggers = []
-    dags_to_trigger = [dag] + dag.subdags
-    for _dag in dags_to_trigger:
-        trigger = _dag.create_dagrun(
+    dag_runs = []
+    dags_to_run = [dag] + dag.subdags
+    for _dag in dags_to_run:
+        dag_run = _dag.create_dagrun(
             run_id=run_id,
             execution_date=execution_date,
             state=State.QUEUED,
@@ -88,9 +88,9 @@ def _trigger_dag(
             external_trigger=True,
             dag_hash=dag_bag.dags_hash.get(dag_id),
         )
+        dag_runs.append(dag_run)
 
-        triggers.append(trigger)
-    return triggers
+    return dag_runs
 
 
 def trigger_dag(


### PR DESCRIPTION
This is a simple change to rename variables to be consistent with code logic and with the "story-line"

So, basically code calls `create_dagrun()` to create a dag run... and assigns it to a variable called "trigger". Although it's "ok" to name that way, it's much more readable to make it clear/explicit and call returned object a "dagrun" as it's an instance of it.
Also reading it in English trigger conveys a bit different meaning i.e. original purpose of the action `airflow dags trigger ...` and so not best name for the returned object and subsequent collection of objects i.e. triggers[]

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
