### PR TITLE
Remove duplicated entries in changelog

### DIFF
--- a/airflow/providers/amazon/CHANGELOG.rst
+++ b/airflow/providers/amazon/CHANGELOG.rst
@@ -27,16 +27,8 @@ Features
 
 * ``MySQLToS3Operator add support for parquet format (#18755)``
 * ``Add RedshiftSQLHook, RedshiftSQLOperator (#18447)``
-* ``Add AWS Fargate profile support (#18645)``
-* ``Add emr cluster link (#18691)``
-* ``AwsGlueJobOperator: add wait_for_completion to Glue job run (#18814)``
-* ``AwsGlueJobOperator: add run_job_kwargs to Glue job run (#16796)``
-* ``Add additional dependency for postgres extra for amazon provider (#18737)``
 * ``Remove extra postgres dependency from AWS Provider (#18844)``
 * ``Removed duplicated code on S3ToRedshiftOperator (#18671)``
-* ``Enable AWS Secrets Manager backend to retrieve conns using different fields (#18764)``
-* ``Enable FTPToS3Operator to transfer several files (#17937)``
-* ``Support all Unix wildcards in S3KeySensor (#18211)``
 
 Bug Fixes
 ~~~~~~~~~
@@ -44,15 +36,7 @@ Bug Fixes
 * ``Fixing ses email backend (#18042)``
 * ``Fixup string concatenations (#19099)``
 * ``Update S3PrefixSensor to support checking multiple prefixes within a bucket (#18807)``
-* ``Adds an s3 list prefixes operator (#17145)``
 * ``Move validation of templated input params to run after the context init (#19048)``
-* ``ECSOperator: airflow exception on edge case when cloudwatch log stream is not found (#18733)``
-
-Other
-~~~~~
-
-* ``Amazon Athena Example (#18785)``
-* ``Amazon SQS Example (#18760)``
 
 .. Below changes are excluded from the changelog. Move them to
    appropriate section above if needed. Do not delete the lines(!):


### PR DESCRIPTION
Amazon provider had wrong tag set (2.3.0 pointed to rc1 instead
of rc2) which resulted in duplicated entries in changelog.

This PR fixes it

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
