### PR TITLE
Chart: Update default Airflow version to 2.2.1

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: airflow
 version: 1.3.0-dev
-appVersion: 2.2.0
+appVersion: 2.2.1
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
 home: https://airflow.apache.org/

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -38,12 +38,12 @@ Run ``helm repo update`` before upgrading the chart to the latest version.
 Airflow Helm Chart 1.3.0 (dev)
 ------------------------------
 
-Default Airflow image is updated to ``2.2.0-python3.7``
-"""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Default Airflow image is updated to ``2.2.1``
+"""""""""""""""""""""""""""""""""""""""""""""
 
-The default Airflow image that is used with the Chart is now ``2.2.0-python3.7``, previously it was ``2.1.4`` (which is Python ``3.6``).
+The default Airflow image that is used with the Chart is now ``2.2.1`` (which is Python ``3.7``), previously it was ``2.1.4`` (which is Python ``3.6``).
 
-The triggerer component requires Python ``3.7``. If you require Python ``3.6`` and Airflow ``2.2.0``, use a ``3.6`` based image and set ``triggerer.enabled=False`` in your values.
+The triggerer component requires Python ``3.7``. If you require Python ``3.6`` and Airflow ``2.2.0`` or later, use a ``3.6`` based image and set ``triggerer.enabled=False`` in your values.
 
 Resources made configurable for ``airflow-run-airflow-migrations`` job
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -67,13 +67,13 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.2.0-python3.7",
+            "default": "2.2.1",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
             "type": "string",
-            "default": "2.2.0",
+            "default": "2.2.1",
             "x-docsSection": "Common"
         },
         "nodeSelector": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,10 +40,10 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.2.0-python3.7"
+defaultAirflowTag: "2.2.1"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.2.0"
+airflowVersion: "2.2.1"
 
 # Images
 images:


### PR DESCRIPTION
`2.2.1` has been released so start using it in the chart by default.