### PR TITLE
Use Viewer role as example public role

### DIFF
--- a/airflow/config_templates/default_webserver_config.py
+++ b/airflow/config_templates/default_webserver_config.py
@@ -49,8 +49,8 @@ AUTH_TYPE = AUTH_DB
 # Uncomment to setup Full admin role name
 # AUTH_ROLE_ADMIN = 'Admin'
 
-# Uncomment to setup Public role name, no authentication needed
-# AUTH_ROLE_PUBLIC = 'Public'
+# Uncomment and set to desired role to enable access without authentication
+# AUTH_ROLE_PUBLIC = 'Viewer'
 
 # Will allow user self registration
 # AUTH_USER_REGISTRATION = True


### PR DESCRIPTION
Currently the sample public role is the `Public` role.  But this role provids no access and still shows the login modal, which makes it seem like the config is not working at all.

More intuitive would be to use `Viewer` role in example in the default config because you can at least view the dags.
