### PR TITLE
Extra containers, volumes and volume mounts for jobs

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -109,15 +109,24 @@ spec:
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+          resources:
+{{ toYaml .Values.createUserJob.resources | indent 12 }}
           volumeMounts:
             - name: config
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
-          resources:
-{{ toYaml .Values.createUserJob.resources | indent 12 }}
+{{- if .Values.createUserJob.extraVolumeMounts }}
+{{ toYaml .Values.createUserJob.extraVolumeMounts | nindent 12 }}
+{{- end }}
+{{- if .Values.createUserJob.extraContainers }}
+{{- toYaml .Values.createUserJob.extraContainers | nindent 8 }}
+{{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}
+{{- if .Values.createUserJob.extraVolumes }}
+{{ toYaml .Values.createUserJob.extraVolumes | nindent 8 }}
+{{- end }}
 {{- end }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -93,13 +93,16 @@ spec:
           env:
           {{- include "custom_airflow_environment" . | indent 10 }}
           {{- include "standard_airflow_environment" . | indent 10 }}
+          resources:
+{{ toYaml .Values.migrateDatabaseJob.resources | indent 12 }}
           volumeMounts:
             - name: config
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
-          resources:
-{{ toYaml .Values.migrateDatabaseJob.resources | indent 12 }}
+{{- if .Values.migrateDatabaseJob.extraVolumeMounts }}
+{{ toYaml .Values.migrateDatabaseJob.extraVolumeMounts | nindent 12 }}
+{{- end }}
 {{- if .Values.migrateDatabaseJob.extraContainers }}
 {{- toYaml .Values.migrateDatabaseJob.extraContainers | nindent 8 }}
 {{- end }}
@@ -107,3 +110,6 @@ spec:
         - name: config
           configMap:
             name: {{ template "airflow_config" . }}
+{{- if .Values.migrateDatabaseJob.extraVolumes }}
+{{ toYaml .Values.migrateDatabaseJob.extraVolumes | nindent 8 }}
+{{- end }}

--- a/chart/tests/test_create_user_job.py
+++ b/chart/tests/test_create_user_job.py
@@ -123,3 +123,48 @@ class CreateUserJobTest(unittest.TestCase):
         )
         annotations = jmespath.search("metadata.annotations", docs[0])
         assert annotations["helm.sh/hook-weight"] == "2"
+
+    def test_should_add_extra_containers(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "extraContainers": [
+                        {"name": "test-container", "image": "test-registry/test-repo:test-tag"}
+                    ],
+                },
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+
+        assert {
+            "name": "test-container",
+            "image": "test-registry/test-repo:test-tag",
+        } == jmespath.search("spec.template.spec.containers[-1]", docs[0])
+
+    def test_should_add_extra_volumes(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "extraVolumes": [{"name": "myvolume", "emptyDir": {}}],
+                },
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+
+        assert {"name": "myvolume", "emptyDir": {}} == jmespath.search(
+            "spec.template.spec.volumes[-1]", docs[0]
+        )
+
+    def test_should_add_extra_volume_mounts(self):
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "extraVolumeMounts": [{"name": "foobar", "mountPath": "foo/bar"}],
+                },
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+
+        assert {"name": "foobar", "mountPath": "foo/bar"} == jmespath.search(
+            "spec.template.spec.containers[0].volumeMounts[-1]", docs[0]
+        )

--- a/chart/tests/test_migrate_database_job.py
+++ b/chart/tests/test_migrate_database_job.py
@@ -172,3 +172,31 @@ class TestMigrateDatabaseJob:
         )
         annotations = jmespath.search("metadata.annotations", docs[0])
         assert annotations["helm.sh/hook-weight"] == "1"
+
+    def test_should_add_extra_volumes(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "extraVolumes": [{"name": "myvolume", "emptyDir": {}}],
+                },
+            },
+            show_only=["templates/jobs/migrate-database-job.yaml"],
+        )
+
+        assert {"name": "myvolume", "emptyDir": {}} == jmespath.search(
+            "spec.template.spec.volumes[-1]", docs[0]
+        )
+
+    def test_should_add_extra_volume_mounts(self):
+        docs = render_chart(
+            values={
+                "migrateDatabaseJob": {
+                    "extraVolumeMounts": [{"name": "foobar", "mountPath": "foo/bar"}],
+                },
+            },
+            show_only=["templates/jobs/migrate-database-job.yaml"],
+        )
+
+        assert {"name": "foobar", "mountPath": "foo/bar"} == jmespath.search(
+            "spec.template.spec.containers[0].volumeMounts[-1]", docs[0]
+        )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1913,6 +1913,30 @@
                         }
                     }
                 },
+                "extraContainers": {
+                    "description": "Launch additional containers for the create user job pod",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                    }
+                },
+                "extraVolumes": {
+                    "description": "Mount additional volumes into create user job",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                    }
+                },
+                "extraVolumeMounts": {
+                    "description": "Mount additional volumes into create user job",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                    }
+                },
                 "nodeSelector": {
                     "description": "Select certain nodes for the create user job pod.",
                     "type": "object",
@@ -2034,6 +2058,22 @@
                     "default": [],
                     "items": {
                         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/container-v1.json"
+                    }
+                },
+                "extraVolumes": {
+                    "description": "Mount additional volumes into migrate database job",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                    }
+                },
+                "extraVolumeMounts": {
+                    "description": "Mount additional volumes into migrate database job",
+                    "type": "array",
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
                     }
                 },
                 "nodeSelector": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -639,6 +639,13 @@ createUserJob:
     # Annotations to add to create user kubernetes service account.
     annotations: {}
 
+  # Launch additional containers into user creation job
+  extraContainers: []
+
+  # Mount additional volumes into user creation job
+  extraVolumes: []
+  extraVolumeMounts: []
+
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -682,6 +689,11 @@ migrateDatabaseJob:
 
   # Launch additional containers into database migration job
   extraContainers: []
+
+  # Mount additional volumes into database migration job
+  extraVolumes: []
+  extraVolumeMounts: []
+
   nodeSelector: {}
   affinity: {}
   tolerations: []


### PR DESCRIPTION
`extraContainers` was added recently (#18379) in the migrate job, but not in the create user job. And both jobs were missing `extraVolumes` and `extraVolumeMounts`.

Added new tests, all tests pass locally.

Unfortunetely, I can't launch `mypy` and `flake8` pre-commit hooks. `./breeze static-check mypy -- --all-files` result in a bunch of `Container ID file found, make sure the other container isn't running or delete ...` errors