### PR TITLE
Add support for storing conn as json in SSM secrets backend

### DIFF
--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -397,7 +397,9 @@ class Connection(Base, LoggingMixin):
 
         raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
 
-    def __eq__(self, other: 'Connection'):
+    def __eq__(self, other):
+        if not isinstance(other, Connection):
+            return NotImplemented
         return (
             self.conn_id == other.conn_id
             and self.conn_type == other.conn_type

--- a/airflow/models/connection.py
+++ b/airflow/models/connection.py
@@ -396,3 +396,15 @@ class Connection(Base, LoggingMixin):
                 )
 
         raise AirflowNotFoundException(f"The conn_id `{conn_id}` isn't defined")
+
+    def __eq__(self, other: 'Connection'):
+        return (
+            self.conn_id == other.conn_id
+            and self.conn_type == other.conn_type
+            and self.login == other.login
+            and self.password == other.password
+            and self.host == other.host
+            and self.port == other.port
+            and self.schema == other.schema
+            and self.extra == other.extra
+        )

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -21,7 +21,11 @@ from typing import Optional
 
 import boto3
 
-from airflow.compat.functools import cached_property
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
+
 from airflow.models import Connection
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -61,6 +61,9 @@ class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):
     :type config_prefix: str
     :param profile_name: The name of a profile to use. If not given, then the default profile is used.
     :type profile_name: str
+    :param connection_as_kwargs: if True, connection should be serialized as JSON; otherwise it should
+        use the Airflow Connection URI format
+    :type connection_as_kwargs: bool
     """
 
     def __init__(

--- a/airflow/providers/amazon/aws/secrets/systems_manager.py
+++ b/airflow/providers/amazon/aws/secrets/systems_manager.py
@@ -17,7 +17,7 @@
 # under the License.
 """Objects relating to sourcing connections from AWS SSM Parameter Store"""
 import json
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import boto3
 
@@ -26,9 +26,11 @@ try:
 except ImportError:
     from cached_property import cached_property
 
-from airflow.models import Connection
 from airflow.secrets import BaseSecretsBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
+
+if TYPE_CHECKING:
+    from airflow.models.connection import Connection
 
 
 class SystemsManagerParameterStoreBackend(BaseSecretsBackend, LoggingMixin):


### PR DESCRIPTION
Some notes

Did not update all tests cus i just want to put it out there for thoughts first.

I think that ultimately we need to pull some of this logic up into base secrets backend.

E.g. perhaps in base secrets backend we can accept parameter `connection_as_kwargs` to let it know whether to expect kwargs or URI.  and i say kwargs instead of json because some things like vault and aws secrets manager are already key value stores that may return dict not json string.

And i think some more logic is commonly duplicated e.g. building out the paths given a secret id. 

And if we want to standardize how airflow conns should be json serialized, we may need to add an abstraction `get_secret` which just gets the raw value --- so that the parsing can be fully handled by the base class.  

Also: Why parameterize with `connection_as_kwargs` instead of subclass?  It doesn't make sense to have a *Json version of every secrets backend, especially because the json part of it only applies to connections and not config or variable.


