### PR TITLE
Workaround libstdcpp TLS error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -487,5 +487,14 @@ LABEL org.apache.airflow.distro="debian" \
 # to learn more about the way how signals are handled by the image
 ENV DUMB_INIT_SETSID="1"
 
+# This one is to workaround https://github.com/apache/airflow/issues/17546
+# issue with /usr/lib/x86_64-linux-gnu/libstdc++.so.6: cannot allocate memory in static TLS block
+# We do not yet a more "correct" solution to the problem but in order to avoid raising new issues
+# by users of the prod image, we implement the workaround now.
+# The side effect of this is slightly (in the range of 100s of milliseconds) slower load for any
+# binary started and a little memory used for Heap allocated by initialization of libstdc++
+# This overhead is not happening for binaries that already link dynamically libstdc++
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libstdc++.so.6"
+
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
 CMD []

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -400,6 +400,16 @@ LABEL org.apache.airflow.distro="debian" \
   org.opencontainers.image.title="Continuous Integration Airflow Image" \
   org.opencontainers.image.description="Installed Apache Airflow with Continuous Integration dependencies"
 
+# This one is to workaround https://github.com/apache/airflow/issues/17546
+# issue with /usr/lib/x86_64-linux-gnu/libstdc++.so.6: cannot allocate memory in static TLS block
+# We do not yet a more "correct" solution to the problem but in order to avoid raising new issues
+# by users of the prod image, we implement the workaround now.
+# The side effect of this is slightly (in the range of 100s of milliseconds) slower load for any
+# binary started and a little memory used for Heap allocated by initialization of libstdc++
+# This overhead is not happening for binaries that already link dynamically libstdc++
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libstdc++.so.6"
+
+
 EXPOSE 8080
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]


### PR DESCRIPTION
Workaround https://github.com/apache/airflow/issues/17546 issue with
/usr/lib/x86_64-linux-gnu/libstdc++.so.6: cannot allocate memory in
static TLS block.

We do not yet a more "correct" solution to the problem but in order to
avoid raising new issues by users of the prod image, we implement the
workaround now.

The side effect of this is slightly (in the range of 100s of
milliseconds) slower load for any binary started and a little memory
used for Heap allocated by initialization of libstdc++.

This overhead is not happening for binaries that already link
dynamically libstdc++.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
