### PR TITLE
Removes hard-coding of /tmp filesystem cache

### DIFF
--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -18,6 +18,7 @@
 #
 import warnings
 from datetime import timedelta
+from tempfile import gettempdir
 from typing import Optional
 
 from flask import Flask
@@ -113,7 +114,7 @@ def create_app(config=None, testing=False):
 
     init_robots(flask_app)
 
-    Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
+    Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': gettempdir()})
 
     init_flash_views(flask_app)
 


### PR DESCRIPTION
Filesystem cache has been hard-coded to /tmp. This would not
work for Windows but (more importantly) it does not work in case
the user has no access to /tmp directory and TMPDIR is set to
a different value.

Fixes: #19206

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
