### PR TITLE
Fix missing permissions for LDAP Auth (add can create)

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4597,6 +4597,7 @@ class MultiResourceUserMixin:
     }
 
     method_permission_name = {
+        'add': 'create',
         'userinfo': 'read',
         'download': 'read',
         'show': 'read',
@@ -4607,6 +4608,7 @@ class MultiResourceUserMixin:
     }
 
     base_permissions = [
+        permissions.ACTION_CAN_CREATE,
         permissions.ACTION_CAN_READ,
         permissions.ACTION_CAN_EDIT,
         permissions.ACTION_CAN_DELETE,


### PR DESCRIPTION
Hi,

This is to add an option to add new users from UsersVeiw if LDAP auth is enabled (if you simply do not want automated user registration with LDAP).
The whole discussion can be found here: [#18290](https://github.com/apache/airflow/discussions/18290)
Fix #18545 (edited to auto-close after merge - @uranusjr)