### PR TITLE
use DefaultAzureCredential if login not provided for Data Factory

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -20,7 +20,7 @@ from functools import wraps
 from typing import Any, Callable, Dict, Optional, Set, Union
 
 from azure.core.polling import LROPoller
-from azure.identity import ClientSecretCredential
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from azure.mgmt.datafactory import DataFactoryManagementClient
 from azure.mgmt.datafactory.models import (
     CreateRunResponse,
@@ -144,10 +144,14 @@ class AzureDataFactoryHook(BaseHook):
         tenant = conn.extra_dejson.get('extra__azure_data_factory__tenantId')
         subscription_id = conn.extra_dejson.get('extra__azure_data_factory__subscriptionId')
 
-        self._conn = DataFactoryManagementClient(
-            credential=ClientSecretCredential(
+        credential = DefaultAzureCredential()
+        if conn.login is not None and conn.password is not None:
+            credential = ClientSecretCredential(
                 client_id=conn.login, client_secret=conn.password, tenant_id=tenant
-            ),
+            )
+        
+        self._conn = DataFactoryManagementClient(
+            credential=credential,
             subscription_id=subscription_id,
         )
 

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -144,15 +144,14 @@ class AzureDataFactoryHook(BaseHook):
         tenant = conn.extra_dejson.get('extra__azure_data_factory__tenantId')
         subscription_id = conn.extra_dejson.get('extra__azure_data_factory__subscriptionId')
 
-        credential = DefaultAzureCredential()
+        credential = None
         if conn.login is not None and conn.password is not None:
             credential = ClientSecretCredential(
                 client_id=conn.login, client_secret=conn.password, tenant_id=tenant
             )
-        self._conn = DataFactoryManagementClient(
-            credential=credential,
-            subscription_id=subscription_id,
-        )
+        else:
+            credential = DefaultAzureCredential()
+        self._conn = self._create_client(credential, subscription_id)
 
         return self._conn
 
@@ -177,6 +176,13 @@ class AzureDataFactoryHook(BaseHook):
         }
 
         return factory_name in factories
+
+    @staticmethod
+    def _create_client(credential, subscription_id):
+        return DataFactoryManagementClient(
+            credential=credential,
+            subscription_id=subscription_id,
+        )
 
     @provide_targeted_factory
     def update_factory(

--- a/airflow/providers/microsoft/azure/hooks/data_factory.py
+++ b/airflow/providers/microsoft/azure/hooks/data_factory.py
@@ -149,7 +149,6 @@ class AzureDataFactoryHook(BaseHook):
             credential = ClientSecretCredential(
                 client_id=conn.login, client_secret=conn.password, tenant_id=tenant
             )
-        
         self._conn = DataFactoryManagementClient(
             credential=credential,
             subscription_id=subscription_id,

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
@@ -27,11 +27,13 @@ The Microsoft Azure Data Factory connection type enables the Azure Data Factory 
 Authenticating to Azure Data Factory
 ------------------------------------
 
-There is one way to connect to Azure Data Factory using Airflow.
+There are multiple ways to connect to Azure Data Factory using Airflow.
 
 1. Use `token credentials
    <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
    i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
+1. Fallback on `DefaultAzureCredential<https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential>`_
+   This includes a mechanism to try different options to authenticate: Managed System Identity, environment variables, authentication through Azure CLI...
 
 Default Connection IDs
 ----------------------
@@ -44,18 +46,21 @@ Configuring the Connection
 Client ID
     Specify the ``client_id`` used for the initial connection.
     This is needed for *token credentials* authentication mechanism.
+    It can be left out to fall back on ``DefaultAzureCredential``.
 
 Secret
     Specify the ``secret`` used for the initial connection.
     This is needed for *token credentials* authentication mechanism.
+    It can be left out to fall back on ``DefaultAzureCredential``.
 
 Tenant ID
     Specify the ``tenantId`` used for the initial connection.
     This is needed for *token credentials* authentication mechanism.
+    It can be left out to fall back on ``DefaultAzureCredential``.
 
 Subscription ID
     Specify the ``subscriptionId`` used for the initial connection.
-    This is needed for *token credentials* authentication mechanism.
+    This is needed for all authentication mechanisms.
 
 Factory Name (optional)
     Specify the Azure Data Factory to interface with.

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
@@ -32,7 +32,7 @@ There are multiple ways to connect to Azure Data Factory using Airflow.
 1. Use `token credentials
    <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
    i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
-1. Fallback on `DefaultAzureCredential
+2. Fallback on `DefaultAzureCredential
    <https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential>`_.
    This includes a mechanism to try different options to authenticate: Managed System Identity, environment variables, authentication through Azure CLI...
 

--- a/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
+++ b/docs/apache-airflow-providers-microsoft-azure/connections/adf.rst
@@ -32,7 +32,8 @@ There are multiple ways to connect to Azure Data Factory using Airflow.
 1. Use `token credentials
    <https://docs.microsoft.com/en-us/azure/developer/python/azure-sdk-authenticate?tabs=cmd#authenticate-with-token-credentials>`_
    i.e. add specific credentials (client_id, secret, tenant) and subscription id to the Airflow connection.
-1. Fallback on `DefaultAzureCredential<https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential>`_
+1. Fallback on `DefaultAzureCredential
+   <https://docs.microsoft.com/en-us/python/api/overview/azure/identity-readme?view=azure-python#defaultazurecredential>`_.
    This includes a mechanism to try different options to authenticate: Managed System Identity, environment variables, authentication through Azure CLI...
 
 Default Connection IDs

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -17,9 +17,11 @@
 
 
 import json
+from typing import Type
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from azure.identity import ClientSecretCredential, DefaultAzureCredential
 from pytest import fixture
 
 from airflow.exceptions import AirflowException
@@ -38,14 +40,17 @@ RESOURCE_GROUP = "testResourceGroup"
 DEFAULT_FACTORY = "defaultFactory"
 FACTORY = "testFactory"
 
+DEFAULT_CONNECTION_CLIENT_SECRET = "azure_data_factory_test_client_secret"
+DEFAULT_CONNECTION_DEFAULT_CREDENTIAL = "azure_data_factory_test_default_credential"
+
 MODEL = object()
 NAME = "testName"
 ID = "testId"
 
 
 def setup_module():
-    connection = Connection(
-        conn_id="azure_data_factory_test",
+    connection_client_secret = Connection(
+        conn_id=DEFAULT_CONNECTION_CLIENT_SECRET,
         conn_type="azure_data_factory",
         login="clientId",
         password="clientSecret",
@@ -58,13 +63,25 @@ def setup_module():
             }
         ),
     )
+    connection_default_credential = Connection(
+        conn_id=DEFAULT_CONNECTION_DEFAULT_CREDENTIAL,
+        conn_type="azure_data_factory",
+        extra=json.dumps(
+            {
+                "extra__azure_data_factory__subscriptionId": "subscriptionId",
+                "extra__azure_data_factory__resource_group_name": DEFAULT_RESOURCE_GROUP,
+                "extra__azure_data_factory__factory_name": DEFAULT_FACTORY,
+            }
+        )
+    )
 
-    db.merge_conn(connection)
+    db.merge_conn(connection_client_secret)
+    db.merge_conn(connection_default_credential)
 
 
 @fixture
 def hook():
-    client = AzureDataFactoryHook(azure_data_factory_conn_id="azure_data_factory_test")
+    client = AzureDataFactoryHook(azure_data_factory_conn_id=DEFAULT_CONNECTION_CLIENT_SECRET)
     client._conn = MagicMock(
         spec=[
             "factories",
@@ -114,6 +131,20 @@ def test_provide_targeted_factory():
     with pytest.raises(AirflowException):
         conn.extra_dejson = {}
         provide_targeted_factory(echo)(hook)
+
+
+@pytest.mark.parametrize(("connection_id", "credential_type"),
+                         [(DEFAULT_CONNECTION_CLIENT_SECRET, ClientSecretCredential),
+                          (DEFAULT_CONNECTION_DEFAULT_CREDENTIAL, DefaultAzureCredential)])
+def test_get_connection_by_credential_client_secret(connection_id: str, credential_type: Type):
+    hook = AzureDataFactoryHook(connection_id)
+
+    with patch.object(hook, "_create_client") as mock_create_client:
+        mock_create_client.return_value = MagicMock()
+        connection = hook.get_conn()
+        mock_create_client.assert_called_once()
+        assert isinstance(mock_create_client.call_args[0][0], credential_type)
+        assert mock_create_client.call_args[0][1] == "subscriptionId"
 
 
 @parametrize(

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -146,6 +146,7 @@ def test_get_connection_by_credential_client_secret(connection_id: str, credenti
     with patch.object(hook, "_create_client") as mock_create_client:
         mock_create_client.return_value = MagicMock()
         connection = hook.get_conn()
+        assert connection is not None
         mock_create_client.assert_called_once()
         assert isinstance(mock_create_client.call_args[0][0], credential_type)
         assert mock_create_client.call_args[0][1] == "subscriptionId"

--- a/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/hooks/test_azure_data_factory.py
@@ -72,7 +72,7 @@ def setup_module():
                 "extra__azure_data_factory__resource_group_name": DEFAULT_RESOURCE_GROUP,
                 "extra__azure_data_factory__factory_name": DEFAULT_FACTORY,
             }
-        )
+        ),
     )
 
     db.merge_conn(connection_client_secret)
@@ -133,9 +133,13 @@ def test_provide_targeted_factory():
         provide_targeted_factory(echo)(hook)
 
 
-@pytest.mark.parametrize(("connection_id", "credential_type"),
-                         [(DEFAULT_CONNECTION_CLIENT_SECRET, ClientSecretCredential),
-                          (DEFAULT_CONNECTION_DEFAULT_CREDENTIAL, DefaultAzureCredential)])
+@pytest.mark.parametrize(
+    ("connection_id", "credential_type"),
+    [
+        (DEFAULT_CONNECTION_CLIENT_SECRET, ClientSecretCredential),
+        (DEFAULT_CONNECTION_DEFAULT_CREDENTIAL, DefaultAzureCredential),
+    ],
+)
 def test_get_connection_by_credential_client_secret(connection_id: str, credential_type: Type):
     hook = AzureDataFactoryHook(connection_id)
 


### PR DESCRIPTION
closes: #19077 

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
