### PR TITLE
Quarantine maintain_hear_rate test

### DIFF
--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -350,6 +350,7 @@ class TestLocalTaskJob:
 
         session.close()
 
+    @pytest.mark.quarantined
     @patch.object(StandardTaskRunner, 'return_code')
     def test_localtaskjob_maintain_heart_rate(self, mock_return_code, caplog, create_dummy_dag):
 


### PR DESCRIPTION
Depending on the circumstances, this test might show very
different timings (and very wrong ones). Example:

```
  >       assert time_end - time_start < job1.heartrate
  E       assert (1633800366.161033 - 1633800360.9558177) < 1.0
  E        +  where 1.0 = <airflow.jobs.local_task_job.LocalTaskJob object at 0x7f1faf784e80>.heartrate
```

This test should likely remain in quarantine for ever.
You will still be able to run it locally, but running it in CI
makes little sense.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
