### PR TITLE
SFTP hook to prefer the SSH paramiko key over the key file path

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -115,9 +115,6 @@ class SFTPHook(SSHHook):
                 if 'ciphers' in extra_options:
                     self.ciphers = extra_options['ciphers']
 
-                if 'private_key' in extra_options:
-                    self.key_file = extra_options.get('private_key')
-
     @tenacity.retry(
         stop=tenacity.stop_after_delay(10),
         wait=tenacity.wait_exponential(multiplier=1, max=10),
@@ -146,7 +143,9 @@ class SFTPHook(SSHHook):
             }
             if self.password and self.password.strip():
                 conn_params['password'] = self.password
-            if self.key_file:
+            if self.pkey:
+                conn_params['private_key'] = self.pkey
+            elif self.key_file:
                 conn_params['private_key'] = self.key_file
             if self.private_key_pass:
                 conn_params['private_key_pass'] = self.private_key_pass

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -146,8 +146,13 @@ class SFTPHook(SSHHook):
             }
             if self.password and self.password.strip():
                 conn_params['password'] = self.password
-            if self.key_file:
+
+            # Try to use the paramiko key from the SSH hook
+            if self.pkey:
+                conn_params['private_key'] = self.pkey
+            elif self.key_file:
                 conn_params['private_key'] = self.key_file
+
             if self.private_key_pass:
                 conn_params['private_key_pass'] = self.private_key_pass
 

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -146,13 +146,8 @@ class SFTPHook(SSHHook):
             }
             if self.password and self.password.strip():
                 conn_params['password'] = self.password
-
-            # Try to use the paramiko key from the SSH hook
-            if self.pkey:
-                conn_params['private_key'] = self.pkey
-            elif self.key_file:
+            if self.key_file:
                 conn_params['private_key'] = self.key_file
-
             if self.private_key_pass:
                 conn_params['private_key_pass'] = self.private_key_pass
 

--- a/docs/apache-airflow-providers-sftp/connections/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/connections/sftp.rst
@@ -72,7 +72,7 @@ Extra (optional)
     * ``host_key``: The base64 encoded ssh-rsa public key of the host, as you would find in the known_hosts file.
       Specifying this, along with no_host_key_check=False allows you to only make the connection if the public key of
       the endpoint matches this value.
-    * ``private_key`` Specify the path to private key file(str) or paramiko.AgentKey
+    * ``private_key`` Specify the content of the private key, the path to the private key file(str) or paramiko.AgentKey
 
 Example “extras” field:
 

--- a/docs/apache-airflow-providers-sftp/connections/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/connections/sftp.rst
@@ -32,9 +32,7 @@ There are two ways to connect to SFTP using Airflow.
 1. Use `host key
    <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.CnOpts>`_
    i.e. host key entered in extras value ``host_key``.
-2. Use a `private key, private key pass, or password
-   <https://pysftp.readthedocs.io/en/release_0.2.9/pysftp.html#pysftp.Connection>`_
-   i.e. use the ``private_key``, ``private_key_pass``, or ``private_key`` extra values.
+2. Use ``private_key`` or ``key_file``, along with the optional ``private_key_pass``
 
 Only one authorization method can be used at a time. If you need to manage multiple credentials or keys then you should
 configure multiple connections.
@@ -73,6 +71,7 @@ Extra (optional)
       Specifying this, along with no_host_key_check=False allows you to only make the connection if the public key of
       the endpoint matches this value.
     * ``private_key`` Specify the content of the private key, the path to the private key file(str) or paramiko.AgentKey
+    * ``key_file`` - Full Path of the private SSH Key file that will be used to connect to the remote_host.
 
 Example “extras” field:
 

--- a/docs/apache-airflow-providers-sftp/connections/sftp.rst
+++ b/docs/apache-airflow-providers-sftp/connections/sftp.rst
@@ -78,7 +78,7 @@ Example “extras” field:
 .. code-block:: bash
 
     {
-       "private_key": "path/to/private_key",
+       "key_file": "path/to/private_key",
        "no_host_key_check": "false",
        "allow_host_key_change": "false",
        "host_key": "AAAHD...YDWwq=="
@@ -89,11 +89,11 @@ it using URI syntax.
 
 Note that all components of the URI should be URL-encoded.
 
-Example connection string with ``private_key``:
+Example connection string with ``key_file``  (path to key file provided in connection):
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_SFTP_DEFAULT='sftp://user:pass@localhost:22?private_key=64bit-encoded-private-key'
+   export AIRFLOW_CONN_SFTP_DEFAULT='sftp://user:pass@localhost:22?key_file=%2Fhome%2Fairflow%2F.ssh%2Fid_rsa'
 
 Example connection string with ``host_key``:
 

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -51,7 +51,6 @@ TEST_HOST_KEY = generate_host_key(pkey=TEST_PKEY)
 TEST_KEY_FILE = "~/.ssh/id_rsa"
 
 
-
 class TestSFTPHook(unittest.TestCase):
     @provide_session
     def update_connection(self, login, session=None):
@@ -240,9 +239,11 @@ class TestSFTPHook(unittest.TestCase):
         connection = Connection(
             login='login',
             host='host',
-            extra=json.dumps({
-                "private_key": key_content_str,
-            }),
+            extra=json.dumps(
+                {
+                    "private_key": key_content_str,
+                }
+            ),
         )
         get_connection.return_value = connection
         hook = SFTPHook()
@@ -254,9 +255,11 @@ class TestSFTPHook(unittest.TestCase):
         connection = Connection(
             login='login',
             host='host',
-            extra=json.dumps({
-                "key_file": TEST_KEY_FILE,
-            }),
+            extra=json.dumps(
+                {
+                    "key_file": TEST_KEY_FILE,
+                }
+            ),
         )
         get_connection.return_value = connection
         hook = SFTPHook()

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -228,6 +228,22 @@ class TestSFTPHook(unittest.TestCase):
         hook = SFTPHook()
         assert hook.host_key is not None
 
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
+    def test_key_content_as_str(self, get_connection):
+        file_obj = StringIO()
+        TEST_PKEY.write_private_key(file_obj)
+        file_obj.seek(0)
+        key_content_str = file_obj.read()
+
+        connection = Connection(
+            login='login',
+            host='host',
+            extra=json.dumps({"private_key": key_content_str}),
+        )
+        get_connection.return_value = connection
+        hook = SFTPHook()
+        assert hook.pkey == TEST_PKEY
+
     @parameterized.expand(
         [
             (os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS), True),

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -48,6 +48,8 @@ SFTP_CONNECTION_USER = "root"
 
 TEST_PKEY = paramiko.RSAKey.generate(4096)
 TEST_HOST_KEY = generate_host_key(pkey=TEST_PKEY)
+TEST_KEY_FILE = "~/.ssh/id_rsa"
+
 
 
 class TestSFTPHook(unittest.TestCase):
@@ -238,11 +240,27 @@ class TestSFTPHook(unittest.TestCase):
         connection = Connection(
             login='login',
             host='host',
-            extra=json.dumps({"private_key": key_content_str}),
+            extra=json.dumps({
+                "private_key": key_content_str,
+            }),
         )
         get_connection.return_value = connection
         hook = SFTPHook()
         assert hook.pkey == TEST_PKEY
+        assert hook.key_file is None
+
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
+    def test_key_file(self, get_connection):
+        connection = Connection(
+            login='login',
+            host='host',
+            extra=json.dumps({
+                "key_file": TEST_KEY_FILE,
+            }),
+        )
+        get_connection.return_value = connection
+        hook = SFTPHook()
+        assert hook.key_file == TEST_KEY_FILE
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Related issue: [#16323](https://github.com/apache/airflow/issues/16323)

The SFTP hook does not allow for a SSH private key string to be used, only a private key file path. As it is based on the SSH hook, which does allow for a private key string to be used, a small change could align these two hooks.

This change first checks if a paramiko object is present after the SSH hook has been initialised, and the prefers that rather than the ssh key file path.

This PR replaces stale PR [#16338](https://github.com/apache/airflow/pull/16338)