### PR TITLE
Add information about keepalives for managed Postgres

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -245,9 +245,34 @@ For more information regarding setup of the PostgresSQL connection, see `Postgre
 
    See also :ref:`Helm Chart production guide <production-guide:pgbouncer>`
 
+
+.. note::
+
+   For managed Postgres such as Redshift, Azure Postgresql, CloudSQL, Amazon RDS, you should use
+   ``keepalives_idle`` in the connection parameters and set it to less than the idle time because those
+   services will close idle connections after some time of inactivity (typically 300 seconds),
+   which results with error ``The error: psycopg2.operationalerror: SSL SYSCALL error: EOF detected``.
+   The ``keepalive`` settings can be changed via ``sql_alchemy_connect_args`` configuration parameter
+   :doc:`../configurations-ref` in ``[core]`` section. You can configure the args for example in your
+   local_settings.py and the ``sql_alchemy_connect_args`` should be a full import path to the dictionary
+   that stores the configuration parameters. You can read about
+   `Postgres Keepalives <https://www.postgresql.org/docs/current/libpq-connect.html>`_.
+   An example setup for ``keepalives`` that has been observe to fix the problem might be:
+
+   .. code-block:: python
+
+      keepalive_kwargs = {
+          "keepalives": 1,
+          "keepalives_idle": 30,
+          "keepalives_interval": 5,
+          "keepalives_count": 5,
+      }
+
+
 .. spelling::
 
      hba
+
 
 Setting up a MsSQL Database
 ---------------------------


### PR DESCRIPTION
The managed Postgres DBs often kill the connection after
some time of inactivity, so if you are using Airflow with those
you need to configure keepalives.

This PR adds description on how to do it. See #18846

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
