### PR TITLE
Cleanup of start_date and default arg use for Amazon example DAGs

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_athena.py
+++ b/airflow/providers/amazon/aws/example_dags/example_athena.py
@@ -36,7 +36,6 @@ SAMPLE_DATA = """"Alice",20
 "Charlie",30
 """
 SAMPLE_FILENAME = 'airflow_sample.csv'
-AWS_CONN_ID = 'aws_default'
 
 
 @task(task_id='setup__add_sample_data_to_s3')
@@ -99,7 +98,6 @@ with DAG(
         output_location=f's3://{S3_BUCKET}/{S3_KEY}',
         sleep_time=30,
         max_tries=None,
-        aws_conn_id=AWS_CONN_ID,
     )
 
     read_table = AWSAthenaOperator(
@@ -109,21 +107,17 @@ with DAG(
         output_location=f's3://{S3_BUCKET}/{S3_KEY}',
         sleep_time=30,
         max_tries=None,
-        aws_conn_id=AWS_CONN_ID,
     )
 
     get_read_state = AthenaSensor(
         task_id='query__get_read_state',
-        query_execution_id="{{ task_instance.xcom_pull('query__read_table', key='return_value') }}",
+        query_execution_id=read_table.output,
         max_retries=None,
         sleep_time=10,
-        aws_conn_id=AWS_CONN_ID,
     )
 
     # Using a task-decorated function to read the results from S3
-    read_results_from_s3 = read_results_from_s3(
-        "{{ task_instance.xcom_pull('query__read_table', key='return_value') }}"
-    )
+    read_results_from_s3 = read_results_from_s3(read_table.output)
 
     drop_table = AWSAthenaOperator(
         task_id='teardown__drop_table',
@@ -132,7 +126,6 @@ with DAG(
         output_location=f's3://{S3_BUCKET}/{S3_KEY}',
         sleep_time=30,
         max_tries=None,
-        aws_conn_id=AWS_CONN_ID,
     )
 
     # Using a task-decorated function to delete the S3 file we created earlier
@@ -148,3 +141,7 @@ with DAG(
         >> remove_sample_data_from_s3
     )
     # [END howto_athena_operator_and_sensor]
+
+    # Task dependencies created via `XComArgs`:
+    #   read_table >> get_read_state
+    #   read_table >> read_results_from_s3

--- a/airflow/providers/amazon/aws/example_dags/example_datasync_1.py
+++ b/airflow/providers/amazon/aws/example_dags/example_datasync_1.py
@@ -47,6 +47,7 @@ with models.DAG(
     "example_datasync_1_1",
     schedule_interval=None,  # Override to match your needs
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
 

--- a/airflow/providers/amazon/aws/example_dags/example_datasync_1.py
+++ b/airflow/providers/amazon/aws/example_dags/example_datasync_1.py
@@ -26,11 +26,11 @@ This DAG relies on the following environment variables:
 * DESTINATION_LOCATION_URI - Destination location URI, usually S3
 """
 
+from datetime import datetime
 from os import getenv
 
 from airflow import models
 from airflow.providers.amazon.aws.operators.datasync import AWSDataSyncOperator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_datasync_1_args_1]
 TASK_ARN = getenv("TASK_ARN", "my_aws_datasync_task_arn")
@@ -46,24 +46,21 @@ DESTINATION_LOCATION_URI = getenv("DESTINATION_LOCATION_URI", "s3://mybucket/pre
 with models.DAG(
     "example_datasync_1_1",
     schedule_interval=None,  # Override to match your needs
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
 
     # [START howto_operator_datasync_1_1]
-    datasync_task_1 = AWSDataSyncOperator(
-        aws_conn_id="aws_default", task_id="datasync_task_1", task_arn=TASK_ARN
-    )
+    datasync_task_1 = AWSDataSyncOperator(task_id="datasync_task_1", task_arn=TASK_ARN)
     # [END howto_operator_datasync_1_1]
 
 with models.DAG(
     "example_datasync_1_2",
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     schedule_interval=None,  # Override to match your needs
 ) as dag:
     # [START howto_operator_datasync_1_2]
     datasync_task_2 = AWSDataSyncOperator(
-        aws_conn_id="aws_default",
         task_id="datasync_task_2",
         source_location_uri=SOURCE_LOCATION_URI,
         destination_location_uri=DESTINATION_LOCATION_URI,

--- a/airflow/providers/amazon/aws/example_dags/example_datasync_2.py
+++ b/airflow/providers/amazon/aws/example_dags/example_datasync_2.py
@@ -35,11 +35,11 @@ This DAG relies on the following environment variables:
 
 import json
 import re
+from datetime import datetime
 from os import getenv
 
 from airflow import models
 from airflow.providers.amazon.aws.operators.datasync import AWSDataSyncOperator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_datasync_2_args]
 SOURCE_LOCATION_URI = getenv("SOURCE_LOCATION_URI", "smb://hostname/directory/")
@@ -72,13 +72,12 @@ UPDATE_TASK_KWARGS = json.loads(getenv("UPDATE_TASK_KWARGS", default_update_task
 with models.DAG(
     "example_datasync_2",
     schedule_interval=None,  # Override to match your needs
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
 
     # [START howto_operator_datasync_2]
     datasync_task = AWSDataSyncOperator(
-        aws_conn_id="aws_default",
         task_id="datasync_task",
         source_location_uri=SOURCE_LOCATION_URI,
         destination_location_uri=DESTINATION_LOCATION_URI,

--- a/airflow/providers/amazon/aws/example_dags/example_datasync_2.py
+++ b/airflow/providers/amazon/aws/example_dags/example_datasync_2.py
@@ -73,6 +73,7 @@ with models.DAG(
     "example_datasync_2",
     schedule_interval=None,  # Override to match your needs
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
 

--- a/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.py
+++ b/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.py
@@ -33,6 +33,7 @@ dag = DAG(
     default_view="graph",
     schedule_interval=None,
     start_date=datetime.datetime(2020, 1, 1),
+    catchup=False,
     tags=["example"],
 )
 # generate dag documentation

--- a/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.py
+++ b/airflow/providers/amazon/aws/example_dags/example_ecs_fargate.py
@@ -30,13 +30,6 @@ from airflow.providers.amazon.aws.operators.ecs import ECSOperator
 
 dag = DAG(
     dag_id="ecs_fargate_dag",
-    default_args={
-        "owner": "airflow",
-        "depends_on_past": False,
-        "email": ["airflow@example.com"],
-        "email_on_failure": False,
-        "email_on_retry": False,
-    },
     default_view="graph",
     schedule_interval=None,
     start_date=datetime.datetime(2020, 1, 1),

--- a/airflow/providers/amazon/aws/example_dags/example_eks_templated.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_templated.py
@@ -48,6 +48,7 @@ with DAG(
     default_args={'cluster_name': "{{ dag_run.conf['cluster_name'] }}"},
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     max_active_runs=1,
     tags=['example', 'templated'],
     # render_template_as_native_obj=True is what converts the Jinja to Python objects, instead of a string.

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_fargate_in_one_step.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_fargate_in_one_step.py
@@ -43,6 +43,7 @@ with DAG(
     default_args={'cluster_name': CLUSTER_NAME},
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     max_active_runs=1,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_fargate_profile.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_fargate_profile.py
@@ -46,6 +46,7 @@ with DAG(
     default_args={'cluster_name': CLUSTER_NAME},
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     max_active_runs=1,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroup_in_one_step.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroup_in_one_step.py
@@ -42,6 +42,7 @@ with DAG(
     default_args={'cluster_name': CLUSTER_NAME},
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     max_active_runs=1,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
@@ -45,6 +45,7 @@ with DAG(
     default_args={'cluster_name': CLUSTER_NAME},
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     max_active_runs=1,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/amazon/aws/example_dags/example_emr_eks_job.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr_eks_job.py
@@ -18,11 +18,10 @@
 This is an example dag for an Amazon EMR on EKS Spark job.
 """
 import os
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.emr_containers import EMRContainerOperator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_emr_eks_env_variables]
 VIRTUAL_CLUSTER_ID = os.getenv("VIRTUAL_CLUSTER_ID", "test-cluster")
@@ -59,7 +58,7 @@ CONFIGURATION_OVERRIDES_ARG = {
 with DAG(
     dag_id='emr_eks_pi_job',
     dagrun_timeout=timedelta(hours=2),
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     schedule_interval="@once",
     tags=["emr_containers", "example"],
 ) as dag:

--- a/airflow/providers/amazon/aws/example_dags/example_emr_eks_job.py
+++ b/airflow/providers/amazon/aws/example_dags/example_emr_eks_job.py
@@ -60,6 +60,7 @@ with DAG(
     dagrun_timeout=timedelta(hours=2),
     start_date=datetime(2021, 1, 1),
     schedule_interval="@once",
+    catchup=False,
     tags=["emr_containers", "example"],
 ) as dag:
 

--- a/airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.py
+++ b/airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.py
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.amazon.aws.operators.glacier import GlacierCreateJobOperator
 from airflow.providers.amazon.aws.sensors.glacier import GlacierJobOperationSensor
 from airflow.providers.amazon.aws.transfers.glacier_to_gcs import GlacierToGCSOperator
-from airflow.utils.dates import days_ago
 
 VAULT_NAME = "airflow"
 BUCKET_NAME = os.environ.get("GLACIER_GCS_BUCKET_NAME", "gs://INVALID BUCKET NAME")
@@ -29,20 +29,15 @@ OBJECT_NAME = os.environ.get("GLACIER_OBJECT", "example-text.txt")
 with models.DAG(
     "example_glacier_to_gcs",
     schedule_interval=None,
-    start_date=days_ago(1),  # Override to match your needs
+    start_date=datetime(2021, 1, 1),  # Override to match your needs
 ) as dag:
     # [START howto_glacier_create_job_operator]
-    create_glacier_job = GlacierCreateJobOperator(
-        task_id="create_glacier_job",
-        aws_conn_id="aws_default",
-        vault_name=VAULT_NAME,
-    )
+    create_glacier_job = GlacierCreateJobOperator(task_id="create_glacier_job", vault_name=VAULT_NAME)
     JOB_ID = '{{ task_instance.xcom_pull("create_glacier_job")["jobId"] }}'
     # [END howto_glacier_create_job_operator]
 
     # [START howto_glacier_job_operation_sensor]
     wait_for_operation_complete = GlacierJobOperationSensor(
-        aws_conn_id="aws_default",
         vault_name=VAULT_NAME,
         job_id=JOB_ID,
         task_id="wait_for_operation_complete",
@@ -52,8 +47,6 @@ with models.DAG(
     # [START howto_glacier_transfer_data_to_gcs]
     transfer_archive_to_gcs = GlacierToGCSOperator(
         task_id="transfer_archive_to_gcs",
-        aws_conn_id="aws_default",
-        gcp_conn_id="google_cloud_default",
         vault_name=VAULT_NAME,
         bucket_name=BUCKET_NAME,
         object_name=OBJECT_NAME,

--- a/airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.py
+++ b/airflow/providers/amazon/aws/example_dags/example_glacier_to_gcs.py
@@ -30,6 +30,7 @@ with models.DAG(
     "example_glacier_to_gcs",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),  # Override to match your needs
+    catchup=False,
 ) as dag:
     # [START howto_glacier_create_job_operator]
     create_glacier_job = GlacierCreateJobOperator(task_id="create_glacier_job", vault_name=VAULT_NAME)

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
@@ -33,13 +33,13 @@ YOUTUBE_CONN_ID is optional for public videos. It does only need to authenticate
 on a YouTube channel you want to retrieve.
 """
 
+from datetime import datetime
 from os import getenv
 
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
-from airflow.operators.python import BranchPythonOperator, get_current_context
+from airflow.operators.python import BranchPythonOperator
 from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_google_api_to_s3_transfer_advanced_env_variables]
 YOUTUBE_CONN_ID = getenv("YOUTUBE_CONN_ID", "google_cloud_default")
@@ -53,13 +53,12 @@ YOUTUBE_VIDEO_FIELDS = getenv("YOUTUBE_VIDEO_FIELDS", "items(id,snippet(descript
 
 
 # [START howto_operator_google_api_to_s3_transfer_advanced_task_1_2]
-def _check_and_transform_video_ids(task_output):
+def _check_and_transform_video_ids(task_output, task_instance):
     video_ids_response = task_output
     video_ids = [item['id']['videoId'] for item in video_ids_response['items']]
 
     if video_ids:
-        context = get_current_context()
-        context["task_instance"].xcom_push(key='video_ids', value={'id': ','.join(video_ids)})
+        task_instance.xcom_push(key='video_ids', value={'id': ','.join(video_ids)})
         return 'video_data_to_s3'
     return 'no_video_ids'
 
@@ -73,7 +72,7 @@ s3_file_name, _ = s3_file.rsplit('.', 1)
 with DAG(
     dag_id="example_google_api_to_s3_transfer_advanced",
     schedule_interval=None,
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
     # [START howto_operator_google_api_to_s3_transfer_advanced_task_1]

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_advanced.py
@@ -73,6 +73,7 @@ with DAG(
     dag_id="example_google_api_to_s3_transfer_advanced",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_google_api_to_s3_transfer_advanced_task_1]

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
@@ -20,11 +20,11 @@ This is a basic example dag for using `GoogleApiToS3Transfer` to retrieve Google
 You need to set all env variables to request the data.
 """
 
+from datetime import datetime
 from os import getenv
 
 from airflow import DAG
 from airflow.providers.amazon.aws.transfers.google_api_to_s3 import GoogleApiToS3Operator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_google_api_to_s3_transfer_basic_env_variables]
 GOOGLE_SHEET_ID = getenv("GOOGLE_SHEET_ID")
@@ -36,7 +36,7 @@ S3_DESTINATION_KEY = getenv("S3_DESTINATION_KEY", "s3://bucket/key.json")
 with DAG(
     dag_id="example_google_api_to_s3_transfer_basic",
     schedule_interval=None,
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     tags=['example'],
 ) as dag:
     # [START howto_operator_google_api_to_s3_transfer_basic_task_1]
@@ -47,6 +47,5 @@ with DAG(
         google_api_endpoint_params={'spreadsheetId': GOOGLE_SHEET_ID, 'range': GOOGLE_SHEET_RANGE},
         s3_destination_key=S3_DESTINATION_KEY,
         task_id='google_sheets_values_to_s3',
-        dag=dag,
     )
     # [END howto_operator_google_api_to_s3_transfer_basic_task_1]

--- a/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
+++ b/airflow/providers/amazon/aws/example_dags/example_google_api_to_s3_transfer_basic.py
@@ -37,6 +37,7 @@ with DAG(
     dag_id="example_google_api_to_s3_transfer_basic",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_google_api_to_s3_transfer_basic_task_1]

--- a/airflow/providers/amazon/aws/example_dags/example_imap_attachment_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_imap_attachment_to_s3.py
@@ -37,6 +37,7 @@ with DAG(
     dag_id="example_imap_attachment_to_s3",
     start_date=datetime(2021, 1, 1),
     schedule_interval=None,
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_imap_attachment_to_s3_task_1]

--- a/airflow/providers/amazon/aws/example_dags/example_imap_attachment_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_imap_attachment_to_s3.py
@@ -20,11 +20,11 @@ This is an example dag for using `ImapAttachmentToS3Operator` to transfer an ema
 protocol from a mail server to S3 Bucket.
 """
 
+from datetime import datetime
 from os import getenv
 
 from airflow import DAG
 from airflow.providers.amazon.aws.transfers.imap_attachment_to_s3 import ImapAttachmentToS3Operator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_imap_attachment_to_s3_env_variables]
 IMAP_ATTACHMENT_NAME = getenv("IMAP_ATTACHMENT_NAME", "test.txt")
@@ -34,7 +34,10 @@ S3_DESTINATION_KEY = getenv("S3_DESTINATION_KEY", "s3://bucket/key.json")
 # [END howto_operator_imap_attachment_to_s3_env_variables]
 
 with DAG(
-    dag_id="example_imap_attachment_to_s3", start_date=days_ago(1), schedule_interval=None, tags=['example']
+    dag_id="example_imap_attachment_to_s3",
+    start_date=datetime(2021, 1, 1),
+    schedule_interval=None,
+    tags=['example'],
 ) as dag:
     # [START howto_operator_imap_attachment_to_s3_task_1]
     task_transfer_imap_attachment_to_s3 = ImapAttachmentToS3Operator(
@@ -43,6 +46,5 @@ with DAG(
         imap_mail_folder=IMAP_MAIL_FOLDER,
         imap_mail_filter=IMAP_MAIL_FILTER,
         task_id='transfer_imap_attachment_to_s3',
-        dag=dag,
     )
     # [END howto_operator_imap_attachment_to_s3_task_1]

--- a/airflow/providers/amazon/aws/example_dags/example_local_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_local_to_s3.py
@@ -29,6 +29,7 @@ with models.DAG(
     "example_local_to_s3",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),  # Override to match your needs
+    catchup=False,
 ) as dag:
     # [START howto_local_transfer_data_to_s3]
     create_local_to_s3_job = LocalFilesystemToS3Operator(

--- a/airflow/providers/amazon/aws/example_dags/example_local_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_local_to_s3.py
@@ -37,6 +37,4 @@ with models.DAG(
         dest_key=S3_KEY,
         dest_bucket=S3_BUCKET,
     )
-
-    create_local_to_s3_job
     # [END howto_local_transfer_data_to_s3]

--- a/airflow/providers/amazon/aws/example_dags/example_redshift.py
+++ b/airflow/providers/amazon/aws/example_dags/example_redshift.py
@@ -25,7 +25,13 @@ from datetime import datetime
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.redshift import RedshiftSQLOperator
 
-with DAG(dag_id="redshift", start_date=datetime(2021, 1, 1), schedule_interval=None, tags=['example']) as dag:
+with DAG(
+    dag_id="redshift",
+    start_date=datetime(2021, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    tags=['example'],
+) as dag:
     # [START howto_operator_redshift_create_table]
     setup__task_create_table = RedshiftSQLOperator(
         task_id='setup__create_table',

--- a/airflow/providers/amazon/aws/example_dags/example_s3_bucket.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_bucket.py
@@ -15,12 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+from datetime import datetime
 
 from airflow.decorators import task
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.operators.s3_bucket import S3CreateBucketOperator, S3DeleteBucketOperator
-from airflow.utils.dates import days_ago
 
 BUCKET_NAME = os.environ.get('BUCKET_NAME', 'test-airflow-12345')
 
@@ -38,28 +38,22 @@ def upload_keys():
         )
 
 
+# [START howto_operator_s3_bucket]
 with DAG(
     dag_id='s3_bucket_dag',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     default_args={"bucket_name": BUCKET_NAME},
     max_active_runs=1,
     tags=['example'],
 ) as dag:
 
-    # [START howto_operator_s3_bucket]
-    create_bucket = S3CreateBucketOperator(
-        task_id='s3_bucket_dag_create',
-        region_name='us-east-1',
-    )
+    create_bucket = S3CreateBucketOperator(task_id='s3_bucket_dag_create', region_name='us-east-1')
 
     # Using a task-decorated function to add keys
     add_keys_to_bucket = upload_keys()
 
-    delete_bucket = S3DeleteBucketOperator(
-        task_id='s3_bucket_dag_delete',
-        force_delete=True,
-    )
-    # [END howto_operator_s3_bucket]
+    delete_bucket = S3DeleteBucketOperator(task_id='s3_bucket_dag_delete', force_delete=True)
 
     create_bucket >> add_keys_to_bucket >> delete_bucket
+    # [END howto_operator_s3_bucket]

--- a/airflow/providers/amazon/aws/example_dags/example_s3_bucket.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_bucket.py
@@ -43,6 +43,7 @@ with DAG(
     dag_id='s3_bucket_dag',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     default_args={"bucket_name": BUCKET_NAME},
     max_active_runs=1,
     tags=['example'],

--- a/airflow/providers/amazon/aws/example_dags/example_s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_bucket_tagging.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import os
+from datetime import datetime
 
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.operators.s3_bucket import S3CreateBucketOperator, S3DeleteBucketOperator
@@ -23,45 +24,33 @@ from airflow.providers.amazon.aws.operators.s3_bucket_tagging import (
     S3GetBucketTaggingOperator,
     S3PutBucketTaggingOperator,
 )
-from airflow.utils.dates import days_ago
 
 BUCKET_NAME = os.environ.get('BUCKET_NAME', 'test-s3-bucket-tagging')
 TAG_KEY = os.environ.get('TAG_KEY', 'test-s3-bucket-tagging-key')
 TAG_VALUE = os.environ.get('TAG_VALUE', 'test-s3-bucket-tagging-value')
 
 
+# [START howto_operator_s3_bucket_tagging]
 with DAG(
     dag_id='s3_bucket_tagging_dag',
     schedule_interval=None,
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
+    default_args={"bucket_name": BUCKET_NAME},
     max_active_runs=1,
     tags=['example'],
 ) as dag:
 
-    create_bucket = S3CreateBucketOperator(
-        task_id='s3_bucket_tagging_dag_create',
-        bucket_name=BUCKET_NAME,
-        region_name='us-east-1',
-    )
+    create_bucket = S3CreateBucketOperator(task_id='s3_bucket_tagging_dag_create', region_name='us-east-1')
 
-    delete_bucket = S3DeleteBucketOperator(
-        task_id='s3_bucket_tagging_dag_delete',
-        bucket_name=BUCKET_NAME,
-        force_delete=True,
-    )
+    delete_bucket = S3DeleteBucketOperator(task_id='s3_bucket_tagging_dag_delete', force_delete=True)
 
-    # [START howto_operator_s3_bucket_tagging]
-    get_tagging = S3GetBucketTaggingOperator(
-        task_id='s3_bucket_tagging_dag_get_tagging', bucket_name=BUCKET_NAME
-    )
+    get_tagging = S3GetBucketTaggingOperator(task_id='s3_bucket_tagging_dag_get_tagging')
 
     put_tagging = S3PutBucketTaggingOperator(
-        task_id='s3_bucket_tagging_dag_put_tagging', bucket_name=BUCKET_NAME, key=TAG_KEY, value=TAG_VALUE
+        task_id='s3_bucket_tagging_dag_put_tagging', key=TAG_KEY, value=TAG_VALUE
     )
 
-    delete_tagging = S3DeleteBucketTaggingOperator(
-        task_id='s3_bucket_tagging_dag_delete_tagging', bucket_name=BUCKET_NAME
-    )
-    # [END howto_operator_s3_bucket_tagging]
+    delete_tagging = S3DeleteBucketTaggingOperator(task_id='s3_bucket_tagging_dag_delete_tagging')
 
     create_bucket >> put_tagging >> get_tagging >> delete_tagging >> delete_bucket
+    # [END howto_operator_s3_bucket_tagging]

--- a/airflow/providers/amazon/aws/example_dags/example_s3_bucket_tagging.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_bucket_tagging.py
@@ -35,6 +35,7 @@ with DAG(
     dag_id='s3_bucket_tagging_dag',
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     default_args={"bucket_name": BUCKET_NAME},
     max_active_runs=1,
     tags=['example'],

--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
@@ -50,7 +50,11 @@ def remove_sample_data_from_s3():
 
 
 with DAG(
-    dag_id="example_s3_to_redshift", start_date=datetime(2021, 1, 1), schedule_interval=None, tags=['example']
+    dag_id="example_s3_to_redshift",
+    start_date=datetime(2021, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    tags=['example'],
 ) as dag:
     add_sample_data_to_s3 = add_sample_data_to_s3()
 

--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_redshift.py
@@ -19,6 +19,7 @@
 This is an example dag for using `S3ToRedshiftOperator` to copy a S3 key into a Redshift table.
 """
 
+from datetime import datetime
 from os import getenv
 
 from airflow import DAG
@@ -27,7 +28,6 @@ from airflow.models.baseoperator import chain
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.amazon.aws.operators.redshift import RedshiftSQLOperator
 from airflow.providers.amazon.aws.transfers.s3_to_redshift import S3ToRedshiftOperator
-from airflow.utils.dates import days_ago
 
 # [START howto_operator_s3_to_redshift_env_variables]
 S3_BUCKET = getenv("S3_BUCKET", "test-bucket")
@@ -50,7 +50,7 @@ def remove_sample_data_from_s3():
 
 
 with DAG(
-    dag_id="example_s3_to_redshift", start_date=days_ago(1), schedule_interval=None, tags=['example']
+    dag_id="example_s3_to_redshift", start_date=datetime(2021, 1, 1), schedule_interval=None, tags=['example']
 ) as dag:
     add_sample_data_to_s3 = add_sample_data_to_s3()
 

--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_sftp.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_sftp.py
@@ -17,10 +17,10 @@
 
 
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.amazon.aws.transfers.s3_to_sftp import S3ToSFTPOperator
-from airflow.utils.dates import days_ago
 
 S3_BUCKET = os.environ.get("S3_BUCKET", "test-bucket")
 S3_KEY = os.environ.get("S3_KEY", "key")
@@ -28,7 +28,7 @@ S3_KEY = os.environ.get("S3_KEY", "key")
 with models.DAG(
     "example_s3_to_sftp",
     schedule_interval=None,
-    start_date=days_ago(1),  # Override to match your needs
+    start_date=datetime(2021, 1, 1),  # Override to match your needs
 ) as dag:
 
     # [START howto_s3_transfer_data_to_sftp]

--- a/airflow/providers/amazon/aws/example_dags/example_s3_to_sftp.py
+++ b/airflow/providers/amazon/aws/example_dags/example_s3_to_sftp.py
@@ -29,6 +29,7 @@ with models.DAG(
     "example_s3_to_sftp",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),  # Override to match your needs
+    catchup=False,
 ) as dag:
 
     # [START howto_s3_transfer_data_to_sftp]

--- a/airflow/providers/amazon/aws/example_dags/example_sftp_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_sftp_to_s3.py
@@ -29,6 +29,7 @@ with models.DAG(
     "example_sftp_to_s3",
     schedule_interval=None,
     start_date=datetime(2021, 1, 1),  # Override to match your needs
+    catchup=False,
 ) as dag:
     # [START howto_sftp_transfer_data_to_s3]
     create_sftp_to_s3_job = SFTPToS3Operator(

--- a/airflow/providers/amazon/aws/example_dags/example_sftp_to_s3.py
+++ b/airflow/providers/amazon/aws/example_dags/example_sftp_to_s3.py
@@ -17,10 +17,10 @@
 
 
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.amazon.aws.transfers.sftp_to_s3 import SFTPToS3Operator
-from airflow.utils.dates import days_ago
 
 S3_BUCKET = os.environ.get("S3_BUCKET", "test-bucket")
 S3_KEY = os.environ.get("S3_KEY", "key")
@@ -28,7 +28,7 @@ S3_KEY = os.environ.get("S3_KEY", "key")
 with models.DAG(
     "example_sftp_to_s3",
     schedule_interval=None,
-    start_date=days_ago(1),  # Override to match your needs
+    start_date=datetime(2021, 1, 1),  # Override to match your needs
 ) as dag:
     # [START howto_sftp_transfer_data_to_s3]
     create_sftp_to_s3_job = SFTPToS3Operator(

--- a/airflow/providers/amazon/aws/example_dags/example_sqs.py
+++ b/airflow/providers/amazon/aws/example_dags/example_sqs.py
@@ -29,18 +29,16 @@ AWS_CONN_ID = 'aws_default'
 
 @task(task_id="create_queue")
 def create_queue_fn():
-    """This is a python callback that creates an SQS queue"""
-    hook = SQSHook(aws_conn_id=AWS_CONN_ID)
-    result = hook.create_queue(
-        queue_name=QUEUE_NAME,
-    )
+    """This is a Python function that creates an SQS queue"""
+    hook = SQSHook()
+    result = hook.create_queue(queue_name=QUEUE_NAME)
     return result['QueueUrl']
 
 
 @task(task_id="delete_queue")
 def delete_queue_fn(queue_url):
-    """This is a python callback that deletes an SQS queue"""
-    hook = SQSHook(aws_conn_id=AWS_CONN_ID)
+    """This is a Python function that deletes an SQS queue"""
+    hook = SQSHook()
     hook.get_conn().delete_queue(QueueUrl=queue_url)
 
 
@@ -63,7 +61,6 @@ with DAG(
         message_content="{{ task_instance }}-{{ execution_date }}",
         message_attributes=None,
         delay_seconds=0,
-        aws_conn_id=AWS_CONN_ID,
     )
 
     read_from_queue = SQSSensor(
@@ -75,7 +72,6 @@ with DAG(
         message_filtering=None,
         message_filtering_match_values=None,
         message_filtering_config=None,
-        aws_conn_id=AWS_CONN_ID,
     )
 
     # Using a task-decorated function to delete the SQS queue we created earlier

--- a/docs/apache-airflow-providers-amazon/operators/dms.rst
+++ b/docs/apache-airflow-providers-amazon/operators/dms.rst
@@ -53,7 +53,7 @@ Create replication task, wait for it completion and delete it.
 Purpose
 """""""
 
-This example dag ``example_dms_full_load_task.py`` uses ``DmsCreateTaskOperator``, ``DmsStartTaskOperator``,
+This example DAG ``example_dms_full_load_task.py`` uses ``DmsCreateTaskOperator``, ``DmsStartTaskOperator``,
 ``DmsTaskCompletedSensor``, ``DmsDeleteTaskOperator`` to create replication task, start it, wait for it
 to be completed, and then delete it.
 
@@ -64,23 +64,8 @@ In the following code we create a new replication task, start it, wait for it to
 
 .. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.py
     :language: python
-    :start-after: [START howto_dms_create_task_operator]
-    :end-before: [END howto_dms_create_task_operator]
-
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.py
-    :language: python
-    :start-after: [START howto_dms_start_task_operator]
-    :end-before: [END howto_dms_start_task_operator]
-
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.py
-    :language: python
-    :start-after: [START howto_dms_task_completed_sensor]
-    :end-before: [END howto_dms_task_completed_sensor]
-
-.. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_dms_full_load_task.py
-    :language: python
-    :start-after: [START howto_dms_delete_task_operator]
-    :end-before: [END howto_dms_delete_task_operator]
+    :start-after: [START howto_dms_operators]
+    :end-before: [END howto_dms_operators]
 
 
 Reference


### PR DESCRIPTION
There is an ongoing effort to enhance example DAGs by setting static values for `start_date` (already complete for core example DAGs), cleaning up and/or implementing useful `default_args`, and removing/limiting the use of redundant, default connection ID values.

This PR mainly addresses these 3 cleanup areas in example DAGs in the Amazon provider.  There are other small docs-related updates, enhancing an example DAG to take advantage of `XComArgs` via the `.output` operator property, and removal of `get_current_context` use in preference for direct `task_instance` access.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
