### PR TITLE
Use gettempdir, respecting tempdir enviroment variables

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import time
+from tempfile import gettempdir
 from typing import Iterable
 
 from sqlalchemy import Table, exc, func, inspect, or_, text
@@ -508,7 +509,7 @@ def create_default_connections(session=None):
         Connection(
             conn_id="sqlite_default",
             conn_type="sqlite",
-            host="/tmp/sqlite_default.db",
+            host=os.path.join(gettempdir(), "sqlite_default.db"),
         ),
         session,
     )

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -18,6 +18,7 @@
 #
 import warnings
 from datetime import timedelta
+from tempfile import gettempdir
 from typing import Optional
 
 from flask import Flask
@@ -113,7 +114,7 @@ def create_app(config=None, testing=False):
 
     init_robots(flask_app)
 
-    Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': '/tmp'})
+    Cache(app=flask_app, config={'CACHE_TYPE': 'filesystem', 'CACHE_DIR': gettempdir()})
 
     init_flash_views(flask_app)
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:


How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

closes: #19206
Use `tempfile.gettempdir()` to get temp directory path, respecting TMPDIR and other standard environment variables - for creating the webserver cache, and also sqlite default location. 
This is backward-compatible: if no special environment variable is set - it defaults to `/tmp`. 

