### PR TITLE
Update Kubernetes library version and backport pickle-fix for Loggers

### DIFF
--- a/airflow/providers/cncf/kubernetes/__init__.py
+++ b/airflow/providers/cncf/kubernetes/__init__.py
@@ -15,3 +15,30 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
+
+if sys.version_info < (3, 7):
+    # This is needed because the Python Kubernetes client >= 12.0 contains a logging object, meaning that
+    # v1.Pod et al. are not pickleable on Python 3.6.
+
+    # Python 3.7 added this via https://bugs.python.org/issue30520 in 2017 -- but Python 3.6 doesn't have this
+    # method.
+
+    # This is duplicated/backported from airflow.logging_config in 2.2, but by having it here as well it means
+    # that we can update the version used in this provider and have it work for older versions
+    import copyreg
+    import logging
+
+    def _reduce_Logger(logger):
+        if logging.getLogger(logger.name) is not logger:
+            import pickle
+
+            raise pickle.PicklingError('logger cannot be pickled')
+        return logging.getLogger, (logger.name,)
+
+    def _reduce_RootLogger(logger):
+        return logging.getLogger, ()
+
+    if logging.Logger not in copyreg.dispatch_table:
+        copyreg.pickle(logging.Logger, _reduce_Logger)
+        copyreg.pickle(logging.RootLogger, _reduce_RootLogger)

--- a/setup.py
+++ b/setup.py
@@ -381,7 +381,7 @@ kerberos = [
 ]
 kubernetes = [
     'cryptography>=2.0.0',
-    'kubernetes>=3.0.0, <12.0.0',
+    'kubernetes>=3.0.0',
 ]
 kylin = ['kylinpy>=2.6']
 ldap = [

--- a/tests/kubernetes/test_client.py
+++ b/tests/kubernetes/test_client.py
@@ -63,5 +63,9 @@ class TestClient(unittest.TestCase):
 
         _disable_verify_ssl()
 
-        configuration = Configuration()
+        # Support wide range of kube client libraries
+        if hasattr(Configuration, 'get_default_copy'):
+            configuration = Configuration.get_default_copy()
+        else:
+            configuration = Configuration()
         self.assertFalse(configuration.verify_ssl)


### PR DESCRIPTION
Previously we pinned this version as v12 as a change to Kube library
internals meant v1.Pod objects now have a logger object inside them, and
couldn't be pickled on Python 3.6.

To fix that we have "backported" the change in Python 3.7 to make Logger
objects be pickled "by name". (In Python 3.7 the change adds
`__reduce__` methods on to the Logger and RootLogger objects, but here
we achieve it `copyreg` stdlib module so we don't monkeypatch
anything.)

This fix is also applied in to airflow core in a separate commit, but we
also apply it here in the provider so that cncf.kubernetes client
library can be updated but still used with older versions of Airflow
that don't have this fix in.

I think we should *NOT* merge this until after 2.2.0 RC is cut, as I don't think we have time to test the kube client upgrade doesn't break anything before the planned RC release.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
