### PR TITLE
Increase default liveness probe timeout

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1225,17 +1225,17 @@
                         "timeoutSeconds": {
                             "description": "Scheduler Liveness probe timeout seconds.",
                             "type": "integer",
-                            "default": 5
+                            "default": 10
                         },
                         "failureThreshold": {
                             "description": "Scheduler Liveness probe failure threshold.",
                             "type": "integer",
-                            "default": 10
+                            "default": 5
                         },
                         "periodSeconds": {
                             "description": "Scheduler Liveness probe period seconds.",
                             "type": "integer",
-                            "default": 30
+                            "default": 60
                         }
                     }
                 },
@@ -1478,17 +1478,17 @@
                         "timeoutSeconds": {
                             "description": "Triggerer Liveness probe timeout seconds.",
                             "type": "integer",
-                            "default": 5
+                            "default": 10
                         },
                         "failureThreshold": {
                             "description": "Triggerer Liveness probe failure threshold.",
                             "type": "integer",
-                            "default": 10
+                            "default": 5
                         },
                         "periodSeconds": {
                             "description": "Triggerer Liveness probe period seconds.",
                             "type": "integer",
-                            "default": 30
+                            "default": 60
                         }
                     }
                 },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -505,13 +505,13 @@ workers:
 
 # Airflow scheduler settings
 scheduler:
-  # If the scheduler stops heartbeating for 5 minutes (10*30s) kill the
+  # If the scheduler stops heartbeating for 5 minutes (5*60s) kill the
   # scheduler and let Kubernetes restart it
   livenessProbe:
     initialDelaySeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 10
-    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 5
+    periodSeconds: 60
   # Airflow 2.0 allows users to run multiple schedulers,
   # However this feature is only recommended for MySQL 8+ and Postgres
   replicas: 1
@@ -786,13 +786,13 @@ triggerer:
       maxSurge: "100%"
       maxUnavailable: "50%"
 
-  # If the triggerer stops heartbeating for 5 minutes (10*30s) kill the
+  # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
   # triggerer and let Kubernetes restart it
   livenessProbe:
     initialDelaySeconds: 10
-    timeoutSeconds: 5
-    failureThreshold: 10
-    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 5
+    periodSeconds: 60
 
   # Create ServiceAccount
   serviceAccount:


### PR DESCRIPTION
In practice the liveness probe can regularly take longer than 5 seconds.  

10 seems like a better default. 

Because it seems to take longer than perhaps initially expected, it seems reasonable to reduce the check frequency to not consume as much CPU.  Though perhaps there's a reason for checking more frequently, so whatever you think on that...

To keep the max downtime to 5 minutes after increasing the check period, I reduce number of failed checks to 5.

closes https://github.com/apache/airflow/issues/19001