### PR TITLE
Fix task instance modal in gantt view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2863,6 +2863,7 @@ class Airflow(AirflowBaseView):
             task_dict['end_date'] = task_dict['end_date'] or timezone.utcnow()
             task_dict['extraLinks'] = dag.get_task(ti.task_id).extra_links
             task_dict['try_number'] = try_count
+            task_dict['execution_date'] = dttm
             tasks.append(task_dict)
 
         tf_count = 0
@@ -2884,6 +2885,7 @@ class Airflow(AirflowBaseView):
             task_dict['operator'] = task.task_type
             task_dict['try_number'] = try_count
             task_dict['extraLinks'] = task.extra_links
+            task_dict['execution_date'] = dttm
             tasks.append(task_dict)
 
         task_names = [ti.task_id for ti in tis]


### PR DESCRIPTION
2.2.0 removed the execution_date from the task_instance table.

So the execution date won't be provided by simply calling `alchemy_to_dict` on the task_instance model. Subsequently this broke the links in the task instance modal on the gantt view.

Closes #19252
