### PR TITLE
Fix release check script

### DIFF
--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -153,7 +153,7 @@ def check_upgrade_check(files: List[str], version: str):
 
 
 def warn_of_missing_files(files):
-    print(f"[red]Check failed. Here are the files we expected but did not find:[/red]\n")
+    print("[red]Check failed. Here are the files we expected but did not find:[/red]\n")
 
     for file in files:
         print(f"    - [red]{file}[/red]")

--- a/dev/check_files.py
+++ b/dev/check_files.py
@@ -17,6 +17,7 @@
 
 import os
 import re
+from itertools import product
 from typing import List
 
 import click as click
@@ -45,26 +46,22 @@ RUN pip install "apache-airflow-upgrade-check=={}"
 
 """
 
-
 DOCKER_CMD = """
 docker build --tag local/airflow .
 docker local/airflow info
 """
 
-
 AIRFLOW = "AIRFLOW"
 PROVIDERS = "PROVIDERS"
 UPGRADE_CHECK = "UPGRADE_CHECK"
 
-ASC = re.compile(r".*\.asc$")
-SHA = re.compile(r".*\.sha512$")
-NORM = re.compile(r".*\.(whl|gz)$")
-
 
 def get_packages() -> List[str]:
-    with open("packages.txt") as file:
-        content = file.read()
-
+    try:
+        with open("packages.txt") as file:
+            content = file.read()
+    except FileNotFoundError:
+        content = ''
     if not content:
         raise SystemExit("List of packages to check is empty. Please add packages to `packages.txt`")
 
@@ -86,66 +83,80 @@ def create_docker(txt: str):
     )
 
 
-def check_all_present(prefix: str, files: List[str]):
-    all_present = True
-    for ext in [ASC, SHA, NORM]:
-        if any(re.match(ext, f) for f in files):
-            print(f"    - {prefix} {ext.pattern}: [green]OK[/green]")
-        else:
-            print(f"    - {prefix} {ext.pattern}: [red]MISSING[/red]")
-            all_present = False
-    return all_present
-
-
-def filter_files(files: List[str], prefix: str):
-    return [f for f in files if f.startswith(prefix)]
-
-
 def check_providers(files: List[str], version: str):
-    name_tpl = "apache_airflow_providers_{}-{}"
-    pip_packages = []
+    print(f"Checking providers for version {version}:\n")
+    version = strip_rc_suffix(version)
+    missing_list = []
     for p in get_packages():
         print(p)
+        expected_files = expand_name_variations(
+            [
+                f"{p}-{version}.tar.gz",
+                f"{p.replace('-', '_')}-{version}-py3-none-any.whl",
+            ]
+        )
 
-        name = name_tpl.format(p.replace(".", "_"), version)
-        # Check sources
-        check_all_present("sources", filter_files(files, name))
+        missing_list.extend(check_all_files(expected_files=expected_files, actual_files=files))
 
-        # Check wheels
-        name = name.replace("_", "-")
-        if check_all_present("wheel", filter_files(files, name)):
-            pip_packages.append(f"{name.rpartition('-')[0]}=={version}")
+    return missing_list
 
-    return pip_packages
+
+def strip_rc_suffix(version):
+    return re.sub(r'rc\d+$', '', version)
+
+
+def print_status(file, is_found: bool):
+    color, status = ('green', 'OK') if is_found else ('red', 'MISSING')
+    print(f"    - {file}: [{color}]{status}[/{color}]")
+
+
+def check_all_files(actual_files, expected_files):
+    missing_list = []
+    for file in expected_files:
+        is_found = file in actual_files
+        if not is_found:
+            missing_list.append(file)
+        print_status(file=file, is_found=is_found)
+    return missing_list
 
 
 def check_release(files: List[str], version: str):
-    print(f"apache_airflow-{version}")
+    print(f"Checking airflow release for version {version}:\n")
+    version = strip_rc_suffix(version)
 
-    # Check bin
-    name = f"apache-airflow-{version}-bin"
-    check_all_present("binaries", filter_files(files, name))
+    expected_files = expand_name_variations(
+        [
+            f"apache-airflow-{version}.tar.gz",
+            f"apache-airflow-{version}-source.tar.gz",
+            f"apache_airflow-{version}-py3-none-any.whl",
+        ]
+    )
+    return check_all_files(expected_files=expected_files, actual_files=files)
 
-    # Check sources
-    name = f"apache-airflow-{version}-source"
-    check_all_present("sources", filter_files(files, name))
 
-    # Check wheels
-    name = f"apache_airflow-{version}-py"
-    check_all_present("wheel", filter_files(files, name))
+def expand_name_variations(files):
+    return list(sorted(base + suffix for base, suffix in product(files, ['', '.asc', '.sha512'])))
 
 
 def check_upgrade_check(files: List[str], version: str):
-    print(f"apache_airflow-upgrade-check-{version}")
+    print(f"Checking upgrade_check for version {version}:\n")
+    version = strip_rc_suffix(version)
 
-    name = f"apache-airflow-upgrade-check-{version}-bin"
-    check_all_present("binaries", filter_files(files, name))
+    expected_files = expand_name_variations(
+        [
+            f"apache-airflow-upgrade-check-{version}-bin.tar.gz",
+            f"apache-airflow-upgrade-check-{version}-source.tar.gz",
+            f"apache_airflow_upgrade_check-{version}-py2.py3-none-any.whl",
+        ]
+    )
+    return check_all_files(expected_files=expected_files, actual_files=files)
 
-    name = f"apache-airflow-upgrade-check-{version}-source"
-    check_all_present("sources", filter_files(files, name))
 
-    name = f"apache_airflow_upgrade_check-{version}-py"
-    check_all_present("wheel", filter_files(files, name))
+def warn_of_missing_files(files):
+    print(f"[red]Check failed. Here are the files we expected but did not find:[/red]\n")
+
+    for file in files:
+        print(f"    - [red]{file}[/red]")
 
 
 @click.command()
@@ -188,24 +199,31 @@ def main(check_type: str, path: str, version: str):
 
     if check_type.upper() == PROVIDERS:
         files = os.listdir(os.path.join(path, "providers"))
-        pips = check_providers(files, version)
+        pips = [f"{p}=={version}" for p in get_packages()]
+        missing_files = check_providers(files, version)
         create_docker(PROVIDERS_DOCKER.format("\n".join(f"RUN pip install '{p}'" for p in pips)))
+        if missing_files:
+            warn_of_missing_files(missing_files)
         return
 
     if check_type.upper() == AIRFLOW:
         files = os.listdir(os.path.join(path, version))
-        check_release(files, version)
+        missing_files = check_release(files, version)
 
         base_version = version.split("rc")[0]
         prev_version = base_version[:-1] + str(int(base_version[-1]) - 1)
         create_docker(AIRFLOW_DOCKER.format(prev_version, version))
+        if missing_files:
+            warn_of_missing_files(missing_files)
         return
 
     if check_type.upper() == UPGRADE_CHECK:
         files = os.listdir(os.path.join(path, "upgrade-check", version))
-        check_upgrade_check(files, version)
+        missing_files = check_upgrade_check(files, version)
 
         create_docker(DOCKER_UPGRADE.format(version))
+        if missing_files:
+            warn_of_missing_files(missing_files)
         return
 
     raise SystemExit(f"Unknown check type: {check_type}")
@@ -213,3 +231,36 @@ def main(check_type: str, path: str, version: str):
 
 if __name__ == "__main__":
     main()
+
+
+def test_check_release_pass():
+    """Passes if all present"""
+    files = [
+        'apache_airflow-2.2.1-py3-none-any.whl',
+        'apache_airflow-2.2.1-py3-none-any.whl.asc',
+        'apache_airflow-2.2.1-py3-none-any.whl.sha512',
+        'apache-airflow-2.2.1-source.tar.gz',
+        'apache-airflow-2.2.1-source.tar.gz.asc',
+        'apache-airflow-2.2.1-source.tar.gz.sha512',
+        'apache-airflow-2.2.1.tar.gz',
+        'apache-airflow-2.2.1.tar.gz.asc',
+        'apache-airflow-2.2.1.tar.gz.sha512',
+    ]
+    assert check_release(files, version='2.2.1rc2') == []
+
+
+def test_check_release_fail():
+    """Fails if missing one"""
+    files = [
+        'apache_airflow-2.2.1-py3-none-any.whl',
+        'apache_airflow-2.2.1-py3-none-any.whl.asc',
+        'apache_airflow-2.2.1-py3-none-any.whl.sha512',
+        'apache-airflow-2.2.1-source.tar.gz',
+        'apache-airflow-2.2.1-source.tar.gz.asc',
+        'apache-airflow-2.2.1-source.tar.gz.sha512',
+        'apache-airflow-2.2.1.tar.gz.asc',
+        'apache-airflow-2.2.1.tar.gz.sha512',
+    ]
+
+    missing_files = check_release(files, version='2.2.1rc2')
+    assert missing_files == ['apache-airflow-2.2.1.tar.gz']


### PR DESCRIPTION
There have been some changes to the filename conventions over time  and the release check script was not updated to reflect this.  This PR fixes the script and tries to simplify it a little bit.  In particular, the regex approach used previously was broken by the removal of the `-bin` identifier.  It is easy enough to simply compute all the expected files exactly and look for them, so that is what we do here

**Note on how you can verify that this works**

You can verify this works on releases we've already released with these commands:

```
python check_files.py -v 1.4.0 -t upgrade_check -p ../../airflow-release/airflow
python check_files.py -v 2.1.1 -t providers -p ../../airflow-release/airflow
python check_files.py -v 2.2.0 -t airflow -p ../../airflow-release/airflow
```

For providers you need to put something in packages.txt e.g. I tested `apache-airflow-providers-airbyte` version 2.1.1.

Assumes you cloned like so: `svn co https://dist.apache.org/repos/dist/release/airflow`

And also works with RCs (which was another issue I think):

```
mkdir ~/code/airflow-rc
cd ~/code/airflow-rc
svn co https://dist.apache.org/repos/dist/dev/airflow
```

Then run:
```
python check_files.py -v 2.2.1rc2 -t airflow -p ../../airflow-rc/airflow
```

**Note on tests**

I included a simple test, since it was helpful as part of development anyway.  Not sure this needs to be part of the normal airflow test suite so I just left it inline.