### PR TITLE
Adding missing `max_ingestion_time` to DruidOperator docstring

### DIFF
--- a/airflow/providers/apache/druid/operators/druid.py
+++ b/airflow/providers/apache/druid/operators/druid.py
@@ -31,6 +31,8 @@ class DruidOperator(BaseOperator):
     :param druid_ingest_conn_id: The connection id of the Druid overlord which
         accepts index jobs
     :type druid_ingest_conn_id: str
+    :param max_ingestion_time: The maximum ingestion time before assuming the job failed
+    :type max_ingestion_time: int
     """
 
     template_fields = ('json_index_file',)


### PR DESCRIPTION
The `DruidOperator` was missing information about the `max_ingestion_time` parameter and therefore missing from the API documentation.  This PR adds this detail to the operator's docstring.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
