### PR TITLE
Add a fix on Ubuntu 20.04 for mysql_config not found error

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -13,9 +13,6 @@ sudo apt install build-essential python3-dev libsqlite3-dev openssl \
 On Ubuntu 20.04 you may get an error of mariadb_config not found 
 and mysql_config not found.
 
-Install mariadb
-sudo apt-get install libmariadb-dev libmariadbclient-dev
-
 Install MariaDB development headers:
 sudo apt-get install libmariadb-dev libmariadbclient-dev
 

--- a/INSTALL
+++ b/INSTALL
@@ -9,6 +9,11 @@ Linux (Debian Buster and Linux Mint Tricia):
 
 sudo apt install build-essential python3-dev libsqlite3-dev openssl \
                  sqlite default-libmysqlclient-dev libmysqlclient-dev postgresql
+            
+On Ubuntu 20.04 you may get an error of mariadb_config not found and mysql_config not found. 
+Install mariadb
+
+sudo apt-get install libmariadb-dev libmariadbclient-dev
 
 MacOS (Mojave/Catalina):
 

--- a/INSTALL
+++ b/INSTALL
@@ -10,9 +10,10 @@ Linux (Debian Buster and Linux Mint Tricia):
 sudo apt install build-essential python3-dev libsqlite3-dev openssl \
                  sqlite default-libmysqlclient-dev libmysqlclient-dev postgresql
             
-On Ubuntu 20.04 you may get an error of mariadb_config not found and mysql_config not found. 
-Install mariadb
+On Ubuntu 20.04 you may get an error of mariadb_config not found 
+and mysql_config not found.
 
+Install mariadb
 sudo apt-get install libmariadb-dev libmariadbclient-dev
 
 MacOS (Mojave/Catalina):

--- a/INSTALL
+++ b/INSTALL
@@ -16,6 +16,9 @@ and mysql_config not found.
 Install mariadb
 sudo apt-get install libmariadb-dev libmariadbclient-dev
 
+Install MariaDB development headers:
+sudo apt-get install libmariadb-dev libmariadbclient-dev
+
 MacOS (Mojave/Catalina):
 
 brew install sqlite mysql postgresql


### PR DESCRIPTION
On running this command on Ubuntu 20.04
```
sudo apt install openssl \
     sqlite default-libmysqlclient-dev libmysqlclient-dev postgresql
```
you may face an error of `mariaddb_config not found` and `mysql_config not found` 

fix this by running 
`sudo apt-get install libmariadb-dev libmariadbclient-dev`
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
