### PR TITLE
Add sensor default timeout config

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2246,6 +2246,16 @@
       type: integer
       example: ~
       default: "100"
+- name: sensors
+  description: ~
+  options:
+    - name: default_timeout
+      description: |
+        Sensor default timeout, 7 days by default.
+      version_added: 2.2.1
+      type: float
+      example: ~
+      default: "604800"
 - name: smart_sensor
   description: ~
   options:

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -2251,7 +2251,7 @@
   options:
     - name: default_timeout
       description: |
-        Sensor default timeout, 7 days by default.
+        Sensor default timeout, 7 days by default (7 * 24 * 60 * 60).
       version_added: 2.2.1
       type: float
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1108,6 +1108,10 @@ worker_pods_queued_check_interval = 60
 # You may want this higher if you have a very large cluster and/or use ``multi_namespace_mode``.
 worker_pods_pending_timeout_batch_size = 100
 
+[sensors]
+# Sensor default timeout, 7 days by default.
+default_timeout = 604800
+
 [smart_sensor]
 # When `use_smart_sensor` is True, Airflow redirects multiple qualified sensor tasks to
 # smart sensor task.

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -1109,7 +1109,7 @@ worker_pods_queued_check_interval = 60
 worker_pods_pending_timeout_batch_size = 100
 
 [sensors]
-# Sensor default timeout, 7 days by default.
+# Sensor default timeout, 7 days by default (7 * 24 * 60 * 60).
 default_timeout = 604800
 
 [smart_sensor]

--- a/airflow/sensors/base.py
+++ b/airflow/sensors/base.py
@@ -97,7 +97,7 @@ class BaseSensorOperator(BaseOperator, SkipMixin):
         self,
         *,
         poke_interval: float = 60,
-        timeout: float = 60 * 60 * 24 * 7,
+        timeout: float = conf.getfloat('sensors', 'default_timeout'),
         soft_fail: bool = False,
         mode: str = 'poke',
         exponential_backoff: bool = False,

--- a/tests/core/test_config_templates.py
+++ b/tests/core/test_config_templates.py
@@ -51,6 +51,7 @@ DEFAULT_AIRFLOW_SECTIONS = [
     'elasticsearch',
     'elasticsearch_configs',
     'kubernetes',
+    'sensors',
     'smart_sensor',
 ]
 


### PR DESCRIPTION
closes: #18878 
Add sensor default timeout config.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
