### PR TITLE
Set default wasb Azure http logging level to warning; fixes #16224

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/wasb.py
+++ b/airflow/providers/microsoft/azure/hooks/wasb.py
@@ -26,6 +26,8 @@ field (see connection `wasb_default` for an example).
 
 """
 
+import logging
+import os
 from typing import Any, Dict, List, Optional
 
 from azure.core.exceptions import HttpResponseError, ResourceExistsError, ResourceNotFoundError
@@ -111,6 +113,12 @@ class WasbHook(BaseHook):
         self.conn_id = wasb_conn_id
         self.public_read = public_read
         self.blob_service_client = self.get_conn()
+
+        logger = logging.getLogger("azure.core.pipeline.policies.http_logging_policy")
+        try:
+            logger.setLevel(os.environ.get("AZURE_HTTP_LOGGING_LEVEL", logging.WARNING))
+        except ValueError:
+            logger.setLevel(logging.WARNING)
 
     def get_conn(self) -> BlobServiceClient:
         """Return the BlobServiceClient object."""


### PR DESCRIPTION
Closes: #16224

Set default Azure wasb http logging level to warning and allow the user to override with an environment variable named "AZURE_HTTP_LOGGING_LEVEL". In the case that a bad level is passed through the environment variable, this will default back to the warning level.

If accepted, please tag the merge with the label **hacktoberfest-accepted**.