### PR TITLE
Skip triggerer in 'breeze start-airflow' if on 3.6

### DIFF
--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -57,9 +57,11 @@ if [[ -z "${USE_AIRFLOW_VERSION=}" ]]; then
     tmux send-keys 'cd /opt/airflow/airflow/www/; yarn install --frozen-lockfile; yarn dev' C-m
 fi
 
-tmux select-pane -t 0
-tmux split-window -h
-tmux send-keys 'airflow triggerer' C-m
+if python -c 'import sys; sys.exit(sys.version_info < (3, 7))'; then
+    tmux select-pane -t 0
+    tmux split-window -h
+    tmux send-keys 'airflow triggerer' C-m
+fi
 
 # Attach Session, on the Main window
 tmux select-pane -t 0


### PR DESCRIPTION
The triggerer does not work on 3.6, there's no point showing a dead pane.

The one liner is probably a bit convoluted, so a quick explaination:

* The `<` only returns True on Python 3.6, False otherwise
* In Python, True and False downcasts to 1 and 0 automatically.
* `sys.exit(int)` means exiting with that code, so the line exits unsuccessfully only on 3.6.
* The Bash if block only runs on 3.7+.