### PR TITLE
Remove repetitive call to get executor class from config

### DIFF
--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -96,10 +96,9 @@ class BaseJob(Base, LoggingMixin):
     def __init__(self, executor=None, heartrate=None, *args, **kwargs):
         self.hostname = get_hostname()
         if executor:
+            # Executor here is used for test suites. So they can inject it for testing
             self.executor = executor
-            self.executor_class = executor.__class__.__name__
-        else:
-            self.executor_class = conf.get('core', 'EXECUTOR')
+        self.executor_class = self.executor.__class__.__name__
         self.start_date = timezone.utcnow()
         self.latest_heartbeat = timezone.utcnow()
         if heartrate is not None:


### PR DESCRIPTION
This is code improvement PR and removes call to get executor class from the config.
It will instead call self.executor property to invoke call to read from config and cache.
This also simplifies code.
I also added comment for that assignment as it looks like executor from the arguments only used for tests and not intended to be  supplied by user.


 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
