### PR TITLE
Remove eagerloading when querying for TI

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -18,7 +18,6 @@
 from flask import Response, current_app, request
 from itsdangerous.exc import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
-from sqlalchemy.orm import eagerload
 
 from airflow.api_connexion import security
 from airflow.api_connexion.exceptions import BadRequest, NotFound
@@ -65,7 +64,6 @@ def get_log(session, dag_id, dag_run_id, task_id, task_try_number, full_content=
         session.query(TaskInstance)
         .filter(TaskInstance.task_id == task_id, TaskInstance.run_id == dag_run_id)
         .join(TaskInstance.dag_run)
-        .options(eagerload(TaskInstance.dag_run))
         .one_or_none()
     )
     if ti is None:

--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -19,7 +19,6 @@ from typing import Any, List, Optional, Tuple
 from flask import current_app, request
 from marshmallow import ValidationError
 from sqlalchemy import and_, func
-from sqlalchemy.orm import eagerload
 from sqlalchemy.orm.exc import NoResultFound
 
 from airflow.api_connexion import security
@@ -57,7 +56,6 @@ def get_task_instance(dag_id: str, dag_run_id: str, task_id: str, session=None):
         session.query(TI)
         .filter(TI.dag_id == dag_id, DR.run_id == dag_run_id, TI.task_id == task_id)
         .join(TI.dag_run)
-        .options(eagerload(TI.dag_run))
         .outerjoin(
             SlaMiss,
             and_(
@@ -127,7 +125,7 @@ def get_task_instances(
     session=None,
 ):
     """Get list of task instances."""
-    base_query = session.query(TI).join(TI.dag_run).options(eagerload(TI.dag_run))
+    base_query = session.query(TI).join(TI.dag_run)
 
     if dag_id != "~":
         base_query = base_query.filter(TI.dag_id == dag_id)
@@ -182,7 +180,7 @@ def get_task_instances_batch(session=None):
         data = task_instance_batch_form.load(body)
     except ValidationError as err:
         raise BadRequest(detail=str(err.messages))
-    base_query = session.query(TI).join(TI.dag_run).options(eagerload(TI.dag_run))
+    base_query = session.query(TI).join(TI.dag_run)
 
     base_query = _apply_array_filter(base_query, key=TI.dag_id, values=data["dag_ids"])
     base_query = _apply_range_filter(
@@ -253,7 +251,7 @@ def post_clear_task_instances(dag_id: str, session=None):
         clear_task_instances(
             task_instances.all(), session, dag=dag, dag_run_state=State.QUEUED if reset_dag_runs else False
         )
-    task_instances = task_instances.join(TI.dag_run).options(eagerload(TI.dag_run))
+
     return task_instance_reference_collection_schema.dump(
         TaskInstanceReferenceCollection(task_instances=task_instances.all())
     )

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -28,7 +28,6 @@ from typing import Iterator, List, Optional, Set, Tuple
 
 from setproctitle import setproctitle
 from sqlalchemy import func, or_
-from sqlalchemy.orm import eagerload
 from sqlalchemy.orm.session import Session
 
 from airflow import models, settings
@@ -393,7 +392,6 @@ class DagFileProcessor(LoggingMixin):
 
         max_tis: Iterator[TI] = (
             session.query(TI)
-            .options(eagerload(TI.dag_run))
             .join(TI.dag_run)
             .filter(
                 TI.dag_id == dag.dag_id,

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -22,7 +22,6 @@ from collections import OrderedDict
 from typing import Optional, Set
 
 import pendulum
-from sqlalchemy.orm import eagerload
 from sqlalchemy.orm.session import Session, make_transient
 from tabulate import tabulate
 
@@ -867,7 +866,6 @@ class BackfillJob(BaseJob):
             resettable_tis = (
                 session.query(TaskInstance)
                 .join(TaskInstance.dag_run)
-                .options(eagerload(TaskInstance.dag_run))
                 .filter(
                     DagRun.state == State.RUNNING,
                     DagRun.run_type != DagRunType.BACKFILL_JOB,

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -31,7 +31,7 @@ from typing import Collection, DefaultDict, Dict, List, Optional, Tuple
 
 from sqlalchemy import and_, func, not_, or_, tuple_
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import eagerload, load_only, selectinload
+from sqlalchemy.orm import load_only, selectinload
 from sqlalchemy.orm.session import Session, make_transient
 
 from airflow import models, settings
@@ -257,7 +257,6 @@ class SchedulerJob(BaseJob):
         query = (
             session.query(TI)
             .join(TI.dag_run)
-            .options(eagerload(TI.dag_run))
             .filter(DR.run_type != DagRunType.BACKFILL_JOB, DR.state != DagRunState.QUEUED)
             .join(TI.dag_model)
             .filter(not_(DM.is_paused))


### PR DESCRIPTION
Since we now have ti.dag_run lazy-loaded eagerly, no need to still have eagerloading on TIs


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
