### PR TITLE
Attempt to fix flaky timeout test

### DIFF
--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2694,7 +2694,7 @@ class TestSchedulerJob:
         session.refresh(run1)
         assert run1.state == State.FAILED
         assert run1_ti.state == State.SKIPPED
-
+        session.flush()
         # Run relevant part of scheduling again to assert run2 has been scheduled
         self.scheduler_job._start_queued_dagruns(session)
         session.flush()


### PR DESCRIPTION
The test_do_schedule_max_active_runs_dag_timed_out test
fails occasionally with task state where it is in
queuing rather than running state:

```
  >       assert run2.state == State.RUNNING
  E       AssertionError: assert 'queued' == <TaskInstance...NG: 'running'>
  E         - running
  E         + queued
```

The most likey reason was that sesion was not flushed after
task state has been set to Failed and the subsequent
query that queues subsequent runs did not see that there are
no more active dag_runs running.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
