### PR TITLE
Update S3PrefixSensor to support checking multiple prefixes within a bucket

### DIFF
--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.sensors.base import BaseSensorOperator
@@ -33,7 +33,7 @@ class S3PrefixSensor(BaseSensorOperator):
     :param bucket_name: Name of the S3 bucket
     :type bucket_name: str
     :param prefix: The prefix being waited on. Relative path from bucket root level.
-    :type prefix: str
+    :type prefix: str or list
     :param delimiter: The delimiter intended to show hierarchy.
         Defaults to '/'.
     :type delimiter: str
@@ -58,7 +58,7 @@ class S3PrefixSensor(BaseSensorOperator):
         self,
         *,
         bucket_name: str,
-        prefix: str,
+        prefix: Union[str, Sequence[str]],
         delimiter: str = '/',
         aws_conn_id: str = 'aws_default',
         verify: Optional[Union[str, bool]] = None,
@@ -67,7 +67,7 @@ class S3PrefixSensor(BaseSensorOperator):
         super().__init__(**kwargs)
         # Parse
         self.bucket_name = bucket_name
-        self.prefix = prefix
+        self.prefix = [prefix] if isinstance(prefix, str) else prefix
         self.delimiter = delimiter
         self.full_url = "s3://" + bucket_name + '/' + prefix
         self.aws_conn_id = aws_conn_id
@@ -76,9 +76,7 @@ class S3PrefixSensor(BaseSensorOperator):
 
     def poke(self, context):
         self.log.info('Poking for prefix : %s in bucket s3://%s', self.prefix, self.bucket_name)
-        return self.get_hook().check_for_prefix(
-            prefix=self.prefix, delimiter=self.delimiter, bucket_name=self.bucket_name
-        )
+        return all(self._check_for_prefix(prefix) for prefix in self.prefix)
 
     def get_hook(self) -> S3Hook:
         """Create and return an S3Hook"""
@@ -87,3 +85,8 @@ class S3PrefixSensor(BaseSensorOperator):
 
         self.hook = S3Hook(aws_conn_id=self.aws_conn_id, verify=self.verify)
         return self.hook
+
+    def _check_for_prefix(self, prefix: str) -> bool:
+        return self.get_hook().check_for_prefix(
+            prefix=prefix, delimiter=self.delimiter, bucket_name=self.bucket_name
+        )

--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -23,7 +23,7 @@ from airflow.sensors.base import BaseSensorOperator
 
 class S3PrefixSensor(BaseSensorOperator):
     """
-    Waits for a prefix to exist. A prefix is the first part of a key,
+    Waits for a prefix or all prefixes to exist. A prefix is the first part of a key,
     thus enabling checking of constructs similar to glob ``airfl*`` or
     SQL LIKE ``'airfl%'``. There is the possibility to precise a delimiter to
     indicate the hierarchy or keys, meaning that the match will stop at that

--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.sensors.base import BaseSensorOperator
@@ -73,7 +73,7 @@ class S3PrefixSensor(BaseSensorOperator):
         self.verify = verify
         self.hook: Optional[S3Hook] = None
 
-    def poke(self, context):
+    def poke(self, context: Dict[str, Any]):
         self.log.info('Poking for prefix : %s in bucket s3://%s', self.prefix, self.bucket_name)
         return all(self._check_for_prefix(prefix) for prefix in self.prefix)
 

--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -69,7 +69,6 @@ class S3PrefixSensor(BaseSensorOperator):
         self.bucket_name = bucket_name
         self.prefix = [prefix] if isinstance(prefix, str) else prefix
         self.delimiter = delimiter
-        self.full_url = "s3://" + bucket_name + '/' + prefix
         self.aws_conn_id = aws_conn_id
         self.verify = verify
         self.hook: Optional[S3Hook] = None

--- a/airflow/providers/amazon/aws/sensors/s3_prefix.py
+++ b/airflow/providers/amazon/aws/sensors/s3_prefix.py
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.sensors.base import BaseSensorOperator
@@ -33,7 +33,7 @@ class S3PrefixSensor(BaseSensorOperator):
     :param bucket_name: Name of the S3 bucket
     :type bucket_name: str
     :param prefix: The prefix being waited on. Relative path from bucket root level.
-    :type prefix: str or list
+    :type prefix: str or list of str
     :param delimiter: The delimiter intended to show hierarchy.
         Defaults to '/'.
     :type delimiter: str
@@ -58,7 +58,7 @@ class S3PrefixSensor(BaseSensorOperator):
         self,
         *,
         bucket_name: str,
-        prefix: Union[str, Sequence[str]],
+        prefix: Union[str, List[str]],
         delimiter: str = '/',
         aws_conn_id: str = 'aws_default',
         verify: Optional[Union[str, bool]] = None,

--- a/tests/providers/amazon/aws/sensors/test_s3_prefix.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_prefix.py
@@ -28,10 +28,10 @@ class TestS3PrefixSensor(unittest.TestCase):
         op = S3PrefixSensor(task_id='s3_prefix', bucket_name='bucket', prefix='prefix')
 
         mock_hook.return_value.check_for_prefix.return_value = False
-        assert not op.poke(None)
+        assert not op.poke({})
         mock_hook.return_value.check_for_prefix.assert_called_once_with(
             prefix='prefix', delimiter='/', bucket_name='bucket'
         )
 
         mock_hook.return_value.check_for_prefix.return_value = True
-        assert op.poke(None)
+        assert op.poke({})

--- a/tests/providers/amazon/aws/sensors/test_s3_prefix.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_prefix.py
@@ -16,26 +16,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 from unittest import mock
 from unittest.mock import call
 
 from airflow.providers.amazon.aws.sensors.s3_prefix import S3PrefixSensor
 
 
-class TestS3PrefixSensor(unittest.TestCase):
-    @mock.patch('airflow.providers.amazon.aws.sensors.s3_prefix.S3Hook')
-    def test_poke(self, mock_hook):
-        op = S3PrefixSensor(task_id='s3_prefix', bucket_name='bucket', prefix='prefix')
+@mock.patch('airflow.providers.amazon.aws.sensors.s3_prefix.S3Hook')
+def test_poke(mock_hook):
+    op = S3PrefixSensor(task_id='s3_prefix', bucket_name='bucket', prefix='prefix')
 
-        mock_hook.return_value.check_for_prefix.return_value = False
-        assert not op.poke({})
-        mock_hook.return_value.check_for_prefix.assert_called_once_with(
-            prefix='prefix', delimiter='/', bucket_name='bucket'
-        )
+    mock_hook.return_value.check_for_prefix.return_value = False
+    assert not op.poke({})
+    mock_hook.return_value.check_for_prefix.assert_called_once_with(
+        prefix='prefix', delimiter='/', bucket_name='bucket'
+    )
 
-        mock_hook.return_value.check_for_prefix.return_value = True
-        assert op.poke({})
+    mock_hook.return_value.check_for_prefix.return_value = True
+    assert op.poke({})
 
 
 @mock.patch('airflow.providers.amazon.aws.sensors.s3_prefix.S3Hook')

--- a/tests/providers/amazon/aws/sensors/test_s3_prefix.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_prefix.py
@@ -18,6 +18,7 @@
 
 import unittest
 from unittest import mock
+from unittest.mock import call
 
 from airflow.providers.amazon.aws.sensors.s3_prefix import S3PrefixSensor
 
@@ -35,3 +36,30 @@ class TestS3PrefixSensor(unittest.TestCase):
 
         mock_hook.return_value.check_for_prefix.return_value = True
         assert op.poke({})
+
+
+@mock.patch('airflow.providers.amazon.aws.sensors.s3_prefix.S3Hook')
+def test_poke_should_check_multiple_prefixes(mock_hook):
+    op = S3PrefixSensor(task_id='s3_prefix', bucket_name='bucket', prefix=['prefix1', 'prefix2'])
+
+    mock_hook.return_value.check_for_prefix.return_value = False
+    assert not op.poke({}), "poke returns false when the prefixes do not exist"
+
+    mock_hook.return_value.check_for_prefix.assert_has_calls(
+        calls=[
+            call(prefix='prefix1', delimiter='/', bucket_name='bucket'),
+        ]
+    )
+
+    mock_hook.return_value.check_for_prefix.side_effect = [True, False]
+    assert not op.poke({}), "poke returns false when only some of the prefixes exist"
+
+    mock_hook.return_value.check_for_prefix.side_effect = [True, True]
+    assert op.poke({}), "poke returns true when both prefixes exist"
+
+    mock_hook.return_value.check_for_prefix.assert_has_calls(
+        calls=[
+            call(prefix='prefix1', delimiter='/', bucket_name='bucket'),
+            call(prefix='prefix2', delimiter='/', bucket_name='bucket'),
+        ]
+    )


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Used the alternate approach as mentioned in https://github.com/apache/airflow/issues/15001#issuecomment-934527384

Summary of changes:
1. Support prefix as a str or list. Haven't changed the name to avoid changes to existing consumers.
2. Removed `self.full_url` since we can't build one for multiple prefixes . Not sure if this needs to be mentioned in [UPDATING.md]
3. Updated existing test to pytest
4. Added tests for multiple prefixes
5. Added context type as Dict[str, Any]. There are other variations across the codebase. 

Other candidates (haven't picked yet, can do in same PR):
1. Use `@cached_property` for the hook 
2. Support a callable parameter which lets the user get finer control on whether all prefixes or a subset of them should be considered as required.

closes: https://github.com/apache/airflow/issues/15001
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
