### PR TITLE
Rename execution date in forms and tables

### DIFF
--- a/airflow/www/forms.py
+++ b/airflow/www/forms.py
@@ -90,7 +90,7 @@ class DateTimeWithTimezoneField(Field):
 class DateTimeForm(FlaskForm):
     """Date filter form needed for task views"""
 
-    execution_date = DateTimeWithTimezoneField("Execution date", widget=AirflowDateTimePickerWidget())
+    execution_date = DateTimeWithTimezoneField("Logical date", widget=AirflowDateTimePickerWidget())
 
 
 class DateTimeWithNumRunsForm(FlaskForm):
@@ -133,7 +133,7 @@ class DagRunEditForm(DynamicForm):
     run_id = StringField(lazy_gettext('Run Id'), widget=BS3TextFieldROWidget())
     state = StringField(lazy_gettext('State'), widget=BS3TextFieldROWidget())
     execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'),
+        lazy_gettext('Logical Date'),
         widget=AirflowDateTimePickerROWidget(),
     )
     conf = TextAreaField(lazy_gettext('Conf'), widget=BS3TextAreaROWidget())
@@ -167,7 +167,7 @@ class TaskInstanceEditForm(DynamicForm):
         validators=[InputRequired()],
     )
     execution_date = DateTimeWithTimezoneField(
-        lazy_gettext('Execution Date'),
+        lazy_gettext('Logical Date'),
         widget=AirflowDateTimePickerROWidget(),
         validators=[InputRequired()],
     )

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3231,6 +3231,11 @@ class SlaMissModelView(AirflowModelView):
     ]
 
     list_columns = ['dag_id', 'task_id', 'execution_date', 'email_sent', 'timestamp']
+
+    label_columns = {
+        'execution_date': 'Logical Date',
+    }
+
     add_columns = ['dag_id', 'task_id', 'execution_date', 'email_sent', 'timestamp']
     edit_columns = ['dag_id', 'task_id', 'execution_date', 'email_sent', 'timestamp']
     search_columns = ['dag_id', 'task_id', 'email_sent', 'timestamp', 'execution_date']
@@ -3266,6 +3271,10 @@ class XComModelView(AirflowModelView):
         permissions.ACTION_CAN_DELETE,
         permissions.ACTION_CAN_ACCESS_MENU,
     ]
+
+    label_columns = {
+        'execution_date': 'Logical Date',
+    }
 
     search_columns = ['key', 'value', 'timestamp', 'execution_date', 'task_id', 'dag_id']
     list_columns = ['key', 'value', 'timestamp', 'execution_date', 'task_id', 'dag_id']
@@ -3943,6 +3952,9 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'end_date',
         'external_trigger',
     ]
+    label_columns = {
+        'execution_date': 'Logical Date',
+    }
     edit_columns = ['state', 'dag_id', 'execution_date', 'start_date', 'end_date', 'run_id', 'conf']
 
     base_order = ('execution_date', 'desc')
@@ -4087,6 +4099,10 @@ class LogModelView(AirflowModelView):
     list_columns = ['id', 'dttm', 'dag_id', 'task_id', 'event', 'execution_date', 'owner', 'extra']
     search_columns = ['dag_id', 'task_id', 'event', 'execution_date', 'owner', 'extra']
 
+    label_columns = {
+        'execution_date': 'Logical Date',
+    }
+
     base_order = ('dttm', 'desc')
 
     base_filters = [['dag_id', DagFilter, lambda: []]]
@@ -4130,7 +4146,7 @@ class TaskRescheduleModelView(AirflowModelView):
     ]
 
     label_columns = {
-        'dag_run.execution_date': 'Execution Date',
+        'dag_run.execution_date': 'Logical Date',
     }
 
     search_columns = [
@@ -4261,7 +4277,7 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
     ]
 
     label_columns = {
-        'dag_run.execution_date': 'Execution Date',
+        'dag_run.execution_date': 'Logical Date',
     }
 
     search_columns = [


### PR DESCRIPTION
Update references of "Execution Date" to "Logical Date" in forms and tables of the UI.

Examples:
<img width="670" alt="Screen Shot 2021-10-18 at 9 48 05 PM" src="https://user-images.githubusercontent.com/4600967/137837436-d77879cc-fcba-4d46-9024-c1160ef42c2c.png">
<img width="455" alt="Screen Shot 2021-10-18 at 9 51 08 PM" src="https://user-images.githubusercontent.com/4600967/137837438-a0304dea-217f-47d3-80d8-08090d3e724c.png">

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
