### PR TITLE
Docs: Move part of timetable guide to concepts

### DIFF
--- a/docs/apache-airflow/concepts/index.rst
+++ b/docs/apache-airflow/concepts/index.rst
@@ -43,6 +43,7 @@ Here you can find detailed documentation about each one of Airflow's core concep
     ../executor/index
     scheduler
     pools
+    timetable
     priority-weight
     cluster-policies
 

--- a/docs/apache-airflow/concepts/timetable.rst
+++ b/docs/apache-airflow/concepts/timetable.rst
@@ -21,8 +21,9 @@ Timetables
 
 A DAG's scheduling strategy is determined by its internal "timetable". This
 timetable can be created by specifying the DAG's ``schedule_interval`` argument,
-as described in :doc:`DAG Run </dag-run>`. The timetable also dictates the data
-interval and the logical time of each run created for the DAG.
+as described in :doc:`DAG Run </dag-run>`, or by passing a ``timetable`` argument 
+directly. The timetable also dictates the data interval and the logical time of each
+run created for the DAG.
 
 Cron expressions and timedeltas are still supported (using
 ``CronDataIntervalTimetable`` and ``DeltaDataIntervalTimetable`` under the hood

--- a/docs/apache-airflow/concepts/timetable.rst
+++ b/docs/apache-airflow/concepts/timetable.rst
@@ -21,7 +21,7 @@ Timetables
 
 A DAG's scheduling strategy is determined by its internal "timetable". This
 timetable can be created by specifying the DAG's ``schedule_interval`` argument,
-as described in :doc:`DAG Run </dag-run>`, or by passing a ``timetable`` argument 
+as described in :doc:`DAG Run </dag-run>`, or by passing a ``timetable`` argument
 directly. The timetable also dictates the data interval and the logical time of each
 run created for the DAG.
 

--- a/docs/apache-airflow/concepts/timetable.rst
+++ b/docs/apache-airflow/concepts/timetable.rst
@@ -1,0 +1,49 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Timetables
+==========
+
+A DAG's scheduling strategy is determined by its internal "timetable". This
+timetable can be created by specifying the DAG's ``schedule_interval`` argument,
+as described in :doc:`DAG Run </dag-run>`. The timetable also dictates the data
+interval and the logical time of each run created for the DAG.
+
+Cron expressions and timedeltas are still supported (using
+``CronDataIntervalTimetable`` and ``DeltaDataIntervalTimetable`` under the hood
+respectively), however, there are situations where they cannot properly express
+the schedule. Some examples are:
+
+* Data intervals with "holes" between. (Instead of continuous, as both the cron
+  expression and ``timedelta`` schedules represent.)
+* Run tasks at different times each day. For example, an astronomer may find it
+  useful to run a task at dawn to process data collected from the previous
+  night-time period.
+* Schedules not following the Gregorian calendar. For example, create a run for
+  each month in the `Traditional Chinese Calendar`_. This is conceptually
+  similar to the sunset case above, but for a different time scale.
+* Rolling windows, or overlapping data intervals. For example, one may want to
+  have a run each day, but make each run cover the period of the previous seven
+  days. It is possible to "hack" this with a cron expression, but a custom data
+  interval would be a more natural representation.
+
+.. _`Traditional Chinese Calendar`: https://en.wikipedia.org/wiki/Chinese_calendar
+
+As such, Airflow allows for custom timetables to be written in plugins and used by
+DAGs. An example demonstrating a custom timetable can be found in the
+:doc:`/howto/timetable` how-to guide.

--- a/docs/apache-airflow/dag-run.rst
+++ b/docs/apache-airflow/dag-run.rst
@@ -22,7 +22,8 @@ A DAG Run is an object representing an instantiation of the DAG in time.
 Each DAG may or may not have a schedule, which informs how DAG Runs are
 created. ``schedule_interval`` is defined as a DAG argument, which can be passed a
 `cron expression <https://en.wikipedia.org/wiki/Cron#CRON_expression>`_ as
-a ``str``, a ``datetime.timedelta`` object, or one of the following cron "presets".
+a ``str``, a ``datetime.timedelta`` object, a ``Timetable`` object,
+or one of the following cron "presets".
 
 .. tip::
     You can use an online editor for CRON expressions such as `Crontab guru <https://crontab.guru/>`_

--- a/docs/apache-airflow/dag-run.rst
+++ b/docs/apache-airflow/dag-run.rst
@@ -22,8 +22,7 @@ A DAG Run is an object representing an instantiation of the DAG in time.
 Each DAG may or may not have a schedule, which informs how DAG Runs are
 created. ``schedule_interval`` is defined as a DAG argument, which can be passed a
 `cron expression <https://en.wikipedia.org/wiki/Cron#CRON_expression>`_ as
-a ``str``, a ``datetime.timedelta`` object, a ``Timetable`` object,
-or one of the following cron "presets".
+a ``str``, a ``datetime.timedelta`` object, or one of the following cron "presets".
 
 .. tip::
     You can use an online editor for CRON expressions such as `Crontab guru <https://crontab.guru/>`_
@@ -84,7 +83,7 @@ scheduled one interval after ``start_date``.
 .. tip::
 
     If ``schedule_interval`` is not enough to express your DAG's schedule,
-    logical date, or data interval, see :doc:`/howto/timetable`.
+    logical date, or data interval, see :doc:`/concepts/timetable`.
 
 Re-run DAG
 ''''''''''

--- a/docs/apache-airflow/howto/timetable.rst
+++ b/docs/apache-airflow/howto/timetable.rst
@@ -19,39 +19,12 @@
 Customizing DAG Scheduling with Timetables
 ==========================================
 
-A DAG's scheduling strategy is determined by its internal "timetable". This
-timetable can be created by specifying the DAG's ``schedule_interval`` argument,
-as described in :doc:`DAG Run </dag-run>`. The timetable also dictates the data
-interval and the logical time of each run created for the DAG.
-
-However, there are situations when a cron expression or simple ``timedelta``
-periods cannot properly express the schedule. Some of the examples are:
-
-* Data intervals with "holes" between. (Instead of continuous, as both the cron
-  expression and ``timedelta`` schedules represent.)
-* Run tasks at different times each day. For example, an astronomer may find it
-  useful to run a task at dawn to process data collected from the previous
-  night-time period.
-* Schedules not following the Gregorian calendar. For example, create a run for
-  each month in the `Traditional Chinese Calendar`_. This is conceptually
-  similar to the sunset case above, but for a different time scale.
-* Rolling windows, or overlapping data intervals. For example, one may want to
-  have a run each day, but make each run cover the period of the previous seven
-  days. It is possible to "hack" this with a cron expression, but a custom data
-  interval would be a more natural representation.
-
-.. _`Traditional Chinese Calendar`: https://en.wikipedia.org/wiki/Chinese_calendar
-
-
 For our example, let's say a company wants to run a job after each weekday to
 process data collected during the work day. The first intuitive answer to this
 would be ``schedule_interval="0 0 * * 1-5"`` (midnight on Monday to Friday), but
 this means data collected on Friday will *not* be processed right after Friday
 ends, but on the next Monday, and that run's interval would be from midnight
-Friday to midnight *Monday*.
-
-This is, therefore, an example in the "holes" category above; the intended
-schedule should not include the two weekend days. What we want is:
+Friday to midnight *Monday*. What we want is:
 
 * Schedule a run for each Monday, Tuesday, Wednesday, Thursday, and Friday. The
   run's data interval would cover from midnight of each day, to midnight of the
@@ -99,6 +72,7 @@ file:
     import datetime
 
     from airflow import DAG
+    from airflow.example_dags.plugins.workday import AfterWorkdayTimetable
 
 
     with DAG(
@@ -277,7 +251,7 @@ serialized DAG is accessed by the scheduler to reconstruct the timetable.
 
 
 Timetable Display in UI
-=======================
+-----------------------
 
 By default, a custom timetable is displayed by their class name in the UI (e.g.
 the *Schedule* column in the "DAGs" table. It is possible to customize this

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1324,6 +1324,7 @@ texttospeech
 tez
 theService
 timedelta
+timedeltas
 timeframe
 timezones
 tis


### PR DESCRIPTION
It took me a while to find the docs for timetables. This proposes moving part of the guide into concepts.

I considered moving part of the top level dag run page here also.

@uranusjr, @ashb, @kaxil - feel free to keep iterating on this while I'm offline.