### PR TITLE
Adds Pendulum 1.x -> 2.x upgrade documentation

### DIFF
--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -365,7 +365,7 @@ For instance the following snippet will now throw errors:
 
 .. code-block:: python
 
-    execution_date.format('YYYY-MM-DD HH:mm:ss', formatter='alternative')
+    execution_date.format("YYYY-MM-DD HH:mm:ss", formatter="alternative")
 
 as the ``formatter`` option is not supported in Pendulum 2.x and ``alternative`` is used by default.
 

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -367,7 +367,7 @@ For instance the following snippet will now throw errors:
 
     execution_date.format('YYYY-MM-DD HH:mm:ss', formatter='alternative')
 
-as the `formatter` option is not supported in Pendulum 2.x and `alternative` is used by default.
+as the ``formatter`` option is not supported in Pendulum 2.x and ``alternative`` is used by default.
 
 For more information, visit https://pendulum.eustace.io/blog/pendulum-2.0.0-is-out.html
 

--- a/docs/apache-airflow/upgrading-from-1-10/index.rst
+++ b/docs/apache-airflow/upgrading-from-1-10/index.rst
@@ -355,6 +355,21 @@ Old Keys                 New keys
 
 For more information, visit https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-oauth
 
+**Breaking Change in Pendulum Support**
+
+Airflow has upgraded from Pendulum 1.x to Pendulum 2.x.
+This comes with a few breaking changes as certain methods and their definitions in Pendulum 2.x
+have changed or have been removed.
+
+For instance the following snippet will now throw errors:
+
+.. code-block:: python
+
+    execution_date.format('YYYY-MM-DD HH:mm:ss', formatter='alternative')
+
+as the `formatter` option is not supported in Pendulum 2.x and `alternative` is used by default.
+
+For more information, visit https://pendulum.eustace.io/blog/pendulum-2.0.0-is-out.html
 
 Step 6: Upgrade Configuration settings
 '''''''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
closes: #18634

Adds documentation about the upgrade from Pendulum `1.x` to `2.x` as discussed in the issue. 
 
Assumptions that were made:

- Most of the Pendulum changes are already documented in the official Pendulum docs.

Added the following: 

- Mention the upgrade from `1.x` to `2.x`
- Added an example of a code snippet that will now throw errors
- Added link to official pendulum `2.x` docs that discuss the changes from `1.x` to `2.x`

The macros documentation as mentioned in the issue were actually pointing to the updated Pendulum documentation, so no changes were added for the same. For instance, consider the link for the macro [prev_execution_date](https://pendulum.eustace.io/docs/#introduction)

As it was a documentation update, didn't run any tests.