### PR TITLE
Document lack of docker compose v2 support with breeze

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -84,7 +84,7 @@ Docker Compose
 - **Version**: Install the latest stable Docker Compose and add it to the PATH.
   See `Docker Compose Installation Guide <https://docs.docker.com/compose/install/>`_ for details.
 
-- **Permissions**: Configure permission to run the ``docker-compose`` command.
+- **Permissions**: Configure permission to run the ``docker-compose`` command or for the ``compose`` plugin.
 
 Docker in WSL 2
 ---------------
@@ -379,7 +379,7 @@ Managing CI environment:
     * Run test specified with ``breeze tests`` command
     * Generate constraints with ``breeze generate-constraints``
     * Execute arbitrary command in the test environment with ``breeze shell`` command
-    * Execute arbitrary docker-compose command with ``breeze docker-compose`` command
+    * Execute arbitrary docker compose command with ``breeze docker-compose`` command
     * Push docker images with ``breeze push-image`` command (require committers rights to push images)
 
 You can optionally reset the Airflow metadata database if specified as extra ``--db-reset`` flag and for CI image
@@ -402,7 +402,7 @@ Managing Prod environment (with ``--production-image`` flag):
     * Stop running interactive environment with ``breeze stop`` command
     * Restart running interactive environment with ``breeze restart`` command
     * Execute arbitrary command in the test environment with ``breeze shell`` command
-    * Execute arbitrary docker-compose command with ``breeze docker-compose`` command
+    * Execute arbitrary docker compose command with ``breeze docker-compose`` command
     * Push docker images with ``breeze push-image`` command (require committers rights to push images)
 
 You can optionally reset database if specified as extra ``--db-reset`` flag. You can also
@@ -509,7 +509,7 @@ Launching Breeze integrations
 -----------------------------
 
 When Breeze starts, it can start additional integrations. Those are additional docker containers
-that are started in the same docker-compose command. Those are required by some of the tests
+that are started in the same docker compose command. Those are required by some of the tests
 as described in `<TESTING.rst#airflow-integration-tests>`_.
 
 By default Breeze starts only airflow container without any integration enabled. If you selected
@@ -949,12 +949,16 @@ Running "Docker Compose" commands
 ---------------------------------
 
 To run Docker Compose commands (such as ``help``, ``pull``, etc), use the
-``docker-compose`` command. To add extra arguments, specify them
+``docker compose`` command. To add extra arguments, specify them
 after ``--`` as extra arguments.
 
 .. code-block:: bash
 
      ./breeze docker-compose pull -- --ignore-pull-failures
+
+Internally, breeze supports the [v1 compose binary](https://docs.docker.com/compose/install/) (``docker-compose``)
+and the [v2 compose plugin](https://docs.docker.com/compose/cli-command/#compose-v2-and-the-new-docker-compose-command)
+(``docker compose``)
 
 Restarting Breeze environment
 -----------------------------
@@ -1149,14 +1153,14 @@ This is the current syntax for  `./breeze <./breeze>`_:
     prepare-airflow-packages                 Prepares airflow packages
     setup-autocomplete                       Sets up autocomplete for breeze
     start-airflow                            Starts Scheduler and Webserver and enters the shell
-    stop                                     Stops the docker-compose environment
-    restart                                  Stops the docker-compose environment including DB cleanup
+    stop                                     Stops the docker compose environment
+    restart                                  Stops the docker compose environment including DB cleanup
     toggle-suppress-cheatsheet               Toggles on/off cheatsheet
     toggle-suppress-asciiart                 Toggles on/off asciiart
 
   Commands with arguments:
 
-    docker-compose                     <ARG>      Executes specified docker-compose command
+    docker-compose                     <ARG>      Executes specified docker compose command
     kind-cluster                       <ARG>      Manages KinD cluster on the host
     prepare-provider-documentation     <ARG>      Prepares provider packages documentation
     prepare-provider-packages          <ARG>      Prepares provider packages
@@ -1186,7 +1190,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
         Enters interactive shell where you can run all tests, start Airflow webserver, scheduler,
         workers, interact with the database, run DAGs etc. It is the default command if no command
         is selected. The shell is executed in the container and in case integrations are chosen,
-        the integrations will be started as separated docker containers - under the docker-compose
+        the integrations will be started as separated docker containers - under the docker compose
         supervision. Local sources are by default mounted to within the container so you can edit
         them locally and run tests immediately in the container. Several folders ('files', 'dist')
         are also mounted so that you can exchange files between the host and container.
@@ -1805,11 +1809,16 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   breeze docker-compose [FLAGS] COMMAND [-- <EXTRA_ARGS>]
 
-        Run docker-compose command instead of entering the environment. Use 'help' as command
+        Run docker compose command instead of entering the environment. Use 'help' as command
         to see available commands. The <EXTRA_ARGS> passed after -- are treated
-        as additional options passed to docker-compose. For example
+        as additional options passed to docker compose. For example
 
         'breeze docker-compose pull -- --ignore-pull-failures'
+
+        Internally, breeze supports the [v1 compose binary](https://docs.docker.com/compose/install/)
+        (``docker-compose``) and the
+        [v2 compose plugin](https://docs.docker.com/compose/cli-command/#compose-v2-and-the-new-docker-compose-command)
+        (``docker compose``)
 
   Flags:
 

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -83,8 +83,12 @@ Docker Compose
 
 - **Version**: Install the latest stable Docker Compose and add it to the PATH.
   See `Docker Compose Installation Guide <https://docs.docker.com/compose/install/>`_ for details.
+  `Compose v2 <https://docs.docker.com/compose/cli-command/>`_ is not yet supported due
+  `to <https://github.com/docker/compose-switch/issues/12>`_
+  `existing <https://github.com/apache/airflow/pull/18725>`_
+  `issues <https://github.com/docker/compose/issues/8742>`_.
 
-- **Permissions**: Configure permission to run the ``docker-compose`` command or for the ``compose`` plugin.
+- **Permissions**: Configure permission to run the ``docker-compose`` command.
 
 Docker in WSL 2
 ---------------
@@ -379,7 +383,7 @@ Managing CI environment:
     * Run test specified with ``breeze tests`` command
     * Generate constraints with ``breeze generate-constraints``
     * Execute arbitrary command in the test environment with ``breeze shell`` command
-    * Execute arbitrary docker compose command with ``breeze docker-compose`` command
+    * Execute arbitrary docker-compose command with ``breeze docker-compose`` command
     * Push docker images with ``breeze push-image`` command (require committers rights to push images)
 
 You can optionally reset the Airflow metadata database if specified as extra ``--db-reset`` flag and for CI image
@@ -402,7 +406,7 @@ Managing Prod environment (with ``--production-image`` flag):
     * Stop running interactive environment with ``breeze stop`` command
     * Restart running interactive environment with ``breeze restart`` command
     * Execute arbitrary command in the test environment with ``breeze shell`` command
-    * Execute arbitrary docker compose command with ``breeze docker-compose`` command
+    * Execute arbitrary docker-compose command with ``breeze docker-compose`` command
     * Push docker images with ``breeze push-image`` command (require committers rights to push images)
 
 You can optionally reset database if specified as extra ``--db-reset`` flag. You can also
@@ -509,7 +513,7 @@ Launching Breeze integrations
 -----------------------------
 
 When Breeze starts, it can start additional integrations. Those are additional docker containers
-that are started in the same docker compose command. Those are required by some of the tests
+that are started in the same docker-compose command. Those are required by some of the tests
 as described in `<TESTING.rst#airflow-integration-tests>`_.
 
 By default Breeze starts only airflow container without any integration enabled. If you selected
@@ -949,16 +953,12 @@ Running "Docker Compose" commands
 ---------------------------------
 
 To run Docker Compose commands (such as ``help``, ``pull``, etc), use the
-``docker compose`` command. To add extra arguments, specify them
+``docker-compose`` command. To add extra arguments, specify them
 after ``--`` as extra arguments.
 
 .. code-block:: bash
 
      ./breeze docker-compose pull -- --ignore-pull-failures
-
-Internally, breeze supports the [v1 compose binary](https://docs.docker.com/compose/install/) (``docker-compose``)
-and the [v2 compose plugin](https://docs.docker.com/compose/cli-command/#compose-v2-and-the-new-docker-compose-command)
-(``docker compose``)
 
 Restarting Breeze environment
 -----------------------------
@@ -1153,14 +1153,14 @@ This is the current syntax for  `./breeze <./breeze>`_:
     prepare-airflow-packages                 Prepares airflow packages
     setup-autocomplete                       Sets up autocomplete for breeze
     start-airflow                            Starts Scheduler and Webserver and enters the shell
-    stop                                     Stops the docker compose environment
-    restart                                  Stops the docker compose environment including DB cleanup
+    stop                                     Stops the docker-compose environment
+    restart                                  Stops the docker-compose environment including DB cleanup
     toggle-suppress-cheatsheet               Toggles on/off cheatsheet
     toggle-suppress-asciiart                 Toggles on/off asciiart
 
   Commands with arguments:
 
-    docker-compose                     <ARG>      Executes specified docker compose command
+    docker-compose                     <ARG>      Executes specified docker-compose command
     kind-cluster                       <ARG>      Manages KinD cluster on the host
     prepare-provider-documentation     <ARG>      Prepares provider packages documentation
     prepare-provider-packages          <ARG>      Prepares provider packages
@@ -1190,7 +1190,7 @@ This is the current syntax for  `./breeze <./breeze>`_:
         Enters interactive shell where you can run all tests, start Airflow webserver, scheduler,
         workers, interact with the database, run DAGs etc. It is the default command if no command
         is selected. The shell is executed in the container and in case integrations are chosen,
-        the integrations will be started as separated docker containers - under the docker compose
+        the integrations will be started as separated docker containers - under the docker-compose
         supervision. Local sources are by default mounted to within the container so you can edit
         them locally and run tests immediately in the container. Several folders ('files', 'dist')
         are also mounted so that you can exchange files between the host and container.
@@ -1809,16 +1809,11 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   breeze docker-compose [FLAGS] COMMAND [-- <EXTRA_ARGS>]
 
-        Run docker compose command instead of entering the environment. Use 'help' as command
+        Run docker-compose command instead of entering the environment. Use 'help' as command
         to see available commands. The <EXTRA_ARGS> passed after -- are treated
-        as additional options passed to docker compose. For example
+        as additional options passed to docker-compose. For example
 
         'breeze docker-compose pull -- --ignore-pull-failures'
-
-        Internally, breeze supports the [v1 compose binary](https://docs.docker.com/compose/install/)
-        (``docker-compose``) and the
-        [v2 compose plugin](https://docs.docker.com/compose/cli-command/#compose-v2-and-the-new-docker-compose-command)
-        (``docker compose``)
 
   Flags:
 

--- a/breeze
+++ b/breeze
@@ -592,8 +592,7 @@ function breeze::prepare_command_file() {
     local compose_file="${3}"
     cat <<EOF >"${file}"
 #!/usr/bin/env bash
-dc_cmd=\$(which docker-compose 2>/dev/null || echo "docker compose")
-docker_compose_version=\$((docker-compose --version || docker compose version || true) 2>/dev/null)
+docker_compose_version=\$(docker-compose --version || true)
 if [[ \${docker_compose_version} =~ .*([0-9]+)\.([0-9]+)\.([0-9]+).* ]]; then
     major=\${BASH_REMATCH[1]}
     minor=\${BASH_REMATCH[2]}
@@ -601,18 +600,18 @@ if [[ \${docker_compose_version} =~ .*([0-9]+)\.([0-9]+)\.([0-9]+).* ]]; then
     if [[ \${major} == "1" ]]; then
         if (( minor < 29 )); then
             echo
-            echo "${COLOR_RED}You have too old version of \${dc_cmd}: \${major}.\${minor}.\${patch}! At least 1.29 is needed! Please upgrade!${COLOR_RESET}"
-            echo "${COLOR_RED}See https://docs.docker.com/compose/install/ for instructions. Make sure \${dc_cmd} you install is first on the PATH variable of yours.${COLOR_RESET}"
+            echo "${COLOR_RED}You have too old version of docker-compose: \${major}.\${minor}.\${patch}! At least 1.29 is needed! Please upgrade!${COLOR_RESET}"
+            echo "${COLOR_RED}See https://docs.docker.com/compose/install/ for instructions. Make sure docker-compose you install is first on the PATH variable of yours.${COLOR_RESET}"
             echo
             exit 1
         fi
     fi
     echo
-    echo "${COLOR_GREEN}Good version of \${dc_cmd}: \${major}.\${minor}.\${patch}${COLOR_RESET}"
+    echo "${COLOR_GREEN}Good version of docker-compose: \${major}.\${minor}.\${patch}${COLOR_RESET}"
     echo
 else
     echo
-    echo "${COLOR_YELLOW}Unknown \${dc_cmd} version. At least 1.29 is needed! If Breeze fails - upgrade to latest available \${dc_cmd} version${COLOR_RESET}"
+    echo "${COLOR_YELLOW}Unknown docker-compose version. At least 1.29 is needed! If Breeze fails - upgrade to latest available docker-compose version${COLOR_RESET}"
     echo
 fi
 
@@ -648,9 +647,7 @@ export SQLITE_URL="${SQLITE_URL}"
 export USE_AIRFLOW_VERSION="${USE_AIRFLOW_VERSION}"
 export USE_PACKAGES_FROM_DIST="${USE_PACKAGES_FROM_DIST}"
 export EXECUTOR="${EXECUTOR}"
-echo ">> Executing \$dc_cmd ${command}"
-\$(echo "\$dc_cmd ${command}")
-
+docker-compose ${command}
 EOF
     chmod u+x "${file}"
 }

--- a/breeze
+++ b/breeze
@@ -592,7 +592,8 @@ function breeze::prepare_command_file() {
     local compose_file="${3}"
     cat <<EOF >"${file}"
 #!/usr/bin/env bash
-docker_compose_version=\$(docker-compose --version || true)
+dc_cmd=\$(which docker-compose 2>/dev/null || echo "docker compose")
+docker_compose_version=\$((docker-compose --version || docker compose version || true) 2>/dev/null)
 if [[ \${docker_compose_version} =~ .*([0-9]+)\.([0-9]+)\.([0-9]+).* ]]; then
     major=\${BASH_REMATCH[1]}
     minor=\${BASH_REMATCH[2]}
@@ -600,18 +601,18 @@ if [[ \${docker_compose_version} =~ .*([0-9]+)\.([0-9]+)\.([0-9]+).* ]]; then
     if [[ \${major} == "1" ]]; then
         if (( minor < 29 )); then
             echo
-            echo "${COLOR_RED}You have too old version of docker-compose: \${major}.\${minor}.\${patch}! At least 1.29 is needed! Please upgrade!${COLOR_RESET}"
-            echo "${COLOR_RED}See https://docs.docker.com/compose/install/ for instructions. Make sure docker-compose you install is first on the PATH variable of yours.${COLOR_RESET}"
+            echo "${COLOR_RED}You have too old version of \${dc_cmd}: \${major}.\${minor}.\${patch}! At least 1.29 is needed! Please upgrade!${COLOR_RESET}"
+            echo "${COLOR_RED}See https://docs.docker.com/compose/install/ for instructions. Make sure \${dc_cmd} you install is first on the PATH variable of yours.${COLOR_RESET}"
             echo
             exit 1
         fi
     fi
     echo
-    echo "${COLOR_GREEN}Good version of docker-compose: \${major}.\${minor}.\${patch}${COLOR_RESET}"
+    echo "${COLOR_GREEN}Good version of \${dc_cmd}: \${major}.\${minor}.\${patch}${COLOR_RESET}"
     echo
 else
     echo
-    echo "${COLOR_YELLOW}Unknown docker-compose version. At least 1.29 is needed! If Breeze fails - upgrade to latest available docker-compose version${COLOR_RESET}"
+    echo "${COLOR_YELLOW}Unknown \${dc_cmd} version. At least 1.29 is needed! If Breeze fails - upgrade to latest available \${dc_cmd} version${COLOR_RESET}"
     echo
 fi
 
@@ -647,7 +648,9 @@ export SQLITE_URL="${SQLITE_URL}"
 export USE_AIRFLOW_VERSION="${USE_AIRFLOW_VERSION}"
 export USE_PACKAGES_FROM_DIST="${USE_PACKAGES_FROM_DIST}"
 export EXECUTOR="${EXECUTOR}"
-docker-compose ${command}
+echo ">> Executing \$dc_cmd ${command}"
+\$(echo "\$dc_cmd ${command}")
+
 EOF
     chmod u+x "${file}"
 }


### PR DESCRIPTION
`docker-compose` (v1) is a (python) binary. In v2, docker has moved to a [plugin based architecture](https://docs.docker.com/compose/cli-command/) (in Golang).

Since the commands have changed from `docker-compose` to `docker compose`, `breeze` doesn't work with v2 yet. These changes update breeze documentation and scripts to be compatible with v1 and v2.

_Side note: I'm new to using `breeze` (and have been using airflow 1.x at work for a while) so I might have missed things. I'm trying to also have a conversation on the #airflow-breeze slack channel to help._
