### PR TITLE
Stabilize occasional test_logging_head_error_request failures

### DIFF
--- a/tests/providers/http/sensors/test_http.py
+++ b/tests/providers/http/sensors/test_http.py
@@ -179,14 +179,6 @@ class TestHttpSensor:
                 mock.call("This endpoint doesn't exist"),
                 mock.call('HTTP error: %s', 'Not Found'),
                 mock.call("This endpoint doesn't exist"),
-                mock.call('HTTP error: %s', 'Not Found'),
-                mock.call("This endpoint doesn't exist"),
-                mock.call('HTTP error: %s', 'Not Found'),
-                mock.call("This endpoint doesn't exist"),
-                mock.call('HTTP error: %s', 'Not Found'),
-                mock.call("This endpoint doesn't exist"),
-                mock.call('HTTP error: %s', 'Not Found'),
-                mock.call("This endpoint doesn't exist"),
             ]
             mock_errors.assert_has_calls(calls)
 


### PR DESCRIPTION
Sometimes, when the test is executed in parallel it managed to
execute the test just 4 times instead of 5 before the timeout and the
test failed. This PR stabilizes the test by verifying if just two
first times were executed. There is no need to check the exact
number of retries - we just have to see that we tried at least
2 times and that the task eventually timed-out.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
