### PR TITLE
Replace default api_version of FacebookAdsReportToGcsOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/facebook_ads_to_gcs.py
@@ -53,7 +53,8 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
     :type gcp_conn_id: str
     :param facebook_conn_id: Airflow Facebook Ads connection ID
     :type facebook_conn_id: str
-    :param api_version: The version of Facebook API. Default to v6.0
+    :param api_version: The version of Facebook API. Default to None. If it is None,
+        it will use the Facebook business SDK default version.
     :type api_version: str
     :param fields: List of fields that is obtained from Facebook. Found in AdsInsights.Field class.
         https://developers.facebook.com/docs/marketing-api/insights/parameters/v6.0
@@ -95,7 +96,7 @@ class FacebookAdsReportToGcsOperator(BaseOperator):
         params: Dict[str, Any] = None,
         parameters: Dict[str, Any] = None,
         gzip: bool = False,
-        api_version: str = "v6.0",
+        api_version: Optional[str] = None,
         gcp_conn_id: str = "google_cloud_default",
         facebook_conn_id: str = "facebook_default",
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,

--- a/tests/providers/google/cloud/transfers/test_facebook_ads_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_facebook_ads_to_gcs.py
@@ -23,7 +23,6 @@ GCS_OBJ_PATH = "Temp/this_is_my_report_json.json"
 GCS_CONN_ID = "google_cloud_default"
 IMPERSONATION_CHAIN = ["ACCOUNT_1", "ACCOUNT_2", "ACCOUNT_3"]
 FACEBOOK_ADS_CONN_ID = "facebook_default"
-API_VERSION = "v6.0"
 FIELDS = [
     "campaign_name",
     "campaign_id",
@@ -58,7 +57,7 @@ class TestFacebookAdsReportToGcsOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         op.execute({})
-        mock_ads_hook.assert_called_once_with(facebook_conn_id=FACEBOOK_ADS_CONN_ID, api_version=API_VERSION)
+        mock_ads_hook.assert_called_once_with(facebook_conn_id=FACEBOOK_ADS_CONN_ID, api_version=None)
         mock_ads_hook.return_value.bulk_facebook_report.assert_called_once_with(
             params=PARAMETERS, fields=FIELDS
         )


### PR DESCRIPTION
The `api_version` default value of `FacebookAdsReportingHook` changed in https://github.com/apache/airflow/pull/18883/ but there was also a default in `FacebookAdsReportToGcsOperator`.
This PR removes the default for the same reasons we did it in https://github.com/apache/airflow/pull/18883/ 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
