### PR TITLE
Adding dag_id_pattern parameter to the /dags endpoint

### DIFF
--- a/airflow/api_connexion/endpoints/dag_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_endpoint.py
@@ -60,12 +60,15 @@ def get_dag_details(dag_id):
 @security.requires_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)])
 @format_parameters({'limit': check_limit})
 @provide_session
-def get_dags(limit, session, offset=0, only_active=True, tags=None):
+def get_dags(limit, session, offset=0, only_active=True, tags=None, dag_id_pattern=None):
     """Get all DAGs."""
     if only_active:
         dags_query = session.query(DagModel).filter(~DagModel.is_subdag, DagModel.is_active)
     else:
         dags_query = session.query(DagModel).filter(~DagModel.is_subdag)
+
+    if dag_id_pattern:
+        dags_query = dags_query.filter(DagModel.dag_id.ilike(f'%{dag_id_pattern}%'))
 
     readable_dags = current_app.appbuilder.sm.get_accessible_dag_ids(g.user)
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -415,6 +415,12 @@ paths:
             default: true
           required: false
           description: Only return active DAGs.
+        - name: dag_id_pattern
+          in: query
+          schema:
+            type: string
+          required: false
+          description: If set, only return DAGs with dag_ids matching this pattern.
       responses:
         '200':
           description: Success.

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -580,6 +580,33 @@ class TestGetDags(TestDagEndpoint):
 
         assert expected_dag_ids == dag_ids
 
+    @parameterized.expand(
+        [
+            ("api/v1/dags?dag_id_pattern=DAG_1", {'TEST_DAG_1', 'SAMPLE_DAG_1'}),
+            ("api/v1/dags?dag_id_pattern=SAMPLE_DAG", {'SAMPLE_DAG_1', 'SAMPLE_DAG_2'}),
+            (
+                "api/v1/dags?dag_id_pattern=_DAG_",
+                {"TEST_DAG_1", "TEST_DAG_2", 'SAMPLE_DAG_1', 'SAMPLE_DAG_2'},
+            ),
+        ]
+    )
+    def test_filter_dags_by_dag_id_works(self, url, expected_dag_ids):
+        # test filter by tags
+        dag1 = DAG(dag_id="TEST_DAG_1")
+        dag2 = DAG(dag_id="TEST_DAG_2")
+        dag3 = DAG(dag_id="SAMPLE_DAG_1")
+        dag4 = DAG(dag_id="SAMPLE_DAG_2")
+        dag1.sync_to_db()
+        dag2.sync_to_db()
+        dag3.sync_to_db()
+        dag4.sync_to_db()
+
+        response = self.client.get(url, environ_overrides={'REMOTE_USER': "test"})
+        assert response.status_code == 200
+        dag_ids = {dag["dag_id"] for dag in response.json["dags"]}
+
+        assert expected_dag_ids == dag_ids
+
     def test_should_respond_200_with_granular_dag_access(self):
         self._create_dag_models(3)
         response = self.client.get(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
One of the issues we run into when developing tools on top of the Airflow API is wanting to get just a subset of DAGs (typically all of the jobs relating to a particular service or data source).

Rather than pulling the entire list of DAGs and then filtering client-side, it would be great if we could push filter all the way to the query and then only return only the required subset of DAGs from the API. The ability to filter by tags is close to providing the required functionality, but it relies on users properly and consistently tagging their DAGs, which isn't always the case.
