### PR TITLE
Check min docker version

### DIFF
--- a/breeze
+++ b/breeze
@@ -3595,6 +3595,8 @@ breeze::read_saved_environment_variables
 
 initialization::initialize_common_environment
 
+initialization::check_docker_version
+
 initialization::get_environment_for_builds_on_ci
 
 breeze::determine_python_version_to_use_in_breeze

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -898,3 +898,29 @@ function initialization::ga_env() {
         echo "${1}=${2}" >>"${GITHUB_ENV}"
     fi
 }
+
+function initialization::ver() {
+  # convert SemVer number to comparable string (strips pre-release version)
+  # shellcheck disable=SC2086,SC2183
+  printf "%04d%04d%04d%.0s" ${1//[.-]/ }
+}
+
+function initialization::check_docker_version() {
+    local docker_version
+    docker_version=$(docker version --format '{{.Client.Version}}')
+    local comparable_docker_version
+    comparable_docker_version=$(initialization::ver "${docker_version}")
+    local min_docker_version="20.10.0"
+    local min_comparable_docker_version
+    min_comparable_docker_version=$(initialization::ver "${min_docker_version}")
+    if (( comparable_docker_version < min_comparable_docker_version )); then
+        echo
+        echo "${COLOR_RED}Your version of docker is too old: ${docker_version}. Please upgrade to at least ${min_docker_version}.${COLOR_RESET}"
+        echo
+        exit 1
+    else
+        if [[ ${PRINT_INFO_FROM_SCRIPTS} != "false" ]]; then
+            echo "${COLOR_GREEN}Good version of docker ${docker_version}.${COLOR_RESET}"
+        fi
+    fi
+}

--- a/scripts/ci/libraries/_script_init.sh
+++ b/scripts/ci/libraries/_script_init.sh
@@ -35,6 +35,8 @@ initialization::create_directories
 
 initialization::initialize_common_environment
 
+initialization::check_docker_version
+
 sanity_checks::basic_sanity_checks
 
 start_end::script_start


### PR DESCRIPTION
We have recently introduced a few features (--pull flag for example)
in our docker commands, that require newer version of Docker
(the `--pull` flag was introduced in 20.10.0). This PR adds check
if the docker version is at least 20.10.0.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
