### PR TITLE
Improving snowflake operator example docs

### DIFF
--- a/airflow/providers/snowflake/example_dags/example_snowflake.py
+++ b/airflow/providers/snowflake/example_dags/example_snowflake.py
@@ -48,6 +48,7 @@ SNOWFLAKE_SLACK_MESSAGE = (
     "Results in an ASCII table:\n```{{ results_df | tabulate(tablefmt='pretty', headers='keys') }}```"
 )
 
+# [START howto_operator_snowflake]
 
 dag = DAG(
     'example_snowflake',
@@ -57,7 +58,6 @@ dag = DAG(
     catchup=False,
 )
 
-# [START howto_operator_snowflake]
 
 snowflake_op_sql_str = SnowflakeOperator(
     task_id='snowflake_op_sql_str',


### PR DESCRIPTION
…specify the snowflake_conn_id

The current [snowflake operator example page](https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/operators/snowflake.html) omits the part where you specify the snowflake_conn_id as a default_arg. Moving this comment up will include the relevant part of the example. This is only moving one comment 9 lines earlier, no code or logic changes.
