### PR TITLE
Add form to delete "moved" tables from web UI

### DIFF
--- a/airflow/security/permissions.py
+++ b/airflow/security/permissions.py
@@ -32,6 +32,7 @@ RESOURCE_DAG_CODE = "DAG Code"
 RESOURCE_DAG_RUN = "DAG Runs"
 RESOURCE_IMPORT_ERROR = "ImportError"
 RESOURCE_JOB = "Jobs"
+RESOURCE_MOVED_DATA = "Moved Data"  # Data moved during db upgrade.
 RESOURCE_MY_PASSWORD = "My Password"
 RESOURCE_MY_PROFILE = "My Profile"
 RESOURCE_PASSWORD = "Passwords"

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -56,7 +56,7 @@ from airflow.utils.session import create_global_lock, create_session, provide_se
 log = logging.getLogger(__name__)
 
 
-def _format_airflow_moved_table_name(source_table, version):
+def format_airflow_moved_table_name(source_table, version):
     return "__".join([settings.AIRFLOW_MOVED_TABLE_PREFIX, version.replace(".", "_"), source_table])
 
 
@@ -735,7 +735,7 @@ def check_run_id_null(session) -> Iterable[str]:
     )
     invalid_dagrun_count = session.query(dagrun_table.c.id).filter(invalid_dagrun_filter).count()
     if invalid_dagrun_count > 0:
-        dagrun_dangling_table_name = _format_airflow_moved_table_name(dagrun_table.name, "2.2")
+        dagrun_dangling_table_name = format_airflow_moved_table_name(dagrun_table.name, "2.2")
         if dagrun_dangling_table_name in inspect(session.get_bind()).get_table_names():
             yield _format_dangling_error(
                 source_table=dagrun_table.name,
@@ -810,7 +810,7 @@ def check_task_tables_without_matching_dagruns(session) -> Iterable[str]:
         if invalid_row_count <= 0:
             continue
 
-        dangling_table_name = _format_airflow_moved_table_name(source_table.name, "2.2")
+        dangling_table_name = format_airflow_moved_table_name(source_table.name, "2.2")
         if dangling_table_name in existing_table_names:
             yield _format_dangling_error(
                 source_table=source_table.name,

--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -145,6 +145,7 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_PASSWORD),
         (permissions.ACTION_CAN_READ, permissions.RESOURCE_ROLE),
         (permissions.ACTION_CAN_EDIT, permissions.RESOURCE_ROLE),
+        (permissions.ACTION_CAN_DELETE, permissions.RESOURCE_MOVED_TABLE),
     ]
 
     # global resource for dag-level access

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -55,22 +55,27 @@
     {% call message(category='error', dismissable=false) %}
       Airflow found incompatible data in the <code>{{ original_table_name }}</code> table in the
       metadatabase, and has moved them to <code>{{ moved_table_name }}</code> during the database migration
-      to upgrade. Please inspect the moved data to decide whether you need to keep them, and manually drop
-      the <code>{{ moved_table_name }}</code> table to dismiss this warning.
+      to upgrade. Please inspect the moved data to decide whether you need to keep them, and drop the
+      <code>{{ moved_table_name }}</code> table to dismiss this warning.
+      <form action="{{ url_for('Airflow.delete_moved_table') }}" method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}" />
+        <input type="hidden" name="original_table_name" value="{{ original_table_name }}" />
+        <button type="submit" class="btn btn-error">Drop <code>{{ moved_table_name }}</code> now.</button>
+      </form>
     {% endcall %}
   {% endfor %}
   {{ super() }}
   {% if sqlite_warning | default(true) %}
-    {% call message(category='warning', dismissable=false)  %}
+    {% call message(category='warning', dismissable=false) %}
       Do not use <b>SQLite</b> as metadata DB in production &#8211; it should only be used for dev/testing
       We recommend using Postgres or MySQL.
-      <a href={{ get_docs_url("howto/set-up-database.html") }}><b>Click here</b></a> for more information.
+      <a href="{{ get_docs_url('howto/set-up-database.html') }}"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
   {% if sequential_executor_warning | default(false) %}
     {% call message(category='warning', dismissable=false)  %}
       Do not use <b>SequentialExecutor</b> in production.
-      <a href={{ get_docs_url("executor/index.html") }}><b>Click here</b></a> for more information.
+      <a href="{{ get_docs_url('executor/index.html') }}"><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
The "data moved" errors are now only shown to admin users that are
authorized to delete those data from UI. The form posts to a new view
for this specific purpose and redirect back to the home page after
completion.

One obvious issue with the current implementation is that, if the web
server's db connection lacks the DROP TABLE permission, the deletion
view will kaboom and emit 500. Is there a way to detect db permission
via SQLAlchemy or the DBAPI?
