### PR TITLE
Restoring additional context in Slack operators how-to guide

### DIFF
--- a/airflow/providers/slack/example_dags/example_slack.py
+++ b/airflow/providers/slack/example_dags/example_slack.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from airflow.models.dag import DAG
 from airflow.providers.slack.operators.slack import SlackAPIFileOperator
 
+# [START slack_operator_howto_guide]
 with DAG(
     dag_id='slack_example_dag',
     schedule_interval=None,
@@ -28,21 +29,19 @@ with DAG(
     max_active_runs=1,
     tags=['example'],
 ) as dag:
-    # [START slack_operator_howto_guide_send_file]
+
     # Send file with filename and filetype
     slack_operator_file = SlackAPIFileOperator(
         task_id="slack_file_upload_1",
         filename="/files/dags/test.txt",
         filetype="txt",
     )
-    # [END slack_operator_howto_guide_send_file]
 
-    # [START slack_operator_howto_guide_send_file_content]
     # Send file content
     slack_operator_file_content = SlackAPIFileOperator(
         task_id="slack_file_upload_2",
         content="file content in txt",
     )
-    # [END slack_operator_howto_guide_send_file_content]
+    # [END slack_operator_howto_guide]
 
     slack_operator_file >> slack_operator_file_content

--- a/docs/apache-airflow-providers-slack/operators/slack_operator_howto_guide.rst
+++ b/docs/apache-airflow-providers-slack/operators/slack_operator_howto_guide.rst
@@ -25,20 +25,14 @@ Slack operators can send text messages (:class:`~airflow.providers.slack.operato
 or files (:class:`~airflow.providers.slack.operators.slack.SlackAPIPostOperator`) to specified Slack channels.
 Provide either ``slack_conn_id`` or ``token`` for the connection, and specify ``channel`` (name or ID).
 
-Example Codes for Sending Files
--------------------------------
+Example Code for Sending Files
+------------------------------
 
-Sending files by specifying file names
-
-.. exampleinclude:: /../../airflow/providers/slack/example_dags/example_slack.py
-    :language: python
-    :start-after: [START slack_operator_howto_guide_send_file]
-    :end-before: [END slack_operator_howto_guide_send_file]
-
-
-Sending files by directly providing file contents
+The example below demonstrates how to send files to a Slack channel by both specifying file names as well as
+directly providing file contents. Note that the ``slack_conn_id``, ``channel``, and ``initial_comment`` values
+for the operators are specified as ``default_args`` of the DAG.
 
 .. exampleinclude:: /../../airflow/providers/slack/example_dags/example_slack.py
     :language: python
-    :start-after: [START slack_operator_howto_guide_send_file_content]
-    :end-before: [END slack_operator_howto_guide_send_file_content]
+    :start-after: [START slack_operator_howto_guide]
+    :end-before: [END slack_operator_howto_guide]


### PR DESCRIPTION
A recent update to the Slack example DAG removed some context of using operators that users may find useful.  Some of the args were moved to `default_args` to simplify authoring of the DAG but these args disappeared from the Slack operator how-to guide as a result.  This PR should be a happy middle ground between example DAG enhancement and how-to guide showcase of the operators.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
