### PR TITLE
Align EcsOperator with DockerOperator capabilities

### DIFF
--- a/airflow/providers/amazon/aws/operators/ecs.py
+++ b/airflow/providers/amazon/aws/operators/ecs.py
@@ -120,7 +120,7 @@ class ECSTaskLogFetcher(Thread):
                 logs_to_skip += 1
             time.sleep(self.fetch_interval.total_seconds())
 
-    def _get_log_events(self, start_from_head=True, skip: int = 0) -> Generator:
+    def _get_log_events(self, skip: int = 0, *, start_from_head: bool = True) -> Generator:
         try:
             yield from self.hook.get_log_events(self.log_group, self.log_stream_name, start_from_head=start_from_head,
                                                 skip=skip)


### PR DESCRIPTION
Hello, I would like some opinions on this PR, it has no open issue,
but it's something I have encountered and fix locally in Airflow 2.0.2, and the code hasn't change in main branch.

Please note this PR has two main changes:

- adding a missing feature, aligning functionality with similar Operator
- refactoring for efficiency and responsivness sake

1. DockerOperator has** the option to send the entire container log into xcom return_value, not just the last line
EcsOperator doesn't have this option, it defaults to only sending the last line, This commit changes that behaviour, adding xcom_all parameter to the Operator, to enable sending all logs lines.

2. In addition, the get_last_log_message function has been refactored,
In an edge case where the log is bigger than 1 MB (up to 10,000 log events) as per aws docs,
it is possible that the function would cause more than one 'GetLogEvents' AWS API call because it defaults to read the logstream/group from beginning,
and using deque with queue size of 1, it would iterate over the entire generator yields, calling get_log_events as much as it needs,
just so that when the generator is exhausted, the queue would keep only the last event, this is a waste of time and data transfer,
AWS get_log_events method has start_from_head parameter, which can be used to actually tail the event log instead of reading from head!
in combination with a single next() yield, we can ensure we only call get_log_events once, and within the response, grab the last message

** DockerOperator is actually also unstable in regard to xcoms, see issue #18874 and PR #19027