### PR TITLE
Add breeze setup-autocomplete zshrc reload

### DIFF
--- a/breeze
+++ b/breeze
@@ -396,6 +396,16 @@ EOF
     echo
     echo "Please exit and re-enter your shell or run:"
     echo
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        if grep "${breeze_comment}" "${HOME}/.zshrc" >/dev/null 2>&1; then
+            echo "    source ~/.zshrc"
+            echo
+            echo "    source ~/.bash_completion.d/breeze-complete"
+            echo
+            exec zsh
+            exit 0
+        fi
+    fi
     echo "    source ~/.bash_completion.d/breeze-complete"
     echo
     exit 0


### PR DESCRIPTION
closes: #18851
Fix for breeze setup-autocomplete in zsh shell terminal. As discussed in issue #18851 error is thrown out after executing the command 
```$source ~/.bash_completion.d/breeze-complete```
Fix includes:
1. Change in instruction to reload .zshrc 
2. Reloading zshrc in breeze.

Test: I have tested in my environment by reverting the changes that ./breeze setup-autocomplete has made. Added the fix and verified by running ./breeze setup-complete command again.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
