### PR TITLE
Remove deprecated usage of init_role() from API

### DIFF
--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -125,8 +125,9 @@ def patch_role(role_name, update_mask=None):
         ]
         _check_action_and_resource(security_manager, perms)
         security_manager.bulk_sync_roles([{"role": role_name, "perms": perms}])
-    if "name" in data:
-        security_manager.update_role(role_id=role.id, name=data["name"])
+    new_name = data.get("name")
+    if new_name is not None and new_name != role.name:
+        security_manager.update_role(role_id=role.id, name=new_name)
     return role_schema.dump(role)
 
 

--- a/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
+++ b/airflow/api_connexion/endpoints/role_and_permission_endpoint.py
@@ -119,14 +119,14 @@ def patch_role(role_name, update_mask=None):
             else:
                 raise BadRequest(detail=f"'{field}' in update_mask is unknown")
         data = data_
-    perms = data.get("permissions", [])
-    if perms:
+    if "permissions" in data:
         perms = [
-            (item['permission']['name'], item['view_menu']['name']) for item in data['permissions'] if item
+            (item["permission"]["name"], item["view_menu"]["name"]) for item in data["permissions"] if item
         ]
         _check_action_and_resource(security_manager, perms)
-    security_manager.update_role(role_id=role.id, name=data['name'])
-    security_manager.init_role(role_name=data['name'], perms=perms or role.permissions)
+        security_manager.bulk_sync_roles([{"role": role_name, "perms": perms}])
+    if "name" in data:
+        security_manager.update_role(role_id=role.id, name=data["name"])
     return role_schema.dump(role)
 
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2694,6 +2694,7 @@ components:
         name:
           type: string
           description: The name of the role
+          minLength: 1
         actions:
           type: array
           items:

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -21,7 +21,6 @@ from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.security import permissions
-from airflow.utils.session import create_session
 from airflow.www.security import EXISTING_ROLES
 from tests.test_utils.api_connexion_utils import (
     assert_401,
@@ -356,10 +355,26 @@ class TestPatchRole(TestRoleEndpoint):
         assert response.json['name'] == expected_name
         assert response.json["actions"] == expected_actions
 
-        with create_session() as session:
-            role_names = {name for name, in session.query(Role.name)}
-        assert expected_name in role_names
-        assert "mytestrole" not in role_names
+    def test_patch_should_update_correct_roles_permissions(self):
+        create_role(self.app, "role_to_change")
+        create_role(self.app, "already_exists")
+
+        response = self.client.patch(
+            "/api/v1/roles/role_to_change",
+            json={
+                "name": "already_exists",
+                "actions": [{"action": {"name": "can_delete"}, "resource": {"name": "XComs"}}],
+            },
+            environ_overrides={"REMOTE_USER": "test"},
+        )
+        assert response.status_code == 200
+
+        updated_permissions = self.app.appbuilder.sm.find_role("role_to_change").permissions
+        assert len(updated_permissions) == 1
+        assert updated_permissions[0].view_menu.name == "XComs"
+        assert updated_permissions[0].permission.name == "can_delete"
+
+        assert len(self.app.appbuilder.sm.find_role("already_exists").permissions) == 0
 
     @parameterized.expand(
         [

--- a/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
+++ b/tests/api_connexion/endpoints/test_role_and_permission_endpoint.py
@@ -21,6 +21,7 @@ from parameterized import parameterized
 
 from airflow.api_connexion.exceptions import EXCEPTIONS_LINK_MAP
 from airflow.security import permissions
+from airflow.utils.session import create_session
 from airflow.www.security import EXISTING_ROLES
 from tests.test_utils.api_connexion_utils import (
     assert_401,
@@ -354,6 +355,11 @@ class TestPatchRole(TestRoleEndpoint):
         assert response.status_code == 200
         assert response.json['name'] == expected_name
         assert response.json["actions"] == expected_actions
+
+        with create_session() as session:
+            role_names = {name for name, in session.query(Role.name)}
+        assert expected_name in role_names
+        assert "mytestrole" not in role_names
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Some cleanups found when investigating #18813.

`init_role()` has been replaced by `bulk_update_roles()`. This PR also slightly tweaked the ordering of operations so `bulk_sync_roles()` is only called when there's a need to update permissions, and added a few lines in the test to make sure role rename is performed successfully.
