### PR TITLE
Fix Toggle Wrap on DAG code page

### DIFF
--- a/airflow/www/static/js/dag_code.js
+++ b/airflow/www/static/js/dag_code.js
@@ -28,7 +28,7 @@ function toggleWrap() {
 const isWrapped = getMetaValue('wrapped');
 
 // pygments generates the HTML so set wrap toggle via js
-if (isWrapped) {
+if (isWrapped === 'True') {
   toggleWrap();
 }
 

--- a/airflow/www/static/js/dag_code.js
+++ b/airflow/www/static/js/dag_code.js
@@ -19,6 +19,15 @@
 
 /* global window, $ */
 
+import getMetaValue from './meta_value';
+
+const isWrapped = getMetaValue('wrapped');
+
+// pygments generates the HTML so set wrap toggle via js
+if (isWrapped) {
+  toggleWrap();
+}
+
 function toggleWrap() {
   $('.code pre').toggleClass('wrap');
 }

--- a/airflow/www/static/js/dag_code.js
+++ b/airflow/www/static/js/dag_code.js
@@ -17,13 +17,10 @@
  * under the License.
  */
 
-/* global $ */
+/* global window, $ */
 
-import getMetaValue from './meta_value';
-
-const isWrapped = getMetaValue('wrapped');
-
-// pygments generates the HTML so set wrap toggle via js
-if (isWrapped) {
+function toggleWrap() {
   $('.code pre').toggleClass('wrap');
 }
+
+window.toggleWrap = toggleWrap;

--- a/airflow/www/static/js/dag_code.js
+++ b/airflow/www/static/js/dag_code.js
@@ -21,15 +21,15 @@
 
 import getMetaValue from './meta_value';
 
+function toggleWrap() {
+  $('.code pre').toggleClass('wrap');
+}
+
 const isWrapped = getMetaValue('wrapped');
 
 // pygments generates the HTML so set wrap toggle via js
 if (isWrapped) {
   toggleWrap();
-}
-
-function toggleWrap() {
-  $('.code pre').toggleClass('wrap');
 }
 
 window.toggleWrap = toggleWrap;

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -21,6 +21,11 @@
 
 {% block page_title %}{{ dag.dag_id }} - Code - {{ appbuilder.app_name }}{% endblock %}
 
+{% block head_meta %}
+  {{ super() }}
+  <meta name="wrapped" content="{{ wrapped }}">
+{% endblock %}
+
 {% block content %}
   {{ super() }}
   <div class="code-wrap">

--- a/airflow/www/templates/airflow/dag_code.html
+++ b/airflow/www/templates/airflow/dag_code.html
@@ -21,11 +21,6 @@
 
 {% block page_title %}{{ dag.dag_id }} - Code - {{ appbuilder.app_name }}{% endblock %}
 
-{% block head_meta %}
-  {{ super() }}
-  <meta name="wrapped" content="{{ wrapped }}">
-{% endblock %}
-
 {% block content %}
   {{ super() }}
   <div class="code-wrap">


### PR DESCRIPTION
Closes #17047

Root of issue: [ToggleWrap](https://github.com/apache/airflow/blob/main/airflow/www/templates/airflow/dag_code.html#L32) function was undefined.

After applying the changes (see line 31):

- Before clicking `Toggle Wrap` :
![before](https://user-images.githubusercontent.com/50751110/138755273-cf6ebba4-9d40-4fe3-b601-a9ebd64e3097.JPG)

- After clicking `Toggle Wrap` :
![after](https://user-images.githubusercontent.com/50751110/138755471-00934d48-35b9-4487-a4ad-61328183a631.JPG)