### PR TITLE
Increment Stats counter for task instance SLA misses

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -429,6 +429,7 @@ class DagFileProcessor(LoggingMixin):
                             timestamp=ts,
                         )
                         sla_misses.append(sla_miss)
+                        Stats.incr(f'ti.sla_miss.{ti.dag_id}.{ti.task_id}')
             if sla_misses:
                 session.add_all(sla_misses)
         session.commit()


### PR DESCRIPTION
Increment a new named stats counter for task instance SLA misses, following
the existing naming convention of other task instance Stats.