### PR TITLE
Install only devel packages

### DIFF
--- a/breeze
+++ b/breeze
@@ -258,7 +258,7 @@ function breeze::initialize_virtualenv() {
         echo
         pushd "${AIRFLOW_SOURCES}" >/dev/null 2>&1 || exit 1
         set +e
-        pip install -e ".[devel_all]" \
+        pip install -e ".[devel]" \
             --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-source-providers-${PYTHON_MAJOR_MINOR_VERSION}.txt"
         res=$?
         set -e


### PR DESCRIPTION
Unblocks `./breeze initialize-local-virtualenv` on Mac OS X.

related: #15770
