### PR TITLE
Remove distutils usages for Python 3.10

### DIFF
--- a/airflow/operators/sql.py
+++ b/airflow/operators/sql.py
@@ -15,7 +15,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from distutils.util import strtobool
 from typing import Any, Dict, Iterable, List, Mapping, Optional, SupportsAbs, Union
 
 from airflow.compat.functools import cached_property
@@ -23,6 +22,19 @@ from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 from airflow.hooks.dbapi import DbApiHook
 from airflow.models import BaseOperator, SkipMixin
+
+
+def parse_boolean(val: str) -> Union[str, bool]:
+    """Try to parse a string into boolean.
+
+    Raises ValueError if the input is not a valid true- or false-like string value.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    if val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    raise ValueError(f"{val!r} is not a boolean-like string value")
 
 
 class BaseSQLOperator(BaseOperator):
@@ -538,7 +550,7 @@ class BranchSQLOperator(BaseSQLOperator, SkipMixin):
                     follow_branch = self.follow_task_ids_if_true
             elif isinstance(query_result, str):
                 # return result is not Boolean, try to convert from String to Boolean
-                if bool(strtobool(query_result)):
+                if parse_boolean(query_result):
                     follow_branch = self.follow_task_ids_if_true
             elif isinstance(query_result, int):
                 if bool(query_result):

--- a/airflow/providers/jenkins/hooks/jenkins.py
+++ b/airflow/providers/jenkins/hooks/jenkins.py
@@ -17,11 +17,10 @@
 # under the License.
 #
 
-from distutils.util import strtobool
-
 import jenkins
 
 from airflow.hooks.base import BaseHook
+from airflow.utils.strings import to_boolean
 
 
 class JenkinsHook(BaseHook):
@@ -38,11 +37,7 @@ class JenkinsHook(BaseHook):
         self.connection = connection
         connection_prefix = 'http'
         # connection.extra contains info about using https (true) or http (false)
-        if connection.extra is None or connection.extra == '':
-            connection.extra = 'false'
-            # set a default value to connection.extra
-            # to avoid rising ValueError in strtobool
-        if strtobool(connection.extra):
+        if to_boolean(connection.extra):
             connection_prefix = 'https'
         url = f'{connection_prefix}://{connection.host}:{connection.port}'
         self.log.info('Trying to connect to %s', url)

--- a/airflow/utils/strings.py
+++ b/airflow/utils/strings.py
@@ -18,6 +18,7 @@
 
 import string
 from random import choice
+from typing import Optional
 
 
 def get_random_string(length=8, choices=string.ascii_letters + string.digits):
@@ -25,6 +26,13 @@ def get_random_string(length=8, choices=string.ascii_letters + string.digits):
     return ''.join(choice(choices) for _ in range(length))
 
 
-def to_boolean(astring):
-    """Convert a string to a boolean"""
-    return False if astring is None else astring.lower() in ['true', 't', 'y', 'yes', '1']
+TRUE_LIKE_VALUES = {"on", "t", "true", "y", "yes", "1"}
+
+
+def to_boolean(astring: Optional[str]) -> bool:
+    """Convert a string to a boolean."""
+    if astring is None:
+        return False
+    if astring.lower() in TRUE_LIKE_VALUES:
+        return True
+    return False

--- a/dev/provider_packages/remove_old_releases.py
+++ b/dev/provider_packages/remove_old_releases.py
@@ -24,11 +24,13 @@ packages found in that directory.
 """
 import argparse
 import glob
+import operator
 import os
 import subprocess
 from collections import defaultdict
-from distutils.version import LooseVersion
 from typing import Dict, List, NamedTuple
+
+from packaging.version import Version
 
 
 class VersionedFile(NamedTuple):
@@ -36,7 +38,7 @@ class VersionedFile(NamedTuple):
     version: str
     suffix: str
     type: str
-    comparable_version: LooseVersion
+    comparable_version: Version
 
 
 def split_version_and_suffix(file_name: str, suffix: str) -> VersionedFile:
@@ -47,7 +49,7 @@ def split_version_and_suffix(file_name: str, suffix: str) -> VersionedFile:
         version=version,
         suffix=suffix,
         type=no_version_file + "-" + suffix,
-        comparable_version=LooseVersion(version),
+        comparable_version=Version(version),
     )
 
 
@@ -60,7 +62,7 @@ def process_all_files(directory: str, suffix: str, execute: bool):
         package_types_dicts[versioned_file.type].append(versioned_file)
 
     for package_types in package_types_dicts.values():
-        package_types.sort(key=lambda x: x.comparable_version)
+        package_types.sort(key=operator.attrgetter("comparable_version"))
 
     for package_types in package_types_dicts.values():
         if len(package_types) == 1:

--- a/docs/exts/sphinx_script_update.py
+++ b/docs/exts/sphinx_script_update.py
@@ -17,9 +17,9 @@
 import hashlib
 import json
 import os
+import shutil
 import sys
 import tempfile
-from distutils.file_util import copy_file
 from functools import lru_cache
 from typing import Dict
 
@@ -28,6 +28,11 @@ from sphinx.builders import html as builders
 from sphinx.util import logging
 
 log = logging.getLogger(__name__)
+
+
+def _copy_file(src: str, dst: str) -> None:
+    log.info("Copying %s -> %s", src, dst)
+    shutil.copy2(src, dst, follow_symlinks=False)
 
 
 def _gethash(string: str):
@@ -107,7 +112,7 @@ def build_finished(app, exception):
     output_filename = "script.js"
 
     cache_filepath = fetch_and_cache(script_url, output_filename)
-    copy_file(cache_filepath, os.path.join(app.builder.outdir, '_static', "redoc.js"))
+    _copy_file(cache_filepath, os.path.join(app.builder.outdir, '_static', "redoc.js"))
 
 
 def setup(app):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ import subprocess
 import sys
 import unittest
 from copy import deepcopy
-from distutils import log
 from os.path import dirname, relpath
 from textwrap import wrap
 from typing import Dict, List
@@ -31,6 +30,10 @@ from typing import Dict, List
 from setuptools import Command, Distribution, find_namespace_packages, setup
 from setuptools.command.develop import develop as develop_orig
 from setuptools.command.install import install as install_orig
+
+# Setuptools patches this import to point to a vendored copy instead of the
+# stdlib, which is deprecated in Python 3.10 and will be removed in 3.12.
+from distutils import log  # isort: skip
 
 # Controls whether providers are installed from packages or directly from sources
 # It is turned on by default in case of development environments such as Breeze


### PR DESCRIPTION
See #19059.

Version parsing capabilities when building provider packages is now provided by `packaging.version.Version` instead. Non-Python software version parsing (sqlite) is re-implemented with regex.

Usages of `strtobool` are replaced by the `to_boolean` utility function in the `airflow.utils.strings` module. This function is a bit more permissive than `strtobool`, but should be good enough for how Airflow uses it for. This function is available since 2.0 and should be safe for usages in provider packages as well.

The `copy_file` usage is replaced by `shutils.copy2()`, which is good enough for Airflow's needs.

The distutils reference in setup.py is kept since the file is only used at build-time against setuptools, which patches the distutils import with a vendored copy and is not deprecated.

See also *Migration Advice* in [PEP 632](https://www.python.org/dev/peps/pep-0632/#migration-advice).