### PR TITLE
Group PATCH DAGrun together with other DAGRun endpoints

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -702,7 +702,7 @@ paths:
       description: Modify a DAG run
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_run_endpoint
       operationId: update_dag_run_state
-      tags: [ UpdateDagRunState ]
+      tags: [DAGRun]
       requestBody:
         required: true
         content:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

The endpoint to modify DAGRuns added in https://github.com/apache/airflow/pull/17839 is given a new tag "UpdateDagRunState", but I think it belongs together with the other DAGRun endpoints, which this PR does.

WRT the 2.2 release: this PR only changes the grouping, the endpoint itself remains the same, so IMO this is fine for the 2.2.1 release.

![image](https://user-images.githubusercontent.com/6249654/136782577-120f7b4d-7b70-49c8-9a1f-f70d368ad9b2.png)

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
