### PR TITLE
add problem and solution documentation for pyenv not found

### DIFF
--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,7 +145,7 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Configure your shell's environment for Pyenv as suggested in Pyenv `Configure your shell's environment for Pyenv <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `README <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
 
 4. Restart your shell so the path changes take effect and verifying installation
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,7 +145,7 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Configure your shell's environment for Pyenv as suggested in Pyenv `README <https://github.com/pyenv/pyenv/blob/master/README.md>`_
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `Configure your shell's environment for Pyenv <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
 
 4. Restart your shell so the path changes take effect and verifying installation
 
@@ -153,10 +153,6 @@ Pyenv and setting up virtual-env
 
   $ exec $SHELL
   $ pyenv --version
-
-On Ubuntu 20.04 you may get an error of ``pyenv not found`` after execute ``exec $SHELL``.
-You can find the solution according to your specific shell in the following link `Configure your shell's environment for Pyenv
-<https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_.
 
 5. Checking available version, installing required Python version to pyenv and verifying it
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,7 +145,7 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Configure your shell's environment for Pyenv as suggested in Pyenv `Readme.md <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `README <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
 
 4. Restart your shell so the path changes take effect and verifying installation
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,7 +145,7 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Configure your shell's environment for Pyenv as suggested in Pyenv `Readme.md <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `README.md <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
 
 4. Restart your shell so the path changes take effect and verifying installation
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,7 +145,7 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Configure your shell's environment for Pyenv as suggested in Pyenv `README.md <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `Readme.md <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
 
 4. Restart your shell so the path changes take effect and verifying installation
 

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -154,6 +154,10 @@ Pyenv and setting up virtual-env
   $ exec $SHELL
   $ pyenv --version
 
+On Ubuntu 20.04 you may get an error of ``pyenv not found`` after execute ``exec $SHELL``.
+You can find the solution according to your specific shell in the following link `Configure your shell's environment for Pyenv
+<https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_.
+
 5. Checking available version, installing required Python version to pyenv and verifying it
 
 .. code-block:: bash

--- a/CONTRIBUTORS_QUICK_START.rst
+++ b/CONTRIBUTORS_QUICK_START.rst
@@ -145,7 +145,7 @@ Pyenv and setting up virtual-env
 
   $ curl https://pyenv.run | bash
 
-3. Configure your shell's environment for Pyenv as suggested in Pyenv `README <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
+3. Configure your shell's environment for Pyenv as suggested in Pyenv `README.md <https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout>`_
 
 4. Restart your shell so the path changes take effect and verifying installation
 

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -80,7 +80,7 @@ Running Unit Tests from Visual Studio Code
 
 To run unit tests from the Visual Studio Code:
 
-1. Using the ``Exteinsions`` view install Python extension, reload if required
+1. Using the ``Extensions`` view install Python extension, reload if required
 
 .. image:: images/vscode_install_python_extension.png
     :align: center

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1350,6 +1350,14 @@
       example: "/path/to/my_html_content_template_file"
       default: ~
       see_also: ":doc:`Email Configuration </howto/email-config>`"
+    - name: from_email
+      description: |
+        Email address that will be used as sender address.
+        It can either be raw email or the complete address in a format ``Sender Name <sender@email.com>``
+      version_added: 2.3.0
+      type: string
+      example: "Airflow <airflow@example.com>"
+      default: ~
 
 - name: smtp
   description: |

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -678,6 +678,11 @@ default_email_on_failure = True
 # Example: html_content_template = /path/to/my_html_content_template_file
 # html_content_template =
 
+# Email address that will be used as sender address.
+# It can either be raw email or the complete address in a format ``Sender Name <sender@email.com>``
+# Example: from_email = Airflow <airflow@example.com>
+# from_email =
+
 [smtp]
 
 # If you want airflow to send emails on retries, failure, and you want to use

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -77,6 +77,7 @@ from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.weight_rule import WeightRule
 
 if TYPE_CHECKING:
+    from airflow.models.dag import DAG
     from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
 
@@ -241,14 +242,17 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     :param retries: the number of retries that should be performed before
         failing the task
     :type retries: int
-    :param retry_delay: delay between retries
-    :type retry_delay: datetime.timedelta
-    :param retry_exponential_backoff: allow progressive longer waits between
+    :param retry_delay: delay between retries, can be set as ``timedelta`` or
+        ``float`` seconds, which will be converted into ``timedelta``,
+        the default is ``timedelta(seconds=300)``.
+    :type retry_delay: datetime.timedelta or float
+    :param retry_exponential_backoff: allow progressively longer waits between
         retries by using exponential backoff algorithm on retry delay (delay
         will be converted into seconds)
     :type retry_exponential_backoff: bool
-    :param max_retry_delay: maximum delay interval between retries
-    :type max_retry_delay: datetime.timedelta
+    :param max_retry_delay: maximum delay interval between retries, can be set as
+        ``timedelta`` or ``float`` seconds, which will be converted into ``timedelta``.
+    :type max_retry_delay: datetime.timedelta or float
     :param start_date: The ``start_date`` for the task, determines
         the ``execution_date`` for the first task instance. The best practice
         is to have the start_date rounded
@@ -486,14 +490,14 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         email_on_retry: bool = conf.getboolean('email', 'default_email_on_retry', fallback=True),
         email_on_failure: bool = conf.getboolean('email', 'default_email_on_failure', fallback=True),
         retries: Optional[int] = conf.getint('core', 'default_task_retries', fallback=0),
-        retry_delay: timedelta = timedelta(seconds=300),
+        retry_delay: Union[timedelta, float] = timedelta(seconds=300),
         retry_exponential_backoff: bool = False,
-        max_retry_delay: Optional[timedelta] = None,
+        max_retry_delay: Optional[Union[timedelta, float]] = None,
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
         depends_on_past: bool = False,
         wait_for_downstream: bool = False,
-        dag=None,
+        dag: Optional['DAG'] = None,
         params: Optional[Dict] = None,
         default_args: Optional[Dict] = None,
         priority_weight: int = 1,
@@ -804,7 +808,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         return self._outlets
 
     @property
-    def dag(self) -> Any:
+    def dag(self) -> 'DAG':
         """Returns the Operator's DAG if set, otherwise raises an error"""
         if self.has_dag():
             return self._dag
@@ -812,7 +816,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             raise AirflowException(f'Operator {self} has not been assigned to a DAG yet')
 
     @dag.setter
-    def dag(self, dag: Any):
+    def dag(self, dag: Optional['DAG']):
         """
         Operators can be assigned to one DAG, one time. Repeat assignments to
         that same DAG are ok.

--- a/airflow/providers/amazon/aws/utils/emailer.py
+++ b/airflow/providers/amazon/aws/utils/emailer.py
@@ -23,6 +23,7 @@ from airflow.providers.amazon.aws.hooks.ses import SESHook
 
 
 def send_email(
+    from_email: str,
     to: Union[List[str], str],
     subject: str,
     html_content: str,
@@ -37,7 +38,7 @@ def send_email(
     """Email backend for SES."""
     hook = SESHook(aws_conn_id=conn_id)
     hook.send_email(
-        mail_from=None,
+        mail_from=from_email,
         to=to,
         subject=subject,
         html_content=html_content,

--- a/airflow/providers/docker/operators/docker_swarm.py
+++ b/airflow/providers/docker/operators/docker_swarm.py
@@ -105,6 +105,9 @@ class DockerSwarmOperator(DockerOperator):
     :type mode: docker.types.ServiceMode
     :param networks: List of network names or IDs or NetworkAttachmentConfig to attach the service to.
     :type networks: List[Union[str, NetworkAttachmentConfig]]
+    :param placement: Placement instructions for the scheduler. If a list is passed instead,
+        it is assumed to be a list of constraints as part of a Placement object.
+    :type placement: Union[types.Placement, List[types.Placement]]
     """
 
     def __init__(
@@ -116,6 +119,7 @@ class DockerSwarmOperator(DockerOperator):
         secrets: Optional[List[types.SecretReference]] = None,
         mode: Optional[types.ServiceMode] = None,
         networks: Optional[List[Union[str, types.NetworkAttachmentConfig]]] = None,
+        placement: Optional[Union[types.Placement, List[types.Placement]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(image=image, **kwargs)
@@ -126,6 +130,7 @@ class DockerSwarmOperator(DockerOperator):
         self.secrets = secrets
         self.mode = mode
         self.networks = networks
+        self.placement = placement
 
     def execute(self, context) -> None:
         self.cli = self._get_cli()
@@ -153,6 +158,7 @@ class DockerSwarmOperator(DockerOperator):
                 restart_policy=types.RestartPolicy(condition='none'),
                 resources=types.Resources(mem_limit=self.mem_limit),
                 networks=self.networks,
+                placement=self.placement,
             ),
             name=f'airflow-{get_random_string()}',
             labels={'name': f'airflow__{self.dag_id}__{self.task_id}'},

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -923,7 +923,7 @@ class SerializedTaskGroup(TaskGroup, BaseSerialization):
     """A JSON serializable representation of TaskGroup."""
 
     @classmethod
-    def serialize_task_group(cls, task_group: TaskGroup) -> Optional[Union[Dict[str, Any]]]:
+    def serialize_task_group(cls, task_group: TaskGroup) -> Optional[Dict[str, Any]]:
         """Serializes TaskGroup into a JSON object."""
         if not task_group:
             return None

--- a/airflow/ti_deps/deps/pool_slots_available_dep.py
+++ b/airflow/ti_deps/deps/pool_slots_available_dep.py
@@ -55,7 +55,7 @@ class PoolSlotsAvailableDep(BaseTIDep):
         else:
             # Controlled by UNIQUE key in slot_pool table,
             # only one result can be returned.
-            open_slots = pools[0].open_slots()
+            open_slots = pools[0].open_slots(session=session)
 
         if ti.state in EXECUTION_STATES:
             open_slots += ti.pool_slots

--- a/airflow/utils/email.py
+++ b/airflow/utils/email.py
@@ -49,6 +49,8 @@ def send_email(
     """Send email using backend specified in EMAIL_BACKEND."""
     backend = conf.getimport('email', 'EMAIL_BACKEND')
     backend_conn_id = conn_id or conf.get("email", "EMAIL_CONN_ID")
+    from_email = conf.get('email', 'from_email', fallback=None)
+
     to_list = get_email_address_list(to)
     to_comma_separated = ", ".join(to_list)
 
@@ -63,6 +65,7 @@ def send_email(
         mime_subtype=mime_subtype,
         mime_charset=mime_charset,
         conn_id=backend_conn_id,
+        from_email=from_email,
         **kwargs,
     )
 
@@ -78,6 +81,7 @@ def send_email_smtp(
     mime_subtype: str = 'mixed',
     mime_charset: str = 'utf-8',
     conn_id: str = "smtp_default",
+    from_email: str = None,
     **kwargs,
 ):
     """
@@ -87,8 +91,10 @@ def send_email_smtp(
     """
     smtp_mail_from = conf.get('smtp', 'SMTP_MAIL_FROM')
 
+    mail_from = smtp_mail_from or from_email
+
     msg, recipients = build_mime_message(
-        mail_from=smtp_mail_from,
+        mail_from=mail_from,
         to=to,
         subject=subject,
         html_content=html_content,
@@ -99,7 +105,7 @@ def send_email_smtp(
         mime_charset=mime_charset,
     )
 
-    send_mime_email(e_from=smtp_mail_from, e_to=recipients, mime_msg=msg, conn_id=conn_id, dryrun=dryrun)
+    send_mime_email(e_from=mail_from, e_to=recipients, mime_msg=msg, conn_id=conn_id, dryrun=dryrun)
 
 
 def build_mime_message(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2863,6 +2863,7 @@ class Airflow(AirflowBaseView):
             task_dict['end_date'] = task_dict['end_date'] or timezone.utcnow()
             task_dict['extraLinks'] = dag.get_task(ti.task_id).extra_links
             task_dict['try_number'] = try_count
+            task_dict['execution_date'] = dttm
             tasks.append(task_dict)
 
         tf_count = 0
@@ -2884,6 +2885,7 @@ class Airflow(AirflowBaseView):
             task_dict['operator'] = task.task_type
             task_dict['try_number'] = try_count
             task_dict['extraLinks'] = task.extra_links
+            task_dict['execution_date'] = dttm
             tasks.append(task_dict)
 
         task_names = [ti.task_id for ti in tis]

--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -383,8 +383,8 @@ This can be done with the Apache RAT tool.
 
 * Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the binary,
   the jar is inside)
-* Unpack the binary (`-bin.tar.gz`) to a folder
-* Enter the folder and run the check (point to the place where you extracted the .jar)
+* Unpack the release source archive (the `<package + version>-source.tar.gz` file) to a folder
+* Enter the sources folder run the check
 
 ```shell script
 java -jar ../../apache-rat-0.13/apache-rat-0.13.jar -E .rat-excludes -d .
@@ -394,7 +394,7 @@ where `.rat-excludes` is the file in the root of Airflow source code.
 
 ## Signature check
 
-Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
+Make sure you have imported into your GPG the PGP key of the person signing the release. You can find the valid keys in
 [KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
 
 You can import the whole KEYS file:
@@ -426,7 +426,7 @@ Once you have the keys, the signatures can be verified by running this:
 ```shell script
 for i in *.asc
 do
-   echo "Checking $i"; gpg --verify $i
+   echo -e "Checking $i\n"; gpg --verify $i
 done
 ```
 
@@ -446,6 +446,7 @@ gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+
 Checking apache_airflow-2.0.2rc4-py2.py3-none-any.whl.asc
 gpg: assuming signed data in 'apache_airflow-2.0.2rc4-py2.py3-none-any.whl'
 gpg: Signature made sob, 22 sie 2020, 20:28:31 CEST
@@ -454,6 +455,7 @@ gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+
 Checking apache-airflow-2.0.2rc4-source.tar.gz.asc
 gpg: assuming signed data in 'apache-airflow-2.0.2rc4-source.tar.gz'
 gpg: Signature made sob, 22 sie 2020, 20:28:25 CEST

--- a/dev/README_RELEASE_AIRFLOW_UPGRADE_CHECK.md
+++ b/dev/README_RELEASE_AIRFLOW_UPGRADE_CHECK.md
@@ -305,8 +305,8 @@ This can be done with the Apache RAT tool.
 
 * Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the binary,
   the jar is inside)
-* Unpack the binary (`-bin.tar.gz`) to a folder
-* Enter the folder and run the check (point to the place where you extracted the .jar)
+* Unpack the release source archive (the `<package + version>-source.tar.gz` file) to a folder
+* Enter the sources folder run the check
 
 ```shell script
 java -jar ../../apache-rat-0.13/apache-rat-0.13.jar -E .rat-excludes -d .
@@ -316,7 +316,7 @@ where `.rat-excludes` is the file in the root of Airflow source code.
 
 ## Signature check
 
-Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
+Make sure you have imported into your GPG the PGP key of the person signing the release. You can find the valid keys in
 [KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
 
 You can import the whole KEYS file:
@@ -348,7 +348,7 @@ Once you have the keys, the signatures can be verified by running this:
 ```shell script
 for i in *.asc
 do
-   echo "Checking $i"; gpg --verify $i
+   echo -e "Checking $i\n"; gpg --verify $i
 done
 ```
 
@@ -368,6 +368,7 @@ gpg: Good signature from "Kaxil Naik <kaxilnaik@apache.org>" [ultimate]
 gpg:                 aka "Kaxil Naik <kaxilnaik@gmail.com>" [ultimate]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
+
 Checking apache-airflow-upgrade-check-1.3.0rc1-source.tar.gz.asc
 gpg: assuming signed data in 'apache-airflow-upgrade-check-1.3.0rc1-source.tar.gz'
 gpg: Signature made Tue  9 Mar 23:22:21 2021 GMT
@@ -376,6 +377,7 @@ gpg: Good signature from "Kaxil Naik <kaxilnaik@apache.org>" [ultimate]
 gpg:                 aka "Kaxil Naik <kaxilnaik@gmail.com>" [ultimate]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
+
 Checking apache_airflow_upgrade_check-1.3.0rc1-py2.py3-none-any.whl.asc
 gpg: assuming signed data in 'apache_airflow_upgrade_check-1.3.0rc1-py2.py3-none-any.whl'
 gpg: Signature made Tue  9 Mar 23:22:27 2021 GMT

--- a/dev/README_RELEASE_HELM_CHART.md
+++ b/dev/README_RELEASE_HELM_CHART.md
@@ -328,8 +328,8 @@ This can be done with the Apache RAT tool.
 
 * Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the binary,
   the jar is inside)
-* Unpack the binary (`-bin.tar.gz`) to a folder
-* Enter the folder and run the check (point to the place where you extracted the .jar)
+* Unpack the release source archive (the `<package + version>-source.tar.gz` file) to a folder
+* Enter the sources folder run the check
 
 ```shell
 java -jar $PATH_TO_RAT/apache-rat-0.13/apache-rat-0.13.jar chart -E .rat-excludes
@@ -339,7 +339,7 @@ where `.rat-excludes` is the file in the root of Chart source code.
 
 ## Signature check
 
-Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
+Make sure you have imported into your GPG the PGP key of the person signing the release. You can find the valid keys in
 [KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
 
 You can import the whole KEYS file:
@@ -371,7 +371,7 @@ Once you have the keys, the signatures can be verified by running this:
 ```shell
 for i in *.asc
 do
-   echo "Checking $i"; gpg --verify $i
+   echo -e "Checking $i\n"; gpg --verify $i
 done
 ```
 
@@ -393,6 +393,7 @@ gpg:                 aka "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
 gpg: WARNING: The key's User ID is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: CDE1 5C6E 4D3A 8EC4 ECF4  BA4B 6674 E08A D7DE 406F
+
 Checking airflow-chart-1.0.0-source.tar.gz.asc
 gpg: assuming signed data in 'airflow-chart-1.0.0-source.tar.gz'
 gpg: Signature made Sun 16 May 02:24:09 2021 BST

--- a/dev/README_RELEASE_PROVIDER_PACKAGES.md
+++ b/dev/README_RELEASE_PROVIDER_PACKAGES.md
@@ -473,8 +473,8 @@ This can be done with the Apache RAT tool.
 
 * Download the latest jar from https://creadur.apache.org/rat/download_rat.cgi (unpack the binary,
   the jar is inside)
-* Unpack the binary (`-bin.tar.gz`) to a folder
-* Enter the folder and run the check (point to the place where you extracted the .jar)
+* Unpack the release source archive (the `<package + version>-source.tar.gz` file) to a folder
+* Enter the sources folder run the check
 
 ```shell script
 java -jar ../../apache-rat-0.13/apache-rat-0.13.jar -E .rat-excludes -d .
@@ -484,7 +484,7 @@ where `.rat-excludes` is the file in the root of Airflow source code.
 
 ### Signature check
 
-Make sure you have the key of person signed imported in your GPG. You can find the valid keys in
+Make sure you have imported into your GPG the PGP key of the person signing the release. You can find the valid keys in
 [KEYS](https://dist.apache.org/repos/dist/release/airflow/KEYS).
 
 You can import the whole KEYS file:
@@ -516,7 +516,7 @@ Once you have the keys, the signatures can be verified by running this:
 ```shell script
 for i in *.asc
 do
-   echo "Checking $i"; gpg --verify $i
+   echo -e "Checking $i\n"; gpg --verify $i
 done
 ```
 
@@ -536,6 +536,7 @@ gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+
 Checking apache_airflow-2.0.2rc4-py2.py3-none-any.whl.asc
 gpg: assuming signed data in 'apache_airflow-2.0.2rc4-py2.py3-none-any.whl'
 gpg: Signature made sob, 22 sie 2020, 20:28:31 CEST
@@ -544,6 +545,7 @@ gpg: Good signature from "Kaxil Naik <kaxilnaik@gmail.com>" [unknown]
 gpg: WARNING: This key is not certified with a trusted signature!
 gpg:          There is no indication that the signature belongs to the owner.
 Primary key fingerprint: 1271 7556 040E EF2E EAF1  B9C2 75FC CD0A 25FA 0E4B
+
 Checking apache-airflow-2.0.2rc4-source.tar.gz.asc
 gpg: assuming signed data in 'apache-airflow-2.0.2rc4-source.tar.gz'
 gpg: Signature made sob, 22 sie 2020, 20:28:25 CEST

--- a/docs/apache-airflow-providers-apache-hdfs/index.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/index.rst
@@ -15,8 +15,8 @@
     specific language governing permissions and limitations
     under the License.
 
-``apache-airflow-providers-hdfs``
-=================================
+``apache-airflow-providers-apache-hdfs``
+========================================
 
 
 Content

--- a/docs/apache-airflow/howto/email-config.rst
+++ b/docs/apache-airflow/howto/email-config.rst
@@ -29,6 +29,8 @@ in the ``[email]`` section.
   subject_template = /path/to/my_subject_template_file
   html_content_template = /path/to/my_html_content_template_file
 
+You can configure sender's email address by setting ``from_email`` in the ``[email]`` section.
+
 To configure SMTP settings, checkout the :ref:`SMTP <config:smtp>` section in the standard configuration.
 If you do not want to store the SMTP credentials in the config or in the environment variables, you can create a
 connection called ``smtp_default`` of ``Email`` type, or choose a custom connection name and set the ``email_conn_id`` with it's name in
@@ -91,6 +93,9 @@ or
    name and set it in ``email_conn_id`` of  'Email' type. Only login and password
    are used from the connection.
 
+4. Configure sender's email address and name either by exporting the environment variables ``SENDGRID_MAIL_FROM`` and ``SENDGRID_MAIL_SENDER`` or
+   in your ``airflow.cfg`` by setting ``from_email`` in the ``[email]`` section.
+
 .. _email-configuration-ses:
 
 Send email using AWS SES
@@ -116,3 +121,5 @@ Follow the steps below to enable it:
 
 3. Create a connection called ``aws_default``, or choose a custom connection
    name and set it in ``email_conn_id``. The type of connection should be ``Amazon Web Services``.
+
+4. Configure sender's email address in your ``airflow.cfg`` by setting ``from_email`` in the ``[email]`` section.

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -415,10 +415,9 @@ Let's break this down into 2 steps: get data & merge data:
 
 .. code-block:: python
 
-  from airflow.decorators import dag, task
-  from airflow.hooks.postgres import PostgresHook
-  from datetime import datetime, timedelta
   import requests
+  from airflow.decorators import task
+  from airflow.hooks.postgres import PostgresHook
 
 
   @task
@@ -446,6 +445,10 @@ Let's break this down into 2 steps: get data & merge data:
 Here we are passing a ``GET`` request to get the data from the URL and save it in ``employees.csv`` file on our Airflow instance and we are dumping the file into a temporary table before merging the data to the final employees table.
 
 .. code-block:: python
+
+  from airflow.decorators import task
+  from airflow.hooks.postgres import PostgresHook
+
 
   @task
   def merge_data():
@@ -475,10 +478,11 @@ Lets look at our DAG:
 
 .. code-block:: python
 
-  from airflow.decorators import dag, task
-  from airflow.hooks.postgres_hook import PostgresHook
   from datetime import datetime, timedelta
+
   import requests
+  from airflow.decorators import dag, task
+  from airflow.hooks.postgres import PostgresHook
 
 
   @dag(

--- a/docs/apache-airflow/tutorial_taskflow_api.rst
+++ b/docs/apache-airflow/tutorial_taskflow_api.rst
@@ -55,7 +55,7 @@ We are creating a DAG which is the collection of our tasks with dependencies bet
 the tasks. This is a very simple definition, since we just want the DAG to be run
 when we set this up with Airflow, without any retries or complex scheduling.
 In this example, please notice that we are creating this DAG using the ``@dag`` decorator
-as shown below, with the python function name acting as the DAG identifier.
+as shown below, with the Python function name acting as the DAG identifier.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial_taskflow_api_etl.py
     :language: python
@@ -94,7 +94,7 @@ the Transform task for summarization, and then invoked the Load task with the su
 The dependencies between the tasks and the passing of data between these tasks which could be
 running on different workers on different nodes on the network is all handled by Airflow.
 
-Now to actually enable this to be run as a DAG, we invoke the python function
+Now to actually enable this to be run as a DAG, we invoke the Python function
 ``tutorial_taskflow_api_etl`` set up using the ``@dag`` decorator earlier, as shown below.
 
 .. exampleinclude:: /../../airflow/example_dags/tutorial_taskflow_api_etl.py
@@ -125,9 +125,9 @@ in the middle of the data pipeline. In Airflow 1.x, this task is defined as show
     :start-after: [START transform_function]
     :end-before: [END transform_function]
 
-As we see here, the data being processed in the Transform function is passed to it using Xcom
+As we see here, the data being processed in the Transform function is passed to it using XCom
 variables. In turn, the summarized data from the Transform function is also placed
-into another Xcom variable which will then be used by the Load task.
+into another XCom variable which will then be used by the Load task.
 
 Contrasting that with TaskFlow API in Airflow 2.0 as shown below.
 
@@ -137,8 +137,8 @@ Contrasting that with TaskFlow API in Airflow 2.0 as shown below.
     :start-after: [START transform]
     :end-before: [END transform]
 
-All of the Xcom usage for data passing between these tasks is abstracted away from the DAG author
-in Airflow 2.0. However, Xcom variables are used behind the scenes and can be viewed using
+All of the XCom usage for data passing between these tasks is abstracted away from the DAG author
+in Airflow 2.0. However, XCom variables are used behind the scenes and can be viewed using
 the Airflow UI as necessary for debugging or DAG monitoring.
 
 Similarly, task dependencies are automatically generated within TaskFlows based on the
@@ -160,20 +160,20 @@ the dependencies as shown below.
     :start-after: [START main_flow]
     :end-before: [END main_flow]
 
-Using the Taskflow API with Docker or Virtual Environments
+Using the TaskFlow API with Docker or Virtual Environments
 ----------------------------------------------------------
 
 If you have tasks that require complex or conflicting requirements then you will have the ability to use the
-Taskflow API with either a Docker container (since version 2.2.0) or Python virtual environment (since 2.0.2).
+TaskFlow API with either a Docker container (since version 2.2.0) or Python virtual environment (since 2.0.2).
 This added functionality will allow a much more
-comprehensive range of use-cases for the Taskflow API, as you will not be limited to the
+comprehensive range of use-cases for the TaskFlow API, as you will not be limited to the
 packages and system libraries of the Airflow worker.
 
-To use a docker image with the Taskflow API, change the decorator to ``@task.docker``
+To use a docker image with the TaskFlow API, change the decorator to ``@task.docker``
 and add any needed arguments to correctly run the task. Please note that the docker
 image must have a working Python installed and take in a bash command as the ``command`` argument.
 
-Below is an example of using the ``@task.docker`` decorator to run a python task.
+Below is an example of using the ``@task.docker`` decorator to run a Python task.
 
 .. exampleinclude:: /../../airflow/providers/docker/example_dags/tutorial_taskflow_api_etl_docker_virtualenv.py
     :language: python
@@ -181,7 +181,7 @@ Below is an example of using the ``@task.docker`` decorator to run a python task
     :start-after: [START transform_docker]
     :end-before: [END transform_docker]
 
-It is worth noting that the python source code (extracted from the decorated function) and any callable args are sent to the container via (encoded and pickled) environment variables so the length of these is not boundless (the exact limit depends on system settings).
+It is worth noting that the Python source code (extracted from the decorated function) and any callable args are sent to the container via (encoded and pickled) environment variables so the length of these is not boundless (the exact limit depends on system settings).
 
 .. note:: Using ``@task.docker`` decorator in one of the earlier Airflow versions
 
@@ -206,11 +206,11 @@ Python version to run your function.
     :end-before: [END extract_virtualenv]
 
 These two options should allow for far greater flexibility for users who wish to keep their workflows more simple
-and pythonic.
+and Pythonic.
 
 Multiple outputs inference
 --------------------------
-Tasks can also infer multiple outputs by using dict python typing.
+Tasks can also infer multiple outputs by using dict Python typing.
 
 .. code-block:: python
 
@@ -224,11 +224,11 @@ is automatically set to true.
 Note, If you manually set the ``multiple_outputs`` parameter the inference is disabled and
 the parameter value is used.
 
-Adding dependencies to decorated tasks from regular tasks
----------------------------------------------------------
-The above tutorial shows how to create dependencies between python-based tasks. However, it is
-quite possible while writing a DAG to have some pre-existing tasks such as :class:`~airflow.operators.bash.BashOperator` or :class:`~airflow.sensors.filesystem.FileSensor`
-based tasks which need to be run first before a python-based task is run.
+Adding dependencies between decorated and traditional tasks
+-----------------------------------------------------------
+The above tutorial shows how to create dependencies between TaskFlow functions. However, dependencies can also
+be set between traditional tasks (such as :class:`~airflow.operators.bash.BashOperator`
+or :class:`~airflow.sensors.filesystem.FileSensor`) and TaskFlow functions.
 
 Building this dependency is shown in the code below:
 
@@ -251,18 +251,45 @@ Building this dependency is shown in the code below:
     file_task >> order_data
 
 
-In the above code block, a new python-based task is defined as ``extract_from_file`` which
+In the above code block, a new TaskFlow function is defined as ``extract_from_file`` which
 reads the data from a known file location.
 In the main DAG, a new ``FileSensor`` task is defined to check for this file. Please note
 that this is a Sensor task which waits for the file.
-Finally, a dependency between this Sensor task and the python-based task is specified.
+Finally, a dependency between this Sensor task and the TaskFlow function is specified.
 
 
-Consuming XCOMs with decorated tasks from regular tasks
----------------------------------------------------------
-You may additionally find it necessary to consume an XCOM from a pre-existing task as an input into python-based tasks.
+Consuming XComs between decorated and traditional tasks
+-------------------------------------------------------
+As noted above, the TaskFlow API allows XComs to be consumed or passed between tasks in a manner that is
+abstracted away from the DAG author. This section dives further into detailed examples of how this is
+possible not only between TaskFlow functions but between both TaskFlow functions *and* traditional tasks.
 
-Building this dependency is shown in the code below:
+You may find it necessary to consume an XCom from traditional tasks, either pushed within the task's execution
+or via its return value, as an input into downstream tasks. You can access the pushed XCom (also known as an
+``XComArg``) by utilizing the ``.output`` property exposed for all operators.
+
+By default, using the ``.output`` property to retrieve an XCom result is the equivalent of:
+
+.. code-block:: python
+
+    task_instance.xcom_pull(task_ids="my_task_id", key="return_value")
+
+To retrieve an XCom result for a key other than ``return_value``, you can use:
+
+.. code-block:: python
+
+    my_op = MyOperator(...)
+    my_op_output = my_op.output["some_other_xcom_key"]
+    # OR
+    my_op_output = my_op.output.get("some_other_xcom_key")
+
+.. note::
+    Using the ``.output`` property as an input to another task is supported only for operator parameters
+    listed as a ``template_field``.
+
+In the code example below, a :class:`~airflow.providers.http.operators.http.SimpleHttpOperator` result
+is captured via :doc:`XComs </concepts/xcoms>`. This XCom result, which is the task output, is then passed
+to a TaskFlow function which parses the response as JSON.
 
 .. code-block:: python
 
@@ -279,18 +306,70 @@ Building this dependency is shown in the code below:
         return json.loads(api_results)
 
 
-    parsed_results = parsed_results(get_api_results_task.output)
+    parsed_results = parsed_results(api_results=get_api_results_task.output)
+
+The reverse can also be done: passing the output of a TaskFlow function as an input to a traditional task.
+
+.. code-block:: python
+
+    @task
+    def create_queue():
+        """This is a Python function that creates an SQS queue"""
+        hook = SQSHook()
+        result = hook.create_queue(queue_name="sample-queue")
+
+        return result["QueueUrl"]
 
 
-In the above code block, a :class:`~airflow.providers.http.operators.http.SimpleHttpOperator` result
-was captured via :doc:`XCOMs </concepts/xcoms>`. This XCOM result, which is the task output, was then passed
-to a TaskFlow decorated task which parses the response as JSON - and the rest continues as expected.
+    sqs_queue = create_queue()
+
+    publish_to_queue = SQSPublishOperator(
+        task_id="publish_to_queue",
+        sqs_queue=sqs_queue,
+        message_content="{{ task_instance }}-{{ execution_date }}",
+        message_attributes=None,
+        delay_seconds=0,
+    )
+
+Take note in the code example above, the output from the ``create_queue`` TaskFlow function, the URL of a
+newly-created Amazon SQS Queue, is then passed to a :class:`~airflow.providers.amazon.aws.operators.sqs.SQSPublishOperator`
+task as the ``sqs_queue`` arg.
+
+Finally, not only can you use traditional operator outputs as inputs for TaskFlow functions, but also as inputs to
+other traditional operators. In the example below, the output from the :class:`~airflow.providers.amazon.aws.transfers.salesforce_to_s3.SalesforceToS3Operator`
+task (which is an S3 URI for a destination file location) is used an input for the :class:`~airflow.providers.amazon.aws.operators.s3_copy_object.S3CopyObjectOperator`
+task to copy the same file to a date-partitioned storage location in S3 for long-term storage in a data lake.
+
+.. code-block:: python
+
+    BASE_PATH = "salesforce/customers"
+    FILE_NAME = "customer_daily_extract_{{ ds_nodash }}.csv"
+
+
+    upload_salesforce_data_to_s3_landing = SalesforceToS3Operator(
+        task_id="upload_salesforce_data_to_s3",
+        salesforce_query="SELECT Id, Name, Company, Phone, Email, LastModifiedDate, IsActive FROM Customers",
+        s3_bucket_name="landing-bucket",
+        s3_key=f"{BASE_PATH}/{FILE_NAME}",
+        salesforce_conn_id="salesforce",
+        aws_conn_id="s3",
+        replace=True,
+    )
+
+
+    store_to_s3_data_lake = S3CopyObjectOperator(
+        task_id="store_to_s3_data_lake",
+        aws_conn_id="s3",
+        source_bucket_key=upload_salesforce_data_to_s3_landing.output,
+        dest_bucket_name="data_lake",
+        dest_bucket_key=f"""{BASE_PATH}/{"{{ execution_date.strftime('%Y/%m/%d') }}"}/{FILE_NAME}""",
+    )
 
 Accessing context variables in decorated tasks
 ----------------------------------------------
 
 When running your callable, Airflow will pass a set of keyword arguments that can be used in your
-function. This set of kwargs correspond exactly to what you can use in your jinja templates.
+function. This set of kwargs correspond exactly to what you can use in your Jinja templates.
 For this to work, you need to define ``**kwargs`` in your function header, or you can add directly the
 keyword arguments you would like to get - for example with the below code your callable will get
 the values of ``ti`` and ``next_ds`` context variables. Note that when explicit keyword arguments are used,

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -57,9 +57,11 @@ if [[ -z "${USE_AIRFLOW_VERSION=}" ]]; then
     tmux send-keys 'cd /opt/airflow/airflow/www/; yarn install --frozen-lockfile; yarn dev' C-m
 fi
 
-tmux select-pane -t 0
-tmux split-window -h
-tmux send-keys 'airflow triggerer' C-m
+if python -c 'import sys; sys.exit(sys.version_info < (3, 7))'; then
+    tmux select-pane -t 0
+    tmux split-window -h
+    tmux send-keys 'airflow triggerer' C-m
+fi
 
 # Attach Session, on the Main window
 tmux select-pane -t 0

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -879,5 +879,5 @@ def test_number_of_queries_single_loop(mock_get_task_runner, return_codes, dag_m
     ti.refresh_from_task(task)
 
     job = LocalTaskJob(task_instance=ti, executor=MockExecutor())
-    with assert_queries_count(20):
+    with assert_queries_count(18):
         job.run()

--- a/tests/providers/amazon/aws/utils/test_emailer.py
+++ b/tests/providers/amazon/aws/utils/test_emailer.py
@@ -16,27 +16,29 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
-from unittest import mock
+from unittest import TestCase, mock
 
 from airflow.providers.amazon.aws.utils.emailer import send_email
 
 
-@mock.patch("airflow.providers.amazon.aws.utils.emailer.SESHook")
-def test_send_email(mock_hook):
-    send_email(
-        to="to@test.com",
-        subject="subject",
-        html_content="content",
-    )
-    mock_hook.return_value.send_email.assert_called_once_with(
-        mail_from=None,
-        to="to@test.com",
-        subject="subject",
-        html_content="content",
-        bcc=None,
-        cc=None,
-        files=None,
-        mime_charset="utf-8",
-        mime_subtype="mixed",
-    )
+class TestSendEmailSes(TestCase):
+    @mock.patch("airflow.providers.amazon.aws.utils.emailer.SESHook")
+    def test_send_ses_email(self, mock_hook):
+        send_email(
+            from_email="From Test <from@test.com>",
+            to="to@test.com",
+            subject="subject",
+            html_content="content",
+        )
+
+        mock_hook.return_value.send_email.assert_called_once_with(
+            mail_from="From Test <from@test.com>",
+            to="to@test.com",
+            subject="subject",
+            html_content="content",
+            bcc=None,
+            cc=None,
+            files=None,
+            mime_charset="utf-8",
+            mime_subtype="mixed",
+        )

--- a/tests/providers/docker/operators/test_docker_swarm.py
+++ b/tests/providers/docker/operators/test_docker_swarm.py
@@ -71,6 +71,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             secrets=[types.SecretReference(secret_id="dummy_secret_id", secret_name="dummy_secret_name")],
             mode=types.ServiceMode(mode="replicated", replicas=3),
             networks=["dummy_network"],
+            placement=types.Placement(constraints=["node.labels.region==east"]),
         )
         operator.execute(None)
 
@@ -79,6 +80,7 @@ class TestDockerSwarmOperator(unittest.TestCase):
             restart_policy=mock_obj,
             resources=mock_obj,
             networks=["dummy_network"],
+            placement=types.Placement(constraints=["node.labels.region==east"]),
         )
         types_mock.ContainerSpec.assert_called_once_with(
             image='ubuntu:latest',

--- a/tests/utils/test_email.py
+++ b/tests/utils/test_email.py
@@ -99,8 +99,22 @@ class TestEmail(unittest.TestCase):
             mime_charset='utf-8',
             mime_subtype='mixed',
             conn_id='smtp_default',
+            from_email=None,
         )
         assert not mock_send_email.called
+
+    @mock.patch('airflow.utils.email.send_email_smtp')
+    @conf_vars(
+        {
+            ('email', 'email_backend'): 'tests.utils.test_email.send_email_test',
+            ('email', 'from_email'): 'from@test.com',
+        }
+    )
+    def test_custom_backend_sender(self, mock_send_email_smtp):
+        utils.email.send_email('to', 'subject', 'content')
+        _, call_kwargs = send_email_test.call_args
+        assert call_kwargs['from_email'] == 'from@test.com'
+        assert not mock_send_email_smtp.called
 
     def test_build_mime_message(self):
         mail_from = 'from@example.com'


### PR DESCRIPTION
While I was following the instruction for the installation of pyenv, I found that adding 'eval "$(pyenv virtualenv-init -)' was not enough to get pyenv ready. In the official pyenv repository more configurations for specific shell and OS were added: https://github.com/pyenv/pyenv/blob/master/README.md#basic-github-checkout. 

It solves the issue in case anyone has: "pyenv not found" after testing pyenv installation.