### PR TITLE
updates pipeline_timeout CloudDataFusionStartPipelineOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -802,7 +802,7 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
         runtime_args: Optional[Dict[str, Any]] = None,
         success_states: Optional[List[str]] = None,
         namespace: str = "default",
-        pipeline_timeout: int = 10 * 60,
+        pipeline_timeout: int = 5 * 60,
         project_id: Optional[str] = None,
         api_version: str = "v1beta1",
         gcp_conn_id: str = "google_cloud_default",

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -823,6 +823,7 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.impersonation_chain = impersonation_chain
         self.asynchronous = asynchronous
+        self.pipeline_timeout = pipeline_timeout
 
         if success_states:
             self.success_states = success_states

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -826,10 +826,8 @@ class CloudDataFusionStartPipelineOperator(BaseOperator):
 
         if success_states:
             self.success_states = success_states
-            self.pipeline_timeout = pipeline_timeout
         else:
             self.success_states = SUCCESS_STATES + [PipelineStates.RUNNING]
-            self.pipeline_timeout = 5 * 60
 
     def execute(self, context: dict) -> str:
         hook = DataFusionHook(


### PR DESCRIPTION
Currently when using the `CloudDataFusionStartPipelineOperator` if you specify `success_states` then the `pipeline_timeout` parameter is overwritten, this is confusing behaviour, specifically as the documentation states that this parameter is ignored if you do not set `success_states`, however if you do, the value you provide is overwritten.

This is especially confusing as the init has a default of `10 * 60` which is overwritten by `5 * 60`


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
