### PR TITLE
fix: dag_id and task_id non ascii char

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -49,6 +49,7 @@ from typing import (
 
 import jinja2
 import pendulum
+import text_unidecode
 from dateutil.relativedelta import relativedelta
 from jinja2.nativetypes import NativeEnvironment
 from sqlalchemy import Boolean, Column, ForeignKey, Index, Integer, String, Text, func, or_
@@ -79,7 +80,7 @@ from airflow.utils import timezone
 from airflow.utils.dag_cycle_tester import check_cycle
 from airflow.utils.dates import cron_presets, date_range as utils_date_range
 from airflow.utils.file import correct_maybe_zipped
-from airflow.utils.helpers import validate_key
+from airflow.utils.helpers import is_ascii, replace_invalid_ascii_char, validate_key
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import Interval, UtcDateTime, skip_locked, with_row_locks
@@ -368,6 +369,11 @@ class DAG(LoggingMixin):
                 DeprecationWarning,
                 stacklevel=2,
             )
+
+        if not is_ascii(dag_id):
+            # using text_unidecode to make non-ascii characters ascii equivalent
+            unicoded_string = text_unidecode.unidecode(dag_id).replace(" ", "-")
+            dag_id = replace_invalid_ascii_char(unicoded_string)
 
         validate_key(dag_id)
 

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -230,3 +230,25 @@ def build_airflow_url_with_query(query: Dict[str, Any]) -> str:
     view = conf.get('webserver', 'dag_default_view').lower()
     url = url_for(f"Airflow.{view}")
     return f"{url}?{parse.urlencode(query)}"
+
+
+def is_ascii(s):
+    """Check if a string is ascii"""
+    return all(ord(c) < 128 for c in s)
+
+
+def replace_invalid_ascii_char(value, delimiter="."):
+    """
+    Substitute unacceptable characters for acceptable equivalent
+        Args:
+
+        value: str
+        delimiter: str e.g ('.', '-')
+    """
+    str = value
+
+    for char in str:
+        if not KEY_REGEX.match(char):
+            str = str.replace(char, delimiter)
+
+    return str


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Used Python Slugify library to convert non-ascii characters to ascii characters that can be interpreted by Airflow

This allows the usage of non-ascii characters for both dag_id and task_id

closes: #18010
related: #8634

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
