### PR TITLE
Clean test_user once assert is complete

### DIFF
--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -23,13 +23,10 @@ from airflow.www.security import EXISTING_ROLES
 @contextmanager
 def create_test_client(app, user_name, role_name, permissions):
     client = app.test_client()
-    try:
-        with create_user_scope(app, username=user_name, role_name=role_name, permissions=permissions) as _:
-            resp = client.post("/login/", data={"username": user_name, "password": user_name})
-            assert resp.status_code == 302
-            yield client
-    finally:
-        pass
+    with create_user_scope(app, username=user_name, role_name=role_name, permissions=permissions) as _:
+        resp = client.post("/login/", data={"username": user_name, "password": user_name})
+        assert resp.status_code == 302
+        yield client
 
 
 @contextmanager

--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -21,6 +21,18 @@ from airflow.www.security import EXISTING_ROLES
 
 
 @contextmanager
+def create_test_client(app, user_name, role_name, permissions):
+    client = app.test_client()
+    try:
+        with create_user_scope(app, username=user_name, role_name=role_name, permissions=permissions) as _:
+            resp = client.post("/login/", data={"username": user_name, "password": user_name})
+            assert resp.status_code == 302
+            yield client
+    finally:
+        pass
+
+
+@contextmanager
 def create_user_scope(app, username, **kwargs):
     """
     Helper function designed to be used with pytest fixture mainly.

--- a/tests/test_utils/api_connexion_utils.py
+++ b/tests/test_utils/api_connexion_utils.py
@@ -22,6 +22,9 @@ from airflow.www.security import EXISTING_ROLES
 
 @contextmanager
 def create_test_client(app, user_name, role_name, permissions):
+    """
+    Helper function to create a client with a temporary user which will be deleted once done
+    """
     client = app.test_client()
     with create_user_scope(app, username=user_name, role_name=role_name, permissions=permissions) as _:
         resp = client.post("/login/", data={"username": user_name, "password": user_name})

--- a/tests/www/views/conftest.py
+++ b/tests/www/views/conftest.py
@@ -25,7 +25,7 @@ import pytest
 from airflow import settings
 from airflow.models import DagBag
 from airflow.www.app import create_app
-from tests.test_utils.api_connexion_utils import create_user, delete_roles
+from tests.test_utils.api_connexion_utils import delete_roles
 from tests.test_utils.decorators import dont_initialize_flask_app_submodules
 from tests.test_utils.www import client_with_login
 
@@ -112,18 +112,6 @@ def viewer_client(app):
 @pytest.fixture()
 def user_client(app):
     return client_with_login(app, username="test_user", password="test_user")
-
-
-@pytest.fixture(scope="module")
-def client_factory(app):
-    def factory(name, role_name, permissions):
-        create_user(app, username=name, role_name=role_name, permissions=permissions)
-        client = app.test_client()
-        resp = client.post("/login/", data={"username": name, "password": name})
-        assert resp.status_code == 302
-        return client
-
-    return factory
 
 
 class _TemplateWithContext(NamedTuple):


### PR DESCRIPTION
Fixing a test that leaves "test user" in the database once testing is finished. 
It moves out a test function from fixture to a generator function to make use generators for auto cleaning
 
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
