### PR TITLE
Updating TaskGroup unit test to handle new tooltip

### DIFF
--- a/tests/utils/test_task_group.py
+++ b/tests/utils/test_task_group.py
@@ -38,8 +38,8 @@ EXPECTED_JSON = {
         'rx': 5,
         'ry': 5,
         'clusterLabelPos': 'top',
+        'tooltip': '',
     },
-    'tooltip': '',
     'children': [
         {
             'id': 'group234',
@@ -50,8 +50,8 @@ EXPECTED_JSON = {
                 'rx': 5,
                 'ry': 5,
                 'clusterLabelPos': 'top',
+                'tooltip': '',
             },
-            'tooltip': '',
             'children': [
                 {
                     'id': 'group234.group34',
@@ -62,8 +62,8 @@ EXPECTED_JSON = {
                         'rx': 5,
                         'ry': 5,
                         'clusterLabelPos': 'top',
+                        'tooltip': '',
                     },
-                    'tooltip': '',
                     'children': [
                         {
                             'id': 'group234.group34.task3',


### PR DESCRIPTION
Fixing current failing tasks on `main` for `tests/utils/test_task_group` to handle  the new tooltip enhancement.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
