### PR TITLE
Handle leading slash in samba path

### DIFF
--- a/airflow/providers/samba/hooks/samba.py
+++ b/airflow/providers/samba/hooks/samba.py
@@ -80,7 +80,7 @@ class SambaHook(BaseHook):
         self._connection_cache.clear()
 
     def _join_path(self, path):
-        return f"//{posixpath.join(self._host, self._share, path)}"
+        return f"//{posixpath.join(self._host, self._share, path.lstrip('/'))}"
 
     @wraps(smbclient.link)
     def link(self, src, dst, follow_symlinks=True):

--- a/tests/providers/samba/hooks/test_samba.py
+++ b/tests/providers/samba/hooks/test_samba.py
@@ -130,3 +130,15 @@ class TestSambaHook(unittest.TestCase):
 
             # We expect keyword arguments to include the connection settings.
             assert dict(kwargs, **connection_settings) == p_kwargs
+
+    @parameterized.expand(
+        [
+            ("/start/path/with/slash", "//ip/share/start/path/with/slash"),
+            ("start/path/without/slash", "//ip/share/start/path/without/slash"),
+        ],
+    )
+    @mock.patch('airflow.hooks.base.BaseHook.get_connection')
+    def test__join_path(self, path, full_path, get_conn_mock):
+        get_conn_mock.return_value = CONNECTION
+        hook = SambaHook('samba_default')
+        assert hook._join_path(path) == full_path


### PR DESCRIPTION
Fix issue that occurs when the path to a file on a samba share has a
slash prepended to it, then the `SambaHook` will treat the path as the
host instead likely resulting trying to connect to the wrong samba host.

For example, this code:
```
hook = SambaHook('samba_test')
hook.push_from_local(
    "/Sales/TestData/sometestfile.txt",
    "/tmp/somefile",
)
```
resulted in:
```
airflow/providers/samba/hooks/samba.py:246: in push_from_local
    with open(local_filepath, "rb") as f, self.open_file(destination_filepath, mode="wb") as g:
airflow/providers/samba/hooks/samba.py:135: in open_file
    **self._conn_kwargs,
/usr/local/lib/python3.6/site-packages/smbclient/_os.py:370: in open_file
    file_attributes=file_attributes, **kwargs)
/usr/local/lib/python3.6/site-packages/smbclient/_io.py:374: in __init__
    tree, fd_path = get_smb_tree(path, **kwargs)
/usr/local/lib/python3.6/site-packages/smbclient/_pool.py:301: in get_smb_tree
    auth_protocol=auth_protocol)
/usr/local/lib/python3.6/site-packages/smbclient/_pool.py:358: in register_session
    connection.connect(timeout=connection_timeout)
/usr/local/lib/python3.6/site-packages/smbprotocol/connection.py:719: in connect
    self.transport.connect()
/usr/local/lib/python3.6/site-packages/smbprotocol/transport.py:74: ValueError

ValueError: Failed to connect to 'Sales:445': [Errno -2] Name or service not known
```

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
