### PR TITLE
Allow specifying extras when using breeze initialize_local_virtualenv

### DIFF
--- a/LOCAL_VIRTUALENV.rst
+++ b/LOCAL_VIRTUALENV.rst
@@ -204,6 +204,13 @@ Activate your virtualenv, e.g. by using ``workon``, and once you are in it, run:
 
   ./breeze initialize-local-virtualenv
 
+By default Breeze installs the ``devel`` extra only. You can optionally control which extras are installed by exporting ``VIRTUALENV_EXTRAS`` before calling Breeze:
+
+.. code-block:: bash
+
+  export VIRTUALENV_EXTRAS="devel,google,postgres"
+  ./breeze initialize-local-virtualenv
+
 5. (optionally) run yarn build if you plan to run the webserver
 
 .. code-block:: bash

--- a/breeze
+++ b/breeze
@@ -230,6 +230,7 @@ function breeze::setup_default_breeze_constants() {
 #    PYTHON_MAJOR_MINOR_VERSION
 #    AIRFLOW_HOME_DIR
 #    AIRFLOW_SOURCES
+#    VIRTUALENV_EXTRAS
 #    DEFAULT_CONSTRAINTS_BRANCH
 #    OSTYPE
 #
@@ -252,13 +253,15 @@ function breeze::initialize_virtualenv() {
         echo
         echo "Initializing the virtualenv: $(command -v python)!"
         echo
+        echo "Extras to be installed: ${VIRTUALENV_EXTRAS}"
+        echo
         echo "This will wipe out ${AIRFLOW_HOME_DIR} and reset all the databases!"
         echo
         "${AIRFLOW_SOURCES}/confirm" "Proceeding with the initialization"
         echo
         pushd "${AIRFLOW_SOURCES}" >/dev/null 2>&1 || exit 1
         set +e
-        pip install -e ".[devel]" \
+        pip install -e ".[${VIRTUALENV_EXTRAS}]" \
             --constraint "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-source-providers-${PYTHON_MAJOR_MINOR_VERSION}.txt"
         res=$?
         set -e

--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -564,6 +564,11 @@ function initialization::initialize_kubernetes_variables() {
     readonly API_SERVER_PORT
 }
 
+function initialization::initialize_virtualenv_variables() {
+    # The extras to install when initializing a virtual env with breeze
+    export VIRTUALENV_EXTRAS=${VIRTUALENV_EXTRAS:="devel"}
+}
+
 function initialization::initialize_git_variables() {
     # SHA of the commit for the current sources
     COMMIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo "Unknown")"
@@ -638,6 +643,7 @@ function initialization::initialize_common_environment() {
     initialization::initialize_image_build_variables
     initialization::initialize_provider_package_building
     initialization::initialize_kubernetes_variables
+    initialization::initialize_virtualenv_variables
     initialization::initialize_git_variables
     initialization::initialize_github_variables
     initialization::initialize_test_variables


### PR DESCRIPTION
In [this Slack thread](https://apache-airflow.slack.com/archives/CQ9QHSFQX/p1634668910074400), a user was attempting to setup a virtual env to do some testing of code changes. The user reported:

>  I got the breeze initialize-local-virtualenv command to complete successfully but I still am missing packages in my venv.

This is because it is not possible to specify to breeze which extras you'd like to install in the venv (this user needed azure). To get specific extras, users have to fall back to manually run commands from our docs which can be error prone.

This change allows users to export the extras they'd like breeze to install for them.

## Testing
Manually tested both the default case (no user export, use `devel`) and overridden case (user exports `VIRTUALENV_EXTRAS`), both cases functioned correctly and installed the expected extras.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
