### PR TITLE
Handle occasional segfaults despite tests succeding

### DIFF
--- a/scripts/in_container/check_junitxml_result.py
+++ b/scripts/in_container/check_junitxml_result.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+import xml.etree.ElementTree as ET
+
+TEXT_RED = '\033[31m'
+TEXT_GREEN = '\033[32m'
+TEXT_RESET = '\033[0m'
+
+if __name__ == '__main__':
+    fname = sys.argv[1]
+    try:
+        with open(fname) as fh:
+            root = ET.parse(fh)
+        testsuite = root.find('.//testsuite')
+        num_failures = int(testsuite.get('failures'))
+        num_errors = int(testsuite.get('errors'))
+        if num_failures == 0 and num_errors == 0:
+            print(f'\n{TEXT_GREEN}==== No errors, no failures. Good to go! ===={TEXT_RESET}\n')
+            sys.exit(0)
+        else:
+            print(
+                f'\n{TEXT_RED}==== Errors: {num_errors}, Failures: {num_failures}. '
+                f'Failing the test! ===={TEXT_RESET}\n'
+            )
+            sys.exit(1)
+    except Exception as e:
+        print(
+            f'\n{TEXT_RED}==== There was an error when parsing the junitxml file.'
+            f' Likely the file was corrupted ===={TEXT_RESET}\n'
+        )
+        print(f'\n{TEXT_RED}==== Error: {e} {TEXT_RESET}\n')
+        sys.exit(2)

--- a/scripts/in_container/run_ci_tests.sh
+++ b/scripts/in_container/run_ci_tests.sh
@@ -27,6 +27,17 @@ pytest "${@}"
 
 RES=$?
 
+if [[ ${RES} == "139" ]]; then
+    echo "${COLOR_YELLOW}Sometimes Pytest fails at exiting with segfault, but all tests actually passed${COLOR_RESET}"
+    echo "${COLOR_YELLOW}We should ignore such case. Checking if junitxml file ${RESULT_LOG_FILE} is there with 0 errors and failures${COLOR_RESET}"
+    if [[ -f ${RESULT_LOG_FILE} ]]; then
+        python "${AIRFLOW_SOURCES}/scripts/in_container/check_junitxml_result.py" "${RESULT_LOG_FILE}"
+        RES=$?
+    else
+        echo "${COLOR_YELLOW}JunitXML file ${RESULT_LOG_FILE} does not exist. Proceeding with failure as we cannot check if there were no failures.${COLOR_RESET}"
+    fi
+fi
+
 set +x
 if [[ "${RES}" == "0" && ${CI:="false"} == "true" ]]; then
     echo "All tests successful"


### PR DESCRIPTION
Sometimes Pytest fail with segfault despite seemingly all tests
succeeded. It manifests with exit code 139

In such case we now check if the junitxml is created, whether
it contains some errors/failures lines and whether all of them
show "0". If so - we pretend nothing happened.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
