### PR TITLE
Update current timestamp and logs datetime format

### DIFF
--- a/airflow/www/static/js/datetime_utils.js
+++ b/airflow/www/static/js/datetime_utils.js
@@ -76,7 +76,7 @@ export function updateAllDateTimes() {
     const dt = moment($el.attr('datetime'));
     // eslint-disable-next-line no-underscore-dangle
     if (dt._isValid) {
-      $el.text(dt.format(defaultFormat));
+      $el.text(dt.format(defaultFormatWithTZ));
     }
     if ($el.attr('title') !== undefined) {
       // If displayed date is not UTC, have the UTC date in a title attribute

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -20,6 +20,7 @@
 
 import {
   dateTimeAttrFormat,
+  defaultFormat,
   formatTimezone,
   isoDateToTimeEl,
   setDisplayedTimezone,
@@ -38,7 +39,7 @@ function displayTime() {
   const now = moment();
   $('#clock')
     .attr('datetime', now.format(dateTimeAttrFormat))
-    .html(`${now.format('YYYY-MM-DD, HH:mm:ss')} <strong>${formatTimezone(now)}</strong>`);
+    .html(`${now.format(defaultFormat)} <strong>${formatTimezone(now)}</strong>`);
 }
 
 function changDisplayedTimezone(tz) {

--- a/airflow/www/static/js/main.js
+++ b/airflow/www/static/js/main.js
@@ -38,7 +38,7 @@ function displayTime() {
   const now = moment();
   $('#clock')
     .attr('datetime', now.format(dateTimeAttrFormat))
-    .html(`${now.format('HH:mm')} <strong>${formatTimezone(now)}</strong>`);
+    .html(`${now.format('YYYY-MM-DD, HH:mm:ss')} <strong>${formatTimezone(now)}</strong>`);
 }
 
 function changDisplayedTimezone(tz) {


### PR DESCRIPTION
I made two changes to the UI datetime format:
1. Display the date in the current timestamp. It was removed during the Airflow 2.0 UI overhaul, but I think it is still useful to have it displayed, because:
    * we now display `Next Run` with the date
    * it is helpful when viewing timestamps in the logs and trying to figure out how long ago something executed
2. Make sure the timezone is still displayed in the logs after changing the default timezone
---
1. Refresh the page to get initial behavior. The default timezone is UTC.
  - Before:
    - Timezone is displayed in the logs before changing default timezone.
![image](https://user-images.githubusercontent.com/40527812/136675546-7f3e6f33-e350-4e55-80d2-1c5574593a28.png)
![image](https://user-images.githubusercontent.com/40527812/136675092-3217c838-d5d9-4ca2-b208-6c9ce1de9c6d.png)
  - After:
    - Current timestamp format is updated.
![image](https://user-images.githubusercontent.com/40527812/136675464-0384df30-18da-47a7-9d73-c3c26410c6b2.png)
![image](https://user-images.githubusercontent.com/40527812/136675262-8daf642c-a1fa-4675-8e19-faef0d38f322.png)


2. Change default timezone to PDT.
  - Before:
    - Timezone disappears from logs.
![image](https://user-images.githubusercontent.com/40527812/136675559-071c8eea-6111-4076-88e9-0c17f8211490.png)
![image](https://user-images.githubusercontent.com/40527812/136675161-ab57e792-6afc-4d61-a5eb-c194fe8e980e.png)
  - After:
    - Timezone is still displayed in logs.
![image](https://user-images.githubusercontent.com/40527812/136675479-039ab4f3-6d3a-4399-af10-802b8596ad1a.png)
![image](https://user-images.githubusercontent.com/40527812/136675335-63dcaa9d-540b-4032-bcbc-96cdb1fe0e1f.png)

3. Change default timezone back to UTC.
  - Before:
    - Timezone missing from logs.
![image](https://user-images.githubusercontent.com/40527812/136675566-5315b93c-56bc-4ce8-9e9d-b9d04d4e5680.png)
![image](https://user-images.githubusercontent.com/40527812/136675202-316a59f7-90f1-4db9-a718-2a3b9fea5f89.png)
  - After:
    - Timezone is still displayed in logs.
![image](https://user-images.githubusercontent.com/40527812/136675490-7758b52a-d4cd-4e23-a4ed-c1031972fc83.png)
![image](https://user-images.githubusercontent.com/40527812/136675358-6efa9a1f-f04c-4a31-80ca-bb5901952cfe.png)





<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
