### PR TITLE
Dataflow Operators - use project and location from job in on_kill method.

### DIFF
--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -657,7 +657,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.poll_sleep = poll_sleep
-        self.job_id = None
+        self.job = None
         self.hook: Optional[DataflowHook] = None
         self.impersonation_chain = impersonation_chain
         self.environment = environment
@@ -674,8 +674,8 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
             wait_until_finished=self.wait_until_finished,
         )
 
-        def set_current_job_id(job_id):
-            self.job_id = job_id
+        def set_current_job(current_job):
+            self.job = current_job
 
         options = self.dataflow_default_options
         options.update(self.options)
@@ -684,7 +684,7 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
             variables=options,
             parameters=self.parameters,
             dataflow_template=self.template,
-            on_new_job_id_callback=set_current_job_id,
+            on_new_job_callback=set_current_job,
             project_id=self.project_id,
             location=self.location,
             environment=self.environment,
@@ -694,8 +694,12 @@ class DataflowTemplatedJobStartOperator(BaseOperator):
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
-        if self.job_id:
-            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)
+        if self.job:
+            self.hook.cancel_job(
+                job_id=self.job.get("id"),
+                project_id=self.job.get("projectId"),
+                location=self.job.get("location"),
+            )
 
 
 class DataflowStartFlexTemplateOperator(BaseOperator):
@@ -787,7 +791,7 @@ class DataflowStartFlexTemplateOperator(BaseOperator):
         self.drain_pipeline = drain_pipeline
         self.cancel_timeout = cancel_timeout
         self.wait_until_finished = wait_until_finished
-        self.job_id = None
+        self.job = None
         self.hook: Optional[DataflowHook] = None
 
     def execute(self, context):
@@ -799,22 +803,26 @@ class DataflowStartFlexTemplateOperator(BaseOperator):
             wait_until_finished=self.wait_until_finished,
         )
 
-        def set_current_job_id(job_id):
-            self.job_id = job_id
+        def set_current_job(current_job):
+            self.job = current_job
 
         job = self.hook.start_flex_template(
             body=self.body,
             location=self.location,
             project_id=self.project_id,
-            on_new_job_id_callback=set_current_job_id,
+            on_new_job_callback=set_current_job,
         )
 
         return job
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
-        if self.job_id:
-            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)
+        if self.job:
+            self.hook.cancel_job(
+                job_id=self.job.get("id"),
+                project_id=self.job.get("projectId"),
+                location=self.job.get("location"),
+            )
 
 
 class DataflowStartSqlJobOperator(BaseOperator):
@@ -890,7 +898,7 @@ class DataflowStartSqlJobOperator(BaseOperator):
         self.gcp_conn_id = gcp_conn_id
         self.delegate_to = delegate_to
         self.drain_pipeline = drain_pipeline
-        self.job_id = None
+        self.job = None
         self.hook: Optional[DataflowHook] = None
 
     def execute(self, context):
@@ -900,8 +908,8 @@ class DataflowStartSqlJobOperator(BaseOperator):
             drain_pipeline=self.drain_pipeline,
         )
 
-        def set_current_job_id(job_id):
-            self.job_id = job_id
+        def set_current_job(current_job):
+            self.job = current_job
 
         job = self.hook.start_sql_job(
             job_name=self.job_name,
@@ -909,15 +917,19 @@ class DataflowStartSqlJobOperator(BaseOperator):
             options=self.options,
             location=self.location,
             project_id=self.project_id,
-            on_new_job_id_callback=set_current_job_id,
+            on_new_job_callback=set_current_job,
         )
 
         return job
 
     def on_kill(self) -> None:
         self.log.info("On kill.")
-        if self.job_id:
-            self.hook.cancel_job(job_id=self.job_id, project_id=self.project_id)
+        if self.job:
+            self.hook.cancel_job(
+                job_id=self.job.get("id"),
+                project_id=self.job.get("projectId"),
+                location=self.job.get("location"),
+            )
 
 
 class DataflowCreatePythonJobOperator(BaseOperator):

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1016,19 +1016,21 @@ class TestDataflowTemplateHook(unittest.TestCase):
     @mock.patch(DATAFLOW_STRING.format('_DataflowJobsController'))
     @mock.patch(DATAFLOW_STRING.format('DataflowHook.get_conn'))
     def test_start_flex_template(self, mock_conn, mock_controller):
+        expected_job = {"id": TEST_JOB_ID}
+
         mock_locations = mock_conn.return_value.projects.return_value.locations
         launch_method = mock_locations.return_value.flexTemplates.return_value.launch
-        launch_method.return_value.execute.return_value = {"job": {"id": TEST_JOB_ID}}
+        launch_method.return_value.execute.return_value = {"job": expected_job}
         mock_controller.return_value.get_jobs.return_value = [{"id": TEST_JOB_ID}]
 
-        on_new_job_id_callback = mock.MagicMock()
+        on_new_job_callback = mock.MagicMock()
         result = self.dataflow_hook.start_flex_template(
             body={"launchParameter": TEST_FLEX_PARAMETERS},
             location=TEST_LOCATION,
             project_id=TEST_PROJECT_ID,
-            on_new_job_id_callback=on_new_job_id_callback,
+            on_new_job_callback=on_new_job_callback,
         )
-        on_new_job_id_callback.assert_called_once_with(TEST_JOB_ID)
+        on_new_job_callback.assert_called_once_with(expected_job)
         launch_method.assert_called_once_with(
             projectId='test-project-id',
             body={'launchParameter': TEST_FLEX_PARAMETERS},
@@ -1080,14 +1082,15 @@ class TestDataflowTemplateHook(unittest.TestCase):
         mock_run.return_value = mock.MagicMock(
             stdout=f"{TEST_JOB_ID}\n".encode(), stderr=f"{TEST_JOB_ID}\n".encode(), returncode=0
         )
-        on_new_job_id_callback = mock.MagicMock()
+        on_new_job_callback = mock.MagicMock()
+
         result = self.dataflow_hook.start_sql_job(
             job_name=TEST_SQL_JOB_NAME,
             query=TEST_SQL_QUERY,
             options=TEST_SQL_OPTIONS,
             location=TEST_LOCATION,
             project_id=TEST_PROJECT,
-            on_new_job_id_callback=on_new_job_id_callback,
+            on_new_job_callback=on_new_job_callback,
         )
         mock_run.assert_called_once_with(
             [
@@ -1135,7 +1138,7 @@ class TestDataflowTemplateHook(unittest.TestCase):
                 options=TEST_SQL_OPTIONS,
                 location=TEST_LOCATION,
                 project_id=TEST_PROJECT,
-                on_new_job_id_callback=mock.MagicMock(),
+                on_new_job_callback=mock.MagicMock(),
             )
 
 

--- a/tests/providers/google/cloud/operators/test_dataflow.py
+++ b/tests/providers/google/cloud/operators/test_dataflow.py
@@ -89,7 +89,7 @@ FROM
     bigquery.table.test-project.beam_samples.beam_table
 GROUP BY sales_region;
 """
-TEST_SQL_JOB_ID = 'test-job-id'
+TEST_SQL_JOB = {'id': 'test-job-id'}
 
 
 class TestDataflowPythonOperator(unittest.TestCase):
@@ -410,7 +410,7 @@ class TestDataflowTemplateOperator(unittest.TestCase):
             variables=expected_options,
             parameters=PARAMETERS,
             dataflow_template=TEMPLATE,
-            on_new_job_id_callback=mock.ANY,
+            on_new_job_callback=mock.ANY,
             project_id=None,
             location=TEST_LOCATION,
             environment={'maxWorkers': 2},
@@ -432,7 +432,7 @@ class TestDataflowStartFlexTemplateOperator(unittest.TestCase):
             body={"launchParameter": TEST_FLEX_PARAMETERS},
             location=TEST_LOCATION,
             project_id=TEST_PROJECT,
-            on_new_job_id_callback=mock.ANY,
+            on_new_job_callback=mock.ANY,
         )
 
     def test_on_kill(self):
@@ -444,10 +444,10 @@ class TestDataflowStartFlexTemplateOperator(unittest.TestCase):
             project_id=TEST_PROJECT,
         )
         start_flex_template.hook = mock.MagicMock()
-        start_flex_template.job_id = JOB_ID
+        start_flex_template.job = {"id": JOB_ID, "projectId": TEST_PROJECT, "location": TEST_LOCATION}
         start_flex_template.on_kill()
         start_flex_template.hook.cancel_job.assert_called_once_with(
-            job_id='test-dataflow-pipeline-id', project_id=TEST_PROJECT
+            job_id='test-dataflow-pipeline-id', project_id=TEST_PROJECT, location=TEST_LOCATION
         )
 
 
@@ -473,8 +473,10 @@ class TestDataflowSqlOperator(unittest.TestCase):
             options=TEST_SQL_OPTIONS,
             location=TEST_LOCATION,
             project_id=None,
-            on_new_job_id_callback=mock.ANY,
+            on_new_job_callback=mock.ANY,
         )
-        start_sql.job_id = TEST_SQL_JOB_ID
+        start_sql.job = TEST_SQL_JOB
         start_sql.on_kill()
-        mock_hook.return_value.cancel_job.assert_called_once_with(job_id='test-job-id', project_id=None)
+        mock_hook.return_value.cancel_job.assert_called_once_with(
+            job_id='test-job-id', project_id=None, location=None
+        )


### PR DESCRIPTION
Reason why we need this is because we can have situation where project_id is set to None but we define it in the dataflow_default_options. Job will start normally without error but in case when we decide to mark running task to different state we will get a error that the job does not exits.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
