### PR TITLE
Don't install SQLAlchemy/Pendulum adapters for other DBs

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -344,24 +344,24 @@ def configure_adapters():
     """Register Adapters and DB Converters"""
     from pendulum import DateTime as Pendulum
 
-    try:
+    if SQL_ALCHEMY_CONN.startswith('sqlite'):
         from sqlite3 import register_adapter
 
         register_adapter(Pendulum, lambda val: val.isoformat(' '))
-    except ImportError:
-        pass
-    try:
-        import MySQLdb.converters
 
-        MySQLdb.converters.conversions[Pendulum] = MySQLdb.converters.DateTime2literal
-    except ImportError:
-        pass
-    try:
-        import pymysql.converters
+    if SQL_ALCHEMY_CONN.startswith('mysql'):
+        try:
+            import MySQLdb.converters
 
-        pymysql.converters.conversions[Pendulum] = pymysql.converters.escape_datetime
-    except ImportError:
-        pass
+            MySQLdb.converters.conversions[Pendulum] = MySQLdb.converters.DateTime2literal
+        except ImportError:
+            pass
+        try:
+            import pymysql.converters
+
+            pymysql.converters.conversions[Pendulum] = pymysql.converters.escape_datetime
+        except ImportError:
+            pass
 
 
 def validate_session():


### PR DESCRIPTION
This stops the MySQL libs being imported "unnecessarily" when Postgres is in use -- and there have been a few confusing reports of the mysql client libs causing problems in rare cases, so lets avoid the import if we can.

This doesn't fix the underlying problem causing #17546 but it might stop it affecting users who aren't using mysql. (Our docker image contains mysql lib, so the import is successful.)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).