### PR TITLE
Add value to "namespaceId" of query

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_datastore.py
+++ b/airflow/providers/google/cloud/example_dags/example_datastore.py
@@ -131,7 +131,7 @@ with models.DAG(
 
     # [START how_to_query_def]
     QUERY = {
-        "partitionId": {"projectId": GCP_PROJECT_ID, "namespaceId": ""},
+        "partitionId": {"projectId": GCP_PROJECT_ID, "namespaceId": "query"},
         "readOptions": {"transaction": begin_transaction_query.output},
         "query": {},
     }


### PR DESCRIPTION
Due to the issue https://github.com/googleapis/google-cloud-php/issues/530 entities should be splitted. So, according to the documentation https://cloud.google.com/datastore/docs/reference/data/rest/v1/PartitionId **namespaceId** is the ID of the namespace to which the entities belong, so adding value to "namespaceId" of query will avoid `too much contention on these datastore entities` error.