### PR TITLE
Remove the docker timeout workaround

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -17,7 +17,6 @@
 """Run ephemeral Docker Swarm services"""
 from typing import List, Optional, Union
 
-import requests
 from docker import types
 
 from airflow.exceptions import AirflowException

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -204,12 +204,6 @@ class DockerSwarmOperator(DockerOperator):
         while True:
             try:
                 log = next(logs)
-            # TODO: Remove this clause once https://github.com/docker/docker-py/issues/931 is fixed
-            except requests.exceptions.ConnectionError:
-                # If the service log stream stopped sending messages, check if it the service has
-                # terminated.
-                if self._has_service_terminated():
-                    break
             except StopIteration:
                 # If the service log stream terminated, stop fetching logs further.
                 break

--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,7 @@ doc = [
     'sphinxcontrib-spelling==7.2.1',
 ]
 docker = [
-    'docker',
+    'docker>=5.0.3',
 ]
 drill = ['sqlalchemy-drill>=1.1.0', 'sqlparse>=0.4.1']
 druid = [

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -184,53 +184,6 @@ class TestDockerSwarmOperator(unittest.TestCase):
             operator.execute(None)
         assert str(ctx.value) == msg
 
-    @mock.patch('airflow.providers.docker.operators.docker.APIClient')
-    @mock.patch('airflow.providers.docker.operators.docker_swarm.types')
-    def test_logging_with_requests_timeout(self, types_mock, client_class_mock):
-
-        mock_obj = mock.Mock()
-
-        def _client_tasks_side_effect():
-            for _ in range(2):
-                yield [{'Status': {'State': 'pending'}}]
-            while True:
-                yield [{'Status': {'State': 'complete'}}]
-
-        def _client_service_logs_effect():
-            yield b'Testing is awesome.'
-            raise requests.exceptions.ConnectionError('')
-
-        client_mock = mock.Mock(spec=APIClient)
-        client_mock.create_service.return_value = {'ID': 'some_id'}
-        client_mock.service_logs.return_value = _client_service_logs_effect()
-        client_mock.images.return_value = []
-        client_mock.pull.return_value = [b'{"status":"pull log"}']
-        client_mock.tasks.side_effect = _client_tasks_side_effect()
-        types_mock.TaskTemplate.return_value = mock_obj
-        types_mock.ContainerSpec.return_value = mock_obj
-        types_mock.RestartPolicy.return_value = mock_obj
-        types_mock.Resources.return_value = mock_obj
-
-        client_class_mock.return_value = client_mock
-
-        operator = DockerSwarmOperator(
-            api_version='1.19',
-            command='env',
-            environment={'UNIT': 'TEST'},
-            image='ubuntu:latest',
-            mem_limit='128m',
-            user='unittest',
-            task_id='unittest',
-            auto_remove=True,
-            tty=True,
-            enable_logging=True,
-        )
-        operator.execute(None)
-
-        client_mock.service_logs.assert_called_once_with(
-            'some_id', follow=True, stdout=True, stderr=True, is_tty=True
-        )
-
     def test_on_kill(self):
         client_mock = mock.Mock(spec=APIClient)
 

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -20,7 +20,6 @@ import unittest
 from unittest import mock
 
 import pytest
-import requests
 from docker import APIClient, types
 from parameterized import parameterized
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #18867 
Remove the workaround because of the upgrade in the docker dependencies
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
