### PR TITLE
Fixes #18943 null execution date on insert to task_fail violating NOT NULL

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1702,7 +1702,8 @@ class TaskInstance(Base, LoggingMixin):
             session.add(Log(State.FAILED, self))
 
             # Log failure duration
-            session.add(TaskFail(task, self.execution_date, self.start_date, self.end_date))
+            dag_run = self.get_dagrun()  # self.dag_run not populated by refresh_from_db
+            session.add(TaskFail(task, dag_run.execution_date, self.start_date, self.end_date))
 
         # Ensure we unset next_method and next_kwargs to ensure that any
         # retries don't re-use them.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1702,7 +1702,7 @@ class TaskInstance(Base, LoggingMixin):
             session.add(Log(State.FAILED, self))
 
             # Log failure duration
-            dag_run = self.get_dagrun()  # self.dag_run not populated by refresh_from_db
+            dag_run = self.get_dagrun(session=session)  # self.dag_run not populated by refresh_from_db
             session.add(TaskFail(task, dag_run.execution_date, self.start_date, self.end_date))
 
         # Ensure we unset next_method and next_kwargs to ensure that any


### PR DESCRIPTION
Insert into task_fail table fails when reaping zombies from the dag processor.

The dag_run property isn't populated by `ti.refresh_from_db()` or by the failure handler.
This resulted in an IntegrityError violating the NOT NULL constraint on execution_date in the task_fail table on Airflow 2.2.0

See #18943 for details