### PR TITLE
Update virtualenv guide to use correct constraints file

### DIFF
--- a/LOCAL_VIRTUALENV.rst
+++ b/LOCAL_VIRTUALENV.rst
@@ -65,7 +65,7 @@ Extra Packages
 
    Only ``pip`` installation is currently officially supported.
 
-   While they are some successes with using other tools like `poetry <https://python-poetry.org/>`_ or
+   While there are some successes with using other tools like `poetry <https://python-poetry.org/>`_ or
    `pip-tools <https://pypi.org/project/pip-tools/>`_, they do not share the same workflow as
    ``pip`` - especially when it comes to constraint vs. requirements management.
    Installing via ``Poetry`` or ``pip-tools`` is not currently supported.
@@ -146,13 +146,12 @@ To create and initialize the local virtualenv:
 
 In case you have problems with installing airflow because of some requirements are not installable, you can
 try to install it with the set of working constraints (note that there are different constraint files
-for different python versions:
+for different python versions). For development on current main source:
 
    .. code-block:: bash
 
     pip install -e ".[devel,<OTHER EXTRAS>]" \
-        --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.6.txt"
-
+        --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-source-providers-3.6.txt"
 
 This will install Airflow in 'editable' mode - where sources of Airflow are taken directly from the source
 code rather than moved to the installation directory. During the installation airflow will install - but then
@@ -164,7 +163,7 @@ You can also install Airflow in non-editable mode:
    .. code-block:: bash
 
     pip install ".[devel,<OTHER EXTRAS>]" \
-        --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.6.txt"
+        --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-source-providers-3.6.txt"
 
 This will copy the sources to directory where usually python packages are installed. You can see the list
 of directories via ``python -m site`` command. In this case the providers are installed from PyPI, not from
@@ -173,7 +172,7 @@ sources, unless you set ``INSTALL_PROVIDERS_FROM_SOURCES`` environment variable 
    .. code-block:: bash
 
     INSTALL_PROVIDERS_FROM_SOURCES="true" pip install ".[devel,<OTHER EXTRAS>]" \
-        --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-3.6.txt"
+        --constraint "https://raw.githubusercontent.com/apache/airflow/constraints-main/constraints-source-providers-3.6.txt"
 
 
 Note: when you first initialize database (the next step), you may encounter some problems.


### PR DESCRIPTION
The constraints file that was used in the example code snippets is a constraints file for released versions (e.g.: airflow/constraints-main/constraints-3.6.txt). Which was leading to long dependency resolution times as well as dependency version conflicts when using the latest source from main. The correct constraints to use in this case is for example: airflow/constraints-main/constraints-source-providers-3.6.txt (docs explaining the differences for each type of constraints file can be [found here](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pinned-constraint-files)).

Note that constraints-source-providers is what is used by breeze if you use it to setup your local virtual env (as [seen here](https://github.com/apache/airflow/blob/e6fcf7776a298cff741d8a55f0990ea796fd0540/breeze#L262)). So this is really bringing the manual steps inline with this.

Further discussion can be found in the Slack thread where this was discussed: https://apache-airflow.slack.com/archives/CQ9QHSFQX/p1634839186006900?thread_ts=1634668910.074400&cid=CQ9QHSFQX

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
