### PR TITLE
Populate TI from callback request's SimpleTaskInstance

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1076,7 +1076,7 @@ class DagFileProcessorManager(LoggingMixin):
             for ti, file_loc in zombies:
                 request = TaskCallbackRequest(
                     full_filepath=file_loc,
-                    simple_task_instance=SimpleTaskInstance(ti),
+                    simple_task_instance=SimpleTaskInstance.create(ti),
                     msg=f"Detected {ti} as zombie",
                 )
                 self.log.info("Detected zombie job: %s", request)

--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -580,8 +580,7 @@ class DagFileProcessor(LoggingMixin):
                 task = dag.get_task(simple_ti.task_id)
                 if request.is_failure_callback:
                     ti = TI(task, run_id=simple_ti.run_id)
-                    # TODO: Use simple_ti to improve performance here in the future
-                    ti.refresh_from_db()
+                    ti.refresh_from_instance(simple_ti)
                     ti.handle_failure_with_callback(error=request.msg, test_mode=self.UNIT_TEST_MODE)
                     self.log.info('Executed failure callback for %s in state %s', ti, ti.state)
 

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -105,7 +105,7 @@ class CeleryKubernetesExecutor(LoggingMixin):
         cfg_path: Optional[str] = None,
     ) -> None:
         """Queues task instance via celery or kubernetes executor"""
-        executor = self._router(SimpleTaskInstance(task_instance))
+        executor = self._router(SimpleTaskInstance.create(task_instance))
         self.log.debug(
             "Using executor: %s to queue_task_instance for %s", executor.__class__.__name__, task_instance.key
         )

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -582,7 +582,7 @@ class SchedulerJob(BaseJob):
                 if task.on_retry_callback or task.on_failure_callback:
                     request = TaskCallbackRequest(
                         full_filepath=ti.dag_model.fileloc,
-                        simple_task_instance=SimpleTaskInstance(ti),
+                        simple_task_instance=SimpleTaskInstance.create(ti),
                         msg=msg % (ti, state, ti.state, info),
                     )
                     self.processor_agent.send_callback_to_execute(request)

--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -544,7 +544,7 @@ class TestDagFileProcessorManager:
                 expected_failure_callback_requests = [
                     TaskCallbackRequest(
                         full_filepath=dag.fileloc,
-                        simple_task_instance=SimpleTaskInstance(ti),
+                        simple_task_instance=SimpleTaskInstance.create(ti),
                         msg="Message",
                     )
                 ]

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -341,7 +341,11 @@ class TestDagFileProcessor:
             session.add(ti)
 
         requests = [
-            TaskCallbackRequest(full_filepath="A", simple_task_instance=SimpleTaskInstance(ti), msg="Message")
+            TaskCallbackRequest(
+                full_filepath="A",
+                simple_task_instance=SimpleTaskInstance.create(ti),
+                msg="Message",
+            ),
         ]
         dag_file_processor.execute_callbacks(dagbag, requests)
         mock_ti_handle_failure.assert_called_once_with(
@@ -368,7 +372,11 @@ class TestDagFileProcessor:
             session.add(ti)
 
         requests = [
-            TaskCallbackRequest(full_filepath="A", simple_task_instance=SimpleTaskInstance(ti), msg="Message")
+            TaskCallbackRequest(
+                full_filepath="A",
+                simple_task_instance=SimpleTaskInstance.create(ti),
+                msg="Message",
+            ),
         ]
         dag_file_processor.execute_callbacks(dagbag, requests)
 
@@ -401,7 +409,7 @@ class TestDagFileProcessor:
             requests = [
                 TaskCallbackRequest(
                     full_filepath=dag.fileloc,
-                    simple_task_instance=SimpleTaskInstance(ti),
+                    simple_task_instance=SimpleTaskInstance.create(ti),
                     msg="Message",
                 )
             ]

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -184,7 +184,7 @@ class TestCeleryExecutor(unittest.TestCase):
                 'command',
                 1,
                 None,
-                SimpleTaskInstance(ti=TaskInstance(task=task, run_id=None)),
+                SimpleTaskInstance.create(TaskInstance(task=task, run_id=None)),
             )
             key = ('fail', 'fake_simple_ti', when, 0)
             executor.queued_tasks[key] = value_tuple
@@ -217,7 +217,7 @@ class TestCeleryExecutor(unittest.TestCase):
                 'command',
                 1,
                 None,
-                SimpleTaskInstance(ti=TaskInstance(task=task, run_id=None)),
+                SimpleTaskInstance.create(TaskInstance(task=task, run_id=None)),
             )
             key = ('fail', 'fake_simple_ti', when, 0)
             executor.queued_tasks[key] = value_tuple


### PR DESCRIPTION
This rewrites SimpleTaskInstance to carry *all* of TaskInstance's columns, instead of "just what's needed". This means the class would carry some dead weight, but that's a practical tradeoff since validating whether a field is needed is too difficult to automate without intimacy to the code base.

A new function refresh_from_instance() is added to TaskInstance, which is used for both "defreeze" a SimpleTaskInstance back into a TI, and loading a TI from the database via refresh_from_db(). Since refresh_from_db() is very heavily used and any errors are caught quickly by various tests, it is very difficult to miss a field in that function, thus indirectly guaranteeing both the SimpleTaskInstance does not miss a
new field added to TaskInstance, and the defreezing process does not miss setting a field on SimpleTaskInstance back to the TI.

Close #16804.