### PR TITLE
Remove duplicate line of code for configuration copy

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -68,7 +68,7 @@ class BaseTaskRunner(LoggingMixin):
         # might not be able to run the cmds to get credentials
         cfg_path = tmp_configuration_copy(chmod=0o600)
 
-        if self.run_as_user and (self.run_as_user != getuser()):
+        if self.run_as_user and self.run_as_user != getuser():
             # Give ownership of file to user; only they can read and write
             subprocess.call(['sudo', 'chown', self.run_as_user, cfg_path], close_fds=True)
 


### PR DESCRIPTION
This is code improvement PR to remove a duplicate line. The code copies config in either cases of IF statement hence duplicate call. 
Moving that before IF makes it unique and sufficient for the purpose.

I have moved first call above IF and removed ELSE block

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
