### PR TITLE
Fix XCom.delete error in Airflow 2.2.0

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -64,6 +64,7 @@ class BaseXCom(Base, LoggingMixin):
             BaseXCom.execution_date == foreign(DagRun.execution_date)
         )""",
         uselist=False,
+        passive_deletes="all",
     )
     run_id = association_proxy("dag_run", "run_id")
 


### PR DESCRIPTION
In Airflow 2.2.0 `XCom.delete` causes error, by trying to update dag_run table dag_id and execution_date columns to NULLs.

> sqlalchemy.exc.IntegrityError: (psycopg2.errors.NotNullViolation) null value in column "dag_id" violates not-null constraint
> [SQL: UPDATE dag_run SET dag_id=%(dag_id)s, execution_date=%(execution_date)s WHERE dag_run.id = %(dag_run_id)s]
> [parameters: {'dag_id': None, 'execution_date': None, 'dag_run_id': 2409}]

Setting passive_deletes to the string value 'all' will disable the "nulling out" behavior.