### PR TITLE
Sentry before send fallback

### DIFF
--- a/airflow/sentry.py
+++ b/airflow/sentry.py
@@ -109,7 +109,7 @@ if conf.getboolean("sentry", 'sentry_on', fallback=False):
                         ", ".join(unsupported_options),
                     )
 
-                sentry_config_opts['before_send'] = conf.getimport('sentry', 'before_send')
+                sentry_config_opts['before_send'] = conf.getimport('sentry', 'before_send', fallback=None)
 
             if dsn:
                 sentry_sdk.init(dsn=dsn, integrations=integrations, **sentry_config_opts)

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -106,6 +106,21 @@ class TestSentryHook:
 
         importlib.reload(sentry)
 
+    @pytest.fixture
+    def sentry_minimum(self):
+        """
+        Minimum sentry config
+        """
+        with conf_vars({
+            ('sentry', 'sentry_on'): 'True',
+        }):
+            from airflow import sentry
+
+            importlib.reload(sentry)
+            yield sentry.Sentry
+
+        importlib.reload(sentry)
+
     def test_add_tagging(self, sentry, task_instance):
         """
         Test adding tags.
@@ -135,3 +150,10 @@ class TestSentryHook:
         called = sentry_sdk.call_args[1]['before_send']
         expected = import_string('tests.core.test_sentry.before_send')
         assert called == expected
+
+    def test_before_send_minimum_config(self, sentry_sdk, sentry_minimum):
+        """
+        Test before_send doesn't raise an exception when not set
+        """
+        assert sentry_minimum
+        sentry_sdk.assert_called_once()

--- a/tests/core/test_sentry.py
+++ b/tests/core/test_sentry.py
@@ -111,9 +111,7 @@ class TestSentryHook:
         """
         Minimum sentry config
         """
-        with conf_vars({
-            ('sentry', 'sentry_on'): 'True',
-        }):
+        with conf_vars({('sentry', 'sentry_on'): 'True'}):
             from airflow import sentry
 
             importlib.reload(sentry)


### PR DESCRIPTION
Add in a fallback to sentry before_send when reading from the config

closes: #18963
