### PR TITLE
Warn about unsupported Python 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ MariaDB is not tested/recommended.
 **Note**: SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development.
 
-**Note**: Python v3.10 is not supported yet. For details, see. [#19059](https://github.com/apache/airflow/issues/19059)
+**Note**: Python v3.10 is not supported yet. For details, see [#19059](https://github.com/apache/airflow/issues/19059).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ MariaDB is not tested/recommended.
 **Note**: SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development.
 
+**Note**: Python v3.10 is not supported yet. For details, see. [#19059](https://github.com/apache/airflow/issues/19059)
+
 ## Getting started
 
 Visit the official Airflow website documentation (latest **stable** release) for help with

--- a/airflow/__init__.py
+++ b/airflow/__init__.py
@@ -36,7 +36,7 @@ from airflow import version
 
 __version__ = version.version
 
-__all__ = ['__version__', 'login', 'DAG', 'PY36', 'PY37', 'PY38', 'PY39']
+__all__ = ['__version__', 'login', 'DAG', 'PY36', 'PY37', 'PY38', 'PY39', 'PY310']
 
 # Make `airflow` an namespace package, supporting installing
 # airflow.providers.* in different locations (i.e. one in site, and one in user
@@ -51,6 +51,7 @@ PY36 = sys.version_info >= (3, 6)
 PY37 = sys.version_info >= (3, 7)
 PY38 = sys.version_info >= (3, 8)
 PY39 = sys.version_info >= (3, 9)
+PY310 = sys.version_info >= (3, 10)
 
 
 def __getattr__(name):

--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -19,7 +19,6 @@
 # under the License.
 
 """Main executable module"""
-import logging
 import os
 import warnings
 
@@ -29,8 +28,6 @@ from airflow import PY310
 from airflow.cli import cli_parser
 from airflow.configuration import conf
 from airflow.utils.docs import get_docs_url
-
-log = logging.getLogger(__file__)
 
 
 def main():

--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -19,13 +19,16 @@
 # under the License.
 
 """Main executable module"""
-
+import logging
 import os
 
 import argcomplete
 
+from airflow import PY310
 from airflow.cli import cli_parser
 from airflow.configuration import conf
+
+log = logging.getLogger(__file__)
 
 
 def main():
@@ -33,6 +36,11 @@ def main():
     if conf.get("core", "security") == 'kerberos':
         os.environ['KRB5CCNAME'] = conf.get('kerberos', 'ccache')
         os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
+    if PY310:
+        log.warning(
+            "Python 3.10 is not official supported yet. Please be careful. For details, see: "
+            "https://github.com/apache/airflow/issues/19059"
+        )
 
     parser = cli_parser.get_parser()
     argcomplete.autocomplete(parser)

--- a/airflow/__main__.py
+++ b/airflow/__main__.py
@@ -21,12 +21,14 @@
 """Main executable module"""
 import logging
 import os
+import warnings
 
 import argcomplete
 
 from airflow import PY310
 from airflow.cli import cli_parser
 from airflow.configuration import conf
+from airflow.utils.docs import get_docs_url
 
 log = logging.getLogger(__file__)
 
@@ -37,9 +39,10 @@ def main():
         os.environ['KRB5CCNAME'] = conf.get('kerberos', 'ccache')
         os.environ['KRB5_KTNAME'] = conf.get('kerberos', 'keytab')
     if PY310:
-        log.warning(
-            "Python 3.10 is not official supported yet. Please be careful. For details, see: "
-            "https://github.com/apache/airflow/issues/19059"
+        docs_url = get_docs_url('installation/prerequisites.html')
+        warnings.warn(
+            "Python v3.10 is not official supported on this version of Airflow. Please be careful. "
+            f"For details, see: {docs_url}"
         )
 
     parser = cli_parser.get_parser()

--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -37,6 +37,8 @@ running multiple schedulers -- please see: :doc:`/concepts/scheduler`. MariaDB i
 **Note:** SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development.
 
+**Note**: Python v3.10 is not supported yet. For details, see. `#19059 <https://github.com/apache/airflow/issues/19059>`__
+
 Starting with Airflow 2.1.2, Airflow is tested with Python 3.6, 3.7, 3.8, and 3.9.
 
 The minimum memory required we recommend Airflow to run with is 4GB, but the actual requirements depends

--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -37,7 +37,7 @@ running multiple schedulers -- please see: :doc:`/concepts/scheduler`. MariaDB i
 **Note:** SQLite is used in Airflow tests. Do not use it in production. We recommend
 using the latest stable version of SQLite for local development.
 
-**Note**: Python v3.10 is not supported yet. For details, see. `#19059 <https://github.com/apache/airflow/issues/19059>`__
+**Note**: Python v3.10 is not supported yet. For details, see `#19059 <https://github.com/apache/airflow/issues/19059>`__.
 
 Starting with Airflow 2.1.2, Airflow is tested with Python 3.6, 3.7, 3.8, and 3.9.
 


### PR DESCRIPTION
Related: https://github.com/apache/airflow/issues/19059
Some users are unaware of the supported Python versions and then have trouble using Airflow. It's best to alert them to be aware of potential compatibility issues. For example, see: 
https://stackoverflow.com/questions/69615585/unable-to-start-airflow-webserver-with-python-3-10

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
