### PR TITLE
Backport fix to allow pickling of Loggers to Python 3.6

### DIFF
--- a/airflow/logging_config.py
+++ b/airflow/logging_config.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import logging
+import sys
 import warnings
 from logging.config import dictConfig
 
@@ -106,3 +107,22 @@ def validate_logging_config(logging_config):
                 "Configured task_log_reader {!r} was not a handler of the 'airflow.task' "
                 "logger.".format(task_log_reader)
             )
+
+
+if sys.version_info < (3, 7):
+    # Python 3.7 added this via https://bugs.python.org/issue30520 -- but Python 3.6 doesn't have this
+    # support.
+    import copyreg
+
+    def _reduce_Logger(logger):
+        if logging.getLogger(logger.name) is not logger:
+            import pickle
+
+            raise pickle.PicklingError('logger cannot be pickled')
+        return logging.getLogger, (logger.name,)
+
+    def _reduce_RootLogger(logger):
+        return logging.getLogger, ()
+
+    copyreg.pickle(logging.Logger, _reduce_Logger)
+    copyreg.pickle(logging.RootLogger, _reduce_RootLogger)


### PR DESCRIPTION
When sending objects around via multiprocessing (on Python 3.6 or lower)
it would fail if that object contained a Logger object.

To fix that we have "backported" the change in Python 3.7 to make Logger
objects be pickled "by name". (In Python 3.7 the change adds
`__reduce__` methods on to the Logger and RootLogger objects, but here
we achieve it `copyreg` stdlib module so we don't monkeypatch
anything.)

This mainly applies to using Kubernetes client >12 (which is not
currently possible as we restrict that version) but this adds support
for it anywhere it might happen inside Python 3.6.