### PR TITLE
GithubTeamAuthorizer example should activate the security manager class

### DIFF
--- a/docs/apache-airflow/security/webserver.rst
+++ b/docs/apache-airflow/security/webserver.rst
@@ -234,6 +234,8 @@ webserver_config.py itself if you wish.
                 f"User info from Github: {user_data}\n" f"Team info from Github: {teams}"
             )
             return {"username": "github_" + user_data.get("login"), "role_keys": roles}
+            
+    SECURITY_MANAGER_CLASS = GithubTeamAuthorizer
 
 
 SSL


### PR DESCRIPTION
It appears `SECURITY_MANAGER_CLASS` is the setting to use if you want to provide AirflowAppBuilder with a custom security manager class instance.

https://github.com/apache/airflow/blob/ee8e0b3a2a87a76bcaf088960bce35a6cee8c500/airflow/www/extensions/init_appbuilder.py#L28

