### PR TITLE
Fix breeze docker version parsing

### DIFF
--- a/scripts/ci/libraries/_initialization.sh
+++ b/scripts/ci/libraries/_initialization.sh
@@ -935,7 +935,7 @@ function initialization::ga_env() {
 function initialization::ver() {
   # convert SemVer number to comparable string (strips pre-release version)
   # shellcheck disable=SC2086,SC2183
-  printf "%03d%03d%03d%.0s" ${1//[.-]/}
+  printf "%03d%03d%03d%.0s" ${1//[.-]/ }
 }
 
 function initialization::check_docker_version() {


### PR DESCRIPTION
After this recent change: [18902](https://github.com/apache/airflow/pull/18902), docker version parsing no longer works in all cases:
```
[onikolas@dev-dsk-onikolas airflow]$ ./breeze 
/home/onikolas/code/airflow/scripts/ci/libraries/_initialization.sh: line 932: printf: 190313ce: invalid number
```
This is specifically due to the whitespace being removed from this line:
```
-  printf "%04d%04d%04d%.0s" ${1//[.-]/ }
+  printf "%03d%03d%03d%.0s" ${1//[.-]/}
```
`printf` is expecting at least 3 `%d` arguments which it parses as integers to 3 decimal places. But the missing whitespace in the bash expansion causes the version to not be split into multiple inputs into `printf` as expected, but rather one string:

**With** whitespace in expansion:
```
[onikolas@dev-dsk-onikolas airflow]$ docker_version="19.03.13"
[onikolas@dev-dsk-onikolas airflow]$ echo ${docker_version//[.-]/ }
19 03 13
[onikolas@dev-dsk-onikolas airflow]$ printf "%03d%03d%03d%.0s" ${docker_version//[.-]/ }
019003013
```
**Without** whitespace in expansion:
```
[onikolas@dev-dsk-onikolas airflow]$ docker_version="19.03.13"
[onikolas@dev-dsk-onikolas airflow]$ echo ${docker_version//[.-]/}
190313
[onikolas@dev-dsk-onikolas airflow]$ printf "%03d%03d%03d%.0s" ${docker_version_2//[.-]/}
190313000000
```
As you can see in the latter case the entire version is used as the first argument to `printf` and then `printf` defaults the second and third `%d` with zeros since input is not provided, which is why 6 trailing zeros are seen in the output.
This defaulting allowed the code to pass undetected when it was tested originally, since the `<=` version comparison still passes with this input. It is not until a community edition docker version is used which includes '-ce' in the version that this breaks:
docker community edition version output:
```
[onikolas@dev-dsk-onikolas airflow]$ docker --version
Docker version 19.03.13-ce, build 4484c46
```
When run through the breeze version extraction logic yields:
```
[onikolas@dev-dsk-onikolas airflow]$ docker_version=$(docker version --format '{{.Client.Version}}' | sed 's/\+.*$//' || true)
[onikolas@dev-dsk-onikolas airflow]$ echo $docker_version
19.03.13-ce
```
When this input is run through the `printf` logic, **with** whitespace, you can see the input version is properly split into separate inputs for `printf`, which uses the first three arguments and the last argument (the `ce` portion) is unused. Yielding a useable version:
```
[onikolas@dev-dsk-onikolas airflow]$ echo ${docker_version//[.-]/ }
19 03 13 ce
[onikolas@dev-dsk-onikolas airflow]$ printf "%03d%03d%03d%.0s" ${docker_version//[.-]/ }
019003013
```
However when the version of the code **without** the whitespace, `printf` is given one large input which it uses as the first arg. Which includes `ce` which is not parseable as a number. Which yields the original error message:
```
[onikolas@dev-dsk-onikolas airflow]$ echo ${docker_version//[.-]/}
190313ce
[onikolas@dev-dsk-onikolas airflow]$ printf "%03d%03d%03d%.0s" ${docker_version_2//[.-]/}
190313000000
[onikolas@dev-dsk-onikolas airflow]$ printf "%03d%03d%03d%.0s" ${docker_version//[.-]/}
-logbash: printf: 190313ce: invalid number
```

This change re-adds the whitespace to the expansion which correctly handles both usecases.
   


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
