### PR TITLE
fix get_connections deprecation warn in hivemetastore hook

### DIFF
--- a/airflow/providers/apache/hive/hooks/hive.py
+++ b/airflow/providers/apache/hive/hooks/hive.py
@@ -544,16 +544,15 @@ class HiveMetastoreHook(BaseHook):
         return hmsclient.HMSClient(iprot=protocol)
 
     def _find_valid_server(self) -> Any:
-        conns = self.get_connections(self.conn_id)
-        for conn in conns:
-            host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            self.log.info("Trying to connect to %s:%s", conn.host, conn.port)
-            if host_socket.connect_ex((conn.host, conn.port)) == 0:
-                self.log.info("Connected to %s:%s", conn.host, conn.port)
-                host_socket.close()
-                return conn
-            else:
-                self.log.error("Could not connect to %s:%s", conn.host, conn.port)
+        conn = self.get_connection(self.conn_id)
+        host_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.log.info("Trying to connect to %s:%s", conn.host, conn.port)
+        if host_socket.connect_ex((conn.host, conn.port)) == 0:
+            self.log.info("Connected to %s:%s", conn.host, conn.port)
+            host_socket.close()
+            return conn
+        else:
+            self.log.error("Could not connect to %s:%s", conn.host, conn.port)
         return None
 
     def get_conn(self) -> Any:


### PR DESCRIPTION
Hive metastore hook logs deprecation warning because of `get_connections` method usage, see https://github.com/apache/airflow/blob/main/airflow/providers/apache/hive/hooks/hive.py#L547 and https://github.com/apache/airflow/blob/main/airflow/hooks/base.py#L50 . This PR removes this warning.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
