### PR TITLE
Always run at least one backfill from BackfillJob

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -408,7 +408,15 @@ def dag_test(args, session=None):
     dag = get_dag(subdir=args.subdir, dag_id=args.dag_id)
     dag.clear(start_date=args.execution_date, end_date=args.execution_date, dag_run_state=State.NONE)
     try:
-        dag.run(executor=DebugExecutor(), start_date=args.execution_date, end_date=args.execution_date)
+        dag.run(
+            executor=DebugExecutor(),
+            start_date=args.execution_date,
+            end_date=args.execution_date,
+            # Always run the DAG at least once even if no logical runs are
+            # available. This does not make a lot of sense, but Airflow has
+            # been doing this prior to 2.2 so we keep compatibility.
+            run_at_least_once=True,
+        )
     except BackfillUnfinished as e:
         print(str(e))
 

--- a/airflow/jobs/backfill_job.py
+++ b/airflow/jobs/backfill_job.py
@@ -137,6 +137,7 @@ class BackfillJob(BaseJob):
         conf=None,
         rerun_failed_tasks=False,
         run_backwards=False,
+        run_at_least_once=False,
         *args,
         **kwargs,
     ):
@@ -167,6 +168,9 @@ class BackfillJob(BaseJob):
         :type rerun_failed_tasks: bool
         :param run_backwards: Whether to process the dates from most to least recent
         :type run_backwards bool
+        :param run_at_least_once: If true, always run the DAG at least once even
+            if no logical run exists within the time range.
+        :type: bool
         :param args:
         :param kwargs:
         """
@@ -184,6 +188,7 @@ class BackfillJob(BaseJob):
         self.conf = conf
         self.rerun_failed_tasks = rerun_failed_tasks
         self.run_backwards = run_backwards
+        self.run_at_least_once = run_at_least_once
         super().__init__(*args, **kwargs)
 
     @provide_session
@@ -778,10 +783,11 @@ class BackfillJob(BaseJob):
                 )
             dagrun_infos = dagrun_infos[::-1]
 
-        dagrun_info_count = len(dagrun_infos)
-        if dagrun_info_count == 0:
-            self.log.info("No run dates were found for the given dates and dag interval.")
-            return
+        if not dagrun_infos:
+            if not self.run_at_least_once:
+                self.log.info("No run dates were found for the given dates and dag interval.")
+                return
+            dagrun_infos = [DagRunInfo.interval(dagrun_start_date, dagrun_end_date)]
 
         # picklin'
         pickle_id = None
@@ -800,7 +806,7 @@ class BackfillJob(BaseJob):
         executor.job_id = "backfill"
         executor.start()
 
-        ti_status.total_runs = dagrun_info_count  # total dag runs in backfill
+        ti_status.total_runs = len(dagrun_infos)  # total dag runs in backfill
 
         try:
             remaining_dates = ti_status.total_runs

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -2184,6 +2184,7 @@ class DAG(LoggingMixin):
         conf=None,
         rerun_failed_tasks=False,
         run_backwards=False,
+        run_at_least_once=False,
     ):
         """
         Runs the DAG.
@@ -2218,7 +2219,9 @@ class DAG(LoggingMixin):
         :type: bool
         :param run_backwards:
         :type: bool
-
+        :param run_at_least_once: If true, always run the DAG at least once even
+            if no logical run exists within the time range.
+        :type: bool
         """
         from airflow.jobs.backfill_job import BackfillJob
 
@@ -2245,6 +2248,7 @@ class DAG(LoggingMixin):
             conf=conf,
             rerun_failed_tasks=rerun_failed_tasks,
             run_backwards=run_backwards,
+            run_at_least_once=run_at_least_once,
         )
         job.run()
 

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -513,6 +513,7 @@ class TestCliDags(unittest.TestCase):
                     executor=mock_executor.return_value,
                     start_date=cli_args.execution_date,
                     end_date=cli_args.execution_date,
+                    run_at_least_once=True,
                 ),
             ]
         )
@@ -543,6 +544,7 @@ class TestCliDags(unittest.TestCase):
                     executor=mock_executor.return_value,
                     start_date=cli_args.execution_date,
                     end_date=cli_args.execution_date,
+                    run_at_least_once=True
                 ),
             ]
         )

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -544,7 +544,7 @@ class TestCliDags(unittest.TestCase):
                     executor=mock_executor.return_value,
                     start_date=cli_args.execution_date,
                     end_date=cli_args.execution_date,
-                    run_at_least_once=True
+                    run_at_least_once=True,
                 ),
             ]
         )


### PR DESCRIPTION
This restores the behavior around this prior to AIP-39 implementation. It is arguably not correct, but nobody ever complained about it (and they have to the new behavior), so we should meet user expectations.

Close #18473.