### PR TITLE
CloudwatchTaskHandler params to create log group/stream

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -193,8 +193,8 @@ if REMOTE_LOGGING:
 
         DEFAULT_LOGGING_CONFIG['handlers'].update(S3_REMOTE_HANDLERS)
     elif REMOTE_BASE_LOG_FOLDER.startswith('cloudwatch://'):
-        create_log_group = conf.get('logging', 'CREATE_CLOUDWATCH_LOG_GROUP', fallback=True)
-        create_log_stream = conf.get('logging', 'CREATE_CLOUDWATCH_LOG_STREAM', fallback=True)
+        create_log_group = conf.getboolean('logging', 'CREATE_CLOUDWATCH_LOG_GROUP', fallback=True)
+        create_log_stream = conf.getboolean('logging', 'CREATE_CLOUDWATCH_LOG_STREAM', fallback=True)
         CLOUDWATCH_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
                 'class': 'airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudwatchTaskHandler',

--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -31,7 +31,6 @@ from airflow.exceptions import AirflowException
 # settings.py and cli.py. Please see AIRFLOW-1455.
 LOG_LEVEL: str = conf.get('logging', 'LOGGING_LEVEL').upper()
 
-
 # Flask appbuilder's info level log is very verbose,
 # so it's set to 'WARN' by default.
 FAB_LOG_LEVEL: str = conf.get('logging', 'FAB_LOGGING_LEVEL').upper()
@@ -194,6 +193,8 @@ if REMOTE_LOGGING:
 
         DEFAULT_LOGGING_CONFIG['handlers'].update(S3_REMOTE_HANDLERS)
     elif REMOTE_BASE_LOG_FOLDER.startswith('cloudwatch://'):
+        create_log_group = conf.get('logging', 'CREATE_CLOUDWATCH_LOG_GROUP', fallback=True)
+        create_log_stream = conf.get('logging', 'CREATE_CLOUDWATCH_LOG_STREAM', fallback=True)
         CLOUDWATCH_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
                 'class': 'airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudwatchTaskHandler',
@@ -201,6 +202,8 @@ if REMOTE_LOGGING:
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
                 'log_group_arn': urlparse(REMOTE_BASE_LOG_FOLDER).netloc,
                 'filename_template': FILENAME_TEMPLATE,
+                'create_log_group': create_log_group,
+                'create_log_stream': create_log_stream,
             },
         }
 

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -620,6 +620,20 @@
       type: string
       example: ~
       default: "8793"
+    - name: create_cloudwatch_log_group
+      description: |
+        Automatically create Cloudwatch log group for Cloudwatch logs
+      version_added: 2.3.0
+      type: string
+      example: ~
+      default: "True"
+    - name: create_cloudwatch_log_stream
+      description: |
+        Automatically create Cloudwatch log stream for Cloudwatch logs
+      version_added: 2.3.0
+      type: string
+      example: ~
+      default: "True"
 - name: metrics
   description: |
     StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -342,6 +342,12 @@ extra_logger_names =
 # visible from the main web server to connect into the workers.
 worker_log_server_port = 8793
 
+# Automatically create Cloudwatch log group for Cloudwatch logs
+create_cloudwatch_log_group = True
+
+# Automatically create Cloudwatch log stream for Cloudwatch logs
+create_cloudwatch_log_stream = True
+
 [metrics]
 
 # StatsD (https://github.com/etsy/statsd) integration settings.

--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -43,9 +43,20 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
     :type log_group_arn: str
     :param filename_template: template for file name (local storage) or log stream name (remote)
     :type filename_template: str
+    :param create_log_group: whether to create Cloudwatch log group
+    :type create_log_group: bool
+    :param create_log_stream: whether to create Cloudwatch log stream
+    :type create_log_stream: bool
     """
 
-    def __init__(self, base_log_folder: str, log_group_arn: str, filename_template: str):
+    def __init__(
+        self,
+        base_log_folder: str,
+        log_group_arn: str,
+        filename_template: str,
+        create_log_group: bool = True,
+        create_log_stream: bool = True,
+    ):
         super().__init__(base_log_folder, filename_template)
         split_arn = log_group_arn.split(':')
 
@@ -53,6 +64,8 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         self.log_group = split_arn[6]
         self.region_name = split_arn[3]
         self.closed = False
+        self.create_log_group = create_log_group
+        self.create_log_stream = create_log_stream
 
     @cached_property
     def hook(self):
@@ -82,6 +95,8 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
             log_group=self.log_group,
             stream_name=self._render_filename(ti, ti.try_number),
             boto3_session=self.hook.get_session(self.region_name),
+            create_log_group=self.create_log_group,
+            create_log_stream=self.create_log_stream,
         )
 
     def close(self):

--- a/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
+++ b/tests/providers/amazon/aws/log/test_cloudwatch_task_handler.py
@@ -104,6 +104,11 @@ class TestCloudwatchTaskHandler(unittest.TestCase):
         self.cloudwatch_task_handler.set_context(self.ti)
         assert isinstance(self.cloudwatch_task_handler.handler, CloudWatchLogHandler)
 
+    def test_create_log_stream(self):
+        handler = self.cloudwatch_task_handler
+        handler.set_context(self.ti)
+        assert handler.handler.create_log_stream is True
+
     def test_write(self):
         handler = self.cloudwatch_task_handler
         handler.set_context(self.ti)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #18549
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #18549

**Todo:**
- [X] Add `__init__` params for CloudwatchTaskHandler which are passed to `watchtower.CloudWatchLogHandler` to control whether a log group/stream are to be created
- [X] Add this to [airflow_local_settings.py](https://github.com/apache/airflow/blob/main/airflow/config_templates/airflow_local_settings.py#L197) with values being read from the config. 

Based on the approach mentioned in the following [comment](https://github.com/apache/airflow/issues/18549#issuecomment-937851583)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
