### PR TITLE
Add missing "end_date" to hash components

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -457,6 +457,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         'retry_exponential_backoff',
         'max_retry_delay',
         'start_date',
+        'end_date',
         'depends_on_past',
         'wait_for_downstream',
         'priority_weight',

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -299,6 +299,7 @@ class DAG(LoggingMixin):
         'task_ids',
         'parent_dag',
         'start_date',
+        'end_date',
         'schedule_interval',
         'fileloc',
         'template_searchpath',


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This field seems to be missing – `start_date` is in there.
