### PR TITLE
Use ``execution_date`` to check for existing ``DagRun`` for ``TriggerDagRunOperator``

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -68,10 +68,10 @@ def _trigger_dag(
             )
 
     run_id = run_id or DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
-    dag_run = DagRun.find(dag_id=dag_id, run_id=run_id)
+    dag_run = DagRun.find(dag_id=dag_id, execution_date=execution_date)
 
     if dag_run:
-        raise DagRunAlreadyExists(f"Run id {run_id} already exists for dag id {dag_id}")
+        raise DagRunAlreadyExists(f"A Dag Run already exists for dag id {dag_id} at {execution_date} with run id {run_id}")
 
     run_conf = None
     if conf:

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -71,7 +71,9 @@ def _trigger_dag(
     dag_run = DagRun.find(dag_id=dag_id, execution_date=execution_date)
 
     if dag_run:
-        raise DagRunAlreadyExists(f"A Dag Run already exists for dag id {dag_id} at {execution_date} with run id {run_id}")
+        raise DagRunAlreadyExists(
+            f"A Dag Run already exists for dag id {dag_id} at {execution_date} with run id {run_id}"
+        )
 
     run_conf = None
     if conf:

--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -68,7 +68,7 @@ def _trigger_dag(
             )
 
     run_id = run_id or DagRun.generate_run_id(DagRunType.MANUAL, execution_date)
-    dag_run = DagRun.find(dag_id=dag_id, execution_date=execution_date)
+    dag_run = DagRun.find_duplicate(dag_id=dag_id, execution_date=execution_date, run_id=run_id)
 
     if dag_run:
         raise DagRunAlreadyExists(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -341,7 +341,7 @@ class DagRun(Base, LoggingMixin):
         run_id: str,
         execution_date: datetime,
         session: Session = None,
-    ) -> List["DagRun"]:
+    ) -> Optional['DagRun']:
         """
         Returns a dag run if there is an existing run for a dag at a specific run_id and execution_date.
 
@@ -358,10 +358,7 @@ class DagRun(Base, LoggingMixin):
 
         qry = session.query(DR)
 
-        qry = qry.filter(
-            DR.dag_id == dag_id,
-            or_(DR.run_id == run_id, DR.execution_date == execution_date)
-        )
+        qry = qry.filter(DR.dag_id == dag_id, or_(DR.run_id == run_id, DR.execution_date == execution_date))
 
         return qry.first()
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -305,7 +305,6 @@ class DagRun(Base, LoggingMixin):
         :param execution_end_date: dag run that was executed until this date
         :type execution_end_date: datetime.datetime
         """
-
         qry = session.query(cls)
         dag_ids = [dag_id] if isinstance(dag_id, str) else dag_id
         if dag_ids:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -357,7 +357,6 @@ class DagRun(Base, LoggingMixin):
         :param session: database session
         :type session: sqlalchemy.orm.session.Session
         """
-
         return (
             session.query(cls)
             .filter(

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -265,9 +265,10 @@ class DagRun(Base, LoggingMixin):
             query.limit(max_number), of=cls, session=session, **skip_locked(session=session)
         )
 
-    @staticmethod
+    @classmethod
     @provide_session
     def find(
+        cls,
         dag_id: Optional[Union[str, List[str]]] = None,
         run_id: Optional[str] = None,
         execution_date: Optional[Union[datetime, List[datetime]]] = None,
@@ -304,35 +305,34 @@ class DagRun(Base, LoggingMixin):
         :param execution_end_date: dag run that was executed until this date
         :type execution_end_date: datetime.datetime
         """
-        DR = DagRun
 
-        qry = session.query(DR)
+        qry = session.query(cls)
         dag_ids = [dag_id] if isinstance(dag_id, str) else dag_id
         if dag_ids:
-            qry = qry.filter(DR.dag_id.in_(dag_ids))
+            qry = qry.filter(cls.dag_id.in_(dag_ids))
         if run_id:
-            qry = qry.filter(DR.run_id == run_id)
+            qry = qry.filter(cls.run_id == run_id)
         if execution_date:
             if isinstance(execution_date, list):
-                qry = qry.filter(DR.execution_date.in_(execution_date))
+                qry = qry.filter(cls.execution_date.in_(execution_date))
             else:
-                qry = qry.filter(DR.execution_date == execution_date)
+                qry = qry.filter(cls.execution_date == execution_date)
         if execution_start_date and execution_end_date:
-            qry = qry.filter(DR.execution_date.between(execution_start_date, execution_end_date))
+            qry = qry.filter(cls.execution_date.between(execution_start_date, execution_end_date))
         elif execution_start_date:
-            qry = qry.filter(DR.execution_date >= execution_start_date)
+            qry = qry.filter(cls.execution_date >= execution_start_date)
         elif execution_end_date:
-            qry = qry.filter(DR.execution_date <= execution_end_date)
+            qry = qry.filter(cls.execution_date <= execution_end_date)
         if state:
-            qry = qry.filter(DR.state == state)
+            qry = qry.filter(cls.state == state)
         if external_trigger is not None:
-            qry = qry.filter(DR.external_trigger == external_trigger)
+            qry = qry.filter(cls.external_trigger == external_trigger)
         if run_type:
-            qry = qry.filter(DR.run_type == run_type)
+            qry = qry.filter(cls.run_type == run_type)
         if no_backfills:
-            qry = qry.filter(DR.run_type != DagRunType.BACKFILL_JOB)
+            qry = qry.filter(cls.run_type != DagRunType.BACKFILL_JOB)
 
-        return qry.order_by(DR.execution_date).all()
+        return qry.order_by(cls.execution_date).all()
 
     @classmethod
     @provide_session

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -153,7 +153,7 @@ class TriggerDagRunOperator(BaseOperator):
                 dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
                 dag = dag_bag.get_dag(self.trigger_dag_id)
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
-                dag_run = DagRun.find(dag_id=dag.dag_id, execution_date=execution_date)[0]
+                dag_run = DagRun.find(dag_id=dag.dag_id, execution_date=self.execution_date)[0]
             else:
                 raise e
 

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -153,7 +153,7 @@ class TriggerDagRunOperator(BaseOperator):
                 dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
                 dag = dag_bag.get_dag(self.trigger_dag_id)
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
-                dag_run = DagRun.find(dag_id=dag.dag_id, run_id=run_id)[0]
+                dag_run = DagRun.find(dag_id=dag.dag_id, execution_date=execution_date)[0]
             else:
                 raise e
 

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -153,7 +153,7 @@ class TriggerDagRunOperator(BaseOperator):
                 dag_bag = DagBag(dag_folder=dag_model.fileloc, read_dags_from_db=True)
                 dag = dag_bag.get_dag(self.trigger_dag_id)
                 dag.clear(start_date=self.execution_date, end_date=self.execution_date)
-                dag_run = DagRun.find(dag_id=dag.dag_id, execution_date=self.execution_date)[0]
+                dag_run = DagRun.find(dag_id=dag.dag_id, run_id=run_id)[0]
             else:
                 raise e
 

--- a/tests/api/common/experimental/test_trigger_dag.py
+++ b/tests/api/common/experimental/test_trigger_dag.py
@@ -49,7 +49,7 @@ class TestTriggerDag(unittest.TestCase):
         dag = DAG(dag_id)
         dag_bag_mock.dags = [dag_id]
         dag_bag_mock.get_dag.return_value = dag
-        dag_run_mock.find.return_value = DagRun()
+        dag_run_mock.find_duplicate.return_value = DagRun()
         with pytest.raises(AirflowException):
             _trigger_dag(dag_id, dag_bag_mock)
 
@@ -60,7 +60,7 @@ class TestTriggerDag(unittest.TestCase):
         dag_id = "trigger_dag"
         dag_bag_mock.dags = [dag_id]
         dag_bag_mock.get_dag.return_value = dag_mock
-        dag_run_mock.find.return_value = None
+        dag_run_mock.find_duplicate.return_value = None
         dag1 = mock.MagicMock(subdags=[])
         dag2 = mock.MagicMock(subdags=[])
         dag_mock.subdags = [dag1, dag2]
@@ -76,7 +76,7 @@ class TestTriggerDag(unittest.TestCase):
         dag_id = "trigger_dag"
         dag_bag_mock.dags = [dag_id]
         dag_bag_mock.get_dag.return_value = dag_mock
-        dag_run_mock.find.return_value = None
+        dag_run_mock.find_duplicate.return_value = None
         dag1 = mock.MagicMock(subdags=[])
         dag2 = mock.MagicMock(subdags=[dag1])
         dag_mock.subdags = [dag1, dag2]

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -142,6 +142,29 @@ class TestDagRun(unittest.TestCase):
         assert 0 == len(models.DagRun.find(dag_id=dag_id2, external_trigger=True))
         assert 1 == len(models.DagRun.find(dag_id=dag_id2, external_trigger=False))
 
+    def test_dagrun_find_duplicate(self):
+        session = settings.Session()
+        now = timezone.utcnow()
+
+        dag_id1 = "test_dagrun_find_duplicate"
+        dag_run = models.DagRun(
+            dag_id=dag_id1,
+            run_id=dag_id1,
+            run_type=DagRunType.MANUAL,
+            execution_date=now,
+            start_date=now,
+            state=State.RUNNING,
+            external_trigger=True,
+        )
+        session.add(dag_run)
+
+        session.commit()
+
+        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=dag_id1, execution_date=now) is not None
+        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=dag_id1, execution_date=None) is not None
+        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=None, execution_date=now) is not None
+        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=None, execution_date=None) is None
+
     def test_dagrun_success_when_all_skipped(self):
         """
         Tests that a DAG run succeeds when all tasks are skipped

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -146,10 +146,10 @@ class TestDagRun(unittest.TestCase):
         session = settings.Session()
         now = timezone.utcnow()
 
-        dag_id1 = "test_dagrun_find_duplicate"
+        dag_id = "test_dagrun_find_duplicate"
         dag_run = models.DagRun(
-            dag_id=dag_id1,
-            run_id=dag_id1,
+            dag_id=dag_id,
+            run_id=dag_id,
             run_type=DagRunType.MANUAL,
             execution_date=now,
             start_date=now,
@@ -160,10 +160,10 @@ class TestDagRun(unittest.TestCase):
 
         session.commit()
 
-        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=dag_id1, execution_date=now) is not None
-        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=dag_id1, execution_date=None) is not None
-        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=None, execution_date=now) is not None
-        assert models.DagRun.find_duplicate(dag_id=dag_id1, run_id=None, execution_date=None) is None
+        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=dag_id, execution_date=now) is not None
+        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=dag_id, execution_date=None) is not None
+        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=None, execution_date=now) is not None
+        assert models.DagRun.find_duplicate(dag_id=dag_id, run_id=None, execution_date=None) is None
 
     def test_dagrun_success_when_all_skipped(self):
         """


### PR DESCRIPTION
A small suggestion to change `DagRun.find` in `trigger_dag` to use `execution_date` as a parameter rather than `run_id`.

I feel it would be better to use this rather than `run_id` as a parameter since using `run_id` will miss out checking for a scheduled run that ran at the same `execution_date` and throw the error below when it tries to create a new run with the same `execution_date`:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "dag_run_dag_id_execution_date_key"
```

There is a constraint in `dag_run` called `dag_run_dag_id_execution_date_key` which can be found [here](https://github.com/apache/airflow/blob/c4f5233cd10ae03ee69fba861c8a6fa64e1f8a71/airflow/models/dagrun.py#L103).
