### PR TITLE
Faster db migration to Airflow 2.2

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -98,6 +98,8 @@ the scheduler can create in a dag. Now, the maximum number is controlled interna
 
 ## Airflow 2.2.0
 
+Note: Upgrading the database to `2.2.0` or later can take some time to complete, particularly if you have a large `task_instance` table.
+
 ### `worker_log_server_port` configuration has been moved to the ``logging`` section.
 
 The `worker_log_server_port` configuration option has been moved from `[celery]` section to `[logging]` section to allow for re-use between different executors.

--- a/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
+++ b/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
@@ -267,20 +267,20 @@ def upgrade():
     else:
         update_query = _multi_table_update(dialect_name, task_instance, task_instance.c.run_id)
         op.execute(update_query)
-        op.drop_column('task_instance', 'execution_date')
 
     with op.batch_alter_table('task_instance', schema=None) as batch_op:
+        if dialect_name != 'postgresql':
+            batch_op.drop_column('execution_date')
+
         # Then make it non-nullable
         batch_op.alter_column(
             'run_id', existing_type=string_id_col_type, existing_nullable=True, nullable=False
         )
-
         batch_op.alter_column(
             'dag_id', existing_type=string_id_col_type, existing_nullable=True, nullable=False
         )
 
         batch_op.create_primary_key('task_instance_pkey', ['dag_id', 'task_id', 'run_id'])
-
         batch_op.create_foreign_key(
             'task_instance_dag_run_fkey',
             'dag_run',

--- a/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
+++ b/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
@@ -214,7 +214,8 @@ def upgrade():
         batch_op.drop_index('ti_pool')
         batch_op.drop_index('ti_state')
         batch_op.drop_index('ti_state_lkp')
-        batch_op.drop_index('ti_trigger_id')
+        if dialect_name != 'mysql':
+            batch_op.drop_index('ti_trigger_id')
 
     update_query = _multi_table_update(dialect_name, task_instance, task_instance.c.run_id)
     op.execute(update_query)
@@ -246,7 +247,8 @@ def upgrade():
         batch_op.create_index('ti_pool', ['pool', 'state', 'priority_weight'])
         batch_op.create_index('ti_state', ['state'])
         batch_op.create_index('ti_state_lkp', ['dag_id', 'task_id', 'run_id', 'state'])
-        batch_op.create_index('ti_trigger_id', ['trigger_id'])
+        if dialect_name != 'mysql':
+            batch_op.create_index('ti_trigger_id', ['trigger_id'])
 
     with op.batch_alter_table('task_reschedule', schema=None) as batch_op:
         batch_op.drop_column('execution_date')

--- a/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
+++ b/airflow/migrations/versions/7b2661a43ba3_taskinstance_keyed_to_dagrun.py
@@ -214,13 +214,56 @@ def upgrade():
         batch_op.drop_index('ti_pool')
         batch_op.drop_index('ti_state')
         batch_op.drop_index('ti_state_lkp')
-        if dialect_name != 'mysql':
-            batch_op.drop_index('ti_trigger_id')
+        batch_op.drop_constraint('task_instance_trigger_id_fkey', type_='foreignkey')
+        batch_op.drop_index('ti_trigger_id')
 
-    update_query = _multi_table_update(dialect_name, task_instance, task_instance.c.run_id)
-    op.execute(update_query)
+    # Recreate task_instance, without execution_date and with dagrun.run_id
+    op.execute(
+        """
+        CREATE TABLE new_task_instance AS SELECT
+            ti.task_id,
+            ti.dag_id,
+            dag_run.run_id,
+            ti.start_date,
+            ti.end_date,
+            ti.duration,
+            ti.state,
+            ti.try_number,
+            ti.hostname,
+            ti.unixname,
+            ti.job_id,
+            ti.pool,
+            ti.queue,
+            ti.priority_weight,
+            ti.operator,
+            ti.queued_dttm,
+            ti.pid,
+            ti.max_tries,
+            ti.executor_config,
+            ti.pool_slots,
+            ti.queued_by_job_id,
+            ti.external_executor_id,
+            ti.trigger_id,
+            ti.trigger_timeout,
+            ti.next_method,
+            ti.next_kwargs
+        FROM task_instance ti
+        INNER JOIN dag_run ON dag_run.dag_id = ti.dag_id AND dag_run.execution_date = ti.execution_date;
+        """
+    )
+    op.drop_table('task_instance')
+    op.rename_table('new_task_instance', 'task_instance')
 
     with op.batch_alter_table('task_instance', schema=None) as batch_op:
+        # Fix up columns after the 'create table as select'
+        batch_op.alter_column(
+            'pool', existing_type=string_id_col_type, existing_nullable=True, nullable=False
+        )
+        batch_op.alter_column('max_tries', existing_type=sa.Integer(), server_default="-1")
+        batch_op.alter_column(
+            'pool_slots', existing_type=sa.Integer(), existing_nullable=True, nullable=False
+        )
+
         # Then make it non-nullable
         batch_op.alter_column(
             'run_id', existing_type=string_id_col_type, existing_nullable=True, nullable=False
@@ -232,7 +275,6 @@ def upgrade():
 
         batch_op.create_primary_key('task_instance_pkey', ['dag_id', 'task_id', 'run_id'])
 
-        batch_op.drop_column('execution_date')
         batch_op.create_foreign_key(
             'task_instance_dag_run_fkey',
             'dag_run',
@@ -247,8 +289,10 @@ def upgrade():
         batch_op.create_index('ti_pool', ['pool', 'state', 'priority_weight'])
         batch_op.create_index('ti_state', ['state'])
         batch_op.create_index('ti_state_lkp', ['dag_id', 'task_id', 'run_id', 'state'])
-        if dialect_name != 'mysql':
-            batch_op.create_index('ti_trigger_id', ['trigger_id'])
+        batch_op.create_foreign_key(
+            'task_instance_trigger_id_fkey', 'trigger', ['trigger_id'], ['id'], ondelete="CASCADE"
+        )
+        batch_op.create_index('ti_trigger_id', ['trigger_id'])
 
     with op.batch_alter_table('task_reschedule', schema=None) as batch_op:
         batch_op.drop_column('execution_date')

--- a/tests/executors/test_base_executor.py
+++ b/tests/executors/test_base_executor.py
@@ -69,5 +69,5 @@ def test_try_adopt_task_instances(dag_maker):
     dagrun = dag_maker.create_dagrun(execution_date=date)
     tis = dagrun.task_instances
 
-    assert [ti.task_id for ti in tis] == ["task_1", "task_2", "task_3"]
+    assert {ti.task_id for ti in tis} == {"task_1", "task_2", "task_3"}
     assert BaseExecutor().try_adopt_task_instances(tis) == tis

--- a/tests/models/test_cleartasks.py
+++ b/tests/models/test_cleartasks.py
@@ -53,7 +53,7 @@ class TestClearTasks:
             state=State.RUNNING,
             run_type=DagRunType.SCHEDULED,
         )
-        ti0, ti1 = dr.task_instances
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         ti0.refresh_from_task(task0)
         ti1.refresh_from_task(task1)
 
@@ -125,7 +125,7 @@ class TestClearTasks:
             state=State.RUNNING,
             run_type=DagRunType.SCHEDULED,
         )
-        ti0, ti1 = dr.task_instances
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         dr.last_scheduling_decision = DEFAULT_DATE
         ti0.state = TaskInstanceState.SUCCESS
         ti1.state = TaskInstanceState.SUCCESS
@@ -160,7 +160,7 @@ class TestClearTasks:
             run_type=DagRunType.SCHEDULED,
         )
 
-        ti0, ti1 = dr.task_instances
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         ti0.refresh_from_task(task0)
         ti1.refresh_from_task(task1)
 
@@ -203,7 +203,7 @@ class TestClearTasks:
             run_type=DagRunType.SCHEDULED,
         )
 
-        ti0, ti1 = dr.task_instances
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         ti0.refresh_from_task(task0)
         ti1.refresh_from_task(task1)
 
@@ -243,7 +243,7 @@ class TestClearTasks:
             run_type=DagRunType.SCHEDULED,
         )
 
-        ti0, ti1 = dr.task_instances
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         ti0.refresh_from_task(task0)
         ti1.refresh_from_task(task1)
         ti0.run()
@@ -292,7 +292,7 @@ class TestClearTasks:
         )
         session = dag_maker.session
 
-        ti0, ti1 = dr.task_instances
+        ti0, ti1 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         ti0.refresh_from_task(task0)
         ti1.refresh_from_task(task1)
 
@@ -409,8 +409,8 @@ class TestClearTasks:
             start_date=DEFAULT_DATE,
             end_date=DEFAULT_DATE + datetime.timedelta(days=10),
         ):
-            op1 = DummyOperator(task_id='bash_op')
-            op2 = DummyOperator(task_id='dummy_op', retries=1)
+            op1 = DummyOperator(task_id='test1')
+            op2 = DummyOperator(task_id='test2', retries=1)
             op1 >> op2
 
         dr = dag_maker.create_dagrun(
@@ -418,7 +418,7 @@ class TestClearTasks:
             run_type=DagRunType.SCHEDULED,
         )
 
-        ti1, ti2 = dr.task_instances
+        ti1, ti2 = sorted(dr.task_instances, key=lambda ti: ti.task_id)
         ti1.task = op1
         ti2.task = op2
 


### PR DESCRIPTION
Bigger Airflow databases can take a long time to migrate the database,
particularly if they have a lot of task instances. Dropping indexes
before setting `run_id` from `dag_run` allows the update to complete
faster.

With my test database containing 2.28 million task instances, this resulted in
a significantly faster migration (~145s to ~50s).