### PR TITLE
Support regional GKE cluster

### DIFF
--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -117,7 +117,8 @@ class GKEHook(GoogleBaseHook):
         :return: The new, updated operation from Google Cloud
         """
         return self.get_conn().get_operation(
-            project_id=project_id or self.project_id, zone=self.location, operation_id=operation_name
+            name=f'projects/{project_id or self.project_id}'
+            + f'/locations/{self.location}/operations/{operation_name}'
         )
 
     @staticmethod
@@ -170,11 +171,13 @@ class GKEHook(GoogleBaseHook):
         :type timeout: float
         :return: The full url to the delete operation if successful, else None
         """
-        self.log.info("Deleting (project_id=%s, zone=%s, cluster_id=%s)", project_id, self.location, name)
+        self.log.info("Deleting (project_id=%s, location=%s, cluster_id=%s)", project_id, self.location, name)
 
         try:
             resource = self.get_conn().delete_cluster(
-                project_id=project_id, zone=self.location, cluster_id=name, retry=retry, timeout=timeout
+                name=f'projects/{project_id}/locations/{self.location}/clusters/{name}',
+                retry=retry,
+                timeout=timeout,
             )
             resource = self.wait_for_operation(resource)
             # Returns server-defined url for the resource
@@ -223,11 +226,14 @@ class GKEHook(GoogleBaseHook):
         self._append_label(cluster, 'airflow-version', 'v' + version.version)
 
         self.log.info(
-            "Creating (project_id=%s, zone=%s, cluster_name=%s)", project_id, self.location, cluster.name
+            "Creating (project_id=%s, location=%s, cluster_name=%s)", project_id, self.location, cluster.name
         )
         try:
             resource = self.get_conn().create_cluster(
-                project_id=project_id, zone=self.location, cluster=cluster, retry=retry, timeout=timeout
+                parent=f'projects/{project_id}/locations/{self.location}',
+                cluster=cluster,
+                retry=retry,
+                timeout=timeout,
             )
             resource = self.wait_for_operation(resource)
 
@@ -261,7 +267,7 @@ class GKEHook(GoogleBaseHook):
         :return: google.cloud.container_v1.types.Cluster
         """
         self.log.info(
-            "Fetching cluster (project_id=%s, zone=%s, cluster_name=%s)",
+            "Fetching cluster (project_id=%s, location=%s, cluster_name=%s)",
             project_id or self.project_id,
             self.location,
             name,
@@ -270,7 +276,9 @@ class GKEHook(GoogleBaseHook):
         return (
             self.get_conn()
             .get_cluster(
-                project_id=project_id, zone=self.location, cluster_id=name, retry=retry, timeout=timeout
+                name=f'projects/{project_id}/locations/{self.location}/clusters/{name}',
+                retry=retry,
+                timeout=timeout,
             )
             .self_link
         )

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -74,9 +74,7 @@ class TestGKEHookDelete(unittest.TestCase):
         )
 
         client_delete.assert_called_once_with(
-            project_id=TEST_GCP_PROJECT_ID,
-            zone=GKE_ZONE,
-            cluster_id=CLUSTER_NAME,
+            name=f'projects/{TEST_GCP_PROJECT_ID}/locations/{GKE_ZONE}/clusters/{CLUSTER_NAME}',
             retry=retry_mock,
             timeout=timeout_mock,
         )
@@ -145,8 +143,7 @@ class TestGKEHookCreate(unittest.TestCase):
         )
 
         client_create.assert_called_once_with(
-            project_id=TEST_GCP_PROJECT_ID,
-            zone=GKE_ZONE,
+            parent=f'projects/{TEST_GCP_PROJECT_ID}/locations/{GKE_ZONE}',
             cluster=mock_cluster_proto,
             retry=retry_mock,
             timeout=timeout_mock,
@@ -173,8 +170,7 @@ class TestGKEHookCreate(unittest.TestCase):
         )
 
         client_create.assert_called_once_with(
-            project_id=TEST_GCP_PROJECT_ID,
-            zone=GKE_ZONE,
+            parent=f'projects/{TEST_GCP_PROJECT_ID}/locations/{GKE_ZONE}',
             cluster=proto_mock,
             retry=retry_mock,
             timeout=timeout_mock,
@@ -228,9 +224,7 @@ class TestGKEHookGet(unittest.TestCase):
         )
 
         client_get.assert_called_once_with(
-            project_id=TEST_GCP_PROJECT_ID,
-            zone=GKE_ZONE,
-            cluster_id=CLUSTER_NAME,
+            name=f'projects/{TEST_GCP_PROJECT_ID}/locations/{GKE_ZONE}/clusters/{CLUSTER_NAME}',
             retry=retry_mock,
             timeout=timeout_mock,
         )
@@ -256,7 +250,7 @@ class TestGKEHook(unittest.TestCase):
         self.gke_hook._client.get_operation = mock.Mock()
         self.gke_hook.get_operation('TEST_OP', project_id=TEST_GCP_PROJECT_ID)
         self.gke_hook._client.get_operation.assert_called_once_with(
-            project_id=TEST_GCP_PROJECT_ID, zone=GKE_ZONE, operation_id='TEST_OP'
+            name=f'projects/{TEST_GCP_PROJECT_ID}/locations/{GKE_ZONE}/operations/TEST_OP'
         )
 
     def test_append_label(self):

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -226,10 +226,53 @@ class TestGKEPodOperator(unittest.TestCase):
                 'clusters',
                 'get-credentials',
                 CLUSTER_NAME,
-                '--zone',
-                PROJECT_LOCATION,
                 '--project',
                 TEST_GCP_PROJECT_ID,
+                '--zone',
+                PROJECT_LOCATION,
+            ]
+        )
+
+        assert self.gke_op.config_file == FILE_NAME
+
+    @mock.patch.dict(os.environ, {})
+    @mock.patch(
+        "airflow.hooks.base.BaseHook.get_connections",
+        return_value=[
+            Connection(
+                extra=json.dumps(
+                    {"extra__google_cloud_platform__keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}
+                )
+            )
+        ],
+    )
+    @mock.patch('airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
+    @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.GoogleBaseHook')
+    @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.execute_in_subprocess')
+    @mock.patch('tempfile.NamedTemporaryFile')
+    def test_execute_regional(
+        self, file_mock, mock_execute_in_subprocess, mock_gcp_hook, exec_mock, get_con_mock
+    ):
+        self.gke_op.regional = True
+        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(
+            side_effect=[FILE_NAME, '/path/to/new-file']
+        )
+
+        self.gke_op.execute(None)
+
+        mock_gcp_hook.return_value.provide_authorized_gcloud.assert_called_once()
+
+        mock_execute_in_subprocess.assert_called_once_with(
+            [
+                'gcloud',
+                'container',
+                'clusters',
+                'get-credentials',
+                CLUSTER_NAME,
+                '--project',
+                TEST_GCP_PROJECT_ID,
+                '--region',
+                PROJECT_LOCATION,
             ]
         )
 
@@ -282,10 +325,10 @@ class TestGKEPodOperator(unittest.TestCase):
                 'clusters',
                 'get-credentials',
                 CLUSTER_NAME,
-                '--zone',
-                PROJECT_LOCATION,
                 '--project',
                 TEST_GCP_PROJECT_ID,
+                '--zone',
+                PROJECT_LOCATION,
                 '--internal-ip',
             ]
         )
@@ -325,12 +368,12 @@ class TestGKEPodOperator(unittest.TestCase):
                 'clusters',
                 'get-credentials',
                 CLUSTER_NAME,
-                '--zone',
-                PROJECT_LOCATION,
                 '--project',
                 TEST_GCP_PROJECT_ID,
                 '--impersonate-service-account',
                 'test_account@example.com',
+                '--zone',
+                PROJECT_LOCATION,
             ]
         )
 
@@ -369,12 +412,12 @@ class TestGKEPodOperator(unittest.TestCase):
                 'clusters',
                 'get-credentials',
                 CLUSTER_NAME,
-                '--zone',
-                PROJECT_LOCATION,
                 '--project',
                 TEST_GCP_PROJECT_ID,
                 '--impersonate-service-account',
                 'test_account@example.com',
+                '--zone',
+                PROJECT_LOCATION,
             ]
         )
 


### PR DESCRIPTION
Currently GKE related operators support only zonal clusters. This PR makes those operators to support regional clusters.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
