### PR TITLE
Chart: Use python 3.7 by default; support disabling triggerer

### DIFF
--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -38,10 +38,12 @@ Run ``helm repo update`` before upgrading the chart to the latest version.
 Airflow Helm Chart 1.3.0 (dev)
 ------------------------------
 
-Default Airflow version is updated to ``2.2.0``
-"""""""""""""""""""""""""""""""""""""""""""""""
+Default Airflow image is updated to ``2.2.0-python3.7``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-The default Airflow version that is installed with the Chart is now ``2.2.0``, previously it was ``2.1.4``.
+The default Airflow image that is used with the Chart is now ``2.2.0-python3.7``, previously it was ``2.1.4`` (which is Python ``3.6``).
+
+The triggerer component requires Python ``3.7``. If you require Python ``3.6`` and Airflow ``2.2.0``, use a ``3.6`` based image and set ``triggerer.enabled=False`` in your values.
 
 Airflow Helm Chart 1.2.0
 ------------------------

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -19,6 +19,7 @@
 ## Airflow Triggerer Deployment
 #################################
 {{- if semverCompare ">=2.2.0" .Values.airflowVersion }}
+{{- if .Values.triggerer.enabled }}
 {{- $nodeSelector := or .Values.nodeSelector .Values.triggerer.nodeSelector }}
 {{- $affinity := or .Values.affinity .Values.triggerer.affinity }}
 {{- $tolerations := or .Values.tolerations .Values.triggerer.tolerations }}
@@ -199,5 +200,6 @@ spec:
         {{- else }}
         - name: logs
           emptyDir: {}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/chart/tests/test_triggerer.py
+++ b/chart/tests/test_triggerer.py
@@ -39,6 +39,18 @@ class TriggererTest(unittest.TestCase):
 
         assert num_docs == len(docs)
 
+    def test_can_be_disabled(self):
+        """
+        Triggerer should be able to be disabled if the users desires
+        (e.g. Python 3.6 or doesn't want to use async tasks)
+        """
+        docs = render_chart(
+            values={"triggerer": {"enabled": False}},
+            show_only=["templates/triggerer/triggerer-deployment.yaml"],
+        )
+
+        assert 0 == len(docs)
+
     def test_should_add_extra_containers(self):
         docs = render_chart(
             values={

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -67,7 +67,7 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.2.0",
+            "default": "2.2.0-python3.7",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
@@ -1465,6 +1465,11 @@
             "x-docsSection": "Triggerer",
             "additionalProperties": false,
             "properties": {
+                "enabled": {
+                    "description": "Enable triggerer (requires Python 3.7+).",
+                    "type": "boolean",
+                    "default": true
+                },
                 "livenessProbe": {
                     "description": "Liveness probe configuration.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,7 +40,7 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.2.0"
+defaultAirflowTag: "2.2.0-python3.7"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
 airflowVersion: "2.2.0"
@@ -772,6 +772,7 @@ webserver:
 
 # Airflow Triggerer Config
 triggerer:
+  enabled: true
   # Number of airflow triggerers in the deployment
   replicas: 1
 


### PR DESCRIPTION
The triggerer is only supported in Python 3.7, so use that as the
default image. For users who do not want to update Python versions,
allow the triggerer component to be disabled.