### PR TITLE
Fix --disable-mssql-client-installation error

### DIFF
--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1391,6 +1391,10 @@ This is the current syntax for  `./breeze <./breeze>`_:
           Disables installation of the mysql client which might be problematic if you are building
           image in controlled environment. Only valid for production image.
 
+  --disable-mssql-client-installation
+          Disables installation of the mssql client which might be problematic if you are building
+          image in controlled environment. Only valid for production image.
+
   --constraints-location
           Url to the constraints file. In case of the production image it can also be a path to the
           constraint file placed in 'docker-context-files' folder, in which case it has to be

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -1994,6 +1994,10 @@ This is the current syntax for  `./breeze <./breeze>`_:
           Disables installation of the mysql client which might be problematic if you are building
           image in controlled environment. Only valid for production image.
 
+  --disable-mssql-client-installation
+          Disables installation of the mssql client which might be problematic if you are building
+          image in controlled environment. Only valid for production image.
+
   --constraints-location
           Url to the constraints file. In case of the production image it can also be a path to the
           constraint file placed in 'docker-context-files' folder, in which case it has to be
@@ -2581,6 +2585,10 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
   --disable-mysql-client-installation
           Disables installation of the mysql client which might be problematic if you are building
+          image in controlled environment. Only valid for production image.
+
+  --disable-mssql-client-installation
+          Disables installation of the mssql client which might be problematic if you are building
           image in controlled environment. Only valid for production image.
 
   --constraints-location

--- a/breeze
+++ b/breeze
@@ -2732,6 +2732,10 @@ Build options:
         Disables installation of the mysql client which might be problematic if you are building
         image in controlled environment. Only valid for production image.
 
+--disable-mssql-client-installation
+        Disables installation of the mssql client which might be problematic if you are building
+        image in controlled environment. Only valid for production image.
+
 --constraints-location
         Url to the constraints file. In case of the production image it can also be a path to the
         constraint file placed in 'docker-context-files' folder, in which case it has to be

--- a/breeze-complete
+++ b/breeze-complete
@@ -180,7 +180,7 @@ github-repository: github-image-id: generate-constraints-mode:
 postgres-version: mysql-version: mssql-version:
 version-suffix-for-pypi: version-suffix-for-svn:
 additional-extras: additional-python-deps: additional-dev-deps: additional-runtime-deps: image-tag:
-disable-mysql-client-installation constraints-location: disable-pip-cache install-from-docker-context-files
+disable-mysql-client-installation disable-mssql-client-installation constraints-location: disable-pip-cache install-from-docker-context-files
 additional-extras: additional-python-deps: disable-pypi-when-building skip-installing-airflow-providers-from-sources
 dev-apt-deps: additional-dev-apt-deps: dev-apt-command: additional-dev-apt-command: additional-dev-apt-env:
 runtime-apt-deps: additional-runtime-apt-deps: runtime-apt-command: additional-runtime-apt-command: additional-runtime-apt-env:


### PR DESCRIPTION
closes: #19293 

This PR adds the flag to disable MSSQL client installation to the appropriate places in the Breeze scripts, bringing it in line with the disable MySQL client installation flag.

To test, I ran the following and confirmed the build argument is passed properly:
```
./breeze build-image \
--production-image \
--disable-mssql-client-installation \
--dry-run-docker
```
