### PR TITLE
Consolidate method names between Airflow Security Manager and FAB default

### DIFF
--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -295,7 +295,9 @@ def remap_permissions():
         for new_action_name, new_resource_name in new:
             new_permission = appbuilder.sm.create_permission(new_action_name, new_resource_name)
             for role in appbuilder.sm.get_all_roles():
-                if appbuilder.sm.permission_exists_in_one_or_more_roles(old_resource_name, old_action_name, [role.id]):
+                if appbuilder.sm.permission_exists_in_one_or_more_roles(
+                    old_resource_name, old_action_name, [role.id]
+                ):
                     appbuilder.sm.add_permission_to_role(role, new_permission)
                     appbuilder.sm.remove_permission_from_role(role, old_permission)
         appbuilder.sm.delete_permission(old_action_name, old_resource_name)

--- a/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
+++ b/airflow/migrations/versions/2c6edca13270_resource_based_permissions.py
@@ -295,7 +295,7 @@ def remap_permissions():
         for new_action_name, new_resource_name in new:
             new_permission = appbuilder.sm.create_permission(new_action_name, new_resource_name)
             for role in appbuilder.sm.get_all_roles():
-                if appbuilder.sm.exist_permission_on_roles(old_resource_name, old_action_name, [role.id]):
+                if appbuilder.sm.permission_exists_in_one_or_more_roles(old_resource_name, old_action_name, [role.id]):
                     appbuilder.sm.add_permission_to_role(role, new_permission)
                     appbuilder.sm.remove_permission_from_role(role, old_permission)
         appbuilder.sm.delete_permission(old_action_name, old_resource_name)

--- a/airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py
+++ b/airflow/migrations/versions/82b7c48c147f_remove_can_read_permission_on_config_.py
@@ -47,7 +47,7 @@ def upgrade():
     )
 
     for role in roles_to_modify:
-        if appbuilder.sm.exist_permission_on_roles(
+        if appbuilder.sm.permission_exists_in_one_or_more_roles(
             permissions.RESOURCE_CONFIG, permissions.ACTION_CAN_READ, [role.id]
         ):
             appbuilder.sm.remove_permission_from_role(role, can_read_on_config_perm)
@@ -64,7 +64,7 @@ def downgrade():
     )
 
     for role in roles_to_modify:
-        if not appbuilder.sm.exist_permission_on_roles(
+        if not appbuilder.sm.permission_exists_in_one_or_more_roles(
             permissions.RESOURCE_CONFIG, permissions.ACTION_CAN_READ, [role.id]
         ):
             appbuilder.sm.add_permission_to_role(role, can_read_on_config_perm)

--- a/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
+++ b/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
@@ -147,7 +147,7 @@ def remap_permissions():
         for new_action_name, new_resource_name in new:
             new_permission = appbuilder.sm.create_permission(new_action_name, new_resource_name)
             for role in appbuilder.sm.get_all_roles():
-                if appbuilder.sm.exist_permission_on_roles(old_resource_name, old_action_name, [role.id]):
+                if appbuilder.sm.permission_exists_in_one_or_more_roles(old_resource_name, old_action_name, [role.id]):
                     appbuilder.sm.add_permission_to_role(role, new_permission)
                     appbuilder.sm.remove_permission_from_role(role, old_permission)
         appbuilder.sm.delete_permission(old_action_name, old_resource_name)

--- a/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
+++ b/airflow/migrations/versions/a13f7613ad25_resource_based_permissions_for_default_.py
@@ -147,7 +147,9 @@ def remap_permissions():
         for new_action_name, new_resource_name in new:
             new_permission = appbuilder.sm.create_permission(new_action_name, new_resource_name)
             for role in appbuilder.sm.get_all_roles():
-                if appbuilder.sm.permission_exists_in_one_or_more_roles(old_resource_name, old_action_name, [role.id]):
+                if appbuilder.sm.permission_exists_in_one_or_more_roles(
+                    old_resource_name, old_action_name, [role.id]
+                ):
                     appbuilder.sm.add_permission_to_role(role, new_permission)
                     appbuilder.sm.remove_permission_from_role(role, old_permission)
         appbuilder.sm.delete_permission(old_action_name, old_resource_name)

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -54,13 +54,10 @@ from flask_appbuilder.security.views import (
     AuthOIDView,
     AuthRemoteUserView,
     PermissionModelView,
-    Permission,
-    PermissionView,
     PermissionViewModelView,
     RegisterUserModelView,
     ResetMyPasswordView,
     ResetPasswordView,
-    Role,
     RoleModelView,
     UserDBModelView,
     UserInfoEditView,
@@ -70,7 +67,6 @@ from flask_appbuilder.security.views import (
     UserRemoteUserModelView,
     UserStatsChartView,
     ViewMenuModelView,
-    ViewMenu,
 )
 from flask_babel import lazy_gettext as _
 from flask_jwt_extended import JWTManager, current_user as current_user_jwt
@@ -1686,7 +1682,7 @@ class BaseSecurityManager:
         """Returns all permissions from public role"""
         raise NotImplementedError
 
-    def get_action(self, name: str) -> Permission:
+    def get_action(self, name: str):
         """
         Gets an existing action record.
 
@@ -1739,7 +1735,7 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def get_all_resources(self) -> List[ViewMenu]:
+    def get_all_resources(self):
         """
         Gets all existing resource records.
 
@@ -1772,7 +1768,7 @@ class BaseSecurityManager:
     ----------------------
     """
 
-    def get_permission(self, action_name: str, resource_name: str) -> PermissionView:
+    def get_permission(self, action_name: str, resource_name: str):
         """
         Gets a permission made with the given action->resource pair, if the permission already exists.
 
@@ -1785,7 +1781,7 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def get_resource_permissions(self, resource: ViewMenu) -> PermissionView:
+    def get_resource_permissions(self, resource):
         """
         Retrieve permission pairs associated with a specific resource object.
 
@@ -1796,7 +1792,7 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def create_permission(self, action_name: str, resource_name: str) -> PermissionView:
+    def create_permission(self, action_name: str, resource_name: str):
         """
         Creates a permission linking an action and resource.
 
@@ -1826,12 +1822,12 @@ class BaseSecurityManager:
     def exist_permission_on_views(self, lst, item):
         raise NotImplementedError
 
-    def add_permission_to_role(self, role: Role, permission: PermissionView) -> None:
+    def add_permission_to_role(self, role, permission) -> None:
         """
         Add an existing permission pair to a role.
 
         :param role: The role about to get a new permission.
-        :type role: Role
+        :type role
         :param permission: The permission pair to add to a role.
         :type permission: PermissionView
         :return: None
@@ -1839,12 +1835,12 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def remove_permission_from_role(self, role: Role, permission: PermissionView) -> None:
+    def remove_permission_from_role(self, role, permission) -> None:
         """
         Remove a permission pair from a role.
 
         :param role: User role containing permissions.
-        :type role: Role
+        :type role
         :param permission: Object representing resource-> action pair
         :type permission: PermissionView
         """

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1425,9 +1425,7 @@ class BaseSecurityManager:
                         # This is a bug in FAB. It has been reported.
                         self.remove_permission_from_role(role, action)
                     self.delete_permission(perm.permission.name, resource_name)
-                elif (
-                    self.auth_role_admin not in self.builtin_roles and perm not in admin_role.permissions
-                ):
+                elif self.auth_role_admin not in self.builtin_roles and perm not in admin_role.permissions:
                     # Role Admin must have all permissions
                     self.add_permission_to_role(admin_role, perm)
 
@@ -1696,7 +1694,9 @@ class BaseSecurityManager:
     def filter_roles_by_perm_with_action(self, permission_name: str, role_ids: List[int]):
         raise NotImplementedError
 
-    def permission_exists_in_one_or_more_roles(self, resource_name: str, action_name: str, role_ids: List[int]) -> bool:
+    def permission_exists_in_one_or_more_roles(
+        self, resource_name: str, action_name: str, role_ids: List[int]
+    ) -> bool:
         """Finds and returns permission views for a group of roles"""
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -54,6 +54,7 @@ from flask_appbuilder.security.views import (
     AuthOIDView,
     AuthRemoteUserView,
     PermissionModelView,
+    PermissionView,
     PermissionViewModelView,
     RegisterUserModelView,
     ResetMyPasswordView,
@@ -1400,7 +1401,7 @@ class BaseSecurityManager:
         if not perm_views:
             # No permissions yet on this view
             for permission in base_permissions:
-                pv = self.add_permission_view_menu(permission, view_menu)
+                pv = self.create_permission(permission, view_menu)
                 if self.auth_role_admin not in self.builtin_roles:
                     role_admin = self.find_role(self.auth_role_admin)
                     self.add_permission_role(role_admin, pv)
@@ -1410,7 +1411,7 @@ class BaseSecurityManager:
             for permission in base_permissions:
                 # Check if base view permissions exist
                 if not self.exist_permission_on_views(perm_views, permission):
-                    pv = self.add_permission_view_menu(permission, view_menu)
+                    pv = self.create_permission(permission, view_menu)
                     if self.auth_role_admin not in self.builtin_roles:
                         self.add_permission_role(role_admin, pv)
             for perm_view in perm_views:
@@ -1441,7 +1442,7 @@ class BaseSecurityManager:
         self.create_resource(view_menu_name)
         pv = self.find_permission_view_menu("menu_access", view_menu_name)
         if not pv:
-            pv = self.add_permission_view_menu("menu_access", view_menu_name)
+            pv = self.create_permission("menu_access", view_menu_name)
         if self.auth_role_admin not in self.builtin_roles:
             role_admin = self.find_role(self.auth_role_admin)
             self.add_permission_role(role_admin, pv)
@@ -1606,7 +1607,7 @@ class BaseSecurityManager:
                 if not new_pvm_states:
                     continue
                 for new_pvm_state in new_pvm_states:
-                    new_pvm = self.add_permission_view_menu(new_pvm_state[1], new_pvm_state[0])
+                    new_pvm = self.create_permission(new_pvm_state[1], new_pvm_state[0])
                     self.add_permission_role(role, new_pvm)
                 if (pvm.view_menu.name, pvm.permission.name) in state_transitions["del_role_pvm"]:
                     self.del_permission_role(role, pvm)
@@ -1761,14 +1762,16 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def add_permission_view_menu(self, permission_name, view_menu_name):
+    def create_permission(self, action_name: str, resource_name: str) -> PermissionView:
         """
-        Adds a permission on a view or menu to the backend
+        Creates a permission linking an action and resource.
 
-        :param permission_name:
-            name of the permission to add: 'can_add','can_edit' etc...
-        :param view_menu_name:
-            name of the view menu to add
+        :param action_name: Name of existing action
+        :type action_name: str
+        :param resource_name: Name of existing resource
+        :type resource_name: str
+        :return: Resource created
+        :rtype: PermissionView
         """
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -54,6 +54,7 @@ from flask_appbuilder.security.views import (
     AuthOIDView,
     AuthRemoteUserView,
     PermissionModelView,
+    Permission,
     PermissionView,
     PermissionViewModelView,
     RegisterUserModelView,
@@ -1422,7 +1423,7 @@ class BaseSecurityManager:
                 if perm_view.permission.name not in base_permissions:
                     # perm to delete
                     roles = self.get_all_roles()
-                    perm = self.find_permission(perm_view.permission.name)
+                    perm = self.get_action(perm_view.permission.name)
                     # del permission from all roles
                     for role in roles:
                         self.del_permission_role(role, perm)
@@ -1684,8 +1685,15 @@ class BaseSecurityManager:
         """Returns all permissions from public role"""
         raise NotImplementedError
 
-    def find_permission(self, name):
-        """Finds and returns a Permission by name"""
+    def get_action(self, name: str) -> Permission:
+        """
+        Gets an existing action record.
+
+        :param name: name
+        :type name: str
+        :return: Action record, if it exists
+        :rtype: Permission
+        """
         raise NotImplementedError
 
     def find_roles_permission_view_menus(self, permission_name: str, role_ids: List[int]):

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -60,6 +60,7 @@ from flask_appbuilder.security.views import (
     RegisterUserModelView,
     ResetMyPasswordView,
     ResetPasswordView,
+    Role,
     RoleModelView,
     UserDBModelView,
     UserInfoEditView,
@@ -1406,7 +1407,7 @@ class BaseSecurityManager:
                 pv = self.create_permission(permission, view_menu)
                 if self.auth_role_admin not in self.builtin_roles:
                     role_admin = self.find_role(self.auth_role_admin)
-                    self.add_permission_role(role_admin, pv)
+                    self.add_permission_to_role(role_admin, pv)
         else:
             # Permissions on this view exist but....
             role_admin = self.find_role(self.auth_role_admin)
@@ -1415,7 +1416,7 @@ class BaseSecurityManager:
                 if not self.exist_permission_on_views(perm_views, permission):
                     pv = self.create_permission(permission, view_menu)
                     if self.auth_role_admin not in self.builtin_roles:
-                        self.add_permission_role(role_admin, pv)
+                        self.add_permission_to_role(role_admin, pv)
             for perm_view in perm_views:
                 if perm_view.permission is None:
                     # Skip this perm_view, it has a null permission
@@ -1432,7 +1433,7 @@ class BaseSecurityManager:
                     self.auth_role_admin not in self.builtin_roles and perm_view not in role_admin.permissions
                 ):
                     # Role Admin must have all permissions
-                    self.add_permission_role(role_admin, perm_view)
+                    self.add_permission_to_role(role_admin, perm_view)
 
     def add_permissions_menu(self, view_menu_name):
         """
@@ -1447,7 +1448,7 @@ class BaseSecurityManager:
             pv = self.create_permission("menu_access", view_menu_name)
         if self.auth_role_admin not in self.builtin_roles:
             role_admin = self.find_role(self.auth_role_admin)
-            self.add_permission_role(role_admin, pv)
+            self.add_permission_to_role(role_admin, pv)
 
     def security_cleanup(self, baseviews, menus):
         """
@@ -1610,7 +1611,7 @@ class BaseSecurityManager:
                     continue
                 for new_pvm_state in new_pvm_states:
                     new_pvm = self.create_permission(new_pvm_state[1], new_pvm_state[0])
-                    self.add_permission_role(role, new_pvm)
+                    self.add_permission_to_role(role, new_pvm)
                 if (pvm.view_menu.name, pvm.permission.name) in state_transitions["del_role_pvm"]:
                     self.del_permission_role(role, pvm)
         for pvm in state_transitions["del_role_pvm"]:
@@ -1826,14 +1827,16 @@ class BaseSecurityManager:
     def exist_permission_on_view(self, lst, permission, view_menu):
         raise NotImplementedError
 
-    def add_permission_role(self, role, perm_view):
+    def add_permission_to_role(self, role: Role, permission: PermissionView) -> None:
         """
-        Add permission-ViewMenu object to Role
+        Add an existing permission pair to a role.
 
-        :param role:
-            The role object
-        :param perm_view:
-            The PermissionViewMenu object
+        :param role: The role about to get a new permission.
+        :type role: Role
+        :param permission: The permission pair to add to a role.
+        :type permission: PermissionView
+        :return: None
+        :rtype: None
         """
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1618,7 +1618,7 @@ class BaseSecurityManager:
         for view_name in state_transitions["del_views"]:
             self.delete_resource(view_name)
         for permission_name in state_transitions["del_perms"]:
-            self.del_permission(permission_name)
+            self.delete_action(permission_name)
         return state_transitions
 
     def find_register_user(self, registration_hash):
@@ -1712,12 +1712,14 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def del_permission(self, name):
+    def delete_action(self, name: str) -> bool:
         """
-        Deletes a permission from the backend, model permission
+        Deletes a permission action.
 
-        :param name:
-            name of the permission: 'can_add','can_edit' etc...
+        :param name: Name of action to delete (e.g. can_read).
+        :type name: str
+        :return: Whether or not delete was successful.
+        :rtype: bool
         """
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1427,7 +1427,7 @@ class BaseSecurityManager:
                     # del permission from all roles
                     for role in roles:
                         self.del_permission_role(role, perm)
-                    self.del_permission_view_menu(perm_view.permission.name, view_menu)
+                    self.delete_permission(perm_view.permission.name, view_menu)
                 elif (
                     self.auth_role_admin not in self.builtin_roles and perm_view not in role_admin.permissions
                 ):
@@ -1471,7 +1471,7 @@ class BaseSecurityManager:
                 for permission in permissions:
                     for role in roles:
                         self.del_permission_role(role, permission)
-                    self.del_permission_view_menu(permission.permission.name, viewmenu.name)
+                    self.delete_permission(permission.permission.name, viewmenu.name)
                 self.del_view_menu(viewmenu.name)
         self.security_converge(baseviews, menus)
 
@@ -1614,7 +1614,7 @@ class BaseSecurityManager:
                 if (pvm.view_menu.name, pvm.permission.name) in state_transitions["del_role_pvm"]:
                     self.del_permission_role(role, pvm)
         for pvm in state_transitions["del_role_pvm"]:
-            self.del_permission_view_menu(pvm[1], pvm[0], cascade=False)
+            self.delete_permission(pvm[1], pvm[0], cascade=False)
         for view_name in state_transitions["del_views"]:
             self.del_view_menu(view_name)
         for permission_name in state_transitions["del_perms"]:
@@ -1804,7 +1804,18 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def del_permission_view_menu(self, permission_name, view_menu_name, cascade=True):
+    def delete_permission(self, action_name: str, resource_name: str) -> None:
+        """
+        Deletes the permission linking an action->resource pair. Doesn't delete the
+        underlying action or resource.
+
+        :param action_name: Name of existing action
+        :type action_name: str
+        :param resource_name: Name of existing resource
+        :type resource_name: str
+        :return: None
+        :rtype: None
+        """
         raise NotImplementedError
 
     def exist_permission_on_views(self, lst, item):

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1718,8 +1718,13 @@ class BaseSecurityManager:
     ----------------------
     """
 
-    def find_view_menu(self, name):
-        """Finds and returns a ViewMenu by name"""
+    def get_resource(self, name: str):
+        """
+        Returns a resource record by name, if it exists.
+
+        :param name: Name of resource
+        :type name: str
+        """
         raise NotImplementedError
 
     def get_all_view_menu(self):

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1472,7 +1472,7 @@ class BaseSecurityManager:
                     for role in roles:
                         self.del_permission_role(role, permission)
                     self.delete_permission(permission.permission.name, viewmenu.name)
-                self.del_view_menu(viewmenu.name)
+                self.delete_resource(viewmenu.name)
         self.security_converge(baseviews, menus)
 
     @staticmethod
@@ -1616,7 +1616,7 @@ class BaseSecurityManager:
         for pvm in state_transitions["del_role_pvm"]:
             self.delete_permission(pvm[1], pvm[0], cascade=False)
         for view_name in state_transitions["del_views"]:
-            self.del_view_menu(view_name)
+            self.delete_resource(view_name)
         for permission_name in state_transitions["del_perms"]:
             self.del_permission(permission_name)
         return state_transitions
@@ -1754,7 +1754,7 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def del_view_menu(self, name):
+    def delete_resource(self, name):
         """
         Deletes a ViewMenu from the backend
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1384,23 +1384,23 @@ class BaseSecurityManager:
         else:
             return self._get_user_permission_view_menus(None, "menu_access", view_menus_name=menu_names)
 
-    def add_permissions_view(self, base_permissions, view_menu):
+    def add_permissions_view(self, base_permissions, resource_name):
         """
         Adds a permission on a view menu to the backend
 
         :param base_permissions:
             list of permissions from view (all exposed methods):
              'can_add','can_edit' etc...
-        :param view_menu:
-            name of the view or menu to add
+        :param resource_name:
+            name of the resource to add
         """
-        resource = self.create_resource(view_menu)
+        resource = self.create_resource(resource_name)
         perms = self.get_resource_permissions(resource)
 
         if not perms:
             # No permissions yet on this view
             for permission in base_permissions:
-                pv = self.create_permission(permission, view_menu)
+                pv = self.create_permission(permission, resource_name)
                 if self.auth_role_admin not in self.builtin_roles:
                     role_admin = self.find_role(self.auth_role_admin)
                     self.add_permission_to_role(role_admin, pv)
@@ -1410,7 +1410,7 @@ class BaseSecurityManager:
             for permission in base_permissions:
                 # Check if base view permissions exist
                 if not self.exist_permission_on_views(perms, permission):
-                    pv = self.create_permission(permission, view_menu)
+                    pv = self.create_permission(permission, resource_name)
                     if self.auth_role_admin not in self.builtin_roles:
                         self.add_permission_to_role(role_admin, pv)
             for perm_view in perms:
@@ -1424,7 +1424,7 @@ class BaseSecurityManager:
                     # del permission from all roles
                     for role in roles:
                         self.remove_permission_from_role(role, perm)
-                    self.delete_permission(perm_view.permission.name, view_menu)
+                    self.delete_permission(perm_view.permission.name, resource_name)
                 elif (
                     self.auth_role_admin not in self.builtin_roles and perm_view not in role_admin.permissions
                 ):

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1394,7 +1394,7 @@ class BaseSecurityManager:
         :param view_menu:
             name of the view or menu to add
         """
-        view_menu_db = self.add_view_menu(view_menu)
+        view_menu_db = self.create_resource(view_menu)
         perm_views = self.find_permissions_view_menu(view_menu_db)
 
         if not perm_views:
@@ -1438,7 +1438,7 @@ class BaseSecurityManager:
         :param view_menu_name:
             The menu name
         """
-        self.add_view_menu(view_menu_name)
+        self.create_resource(view_menu_name)
         pv = self.find_permission_view_menu("menu_access", view_menu_name)
         if not pv:
             pv = self.add_permission_view_menu("menu_access", view_menu_name)
@@ -1724,11 +1724,12 @@ class BaseSecurityManager:
     def get_all_view_menu(self):
         raise NotImplementedError
 
-    def add_view_menu(self, name):
+    def create_resource(self, name):
         """
-        Adds a view or menu to the backend, model view_menu
-        :param name:
-            name of the view menu to add
+        Create a resource with the given name.
+
+        :param name: The name of the resource to create created.
+        :type name: str
         """
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1704,7 +1704,7 @@ class BaseSecurityManager:
         """Finds and returns permission views for a group of roles"""
         raise NotImplementedError
 
-    def add_permission(self, name):
+    def create_action(self, name):
         """
         Adds a permission to the backend, model permission
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1326,7 +1326,7 @@ class BaseSecurityManager:
             for permission in self.builtin_roles[role.name]:
                 result.add((permission[1], permission[0]))
         else:
-            for permission in self.get_db_role_permissions(role.id):
+            for permission in self.get_role_permissions_from_db(role.id):
                 result.add((permission.permission.name, permission.view_menu.name))
         return result
 
@@ -1646,7 +1646,7 @@ class BaseSecurityManager:
         """Generic function that returns all existing users"""
         raise NotImplementedError
 
-    def get_db_role_permissions(self, role_id: int) -> List[object]:
+    def get_role_permissions_from_db(self, role_id: int) -> List[object]:
         """Get all DB permissions from a role id"""
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1826,9 +1826,6 @@ class BaseSecurityManager:
     def exist_permission_on_views(self, lst, item):
         raise NotImplementedError
 
-    def exist_permission_on_view(self, lst, permission, view_menu):
-        raise NotImplementedError
-
     def add_permission_to_role(self, role: Role, permission: PermissionView) -> None:
         """
         Add an existing permission pair to a role.

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1351,7 +1351,7 @@ class BaseSecurityManager:
             # include public role
             roles = [self.get_public_role()]
         else:
-            roles = user.roles
+            roles = user.rolesxsd
         # First check against builtin (statically configured) roles
         # because no database query is needed
         result = set()
@@ -1364,7 +1364,7 @@ class BaseSecurityManager:
                 db_role_ids.append(role.id)
         # Then check against database-stored roles
         pvms_names = [
-            pvm.view_menu.name for pvm in self.find_roles_permission_view_menus(permission_name, db_role_ids)
+            pvm.view_menu.name for pvm in self.filter_roles_by_perm_with_action(permission_name, db_role_ids)
         ]
         result.update(pvms_names)
         return result
@@ -1697,7 +1697,7 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def find_roles_permission_view_menus(self, permission_name: str, role_ids: List[int]):
+    def filter_roles_by_perm_with_action(self, permission_name: str, role_ids: List[int]):
         raise NotImplementedError
 
     def permission_exists_in_one_or_more_roles(self, resource_name: str, action_name: str, role_ids: List[int]) -> bool:

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1399,7 +1399,7 @@ class BaseSecurityManager:
             name of the view or menu to add
         """
         view_menu_db = self.create_resource(view_menu)
-        perm_views = self.find_permissions_view_menu(view_menu_db)
+        perm_views = self.get_resource_permissions(view_menu_db)
 
         if not perm_views:
             # No permissions yet on this view
@@ -1468,7 +1468,7 @@ class BaseSecurityManager:
             if menus.find(viewmenu.name):
                 found = True
             if not found:
-                permissions = self.find_permissions_view_menu(viewmenu)
+                permissions = self.get_resource_permissions(viewmenu)
                 for permission in permissions:
                     for role in roles:
                         self.del_permission_role(role, permission)
@@ -1785,12 +1785,14 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def find_permissions_view_menu(self, view_menu):
+    def get_resource_permissions(self, resource: ViewMenu) -> PermissionView:
         """
-        Finds all permissions from ViewMenu, returns list of PermissionView
+        Retrieve permission pairs associated with a specific resource object.
 
-        :param view_menu: ViewMenu object
-        :return: list of PermissionView objects
+        :param resource: Object representing a single resource.
+        :type resource: ViewMenu
+        :return: Permission objects representing resource->action pair
+        :rtype: PermissionView
         """
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1440,7 +1440,7 @@ class BaseSecurityManager:
             The menu name
         """
         self.create_resource(view_menu_name)
-        pv = self.find_permission_view_menu("menu_access", view_menu_name)
+        pv = self.get_permission("menu_access", view_menu_name)
         if not pv:
             pv = self.create_permission("menu_access", view_menu_name)
         if self.auth_role_admin not in self.builtin_roles:
@@ -1749,8 +1749,17 @@ class BaseSecurityManager:
     ----------------------
     """
 
-    def find_permission_view_menu(self, permission_name, view_menu_name):
-        """Finds and returns a PermissionView by names"""
+    def get_permission(self, action_name: str, resource_name: str) -> PermissionView:
+        """
+        Gets a permission made with the given action->resource pair, if the permission already exists.
+
+        :param action_name: Name of action
+        :type action_name: str
+        :param resource_name: Name of resource
+        :type resource_name: str
+        :return: The existing permission
+        :rtype: PermissionView
+        """
         raise NotImplementedError
 
     def find_permissions_view_menu(self, view_menu):

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1398,10 +1398,10 @@ class BaseSecurityManager:
         :param view_menu:
             name of the view or menu to add
         """
-        view_menu_db = self.create_resource(view_menu)
-        perm_views = self.get_resource_permissions(view_menu_db)
+        resource = self.create_resource(view_menu)
+        perms = self.get_resource_permissions(resource)
 
-        if not perm_views:
+        if not perms:
             # No permissions yet on this view
             for permission in base_permissions:
                 pv = self.create_permission(permission, view_menu)
@@ -1413,11 +1413,11 @@ class BaseSecurityManager:
             role_admin = self.find_role(self.auth_role_admin)
             for permission in base_permissions:
                 # Check if base view permissions exist
-                if not self.exist_permission_on_views(perm_views, permission):
+                if not self.exist_permission_on_views(perms, permission):
                     pv = self.create_permission(permission, view_menu)
                     if self.auth_role_admin not in self.builtin_roles:
                         self.add_permission_to_role(role_admin, pv)
-            for perm_view in perm_views:
+            for perm_view in perms:
                 if perm_view.permission is None:
                     # Skip this perm_view, it has a null permission
                     continue

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1311,7 +1311,7 @@ class BaseSecurityManager:
                 db_role_ids.append(role.id)
 
         # If it's not a builtin role check against database store roles
-        return self.exist_permission_on_roles(view_name, permission_name, db_role_ids)
+        return self.permission_exists_in_one_or_more_roles(view_name, permission_name, db_role_ids)
 
     def get_user_roles(self, user) -> List[object]:
         """Get current user roles, if user is not authenticated returns the public role"""
@@ -1700,7 +1700,7 @@ class BaseSecurityManager:
     def find_roles_permission_view_menus(self, permission_name: str, role_ids: List[int]):
         raise NotImplementedError
 
-    def exist_permission_on_roles(self, view_name: str, permission_name: str, role_ids: List[int]) -> bool:
+    def permission_exists_in_one_or_more_roles(self, resource_name: str, action_name: str, role_ids: List[int]) -> bool:
         """Finds and returns permission views for a group of roles"""
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -68,6 +68,7 @@ from flask_appbuilder.security.views import (
     UserRemoteUserModelView,
     UserStatsChartView,
     ViewMenuModelView,
+    ViewMenu,
 )
 from flask_babel import lazy_gettext as _
 from flask_jwt_extended import JWTManager, current_user as current_user_jwt
@@ -1454,7 +1455,7 @@ class BaseSecurityManager:
         :param baseviews: A list of BaseViews class
         :param menus: Menu class
         """
-        viewsmenus = self.get_all_view_menu()
+        viewsmenus = self.get_all_resources()
         roles = self.get_all_roles()
         for viewmenu in viewsmenus:
             found = False
@@ -1727,7 +1728,13 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def get_all_view_menu(self):
+    def get_all_resources(self) -> List[ViewMenu]:
+        """
+        Gets all existing resource records.
+
+        :return: List of all resources
+        :rtype: List[ViewMenu]
+        """
         raise NotImplementedError
 
     def create_resource(self, name):

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1427,7 +1427,7 @@ class BaseSecurityManager:
                     perm = self.get_action(perm_view.permission.name)
                     # del permission from all roles
                     for role in roles:
-                        self.del_permission_role(role, perm)
+                        self.remove_permission_from_role(role, perm)
                     self.delete_permission(perm_view.permission.name, view_menu)
                 elif (
                     self.auth_role_admin not in self.builtin_roles and perm_view not in role_admin.permissions
@@ -1471,7 +1471,7 @@ class BaseSecurityManager:
                 permissions = self.get_resource_permissions(viewmenu)
                 for permission in permissions:
                     for role in roles:
-                        self.del_permission_role(role, permission)
+                        self.remove_permission_from_role(role, permission)
                     self.delete_permission(permission.permission.name, viewmenu.name)
                 self.delete_resource(viewmenu.name)
         self.security_converge(baseviews, menus)
@@ -1613,7 +1613,7 @@ class BaseSecurityManager:
                     new_pvm = self.create_permission(new_pvm_state[1], new_pvm_state[0])
                     self.add_permission_to_role(role, new_pvm)
                 if (pvm.view_menu.name, pvm.permission.name) in state_transitions["del_role_pvm"]:
-                    self.del_permission_role(role, pvm)
+                    self.remove_permission_from_role(role, pvm)
         for pvm in state_transitions["del_role_pvm"]:
             self.delete_permission(pvm[1], pvm[0], cascade=False)
         for view_name in state_transitions["del_views"]:
@@ -1842,14 +1842,14 @@ class BaseSecurityManager:
         """
         raise NotImplementedError
 
-    def del_permission_role(self, role, perm_view):
+    def remove_permission_from_role(self, role: Role, permission: PermissionView) -> None:
         """
-        Remove permission-ViewMenu object to Role
+        Remove a permission pair from a role.
 
-        :param role:
-            The role object
-        :param perm_view:
-            The PermissionViewMenu object
+        :param role: User role containing permissions.
+        :type role: Role
+        :param permission: Object representing resource-> action pair
+        :type permission: PermissionView
         """
         raise NotImplementedError
 

--- a/airflow/www/fab_security/manager.py
+++ b/airflow/www/fab_security/manager.py
@@ -1345,7 +1345,7 @@ class BaseSecurityManager:
             # include public role
             roles = [self.get_public_role()]
         else:
-            roles = user.rolesxsd
+            roles = user.roles
         # First check against builtin (statically configured) roles
         # because no database query is needed
         result = set()

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -350,7 +350,7 @@ class SecurityManager(BaseSecurityManager):
             .all()
         )
 
-    def add_permission(self, name):
+    def create_action(self, name):
         """
         Adds a permission to the backend, model permission
 
@@ -522,7 +522,7 @@ class SecurityManager(BaseSecurityManager):
         if pv:
             return pv
         vm = self.create_resource(view_menu_name)
-        perm = self.add_permission(permission_name)
+        perm = self.create_action(permission_name)
         pv = self.permissionview_model()
         pv.view_menu_id, pv.permission_id = vm.id, perm.id
         try:

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -579,12 +579,6 @@ class SecurityManager(BaseSecurityManager):
                 return True
         return False
 
-    def exist_permission_on_view(self, lst, permission, view_menu):
-        for i in lst:
-            if i.permission.name == permission and i.view_menu.name == view_menu:
-                return True
-        return False
-
     def add_permission_to_role(self, role: Role, permission: PermissionView) -> None:
         """
         Add an existing permission pair to a role.

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -391,8 +391,15 @@ class SecurityManager(BaseSecurityManager):
             self.get_session.rollback()
             return False
 
-    def find_view_menu(self, name):
-        """Finds and returns a ViewMenu by name"""
+    def get_resource(self, name: str) -> ViewMenu:
+        """
+        Returns a resource record by name, if it exists.
+
+        :param name: Name of resource
+        :type name: str
+        :return: Resource record
+        :rtype: ViewMenu
+        """
         return self.get_session.query(self.viewmenu_model).filter_by(name=name).one_or_none()
 
     def get_all_view_menu(self):
@@ -407,7 +414,7 @@ class SecurityManager(BaseSecurityManager):
         :return: The FAB resource created.
         :rtype: ViewMenu
         """
-        view_menu = self.find_view_menu(name)
+        view_menu = self.get_resource(name)
         if view_menu is None:
             try:
                 view_menu = self.viewmenu_model()
@@ -427,7 +434,7 @@ class SecurityManager(BaseSecurityManager):
         :param name:
             name of the ViewMenu
         """
-        view_menu = self.find_view_menu(name)
+        view_menu = self.get_resource(name)
         if not view_menu:
             log.warning(c.LOGMSG_WAR_SEC_DEL_VIEWMENU.format(name))
             return False
@@ -466,7 +473,7 @@ class SecurityManager(BaseSecurityManager):
         :rtype: PermissionView
         """
         permission = self.find_permission(action_name)
-        view_menu = self.find_view_menu(resource_name)
+        view_menu = self.get_resource(resource_name)
         if permission and view_menu:
             return (
                 self.get_session.query(self.permissionview_model)

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -320,7 +320,7 @@ class SecurityManager(BaseSecurityManager):
             return self.appbuilder.get_session.query(literal(True)).filter(q).scalar()
         return self.appbuilder.get_session.query(q).scalar()
 
-    def find_roles_permission_view_menus(self, permission_name: str, role_ids: List[int]):
+    def filter_roles_by_perm_with_action(self, action_name: str, role_ids: List[int]):
         """Find roles with permission"""
         return (
             self.appbuilder.get_session.query(self.permissionview_model)
@@ -332,7 +332,7 @@ class SecurityManager(BaseSecurityManager):
             .join(self.permission_model)
             .join(self.viewmenu_model)
             .filter(
-                self.permission_model.name == permission_name,
+                self.permission_model.name == action_name,
                 self.role_model.id.in_(role_ids),
             )
         ).all()

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -370,12 +370,14 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.rollback()
         return perm
 
-    def del_permission(self, name: str) -> bool:
+    def delete_action(self, name: str) -> bool:
         """
-        Deletes a permission from the backend, model permission
+        Deletes a permission action.
 
-        :param name:
-            name of the permission: 'can_add','can_edit' etc...
+        :param name: Name of action to delete (e.g. can_read).
+        :type name: str
+        :return: Whether or not delete was successful.
+        :rtype: bool
         """
         perm = self.get_action(name)
         if not perm:
@@ -563,7 +565,7 @@ class SecurityManager(BaseSecurityManager):
                 .filter_by(permission=pv.permission)
                 .all()
             ):
-                self.del_permission(pv.permission.name)
+                self.delete_action(pv.permission.name)
             log.info(c.LOGMSG_INF_SEC_DEL_PERMVIEW.format(action_name, resource_name))
         except Exception as e:
             log.error(c.LOGMSG_ERR_SEC_DEL_PERMVIEW.format(str(e)))

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -337,7 +337,7 @@ class SecurityManager(BaseSecurityManager):
             )
         ).all()
 
-    def get_db_role_permissions(self, role_id: int) -> List[PermissionView]:
+    def get_role_permissions_from_db(self, role_id: int) -> List[PermissionView]:
         """Get all DB permissions from a role (one single query)"""
         return (
             self.appbuilder.get_session.query(PermissionView)

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -496,14 +496,16 @@ class SecurityManager(BaseSecurityManager):
                 .one_or_none()
             )
 
-    def find_permissions_view_menu(self, view_menu):
+    def get_resource_permissions(self, resource: ViewMenu) -> PermissionView:
         """
-        Finds all permissions from ViewMenu, returns list of PermissionView
+        Retrieve permission pairs associated with a specific resource object.
 
-        :param view_menu: ViewMenu object
-        :return: list of PermissionView objects
+        :param resource: Object representing a single resource.
+        :type resource: ViewMenu
+        :return: Permission objects representing resource->action pair
+        :rtype: PermissionView
         """
-        return self.get_session.query(self.permissionview_model).filter_by(view_menu_id=view_menu.id).all()
+        return self.get_session.query(self.permissionview_model).filter_by(view_menu_id=resource.id).all()
 
     def create_permission(self, permission_name, view_menu_name):
         """

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -357,18 +357,18 @@ class SecurityManager(BaseSecurityManager):
         :param name:
             name of the permission: 'can_add','can_edit' etc...
         """
-        perm = self.get_action(name)
-        if perm is None:
+        action = self.get_action(name)
+        if action is None:
             try:
-                perm = self.permission_model()
-                perm.name = name
-                self.get_session.add(perm)
+                action = self.permission_model()
+                action.name = name
+                self.get_session.add(action)
                 self.get_session.commit()
-                return perm
+                return action
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_ADD_PERMISSION.format(str(e)))
                 self.get_session.rollback()
-        return perm
+        return action
 
     def delete_action(self, name: str) -> bool:
         """
@@ -379,20 +379,20 @@ class SecurityManager(BaseSecurityManager):
         :return: Whether or not delete was successful.
         :rtype: bool
         """
-        perm = self.get_action(name)
-        if not perm:
+        action = self.get_action(name)
+        if not action:
             log.warning(c.LOGMSG_WAR_SEC_DEL_PERMISSION.format(name))
             return False
         try:
-            pvms = (
+            perms = (
                 self.get_session.query(self.permissionview_model)
-                .filter(self.permissionview_model.permission == perm)
+                .filter(self.permissionview_model.permission == action)
                 .all()
             )
-            if pvms:
-                log.warning(c.LOGMSG_WAR_SEC_DEL_PERM_PVM.format(perm, pvms))
+            if perms:
+                log.warning(c.LOGMSG_WAR_SEC_DEL_PERM_PVM.format(action, perms))
                 return False
-            self.get_session.delete(perm)
+            self.get_session.delete(action)
             self.get_session.commit()
             return True
         except Exception as e:
@@ -429,40 +429,40 @@ class SecurityManager(BaseSecurityManager):
         :return: The FAB resource created.
         :rtype: ViewMenu
         """
-        view_menu = self.get_resource(name)
-        if view_menu is None:
+        resource = self.get_resource(name)
+        if resource is None:
             try:
-                view_menu = self.viewmenu_model()
-                view_menu.name = name
-                self.get_session.add(view_menu)
+                resource = self.viewmenu_model()
+                resource.name = name
+                self.get_session.add(resource)
                 self.get_session.commit()
-                return view_menu
+                return resource
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_ADD_VIEWMENU.format(str(e)))
                 self.get_session.rollback()
-        return view_menu
+        return resource
 
     def delete_resource(self, name: str) -> bool:
         """
         Deletes a ViewMenu from the backend
 
         :param name:
-            name of the ViewMenu
+            name of the resource
         """
-        view_menu = self.get_resource(name)
-        if not view_menu:
+        resource = self.get_resource(name)
+        if not resource:
             log.warning(c.LOGMSG_WAR_SEC_DEL_VIEWMENU.format(name))
             return False
         try:
-            pvms = (
+            perms = (
                 self.get_session.query(self.permissionview_model)
-                .filter(self.permissionview_model.view_menu == view_menu)
+                .filter(self.permissionview_model.view_menu == resource)
                 .all()
             )
-            if pvms:
-                log.warning(c.LOGMSG_WAR_SEC_DEL_VIEWMENU_PVM.format(view_menu, pvms))
+            if perms:
+                log.warning(c.LOGMSG_WAR_SEC_DEL_VIEWMENU_PVM.format(resource, perms))
                 return False
-            self.get_session.delete(view_menu)
+            self.get_session.delete(resource)
             self.get_session.commit()
             return True
         except Exception as e:
@@ -487,12 +487,12 @@ class SecurityManager(BaseSecurityManager):
         :return: The existing permission
         :rtype: PermissionView
         """
-        permission = self.get_action(action_name)
-        view_menu = self.get_resource(resource_name)
-        if permission and view_menu:
+        action = self.get_action(action_name)
+        resource = self.get_resource(resource_name)
+        if action and resource:
             return (
                 self.get_session.query(self.permissionview_model)
-                .filter_by(permission=permission, view_menu=view_menu)
+                .filter_by(permission=action, view_menu=resource)
                 .one_or_none()
             )
 
@@ -507,29 +507,29 @@ class SecurityManager(BaseSecurityManager):
         """
         return self.get_session.query(self.permissionview_model).filter_by(view_menu_id=resource.id).all()
 
-    def create_permission(self, permission_name, view_menu_name):
+    def create_permission(self, action_name, resource_name):
         """
         Adds a permission on a view or menu to the backend
 
-        :param permission_name:
-            name of the permission to add: 'can_add','can_edit' etc...
-        :param view_menu_name:
-            name of the view menu to add
+        :param action_name:
+            name of the action to add: 'can_add','can_edit' etc...
+        :param resource_name:
+            name of the resource to add
         """
-        if not (permission_name and view_menu_name):
+        if not (action_name and resource_name):
             return None
-        pv = self.get_permission(permission_name, view_menu_name)
-        if pv:
-            return pv
-        vm = self.create_resource(view_menu_name)
-        perm = self.create_action(permission_name)
-        pv = self.permissionview_model()
-        pv.view_menu_id, pv.permission_id = vm.id, perm.id
+        perm = self.get_permission(action_name, resource_name)
+        if perm:
+            return perm
+        resource = self.create_resource(resource_name)
+        action = self.create_action(action_name)
+        perm = self.permissionview_model()
+        perm.view_menu_id, perm.permission_id = resource.id, action.id
         try:
-            self.get_session.add(pv)
+            self.get_session.add(perm)
             self.get_session.commit()
-            log.info(c.LOGMSG_INF_SEC_ADD_PERMVIEW.format(str(pv)))
-            return pv
+            log.info(c.LOGMSG_INF_SEC_ADD_PERMVIEW.format(str(perm)))
+            return perm
         except Exception as e:
             log.error(c.LOGMSG_ERR_SEC_ADD_PERMVIEW.format(str(e)))
             self.get_session.rollback()
@@ -548,34 +548,34 @@ class SecurityManager(BaseSecurityManager):
         """
         if not (action_name and resource_name):
             return
-        pv = self.get_permission(action_name, resource_name)
-        if not pv:
+        perm = self.get_permission(action_name, resource_name)
+        if not perm:
             return
-        roles_pvs = (
-            self.get_session.query(self.role_model).filter(self.role_model.permissions.contains(pv)).first()
+        roles = (
+            self.get_session.query(self.role_model).filter(self.role_model.permissions.contains(perm)).first()
         )
-        if roles_pvs:
-            log.warning(c.LOGMSG_WAR_SEC_DEL_PERMVIEW.format(resource_name, action_name, roles_pvs))
+        if roles:
+            log.warning(c.LOGMSG_WAR_SEC_DEL_PERMVIEW.format(resource_name, action_name, roles))
             return
         try:
             # delete permission on view
-            self.get_session.delete(pv)
+            self.get_session.delete(perm)
             self.get_session.commit()
             # if no more permission on permission view, delete permission
             if (
                 not self.get_session.query(self.permissionview_model)
-                .filter_by(permission=pv.permission)
+                .filter_by(permission=perm.permission)
                 .all()
             ):
-                self.delete_action(pv.permission.name)
+                self.delete_action(perm.permission.name)
             log.info(c.LOGMSG_INF_SEC_DEL_PERMVIEW.format(action_name, resource_name))
         except Exception as e:
             log.error(c.LOGMSG_ERR_SEC_DEL_PERMVIEW.format(str(e)))
             self.get_session.rollback()
 
-    def exist_permission_on_views(self, lst, item):
-        for i in lst:
-            if i.permission and i.permission.name == item:
+    def perms_include_action(self, perms, action_name):
+        for perm in perms:
+            if perm.permission and perm.permission.name == action_name:
                 return True
         return False
 

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -289,13 +289,13 @@ class SecurityManager(BaseSecurityManager):
         """
         return self.get_session.query(self.permission_model).filter_by(name=name).one_or_none()
 
-    def exist_permission_on_roles(self, view_name: str, permission_name: str, role_ids: List[int]) -> bool:
+    def permission_exists_in_one_or_more_roles(self, resource_name: str, action_name: str, role_ids: List[int]) -> bool:
         """
             Method to efficiently check if a certain permission exists
             on a list of role id's. This is used by `has_access`
 
-        :param view_name: The view's name to check if exists on one of the roles
-        :param permission_name: The permission name to check if exists
+        :param resource_name: The view's name to check if exists on one of the roles
+        :param action_name: The permission name to check if exists
         :param role_ids: a list of Role ids
         :return: Boolean
         """
@@ -309,8 +309,8 @@ class SecurityManager(BaseSecurityManager):
             .join(self.permission_model)
             .join(self.viewmenu_model)
             .filter(
-                self.viewmenu_model.name == view_name,
-                self.permission_model.name == permission_name,
+                self.viewmenu_model.name == resource_name,
+                self.permission_model.name == action_name,
                 self.role_model.id.in_(role_ids),
             )
             .exists()

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -289,7 +289,9 @@ class SecurityManager(BaseSecurityManager):
         """
         return self.get_session.query(self.permission_model).filter_by(name=name).one_or_none()
 
-    def permission_exists_in_one_or_more_roles(self, resource_name: str, action_name: str, role_ids: List[int]) -> bool:
+    def permission_exists_in_one_or_more_roles(
+        self, resource_name: str, action_name: str, role_ids: List[int]
+    ) -> bool:
         """
             Method to efficiently check if a certain permission exists
             on a list of role id's. This is used by `has_access`

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -440,7 +440,7 @@ class SecurityManager(BaseSecurityManager):
                 self.get_session.rollback()
         return view_menu
 
-    def del_view_menu(self, name: str) -> bool:
+    def delete_resource(self, name: str) -> bool:
         """
         Deletes a ViewMenu from the backend
 

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -474,7 +474,7 @@ class SecurityManager(BaseSecurityManager):
         """
         return self.get_session.query(self.permissionview_model).filter_by(view_menu_id=view_menu.id).all()
 
-    def add_permission_view_menu(self, permission_name, view_menu_name):
+    def create_permission(self, permission_name, view_menu_name):
         """
         Adds a permission on a view or menu to the backend
 

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -398,12 +398,14 @@ class SecurityManager(BaseSecurityManager):
     def get_all_view_menu(self):
         return self.get_session.query(self.viewmenu_model).all()
 
-    def add_view_menu(self, name):
+    def create_resource(self, name) -> ViewMenu:
         """
-        Adds a view or menu to the backend, model view_menu
+        Create a resource with the given name.
 
-        :param name:
-            name of the view menu to add
+        :param name: The name of the resource to create created.
+        :type name: str
+        :return: The FAB resource created.
+        :rtype: ViewMenu
         """
         view_menu = self.find_view_menu(name)
         if view_menu is None:
@@ -486,7 +488,7 @@ class SecurityManager(BaseSecurityManager):
         pv = self.find_permission_view_menu(permission_name, view_menu_name)
         if pv:
             return pv
-        vm = self.add_view_menu(view_menu_name)
+        vm = self.create_resource(view_menu_name)
         perm = self.add_permission(permission_name)
         pv = self.permissionview_model()
         pv.view_menu_id, pv.permission_id = vm.id, perm.id

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -606,21 +606,21 @@ class SecurityManager(BaseSecurityManager):
                 log.error(c.LOGMSG_ERR_SEC_ADD_PERMROLE.format(str(e)))
                 self.get_session.rollback()
 
-    def del_permission_role(self, role, permission):
+    def remove_permission_from_role(self, role: Role, permission: PermissionView) -> None:
         """
-        Remove permission-ViewMenu object to Role
+        Remove a permission pair from a role.
 
-        :param role:
-            The role object
-        :param perm_view:
-            The PermissionViewMenu object
+        :param role: User role containing permissions.
+        :type role: Role
+        :param permission: Object representing resource-> action pair
+        :type permission: PermissionView
         """
-        if perm_view in role.permissions:
+        if permission in role.permissions:
             try:
-                role.permissions.remove(perm_view)
+                role.permissions.remove(permission)
                 self.get_session.merge(role)
                 self.get_session.commit()
-                log.info(c.LOGMSG_INF_SEC_DEL_PERMROLE.format(str(perm_view), role.name))
+                log.info(c.LOGMSG_INF_SEC_DEL_PERMROLE.format(str(permission), role.name))
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_DEL_PERMROLE.format(str(e)))
                 self.get_session.rollback()

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -583,26 +583,28 @@ class SecurityManager(BaseSecurityManager):
                 return True
         return False
 
-    def add_permission_role(self, role, perm_view):
+    def add_permission_to_role(self, role: Role, permission: PermissionView) -> None:
         """
-        Add permission-ViewMenu object to Role
+        Add an existing permission pair to a role.
 
-        :param role:
-            The role object
-        :param perm_view:
-            The PermissionViewMenu object
+        :param role: The role about to get a new permission.
+        :type role: Role
+        :param permission: The permission pair to add to a role.
+        :type permission: PermissionView
+        :return: None
+        :rtype: None
         """
-        if perm_view and perm_view not in role.permissions:
+        if permission and permission not in role.permissions:
             try:
-                role.permissions.append(perm_view)
+                role.permissions.append(permission)
                 self.get_session.merge(role)
                 self.get_session.commit()
-                log.info(c.LOGMSG_INF_SEC_ADD_PERMROLE.format(str(perm_view), role.name))
+                log.info(c.LOGMSG_INF_SEC_ADD_PERMROLE.format(str(permission), role.name))
             except Exception as e:
                 log.error(c.LOGMSG_ERR_SEC_ADD_PERMROLE.format(str(e)))
                 self.get_session.rollback()
 
-    def del_permission_role(self, role, perm_view):
+    def del_permission_role(self, role, permission):
         """
         Remove permission-ViewMenu object to Role
 

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -454,10 +454,19 @@ class SecurityManager(BaseSecurityManager):
     ----------------------
     """
 
-    def find_permission_view_menu(self, permission_name, view_menu_name):
-        """Finds and returns a PermissionView by names"""
-        permission = self.find_permission(permission_name)
-        view_menu = self.find_view_menu(view_menu_name)
+    def get_permission(self, action_name: str, resource_name: str) -> PermissionView:
+        """
+        Gets a permission made with the given action->resource pair, if the permission already exists.
+
+        :param action_name: Name of action
+        :type action_name: str
+        :param resource_name: Name of resource
+        :type resource_name: str
+        :return: The existing permission
+        :rtype: PermissionView
+        """
+        permission = self.find_permission(action_name)
+        view_menu = self.find_view_menu(resource_name)
         if permission and view_menu:
             return (
                 self.get_session.query(self.permissionview_model)
@@ -485,7 +494,7 @@ class SecurityManager(BaseSecurityManager):
         """
         if not (permission_name and view_menu_name):
             return None
-        pv = self.find_permission_view_menu(permission_name, view_menu_name)
+        pv = self.get_permission(permission_name, view_menu_name)
         if pv:
             return pv
         vm = self.create_resource(view_menu_name)
@@ -504,7 +513,7 @@ class SecurityManager(BaseSecurityManager):
     def del_permission_view_menu(self, permission_name, view_menu_name, cascade=True):
         if not (permission_name and view_menu_name):
             return
-        pv = self.find_permission_view_menu(permission_name, view_menu_name)
+        pv = self.get_permission(permission_name, view_menu_name)
         if not pv:
             return
         roles_pvs = (

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -278,8 +278,15 @@ class SecurityManager(BaseSecurityManager):
             return role.permissions
         return []
 
-    def find_permission(self, name):
-        """Finds and returns a Permission by name"""
+    def get_action(self, name: str) -> Permission:
+        """
+        Gets an existing action record.
+
+        :param name: name
+        :type name: str
+        :return: Action record, if it exists
+        :rtype: Permission
+        """
         return self.get_session.query(self.permission_model).filter_by(name=name).one_or_none()
 
     def exist_permission_on_roles(self, view_name: str, permission_name: str, role_ids: List[int]) -> bool:
@@ -350,7 +357,7 @@ class SecurityManager(BaseSecurityManager):
         :param name:
             name of the permission: 'can_add','can_edit' etc...
         """
-        perm = self.find_permission(name)
+        perm = self.get_action(name)
         if perm is None:
             try:
                 perm = self.permission_model()
@@ -370,7 +377,7 @@ class SecurityManager(BaseSecurityManager):
         :param name:
             name of the permission: 'can_add','can_edit' etc...
         """
-        perm = self.find_permission(name)
+        perm = self.get_action(name)
         if not perm:
             log.warning(c.LOGMSG_WAR_SEC_DEL_PERMISSION.format(name))
             return False
@@ -478,7 +485,7 @@ class SecurityManager(BaseSecurityManager):
         :return: The existing permission
         :rtype: PermissionView
         """
-        permission = self.find_permission(action_name)
+        permission = self.get_action(action_name)
         view_menu = self.get_resource(resource_name)
         if permission and view_menu:
             return (

--- a/airflow/www/fab_security/sqla/manager.py
+++ b/airflow/www/fab_security/sqla/manager.py
@@ -402,7 +402,13 @@ class SecurityManager(BaseSecurityManager):
         """
         return self.get_session.query(self.viewmenu_model).filter_by(name=name).one_or_none()
 
-    def get_all_view_menu(self):
+    def get_all_resources(self) -> List[ViewMenu]:
+        """
+        Gets all existing resource records.
+
+        :return: List of all resources
+        :rtype: List[ViewMenu]
+        """
         return self.get_session.query(self.viewmenu_model).all()
 
     def create_resource(self, name) -> ViewMenu:

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -533,17 +533,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         self.get_session.commit()
 
-    def remove_permission_from_role(self, role: Role, permission: PermissionView) -> None:
-        """
-        Remove a permission pair from a role.
-
-        :param role: User role containing permissions.
-        :type role: Role
-        :param permission: Object representing resource-> action pair
-        :type permission: PermissionView
-        """
-        self.del_permission_role(role, permission)
-
     def get_all_permissions(self) -> Set[Tuple[str, str]]:
         """Returns all permissions as a set of tuples with the action and resource names"""
         return set(

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -22,6 +22,7 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from flask import current_app, g
 from flask_appbuilder.security.sqla import models as sqla_models
+from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_appbuilder.security.sqla.models import Permission, PermissionView, Role, User, ViewMenu
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
@@ -31,7 +32,6 @@ from airflow.models import DagBag, DagModel
 from airflow.security import permissions
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
-from airflow.www.fab_security.sqla.manager import SecurityManager
 from airflow.www.utils import CustomSQLAInterface
 from airflow.www.views import (
     CustomPermissionModelView,
@@ -846,17 +846,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             for action_name in action_names:
                 dag_perm = _get_or_create_dag_permission(action_name)
                 self.add_permission_to_role(role, dag_perm)
-
-    def create_resource(self, name: str) -> ViewMenu:
-        """
-        Create a resource with the given name.
-
-        :param name: The name of the resource to create created.
-        :type name: str
-        :return: The FAB resource created.
-        :rtype: ViewMenu
-        """
-        return self.add_view_menu(name)
 
     def create_perm_vm_for_all_dag(self):
         """Create perm-vm if not exist and insert into FAB security model for all-dags."""

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -283,19 +283,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """
         return self.find_permission_view_menu(action_name, resource_name)
 
-    def create_permission(self, action_name: str, resource_name: str) -> PermissionView:
-        """
-        Creates a permission linking an action and resource.
-
-        :param action_name: Name of existing action
-        :type action_name: str
-        :param resource_name: Name of existing resource
-        :type resource_name: str
-        :return: Resource created
-        :rtype: PermissionView
-        """
-        return self.add_permission_view_menu(action_name, resource_name)
-
     def delete_permission(self, action_name: str, resource_name: str) -> None:
         """
         Deletes the permission linking an action->resource pair. Doesn't delete the

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -18,7 +18,7 @@
 #
 
 import warnings
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Dict, Optional, Sequence, Set, Tuple
 
 from flask import current_app, g
 from flask_appbuilder.security.sqla import models as sqla_models

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -22,7 +22,6 @@ from typing import Dict, List, Optional, Sequence, Set, Tuple
 
 from flask import current_app, g
 from flask_appbuilder.security.sqla import models as sqla_models
-from flask_appbuilder.security.sqla.manager import SecurityManager
 from flask_appbuilder.security.sqla.models import Permission, PermissionView, Role, User, ViewMenu
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload
@@ -33,6 +32,7 @@ from airflow.security import permissions
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.www.utils import CustomSQLAInterface
+from airflow.www.fab_security.sqla.manager import SecurityManager
 from airflow.www.views import (
     CustomPermissionModelView,
     CustomPermissionViewModelView,

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -239,17 +239,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             permission = self.create_permission(action_name, resource_name)
             self.add_permission_to_role(role, permission)
 
-    def get_resource(self, name: str) -> ViewMenu:
-        """
-        Returns a resource record by name, if it exists.
-
-        :param name: Name of resource
-        :type name: str
-        :return: Resource record
-        :rtype: ViewMenu
-        """
-        return self.find_view_menu(name)
-
     def get_all_resources(self) -> List[ViewMenu]:
         """
         Gets all existing resource records.

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -239,17 +239,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             permission = self.create_permission(action_name, resource_name)
             self.add_permission_to_role(role, permission)
 
-    def get_action(self, name: str) -> Permission:
-        """
-        Gets an existing action record.
-
-        :param name: name
-        :type name: str
-        :return: Action record, if it exists
-        :rtype: Permission
-        """
-        return self.find_permission(name)
-
     def delete_permission(self, action_name: str, resource_name: str) -> None:
         """
         Deletes the permission linking an action->resource pair. Doesn't delete the

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -31,8 +31,8 @@ from airflow.models import DagBag, DagModel
 from airflow.security import permissions
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
-from airflow.www.utils import CustomSQLAInterface
 from airflow.www.fab_security.sqla.manager import SecurityManager
+from airflow.www.utils import CustomSQLAInterface
 from airflow.www.views import (
     CustomPermissionModelView,
     CustomPermissionViewModelView,

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -557,17 +557,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """
         self.del_permission_role(role, permission)
 
-    def delete_action(self, name: str) -> bool:
-        """
-        Deletes a permission action.
-
-        :param name: Name of action to delete (e.g. can_read).
-        :type name: str
-        :return: Whether or not delete was successful.
-        :rtype: bool
-        """
-        return self.del_permission(name)
-
     def get_all_permissions(self) -> Set[Tuple[str, str]]:
         """Returns all permissions as a set of tuples with the action and resource names"""
         return set(

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -681,17 +681,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         if access_control:
             self._sync_dag_view_permissions(dag_resource_name, access_control)
 
-    def get_resource_permissions(self, resource: ViewMenu) -> PermissionView:
-        """
-        Retrieve permission pairs associated with a specific resource object.
-
-        :param resource: Object representing a single resource.
-        :type resource: ViewMenu
-        :return: Permission objects representing resource->action pair
-        :rtype: PermissionView
-        """
-        return self.find_permissions_view_menu(resource)
-
     def _sync_dag_view_permissions(self, dag_id, access_control):
         """
         Set the access policy on the given DAG's ViewModel.

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -533,19 +533,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
 
         self.get_session.commit()
 
-    def add_permission_to_role(self, role: Role, permission: PermissionView) -> None:
-        """
-        Add an existing permission pair to a role.
-
-        :param role: The role about to get a new permission.
-        :type role: Role
-        :param permission: The permission pair to add to a role.
-        :type permission: PermissionView
-        :return: None
-        :rtype: None
-        """
-        self.add_permission_role(role, permission)
-
     def remove_permission_from_role(self, role: Role, permission: PermissionView) -> None:
         """
         Remove a permission pair from a role.

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -239,15 +239,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             permission = self.create_permission(action_name, resource_name)
             self.add_permission_to_role(role, permission)
 
-    def get_all_resources(self) -> List[ViewMenu]:
-        """
-        Gets all existing resource records.
-
-        :return: List of all resources
-        :rtype: List[ViewMenu]
-        """
-        return self.get_all_view_menu()
-
     def get_action(self, name: str) -> Permission:
         """
         Gets an existing action record.

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -270,19 +270,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         """
         return self.find_permission(name)
 
-    def get_permission(self, action_name: str, resource_name: str) -> PermissionView:
-        """
-        Gets a permission made with the given action->resource pair, if the permission already exists.
-
-        :param action_name: Name of action
-        :type action_name: str
-        :param resource_name: Name of resource
-        :type resource_name: str
-        :return: The existing permission
-        :rtype: PermissionView
-        """
-        return self.find_permission_view_menu(action_name, resource_name)
-
     def delete_permission(self, action_name: str, resource_name: str) -> None:
         """
         Deletes the permission linking an action->resource pair. Doesn't delete the

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -239,20 +239,6 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             permission = self.create_permission(action_name, resource_name)
             self.add_permission_to_role(role, permission)
 
-    def delete_permission(self, action_name: str, resource_name: str) -> None:
-        """
-        Deletes the permission linking an action->resource pair. Doesn't delete the
-        underlying action or resource.
-
-        :param action_name: Name of existing action
-        :type action_name: str
-        :param resource_name: Name of existing resource
-        :type resource_name: str
-        :return: None
-        :rtype: None
-        """
-        self.del_permission_view_menu(action_name, resource_name)
-
     def delete_role(self, role_name):
         """
         Delete the given Role

--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -76,7 +76,7 @@ def create_role(app, name, permissions=None):
         permissions = []
     for permission in permissions:
         perm_object = appbuilder.sm.get_permission(*permission)
-        appbuilder.sm.add_permission_role(role, perm_object)
+        appbuilder.sm.add_permission_to_role(role, perm_object)
     return role
 
 

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -197,7 +197,7 @@ class TestSecurity(unittest.TestCase):
         role = self.security_manager.find_role(role_name)
 
         perm = self.security_manager.get_permission(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_ROLE)
-        self.security_manager.add_permission_role(role, perm)
+        self.security_manager.add_permission_to_role(role, perm)
         role_perms_len = len(role.permissions)
 
         self.security_manager.bulk_sync_roles(mock_roles)

--- a/tests/www/test_security.py
+++ b/tests/www/test_security.py
@@ -579,11 +579,11 @@ class TestSecurity(unittest.TestCase):
         assert len(roles_to_check) >= 5
         for role in roles_to_check:
             if role.name in ["Admin", "Op"]:
-                assert self.security_manager.exist_permission_on_roles(
+                assert self.security_manager.permission_exists_in_one_or_more_roles(
                     permissions.RESOURCE_CONFIG, permissions.ACTION_CAN_READ, [role.id]
                 )
             else:
-                assert not self.security_manager.exist_permission_on_roles(
+                assert not self.security_manager.permission_exists_in_one_or_more_roles(
                     permissions.RESOURCE_CONFIG, permissions.ACTION_CAN_READ, [role.id]
                 ), (
                     f"{role.name} should not have {permissions.ACTION_CAN_READ} "

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -201,7 +201,7 @@ def user_edit_one_dag(acl_app):
 @pytest.mark.usefixtures("user_edit_one_dag")
 def test_permission_exist(acl_app):
     perms_views = acl_app.appbuilder.sm.find_permissions_view_menu(
-        acl_app.appbuilder.sm.find_view_menu('DAG:example_bash_operator'),
+        acl_app.appbuilder.sm.get_resource('DAG:example_bash_operator'),
     )
     assert len(perms_views) == 2
 

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -200,7 +200,7 @@ def user_edit_one_dag(acl_app):
 
 @pytest.mark.usefixtures("user_edit_one_dag")
 def test_permission_exist(acl_app):
-    perms_views = acl_app.appbuilder.sm.find_permissions_view_menu(
+    perms_views = acl_app.appbuilder.sm.get_resource_permissions(
         acl_app.appbuilder.sm.get_resource('DAG:example_bash_operator'),
     )
     assert len(perms_views) == 2

--- a/tests/www/views/test_views_acl.py
+++ b/tests/www/views/test_views_acl.py
@@ -96,42 +96,42 @@ def acl_app(app):
     edit_perm_on_dag = security_manager.get_permission(
         permissions.ACTION_CAN_EDIT, 'DAG:example_bash_operator'
     )
-    security_manager.add_permission_role(dag_tester_role, edit_perm_on_dag)
+    security_manager.add_permission_to_role(dag_tester_role, edit_perm_on_dag)
     read_perm_on_dag = security_manager.get_permission(
         permissions.ACTION_CAN_READ, 'DAG:example_bash_operator'
     )
-    security_manager.add_permission_role(dag_tester_role, read_perm_on_dag)
-    security_manager.add_permission_role(dag_tester_role, website_permission)
+    security_manager.add_permission_to_role(dag_tester_role, read_perm_on_dag)
+    security_manager.add_permission_to_role(dag_tester_role, website_permission)
 
     all_dag_role = security_manager.find_role('all_dag_role')
     edit_perm_on_all_dag = security_manager.get_permission(
         permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG
     )
-    security_manager.add_permission_role(all_dag_role, edit_perm_on_all_dag)
+    security_manager.add_permission_to_role(all_dag_role, edit_perm_on_all_dag)
     read_perm_on_all_dag = security_manager.get_permission(
         permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG
     )
-    security_manager.add_permission_role(all_dag_role, read_perm_on_all_dag)
+    security_manager.add_permission_to_role(all_dag_role, read_perm_on_all_dag)
     read_perm_on_task_instance = security_manager.get_permission(
         permissions.ACTION_CAN_READ, permissions.RESOURCE_TASK_INSTANCE
     )
-    security_manager.add_permission_role(all_dag_role, read_perm_on_task_instance)
-    security_manager.add_permission_role(all_dag_role, website_permission)
+    security_manager.add_permission_to_role(all_dag_role, read_perm_on_task_instance)
+    security_manager.add_permission_to_role(all_dag_role, website_permission)
 
     role_user = security_manager.find_role('User')
-    security_manager.add_permission_role(role_user, read_perm_on_all_dag)
-    security_manager.add_permission_role(role_user, edit_perm_on_all_dag)
-    security_manager.add_permission_role(role_user, website_permission)
+    security_manager.add_permission_to_role(role_user, read_perm_on_all_dag)
+    security_manager.add_permission_to_role(role_user, edit_perm_on_all_dag)
+    security_manager.add_permission_to_role(role_user, website_permission)
 
     read_only_perm_on_dag = security_manager.get_permission(
         permissions.ACTION_CAN_READ, 'DAG:example_bash_operator'
     )
     dag_read_only_role = security_manager.find_role('dag_acl_read_only')
-    security_manager.add_permission_role(dag_read_only_role, read_only_perm_on_dag)
-    security_manager.add_permission_role(dag_read_only_role, website_permission)
+    security_manager.add_permission_to_role(dag_read_only_role, read_only_perm_on_dag)
+    security_manager.add_permission_to_role(dag_read_only_role, website_permission)
 
     dag_acl_faker_role = security_manager.find_role('dag_acl_faker')
-    security_manager.add_permission_role(dag_acl_faker_role, website_permission)
+    security_manager.add_permission_to_role(dag_acl_faker_role, website_permission)
 
     yield app
 


### PR DESCRIPTION
This PR:
- Updates the base security manager classes method names to use the action, resource, permission naming scheme.
- Removes wrapper methods from the Airflow security manager that call the FAB methods previously using the old naming scheme.

This follows the work completed in #16647, where I copied the base FAB security manager classes into the Airflow codebase. This is a step forward in merging the Airflow-specific security manager code with the default FAB security manager code.


