### PR TITLE
Add role export/import to cli tools

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -694,6 +694,13 @@ ARG_SKIP_SERVE_LOGS = Arg(
     help="Don't start the serve logs process along with the workers",
     action="store_true",
 )
+ARG_ROLE_IMPORT = Arg(("file",), help="Import roles from JSON file", nargs=None)
+ARG_ROLE_EXPORT = Arg(("file",), help="Export all roles to JSON file", nargs=None)
+ARG_ROLE_EXPORT_FMT = Arg(
+    ('-p', '--pretty'),
+    help='Format output JSON file by sorting role names and indenting by 4 spaces',
+    action='store_true',
+)
 
 # info
 ARG_ANONYMIZE = Arg(
@@ -1380,6 +1387,18 @@ ROLES_COMMANDS = (
         help='Create role',
         func=lazy_load_command('airflow.cli.commands.role_command.roles_create'),
         args=(ARG_ROLES, ARG_VERBOSE),
+    ),
+    ActionCommand(
+        name='export',
+        help='Export roles from db to JSON file',
+        func=lazy_load_command('airflow.cli.commands.role_command.roles_export'),
+        args=(ARG_ROLE_EXPORT, ARG_ROLE_EXPORT_FMT, ARG_VERBOSE),
+    ),
+    ActionCommand(
+        name='import',
+        help='Import roles from JSON file to db',
+        func=lazy_load_command('airflow.cli.commands.role_command.roles_import'),
+        args=(ARG_ROLE_IMPORT, ARG_VERBOSE),
     ),
 )
 

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1390,7 +1390,7 @@ ROLES_COMMANDS = (
     ),
     ActionCommand(
         name='export',
-        help='Export roles from db to JSON file',
+        help='Export roles (without permissions) from db to JSON file',
         func=lazy_load_command('airflow.cli.commands.role_command.roles_export'),
         args=(ARG_ROLE_EXPORT, ARG_ROLE_EXPORT_FMT, ARG_VERBOSE),
     ),

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -1396,7 +1396,7 @@ ROLES_COMMANDS = (
     ),
     ActionCommand(
         name='import',
-        help='Import roles from JSON file to db',
+        help='Import roles (without permissions) from JSON file to db',
         func=lazy_load_command('airflow.cli.commands.role_command.roles_import'),
         args=(ARG_ROLE_IMPORT, ARG_VERBOSE),
     ),

--- a/airflow/cli/commands/role_command.py
+++ b/airflow/cli/commands/role_command.py
@@ -17,11 +17,14 @@
 # under the License.
 #
 """Roles sub-commands"""
+import json
+import os
 
 from airflow.cli.simple_table import AirflowConsole
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import suppress_logs_and_warning
 from airflow.www.app import cached_app
+from airflow.www.security import EXISTING_ROLES
 
 
 @suppress_logs_and_warning
@@ -42,3 +45,46 @@ def roles_create(args):
     for role_name in args.role:
         appbuilder.sm.add_role(role_name)
     print(f"Added {len(args.role)} role(s)")
+
+
+@suppress_logs_and_warning
+def roles_export(args):
+    """
+    Exports all the rules from the data base to a file.
+    Note, this function does not export the permissions associated for each role.
+    Strictly, it exports the role names into the passed role json file.
+    """
+    appbuilder = cached_app().appbuilder
+    roles = appbuilder.sm.get_all_roles()
+    exporting_roles = [role.name for role in roles if role.name not in EXISTING_ROLES]
+    filename = os.path.expanduser(args.file)
+    kwargs = {} if not args.pretty else {'sort_keys': True, 'indent': 4}
+    with open(filename, 'w', encoding='utf-8') as f:
+        json.dump(exporting_roles, f, **kwargs)
+    print(f"{len(exporting_roles)} roles successfully exported to {filename}")
+
+
+@cli_utils.action_logging
+@suppress_logs_and_warning
+def roles_import(args):
+    """
+    Import all the roles into the db from the given json file.
+    Note, this function does not import the permissions for different roles and import them as well.
+    Strictly, it imports the role names in the role json file passed.
+    """
+    json_file = args.file
+    try:
+        with open(json_file) as f:
+            role_list = json.load(f)
+    except FileNotFoundError:
+        print(f"File '{json_file}' does not exist")
+        exit(1)
+    except ValueError as e:
+        print(f"File '{json_file}' is not a valid JSON file. Error: {e}")
+        exit(1)
+    appbuilder = cached_app().appbuilder
+    existing_roles = [role.name for role in appbuilder.sm.get_all_roles()]
+    roles_to_import = [role for role in role_list if role not in existing_roles]
+    for role_name in roles_to_import:
+        appbuilder.sm.add_role(role_name)
+    print(f"roles '{roles_to_import}' successfully imported")

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -17,6 +17,7 @@
 # under the License.
 #
 import io
+import json
 from contextlib import redirect_stdout
 
 import pytest
@@ -81,3 +82,28 @@ class TestCliRoles:
 
     def test_cli_list_roles_with_args(self):
         role_command.roles_list(self.parser.parse_args(['roles', 'list', '--output', 'yaml']))
+
+    def test_cli_import_roles(self, tmp_path):
+        fn = tmp_path / 'import_roles.json'
+        fn.touch()
+        roles_list = ['FakeTeamA', 'FakeTeamB']
+        with open(fn, 'w') as outfile:
+            json.dump(roles_list, outfile)
+        role_command.roles_import(self.parser.parse_args(['roles', 'import', fn]))
+        assert self.appbuilder.sm.find_role('FakeTeamA') is not None
+        assert self.appbuilder.sm.find_role('FakeTeamB') is not None
+
+    def test_cli_export_roles(self, tmp_path):
+        fn = tmp_path / 'export_roles.json'
+        fn.touch()
+        args = self.parser.parse_args(['roles', 'create', 'FakeTeamA', 'FakeTeamB'])
+        role_command.roles_create(args)
+
+        assert self.appbuilder.sm.find_role('FakeTeamA') is not None
+        assert self.appbuilder.sm.find_role('FakeTeamB') is not None
+
+        role_command.roles_export(self.parser.parse_args(['roles', 'export', fn]))
+        with open(fn) as outfile:
+            roles_exported = json.load(outfile)
+        assert 'FakeTeamA' in roles_exported
+        assert 'FakeTeamB' in roles_exported

--- a/tests/cli/commands/test_role_command.py
+++ b/tests/cli/commands/test_role_command.py
@@ -89,7 +89,7 @@ class TestCliRoles:
         roles_list = ['FakeTeamA', 'FakeTeamB']
         with open(fn, 'w') as outfile:
             json.dump(roles_list, outfile)
-        role_command.roles_import(self.parser.parse_args(['roles', 'import', fn]))
+        role_command.roles_import(self.parser.parse_args(['roles', 'import', str(fn)]))
         assert self.appbuilder.sm.find_role('FakeTeamA') is not None
         assert self.appbuilder.sm.find_role('FakeTeamB') is not None
 
@@ -102,7 +102,7 @@ class TestCliRoles:
         assert self.appbuilder.sm.find_role('FakeTeamA') is not None
         assert self.appbuilder.sm.find_role('FakeTeamB') is not None
 
-        role_command.roles_export(self.parser.parse_args(['roles', 'export', fn]))
+        role_command.roles_export(self.parser.parse_args(['roles', 'export', str(fn)]))
         with open(fn) as outfile:
             roles_exported = json.load(outfile)
         assert 'FakeTeamA' in roles_exported


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
The purpose of this PR is to add the ability to import and export roles to and from the DB to a JSON file locally.
The reason why at Pinterest we need this flexibility is that our production environment have a lot of different team roles from all the different organizations. Then we have users bring up their own dev environments, but when they load the dags (mono-repo), the dags will fail due to the roles not existing. So part of our deploy tools for users to setup their dev environments, we import the roles from a central file. I.e. we export the roles from the production periodically to a file that we push to s3, and then for dev, we import the roles from that file.
We keep it as local file to maintain flexibility. We also use this feature to just backup the roles in case.
We do not allow dev hosts talk to the productions dbs/hosts for security and permission concerns.

Some examples of the use case:
```
Step 1 : airflow roles list
Existing roles:
╒════════════╕
│ Role │
╞════════════╡
│ Admin │
├────────────┤
│ Op │
├────────────┤
│ Public │
├────────────┤
│ User │
├────────────┤
│ Viewer │
├────────────┤
│ test2_role │
├────────────┤
│ test3_role │
├────────────┤
│ test_role │
╘════════════╛

Step 2: airflow roles export ./test.json
3 roles successfully exported to ./test.json

check: cat ./test.json
[
"test2_role",
"test3_role",
"test_role"
]

->. modify the test.json to :
[
"test2_role",
"test3_role",
"test4_role",
"test_role"
]

Step 3: airflow roles import ./test.json
roles '['test4_role']' successfully imported

Step 4 (sanity): airflow roles list
╒════════════╕
│ Role │
╞════════════╡
│ Admin │
├────────────┤
│ Op │
├────────────┤
│ Public │
├────────────┤
│ User │
├────────────┤
│ Viewer │
├────────────┤
│ test2_role │
├────────────┤
│ test3_role │
├────────────┤
│ test4_role │
├────────────┤
│ test_role │
╘════════════╛
```
How the help messages look:
```
root@dev-ahaidrey:/mnt/pinboard# airflow roles import --help
/usr/local/lib/python3.7/dist-packages/airflow/configuration.py:342 DeprecationWarning: The remote_logging option in [core] has been moved to the remote_logging option in [logging] - the old setting has been used, but please update your config.
usage: airflow roles import [-h] [-v] file

Import roles from JSON file to db

positional arguments:
  file           Import roles from JSON file

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  Make logging output more verbose
root@dev-ahaidrey:/mnt/pinboard# airflow roles export --help
/usr/local/lib/python3.7/dist-packages/airflow/configuration.py:342 DeprecationWarning: The remote_logging option in [core] has been moved to the remote_logging option in [logging] - the old setting has been used, but please update your config.
usage: airflow roles export [-h] [-v] file

Export roles from db to JSON file

positional arguments:
  file           Export all roles to JSON file

optional arguments:
  -h, --help     show this help message and exit
  -v, --verbose  Make logging output more verbose
root@dev-ahaidrey:/mnt/pinboard# airflow roles --help
/usr/local/lib/python3.7/dist-packages/airflow/configuration.py:342 DeprecationWarning: The remote_logging option in [core] has been moved to the remote_logging option in [logging] - the old setting has been used, but please update your config.
usage: airflow roles [-h] COMMAND ...

Manage roles

positional arguments:
  COMMAND
    create    Create role
    export    Export roles from db to JSON file
    import    Import roles from JSON file to db
    list      List roles

optional arguments:
  -h, --help  show this help message and exit
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
