### PR TITLE
Add DagRun.logical_date as a property

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -181,6 +181,10 @@ class DagRun(Base, LoggingMixin):
             external_trigger=self.external_trigger,
         )
 
+    @property
+    def logical_date(self) -> datetime:
+        return self.execution_date
+
     def get_state(self):
         return self._state
 


### PR DESCRIPTION
This is actually described in the template ref documentation, but somehow got lost during merges.