### PR TITLE
Properly handle verify parameter in TrinoHook

### DIFF
--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -18,10 +18,10 @@
 import os
 from typing import Any, Iterable, Optional
 
-import trino
 from trino.exceptions import DatabaseError
 from trino.transaction import IsolationLevel
 
+import trino
 from airflow import AirflowException
 from airflow.configuration import conf
 from airflow.hooks.dbapi import DbApiHook
@@ -81,7 +81,6 @@ class TrinoHook(DbApiHook):
                 delegate=_boolify(extra.get('kerberos__delegate', False)),
                 ca_bundle=extra.get('kerberos__ca_bundle'),
             )
-
         trino_conn = trino.dbapi.connect(
             host=db.host,
             port=db.port,
@@ -92,12 +91,8 @@ class TrinoHook(DbApiHook):
             schema=db.schema,
             auth=auth,
             isolation_level=self.get_isolation_level(),  # type: ignore[func-returns-value]
+            verify=_boolify(extra.get('verify', True))
         )
-        if extra.get('verify') is not None:
-            # Unfortunately verify parameter is available via public API.
-            # The PR is merged in the trino library, but has not been released.
-            # See: https://github.com/trinodb/trino-python-client/pull/31
-            trino_conn._http_session.verify = _boolify(extra['verify'])
 
         return trino_conn
 

--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -18,10 +18,10 @@
 import os
 from typing import Any, Iterable, Optional
 
+import trino
 from trino.exceptions import DatabaseError
 from trino.transaction import IsolationLevel
 
-import trino
 from airflow import AirflowException
 from airflow.configuration import conf
 from airflow.hooks.dbapi import DbApiHook
@@ -85,13 +85,13 @@ class TrinoHook(DbApiHook):
             host=db.host,
             port=db.port,
             user=db.login,
-            source=db.extra_dejson.get('source', 'airflow'),
-            http_scheme=db.extra_dejson.get('protocol', 'http'),
-            catalog=db.extra_dejson.get('catalog', 'hive'),
+            source=extra.get('source', 'airflow'),
+            http_scheme=extra.get('protocol', 'http'),
+            catalog=extra.get('catalog', 'hive'),
             schema=db.schema,
             auth=auth,
             isolation_level=self.get_isolation_level(),  # type: ignore[func-returns-value]
-            verify=_boolify(extra.get('verify', True))
+            verify=_boolify(extra.get('verify', True)),
         )
 
         return trino_conn

--- a/setup.py
+++ b/setup.py
@@ -476,7 +476,7 @@ tableau = [
 telegram = [
     'python-telegram-bot~=13.0',
 ]
-trino = ['trino']
+trino = ['trino>=0.301.0']
 vertica = [
     'vertica-python>=0.5.1',
 ]

--- a/tests/providers/trino/hooks/test_trino.py
+++ b/tests/providers/trino/hooks/test_trino.py
@@ -51,6 +51,7 @@ class TestTrinoHookConn(unittest.TestCase):
             user='login',
             isolation_level=0,
             auth=mock_basic_auth.return_value,
+            verify=True
         )
         mock_basic_auth.assert_called_once_with('login', 'password')
         assert mock_connect.return_value == conn
@@ -89,6 +90,7 @@ class TestTrinoHookConn(unittest.TestCase):
                     'kerberos__principal': 'TEST_PRINCIPAL',
                     'kerberos__delegate': 'TEST_DELEGATE',
                     'kerberos__ca_bundle': 'TEST_CA_BUNDLE',
+                    'verify': 'true'
                 }
             ),
         )
@@ -104,6 +106,7 @@ class TestTrinoHookConn(unittest.TestCase):
             user='login',
             isolation_level=0,
             auth=mock_auth.return_value,
+            verify=True
         )
         mock_auth.assert_called_once_with(
             ca_bundle='TEST_CA_BUNDLE',
@@ -135,11 +138,8 @@ class TestTrinoHookConn(unittest.TestCase):
             mock_get_connection.return_value = Connection(
                 login='login', host='host', schema='hive', extra=json.dumps({'verify': current_verify})
             )
-            mock_verify = mock.PropertyMock()
-            type(mock_connect.return_value._http_session).verify = mock_verify
 
             conn = TrinoHook().get_conn()
-            mock_verify.assert_called_once_with(expected_verify)
             assert mock_connect.return_value == conn
 
 

--- a/tests/providers/trino/hooks/test_trino.py
+++ b/tests/providers/trino/hooks/test_trino.py
@@ -140,6 +140,18 @@ class TestTrinoHookConn(unittest.TestCase):
             )
 
             conn = TrinoHook().get_conn()
+            mock_connect.assert_called_once_with(
+                catalog='hive',
+                host='host',
+                port=None,
+                http_scheme='http',
+                schema='hive',
+                source='airflow',
+                user='login',
+                auth=None,
+                isolation_level=0,
+                verify=expected_verify,
+            )
             assert mock_connect.return_value == conn
 
 

--- a/tests/providers/trino/hooks/test_trino.py
+++ b/tests/providers/trino/hooks/test_trino.py
@@ -51,7 +51,7 @@ class TestTrinoHookConn(unittest.TestCase):
             user='login',
             isolation_level=0,
             auth=mock_basic_auth.return_value,
-            verify=True
+            verify=True,
         )
         mock_basic_auth.assert_called_once_with('login', 'password')
         assert mock_connect.return_value == conn
@@ -90,7 +90,7 @@ class TestTrinoHookConn(unittest.TestCase):
                     'kerberos__principal': 'TEST_PRINCIPAL',
                     'kerberos__delegate': 'TEST_DELEGATE',
                     'kerberos__ca_bundle': 'TEST_CA_BUNDLE',
-                    'verify': 'true'
+                    'verify': 'true',
                 }
             ),
         )
@@ -106,7 +106,7 @@ class TestTrinoHookConn(unittest.TestCase):
             user='login',
             isolation_level=0,
             auth=mock_auth.return_value,
-            verify=True
+            verify=True,
         )
         mock_auth.assert_called_once_with(
             ca_bundle='TEST_CA_BUNDLE',


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/18770

Added `verify` to the `TrinoHook` class 

One thing to bear in mind is the default value.
I set it up to `True` due to the fact that this value was chosen in the Trino class as well as described in their PR: trinodb/trino-python-client#31  (No breaking changes)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
