### PR TITLE
Fix comparision of docker versions

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -929,7 +929,7 @@ function initialization::ga_env() {
 function initialization::ver() {
   # convert SemVer number to comparable string (strips pre-release version)
   # shellcheck disable=SC2086,SC2183
-  printf "%04d%04d%04d%.0s" ${1//[.-]/ }
+  printf "%03d%03d%03d%.0s" ${1//[.-]/}
 }
 
 function initialization::check_docker_version() {
@@ -947,7 +947,8 @@ function initialization::check_docker_version() {
     local min_docker_version="20.10.0"
     local min_comparable_docker_version
     min_comparable_docker_version=$(initialization::ver "${min_docker_version}")
-    if (( comparable_docker_version < min_comparable_docker_version )); then
+    # The #0 Strips leading zeros
+    if [[ ${comparable_docker_version#0} -lt ${min_comparable_docker_version#0} ]]; then
         echo
         echo "${COLOR_RED}Your version of docker is too old: ${docker_version}. Please upgrade to at least ${min_docker_version}.${COLOR_RESET}"
         echo


### PR DESCRIPTION
In some shells the comparable string with version was too long.
The number leading with 0 was interpreted as octal number and
it had too many digits for octal number to handle.

This change;

1) decreases the length of the string by using 3-digit numbers
2) strips leading 0s during comparision making comparision work
   in decimal

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
