### PR TITLE
Problem solution pyenv configuration: pyenv not found

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -205,10 +205,10 @@ The Docker env is here to maintain a consistent and common development environme
 
 You can configure the Docker-based Breeze development environment as follows:
 
-1. Install the latest versions of the Docker Community Edition
-   and Docker Compose and add them to the PATH.
+1. Install the latest versions of the `Docker Community Edition <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition>`_
+   and `Docker Compose <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose>`_ and add them to the PATH.
 
-2. Install jq on your machine. The exact command depends on the operating system (or Linux distribution) you use.
+2. Install jq on your machine. The exact command depends on the operating system (or Linux distribution) you use. `More information <https://stedolan.github.io/jq/download/>`_
 For example, on Ubuntu:
 
 .. code-block:: bash
@@ -221,7 +221,11 @@ or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
 
   brew install jq
 
-3. Enter Breeze: ``./breeze``
+3. Enter Breeze, in airflow folder run:
+
+.. code-block:: bash
+
+  ./breeze
 
    Breeze starts with downloading the Airflow CI image from
    the Docker Hub and installing all required dependencies.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -227,8 +227,8 @@ or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
 
   ./breeze
 
-   Breeze starts with downloading the Airflow CI image from
-   the Docker Hub and installing all required dependencies.
+  Breeze starts with downloading the Airflow CI image from
+  the Docker Hub and installing all required dependencies.
 
 4. Enter the Docker environment and mount your local sources
    to make them immediately visible in the environment.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -206,7 +206,7 @@ The Docker env is here to maintain a consistent and common development environme
 You can configure the Docker-based Breeze development environment as follows:
 
 1. Install the latest versions of the `Docker Community Edition <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition>`_
-   and `Docker Compose <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose>`_ and add them to the PATH.
+and `Docker Compose <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose>`_ and add them to the PATH.
 
 2. Install jq on your machine. The exact command depends on the operating system (or Linux distribution) you use. `More information <https://stedolan.github.io/jq/download/>`_
 For example, on Ubuntu:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -221,7 +221,7 @@ or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
 
   brew install jq
 
-3. Enter Breeze, in airflow folder run:
+3. Enter Breeze, and run the following in the Airflow source code directory:
 
 .. code-block:: bash
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -208,7 +208,7 @@ You can configure the Docker-based Breeze development environment as follows:
 1. Install the latest versions of the `Docker Community Edition <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition>`_
 and `Docker Compose <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose>`_ and add them to the PATH.
 
-2. Install jq on your machine. The exact command depends on the operating system (or Linux distribution) you use. `More information <https://stedolan.github.io/jq/download/>`_
+2. Install `jq <https://stedolan.github.io/jq/download/>`_ on your machine. The exact command depends on the operating system (or Linux distribution) you use.
 For example, on Ubuntu:
 
 .. code-block:: bash

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -227,8 +227,8 @@ or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
 
   ./breeze
 
-  Breeze starts with downloading the Airflow CI image from
-  the Docker Hub and installing all required dependencies.
+Breeze starts with downloading the Airflow CI image from
+the Docker Hub and installing all required dependencies.
 
 4. Enter the Docker environment and mount your local sources
    to make them immediately visible in the environment.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,37 +198,37 @@ Step 2: Configure Your Environment
 ----------------------------------
 
 You can use either a local virtual env or a Docker-based env. The differences
-between the two are explained `here <https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments>`_.
+between the two are explained here_. .._https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments
 
 The local env's instructions can be found in full in the  `LOCAL_VIRTUALENV.rst <https://github.com/apache/airflow/blob/main/LOCAL_VIRTUALENV.rst>`_ file.
 The Docker env is here to maintain a consistent and common development environment so that you can replicate CI failures locally and work on solving them locally rather by pushing to CI.
 
 You can configure the Docker-based Breeze development environment as follows:
 
-1. Install the latest versions of the `Docker Community Edition <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition>`_
-and `Docker Compose <https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose>`_ and add them to the PATH.
+1. Install the latest versions of the `Docker Community Edition`_ .. _Docker Community Edition: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition_
+   and `Docker Compose`_. ..Docker Compose: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose and add them to the PATH.
 
 2. Install `jq <https://stedolan.github.io/jq/download/>`_ on your machine. The exact command depends on the operating system (or Linux distribution) you use.
-For example, on Ubuntu:
+   For example, on Ubuntu:
 
 .. code-block:: bash
 
-  sudo apt install jq
+   sudo apt install jq
 
-or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
+   or on macOS with `Homebrew <https://formulae.brew.sh/formula/jq>`_
 
 .. code-block:: bash
 
-  brew install jq
+   brew install jq
 
 3. Enter Breeze, in airflow folder run:
 
 .. code-block:: bash
 
-  ./breeze
+   ./breeze
 
-Breeze starts with downloading the Airflow CI image from
-the Docker Hub and installing all required dependencies.
+  Breeze starts with downloading the Airflow CI image from
+  the Docker Hub and installing all required dependencies.
 
 4. Enter the Docker environment and mount your local sources
    to make them immediately visible in the environment.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,17 +198,17 @@ Step 2: Configure Your Environment
 ----------------------------------
 
 You can use either a local virtual env or a Docker-based env. The differences
-between the two are explained `_here <https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments>`_.
+between the two are explained `here <https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments>`_.
 
-The local env's instructions can be found in full in the  _`LOCAL_VIRTUALENV.rst_ <https://github.com/apache/airflow/blob/main/LOCAL_VIRTUALENV.rst`_ file.
+The local env's instructions can be found in full in the  _LOCAL_VIRTUALENV.rst: https://github.com/apache/airflow/blob/main/LOCAL_VIRTUALENV.rst file.
 The Docker env is here to maintain a consistent and common development environment so that you can replicate CI failures locally and work on solving them locally rather by pushing to CI.
 
 You can configure the Docker-based Breeze development environment as follows:
 
-1. Install the latest versions of the `Docker Community Edition`_ .. _Docker Community Edition: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition
-   and `Docker Compose`_ .. _Docker Compose: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose and add them to the PATH.
+1. Install the latest versions of the _Docker Community Edition: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition
+   and _Docker Compose: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose and add them to the PATH.
 
-2. Install jq_ .. _jq: https://stedolan.github.io/jq/download/ on your machine. The exact command depends on the operating system (or Linux distribution) you use.
+2. Install _jq: https://stedolan.github.io/jq/download/ on your machine. The exact command depends on the operating system (or Linux distribution) you use.
    For example, on Ubuntu:
 
 .. code-block:: bash

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,17 +198,17 @@ Step 2: Configure Your Environment
 ----------------------------------
 
 You can use either a local virtual env or a Docker-based env. The differences
-between the two are explained here_. .._https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments
+between the two are explained `_here <https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#development-environments>`_.
 
-The local env's instructions can be found in full in the  `LOCAL_VIRTUALENV.rst <https://github.com/apache/airflow/blob/main/LOCAL_VIRTUALENV.rst>`_ file.
+The local env's instructions can be found in full in the  _`LOCAL_VIRTUALENV.rst_ <https://github.com/apache/airflow/blob/main/LOCAL_VIRTUALENV.rst`_ file.
 The Docker env is here to maintain a consistent and common development environment so that you can replicate CI failures locally and work on solving them locally rather by pushing to CI.
 
 You can configure the Docker-based Breeze development environment as follows:
 
-1. Install the latest versions of the `Docker Community Edition`_ .. _Docker Community Edition: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition_
-   and `Docker Compose`_. ..Docker Compose: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose and add them to the PATH.
+1. Install the latest versions of the `Docker Community Edition`_ .. _Docker Community Edition: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-community-edition
+   and `Docker Compose`_ .. _Docker Compose: https://github.com/apache/airflow/blob/main/BREEZE.rst#docker-compose and add them to the PATH.
 
-2. Install `jq <https://stedolan.github.io/jq/download/>`_ on your machine. The exact command depends on the operating system (or Linux distribution) you use.
+2. Install jq_ .. _jq: https://stedolan.github.io/jq/download/ on your machine. The exact command depends on the operating system (or Linux distribution) you use.
    For example, on Ubuntu:
 
 .. code-block:: bash
@@ -230,22 +230,22 @@ You can configure the Docker-based Breeze development environment as follows:
   Breeze starts with downloading the Airflow CI image from
   the Docker Hub and installing all required dependencies.
 
-4. Enter the Docker environment and mount your local sources
-   to make them immediately visible in the environment.
+  This will enter the Docker Docker environment and mount your local sources
+  to make them immediately visible in the environment.
 
-5. Create a local virtualenv, for example:
+4. Create a local virtualenv, for example:
 
 .. code-block:: bash
 
    mkvirtualenv myenv --python=python3.6
 
-6. Initialize the created environment:
+5. Initialize the created environment:
 
 .. code-block:: bash
 
    ./breeze initialize-local-virtualenv --python 3.6
 
-7. Open your IDE (for example, PyCharm) and select the virtualenv you created
+6. Open your IDE (for example, PyCharm) and select the virtualenv you created
    as the project's default virtualenv in your IDE.
 
 Step 3: Connect with People

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -221,7 +221,7 @@ You can configure the Docker-based Breeze development environment as follows:
 
    brew install jq
 
-3. Enter Breeze, in airflow folder run:
+3. Enter Breeze, and run the following in the Airflow source code directory:
 
 .. code-block:: bash
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -154,9 +154,9 @@ Pyenv and setting up virtual-env
   $ exec $SHELL
   $ pyenv --version
 
-On Ubuntu 20.04 you may get an error of ``pyenv not found``
+On Ubuntu 20.04 you may get an error of ``pyenv not found`` after execute ``exec $SHELL``.
 You can find the solution according to your specific shell in the following link `Configure your shell's environment for Pyenv
-<https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+<https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_.
 
 
 5. Checking available version, installing required Python version to pyenv and verifying it

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -154,6 +154,11 @@ Pyenv and setting up virtual-env
   $ exec $SHELL
   $ pyenv --version
 
+On Ubuntu 20.04 you may get an error of ``pyenv not found``
+You can find the solution according to your specific shell in the following link `Configure your shell's environment for Pyenv
+<https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+
+
 5. Checking available version, installing required Python version to pyenv and verifying it
 
 .. code-block:: bash


### PR DESCRIPTION
While I was following the instruction for the installation of pyenv, I found that adding 'eval "$(pyenv virtualenv-init -)' was not enough to get pyenv ready, so in the repo of the official pyenv they wrote a new configuration on their Readme.md where is added a configuration for specific shell and OS: https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout. I tried this new configuration on a clean instance on Google (Ubuntu 20.04) and it worked. 
I suggest adding this link for people who may have the same problem that, also it was an issue registered to pyenv this year.