### PR TITLE
Fix queued dag runs changes catchup=False behaviour

### DIFF
--- a/airflow/timetables/interval.py
+++ b/airflow/timetables/interval.py
@@ -81,9 +81,15 @@ class _DataIntervalTimetable(Timetable):
                 return None
             start = self._align(earliest)
         else:
-            # There's a previous run. Create a data interval starting from when
-            # the end of the previous interval.
-            start = last_automated_data_interval.end
+            # There's a previous run.
+            if earliest is not None:
+                # Catchup is False or DAG has new start date in the future.
+                # Make sure we get the latest start date
+                start = max(last_automated_data_interval.end, earliest)
+            else:
+                # Create a data interval starting from when the end of the previous interval.
+                start = last_automated_data_interval.end
+
         if restriction.latest is not None and start > restriction.latest:
             return None
         end = self._get_next(start)


### PR DESCRIPTION
closes: https://github.com/apache/airflow/issues/18487
When a dag has catchup=False we want to select the max value from the earliest possible execution_date and the end of the last execution period.

Thus if a dag is behind schedule it will now select the latest execution date as opposed to just picking the next execution date from the previous dag run