### PR TITLE
Add Labels to jobs created by cleanup pods

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -48,6 +48,13 @@ spec:
       backoffLimit: 1
       template:
         metadata:
+          labels:
+            tier: airflow
+            component: airflow-cleanup-pods
+            release: {{ .Release.Name }}
+{{- with .Values.labels }}
+{{ toYaml . | indent 12 }}
+{{- end }}
           annotations:
             sidecar.istio.io/inject: "false"
         spec:

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -158,3 +158,21 @@ class CleanupPodsTest(unittest.TestCase):
             "spec.jobTemplate.spec.template.spec.containers[0].command", docs[0]
         )
         assert ["Helm"] == jmespath.search("spec.jobTemplate.spec.template.spec.containers[0].args", docs[0])
+
+    def test_should_set_labels_to_jobs_from_cronjob(self):
+        docs = render_chart(
+            values={
+                "cleanup": {"enabled": True},
+                "labels": {"project": "airflow"},
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+
+        print(docs[0])
+
+        assert {
+            "tier": "airflow",
+            "component": "airflow-cleanup-pods",
+            "release": "RELEASE-NAME",
+            "project": "airflow",
+        } == jmespath.search("spec.jobTemplate.spec.template.metadata.labels", docs[0])

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -168,8 +168,6 @@ class CleanupPodsTest(unittest.TestCase):
             show_only=["templates/cleanup/cleanup-cronjob.yaml"],
         )
 
-        print(docs[0])
-
         assert {
             "tier": "airflow",
             "component": "airflow-cleanup-pods",


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
Problem:
Currently pods created by cleanup jobs doesn't add labels similar to metadata.labels.
This prevents us to use network policies to block / allow to communication to internal services

How does this PR fix the problem above:

This PR adds ability to utilise existing labels and allow to use new labels from values.yaml

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
