### PR TITLE
Updating explicit arg example in TaskFlow API tutorial doc

### DIFF
--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -293,14 +293,16 @@ When running your callable, Airflow will pass a set of keyword arguments that ca
 function. This set of kwargs correspond exactly to what you can use in your jinja templates.
 For this to work, you need to define ``**kwargs`` in your function header, or you can add directly the
 keyword arguments you would like to get - for example with the below code your callable will get
-the values of ``ti`` and ``next_ds`` context variables.
+the values of ``ti`` and ``next_ds`` context variables. Note that when explicit keyword arguments are used,
+they must be made optional in the function header to avoid ``TypeError`` exceptions during DAG parsing as
+these values are not available until task execution.
 
 With explicit arguments:
 
 .. code-block:: python
 
    @task
-   def my_python_callable(ti, next_ds):
+   def my_python_callable(ti=None, next_ds=None):
        pass
 
 With kwargs:


### PR DESCRIPTION
Small update the new TaskFlow API tutorial doc related to the example showing how to access execution-context variables explicitly: making sure the documentation is clear that the args need to be optional in a function header to avoid `TypeError` exceptions.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
