### PR TITLE
Removing redundant max_tis_per_query initialisation on SchedulerJob

### DIFF
--- a/airflow/jobs/base_job.py
+++ b/airflow/jobs/base_job.py
@@ -105,7 +105,7 @@ class BaseJob(Base, LoggingMixin):
         if heartrate is not None:
             self.heartrate = heartrate
         self.unixname = getuser()
-        self.max_tis_per_query = conf.getint('scheduler', 'max_tis_per_query')
+        self.max_tis_per_query: int = conf.getint('scheduler', 'max_tis_per_query')
         super().__init__(*args, **kwargs)
 
     @cached_property

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -141,7 +141,6 @@ class SchedulerJob(BaseJob):
         self.using_sqlite = sql_conn.startswith('sqlite')
         self.using_mysql = sql_conn.startswith('mysql')
 
-        self.max_tis_per_query: int = conf.getint('scheduler', 'max_tis_per_query')
         self.processor_agent: Optional[DagFileProcessorAgent] = None
 
         self.dagbag = DagBag(dag_folder=self.subdir, read_dags_from_db=True, load_op_links=False)


### PR DESCRIPTION
This is redundant initialisation as it's super class (Base) does exactly the same initialisation inside its own init. 
Removing to clean code duplication.
  
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
