### PR TITLE
Add a skip parameter to Variable to skip the secret backend

### DIFF
--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -125,7 +125,7 @@ class Variable(Base, LoggingMixin):
         key: str,
         default_var: Any = __NO_DEFAULT_SENTINEL,
         deserialize_json: bool = False,
-        skip_external_backends: bool = False,
+        skip_secret_backend: bool = False,
     ) -> Any:
         """
         Gets a value for an Airflow Variable Key
@@ -133,10 +133,10 @@ class Variable(Base, LoggingMixin):
         :param key: Variable Key
         :param default_var: Default value of the Variable if the Variable doesn't exists
         :param deserialize_json: Deserialize the value to a Python dict
-        :param skip_external_backends: todo
+        :param skip_secret_backend: todo
         """
 
-        var_val = Variable.get_variable_from_backends(key=key, skip_external_backends=skip_external_backends)
+        var_val = Variable.get_variable_from_backends(key=key, skip_secret_backend=skip_secret_backend)
         if var_val is None:
             if default_var is not cls.__NO_DEFAULT_SENTINEL:
                 return default_var
@@ -207,7 +207,7 @@ class Variable(Base, LoggingMixin):
         if not skip_external_backends:
             cls.check_for_write_conflict(key)
 
-        if cls.get_variable_from_backends(key=key, skip_external_backends=skip_external_backends) is None:
+        if cls.get_variable_from_backends(key=key, skip_secret_backend=skip_external_backends) is None:
             raise KeyError(f'Variable {key} does not exist')
 
         obj = session.query(cls).filter(cls.key == key).first()
@@ -265,16 +265,16 @@ class Variable(Base, LoggingMixin):
             return None
 
     @staticmethod
-    def get_variable_from_backends(key: str, skip_external_backends: Optional[bool] = False) -> Optional[str]:
+    def get_variable_from_backends(key: str, skip_secret_backend: Optional[bool] = False) -> Optional[str]:
         """
         Get Airflow Variable by iterating over all Secret Backends.
 
         :param key: Variable Key
-        :param skip_external_backends: todo
+        :param skip_secret_backend: todo
         :return: Variable Value
         """
         for backend in ensure_secrets_loaded():
-            if skip_external_backends and (
+            if skip_secret_backend and (
                 not isinstance(backend, MetastoreBackend) and
                 not isinstance(backend, EnvironmentVariablesBackend)
             ):

--- a/airflow/models/variable.py
+++ b/airflow/models/variable.py
@@ -29,6 +29,7 @@ from airflow.configuration import ensure_secrets_loaded
 from airflow.models.base import ID_LEN, Base
 from airflow.models.crypto import get_fernet
 from airflow.secrets.environment_variables import EnvironmentVariablesBackend
+from airflow.secrets.local_filesystem import LocalFilesystemBackend
 from airflow.secrets.metastore import MetastoreBackend
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.log.secrets_masker import mask_secret
@@ -276,7 +277,8 @@ class Variable(Base, LoggingMixin):
         for backend in ensure_secrets_loaded():
             if skip_secret_backend and (
                 not isinstance(backend, MetastoreBackend) and
-                not isinstance(backend, EnvironmentVariablesBackend)
+                not isinstance(backend, EnvironmentVariablesBackend) and
+                not isinstance(backend, LocalFilesystemBackend)
             ):
                 continue
             try:

--- a/tests/secrets/test_local_filesystem.py
+++ b/tests/secrets/test_local_filesystem.py
@@ -25,10 +25,13 @@ from unittest import mock
 import pytest
 from parameterized import parameterized
 
+from airflow.configuration import ensure_secrets_loaded
 from airflow.exceptions import AirflowException, AirflowFileParseException, ConnectionNotUnique
+from airflow.models import Variable
 from airflow.secrets import local_filesystem
 from airflow.secrets.local_filesystem import LocalFilesystemBackend
 
+from tests.test_utils.config import conf_vars
 
 @contextmanager
 def mock_local_file(content):
@@ -380,15 +383,34 @@ class TestLocalFileBackend(unittest.TestCase):
             assert "VAL_A" == backend.get_variable("KEY_A")
             assert backend.get_variable("KEY_B") is None
 
+    @conf_vars(
+        {
+            (
+                "secrets",
+                "backend",
+            ): "airflow.secrets.local_filesystem.LocalFilesystemBackend",
+            ("secrets", "backend_kwargs"): '{"variables_file_path": "var.env"}',
+        }
+    )
+    def test_should_read_variable_skip_secret_backend(self):
+
+        with mock_local_file("KEY_A=VAL_A"):
+            backends = ensure_secrets_loaded()
+
+            backend_classes = [backend.__class__.__name__ for backend in backends]
+            assert 'LocalFilesystemBackend' in backend_classes
+            assert Variable.get("KEY_A") == "VAL_A"
+            assert Variable.get("KEY_A", skip_secret_backend=True) == "VAL_A"
+
     def test_should_read_connection(self):
         with NamedTemporaryFile(suffix=".env") as tmp_file:
             tmp_file.write(b"CONN_A=mysql://host_a")
             tmp_file.flush()
             backend = LocalFilesystemBackend(connections_file_path=tmp_file.name)
-            assert ["mysql://host_a"] == [conn.get_uri() for conn in backend.get_connections("CONN_A")]
+            assert "mysql://host_a" == backend.get_connection("CONN_A").get_uri()
             assert backend.get_variable("CONN_B") is None
 
     def test_files_are_optional(self):
         backend = LocalFilesystemBackend()
-        assert [] == backend.get_connections("CONN_A")
+        assert None is backend.get_connection("CONN_A")
         assert backend.get_variable("VAR_A") is None

--- a/tests/secrets/test_secrets.py
+++ b/tests/secrets/test_secrets.py
@@ -130,7 +130,7 @@ class TestVariableFromSecrets(unittest.TestCase):
         mock_meta_get.assert_called_once_with(key="fake_var_key")
         mock_env_get.assert_called_once_with(key="fake_var_key")
 
-        Variable.get_variable_from_backends("fake_var_key_2", skip_external_backends=True)
+        Variable.get_variable_from_backends("fake_var_key_2", skip_secret_backend=True)
         mock_meta_get.assert_called_with(key="fake_var_key_2")
         mock_env_get.assert_called_with(key="fake_var_key_2")
 
@@ -146,7 +146,7 @@ class TestVariableFromSecrets(unittest.TestCase):
         mock_env_get.assert_called_once_with(key="fake_var_key")
         mock_meta_get.assert_not_called()
 
-        Variable.get_variable_from_backends("fake_var_key_2", skip_external_backends=True)
+        Variable.get_variable_from_backends("fake_var_key_2", skip_secret_backend=True)
         mock_env_get.assert_called_with(key="fake_var_key_2")
         mock_meta_get.assert_not_called()
 
@@ -158,7 +158,7 @@ class TestVariableFromSecrets(unittest.TestCase):
         variable_value = Variable.get(key="test_var", default_var="new")
         assert "new" == variable_value
 
-        variable_value = Variable.get(key="test_var", default_var="new", skip_external_backends=True)
+        variable_value = Variable.get(key="test_var", default_var="new", skip_secret_backend=True)
         assert "new" == variable_value
 
     @conf_vars(
@@ -181,7 +181,7 @@ class TestVariableFromSecrets(unittest.TestCase):
         "airflow.providers.amazon.aws.secrets.systems_manager."
         "SystemsManagerParameterStoreBackend.get_variable"
     )
-    def test_backend_variable_skip_external_backends(self, mock_secret_get, mock_meta_get):
+    def test_backend_variable_skip_secret_backend(self, mock_secret_get, mock_meta_get):
         mock_secret_get.return_value = "a_secret_value"
         mock_meta_get.return_value = "a_metastore_value"
 
@@ -189,11 +189,11 @@ class TestVariableFromSecrets(unittest.TestCase):
         backend_classes = [backend.__class__.__name__ for backend in backends]
         assert 'SystemsManagerParameterStoreBackend' in backend_classes
 
-        assert "a_venv_value" == Variable.get(key="MYVAR", skip_external_backends=True)
+        assert "a_venv_value" == Variable.get(key="MYVAR", skip_secret_backend=True)
         mock_secret_get.assert_not_called()
         mock_meta_get.assert_not_called()
 
-        assert "a_metastore_value" == Variable.get(key="not_myvar", skip_external_backends=True)
+        assert "a_metastore_value" == Variable.get(key="not_myvar", skip_secret_backend=True)
         mock_secret_get.assert_not_called()
         mock_meta_get.assert_called_once_with(key="not_myvar")
 


### PR DESCRIPTION
close #19251 

the new parameter will skip ~~all external~~ the secret backend for variables

so it will not skip the [env variables](https://airflow.apache.org/docs/apache-airflow/stable/howto/variable.html#storing-variables-in-environment-variables) set by `AIRFLOW_VAR_FOO`

and the variables inside the airflow db 

and (if setup) a LocalFilesystemBackend