### PR TITLE
Fix bug in Dataflow hook when no jobs are returned

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -356,10 +356,15 @@ class _DataflowJobsController(LoggingMixin):
             .jobs()
             .list(projectId=self._project_number, location=self._job_location)
         )
-        jobs: List[dict] = []
+        all_jobs: List[dict] = []
         while request is not None:
             response = request.execute(num_retries=self._num_retries)
-            jobs.extend(response["jobs"])
+            if response is None:
+                break
+            jobs = response.get("jobs")
+            if jobs is None:
+                break
+            all_jobs.extend(jobs)
 
             request = (
                 self._dataflow.projects()
@@ -367,7 +372,7 @@ class _DataflowJobsController(LoggingMixin):
                 .jobs()
                 .list_next(previous_request=request, previous_response=response)
             )
-        return jobs
+        return all_jobs
 
     def _fetch_jobs_by_prefix_name(self, prefix_name: str) -> List[dict]:
         jobs = self._fetch_all_jobs()

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -359,8 +359,6 @@ class _DataflowJobsController(LoggingMixin):
         all_jobs: List[dict] = []
         while request is not None:
             response = request.execute(num_retries=self._num_retries)
-            if response is None:
-                break
             jobs = response.get("jobs")
             if jobs is None:
                 break

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1699,16 +1699,15 @@ class TestDataflowJob(unittest.TestCase):
 
     def test_fetch_all_jobs_when_no_jobs_returned(self):
         # fmt: off
-        mock_list = (
+        (
             self.mock_dataflow
-                .projects.return_value
-                .locations.return_value
-                .jobs.return_value
-                .list
-        )
-
+            .projects.return_value
+            .locations.return_value
+            .jobs.return_value
+            .list.return_value
+            .execute.return_value
+        ) = {}
         # fmt: on
-        mock_list.return_value.execute.return_value = {}
 
         jobs_controller = _DataflowJobsController(
             dataflow=self.mock_dataflow,

--- a/tests/providers/google/cloud/hooks/test_dataflow.py
+++ b/tests/providers/google/cloud/hooks/test_dataflow.py
@@ -1697,6 +1697,28 @@ class TestDataflowJob(unittest.TestCase):
         )
         assert result == ["response_1"]
 
+    def test_fetch_all_jobs_when_no_jobs_returned(self):
+        # fmt: off
+        mock_list = (
+            self.mock_dataflow
+                .projects.return_value
+                .locations.return_value
+                .jobs.return_value
+                .list
+        )
+
+        # fmt: on
+        mock_list.return_value.execute.return_value = {}
+
+        jobs_controller = _DataflowJobsController(
+            dataflow=self.mock_dataflow,
+            project_number=TEST_PROJECT,
+            location=TEST_LOCATION,
+            job_id=TEST_JOB_ID,
+        )
+        result = jobs_controller._fetch_all_jobs()
+        assert result == []
+
     @mock.patch(DATAFLOW_STRING.format('_DataflowJobsController._fetch_list_job_messages_responses'))
     def test_fetch_job_messages_by_id(self, mock_fetch_responses):
         mock_fetch_responses.return_value = iter(


### PR DESCRIPTION
There was a bug which assumed that there will be always some job when fetching jobs from DataFlow which caused KeyError in DataFlow hook.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).