### PR TITLE
Add support of placement in the DockerSwarmOperator

### DIFF
--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -105,8 +105,8 @@ class DockerSwarmOperator(DockerOperator):
     :type mode: docker.types.ServiceMode
     :param networks: List of network names or IDs or NetworkAttachmentConfig to attach the service to.
     :type networks: List[Union[str, NetworkAttachmentConfig]]
-    :param placement: Placement instructions for the scheduler. If a list is passed instead, it is assumed to be a
-        list of constraints as part of a Placement object.
+    :param placement: Placement instructions for the scheduler. If a list is passed instead,
+        it is assumed to be a list of constraints as part of a Placement object.
     :type placement: Union[types.Placement, List[types.Placement]]
     """
 

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -105,6 +105,9 @@ class DockerSwarmOperator(DockerOperator):
     :type mode: docker.types.ServiceMode
     :param networks: List of network names or IDs or NetworkAttachmentConfig to attach the service to.
     :type networks: List[Union[str, NetworkAttachmentConfig]]
+    :param placement: Placement instructions for the scheduler. If a list is passed instead, it is assumed to be a
+        list of constraints as part of a Placement object.
+    :type placement: Union[types.Placement, List[types.Placement]]
     """
 
     def __init__(
@@ -116,6 +119,7 @@ class DockerSwarmOperator(DockerOperator):
         secrets: Optional[List[types.SecretReference]] = None,
         mode: Optional[types.ServiceMode] = None,
         networks: Optional[List[Union[str, types.NetworkAttachmentConfig]]] = None,
+        placement: Optional[Union[types.Placement, List[types.Placement]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
@@ -126,6 +130,7 @@ class DockerSwarmOperator(DockerOperator):
         self.secrets = secrets
         self.mode = mode
         self.networks = networks
+        self.placement = placement
 
     def execute(self, context) -> None:
         self.cli = self._get_cli()
@@ -153,6 +158,7 @@ class DockerSwarmOperator(DockerOperator):
                 restart_policy=types.RestartPolicy(condition='none'),
                 resources=types.Resources(mem_limit=self.mem_limit),
                 networks=self.networks,
+                placement=self.placement,
             ),
             name=f'airflow-{get_random_string()}',
             labels={'name': f'airflow__{self.dag_id}__{self.task_id}'},

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -53,6 +53,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
+        types_mock.Placement.return_value = mock_obj
 
         client_class_mock.return_value = client_mock
 
@@ -71,6 +72,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             secrets=[types.SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
             mode=types.ServiceMode(mode="replicated", replicas=3),
             networks=["dummy_network"],
+            placement=types.Placement(constraints=["node.labels.region==east"])
         )
         operator.execute(None)
 
@@ -79,6 +81,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             restart_policy=mock_obj,
             resources=mock_obj,
             networks=["dummy_network"],
+            placement=mock_obj,
         )
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest',
@@ -92,6 +95,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')
+        types_mock.Placement.assert_called_once_with(constraints=["node.labels.region==east"])
 
         client_class_mock.assert_called_once_with(
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -53,7 +53,6 @@ class TestDockerSwarmOperator(unittest.TestCase):
         types_mock.ContainerSpec.return_value = mock_obj
         types_mock.RestartPolicy.return_value = mock_obj
         types_mock.Resources.return_value = mock_obj
-        types_mock.Placement.return_value = mock_obj
 
         client_class_mock.return_value = client_mock
 
@@ -81,7 +80,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             restart_policy=mock_obj,
             resources=mock_obj,
             networks=["dummy_network"],
-            placement=mock_obj,
+            placement=types.Placement(constraints=["node.labels.region==east"])
         )
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest',
@@ -95,7 +94,6 @@ class TestDockerSwarmOperator(unittest.TestCase):
         )
         types_mock.RestartPolicy.assert_called_once_with(condition='none')
         types_mock.Resources.assert_called_once_with(mem_limit='128m')
-        types_mock.Placement.assert_called_once_with(constraints=["node.labels.region==east"])
 
         client_class_mock.assert_called_once_with(
             base_url='unix://var/run/docker.sock', tls=None, version='1.19'

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -80,7 +80,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             restart_policy=mock_obj,
             resources=mock_obj,
             networks=["dummy_network"],
-            placement=types.Placement(constraints=["node.labels.region==east"])
+            placement=types.Placement(constraints=["node.labels.region==east"]),
         )
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest',

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -71,7 +71,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             secrets=[types.SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
             mode=types.ServiceMode(mode="replicated", replicas=3),
             networks=["dummy_network"],
-            placement=types.Placement(constraints=["node.labels.region==east"])
+            placement=types.Placement(constraints=["node.labels.region==east"]),
         )
         operator.execute(None)
 


### PR DESCRIPTION
This PR adds support for placement constraints in the DockerSwarmOperator.
Placement are useful to put constraints on which nodes to deploy the docker swarm service.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
