### PR TITLE
Chart: allow specifying keytab in values.yaml

### DIFF
--- a/chart/templates/secrets/kerberos-keytab.yaml
+++ b/chart/templates/secrets/kerberos-keytab.yaml
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{ if .Values.kerberos.keytabBase64Content }}
+apiVersion: v1
+metadata:
+  name: {{ include "kerberos_keytab_secret" . | quote }}
+  labels:
+    tier: airflow
+    component: webserver
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+data:
+  kerberos.keytab: {{ .Values.kerberos.keytabBase64Content }}
+kind: Secret
+type: Opaque
+{{ end }}

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -68,6 +68,7 @@ spec:
         checksum/result-backend-secret: {{ include (print $.Template.BasePath "/secrets/result-backend-connection-secret.yaml") . | sha256sum }}
         checksum/pgbouncer-config-secret: {{ include (print $.Template.BasePath "/secrets/pgbouncer-config-secret.yaml") . | sha256sum }}
         checksum/webserver-secret-key: {{ include (print $.Template.BasePath "/secrets/webserver-secret-key-secret.yaml") . | sha256sum }}
+        checksum/kerberos-keytab: {{ include (print $.Template.BasePath "/secrets/kerberos-keytab.yaml") . | sha256sum }}
         checksum/airflow-config: {{ include (print $.Template.BasePath "/configmaps/configmap.yaml") . | sha256sum }}
         checksum/extra-configmaps: {{ include (print $.Template.BasePath "/configmaps/extra-configmaps.yaml") . | sha256sum }}
         checksum/extra-secrets: {{ include (print $.Template.BasePath "/secrets/extra-secrets.yaml") . | sha256sum }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -862,6 +862,14 @@
                     "type": "string",
                     "default": "/etc/krb5.conf"
                 },
+                "keytabBase64Content": {
+                    "description": "Kerberos keytab base64 encoded content.",
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "default": null
+                },
                 "keytabPath": {
                     "description": "Path to mount the keytab for refreshing credentials in the kerberos sidecar.",
                     "type": "string",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -327,11 +327,17 @@ webserverSecretKeySecretName: ~
 #
 #  kubectl create secret generic {{ .Release.name }}-kerberos-keytab --from-file=kerberos.keytab
 #
+#
+#  Alternatively, instead of manually creating the secret, it is possible to specify
+#  kerberos.keytabBase64Content parameter. This parameter should contain base64 encoded keytab.
+#
+
 kerberos:
   enabled: false
   ccacheMountPath: /var/kerberos-ccache
   ccacheFileName: cache
   configPath: /etc/krb5.conf
+  keytabBase64Content: ~
   keytabPath: /etc/airflow.keytab
   principal: airflow@FOO.COM
   reinitFrequency: 3600


### PR DESCRIPTION
This PR adds parameter for specifying base64 encoded keytab content in values.yaml. This makes it possible to manage keytab updates with the chart.