### PR TITLE
documentation grammar check - remove a word

### DIFF
--- a/docs/apache-airflow/templates-ref.rst
+++ b/docs/apache-airflow/templates-ref.rst
@@ -130,7 +130,7 @@ Just like with ``var`` it's possible to fetch a connection by string  (e.g. ``{{
 Filters
 -------
 
-Airflow defines the some Jinja filters that can be used to format values.
+Airflow defines some Jinja filters that can be used to format values.
 
 For example, using ``{{ execution_date | ds }}`` will output the execution_date in the ``YYYY-MM-DD`` format.
 


### PR DESCRIPTION
Remove "the" from this line:

"Airflow defines the some Jinja filters that can be used to format values."

https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
