### PR TITLE
Replacing non-attribute template_fields for BigQueryToMsSqlOperator

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_bigquery_to_mssql.py
+++ b/airflow/providers/google/cloud/example_dags/example_bigquery_to_mssql.py
@@ -44,7 +44,7 @@ with models.DAG(
 ) as dag:
     bigquery_to_mssql = BigQueryToMsSqlOperator(
         task_id="bigquery_to_mssql",
-        source_project_dataset_table=f'{DATASET_NAME}.{TABLE}',
+        source_project_dataset_table=f'{PROJECT_ID}.{DATASET_NAME}.{TABLE}',
         mssql_table=destination_table,
         replace=False,
     )

--- a/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_mssql.py
@@ -82,12 +82,7 @@ class BigQueryToMsSqlOperator(BaseOperator):
     :type impersonation_chain: Union[str, Sequence[str]]
     """
 
-    template_fields = (
-        'dataset_id',
-        'table_id',
-        'mssql_table',
-        'impersonation_chain',
-    )
+    template_fields = ('source_project_dataset_table', 'mssql_table', 'impersonation_chain')
 
     def __init__(
         self,


### PR DESCRIPTION
The `BigQueryToMsSqlOperator` has `template_fields` values for attributes that do not exist for the operator: `dataset_id` and `table_id`.  As a result, the following exception is thrown during task execution as reported in #19047:

```
AttributeError: 'BigQueryToMsSqlOperator' object has no attribute 'dataset_id'
```

This PR replaces both `dataset_id` and `table_id` for `source_project_dataset_table` in the operator's `template_fields`.  Additionally the corresponding example DAG, `example_bigquery_to_mssql`, has been updated such that the `source_project_dataset_table` arg used is a correct, fully-qualified ID to mitigate DAG failure if run.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
