### PR TITLE
Rename trigger page label to Logical Date

### DIFF
--- a/airflow/www/templates/airflow/trigger.html
+++ b/airflow/www/templates/airflow/trigger.html
@@ -36,7 +36,7 @@
     <input type="hidden" name="dag_id" value="{{ dag_id }}">
     <input type="hidden" name="origin" value="{{ origin }}">
   <div class="form-group">
-      <label class="sr-only" for="execution_date">Execution date</label>
+      <label class="sr-only" for="execution_date">Logical date</label>
       <div class="input-group">
         {{ form.execution_date(class_="form-control", disabled=False) }}
       </div>


### PR DESCRIPTION
AIP-39 changed the canonical name from Execution Date, and this should match it.

I'm wondering whether we should change the trigger page to have _two_ calendar pickers to represent the data interval's start and end in the longer term instead (the end date being optional). But this should do for now.