### PR TITLE
Fix hidden tooltip position

### DIFF
--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -454,3 +454,11 @@ label[for="timezone-other"],
   color: #262626;
   background-color: #f5f5f5;
 }
+
+.tooltip {
+  z-index: 0;
+}
+
+.tooltip.in {
+  z-index: 1070;
+}

--- a/airflow/www/static/css/main.css
+++ b/airflow/www/static/css/main.css
@@ -459,6 +459,7 @@ label[for="timezone-other"],
   z-index: 0;
 }
 
-.tooltip.in {
+.tooltip.in,
+.tooltip.d3-tip {
   z-index: 1070;
 }


### PR DESCRIPTION
Only apply a large z-index when the tooltip is supposed to be display. Our bootstrap tooltips don't work great and could probably be improved but this was the simplest fix to the issue.

Fixes: #18732

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
