### PR TITLE
Fix eager-upgrade builds for Airflow main.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,10 @@ flask_appbuilder_authlib = [
 ]
 google = [
     'PyOpenSSL',
-    'google-ads>=12.0.0',
+    # The Google Ads 14.0.1 breaks PIP and eager upgrade as it requires
+    # google-api-core>=2.0.0 which cannot be used yet (see below comment)
+    # and https://github.com/apache/airflow/issues/18705#issuecomment-933746150
+    'google-ads>=12.0.0,<14.0.1',
     # Maintainers, please do not require google-api-core>=2.x.x
     # Until this issue is closed
     # https://github.com/googleapis/google-cloud-python/issues/10566


### PR DESCRIPTION
For 5 days now Airflow's main did not build with eager upgrade
for Python 3.7+. Unfortunately PIP did not give us enough clues
of what happend, so we had to investigated it and found out
that google-ads 14.0.1 bumped google-python-core-api dependency
to above 2.0.0 and we have limits in place as some other libraries
are not compatible with it.

See:

https://github.com/apache/airflow/issues/18705#issuecomment-933746150

Fix is to limit google-ads.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
