### PR TITLE
Update known warnings for Python 3.7

### DIFF
--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2026,6 +2026,9 @@ def summarise_total_vs_bad_and_warnings(total: int, bad: int, warns: List[warnin
         console.print()
         raise_error = True
     if warns:
+        if os.environ.get('GITHUB_ACTIONS'):
+            # Ends group in GitHub Actions so that the errors are immediately visible in CI log
+            console.print("::endgroup::")
         console.print()
         console.print("[red]Unknown warnings generated:[/]")
         console.print()
@@ -2072,13 +2075,8 @@ KNOWN_DEPRECATED_MESSAGES: Set[Tuple[str, str]] = {
     ),
     (
         "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since"
-        " Python 3.3, and in 3.10 it will stop working",
+        " Python 3.3,and in 3.9 it will stop working",
         "apache_beam",
-    ),
-    (
-        "Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since"
-        " Python 3.3, and in 3.10 it will stop working",
-        "dns",
     ),
     (
         'pyarrow.HadoopFileSystem is deprecated as of 2.0.0, please use pyarrow.fs.HadoopFileSystem instead.',


### PR DESCRIPTION
After seting 3.7 the default (#19317) the warning printed by
Python during importing all providers (specifically apache beam)
has slightly changed. Apparently collections.abc warning was
a bit more "scary" - warning that it's 3.9 not 3.10 where the
old collection imports will stop working (Note that actually
this did not happen even in 3.10, apparently)

This PR fixes the "known" warning message to match it but also
a separate PR (https://github.com/apache/beam/pull/15850) was
opened to Beam to get rid of the warnings altogether.

Also seems 'dns` stopped generating this warning so I removed it.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
