### PR TITLE
Relax packaging requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -126,7 +126,7 @@ install_requires =
     marshmallow-oneofschema>=2.0.1
     # Required by vendored-in connexion
     openapi-spec-validator>=0.2.4
-    packaging~=21.0
+    packaging>=14.0
     pendulum~=2.0
     pep562~=1.0;python_version<"3.7"
     psutil>=4.2.0, <6.0.0


### PR DESCRIPTION
We only use packaging for version parsing, which has existed since 14.0, so let's relax the version range. The previous range causes issues with dbt-core, which (IMO) also unreasonably pins packaging to a tight range.

cc @andrewgodwin (author of #18122) and @collinmcnulty 