### PR TITLE
Static start_date and default arg cleanup for Microsoft providers example DAGs

### DIFF
--- a/airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_adls_delete.py
@@ -16,11 +16,11 @@
 # under the License.
 
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.microsoft.azure.operators.adls import ADLSDeleteOperator
 from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalFilesystemToADLSOperator
-from airflow.utils.dates import days_ago
 
 LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", 'localfile.txt')
 REMOTE_FILE_PATH = os.environ.get("REMOTE_LOCAL_PATH", 'remote.txt')
@@ -28,7 +28,7 @@ REMOTE_FILE_PATH = os.environ.get("REMOTE_LOCAL_PATH", 'remote.txt')
 
 with models.DAG(
     "example_adls_delete",
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     schedule_interval=None,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_container_instances.py
@@ -27,17 +27,10 @@ from airflow.providers.microsoft.azure.operators.azure_container_instances impor
 
 with DAG(
     dag_id='aci_example',
-    default_args={
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'email': ['airflow@example.com'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-        'retries': 1,
-        'retry_delay': timedelta(minutes=5),
-    },
-    schedule_interval=timedelta(1),
+    default_args={'retries': 1},
+    schedule_interval=timedelta(days=1),
     start_date=datetime(2018, 11, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
 

--- a/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_azure_cosmosdb.py
@@ -26,39 +26,31 @@ You can trigger this manually with `airflow dags trigger example_cosmosdb_sensor
 this example.*
 """
 
+from datetime import datetime
+
 from airflow import DAG
 from airflow.providers.microsoft.azure.operators.azure_cosmos import AzureCosmosInsertDocumentOperator
 from airflow.providers.microsoft.azure.sensors.azure_cosmos import AzureCosmosDocumentSensor
-from airflow.utils import dates
 
 with DAG(
     dag_id='example_azure_cosmosdb_sensor',
-    default_args={
-        'owner': 'airflow',
-        'depends_on_past': False,
-        'email': ['airflow@example.com'],
-        'email_on_failure': False,
-        'email_on_retry': False,
-    },
-    start_date=dates.days_ago(2),
+    default_args={'database_name': 'airflow_example_db'},
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
     doc_md=__doc__,
     tags=['example'],
 ) as dag:
 
     t1 = AzureCosmosDocumentSensor(
         task_id='check_cosmos_file',
-        database_name='airflow_example_db',
         collection_name='airflow_example_coll',
         document_id='airflow_checkid',
-        azure_cosmos_conn_id='azure_cosmos_default',
     )
 
     t2 = AzureCosmosInsertDocumentOperator(
         task_id='insert_cosmos_file',
-        database_name='airflow_example_db',
         collection_name='new-collection',
         document={"id": "someuniqueid", "param1": "value1", "param2": "value2"},
-        azure_cosmos_conn_id='azure_cosmos_default',
     )
 
     t1 >> t2

--- a/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
@@ -15,10 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime
+
 from airflow.decorators import task
 from airflow.models import DAG
 from airflow.providers.microsoft.azure.hooks.azure_fileshare import AzureFileShareHook
-from airflow.utils.dates import days_ago
 
 NAME = 'myfileshare'
 DIRECTORY = "mydirectory"
@@ -42,5 +43,5 @@ def delete_fileshare():
     hook.delete_share(NAME)
 
 
-with DAG("example_fileshare", schedule_interval="@once", start_date=days_ago(2)) as dag:
+with DAG("example_fileshare", schedule_interval="@once", start_date=datetime(2021, 1, 1)) as dag:
     create_fileshare() >> delete_fileshare()

--- a/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.py
@@ -16,18 +16,18 @@
 # under the License.
 
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.microsoft.azure.operators.adls import ADLSDeleteOperator
 from airflow.providers.microsoft.azure.transfers.local_to_adls import LocalFilesystemToADLSOperator
-from airflow.utils.dates import days_ago
 
 LOCAL_FILE_PATH = os.environ.get("LOCAL_FILE_PATH", 'localfile.txt')
 REMOTE_FILE_PATH = os.environ.get("REMOTE_LOCAL_PATH", 'remote.txt')
 
 with models.DAG(
     "example_local_to_adls",
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     schedule_interval=None,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/microsoft/azure/example_dags/example_local_to_wasb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_local_to_wasb.py
@@ -16,17 +16,21 @@
 # under the License.
 
 import os
+from datetime import datetime
 
 from airflow.models import DAG
 from airflow.providers.microsoft.azure.operators.wasb_delete_blob import WasbDeleteBlobOperator
 from airflow.providers.microsoft.azure.transfers.local_to_wasb import LocalFilesystemToWasbOperator
-from airflow.utils.dates import days_ago
 
 PATH_TO_UPLOAD_FILE = os.environ.get('AZURE_PATH_TO_UPLOAD_FILE', 'example-text.txt')
 
-with DAG("example_local_to_wasb", schedule_interval="@once", start_date=days_ago(2)) as dag:
-    upload = LocalFilesystemToWasbOperator(
-        task_id="upload_file", file_path=PATH_TO_UPLOAD_FILE, container_name="mycontainer", blob_name='myblob'
-    )
-    delete = WasbDeleteBlobOperator(task_id="delete_file", container_name="mycontainer", blob_name="myblob")
+with DAG(
+    "example_local_to_wasb",
+    schedule_interval="@once",
+    start_date=datetime(2021, 1, 1),
+    default_args={"container_name": "mycontainer", "blob_name": "myblob"},
+) as dag:
+    upload = LocalFilesystemToWasbOperator(task_id="upload_file", file_path=PATH_TO_UPLOAD_FILE)
+    delete = WasbDeleteBlobOperator(task_id="delete_file")
+
     upload >> delete

--- a/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
+++ b/airflow/providers/microsoft/winrm/example_dags/example_winrm.py
@@ -28,23 +28,22 @@
 """
 This is an example dag for using the WinRMOperator.
 """
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.providers.microsoft.winrm.hooks.winrm import WinRMHook
 from airflow.providers.microsoft.winrm.operators.winrm import WinRMOperator
-from airflow.utils.dates import days_ago
 
 with DAG(
     dag_id='POC_winrm_parallel',
     schedule_interval='0 0 * * *',
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     dagrun_timeout=timedelta(minutes=60),
     tags=['example'],
+    catchup=False,
 ) as dag:
 
-    cmd = 'ls -l'
     run_this_last = DummyOperator(task_id='run_this_last')
 
     winRMHook = WinRMHook(ssh_conn_id='ssh_POC1')

--- a/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/operators/azure_blob_to_gcs.rst
@@ -51,10 +51,10 @@ Operator transfers data from Azure Blob Storage to specified bucket in Google Cl
 
 To get information about jobs within a Azure Blob Storage use:
 :class:`~airflow.providers.microsoft.azure.transfers.azure_blob_to_gcs.AzureBlobStorageToGCSOperator`
+
 Example usage:
 
 .. exampleinclude:: /../../airflow/providers/microsoft/azure/example_dags/example_azure_blob_to_gcs.py
     :language: python
-    :dedent: 4
     :start-after: [START how_to_azure_blob_to_gcs]
     :end-before: [END how_to_azure_blob_to_gcs]


### PR DESCRIPTION
There is an ongoing effort to enhance example DAGs by setting static values for `start_date` (already complete for core example DAGs), cleaning up and/or implementing useful `default_args`, and removing/limiting the use of redundant, default connection ID values.

This PR mainly addresses these 3 cleanup areas in example DAGs across Microsoft providers.  There are other small docs updates.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
