### PR TITLE
Fix airflow jobs check cmd for TriggererJob

### DIFF
--- a/airflow/jobs/__init__.py
+++ b/airflow/jobs/__init__.py
@@ -19,4 +19,5 @@
 import airflow.jobs.backfill_job
 import airflow.jobs.base_job
 import airflow.jobs.local_task_job
-import airflow.jobs.scheduler_job  # noqa
+import airflow.jobs.scheduler_job
+import airflow.jobs.triggerer_job  # noqa


### PR DESCRIPTION
The health checks for docker-compose is still broken.
When we try to use it we will see an error like below because the class must be loaded first.
```
AssertionError: No such polymorphic_identity 'TriggererJob' is defined
```
This change forces the class to be loaded, and this command finally starts working properly.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
