### PR TITLE
Resurrect python openapi client generator

### DIFF
--- a/clients/gen/common.sh
+++ b/clients/gen/common.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-OPENAPI_GENERATOR_CLI_VER=5.1.1
+OPENAPI_GENERATOR_CLI_VER=5.3.0
 readonly OPENAPI_GENERATOR_CLI_VER
 
 GIT_USER=${GIT_USER:-apache}

--- a/clients/gen/common.sh
+++ b/clients/gen/common.sh
@@ -71,6 +71,7 @@ function run_pre_commit {
 
     # prepend license headers
     pre-commit run --all-files || true
+    echo "Output above might state Failed: 'Some sources were modified by the hook' - This is expected as the hook is used to add the licences."
 }
 
 function gen_client {

--- a/clients/gen/python.sh
+++ b/clients/gen/python.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -ueo pipefail
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -61,3 +62,4 @@ find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed "${INPLACE_ARG[@]}" -
 find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed "${INPLACE_ARG[@]}" -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
 
 run_pre_commit
+echo "Generation successful"

--- a/clients/gen/python.sh
+++ b/clients/gen/python.sh
@@ -25,7 +25,7 @@ readonly CLEANUP_DIRS
 # shellcheck source=./clients/gen/common.sh
 source "${CLIENTS_GEN_DIR}/common.sh"
 
-VERSION=2.1.0
+VERSION=2.2.1
 readonly VERSION
 
 python_config=(

--- a/clients/gen/python.sh
+++ b/clients/gen/python.sh
@@ -43,16 +43,21 @@ echo "--- Patching generated code..."
 
 # Post-processing of the generated Python wrapper.
 
+INPLACE_ARG=("-i")
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    INPLACE_ARG=(-i '')
+fi
+
 touch "${OUTPUT_DIR}/__init__.py"
-find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed -i '' -e 's/client/airflow_client.client/g' {} +
-find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/# client/# Apache Airflow Python Client/g' {} +
-find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/import client/import airflow_client.client/g' {} +
-find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/from client/from airflow_client.client/g' {} +
-find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed -i '' -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
+find "${OUTPUT_DIR}/test" -type f -name \*.py -exec sed "${INPLACE_ARG[@]}" -e 's/client/airflow_client.client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed "${INPLACE_ARG[@]}" -e 's/# client/# Apache Airflow Python Client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed "${INPLACE_ARG[@]}" -e 's/import client/import airflow_client.client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed "${INPLACE_ARG[@]}" -e 's/from client/from airflow_client.client/g' {} +
+find "${OUTPUT_DIR}" -type f -a -name \*.md -exec sed "${INPLACE_ARG[@]}" -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
 
 # fix imports
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i '' -e 's/import client\./import airflow_client.client./g' {} +
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i '' -e 's/from client/from airflow_client.client/g' {} +
-find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed -i '' -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed "${INPLACE_ARG[@]}" -e 's/import client\./import airflow_client.client./g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed "${INPLACE_ARG[@]}" -e 's/from client/from airflow_client.client/g' {} +
+find "${OUTPUT_DIR}/client/" -type f -name \*.py -exec sed "${INPLACE_ARG[@]}" -e 's/getattr(client\.models/getattr(airflow_client.client.models/g' {} +
 
 run_pre_commit


### PR DESCRIPTION
These changes enable the airflow-client-python to be generated and used successfully.

* Update openapi generator to 5.2.1, this fixes the client to not send readonly-fields which was the reason for most of the client to not work at all.
  Fixes airflow/airflow-client-python#4
  Fixes airflow/airflow-client-python#21
* Ability to run generator on Ubuntu, previous sed-flags assumed OSX only.
* Update version number to match latest airflow release 2.2.0
* Improve console output on successful generation.

With these changes, I've tried generating the client and can now successfully call the post_dag_run from it, which was not possible before.
Generated airflow-client-python/airflow_client/test unit tests are passing.
