### PR TITLE
Update taskinstance REST API schema to include dag_run_id field

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2297,6 +2297,12 @@ components:
           type: string
         dag_id:
           type: string
+        dag_run_id:
+          type: string
+          description: |
+            The DagRun ID for this task instance
+
+            *New in version 2.2.1*
         execution_date:
           type: string
           format: datetime

--- a/airflow/api_connexion/schemas/task_instance_schema.py
+++ b/airflow/api_connexion/schemas/task_instance_schema.py
@@ -19,6 +19,7 @@ from typing import List, NamedTuple, Optional, Tuple
 
 from marshmallow import Schema, ValidationError, fields, validate, validates_schema
 from marshmallow.utils import get_value
+from marshmallow_sqlalchemy import SQLAlchemySchema, auto_field
 
 from airflow.api_connexion.parameters import validate_istimezone
 from airflow.api_connexion.schemas.enum_schemas import TaskInstanceStateField
@@ -27,28 +28,34 @@ from airflow.models import SlaMiss, TaskInstance
 from airflow.utils.state import State
 
 
-class TaskInstanceSchema(Schema):
+class TaskInstanceSchema(SQLAlchemySchema):
     """Task instance schema"""
 
-    task_id = fields.Str()
-    dag_id = fields.Str()
-    execution_date = fields.DateTime(validate=validate_istimezone)
-    start_date = fields.DateTime(validate=validate_istimezone)
-    end_date = fields.DateTime(validate=validate_istimezone)
-    duration = fields.Float()
-    state = TaskInstanceStateField()
-    _try_number = fields.Int(data_key="try_number")
-    max_tries = fields.Int()
-    hostname = fields.Str()
-    unixname = fields.Str()
-    pool = fields.Str()
-    pool_slots = fields.Int()
-    queue = fields.Str()
-    priority_weight = fields.Int()
-    operator = fields.Str()
-    queued_dttm = fields.DateTime(data_key="queued_when")
-    pid = fields.Int()
-    executor_config = fields.Str()
+    class Meta:
+        """Meta"""
+
+        model = TaskInstance
+
+    task_id = auto_field()
+    dag_id = auto_field()
+    run_id = auto_field(data_key="dag_run_id")
+    execution_date = auto_field()
+    start_date = auto_field()
+    end_date = auto_field()
+    duration = auto_field()
+    state = auto_field()
+    _try_number = auto_field(data_key="try_number")
+    max_tries = auto_field()
+    hostname = auto_field()
+    unixname = auto_field()
+    pool = auto_field()
+    pool_slots = auto_field()
+    queue = auto_field()
+    priority_weight = auto_field()
+    operator = auto_field()
+    queued_dttm = auto_field(data_key="queued_when")
+    pid = auto_field()
+    executor_config = auto_field()
     sla_miss = fields.Nested(SlaMissSchema, dump_default=None)
 
     def get_attribute(self, obj, attr, default):

--- a/tests/api_connexion/endpoints/test_task_instance_endpoint.py
+++ b/tests/api_connexion/endpoints/test_task_instance_endpoint.py
@@ -197,6 +197,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "task_id": "print_the_context",
             "try_number": 0,
             "unixname": getuser(),
+            "dag_run_id": "TEST_DAG_RUN_ID",
         }
 
     def test_should_respond_200_with_task_state_in_removed(self, session):
@@ -227,6 +228,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "task_id": "print_the_context",
             "try_number": 0,
             "unixname": getuser(),
+            "dag_run_id": "TEST_DAG_RUN_ID",
         }
 
     def test_should_respond_200_task_instance_with_sla(self, session):
@@ -275,6 +277,7 @@ class TestGetTaskInstance(TestTaskInstanceEndpoint):
             "task_id": "print_the_context",
             "try_number": 0,
             "unixname": getuser(),
+            "dag_run_id": "TEST_DAG_RUN_ID",
         }
 
     def test_should_raises_401_unauthenticated(self):

--- a/tests/api_connexion/schemas/test_task_instance_schema.py
+++ b/tests/api_connexion/schemas/test_task_instance_schema.py
@@ -88,6 +88,7 @@ class TestTaskInstanceSchema:
             "task_id": "TEST_TASK_ID",
             "try_number": 0,
             "unixname": getuser(),
+            "dag_run_id": None,
         }
         assert serialized_ti == expected_json
 
@@ -132,6 +133,7 @@ class TestTaskInstanceSchema:
             "task_id": "TEST_TASK_ID",
             "try_number": 0,
             "unixname": getuser(),
+            "dag_run_id": None,
         }
         assert serialized_ti == expected_json
 


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/19103
This PR adds dag_run_id field to taskinstance schema



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
