### PR TITLE
Fix serialization of Params with set data type

### DIFF
--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -49,6 +49,7 @@ class Param:
     """
 
     __NO_VALUE_SENTINEL = NoValueSentinel()
+    CLASS_IDENTIFIER = '__class'
 
     def __init__(self, default: Any = __NO_VALUE_SENTINEL, description: str = None, **kwargs):
         self.value = default
@@ -90,7 +91,7 @@ class Param:
 
     def dump(self) -> dict:
         """Dump the Param as a dictionary"""
-        out_dict = {'__class': f'{self.__module__}.{self.__class__.__name__}'}
+        out_dict = {self.CLASS_IDENTIFIER: f'{self.__module__}.{self.__class__.__name__}'}
         out_dict.update(self.__dict__)
         return out_dict
 

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -14,7 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+import json
+import warnings
 from typing import Any, Dict, Optional
 
 import jsonschema
@@ -52,16 +53,34 @@ class Param:
     CLASS_IDENTIFIER = '__class'
 
     def __init__(self, default: Any = __NO_VALUE_SENTINEL, description: str = None, **kwargs):
+
         self.value = default
         self.description = description
         self.schema = kwargs.pop('schema') if 'schema' in kwargs else kwargs
 
-        # If we have a value, validate it once. May raise ValueError.
         if self.has_value:
-            try:
-                jsonschema.validate(self.value, self.schema, format_checker=FormatChecker())
-            except ValidationError as err:
-                raise ValueError(err)
+            self._validate(self.value, self.schema)
+
+    @staticmethod
+    def _validate(value, schema):
+        """
+        1. Check that value is json-serializable; if not, warn.  In future release we will require
+        the value to be json-serializable.
+        2. Validate ``value`` against ``schema``
+        """
+        try:
+            json.dumps(value)
+        except TypeError:
+            warnings.warn(
+                "The use of non-json-serializable params is deprecated and will be removed in a"
+                " future release",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        try:
+            jsonschema.validate(value, schema, format_checker=FormatChecker())
+        except ValidationError as err:
+            raise ValueError(err)
 
     def resolve(self, value: Optional[Any] = __NO_VALUE_SENTINEL, suppress_exception: bool = False) -> Any:
         """

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -78,7 +78,7 @@
     "dag": {
       "type": "object",
       "properties": {
-        "params": {"anyOf": [{ "$ref": "#/definitions/params_dict" }, {"$ref": "#/definitions/dict"}]},
+        "params": { "$ref": "#/definitions/params_dict" },
         "_dag_id": { "type": "string" },
         "tasks": {  "$ref": "#/definitions/tasks" },
         "timezone": { "$ref": "#/definitions/timezone" },
@@ -184,7 +184,7 @@
         "retry_delay": { "$ref": "#/definitions/timedelta" },
         "retry_exponential_backoff": { "type": "boolean" },
         "max_retry_delay": { "$ref": "#/definitions/timedelta" },
-        "params": {"anyOf": [{ "$ref": "#/definitions/params_dict" }, {"$ref": "#/definitions/dict"}]},
+        "params": { "$ref": "#/definitions/params_dict" },
         "priority_weight": { "type": "number" },
         "weight_rule": { "type": "string" },
         "executor_config": { "$ref": "#/definitions/dict" },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -78,7 +78,7 @@
     "dag": {
       "type": "object",
       "properties": {
-        "params": { "$ref": "#/definitions/dict" },
+        "params": { "$ref": "#/definitions/params" },
         "_dag_id": { "type": "string" },
         "tasks": {  "$ref": "#/definitions/tasks" },
         "timezone": { "$ref": "#/definitions/timezone" },
@@ -145,13 +145,14 @@
       "required": [
         "__class",
         "default"
-          ],
-          "properties": {
+      ],
+      "properties": {
         "__class": { "type": "string" },
         "default": { "$ref": "#/definitions/dict" },
         "description": { "type": "string" },
         "schema": { "$ref": "#/definitions/dict" }
-          }},
+      }
+    },
     "operator": {
       "$comment": "A task/operator in a DAG",
       "type": "object",

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -78,7 +78,7 @@
     "dag": {
       "type": "object",
       "properties": {
-        "params": { "$ref": "#/definitions/params_dict" },
+        "params": {"anyOf": [{ "$ref": "#/definitions/params_dict" }, {"$ref": "#/definitions/dict"}]},
         "_dag_id": { "type": "string" },
         "tasks": {  "$ref": "#/definitions/tasks" },
         "timezone": { "$ref": "#/definitions/timezone" },
@@ -184,7 +184,7 @@
         "retry_delay": { "$ref": "#/definitions/timedelta" },
         "retry_exponential_backoff": { "type": "boolean" },
         "max_retry_delay": { "$ref": "#/definitions/timedelta" },
-        "params": { "$ref": "#/definitions/params_dict" },
+        "params": {"anyOf": [{ "$ref": "#/definitions/params_dict" }, {"$ref": "#/definitions/dict"}]},
         "priority_weight": { "type": "number" },
         "weight_rule": { "type": "string" },
         "executor_config": { "$ref": "#/definitions/dict" },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -135,6 +135,23 @@
       "type": "array",
       "additionalProperties": { "$ref": "#/definitions/operator" }
     },
+    "params": {
+      "type": "array",
+      "additionalProperties": { "$ref": "#/definitions/param" }
+    },
+    "param": {
+      "$comment": "A param for a dag / operator",
+      "type": "object",
+      "required": [
+        "__class",
+        "default"
+          ],
+          "properties": {
+        "__class": { "type": "string" },
+        "default": { "$ref": "#/definitions/dict" },
+        "description": { "type": "string" },
+        "schema": { "$ref": "#/definitions/dict" }
+          }},
     "operator": {
       "$comment": "A task/operator in a DAG",
       "type": "object",
@@ -166,7 +183,7 @@
         "retry_delay": { "$ref": "#/definitions/timedelta" },
         "retry_exponential_backoff": { "type": "boolean" },
         "max_retry_delay": { "$ref": "#/definitions/timedelta" },
-        "params": { "$ref": "#/definitions/dict" },
+        "params": { "$ref": "#/definitions/params" },
         "priority_weight": { "type": "number" },
         "weight_rule": { "type": "string" },
         "executor_config": { "$ref": "#/definitions/dict" },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -137,7 +137,7 @@
     },
     "params_dict": {
       "type": "object",
-      "additionalProperties": {"anyOf": [ { "$ref": "#/definitions/param" }, { "type":  "object"}]}
+      "additionalProperties": {"$ref": "#/definitions/param" }
     },
     "param": {
       "$comment": "A param for a dag / operator",
@@ -148,8 +148,8 @@
       ],
       "properties": {
         "__class": { "type": "string" },
-        "default": { "$ref": "#/definitions/dict" },
-        "description": { "type": "string" },
+        "default": {},
+        "description": {"anyOf": [{"type":"string"}, {"type":"null"}]},
         "schema": { "$ref": "#/definitions/dict" }
       }
     },

--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -78,7 +78,7 @@
     "dag": {
       "type": "object",
       "properties": {
-        "params": { "$ref": "#/definitions/params" },
+        "params": { "$ref": "#/definitions/params_dict" },
         "_dag_id": { "type": "string" },
         "tasks": {  "$ref": "#/definitions/tasks" },
         "timezone": { "$ref": "#/definitions/timezone" },
@@ -135,9 +135,9 @@
       "type": "array",
       "additionalProperties": { "$ref": "#/definitions/operator" }
     },
-    "params": {
-      "type": "array",
-      "additionalProperties": { "$ref": "#/definitions/param" }
+    "params_dict": {
+      "type": "object",
+      "additionalProperties": {"anyOf": [ { "$ref": "#/definitions/param" }, { "type":  "object"}]}
     },
     "param": {
       "$comment": "A param for a dag / operator",
@@ -184,7 +184,7 @@
         "retry_delay": { "$ref": "#/definitions/timedelta" },
         "retry_exponential_backoff": { "type": "boolean" },
         "max_retry_delay": { "$ref": "#/definitions/timedelta" },
-        "params": { "$ref": "#/definitions/params" },
+        "params": { "$ref": "#/definitions/params_dict" },
         "priority_weight": { "type": "number" },
         "weight_rule": { "type": "string" },
         "executor_config": { "$ref": "#/definitions/dict" },

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -409,15 +409,15 @@ class BaseSerialization:
 
     @classmethod
     def _serialize_param(cls, param: Param):
-        d = param.dump()
-        d['value'] = cls._serialize(d['value'])
-        return d
+        param_dict = param.dump()
+        param_dict['default'] = cls._serialize(param_dict.pop('value'))
+        return param_dict
 
     @classmethod
-    def _deserialize_param(cls, param: Dict):
-        param_class = import_string(param['__class'])
-        param['value'] = cls._deserialize(param['value'])
-        return param_class(default=param['value'], description=param['description'])
+    def _deserialize_param(cls, param_dict: Dict):
+        param_class = import_string(param_dict['__class'])
+        param_dict['default'] = cls._deserialize(param_dict['default'])
+        return param_class(**param_dict)
 
     @classmethod
     def _serialize_params_dict(cls, params: ParamsDict):

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -417,6 +417,11 @@ class BaseSerialization:
 
     @classmethod
     def _deserialize_param(cls, param_dict: Dict):
+        """
+        In 2.2.0, Param attrs were assumed to be json-serializable and were not run through
+        this class's ``_serialize`` method.  So before running through ``_deserialize``,
+        we first verify that it's necessary to do.
+        """
         class_name = param_dict['__class']
         class_ = import_string(class_name)  # type: Type[Param]
         attrs = ('default', 'description', 'schema')

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -417,7 +417,10 @@ class BaseSerialization:
     @classmethod
     def _deserialize_param(cls, param_dict: Dict):
         param_class = import_string(param_dict.pop(Param.CLASS_IDENTIFIER))
-        param_kwargs = cls._deserialize(param_dict)
+        try:
+            param_kwargs = cls._deserialize(param_dict)
+        except KeyError:
+            param_kwargs = param_dict
         return param_class(**param_kwargs)
 
     @classmethod

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -410,14 +410,15 @@ class BaseSerialization:
     @classmethod
     def _serialize_param(cls, param: Param):
         param_dict = param.dump()
-        param_dict['default'] = cls._serialize(param_dict.pop('value'))
-        return param_dict
+        param_class_name = param_dict.pop(Param.CLASS_IDENTIFIER)
+        param_kwargs = dict(default=param_dict.pop('value'), **param_dict)
+        return {Param.CLASS_IDENTIFIER: param_class_name, **cls._serialize(param_kwargs)}
 
     @classmethod
     def _deserialize_param(cls, param_dict: Dict):
-        param_class = import_string(param_dict['__class'])
-        param_dict['default'] = cls._deserialize(param_dict['default'])
-        return param_class(**param_dict)
+        param_class = import_string(param_dict.pop(Param.CLASS_IDENTIFIER))
+        param_kwargs = cls._deserialize(param_dict)
+        return param_class(**param_kwargs)
 
     @classmethod
     def _serialize_params_dict(cls, params: ParamsDict):

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1472,7 +1472,6 @@ class TestStringifiedDAGs:
                 "params": {"none": None, "str": "str", "dict": {"a": "b"}},
             },
         }
-        SerializedDAG.validate_schema(serialized)
         dag = SerializedDAG.from_dict(serialized)
 
         assert dag.params["none"] is None

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -21,6 +21,7 @@
 import copy
 import importlib
 import importlib.util
+import json
 import multiprocessing
 import os
 from datetime import datetime, timedelta
@@ -724,6 +725,7 @@ class TestStringifiedDAGs:
         [
             (None, {}),
             ({"param_1": "value_1"}, {"param_1": "value_1"}),
+            ({"param_1": {1, 2, 3}}, {"param_1": {1, 2, 3}}),
         ],
     )
     def test_dag_params_roundtrip(self, val, expected_val):
@@ -734,6 +736,10 @@ class TestStringifiedDAGs:
         BaseOperator(task_id='simple_task', dag=dag, start_date=datetime(2019, 8, 1))
 
         serialized_dag = SerializedDAG.to_dict(dag)
+
+        # serialized dag dict must be json serializable
+        json.dumps(serialized_dag)
+
         assert "params" in serialized_dag["dag"]
 
         deserialized_dag = SerializedDAG.from_dict(serialized_dag)

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -1466,7 +1466,7 @@ class TestStringifiedDAGs:
             "__version": 1,
             "dag": {
                 "_dag_id": "simple_dag",
-                "fileloc": '__file__',
+                "fileloc": '/path/to/file.py',
                 "tasks": [],
                 "timezone": "UTC",
                 "params": {"none": None, "str": "str", "dict": {"a": "b"}},

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -775,14 +775,14 @@ class TestStringifiedDAGs:
             Param('my value', description='hello', schema={'type': 'string'}),
             Param('my value', description='hello'),
             Param(None, description=None),
-        ]
+        ],
     )
     def test_full_param_roundtrip(self, param):
         """
         Test to make sure that only native Param objects are being passed as dag or task params
         """
 
-        dag = DAG(dag_id='simple_dag', params={'my_param':param})
+        dag = DAG(dag_id='simple_dag', params={'my_param': param})
         serialized_json = SerializedDAG.to_json(dag)
         serialized = json.loads(serialized_json)
         SerializedDAG.validate_schema(serialized)
@@ -1095,56 +1095,56 @@ class TestStringifiedDAGs:
         base_operator = BaseOperator(task_id="10")
         fields = base_operator.__dict__
         assert {
-                   '_BaseOperator__instantiated': True,
-                   '_dag': None,
-                   '_downstream_task_ids': set(),
-                   '_inlets': [],
-                   '_log': base_operator.log,
-                   '_outlets': [],
-                   '_upstream_task_ids': set(),
-                   '_pre_execute_hook': None,
-                   '_post_execute_hook': None,
-                   'depends_on_past': False,
-                   'do_xcom_push': True,
-                   'doc': None,
-                   'doc_json': None,
-                   'doc_md': None,
-                   'doc_rst': None,
-                   'doc_yaml': None,
-                   'email': None,
-                   'email_on_failure': True,
-                   'email_on_retry': True,
-                   'end_date': None,
-                   'execution_timeout': None,
-                   'executor_config': {},
-                   'inlets': [],
-                   'label': '10',
-                   'max_active_tis_per_dag': None,
-                   'max_retry_delay': None,
-                   'on_execute_callback': None,
-                   'on_failure_callback': None,
-                   'on_retry_callback': None,
-                   'on_success_callback': None,
-                   'outlets': [],
-                   'owner': 'airflow',
-                   'params': {},
-                   'pool': 'default_pool',
-                   'pool_slots': 1,
-                   'priority_weight': 1,
-                   'queue': 'default',
-                   'resources': None,
-                   'retries': 0,
-                   'retry_delay': timedelta(0, 300),
-                   'retry_exponential_backoff': False,
-                   'run_as_user': None,
-                   'sla': None,
-                   'start_date': None,
-                   'subdag': None,
-                   'task_id': '10',
-                   'trigger_rule': 'all_success',
-                   'wait_for_downstream': False,
-                   'weight_rule': 'downstream',
-               } == fields, """
+            '_BaseOperator__instantiated': True,
+            '_dag': None,
+            '_downstream_task_ids': set(),
+            '_inlets': [],
+            '_log': base_operator.log,
+            '_outlets': [],
+            '_upstream_task_ids': set(),
+            '_pre_execute_hook': None,
+            '_post_execute_hook': None,
+            'depends_on_past': False,
+            'do_xcom_push': True,
+            'doc': None,
+            'doc_json': None,
+            'doc_md': None,
+            'doc_rst': None,
+            'doc_yaml': None,
+            'email': None,
+            'email_on_failure': True,
+            'email_on_retry': True,
+            'end_date': None,
+            'execution_timeout': None,
+            'executor_config': {},
+            'inlets': [],
+            'label': '10',
+            'max_active_tis_per_dag': None,
+            'max_retry_delay': None,
+            'on_execute_callback': None,
+            'on_failure_callback': None,
+            'on_retry_callback': None,
+            'on_success_callback': None,
+            'outlets': [],
+            'owner': 'airflow',
+            'params': {},
+            'pool': 'default_pool',
+            'pool_slots': 1,
+            'priority_weight': 1,
+            'queue': 'default',
+            'resources': None,
+            'retries': 0,
+            'retry_delay': timedelta(0, 300),
+            'retry_exponential_backoff': False,
+            'run_as_user': None,
+            'sla': None,
+            'start_date': None,
+            'subdag': None,
+            'task_id': '10',
+            'trigger_rule': 'all_success',
+            'wait_for_downstream': False,
+            'weight_rule': 'downstream',
+        } == fields, """
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
      ACTION NEEDED! PLEASE READ THIS CAREFULLY AND CORRECT TESTS CAREFULLY
@@ -1500,9 +1500,6 @@ class TestStringifiedDAGs:
         assert dag.params["str"] == "str"
 
     def test_params_serialize_default(self):
-        """In 2.0.0, param ``default`` was assumed to be json-serializable objects and were not run though
-        the standard serializer function.  In 2.2.2 we serialize param ``default``.  We keep this
-        test only to ensure that params stored in 2.2.0 can still be parsed correctly."""
         serialized = {
             "__version": 1,
             "dag": {
@@ -1510,9 +1507,14 @@ class TestStringifiedDAGs:
                 "fileloc": '/path/to/file.py',
                 "tasks": [],
                 "timezone": "UTC",
-                "params": {"my_param": {"default": "a string value", "description": "hello",
-                                        "schema": {"__var": {"type": "string"}, "__type": "dict"},
-                                        "__class": "airflow.models.param.Param"}},
+                "params": {
+                    "my_param": {
+                        "default": "a string value",
+                        "description": "hello",
+                        "schema": {"__var": {"type": "string"}, "__type": "dict"},
+                        "__class": "airflow.models.param.Param",
+                    }
+                },
             },
         }
         SerializedDAG.validate_schema(serialized)


### PR DESCRIPTION
This is a solution for https://github.com/apache/airflow/issues/19096

Previously, the serialization of params did not run the param value through the `_serialize` function, resulting in non-json-serializable dictionaries.  This manifested when a user, for example, tried to use params with a default value of type `set`.

Here we change the logic to run the param value through the serialization process.  And I add a test for the `set` case.

Could def use extra set of eyes on schema definition. btw i added hook for formatting this -- i can do that in separate pr if that's helpful.