### PR TITLE
Ensure task state doesn't change when marked as failed/success/skipped

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -431,6 +431,9 @@ class SchedulerJob(BaseJob):
         """
         # actually enqueue them
         for ti in task_instances:
+            if ti.dag_run.state in State.finished:
+                ti.set_state(State.NONE)
+                continue
             command = ti.command_as_list(
                 local=True,
                 pickle_id=ti.dag_model.pickle_id,

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1366,7 +1366,7 @@ class TaskInstance(Base, LoggingMixin):
             # for case when task is marked as success/failed externally
             # or dagrun timed out and task is marked as skipped
             # current behavior doesn't hit the callbacks
-            if self.state in {State.SUCCESS, State.FAILED, State.SKIPPED}:
+            if self.state in State.finished:
                 return
             else:
                 self.handle_failure(e, test_mode, error_file=error_file, session=session)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1361,9 +1361,12 @@ class TaskInstance(Base, LoggingMixin):
             session.commit()
             raise
         except AirflowException as e:
+            if not test_mode:
+                self.refresh_from_db(lock_for_update=True, session=session)
             # for case when task is marked as success/failed externally
-            # current behavior doesn't hit the success callback
-            if self.state in {State.SUCCESS, State.FAILED}:
+            # or dagrun timed out and task is marked as skipped
+            # current behavior doesn't hit the callbacks
+            if self.state in {State.SUCCESS, State.FAILED, State.SKIPPED}:
                 return
             else:
                 self.handle_failure(e, test_mode, error_file=error_file, session=session)


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/16078

Currently, when a dagrun is marked as success in the UI, the expected
sigterm is sent but the task continues running, changing the dagrun to running
before eventually failing. Same as well when marked as failed.

Also, queued tasks continue running even when the dagrun was failed

The same thing happens when a dagrun times out. The tasks that are marked
skipped, starts again, and then fails.

This PR fixes these issues

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
