### PR TITLE
Update version added field in config after 2.2.0 release

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -613,7 +613,7 @@
       description: |
         A comma\-separated list of third-party logger names that will be configured to print messages to
         consoles\.
-      version_added: 2.0.0
+      version_added: 2.2.0
       type: string
       example: "connexion,sqlalchemy"
       default: ""
@@ -1967,14 +1967,14 @@
     - name: forwardable
       description: |
         Allow to disable ticket forwardability.
-      version_added: ~
+      version_added: 2.2.0
       type: boolean
       example: ~
       default: "True"
     - name: include_ip
       description: |
         Allow to remove source IP from token, useful when using token behind NATted Docker host.
-      version_added: ~
+      version_added: 2.2.0
       type: boolean
       example: ~
       default: "True"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -613,7 +613,7 @@
       description: |
         A comma\-separated list of third-party logger names that will be configured to print messages to
         consoles\.
-      version_added: 2.2.0
+      version_added: 2.0.0
       type: string
       example: "connexion,sqlalchemy"
       default: ""

--- a/dev/validate_version_added_fields_in_config.py
+++ b/dev/validate_version_added_fields_in_config.py
@@ -28,6 +28,12 @@ import yaml
 
 ROOT_DIR = Path(__file__).resolve().parent / ".."
 
+KNOWN_FALSE_DETECTIONS = {
+    # This option has been added in v2.0.0, but we had mistake in config.yml file until v2.2.0.
+    # https://github.com/apache/airflow/pull/17808
+    ('logging', 'extra_logger_names', '2.2.0')
+}
+
 
 def fetch_pypi_versions() -> List[str]:
     r = requests.get('https://pypi.org/pypi/apache-airflow/json')
@@ -104,6 +110,8 @@ local_options_with_version_added: Set[Tuple[str, str, str]] = {
     if version_added
 }
 diff_options: Set[Tuple[str, str, str]] = computed_options - local_options_with_version_added
+
+diff_options -= KNOWN_FALSE_DETECTIONS
 
 if diff_options:
     pprint(diff_options)


### PR DESCRIPTION
We added new config options in Airflow 2.2.0. 

Detected by [dev/validate_version_added_fields_in_config.py](https://github.com/apache/airflow/blob/c0fbe3ad12eae4dc408a0ef103f2a359762f73e3/dev/validate_version_added_fields_in_config.py)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
