### PR TITLE
Strips post-fixes from docker version

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -907,7 +907,14 @@ function initialization::ver() {
 
 function initialization::check_docker_version() {
     local docker_version
-    docker_version=$(docker version --format '{{.Client.Version}}')
+    # In GitHub Code QL, the version of docker has +azure suffix which we should remove
+    docker_version=$(docker version --format '{{.Client.Version}}' | sed 's/\+.*$//' || true)
+    if [ "${docker_version}" == "" ]; then
+        echo
+        echo "${COLOR_YELLOW}Your version of docker is unknown. If the scripts faill, please make sure to install docker at least: ${min_docker_version} version.${COLOR_RESET}"
+        echo
+        return
+    fi
     local comparable_docker_version
     comparable_docker_version=$(initialization::ver "${docker_version}")
     local min_docker_version="20.10.0"


### PR DESCRIPTION
This version will strip any + alpha postfixes from docker version.
Seems that CodeQL uses azure-specific docker version and the
version is postfixed with `+azure`. This change will strip postfix
but also will not fail docker version check in case of similar
error, it will continue running with a warning if version cannot
be retrieved.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
