### PR TITLE
Referencing Connections in tutorial doc

### DIFF
--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -374,26 +374,29 @@ Lets look at another example; we need to get some data from a file which is host
 Initial setup
 ''''''''''''''''''''
 We need to have docker and postgres installed.
-We will be using this `docker file <https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html#docker-compose-yaml>`_
+We will be using this :doc:`docker file <start/docker>`
 Follow the instructions properly to set up Airflow.
 
 .. note::
-    Airflow manages databases using `connections <https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html>`.
+
+    Airflow manages databases using :doc:`connections <howto/connection>`.
     When running the code below, you will need to either configure a relevant postgres connection named ``postgres_docker`` or configure one
     as appropriate for your system and update the code below to reference the appropriate Connection id.
 
-    If using the aforementioned `docker setup <https://airflow.apache.org/docs/apache-airflow/stable/start/docker.html#docker-compose-yaml>`
+    If using the aforementioned :doc:`docker setup <start/docker>`
     note that none of the out-of-the-box connections are quite right; you will likely (either via the webserver UI or command line)
     want to add a docker-appropriate postgres connection (the following creates one that matches postgres as
-    configured in ``docker-compose.yml``)
+    configured in ``docker-compose.yml``):
 
-    .. code-block:: bash
-        airflow connections add 'postgres_docker' \
-            --conn-type 'postgres' \
-            --conn-login 'airflow' \
-            --conn-password 'airflow' \
-            --conn-host 'postgres' \
-            --conn-schema 'airflow'
+.. code-block:: bash
+
+    airflow connections add 'postgres_docker' \
+        --conn-type 'postgres' \
+        --conn-login 'airflow' \
+        --conn-password 'airflow' \
+        --conn-host 'postgres' \
+        --conn-schema 'airflow'
+
 
 Create a Employee table in postgres using this
 


### PR DESCRIPTION
closes: #18950 

- added notes on configuring a `Connection` in tutorial example
- added logging to tutorial example
- used streaming ingest in tutorial example

## Questions/alternatives

A simpler approach for a new engineer here would be if the default airflow docker postgres configuration matched the default postgres connection defined in `airflow/utils/db.py`. That is, `postgres_default` defines username (er "login") `postgres`, while the airflow `docker-compose.yml` file uses login `airflow`. If these matched, the tutorial could skip the preamble and would work out of the box with a hard-coded connection id of `postgres_default`.

I've chosen to update the documentation to match the current realities here, as I'm new to airflow and am not clear on what impact changing `docker-compose` or the default postgres connection would have.
