### PR TITLE
Document `hdfs_namenode_principal` for HDFS connections

### DIFF
--- a/docs/apache-airflow-providers-apache-hdfs/connections.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/connections.rst
@@ -44,7 +44,6 @@ Extra (optional, connection parameters)
     parameters out of the standard python parameters are supported:
 
     * ``autoconfig`` - Default value is bool: False. Use snakebite's automatically configured client. This HDFSHook implementation requires snakebite.
-    
     * ``hdfs_namenode_principal`` - Specifies the Kerberos principal to use for HDFS.
 
     The following extra parameters can be used to configure SSL for Web HDFS Hook:

--- a/docs/apache-airflow-providers-apache-hdfs/connections.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/connections.rst
@@ -44,6 +44,8 @@ Extra (optional, connection parameters)
     parameters out of the standard python parameters are supported:
 
     * ``autoconfig`` - Default value is bool: False. Use snakebite's automatically configured client. This HDFSHook implementation requires snakebite.
+    
+    * ``hdfs_namenode_principal`` - Specifies the Kerberos principal to use for HDFS.
 
     The following extra parameters can be used to configure SSL for Web HDFS Hook:
 


### PR DESCRIPTION
Documents `hdfs_namenode_principal` for HDFS connections which is supported by `HDFSHook`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
