### PR TITLE
Fixing flaky task that fails in first check ocasionally

### DIFF
--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -102,11 +102,14 @@ class TestCliTasks(unittest.TestCase):
 
         args = self.parser.parse_args(["tasks", "test", self.dag_id, task_id, DEFAULT_DATE.isoformat()])
 
-        with redirect_stdout(io.StringIO()) as stdout:
+        with self.assertLogs('airflow.models', level='INFO') as cm:
             task_command.task_test(args)
-
-        # Check that prints, and log messages, are shown
-        assert f"Marking task as SUCCESS. dag_id={self.dag_id}, task_id={task_id}" in stdout.getvalue()
+            assert any(
+                [
+                    f"Marking task as SUCCESS. dag_id={self.dag_id}, task_id={task_id}" in log
+                    for log in cm.output
+                ]
+            )
 
     @mock.patch("airflow.cli.commands.task_command.LocalTaskJob")
     def test_run_with_existing_dag_run_id(self, mock_local_job):


### PR DESCRIPTION
This test case fails occasionally.

To reproduce the issue:
```
./breeze
pytest tests/cli/commands/test_task_command.py::TestCliTasks::test_test_with_existing_dag_run
```
In first run it fails and subsequent repletion of the same succeeds 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
