### PR TITLE
Enable mouse mode by default in start_airflow tmux session

### DIFF
--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -39,6 +39,11 @@ export TMUX_SESSION="Airflow"
 # Start New Session with our name
 tmux new-session -d -s "${TMUX_SESSION}"
 
+# Enable mouse interaction with tmux. This allows selecting between the panes
+# by clicking with the mouse and also allows scrolling back through terminal
+# output with the mouse wheel.
+tmux set mouse on
+
 # Name first Pane and start bash
 tmux rename-window -t 0 'Main'
 tmux send-keys -t 'Main' 'bash' C-m 'clear' C-m


### PR DESCRIPTION
This PR proposes to add mouse mode on for the tmux session used within breeze (the session you are dropped into by `./breeze start-airflow` for example).

Mouse mode allows users to move between panes by clicking with their mouse and they can also scroll back through terminal log history with their mouse wheel.

This option could be set by each user by using tmux config file, but mouse mode is a very intuitive user experience, especially for those that are not familiar with tmux, and it's harmless (to my knowledge) to enable. So it seems reasonable to enable it by default within the `run_tmux` script.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
