### PR TITLE
Fix: Add taskgroup tooltip to graph view

### DIFF
--- a/airflow/www/static/js/graph.js
+++ b/airflow/www/static/js/graph.js
@@ -451,8 +451,12 @@ function groupTooltip(node, tis) {
   });
 
   const groupDuration = convertSecsToHumanReadable(moment(maxEnd).diff(minStart, 'second'));
+  const tooltipText = node.tooltip ? `<p>${node.tooltip}</p>` : '';
 
-  let tt = `<strong>Duration:</strong> ${groupDuration} <br><br>`;
+  let tt = `
+    ${tooltipText}
+    <strong>Duration:</strong> ${groupDuration} <br><br>
+  `;
   numMap.forEach((key, val) => {
     if (key > 0) {
       tt += `<strong>${escapeHtml(val)}:</strong> ${key} <br>`;

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -276,8 +276,8 @@ def task_group_to_dict(task_group):
             'rx': 5,
             'ry': 5,
             'clusterLabelPos': 'top',
+            'tooltip': task_group.tooltip,
         },
-        'tooltip': task_group.tooltip,
         'children': children,
     }
 


### PR DESCRIPTION
Add the DAG file defined `tooltip` in the Task Group tooltip on the graph view.

Closes: #19078

<img width="271" alt="Screen Shot 2021-10-19 at 11 32 49 AM" src="https://user-images.githubusercontent.com/4600967/137960031-9281cd5a-8403-41bc-a97c-1c4d911a27c8.png">


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
