### PR TITLE
Chart: add resources for cleanup and createuser jobs

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -87,6 +87,8 @@ spec:
                   mountPath: {{ template "airflow_config_path" . }}
                   subPath: airflow.cfg
                   readOnly: true
+              resources:
+{{ toYaml .Values.cleanup.resources | indent 16 }}
           volumes:
             - name: config
               configMap:

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -111,6 +111,8 @@ spec:
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
+          resources:
+{{ toYaml .Values.createUserJob.resources | indent 12 }}
       volumes:
         - name: config
           configMap:

--- a/chart/tests/test_cleanup_pods.py
+++ b/chart/tests/test_cleanup_pods.py
@@ -174,3 +174,28 @@ class CleanupPodsTest(unittest.TestCase):
             "release": "RELEASE-NAME",
             "project": "airflow",
         } == jmespath.search("spec.jobTemplate.spec.template.metadata.labels", docs[0])
+
+    def test_cleanup_resources_are_configurable(self):
+        resources = {
+            "requests": {
+                "cpu": "128m",
+                "memory": "256Mi",
+            },
+            "limits": {
+                "cpu": "256m",
+                "memory": "512Mi",
+            },
+        }
+        docs = render_chart(
+            values={
+                "cleanup": {
+                    "enabled": True,
+                    "resources": resources,
+                },
+            },
+            show_only=["templates/cleanup/cleanup-cronjob.yaml"],
+        )
+
+        assert resources == jmespath.search(
+            "spec.jobTemplate.spec.template.spec.containers[0].resources", docs[0]
+        )

--- a/chart/tests/test_create_user_job.py
+++ b/chart/tests/test_create_user_job.py
@@ -84,3 +84,25 @@ class CreateUserJobTest(unittest.TestCase):
             "spec.template.spec.tolerations[0].key",
             docs[0],
         )
+
+    def test_create_user_job_resources_are_configurable(self):
+        resources = {
+            "requests": {
+                "cpu": "128m",
+                "memory": "256Mi",
+            },
+            "limits": {
+                "cpu": "256m",
+                "memory": "512Mi",
+            },
+        }
+        docs = render_chart(
+            values={
+                "createUserJob": {
+                    "resources": resources,
+                },
+            },
+            show_only=["templates/jobs/create-user-job.yaml"],
+        )
+
+        assert resources == jmespath.search("spec.template.spec.containers[0].resources", docs[0])

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -1694,6 +1694,24 @@
                     "description": "Specify Tolerations for the create user job pod.",
                     "type": "array",
                     "default": []
+                },
+                "resources": {
+                    "description": "Resources for the create user job pod",
+                    "type": "object",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "default": {},
+                    "examples": [
+                        {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            }
+                        }
+                    ]
                 }
             }
         },
@@ -3028,6 +3046,24 @@
                     "description": "Specify Tolerations for cleanup pods.",
                     "type": "array",
                     "default": []
+                },
+                "resources": {
+                    "description": "Resources for or cleanup pods",
+                    "type": "object",
+                    "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                    "default": {},
+                    "examples": [
+                        {
+                            "limits": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "128Mi"
+                            }
+                        }
+                    ]
                 },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -622,6 +622,14 @@ createUserJob:
   affinity: {}
   tolerations: []
 
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 # Airflow database migration job settings
 migrateDatabaseJob:
   # Annotations on the database migration pod
@@ -1191,6 +1199,14 @@ cleanup:
   nodeSelector: {}
   affinity: {}
   tolerations: []
+
+  resources: {}
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi
 
   # Create ServiceAccount
   serviceAccount:

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -30,6 +30,7 @@ Helm Chart for Apache Airflow
     adding-connections-and-variables
     manage-dags-files
     manage-logs
+    setting-resources-for-containers
     keda
     using-additional-containers
     Installing from sources<installing-helm-chart-from-sources>

--- a/docs/helm-chart/setting-resources-for-containers.rst
+++ b/docs/helm-chart/setting-resources-for-containers.rst
@@ -1,0 +1,66 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Setting resources for containers
+--------------------------------
+
+It is possible to set `resources <https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/>`__ for the Containers managed by the chart. You can define different resources for various airflow k8s Containers. By default the resources are not set.
+
+.. note::
+    The k8s scheduler can use resources to decide which node to place the Pod on. Since a Pod resource request/limit is the sum of the resource requests/limits for each Container in the Pod, it is advised to specify resources for each Container in the Pod.
+
+Possible Containers where resources can be configured include:
+
+* Main airflow Containers and their sidecars. You can add the resources for these Containers through the following parameters:
+
+   * ``workers.resources``
+   * ``workers.logGroomerSidecar.resources``
+   * ``workers.kerberosSidecar.resources``
+   * ``scheduler.resources``
+   * ``scheduler.logGroomerSidecar.resources``
+   * ``dags.gitSync.resources``
+   * ``webserver.resources``
+   * ``flower.resources``
+   * ``triggerer.resources``
+
+* Containers used for airflow k8s jobs or cron jobs. You can add the resources for these Containers through the following parameters:
+
+   * ``cleanup.resources``
+   * ``createUserJob.resources``
+   * ``migrateDatabaseJob.resources``
+
+* Other containers that can be deployed by the chart. You can add the resources for these Containers through the following parameters:
+
+   * ``statsd.resources``
+   * ``pgbouncer.resources``
+   * ``pgbouncer.metricsExporterSidecar.resources``
+   * ``redis.resources``
+
+
+For example, specifying resources for worker kerberos sidecar:
+
+.. code-block:: yaml
+
+  workers:
+    kerberosSidecar:
+      resources:
+        limits:
+          cpu: 200m
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 128Mi


### PR DESCRIPTION
Currently it's not possible to configure createUser Job and cleanup cronjob resources. This PR makes resources of these jobs configurable.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
