### PR TITLE
Make REST API patch user endpoint work the same way as the UI

### DIFF
--- a/airflow/api_connexion/endpoints/user_endpoint.py
+++ b/airflow/api_connexion/endpoints/user_endpoint.py
@@ -112,7 +112,7 @@ def post_user():
 
 @security.requires_access([(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_USER)])
 def patch_user(username, update_mask=None):
-    """Update a role"""
+    """Update a user"""
     try:
         data = user_schema.load(request.json)
     except ValidationError as e:
@@ -124,9 +124,19 @@ def patch_user(username, update_mask=None):
     if user is None:
         detail = f"The User with username `{username}` was not found"
         raise NotFound(title="User not found", detail=detail)
+    # Check unique username
+    new_username = data.get('username')
+    if new_username and new_username != username:
+        if security_manager.find_user(username=new_username):
+            raise AlreadyExists(detail=f"The username `{new_username}` already exists")
 
-    # Get fields to update. 'username' is always excluded (and it's an error to
-    # include it in update_maek).
+    # Check unique email
+    email = data.get('email')
+    if email and email != user.email:
+        if security_manager.find_user(email=email):
+            raise AlreadyExists(detail=f"The email `{email}` already exists")
+
+    # Get fields to update.
     if update_mask is not None:
         masked_data = {}
         missing_mask_names = []
@@ -139,11 +149,7 @@ def patch_user(username, update_mask=None):
         if missing_mask_names:
             detail = f"Unknown update masks: {', '.join(repr(n) for n in missing_mask_names)}"
             raise BadRequest(detail=detail)
-        if "username" in masked_data:
-            raise BadRequest("Cannot update fields: 'username'")
         data = masked_data
-    else:
-        data.pop("username", None)
 
     if "roles" in data:
         roles_to_update = []

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -1765,15 +1765,19 @@ components:
         first_name:
           type: string
           description: The user firstname
+          minLength: 1
         last_name:
           type: string
           description: The user lastname
+          minLength: 1
         username:
           type: string
           description: The username
+          minLength: 1
         email:
           type: string
           description: The user's email
+          minLength: 1
         active:
           type: boolean
           description: Whether the user is active


### PR DESCRIPTION
Username is updateable in the UI and already exists error is also
raised when trying to update with username/email that already exists.
This PR ensures that the REST API works the same way

Fix #18702, fix #18703 (updated by @uranusjr)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
