### PR TITLE
Jinja templates should be rendered in dict keys

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -373,6 +373,14 @@
       type: integer
       example: ~
       default: "1024"
+    - name: render_dict_keys
+      description: |
+        Flag to enable jinja2 rendering of dictionary keys inside fields of template_fields.
+        Disabled by default, and if jinja template is detected, warning is issued
+      version_added: 2.3.0
+      type: boolean
+      example: ~
+      default: "False"
 
 - name: database
   description: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -212,6 +212,10 @@ default_pool_task_slot_count = 128
 # mapped tasks from clogging the scheduler.
 max_map_length = 1024
 
+# Flag to enable jinja2 rendering of dictionary keys inside fields of template_fields.
+# Disabled by default, and if jinja template is detected, warning is issued
+render_dict_keys = False
+
 [database]
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engines.

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -174,7 +174,7 @@ class TestBaseOperator:
             (
                 {"key_{{ foo }}_1": 1, "key_2": "{{ foo }}_2"},
                 {"foo": "bar"},
-                {"key_bar_1": 1, "key_2": "bar_2"},
+                {"key_{{ foo }}_1": 1, "key_2": "bar_2"},
             ),
             (date(2018, 12, 6), {"foo": "bar"}, date(2018, 12, 6)),
             (datetime(2018, 12, 6, 10, 55), {"foo": "bar"}, datetime(2018, 12, 6, 10, 55)),
@@ -233,6 +233,20 @@ class TestBaseOperator:
 
         result = task.render_template(content, context)
         assert result == expected_output
+
+    def test_render_template_with_flag(self):
+        """Test render_template given various input types."""
+        content = {"key_{{ foo }}_1": 1, "key_2": "{{ foo }}_2"}
+        context = {"foo": "bar"}
+        expected_output = {"key_bar_1": 1, "key_2": "bar_2"}
+
+        task = BaseOperator(task_id="op1")
+
+        with mock.patch("airflow.configuration.conf") as conf_mock:
+            conf_mock.getboolean.return_value = True
+            result = task.render_template(content, context)
+            assert result == expected_output
+            conf_mock.getboolean.assert_called_with('core', 'render_dict_keys')
 
     @pytest.mark.parametrize(
         ("content", "context", "expected_output"),

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -234,7 +234,8 @@ class TestBaseOperator:
         result = task.render_template(content, context)
         assert result == expected_output
 
-    def test_render_template_with_flag(self):
+    @mock.patch("airflow.configuration.conf.getboolean")
+    def test_render_template_with_flag(self, getboolean_mock):
         """Test render_template given various input types."""
         content = {"key_{{ foo }}_1": 1, "key_2": "{{ foo }}_2"}
         context = {"foo": "bar"}
@@ -242,11 +243,10 @@ class TestBaseOperator:
 
         task = BaseOperator(task_id="op1")
 
-        with mock.patch("airflow.configuration.conf") as conf_mock:
-            conf_mock.getboolean.return_value = True
-            result = task.render_template(content, context)
-            assert result == expected_output
-            conf_mock.getboolean.assert_called_with('core', 'render_dict_keys')
+        getboolean_mock.return_value = True
+        result = task.render_template(content, context)
+        assert result == expected_output
+        getboolean_mock.assert_called_with('core', 'render_dict_keys')
 
     @pytest.mark.parametrize(
         ("content", "context", "expected_output"),

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -174,7 +174,7 @@ class TestBaseOperator:
             (
                 {"key_{{ foo }}_1": 1, "key_2": "{{ foo }}_2"},
                 {"foo": "bar"},
-                {"key_{{ foo }}_1": 1, "key_2": "bar_2"},
+                {"key_bar_1": 1, "key_2": "bar_2"},
             ),
             (date(2018, 12, 6), {"foo": "bar"}, date(2018, 12, 6)),
             (datetime(2018, 12, 6, 10, 55), {"foo": "bar"}, datetime(2018, 12, 6, 10, 55)),

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -243,6 +243,7 @@ class TestBaseOperator:
 
         task = BaseOperator(task_id="op1")
 
+        getboolean_mock.return_value = True
         result = task.render_template(content, context)
         assert result == expected_output
         getboolean_mock.assert_called_with('core', 'render_dict_keys')

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -234,7 +234,7 @@ class TestBaseOperator:
         result = task.render_template(content, context)
         assert result == expected_output
 
-    @mock.patch("airflow.configuration.conf.getboolean")
+    @mock.patch("airflow.models.abstractoperator.conf.getboolean")
     def test_render_template_with_flag(self, getboolean_mock):
         """Test render_template given various input types."""
         content = {"key_{{ foo }}_1": 1, "key_2": "{{ foo }}_2"}
@@ -243,7 +243,6 @@ class TestBaseOperator:
 
         task = BaseOperator(task_id="op1")
 
-        getboolean_mock.return_value = True
         result = task.render_template(content, context)
         assert result == expected_output
         getboolean_mock.assert_called_with('core', 'render_dict_keys')


### PR DESCRIPTION
Currently keys stay unrendered which is confusing for the users and require workaround like explicitly using `Variable.get`, which is evaluated eagerly during dag rendering, leading to further need for workarounds.

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
