### PR TITLE
Update openapi generator to 5.2.1

### DIFF
--- a/clients/gen/common.sh
+++ b/clients/gen/common.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OPENAPI_GENERATOR_CLI_VER=5.1.1
+OPENAPI_GENERATOR_CLI_VER=5.2.1
 readonly OPENAPI_GENERATOR_CLI_VER
 
 GIT_USER=${GIT_USER:-apache}


### PR DESCRIPTION
This new version is required to exclude readonly fields from being sent in the request.

Fixes airflow-client-python#4
Fixes airflow-client-python#21