### PR TITLE
Simplify "invalid TI state" message

### DIFF
--- a/airflow/ti_deps/deps/valid_state_dep.py
+++ b/airflow/ti_deps/deps/valid_state_dep.py
@@ -57,9 +57,4 @@ class ValidStateDep(BaseTIDep):
             yield self._passing_status(reason=f"Task state {ti.state} was valid.")
             return
 
-        yield self._failing_status(
-            reason=(
-                f"Task is in the '{ti.state}' state which is not a valid state for execution. "
-                f"The task must be cleared in order to be run."
-            )
-        )
+        yield self._failing_status(reason=f"Task is in the '{ti.state}' state.")

--- a/tests/www/views/test_views_tasks.py
+++ b/tests/www/views/test_views_tasks.py
@@ -477,10 +477,7 @@ def test_run_with_runnable_states(_, admin_client, session, state):
     resp = admin_client.post('run', data=form, follow_redirects=True)
     check_content_in_response('', resp)
 
-    msg = (
-        f"Task is in the &#39;{state}&#39; state which is not a valid state for "
-        f"execution. The task must be cleared in order to be run"
-    )
+    msg = f"Task is in the &#39;{state}&#39 state."
     assert not re.search(msg, resp.get_data(as_text=True))
 
 
@@ -509,10 +506,7 @@ def test_run_with_not_runnable_states(_, admin_client, session, state):
     resp = admin_client.post('run', data=form, follow_redirects=True)
     check_content_in_response('', resp)
 
-    msg = (
-        f"Task is in the &#39;{state}&#39; state which is not a valid state for "
-        f"execution. The task must be cleared in order to be run"
-    )
+    msg = f"Task is in the &#39;{state}&#39; state."
     assert re.search(msg, resp.get_data(as_text=True))
 
 


### PR DESCRIPTION
Currently in the web UI on task instance details page, if a task is in the "up for retry" state
we will see this message:

> Task is in the up_for_retry state which is not a valid state for execution. The task must be cleared in order to be run.

First of all, there's nothing really "invalid" about this state -- it's expected that sometimes tasks will fail, then be in up-for-retry state before being retried.  So, it is a valid state, and it will get picked up after the retry interval.

But the language "The task must be cleared in order to be run" suggests to the user "you need to clear this in order for this task to run".  But this is not true.  

Unfortunately it is not simple to make it clearer, because this function is used for a lot of different scenarios.  For example, checking for "schedulable" tasks, and "queueable" tasks. So not only would we need to keep track of which states actually require user intervention, but the desired action (e.g. queue vs schedule vs run). 

So I think the best course of action is to amend this to say less, i.e. to say only what is always true, which is simply the state.

