### PR TITLE
Fix "Test" connection button when app not mounted at `/`

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -24,6 +24,7 @@
 import getMetaValue from './meta_value';
 
 const restApiEnabled = getMetaValue('rest_api_enabled') === 'True';
+const connectionTestUrl = getMetaValue('test_url');
 
 function decode(str) {
   return new DOMParser().parseFromString(str, 'text/html').documentElement.textContent;
@@ -206,7 +207,7 @@ $(document).ready(() => {
   $('#test-connection').on('click', (e) => {
     e.preventDefault();
     $.ajax({
-      url: '/api/v1/connections/test',
+      url: connectionTestUrl,
       type: 'post',
       contentType: 'application/json',
       dataType: 'json',

--- a/airflow/www/templates/airflow/conn_create.html
+++ b/airflow/www/templates/airflow/conn_create.html
@@ -22,6 +22,7 @@
 {% block head_css %}
   {{ super() }}
   <meta name="rest_api_enabled" content="{{ rest_api_enabled }}">
+  <meta name="test_url" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_connection_endpoint_test_connection') }}">
 {% endblock %}
 
 {% block tail %}

--- a/airflow/www/templates/airflow/conn_edit.html
+++ b/airflow/www/templates/airflow/conn_edit.html
@@ -22,6 +22,7 @@
 {% block head_css %}
   {{ super() }}
   <meta name="rest_api_enabled" content="{{ rest_api_enabled }}">
+  <meta name="test_url" content="{{ url_for('/api/v1.airflow_api_connexion_endpoints_connection_endpoint_test_connection') }}">
 {% endblock %}
 
 {% block tail %}


### PR DESCRIPTION
If the app is at `/airflow` requesting `/api/v1/...` isn't going to work :)