### PR TITLE
Correctly handle get_pty attribute if command passed as XComArg or template

### DIFF
--- a/airflow/providers/ssh/operators/ssh.py
+++ b/airflow/providers/ssh/operators/ssh.py
@@ -98,7 +98,7 @@ class SSHOperator(BaseOperator):
         if self.cmd_timeout is None:
             self.cmd_timeout = self.timeout if self.timeout else CMD_TIMEOUT
         self.environment = environment
-        self.get_pty = (self.command.startswith('sudo') or get_pty) if self.command else get_pty
+        self.get_pty = get_pty
 
         if self.timeout:
             warnings.warn(
@@ -209,6 +209,10 @@ class SSHOperator(BaseOperator):
         result = None
         if self.command is None:
             raise AirflowException("SSH operator error: SSH command not specified. Aborting.")
+
+        # Forcing get_pty to True if the command begins with "sudo".
+        self.get_pty = self.command.startswith('sudo') or self.get_pty
+
         try:
             with self.get_ssh_client() as ssh_client:
                 result = self.run_ssh_client_command(ssh_client, self.command)

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -22,7 +22,7 @@ from base64 import b64encode
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.models import DAG
+from airflow.models import DAG, Variable
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils.timezone import datetime
 from tests.test_utils.config import conf_vars
@@ -227,7 +227,7 @@ class TestSSHOperator:
             assert str(ctx.value) == "SSH operator error: SSH command not specified. Aborting."
         else:
             task.execute(None)
-        assert task.get_pty == get_pty_out
+            assert task.get_pty == get_pty_out
 
     def test_ssh_client_managed_correctly(self):
         # Ensure ssh_client gets created once

--- a/tests/providers/ssh/operators/test_ssh.py
+++ b/tests/providers/ssh/operators/test_ssh.py
@@ -22,7 +22,7 @@ from base64 import b64encode
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.models import DAG, Variable
+from airflow.models import DAG
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from airflow.utils.timezone import datetime
 from tests.test_utils.config import conf_vars


### PR DESCRIPTION
Closes: #19071

The `command` parameter in the `SSHOperator` is listed as a `template_field` which means users could pass in an arg for this parameter as an output from a TaskFlow function via `XComArgs`. However, the current constructor of the operator performs a string validation on the `command` arg to set another parameter, `get_pty`. This parameter is force to True if the `command` starts with "sudo". If the arg is passed in as an `XComArg` the DAG fails to parse with an `AttributeError: 'XComArg' object has no attribute 'startswith'`.

Additionally, if the `command` is passed as part of a Jinja template expression but the string does not explicitly begin with "sudo", `get_pty` will be set to an incorrect value.  For example in the below DAG, the `get_pty` parameter will be set to False even though the rendered `command` value will begin with "sudo":
```python
def generate_sudo_command():
    return "sudo command"


@dag(
    schedule_interval=None,
    start_date=datetime(2021, 10, 29),
    tags=['example'],
    user_defined_macros={"generate_sudo_command": generate_sudo_command},
)
def example_dag_decorator_ssh():
    run = SSHOperator(task_id='run_my_command', command="{{ generate_sudo_command() }}")


dag = example_dag_decorator_ssh()
```

This PR moves the string validation to the `execute()` method of the operator such that the `XComArg` and templated value can be rendered prior to setting the `get_pty` attribute of the operator.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
