### PR TITLE
Fix Unexpected commit error in schedulerjob

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -421,7 +421,8 @@ class SchedulerJob(BaseJob):
             make_transient(ti)
         return executable_tis
 
-    def _enqueue_task_instances_with_queued_state(self, task_instances: List[TI]) -> None:
+    @provide_session
+    def _enqueue_task_instances_with_queued_state(self, task_instances: List[TI], session=None) -> None:
         """
         Takes task_instances, which should have been set to queued, and enqueues them
         with the executor.
@@ -432,7 +433,7 @@ class SchedulerJob(BaseJob):
         # actually enqueue them
         for ti in task_instances:
             if ti.dag_run.state in State.finished:
-                ti.set_state(State.NONE)
+                ti.set_state(State.NONE, session=session)
                 continue
             command = ti.command_as_list(
                 local=True,
@@ -476,7 +477,7 @@ class SchedulerJob(BaseJob):
             max_tis = min(self.max_tis_per_query, self.executor.slots_available)
         queued_tis = self._executable_task_instances_to_queued(max_tis, session=session)
 
-        self._enqueue_task_instances_with_queued_state(queued_tis)
+        self._enqueue_task_instances_with_queued_state(queued_tis, session=session)
         return len(queued_tis)
 
     @provide_session

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -422,13 +422,17 @@ class SchedulerJob(BaseJob):
         return executable_tis
 
     @provide_session
-    def _enqueue_task_instances_with_queued_state(self, task_instances: List[TI], session=None) -> None:
+    def _enqueue_task_instances_with_queued_state(
+        self, task_instances: List[TI], session: Session = None
+    ) -> None:
         """
         Takes task_instances, which should have been set to queued, and enqueues them
         with the executor.
 
         :param task_instances: TaskInstances to enqueue
         :type task_instances: list[TaskInstance]
+        :param session: The session object
+        :type session: Session
         """
         # actually enqueue them
         for ti in task_instances:


### PR DESCRIPTION
When changing the state of ti to None if the dagrun is in a finished state, to avoid
queueing the task, scheduler raises unexpected commit.

The reason is that I didn't pass a session to ti.set_state in #19095

This happens when you mark a dagrun successful/failed and there are some taskinstances that are not yet queued in the dagrun.

```
File "/home/airflow/.local/lib/python3.9/site-packages/airflow/jobs/scheduler_job.py", line 815, in _do_scheduling        
││     num_queued_tis = self._critical_section_execute_task_instances(session=session)                                         
││   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/jobs/scheduler_job.py", line 480, in _critical_section_exe 
││     self._enqueue_task_instances_with_queued_state(queued_tis)                                                              
││   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/jobs/scheduler_job.py", line 436, in _enqueue_task_instanc 
││     ti.set_state(State.NONE)                                                                                                
││   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/session.py", line 70, in wrapper                     
││     return func(*args, session=session, **kwargs)                                                                           
││   File "/usr/local/lib/python3.9/contextlib.py", line 126, in __exit__                                                      
││     next(self.gen)                                                                                                          
││   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/session.py", line 32, in create_session              
││     session.commit()                                                                                                        
││   File "/home/airflow/.local/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 1046, in commit                   
││     self.transaction.commit()                                                                                               
││   File "/home/airflow/.local/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 504, in commit                    
││     self._prepare_impl()                                                                                                    
││   File "/home/airflow/.local/lib/python3.9/site-packages/sqlalchemy/orm/session.py", line 472, in _prepare_impl             
││     self.session.dispatch.before_commit(self.session) 
 File "/home/airflow/.local/lib/python3.9/site-packages/sqlalchemy/event/attr.py", line 322, in __call__                   
 ││     fn(*args, **kw)                                                                                                         
 ││   File "/home/airflow/.local/lib/python3.9/site-packages/airflow/utils/sqlalchemy.py", line 265, in _validate_commit        
 ││     raise RuntimeError("UNEXPECTED COMMIT - THIS WILL BREAK HA LOCKS!")                                                     
 ││ RuntimeError: UNEXPECTED COMMIT - THIS WILL BREAK HA LOCKS!                                                                 
 ││ stream closed 
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
