### PR TITLE
add detailed information to logging when a dag or a task finishes.

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -535,7 +535,7 @@ class SchedulerJob(BaseJob):
             msg = (
                 "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
                 "run_start_date=%s, run_end_date=%s, "
-                "run_duration=%f, state=%s, executor_state=%s, try_number=%d, max_tries=%d, job_id=%d, "
+                "run_duration=%s, state=%s, executor_state=%s, try_number=%s, max_tries=%s, job_id=%s, "
                 "pool=%s, queue=%s, priority_weight=%d, operator=%s"
             )
             self.log.info(

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -533,13 +533,11 @@ class SchedulerJob(BaseJob):
                 continue
 
             msg = ("TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
-                   "run_start_time=%f, run_end_time=%f, "
+                   "run_start_date=%s, run_end_date=%s, "
                    "run_duration=%f, state=%s, executor_state=%s, try_number=%d, max_tries=%d, job_id=%d, "
                    "pool=%s, queue=%s, priority_weight=%d, operator=%s"
             )
-            self.log.info(msg, ti.dag_id, ti.task_id, ti.run_id,
-                          ti.start_date.timestamp() if ti.start_date is not None else 0,
-                          ti.end_date.timestamp() if ti.end_date is not None else 0,
+            self.log.info(msg, ti.dag_id, ti.task_id, ti.run_id, ti.start_date, ti.end_date,
                           ti.duration, ti.state, state, try_number, ti.max_tries, ti.job_id,
                           ti.pool, ti.queue, ti.priority_weight, ti.operator)
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -532,14 +532,30 @@ class SchedulerJob(BaseJob):
                 self.log.info("Setting external_id for %s to %s", ti, info)
                 continue
 
-            msg = ("TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
-                   "run_start_date=%s, run_end_date=%s, "
-                   "run_duration=%f, state=%s, executor_state=%s, try_number=%d, max_tries=%d, job_id=%d, "
-                   "pool=%s, queue=%s, priority_weight=%d, operator=%s"
+            msg = (
+                "TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
+                "run_start_date=%s, run_end_date=%s, "
+                "run_duration=%f, state=%s, executor_state=%s, try_number=%d, max_tries=%d, job_id=%d, "
+                "pool=%s, queue=%s, priority_weight=%d, operator=%s"
             )
-            self.log.info(msg, ti.dag_id, ti.task_id, ti.run_id, ti.start_date, ti.end_date,
-                          ti.duration, ti.state, state, try_number, ti.max_tries, ti.job_id,
-                          ti.pool, ti.queue, ti.priority_weight, ti.operator)
+            self.log.info(
+                msg,
+                ti.dag_id,
+                ti.task_id,
+                ti.run_id,
+                ti.start_date,
+                ti.end_date,
+                ti.duration,
+                ti.state,
+                state,
+                try_number,
+                ti.max_tries,
+                ti.job_id,
+                ti.pool,
+                ti.queue,
+                ti.priority_weight,
+                ti.operator,
+            )
 
             if ti.try_number == buffer_key.try_number and ti.state == State.QUEUED:
                 Stats.incr('scheduler.tasks.killed_externally')

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -529,6 +529,17 @@ class SchedulerJob(BaseJob):
                 self.log.info("Setting external_id for %s to %s", ti, info)
                 continue
 
+            msg = ("TaskInstance Finished: dag_id=%s, task_id=%s, run_id=%s, "
+                   "run_start_time=%f, run_end_time=%f, "
+                   "run_duration=%f, state=%s, executor_state=%s, try_number=%d, max_tries=%d, job_id=%d, "
+                   "pool=%s, queue=%s, priority_weight=%d, operator=%s"
+            )
+            self.log.info(msg, ti.dag_id, ti.task_id, ti.run_id,
+                          ti.start_date.timestamp() if ti.start_date is not None else 0,
+                          ti.end_date.timestamp() if ti.end_date is not None else 0,
+                          ti.duration, ti.state, state, try_number, ti.max_tries, ti.job_id,
+                          ti.pool, ti.queue, ti.priority_weight, ti.operator)
+
             if ti.try_number == buffer_key.try_number and ti.state == State.QUEUED:
                 Stats.incr('scheduler.tasks.killed_externally')
                 msg = (

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -556,8 +556,9 @@ class DagRun(Base, LoggingMixin):
                 self.run_id,
                 self.start_date,
                 self.end_date,
-                (self.end_date - self.start_date).total_seconds() if self.start_date and self.end_date else None,
-                self._state,
+                (self.end_date - self.start_date).total_seconds()
+                if self.start_date and self.end_date
+                else None,
                 self.external_trigger,
                 self.run_type,
                 self.data_interval_start,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -545,7 +545,7 @@ class DagRun(Base, LoggingMixin):
         if self._state == State.FAILED or self._state == State.SUCCESS:
             msg = (
                 "DagRun Finished: dag_id=%s, execution_date=%s, run_id=%s, "
-                "run_start_date=%s, run_end_date=%s, run_duration=%s"
+                "run_start_date=%s, run_end_date=%s, run_duration=%s, "
                 "state=%s, external_trigger=%s, run_type=%s, "
                 "data_interval_start=%s, data_interval_end=%s, dag_hash=%s"
             )

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -528,13 +528,12 @@ class DagRun(Base, LoggingMixin):
 
         if (self.get_state() == State.FAILED or self.get_state() == State.SUCCESS):
             msg = ("DagRun Finished: dag_id=%s, execution_date=%s, run_id=%s, "
-                   "run_start_time=%f, run_end_time=%f, "
+                   "run_start_date=%s, run_end_date=%s, "
                    "state=%s, external_trigger=%s, run_type=%s, "
                    "data_interval_start=%s, data_interval_end=%s, dag_hash=%s"
             )
             self.log.info(msg, self.dag_id, self.execution_date, self.run_id,
-                          self.start_date.timestamp() if self.start_date is not None else 0,
-                          self.end_date.timestamp() if self.end_date is not None else 0,
+                          self.start_date, self.end_date,
                           self.get_state(), self.external_trigger, self.run_type,
                           self.data_interval_start, self.data_interval_end, self.dag_hash)
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -526,16 +526,27 @@ class DagRun(Base, LoggingMixin):
         else:
             self.set_state(State.RUNNING)
 
-        if (self.get_state() == State.FAILED or self.get_state() == State.SUCCESS):
-            msg = ("DagRun Finished: dag_id=%s, execution_date=%s, run_id=%s, "
-                   "run_start_date=%s, run_end_date=%s, "
-                   "state=%s, external_trigger=%s, run_type=%s, "
-                   "data_interval_start=%s, data_interval_end=%s, dag_hash=%s"
+        if self.get_state() == State.FAILED or self.get_state() == State.SUCCESS:
+            msg = (
+                "DagRun Finished: dag_id=%s, execution_date=%s, run_id=%s, "
+                "run_start_date=%s, run_end_date=%s, "
+                "state=%s, external_trigger=%s, run_type=%s, "
+                "data_interval_start=%s, data_interval_end=%s, dag_hash=%s"
             )
-            self.log.info(msg, self.dag_id, self.execution_date, self.run_id,
-                          self.start_date, self.end_date,
-                          self.get_state(), self.external_trigger, self.run_type,
-                          self.data_interval_start, self.data_interval_end, self.dag_hash)
+            self.log.info(
+                msg,
+                self.dag_id,
+                self.execution_date,
+                self.run_id,
+                self.start_date,
+                self.end_date,
+                self.get_state(),
+                self.external_trigger,
+                self.run_type,
+                self.data_interval_start,
+                self.data_interval_end,
+                self.dag_hash,
+            )
 
         self._emit_true_scheduling_delay_stats_for_finished_state(finished_tasks)
         self._emit_duration_stats_for_finished_state()

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -542,10 +542,10 @@ class DagRun(Base, LoggingMixin):
         else:
             self.set_state(State.RUNNING)
 
-        if self.get_state() == State.FAILED or self.get_state() == State.SUCCESS:
+        if self._state == State.FAILED or self._state == State.SUCCESS:
             msg = (
                 "DagRun Finished: dag_id=%s, execution_date=%s, run_id=%s, "
-                "run_start_date=%s, run_end_date=%s, "
+                "run_start_date=%s, run_end_date=%s, run_duration=%s"
                 "state=%s, external_trigger=%s, run_type=%s, "
                 "data_interval_start=%s, data_interval_end=%s, dag_hash=%s"
             )
@@ -556,7 +556,8 @@ class DagRun(Base, LoggingMixin):
                 self.run_id,
                 self.start_date,
                 self.end_date,
-                self.get_state(),
+                (self.end_date - self.start_date).total_seconds() if self.start_date and self.end_date else None,
+                self._state,
                 self.external_trigger,
                 self.run_type,
                 self.data_interval_start,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -526,6 +526,18 @@ class DagRun(Base, LoggingMixin):
         else:
             self.set_state(State.RUNNING)
 
+        if (self.get_state() == State.FAILED or self.get_state() == State.SUCCESS):
+            msg = ("DagRun Finished: dag_id=%s, execution_date=%s, run_id=%s, "
+                   "run_start_time=%f, run_end_time=%f, "
+                   "state=%s, external_trigger=%s, run_type=%s, "
+                   "data_interval_start=%s, data_interval_end=%s, dag_hash=%s"
+            )
+            self.log.info(msg, self.dag_id, self.execution_date, self.run_id,
+                          self.start_date.timestamp() if self.start_date is not None else 0,
+                          self.end_date.timestamp() if self.end_date is not None else 0,
+                          self.get_state(), self.external_trigger, self.run_type,
+                          self.data_interval_start, self.data_interval_end, self.dag_hash)
+
         self._emit_true_scheduling_delay_stats_for_finished_state(finished_tasks)
         self._emit_duration_stats_for_finished_state()
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -559,6 +559,7 @@ class DagRun(Base, LoggingMixin):
                 (self.end_date - self.start_date).total_seconds()
                 if self.start_date and self.end_date
                 else None,
+                self._state,
                 self.external_trigger,
                 self.run_type,
                 self.data_interval_start,


### PR DESCRIPTION
Adding 2 new log messages for when a task run and a dag run reaches a terminal state (SUCCESS/FAILED).  

Examples:

```
scheduler | [2021-10-19 21:27:55,681] {scheduler_job.py:529} INFO - Task Finished: dag_id=example_bash_operator, task_id=runme_0, run_id=scheduled__2021-10-19T00:00:00+00:00, run_start_date=2021-10-19 21:27:34.142493, run_end_date=2021-10-19 21:27:35.508459, run_duration=1.365966, state=success, executor_state=success, try_number=1, max_tries=0, job_id=87, pool=default_pool, queue=default, priority_weight=3, operator=BashOperator
```

```
scheduler | [2021-10-19 22:11:22,730] {dagrun.py:535} INFO - DagRun Finished: dag_id=example_branch_dop_operator_v3, execution_date=2021-10-19 21:52:00+00:00, run_id=scheduled__2021-10-19T21:52:00+00:00, run_start_time=2021-10-19 21:55:28.363682, run_end_time=2021-10-19 22:11:22.730577, run_duration=954.366894, state=failed, external_trigger=False, run_type=scheduled, data_interval_start=2021-10-19 21:52:00+00:00, data_interval_end=2021-10-19 21:53:00+00:00, dag_hash=3f534eba2aff8e72d5ad1db5aff1e64b
```

