### PR TITLE
Cast to string in ds macro functions

### DIFF
--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -39,7 +39,7 @@ def ds_add(ds, days):
     >>> ds_add('2015-01-06', -5)
     '2015-01-01'
     """
-    ds = datetime.strptime(ds, '%Y-%m-%d')
+    ds = datetime.strptime(str(ds), '%Y-%m-%d')
     if days:
         ds = ds + timedelta(days)
     return ds.isoformat()[:10]
@@ -62,7 +62,7 @@ def ds_format(ds, input_format, output_format):
     >>> ds_format('1/5/2015', "%m/%d/%Y",  "%Y-%m-%d")
     '2015-01-05'
     """
-    return datetime.strptime(ds, input_format).strftime(output_format)
+    return datetime.strptime(str(ds), input_format).strftime(output_format)
 
 
 def datetime_diff_for_humans(dt, since=None):


### PR DESCRIPTION

As already written in this issue https://github.com/apache/airflow/issues/19241 strptime function required string, but got proxy if the variables ds/next_ds (the types of these variables changed on version 2.2.0) sent.
This change will make the function `ds_add` and `ds_format` backward compatible.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
