### PR TITLE
Handle case of nonexistent file when preparing file path queue

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -975,7 +975,11 @@ class DagFileProcessorManager(LoggingMixin):
         for file_path in self._file_paths:
 
             if is_mtime_mode:
-                files_with_mtime[file_path] = os.path.getmtime(file_path)
+                try:
+                    files_with_mtime[file_path] = os.path.getmtime(file_path)
+                except FileNotFoundError:
+                    self.log.warning("Skipping processing of missing file: %s", file_path)
+                    continue
                 file_modified_time = timezone.make_aware(datetime.fromtimestamp(files_with_mtime[file_path]))
             else:
                 file_paths.append(file_path)

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -372,6 +372,34 @@ class TestDagFileProcessorManager:
     @mock.patch("airflow.utils.file.find_path_from_directory", return_value=True)
     @mock.patch("airflow.utils.file.os.path.isfile", return_value=True)
     @mock.patch("airflow.utils.file.os.path.getmtime")
+    def test_file_paths_in_queue_excludes_missing_file(
+        self, mock_getmtime, mock_isfile, mock_find_path, mock_might_contain_dag, mock_zipfile
+    ):
+        """Check that a file is not enqueued for processing if it has been deleted"""
+        dag_files = ["file_3.py", "file_2.py", "file_4.py"]
+        mock_getmtime.side_effect = [1.0, 2.0, FileNotFoundError()]
+        mock_find_path.return_value = dag_files
+
+        manager = DagFileProcessorManager(
+            dag_directory='directory',
+            max_runs=1,
+            processor_timeout=timedelta.max,
+            signal_conn=MagicMock(),
+            dag_ids=[],
+            pickle_dags=False,
+            async_mode=True,
+        )
+
+        manager.set_file_paths(dag_files)
+        manager.prepare_file_path_queue()
+        assert manager._file_path_queue == ['file_2.py', 'file_3.py']
+
+    @conf_vars({("scheduler", "file_parsing_sort_mode"): "modified_time"})
+    @mock.patch("zipfile.is_zipfile", return_value=True)
+    @mock.patch("airflow.utils.file.might_contain_dag", return_value=True)
+    @mock.patch("airflow.utils.file.find_path_from_directory", return_value=True)
+    @mock.patch("airflow.utils.file.os.path.isfile", return_value=True)
+    @mock.patch("airflow.utils.file.os.path.getmtime")
     def test_recently_modified_file_is_parsed_with_mtime_mode(
         self, mock_getmtime, mock_isfile, mock_find_path, mock_might_contain_dag, mock_zipfile
     ):


### PR DESCRIPTION
In rare cases a DAG file can be deleted between the time that the DAGs directory is scanned and the time that the file itself is processed. 

This causes unhandled FileNotFoundErrors when the DagFileProcessorManager tries to get the mtime on a nonexistent file, which then crashes the DagFileProcessorManager. 

Full stack trace of the issue (from Airflow 2.1.2):

```
Traceback (most recent call last):
--
File "/usr/local/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
self.run()
File "/usr/local/lib/python3.8/multiprocessing/process.py", line 108, in run
self._target(*self._args, **self._kwargs)
File "/usr/local/lib/python3.8/site-packages/airflow/utils/dag_processing.py", line 370, in _run_processor_manager
processor_manager.start()
File "/usr/local/lib/python3.8/site-packages/airflow/utils/dag_processing.py", line 610, in start
return self._run_parsing_loop()
File "/usr/local/lib/python3.8/site-packages/airflow/utils/dag_processing.py", line 684, in _run_parsing_loop
self.prepare_file_path_queue()
File "/usr/local/lib/python3.8/site-packages/airflow/utils/dag_processing.py", line 1055, in prepare_file_path_queue
files_with_mtime[file_path] = os.path.getmtime(file_path)
File "/usr/local/lib/python3.8/genericpath.py", line 55, in getmtime
return os.stat(filename).st_mtime
FileNotFoundError: [Errno 2] No such file or directory: '/path/to/dag.py'
```

Followed shortly by:
```
2021-10-08 00:53:04,896 {dag_processing.py:401} WARNING - DagFileProcessorManager (PID=1362135) exited with exit code 1 - re-launching
```

This PR introduces handling for this case - FileNotFoundErrors will now be handled gracefully and those file paths will be removed from the finalized processing queue. 