### PR TITLE
Properly set start_date for cleared tasks

### DIFF
--- a/airflow/api_connexion/endpoints/task_instance_endpoint.py
+++ b/airflow/api_connexion/endpoints/task_instance_endpoint.py
@@ -250,7 +250,7 @@ def post_clear_task_instances(dag_id: str, session=None):
     task_instances = dag.clear(dry_run=True, dag_bag=current_app.dag_bag, **data)
     if not dry_run:
         clear_task_instances(
-            task_instances.all(), session, dag=dag, dag_run_state=State.RUNNING if reset_dag_runs else False
+            task_instances.all(), session, dag=dag, dag_run_state=State.QUEUED if reset_dag_runs else False
         )
     task_instances = task_instances.join(TI.dag_run).options(eagerload(TI.dag_run))
     return task_instance_reference_collection_schema.dump(

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -271,9 +271,10 @@ def clear_task_instances(
         )
         for dr in drs:
             dr.state = dag_run_state
-            dr.start_date = None
+            dr.start_date = timezone.utcnow()
             if dag_run_state == State.QUEUED:
                 dr.last_scheduling_decision = None
+                dr.start_date = None
 
 
 class TaskInstanceKey(NamedTuple):

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -131,7 +131,7 @@ class TestClearTasks:
         session.refresh(dr)
 
         assert dr.state == state
-        assert dr.start_date is None
+        assert dr.start_date is None if state == State.QUEUED else dr.start_date
         assert dr.last_scheduling_decision == last_scheduling
 
     def test_clear_task_instances_without_task(self, dag_maker):


### PR DESCRIPTION
This PR ensures that when we clear task instances, the start_date for the dagrun is set correctly.
If the dag_run_state is queued we should set the start_date to None otherwise start_date should be
set to timezone.utcnow

Also, in the clear task instances API endpoint, the state of the dagrun is being set to RUNNING on
clear. This PR addresses it too.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
