### PR TITLE
Authentication with AAD tokens in Databricks provider

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -34,6 +34,8 @@ from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
+DEFAULT_DATABRICKS_SCOPE = "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default"
+
 RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")
 START_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/start")
 TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/delete")
@@ -196,7 +198,7 @@ class DatabricksHook(BaseHook):
                     tenant_id=self.databricks_conn.extra_dejson['azure_tenant_id'],
                 )
 
-            aad_token = self.add_credentials.get_token("2ff814a6-3304-4ab8-85cb-cd0e6f879c1d/.default")
+            aad_token = self.add_credentials.get_token(DEFAULT_DATABRICKS_SCOPE)
             auth = _TokenAuth(aad_token.token)
 
         else:

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -34,8 +34,11 @@ There are several ways to connect to Databricks using Airflow.
    i.e. add a token to the Airflow connection. This is the recommended method.
 2. Use Databricks login credentials
    i.e. add the username and password used to login to the Databricks account to the Airflow connection.
-3. Using Azure Active Directory (AAD) token generated from Azure Service Principal's ID and secret (only on Azure Databricks).  Service principal could be defined as a `user inside workspace <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-azure-databricks-workspace-users-and-admins>`_, or `outside of workspace having Owner or Contributor permissions <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-not-workspace-users>`_
-
+3. Using Azure Active Directory (AAD) token generated from Azure Service Principal's ID and secret
+   (only on Azure Databricks).  Service principal could be defined as a
+   `user inside workspace <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-azure-databricks-workspace-users-and-admins>`_, or `outside of workspace having Owner or Contributor permissions <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-not-workspace-users>`_
+4. Using Azure Active Directory (AAD) token obtained for `Azure managed identity <https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-use-vm-token>`_,
+   when Airflow runs on the VM with assigned managed identity (system-assigned or user-assigned)
 
 Default Connection IDs
 ----------------------
@@ -49,12 +52,12 @@ Host (required)
     Specify the Databricks workspace URL
 
 Login (optional)
-    Specify the ``username`` used to login to Databricks.
-    This is only needed if using the *Databricks login credentials* authentication method.
+    * If authentication with *Databricks login credentials* is used then specify the ``username`` used to login to Databricks.
+    * If *authentication with Azure Service Principal* is used then specify the ID of the Azure Service Principal
 
 Password (optional)
-    Specify the ``password`` used to login to Databricks.
-    This is only needed if using the *Databricks login credentials* authentication method.
+    * If authentication with *Databricks login credentials*  is used then specify the ``password`` used to login to Databricks.
+    * If *authentication with Azure Service Principal* is used then specify the secret of the Azure Service Principal
 
 Extra (optional)
     Specify the extra parameter (as json dictionary) that can be used in the Databricks connection.
@@ -65,11 +68,17 @@ Extra (optional)
 
     Following parameters are necessary if using authentication with AAD token:
 
-    * ``azure_client_id``: ID of the Azure Service Principal
-    * ``azure_client_secret``: secret of the Azure Service Principal
     * ``azure_tenant_id``: ID of the Azure Active Directory tenant
-    * ``azure_resource_id``: Resource ID of the Azure Databricks workspace (required if Service Principal isn't
+    * ``azure_resource_id``: optional Resource ID of the Azure Databricks workspace (required if Service Principal isn't
       a user inside workspace)
+
+    Following parameters are necessary if using authentication with AAD token for Azure managed identity:
+
+    * ``use_azure_managed_identity``: required boolean flag to specify if managed identity needs to be used instead of
+      service principal
+    * ``azure_resource_id``: optional Resource ID of the Azure Databricks workspace (required if managed identity isn't
+      a user inside workspace)
+
 
 When specifying the connection using an environment variable you should specify
 it using URI syntax.

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -27,13 +27,14 @@ The Databricks connection type enables the Databricks Integration.
 Authenticating to Databricks
 ----------------------------
 
-There are two ways to connect to Databricks using Airflow.
+There are several ways to connect to Databricks using Airflow.
 
 1. Use a `Personal Access Token (PAT)
    <https://docs.databricks.com/dev-tools/api/latest/authentication.html>`_
    i.e. add a token to the Airflow connection. This is the recommended method.
 2. Use Databricks login credentials
    i.e. add the username and password used to login to the Databricks account to the Airflow connection.
+3. Using Azure Active Directory (AAD) token generated from Azure Service Principal's ID and secret (only on Azure Databricks).
 
 
 Default Connection IDs
@@ -57,9 +58,16 @@ Password (optional)
 
 Extra (optional)
     Specify the extra parameter (as json dictionary) that can be used in the Databricks connection.
-    This parameter is necessary if using the *PAT* authentication method (recommended):
+
+    Following parameter is necessary if using the *PAT* authentication method (recommended):
 
     * ``token``: Specify PAT to use.
+
+    Following parameters are necessary if using authentication with AAD token:
+
+    * ``azure_client_id``: ID of the Azure Service Principal (SP)
+    * ``azure_client_secret``: secret of the Azure Service Principal (SP)
+    * ``azure_tenant_id``: ID of the Azure Active Directory tenant
 
 When specifying the connection using an environment variable you should specify
 it using URI syntax.

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -34,7 +34,7 @@ There are several ways to connect to Databricks using Airflow.
    i.e. add a token to the Airflow connection. This is the recommended method.
 2. Use Databricks login credentials
    i.e. add the username and password used to login to the Databricks account to the Airflow connection.
-3. Using Azure Active Directory (AAD) token generated from Azure Service Principal's ID and secret (only on Azure Databricks).
+3. Using Azure Active Directory (AAD) token generated from Azure Service Principal's ID and secret (only on Azure Databricks).  Service principal could be defined as a `user inside workspace <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-azure-databricks-workspace-users-and-admins>`_, or `outside of workspace having Owner or Contributor permissions <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token#--api-access-for-service-principals-that-are-not-workspace-users>`_
 
 
 Default Connection IDs
@@ -65,9 +65,11 @@ Extra (optional)
 
     Following parameters are necessary if using authentication with AAD token:
 
-    * ``azure_client_id``: ID of the Azure Service Principal (SP)
-    * ``azure_client_secret``: secret of the Azure Service Principal (SP)
+    * ``azure_client_id``: ID of the Azure Service Principal
+    * ``azure_client_secret``: secret of the Azure Service Principal
     * ``azure_tenant_id``: ID of the Azure Active Directory tenant
+    * ``azure_resource_id``: Resource ID of the Azure Databricks workspace (required if Service Principal isn't
+      a user inside workspace)
 
 When specifying the connection using an environment variable you should specify
 it using URI syntax.

--- a/setup.py
+++ b/setup.py
@@ -244,6 +244,7 @@ dask = [
 ]
 databricks = [
     'requests>=2.26.0, <3',
+    'azure-identity>=1.3.1',
 ]
 datadog = [
     'datadog>=0.14.0',

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,6 @@ dask = [
 ]
 databricks = [
     'requests>=2.26.0, <3',
-    'azure-identity>=1.3.1',
 ]
 datadog = [
     'datadog>=0.14.0',


### PR DESCRIPTION
Many organizations don't allow to use personal access tokens, and instead force to use native platform authentication.  This PR adds the possibility to authenticate to Azure Databricks workspaces using the Azure Active Directory tokens generated from Azure Service Princpal's ID and secret. It supports authentication when SP is either user inside workspace or it's outside of the workspace
