### PR TITLE
Add standard hook fields to pagerdutyHook to make hook show up in UI

### DIFF
--- a/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -33,10 +33,11 @@ class PagerdutyHook(BaseHook):
     :param token: PagerDuty API token
     :param pagerduty_conn_id: connection that has PagerDuty API token in the password field
     """
-    conn_name_attr = 'pagerduty_conn_id'
-    default_conn_name = 'pagerduty_default'
-    conn_type = 'pagerduty'
-    hook_name = 'Pagerduty'
+
+    conn_name_attr = "pagerduty_conn_id"
+    default_conn_name = "pagerduty_default"
+    conn_type = "pagerduty"
+    hook_name = "Pagerduty"
 
     def __init__(self, token: Optional[str] = None, pagerduty_conn_id: Optional[str] = None) -> None:
         super().__init__()

--- a/airflow/providers/pagerduty/hooks/pagerduty.py
+++ b/airflow/providers/pagerduty/hooks/pagerduty.py
@@ -33,6 +33,10 @@ class PagerdutyHook(BaseHook):
     :param token: PagerDuty API token
     :param pagerduty_conn_id: connection that has PagerDuty API token in the password field
     """
+    conn_name_attr = 'pagerduty_conn_id'
+    default_conn_name = 'pagerduty_default'
+    conn_type = 'pagerduty'
+    hook_name = 'Pagerduty'
 
     def __init__(self, token: Optional[str] = None, pagerduty_conn_id: Optional[str] = None) -> None:
         super().__init__()

--- a/airflow/providers/pagerduty/provider.yaml
+++ b/airflow/providers/pagerduty/provider.yaml
@@ -37,6 +37,13 @@ integrations:
     tags: [service]
 
 
+hook-class-names: # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
+  - airflow.providers.pagerduty.hooks.pagerduty.PagerdutyHook
+
+connection-types:
+  - hook-class-name: airflow.providers.pagerduty.hooks.pagerduty.PagerdutyHook
+    connection-type: pagerduty
+
 hooks:
   - integration-name: Pagerduty
     python-modules:

--- a/airflow/providers/pagerduty/provider.yaml
+++ b/airflow/providers/pagerduty/provider.yaml
@@ -36,10 +36,6 @@ integrations:
     logo: /integration-logos/pagerduty/PagerDuty.png
     tags: [service]
 
-
-hook-class-names: # deprecated - to be removed after providers add dependency on Airflow 2.2.0+
-  - airflow.providers.pagerduty.hooks.pagerduty.PagerdutyHook
-
 connection-types:
   - hook-class-name: airflow.providers.pagerduty.hooks.pagerduty.PagerdutyHook
     connection-type: pagerduty


### PR DESCRIPTION
Pagerduty is not shown as a Connection type in the Connection view. That is because of two reasons:
1. The PagerdutyHook class is not added in the provider.yaml, nor in the field `connection-types`, nor in the soon to be deprecated field `hook-class-names`. This PR fixes this.
2. Even after fixing 1, the hooks could not be added as some required fields were missing: `conn_name_attr`, `default_conn_name`, `conn_type`, `hook_name`. This PR adds those.

closes: #18748
