### PR TITLE
Adjust trimmed_pod_id and replace '.' with '-'

### DIFF
--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -466,8 +466,7 @@ class PodGenerator:
         trimmed_pod_id = pod_id[:label_prefix_length].rstrip('-.')
 
         # previously used a '.' as the separator, but this could create errors in some situations
-        safe_pod_id = f"{trimmed_pod_id}-{safe_uuid}"
-        return safe_pod_id
+        return f"{trimmed_pod_id}-{safe_uuid}"
 
 
 def merge_objects(base_obj, client_obj):

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -462,10 +462,10 @@ class PodGenerator:
 
         # Get prefix length after subtracting the uuid length. Clean up . and - from
         # end of podID because they can't be followed by '.'
-        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid)
+        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid) - 1 # -1 for seperator
         trimmed_pod_id = pod_id[:label_prefix_length].rstrip('-.')
 
-        # previously used a '.' as the seperator, but this could create errors in some situations
+        # previously used a '.' as the separator, but this could create errors in some situations
         safe_pod_id = f"{trimmed_pod_id}-{safe_uuid}"
         return safe_pod_id
 

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -462,7 +462,7 @@ class PodGenerator:
 
         # Get prefix length after subtracting the uuid length. Clean up . and - from
         # end of podID because they can't be followed by '.'
-        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid) - 1 # -1 for seperator
+        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid) - 1 # -1 for separator
         trimmed_pod_id = pod_id[:label_prefix_length].rstrip('-.')
 
         # previously used a '.' as the separator, but this could create errors in some situations

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -459,9 +459,13 @@ class PodGenerator:
             return None
 
         safe_uuid = uuid.uuid4().hex  # safe uuid will always be less than 63 chars
-        # Strip trailing '-' and '.' as they can't be followed by '.'
-        trimmed_pod_id = pod_id[:MAX_LABEL_LEN-len(safe_uuid)].rstrip('-.')
 
+        # Get prefix length after subtracting the uuid length. Clean up . and - from
+        # end of podID because they can't be followed by '.'
+        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid)
+        trimmed_pod_id = pod_id[:label_prefix_length].rstrip('-.')
+
+        # previously used a '.' as the seperator, but this could create errors in some situations
         safe_pod_id = f"{trimmed_pod_id}-{safe_uuid}"
         return safe_pod_id
 

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -462,7 +462,7 @@ class PodGenerator:
 
         # Get prefix length after subtracting the uuid length. Clean up . and - from
         # end of podID because they can't be followed by '.'
-        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid) - 1 # -1 for separator
+        label_prefix_length = MAX_LABEL_LEN - len(safe_uuid) - 1  # -1 for separator
         trimmed_pod_id = pod_id[:label_prefix_length].rstrip('-.')
 
         # previously used a '.' as the separator, but this could create errors in some situations

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -460,8 +460,8 @@ class PodGenerator:
 
         safe_uuid = uuid.uuid4().hex  # safe uuid will always be less than 63 chars
 
-        # Get prefix length after subtracting the uuid length. Clean up . and - from
-        # end of podID because they can't be followed by '.'
+        # Get prefix length after subtracting the uuid length. Clean up '.' and '-' from
+        # end of podID ('.' can't be followed by '-').
         label_prefix_length = MAX_LABEL_LEN - len(safe_uuid) - 1  # -1 for separator
         trimmed_pod_id = pod_id[:label_prefix_length].rstrip('-.')
 

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -460,9 +460,9 @@ class PodGenerator:
 
         safe_uuid = uuid.uuid4().hex  # safe uuid will always be less than 63 chars
         # Strip trailing '-' and '.' as they can't be followed by '.'
-        trimmed_pod_id = pod_id[:MAX_LABEL_LEN].rstrip('-.')
+        trimmed_pod_id = pod_id[:MAX_LABEL_LEN-len(safe_uuid)].rstrip('-.')
 
-        safe_pod_id = f"{trimmed_pod_id}.{safe_uuid}"
+        safe_pod_id = f"{trimmed_pod_id}-{safe_uuid}"
         return safe_pod_id
 
 

--- a/tests/kubernetes/models/test_secret.py
+++ b/tests/kubernetes/models/test_secret.py
@@ -83,7 +83,7 @@ class TestSecret(unittest.TestCase):
             'kind': 'Pod',
             'metadata': {
                 'labels': {'app': 'myapp'},
-                'name': 'myapp-pod.cf4a56d281014217b0272af6216feb48',
+                'name': 'myapp-pod-cf4a56d281014217b0272af6216feb48',
                 'namespace': 'default',
             },
             'spec': {

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -502,9 +502,8 @@ class TestPodGenerator:
             pod_override_object=None,
             base_worker_pod=worker_config,
         )
-        len_uuid = len(self.static_uuid.hex)
 
-        assert result.metadata.name == 'a' * (63 - len_uuid) + '-' + self.static_uuid.hex
+        assert result.metadata.name == ('a' * 63)[:-33] + '-' + self.static_uuid.hex
         for _, v in result.metadata.labels.items():
             assert len(v) <= 63
 
@@ -665,8 +664,9 @@ class TestPodGenerator:
     def test_pod_name_confirm_to_max_length(self, _, pod_id):
         name = PodGenerator.make_unique_pod_id(pod_id)
         assert len(name) <= 253
+        #parts = name[:-33]
         parts = name.split("-")
-        if len(pod_id) <= 63:
+        if len(pod_id) <= 63-33:
             assert len(parts[0]) == len(pod_id)
         else:
             assert len(parts[0]) <= 63
@@ -691,7 +691,7 @@ class TestPodGenerator:
             len(name) <= 253 and all(ch.lower() == ch for ch in name) and re.match(regex, name)
         ), "pod_id is invalid - fails allowed regex check"
 
-        assert name.rsplit("-")[0] == expected_starts_with
+        assert name[:-33] == expected_starts_with
 
     def test_deserialize_model_string(self):
         fixture = """

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -667,7 +667,7 @@ class TestPodGenerator:
         parts = name.split("-")
 
         # 63 is the MAX_LABEL_LEN in pod_generator.py
-        # 33 is the length of uuid4 + 1 for the seperating '-' (32 + 1)
+        # 33 is the length of uuid4 + 1 for the separating '-' (32 + 1)
         # 30 is the max length of the prefix
         # so 30 = 63 - (32 + 1)
         assert len(parts[0]) <= 30

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -503,7 +503,7 @@ class TestPodGenerator:
             base_worker_pod=worker_config,
         )
 
-        assert result.metadata.name == ('a' * 63)[:-33] + '-' + self.static_uuid.hex
+        assert result.metadata.name == 'a' * 30 + '-' + self.static_uuid.hex
         for _, v in result.metadata.labels.items():
             assert len(v) <= 63
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -672,7 +672,6 @@ class TestPodGenerator:
             assert len(parts[0]) <= 63
         assert len(parts[1]) <= 63
 
-    @mock.patch(uuid.uuid4)
     @parameterized.expand(
         (
             ("pod-name-with-hyphen-", "pod-name-with-hyphen"),

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -665,11 +665,8 @@ class TestPodGenerator:
         name = PodGenerator.make_unique_pod_id(pod_id)
         assert len(name) <= 253
         parts = name.split("-")
-        if len(pod_id) <= 63 - 33:
-            assert len(parts[0]) == len(pod_id)
-        else:
-            assert len(parts[0]) <= 63
-        assert len(parts[1]) == 32
+        assert parts[0] == pod_id[:30]
+        assert len(parts[1]) <= 63
 
     @parameterized.expand(
         (

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -687,7 +687,7 @@ class TestPodGenerator:
             len(name) <= 253 and all(ch.lower() == ch for ch in name) and re.match(regex, name)
         ), "pod_id is invalid - fails allowed regex check"
 
-        assert name[:-33] == expected_starts_with
+        assert name.rsplit("-")[0] == expected_starts_with
 
     def test_deserialize_model_string(self):
         fixture = """

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -109,7 +109,7 @@ class TestPodGenerator:
             kind="Pod",
             metadata=k8s.V1ObjectMeta(
                 namespace="default",
-                name='myapp-pod.' + self.static_uuid.hex,
+                name='myapp-pod-' + self.static_uuid.hex,
                 labels={'app': 'myapp'},
             ),
             spec=k8s.V1PodSpec(
@@ -433,7 +433,7 @@ class TestPodGenerator:
         expected.metadata.labels = self.labels
         expected.metadata.labels['app'] = 'myapp'
         expected.metadata.annotations = self.annotations
-        expected.metadata.name = 'pod_id.' + self.static_uuid.hex
+        expected.metadata.name = 'pod_id-' + self.static_uuid.hex
         expected.metadata.namespace = 'test_namespace'
         expected.spec.containers[0].args = ['command']
         expected.spec.containers[0].image = expected_image
@@ -475,7 +475,7 @@ class TestPodGenerator:
         worker_config.metadata.annotations = self.annotations
         worker_config.metadata.labels = self.labels
         worker_config.metadata.labels['app'] = 'myapp'
-        worker_config.metadata.name = 'pod_id.' + self.static_uuid.hex
+        worker_config.metadata.name = 'pod_id-' + self.static_uuid.hex
         worker_config.metadata.namespace = 'namespace'
         worker_config.spec.containers[0].env.append(
             k8s.V1EnvVar(name="AIRFLOW_IS_K8S_EXECUTOR_POD", value='True')
@@ -502,8 +502,9 @@ class TestPodGenerator:
             pod_override_object=None,
             base_worker_pod=worker_config,
         )
+        len_uuid = len(self.static_uuid.hex)
 
-        assert result.metadata.name == 'a' * 63 + '-' + self.static_uuid.hex
+        assert result.metadata.name == 'a' * (63 - len_uuid) + '-' + self.static_uuid.hex
         for _, v in result.metadata.labels.items():
             assert len(v) <= 63
 

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -687,7 +687,7 @@ class TestPodGenerator:
             len(name) <= 253 and all(ch.lower() == ch for ch in name) and re.match(regex, name)
         ), "pod_id is invalid - fails allowed regex check"
 
-        assert name.rsplit("-")[0] == expected_starts_with
+        assert name.rsplit("-", 1)[0] == expected_starts_with
 
     def test_deserialize_model_string(self):
         fixture = """

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -665,8 +665,13 @@ class TestPodGenerator:
         name = PodGenerator.make_unique_pod_id(pod_id)
         assert len(name) <= 253
         parts = name.split("-")
-        assert parts[0] == pod_id[:30]
-        assert len(parts[1]) <= 63
+
+        # 63 is the MAX_LABEL_LEN in pod_generator.py
+        # 33 is the length of uuid4 + 1 for the seperating '-' (32 + 1)
+        # 30 is the max length of the prefix
+        # so 30 = 63 - (32 + 1)
+        assert len(parts[0]) <= 30
+        assert len(parts[1]) == 32
 
     @parameterized.expand(
         (

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -503,7 +503,7 @@ class TestPodGenerator:
             base_worker_pod=worker_config,
         )
 
-        assert result.metadata.name == 'a' * 63 + '.' + self.static_uuid.hex
+        assert result.metadata.name == 'a' * 63 + '-' + self.static_uuid.hex
         for _, v in result.metadata.labels.items():
             assert len(v) <= 63
 
@@ -664,13 +664,14 @@ class TestPodGenerator:
     def test_pod_name_confirm_to_max_length(self, _, pod_id):
         name = PodGenerator.make_unique_pod_id(pod_id)
         assert len(name) <= 253
-        parts = name.split(".")
+        parts = name.split("-")
         if len(pod_id) <= 63:
             assert len(parts[0]) == len(pod_id)
         else:
             assert len(parts[0]) <= 63
         assert len(parts[1]) <= 63
 
+    @mock.patch(uuid.uuid4)
     @parameterized.expand(
         (
             ("pod-name-with-hyphen-", "pod-name-with-hyphen"),
@@ -690,7 +691,7 @@ class TestPodGenerator:
             len(name) <= 253 and all(ch.lower() == ch for ch in name) and re.match(regex, name)
         ), "pod_id is invalid - fails allowed regex check"
 
-        assert name.rsplit(".")[0] == expected_starts_with
+        assert name.rsplit("-")[0] == expected_starts_with
 
     def test_deserialize_model_string(self):
         fixture = """

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -669,7 +669,7 @@ class TestPodGenerator:
             assert len(parts[0]) == len(pod_id)
         else:
             assert len(parts[0]) <= 63
-        assert len(parts[1]) <= 63
+        assert len(parts[1]) == 32
 
     @parameterized.expand(
         (

--- a/tests/kubernetes/test_pod_generator.py
+++ b/tests/kubernetes/test_pod_generator.py
@@ -664,9 +664,8 @@ class TestPodGenerator:
     def test_pod_name_confirm_to_max_length(self, _, pod_id):
         name = PodGenerator.make_unique_pod_id(pod_id)
         assert len(name) <= 253
-        #parts = name[:-33]
         parts = name.split("-")
-        if len(pod_id) <= 63-33:
+        if len(pod_id) <= 63 - 33:
             assert len(parts[0]) == len(pod_id)
         else:
             assert len(parts[0]) <= 63


### PR DESCRIPTION

closes: #16611 
related: #16980

Having a period in the name could cause issues with the hostname. Reverting to hyphen will should fix the issues. I also included changes talked about in a [previous PR](https://github.com/apache/airflow/pull/16980#pullrequestreview-721302569).
