### PR TITLE
Support query timeout as an argument in CassandraToGCSOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
@@ -117,7 +117,7 @@ class CassandraToGCSOperator(BaseOperator):
         google_cloud_storage_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
-        query_timeout: Optional[Union[float, NotSetType]] = NOT_SET,
+        query_timeout: Union[float, None, NotSetType] = NOT_SET,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)

--- a/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
@@ -87,7 +87,7 @@ class CassandraToGCSOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :type impersonation_chain: Union[str, Sequence[str]]
-    :param query_timeout: (Optional) The floating-point timeout used to execute the Cassandra query.
+    :param query_timeout: (Optional) The amount of time, in seconds, used to execute the Cassandra query.
         If not set, the timeout value will be set in Session.execute() by Cassandra driver.
         If set to None, there is no timeout.
     :type query_timeout: float | None

--- a/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
@@ -26,7 +26,7 @@ from base64 import b64encode
 from datetime import datetime
 from decimal import Decimal
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Iterable, List, NewType, Optional, Sequence, Tuple, Union
 from uuid import UUID
 
 from cassandra.util import Date, OrderedMapSerializedKey, SortedSet, Time
@@ -35,6 +35,9 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.apache.cassandra.hooks.cassandra import CassandraHook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
+
+NotSetType = NewType('NotSetType', object)
+NOT_SET = NotSetType(object())
 
 
 class CassandraToGCSOperator(BaseOperator):
@@ -84,6 +87,10 @@ class CassandraToGCSOperator(BaseOperator):
         Service Account Token Creator IAM role to the directly preceding identity, with first
         account from the list granting this role to the originating account (templated).
     :type impersonation_chain: Union[str, Sequence[str]]
+    :param query_timeout: (Optional) The floating-point timeout used to execute the Cassandra query.
+        If not set, the timeout value will be set in Session.execute() by Cassandra driver.
+        If set to None, there is no timeout.
+    :type query_timeout: Union[float, NotSetType]
     """
 
     template_fields = (
@@ -110,6 +117,7 @@ class CassandraToGCSOperator(BaseOperator):
         google_cloud_storage_conn_id: Optional[str] = None,
         delegate_to: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
+        query_timeout: Optional[Union[float, NotSetType]] = NOT_SET,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -133,6 +141,7 @@ class CassandraToGCSOperator(BaseOperator):
         self.delegate_to = delegate_to
         self.gzip = gzip
         self.impersonation_chain = impersonation_chain
+        self.query_timeout = query_timeout
 
     # Default Cassandra to BigQuery type mapping
     CQL_TYPE_MAP = {
@@ -162,7 +171,12 @@ class CassandraToGCSOperator(BaseOperator):
 
     def execute(self, context: Dict[str, str]):
         hook = CassandraHook(cassandra_conn_id=self.cassandra_conn_id)
-        cursor = hook.get_conn().execute(self.cql)
+
+        query_extra = {}
+        if self.query_timeout is not NOT_SET:
+            query_extra['timeout'] = self.query_timeout
+
+        cursor = hook.get_conn().execute(self.cql, **query_extra)
 
         files_to_upload = self._write_local_data_files(cursor)
 

--- a/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/cassandra_to_gcs.py
@@ -90,7 +90,7 @@ class CassandraToGCSOperator(BaseOperator):
     :param query_timeout: (Optional) The floating-point timeout used to execute the Cassandra query.
         If not set, the timeout value will be set in Session.execute() by Cassandra driver.
         If set to None, there is no timeout.
-    :type query_timeout: Union[float, NotSetType]
+    :type query_timeout: float | None
     """
 
     template_fields = (

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -49,7 +49,9 @@ class TestCassandraToGCS(unittest.TestCase):
         )
         operator.execute(None)
         mock_hook.return_value.get_conn.assert_called_once_with()
-        mock_hook.return_value.get_conn.return_value.execute.assert_called_once_with(cql, timeout=query_timeout)
+        mock_hook.return_value.get_conn.return_value.execute.assert_called_once_with(
+            cql, timeout=query_timeout
+        )
 
         call_schema = call(
             bucket_name=test_bucket,

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -30,6 +30,7 @@ class TestCassandraToGCS(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.transfers.cassandra_to_gcs.GCSHook.upload")
     @mock.patch("airflow.providers.google.cloud.transfers.cassandra_to_gcs.CassandraHook")
     def test_execute(self, mock_hook, mock_upload, mock_tempfile):
+        cql = "select * from keyspace1.table1"
         test_bucket = "test-bucket"
         schema = "schema.json"
         filename = "data.json"
@@ -39,7 +40,7 @@ class TestCassandraToGCS(unittest.TestCase):
 
         operator = CassandraToGCSOperator(
             task_id="test-cas-to-gcs",
-            cql="select * from keyspace1.table1",
+            cql=cql,
             bucket=test_bucket,
             filename=filename,
             schema_filename=schema,
@@ -48,6 +49,10 @@ class TestCassandraToGCS(unittest.TestCase):
         )
         operator.execute(None)
         mock_hook.return_value.get_conn.assert_called_once_with()
+        mock_hook.return_value.get_conn.return_value.execute.assert_called_once_with(
+            query=cql,
+            timeout=query_timeout
+        )
 
         call_schema = call(
             bucket_name=test_bucket,

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -34,6 +34,7 @@ class TestCassandraToGCS(unittest.TestCase):
         schema = "schema.json"
         filename = "data.json"
         gzip = True
+        query_timeout = 20
         mock_tempfile.return_value.name = TMP_FILE_NAME
 
         operator = CassandraToGCSOperator(
@@ -43,6 +44,7 @@ class TestCassandraToGCS(unittest.TestCase):
             filename=filename,
             schema_filename=schema,
             gzip=gzip,
+            query_timeout=query_timeout,
         )
         operator.execute(None)
         mock_hook.return_value.get_conn.assert_called_once_with()

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -49,10 +49,7 @@ class TestCassandraToGCS(unittest.TestCase):
         )
         operator.execute(None)
         mock_hook.return_value.get_conn.assert_called_once_with()
-        mock_hook.return_value.get_conn.return_value.execute.assert_called_once_with(
-            query=cql,
-            timeout=query_timeout
-        )
+        mock_hook.return_value.get_conn.return_value.execute.assert_called_once_with(cql, timeout=query_timeout)
 
         call_schema = call(
             bucket_name=test_bucket,

--- a/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_cassandra_to_gcs.py
@@ -30,7 +30,6 @@ class TestCassandraToGCS(unittest.TestCase):
     @mock.patch("airflow.providers.google.cloud.transfers.cassandra_to_gcs.GCSHook.upload")
     @mock.patch("airflow.providers.google.cloud.transfers.cassandra_to_gcs.CassandraHook")
     def test_execute(self, mock_hook, mock_upload, mock_tempfile):
-        cql = "select * from keyspace1.table1"
         test_bucket = "test-bucket"
         schema = "schema.json"
         filename = "data.json"
@@ -40,7 +39,7 @@ class TestCassandraToGCS(unittest.TestCase):
 
         operator = CassandraToGCSOperator(
             task_id="test-cas-to-gcs",
-            cql=cql,
+            cql="select * from keyspace1.table1",
             bucket=test_bucket,
             filename=filename,
             schema_filename=schema,
@@ -50,7 +49,8 @@ class TestCassandraToGCS(unittest.TestCase):
         operator.execute(None)
         mock_hook.return_value.get_conn.assert_called_once_with()
         mock_hook.return_value.get_conn.return_value.execute.assert_called_once_with(
-            cql, timeout=query_timeout
+            "select * from keyspace1.table1",
+            timeout=20,
         )
 
         call_schema = call(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
closes: #18921

- Add query_timeout as an argument in CassandraToGCSOperator constructor
- Support query execution with a timeout parameter
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
