### PR TITLE
Remove extra postgres dependency from AWS Provider

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -659,7 +659,7 @@ Here is the list of packages and their extras:
 Package                    Extras
 ========================== ===========================
 airbyte                    http
-amazon                     apache.hive,cncf.kubernetes,exasol,ftp,google,imap,mongo,mysql,postgres,salesforce,ssh
+amazon                     apache.hive,cncf.kubernetes,exasol,ftp,google,imap,mongo,mysql,salesforce,ssh
 apache.beam                google
 apache.druid               apache.hive
 apache.hive                amazon,microsoft.mssql,mysql,presto,samba,vertica

--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
@@ -25,8 +25,8 @@ from airflow import DAG
 from airflow.decorators import task
 from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.amazon.aws.operators.redshift import RedshiftSQLOperator
 from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
-from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.utils.dates import days_ago
 
 # [START howto_operator_s3_to_redshift_env_variables]
@@ -54,9 +54,8 @@ with DAG(
 ) as dag:
     add_sample_data_to_s3 = add_sample_data_to_s3()
 
-    setup__task_create_table = PostgresOperator(
+    setup__task_create_table = RedshiftSQLOperator(
         sql=f'CREATE TABLE IF NOT EXISTS {REDSHIFT_TABLE}(Id int, Name varchar)',
-        postgres_conn_id='redshift_default',
         task_id='setup__create_table',
     )
     # [START howto_operator_s3_to_redshift_task_1]
@@ -69,9 +68,8 @@ with DAG(
         task_id='transfer_s3_to_redshift',
     )
     # [END howto_operator_s3_to_redshift_task_1]
-    teardown__task_drop_table = PostgresOperator(
+    teardown__task_drop_table = RedshiftSQLOperator(
         sql=f'DROP TABLE IF EXISTS {REDSHIFT_TABLE}',
-        postgres_conn_id='redshift_default',
         task_id='teardown__drop_table',
     )
 

--- a/airflow/providers/amazon/aws/hooks/redshift.py
+++ b/airflow/providers/amazon/aws/hooks/redshift.py
@@ -212,6 +212,30 @@ class RedshiftSQLHook(DbApiHook):
 
         return create_engine(self.get_uri(), **engine_kwargs)
 
+    def get_table_primary_key(self, table: str, schema: Optional[str] = "public") -> List[str]:
+        """
+        Helper method that returns the table primary key
+        :param table: Name of the target table
+        :type table: str
+        :param table: Name of the target schema, public by default
+        :type table: str
+        :return: Primary key columns list
+        :rtype: List[str]
+        """
+        sql = """
+            select kcu.column_name
+            from information_schema.table_constraints tco
+                    join information_schema.key_column_usage kcu
+                        on kcu.constraint_name = tco.constraint_name
+                            and kcu.constraint_schema = tco.constraint_schema
+                            and kcu.constraint_name = tco.constraint_name
+            where tco.constraint_type = 'PRIMARY KEY'
+            and kcu.table_schema = %s
+            and kcu.table_name = %s
+        """
+        pk_columns = [row[0] for row in self.get_records(sql, (schema, table))]
+        return pk_columns or None
+
     def get_conn(self) -> RedshiftConnection:
         """Returns a redshift_connector.Connection object"""
         conn_params = self._get_conn_params()

--- a/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/redshift_to_s3.py
@@ -19,9 +19,9 @@
 from typing import Iterable, List, Mapping, Optional, Union
 
 from airflow.models import BaseOperator
+from airflow.providers.amazon.aws.hooks.redshift import RedshiftSQLHook
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.utils.redshift import build_credentials_block
-from airflow.providers.postgres.hooks.postgres import PostgresHook
 
 
 class RedshiftToS3Operator(BaseOperator):
@@ -136,7 +136,7 @@ class RedshiftToS3Operator(BaseOperator):
         """
 
     def execute(self, context) -> None:
-        postgres_hook = PostgresHook(postgres_conn_id=self.redshift_conn_id)
+        redshift_hook = RedshiftSQLHook(redshift_conn_id=self.redshift_conn_id)
         conn = S3Hook.get_connection(conn_id=self.aws_conn_id)
 
         credentials_block = None
@@ -154,5 +154,5 @@ class RedshiftToS3Operator(BaseOperator):
         )
 
         self.log.info('Executing UNLOAD command...')
-        postgres_hook.run(unload_query, self.autocommit, parameters=self.parameters)
+        redshift_hook.run(unload_query, self.autocommit, parameters=self.parameters)
         self.log.info("UNLOAD command complete...")

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -35,9 +35,6 @@ versions:
 additional-dependencies:
   - apache-airflow>=2.1.0
 
-additional-extras:
-  postgres: apache-airflow-providers-postgres>=2.3.0
-
 integrations:
   - integration-name: Amazon Athena
     external-doc-url: https://aws.amazon.com/athena/

--- a/airflow/providers/dependencies.json
+++ b/airflow/providers/dependencies.json
@@ -11,7 +11,6 @@
     "imap",
     "mongo",
     "mysql",
-    "postgres",
     "salesforce",
     "ssh"
   ],

--- a/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
+++ b/tests/providers/amazon/aws/transfers/test_redshift_to_s3.py
@@ -39,7 +39,7 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_table_unloading(
         self,
         table_as_file_name,
@@ -103,7 +103,7 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_execute_sts_token(
         self,
         table_as_file_name,
@@ -171,7 +171,7 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_custom_select_query_unloading(
         self,
         table,
@@ -234,7 +234,7 @@ class TestRedshiftToS3Transfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_table_unloading_role_arn(
         self,
         table_as_file_name,

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -33,7 +33,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_execute(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -78,7 +78,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_execute_with_column_list(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -125,7 +125,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_deprecated_truncate(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -177,7 +177,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_replace(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -229,7 +229,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_upsert(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -284,7 +284,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_execute_sts_token(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "ASIA_aws_access_key_id"
         secret_key = "aws_secret_access_key"
@@ -331,7 +331,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.s3.S3Hook.get_connection")
     @mock.patch("airflow.models.connection.Connection")
     @mock.patch("boto3.session.Session")
-    @mock.patch("airflow.providers.postgres.hooks.postgres.PostgresHook.run")
+    @mock.patch("airflow.providers.amazon.aws.hooks.redshift.RedshiftSQLHook.run")
     def test_execute_role_arn(self, mock_run, mock_session, mock_connection, mock_hook):
         access_key = "ASIA_aws_access_key_id"
         secret_key = "aws_secret_access_key"


### PR DESCRIPTION
Removed postgres provider specific versions dependency generated on #18027 (more details on #18671).
Using the `RedshiftSQLHook ` introduced on #18447 and replicating the method `get_table_primary_key` to it.
The `get_table_primary_key` wasn't removed from `PostgresHook` because can be used on it.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
