### PR TITLE
Increase timeout of the job pushing to GitHub registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1214,7 +1214,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
   push-images-to-github-registry:
     permissions:
       packages: write
-    timeout-minutes: 10
+    timeout-minutes: 40
     name: "Push images as cache to GitHub Registry"
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs:


### PR DESCRIPTION
Building and pushing image to GitHub Registry might take more than
10 minutes, depending on the "CI Build step" - it can take
shorter or longer, depending on whether the change in Dockerfile,
setup.py, setup.cfg.

The jobs occassionally fail with 10 minute limit. Changing it to
40 minutes seems much more reasonable.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
