### PR TITLE
Updating Apache HDFS title in index doc to match convention

### DIFF
--- a/docs/apache-airflow-providers-apache-hdfs/index.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/index.rst
@@ -15,8 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
-``apache-airflow-providers-hdfs``
-=================================
+``apache-airflow-providers-apache-hdfs``
+========================================
 
 
 Content


### PR DESCRIPTION
The current title in the Apache HDFS index doc is "apache-airflow-providers-hdfs".  This PR updates the title of the index doc to "apache-airflow-providers-apache-hdfs" which follow the same naming convention to use the package name as the providers index-doc title.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
