### PR TITLE
fixed incorrect KubernetesPodOperator param name

### DIFF
--- a/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
+++ b/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py
@@ -57,7 +57,7 @@ init_environments = [k8s.V1EnvVar(name='key1', value='value1'), k8s.V1EnvVar(nam
 init_container = k8s.V1Container(
     name="init-container",
     image="ubuntu:16.04",
-    env=init_environments,
+    env_vars=init_environments,
     volume_mounts=init_container_volume_mounts,
     command=["bash", "-cx"],
     args=["echo 10"],


### PR DESCRIPTION
This change fixes an incorrect parameter name in the "init_container" in the example dag for using the KubernetesPodOperator. 

The current doc has the parameter name as "env", which is incorrect, found here: https://github.com/apache/airflow/blob/6032159aadc65b39d385dfa4d24e7f77899f6d46/airflow/providers/cncf/kubernetes/example_dags/example_kubernetes.py#L60 and this change makes it "env_vars".

Kubernetes Pod Operator param: https://github.com/apache/airflow/blob/b8d06e812ac56af6b0d17830c63b705ace9d4959/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py#L188

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
