### PR TITLE
AwsGlueJobOperator: add wait_for_completion to Glue job run

### DIFF
--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -54,6 +54,8 @@ class AwsGlueJobOperator(BaseOperator):
     :type create_job_kwargs: Optional[dict]
     :param run_job_kwargs: Extra arguments for Glue Job Run
     :type run_job_kwargs: Optional[dict]
+    :param wait_for_completion: Whether or not wait for job run completion. (default: True)
+    :type wait_for_completion: bool
     """
 
     template_fields = ('script_args',)
@@ -80,6 +82,7 @@ class AwsGlueJobOperator(BaseOperator):
         iam_role_name: Optional[str] = None,
         create_job_kwargs: Optional[dict] = None,
         run_job_kwargs: Optional[dict] = None,
+        wait_for_completion: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -98,6 +101,7 @@ class AwsGlueJobOperator(BaseOperator):
         self.s3_artifacts_prefix = 'artifacts/glue-scripts/'
         self.create_job_kwargs = create_job_kwargs
         self.run_job_kwargs = run_job_kwargs or {}
+        self.wait_for_completion = wait_for_completion
 
     def execute(self, context):
         """
@@ -127,13 +131,22 @@ class AwsGlueJobOperator(BaseOperator):
             iam_role_name=self.iam_role_name,
             create_job_kwargs=self.create_job_kwargs,
         )
-        self.log.info("Initializing AWS Glue Job: %s", self.job_name)
-        glue_job_run = glue_job.initialize_job(self.script_args, self.run_job_kwargs)
-        glue_job_run = glue_job.job_completion(self.job_name, glue_job_run['JobRunId'])
         self.log.info(
-            "AWS Glue Job: %s status: %s. Run Id: %s",
+            "Initializing AWS Glue Job: %s. Wait for completion: %s",
             self.job_name,
-            glue_job_run['JobRunState'],
-            glue_job_run['JobRunId'],
+            self.wait_for_completion,
         )
+        glue_job_run = glue_job.initialize_job(self.script_args, self.run_job_kwargs)
+        if self.wait_for_completion:
+            glue_job_run = glue_job.job_completion(self.job_name, glue_job_run['JobRunId'])
+            self.log.info(
+                "AWS Glue Job: %s status: %s. Run Id: %s",
+                self.job_name,
+                glue_job_run['JobRunState'],
+                glue_job_run['JobRunId'],
+            )
+        else:
+            self.log.info(
+                "AWS Glue Job: %s. Run Id: %s", self.job_name, glue_job_run['JobRunId']
+            )
         return glue_job_run['JobRunId']

--- a/airflow/providers/amazon/aws/operators/glue.py
+++ b/airflow/providers/amazon/aws/operators/glue.py
@@ -146,7 +146,5 @@ class AwsGlueJobOperator(BaseOperator):
                 glue_job_run['JobRunId'],
             )
         else:
-            self.log.info(
-                "AWS Glue Job: %s. Run Id: %s", self.job_name, glue_job_run['JobRunId']
-            )
+            self.log.info("AWS Glue Job: %s. Run Id: %s", self.job_name, glue_job_run['JobRunId'])
         return glue_job_run['JobRunId']


### PR DESCRIPTION
This PR adds the possibility to specify a `wait_for_completion` flag in an `AwsGlueJobOperator` to indicate whether or not to wait for job run completion.

This is really useful because you can use the `run_id` available via `xcom` and put an `AwsGlueJobSensor` in the downstream to wait for completion.  
With this pattern (fire & forget + sensor) we avoid re-launching a Glue job if the task fails while waiting for completion.

E.g: We create the `run_job` task and put a `sensor_job` in the downstream.

```python
# ...
from airflow.providers.amazon.aws.sensors.glue import AwsGlueJobSensor
from airflow.providers.amazon.aws.operators.glue import AwsGlueJobOperator
# ...
script_args = {
    "--timestamp": "{{ ts }}",
}

run_job = AwsGlueJobOperator(
    task_id="run_glue_job",
    job_name="exmaple-glue-job",
    script_args=script_args,
    wait_for_completion=False,
)

sensor_job = AwsGlueJobSensor(
    task_id="sensor_glue_job",
    job_name="exmaple-glue-job",
    run_id="{{ ti.xcom_pull(task_ids='run_glue_job') }}"
)

run_job >> sensor_job
# ...
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
