### PR TITLE
fail backfill command before loading DAGs if missing args

### DIFF
--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -67,10 +67,10 @@ def dag_backfill(args, dag=None):
     if args.ignore_first_depends_on_past is False:
         args.ignore_first_depends_on_past = True
 
-    dag = dag or get_dag(args.subdir, args.dag_id)
-
     if not args.start_date and not args.end_date:
         raise AirflowException("Provide a start_date and/or end_date")
+
+    dag = dag or get_dag(args.subdir, args.dag_id)
 
     # If only one date is passed, using same as start and end
     args.end_date = args.end_date or args.start_date

--- a/tests/cli/commands/test_dag_command.py
+++ b/tests/cli/commands/test_dag_command.py
@@ -158,6 +158,16 @@ class TestCliDags(unittest.TestCase):
         )
         mock_run.reset_mock()
 
+    @mock.patch("airflow.cli.commands.dag_command.get_dag")
+    def test_backfill_fails_without_loading_dags(self, mock_get_dag):
+
+        cli_args = self.parser.parse_args(['dags', 'backfill', 'example_bash_operator'])
+
+        with pytest.raises(AirflowException):
+            dag_command.dag_backfill(cli_args)
+
+        mock_get_dag.assert_not_called()
+
     def test_show_dag_print(self):
         with contextlib.redirect_stdout(io.StringIO()) as temp_stdout:
             dag_command.dag_show(self.parser.parse_args(['dags', 'show', 'example_bash_operator']))


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
I was looking through some of the CLI code last week trying to improve the speed of `airflow user` commands and I noticed this small issue. 

If neither the `start_date` or `end_date` argument is provided then the command will fail, but it will first parse all of the DAGs which can take up to several minutes in large deployments. 

Now the command will fail faster, allowing the user to adjust their command and retry. 
