### PR TITLE
Don't ignore legacy `concurrency` dag parameter

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -372,7 +372,7 @@ class DAG(LoggingMixin):
         validate_key(dag_id)
 
         self._dag_id = dag_id
-        if concurrency and not max_active_tasks:
+        if concurrency:
             # TODO: Remove in Airflow 3.0
             warnings.warn(
                 "The 'concurrency' parameter is deprecated. Please use 'max_active_tasks'.",


### PR DESCRIPTION
Currently, even if legacy `concurrency` dag parameter is specified, it is always ignored because `max_active_tasks` is always initialized from `core.max_active_tasks_per_dag`.
In our case this caused unexpected throttling of the task concurrency on production and performance issues.

`concurrency` parameter should always be used, if provided, as this preserves backward compatibility for users performing the migration.

Tested locally:
```
DAG(
    dag_id='xxx',
...
    concurrency=1,
)
```
Before fix:
```
{scheduler_job.py:413} INFO - DAG xxx has 1/16 running and queued tasks
```
After fix:
```
{scheduler_job.py:413} INFO - DAG xxx has 1/1 running and queued tasks
```

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
