### PR TITLE
MySQLToS3Operator  actually allow writing parquet files to s3.

### DIFF
--- a/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
@@ -44,6 +44,11 @@ FILE_OPTIONS_MAP = {
     FILE_FORMAT.PARQUET: FileOptions('rb+', '.parquet'),
 }
 
+MATERIALIZATION_FUNCTION_MAP = {
+    FILE_FORMAT.CSV: pd.to_csv,
+    FILE_FORMAT.PARQUET: pd.to_parquet,
+}
+
 
 class MySQLToS3Operator(BaseOperator):
     """
@@ -170,7 +175,7 @@ class MySQLToS3Operator(BaseOperator):
         self._fix_int_dtypes(data_df)
         file_options = FILE_OPTIONS_MAP[self.file_format]
         with NamedTemporaryFile(mode=file_options.mode, suffix=file_options.suffix) as tmp_file:
-            data_df.to_csv(tmp_file.name, **self.pd_kwargs)
+            MATERIALIZATION_FUNCTION_MAP[self.file_format](tmp_file.name, **self.pd_kwargs)
             s3_conn.load_file(filename=tmp_file.name, key=self.s3_key, bucket_name=self.s3_bucket)
 
         if s3_conn.check_for_key(self.s3_key, bucket_name=self.s3_bucket):

--- a/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
+++ b/airflow/providers/amazon/aws/transfers/mysql_to_s3.py
@@ -44,11 +44,6 @@ FILE_OPTIONS_MAP = {
     FILE_FORMAT.PARQUET: FileOptions('rb+', '.parquet'),
 }
 
-MATERIALIZATION_FUNCTION_MAP = {
-    FILE_FORMAT.CSV: pd.to_csv,
-    FILE_FORMAT.PARQUET: pd.to_parquet,
-}
-
 
 class MySQLToS3Operator(BaseOperator):
     """
@@ -175,7 +170,10 @@ class MySQLToS3Operator(BaseOperator):
         self._fix_int_dtypes(data_df)
         file_options = FILE_OPTIONS_MAP[self.file_format]
         with NamedTemporaryFile(mode=file_options.mode, suffix=file_options.suffix) as tmp_file:
-            MATERIALIZATION_FUNCTION_MAP[self.file_format](tmp_file.name, **self.pd_kwargs)
+            if self.file_format == FILE_FORMAT.CSV:
+                data_df.to_csv(tmp_file.name, **self.pd_kwargs)
+            else:
+                data_df.to_parquet(tmp_file.name, **self.pd_kwargs)
             s3_conn.load_file(filename=tmp_file.name, key=self.s3_key, bucket_name=self.s3_bucket)
 
         if s3_conn.check_for_key(self.s3_key, bucket_name=self.s3_bucket):


### PR DESCRIPTION
Followup on https://github.com/apache/airflow/pull/18755
Actually call to_parquet when file format is parquet.
