### PR TITLE
Chart: Fix `extraEnvFrom` examples

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -597,8 +597,8 @@
             "x-docsSection": "Airflow",
             "default": null,
             "examples": [
-                "- secretRef:\n  name: '{{ .Release.Name }}-airflow-connections'",
-                "- configMapRef:\n  name: '{{ .Release.Name }}-airflow-variables'"
+                "- secretRef:\n    name: '{{ .Release.Name }}-airflow-connections'",
+                "- configMapRef:\n    name: '{{ .Release.Name }}-airflow-variables'"
             ]
         },
         "extraSecrets": {


### PR DESCRIPTION
The examples were broken as they were missing 2 spaces.