### PR TITLE
pyenv related docs added, warning message in breeze initialize-local-virtualenv command

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -147,10 +147,10 @@ Pyenv and setting up virtual-env
 
 3. Add the lines suggested at the end of installation  to ~/.bashrc
 
-4. If you are in macOS Big Sur 11.4, pyenv may face issues. It can be fixed by adding the below command to ~/.zshrc 
+4. If you are in macOS Big Sur 11.4, pyenv may face issues. It can be fixed by adding the below command to ~/.zshrc
 
 .. code-block:: bash
-  
+
   eval "$(pyenv init --path)"
   eval "$(pyenv init -)"
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -147,14 +147,21 @@ Pyenv and setting up virtual-env
 
 3. Add the lines suggested at the end of installation  to ~/.bashrc
 
-4. Restart your shell so the path changes take effect and verifying installation
+4. If you are in macOS Big Sur 11.4, pyenv may face issues. It can be fixed by adding the below command to ~/.zshrc 
+
+.. code-block:: bash
+  
+  eval "$(pyenv init --path)"
+  eval "$(pyenv init -)"
+
+5. Restart your shell so the path changes take effect and verifying installation
 
 .. code-block:: bash
 
   $ exec $SHELL
   $ pyenv --version
 
-5. Checking available version, installing required Python version to pyenv and verifying it
+6. Checking available version, installing required Python version to pyenv and verifying it
 
 .. code-block:: bash
 
@@ -162,14 +169,14 @@ Pyenv and setting up virtual-env
   $ pyenv install 3.8.5
   $ pyenv versions
 
-6. Creating new virtual environment named ``airflow-env`` for installed version python. In next chapter virtual
+7. Creating new virtual environment named ``airflow-env`` for installed version python. In next chapter virtual
    environment ``airflow-env`` will be used for installing airflow.
 
 .. code-block:: bash
 
   $ pyenv virtualenv 3.8.5 airflow-env
 
-7. Entering virtual environment ``airflow-env``
+8. Entering virtual environment ``airflow-env``
 
 .. code-block:: bash
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,23 +145,16 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Add the lines suggested at the end of installation  to ~/.bashrc
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `README <https://github.com/pyenv/pyenv/blob/master/README.md>`_
 
-4. If you are in macOS Big Sur 11.4, pyenv may face issues. It can be fixed by adding the below command to ~/.zshrc
-
-.. code-block:: bash
-
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
-
-5. Restart your shell so the path changes take effect and verifying installation
+4. Restart your shell so the path changes take effect and verifying installation
 
 .. code-block:: bash
 
   $ exec $SHELL
   $ pyenv --version
 
-6. Checking available version, installing required Python version to pyenv and verifying it
+5. Checking available version, installing required Python version to pyenv and verifying it
 
 .. code-block:: bash
 
@@ -169,14 +162,14 @@ Pyenv and setting up virtual-env
   $ pyenv install 3.8.5
   $ pyenv versions
 
-7. Creating new virtual environment named ``airflow-env`` for installed version python. In next chapter virtual
+6. Creating new virtual environment named ``airflow-env`` for installed version python. In next chapter virtual
    environment ``airflow-env`` will be used for installing airflow.
 
 .. code-block:: bash
 
   $ pyenv virtualenv 3.8.5 airflow-env
 
-8. Entering virtual environment ``airflow-env``
+7. Entering virtual environment ``airflow-env``
 
 .. code-block:: bash
 

--- a/breeze
+++ b/breeze
@@ -396,6 +396,16 @@ EOF
     echo
     echo "Please exit and re-enter your shell or run:"
     echo
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        if grep "${breeze_comment}" "${HOME}/.zshrc" >/dev/null 2>&1; then
+            echo "    source ~/.zshrc"
+            echo
+            echo "    source ~/.bash_completion.d/breeze-complete"
+            echo
+            exec zsh
+            exit 0
+        fi
+    fi
     echo "    source ~/.bash_completion.d/breeze-complete"
     echo
     exit 0

--- a/breeze
+++ b/breeze
@@ -283,6 +283,13 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Wiping and recreating ${AIRFLOW_HOME_DIR}"
         echo
+        SCRIPTPATH="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
+        if [ "${SCRIPTPATH}" = "${AIRFLOW_HOME_DIR}" ]; then
+            echo "AIRFLOW_HOME and Source code for Apache Airflow resides in the same path ${AIRFLOW_HOME_DIR}"
+            echo "When running this command it will delete all the files in the path ${AIRFLOW_HOME_DIR} to clear dynamic files like config/logs/db"
+            echo "Move your source code for Apache Airflow to different folder to avoid deletion"
+            exit 0
+        fi
         rm -rvf "${AIRFLOW_HOME_DIR}"
         mkdir -p "${AIRFLOW_HOME_DIR}"
         echo

--- a/breeze
+++ b/breeze
@@ -283,12 +283,11 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Wiping and recreating ${AIRFLOW_HOME_DIR}"
         echo
-        SCRIPTPATH="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
-        if [ "${SCRIPTPATH}" = "${AIRFLOW_HOME_DIR}" ]; then
+        if [[ "${AIRFLOW_SOURCES}" = "${AIRFLOW_HOME_DIR}" ]]; then
             echo "AIRFLOW_HOME and Source code for Apache Airflow resides in the same path ${AIRFLOW_HOME_DIR}"
             echo "When running this command it will delete all the files in the path ${AIRFLOW_HOME_DIR} to clear dynamic files like config/logs/db"
             echo "Move your source code for Apache Airflow to different folder to avoid deletion"
-            exit 0
+            exit 1
         fi
         rm -rvf "${AIRFLOW_HOME_DIR}"
         mkdir -p "${AIRFLOW_HOME_DIR}"

--- a/breeze
+++ b/breeze
@@ -283,7 +283,7 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Wiping and recreating ${AIRFLOW_HOME_DIR}"
         echo
-        if [[ "${AIRFLOW_SOURCES}" = "${AIRFLOW_HOME_DIR}" ]]; then
+        if [[ "${AIRFLOW_SOURCES}" == "${AIRFLOW_HOME_DIR}" ]]; then
             echo "AIRFLOW_HOME and Source code for Apache Airflow resides in the same path ${AIRFLOW_HOME_DIR}"
             echo "When running this command it will delete all the files in the path ${AIRFLOW_HOME_DIR} to clear dynamic files like config/logs/db"
             echo "Move your source code for Apache Airflow to different folder to avoid deletion"

--- a/breeze
+++ b/breeze
@@ -286,12 +286,11 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Wiping and recreating ${AIRFLOW_HOME_DIR}"
         echo
-        SCRIPTPATH="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
-        if [ "${SCRIPTPATH}" = "${AIRFLOW_HOME_DIR}" ]; then
+        if [[ "${AIRFLOW_SOURCES}" = "${AIRFLOW_HOME_DIR}" ]]; then
             echo "AIRFLOW_HOME and Source code for Apache Airflow resides in the same path ${AIRFLOW_HOME_DIR}"
             echo "When running this command it will delete all the files in the path ${AIRFLOW_HOME_DIR} to clear dynamic files like config/logs/db"
             echo "Move your source code for Apache Airflow to different folder to avoid deletion"
-            exit 0
+            exit 1
         fi
         rm -rvf "${AIRFLOW_HOME_DIR}"
         mkdir -p "${AIRFLOW_HOME_DIR}"

--- a/breeze
+++ b/breeze
@@ -286,7 +286,7 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Wiping and recreating ${AIRFLOW_HOME_DIR}"
         echo
-        if [[ "${AIRFLOW_SOURCES}" = "${AIRFLOW_HOME_DIR}" ]]; then
+        if [[ "${AIRFLOW_SOURCES}" == "${AIRFLOW_HOME_DIR}" ]]; then
             echo "AIRFLOW_HOME and Source code for Apache Airflow resides in the same path ${AIRFLOW_HOME_DIR}"
             echo "When running this command it will delete all the files in the path ${AIRFLOW_HOME_DIR} to clear dynamic files like config/logs/db"
             echo "Move your source code for Apache Airflow to different folder to avoid deletion"

--- a/breeze
+++ b/breeze
@@ -286,6 +286,13 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Wiping and recreating ${AIRFLOW_HOME_DIR}"
         echo
+        SCRIPTPATH="$( cd -- "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 ; pwd -P )"
+        if [ "${SCRIPTPATH}" = "${AIRFLOW_HOME_DIR}" ]; then
+            echo "AIRFLOW_HOME and Source code for Apache Airflow resides in the same path ${AIRFLOW_HOME_DIR}"
+            echo "When running this command it will delete all the files in the path ${AIRFLOW_HOME_DIR} to clear dynamic files like config/logs/db"
+            echo "Move your source code for Apache Airflow to different folder to avoid deletion"
+            exit 0
+        fi
         rm -rvf "${AIRFLOW_HOME_DIR}"
         mkdir -p "${AIRFLOW_HOME_DIR}"
         echo

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1298,6 +1298,7 @@ sudo
 sudoers
 summarization
 superclass
+sur
 svg
 swp
 symlink


### PR DESCRIPTION
Pyenv related docs - macOS Big Sur pyenv issue can be fixed by adding commands into ~/.zshrc file
Having AIRFLOW_HOME and Source code in ${HOME} can lead to disastrous effect of deleting all the file in the Airflow folder. Added a warning message to prevent deletion

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
