### PR TITLE
Dags-in-image pod template example should not have dag mounts

### DIFF
--- a/airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml
+++ b/airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml
@@ -54,13 +54,6 @@ spec:
       volumeMounts:
         - mountPath: "/opt/airflow/logs"
           name: airflow-logs
-        - mountPath: /opt/airflow/dags
-          name: airflow-dags
-          readOnly: false
-        - mountPath: /opt/airflow/dags
-          name: airflow-dags
-          readOnly: true
-          subPath: repo/tests/dags
   hostNetwork: false
   restartPolicy: Never
   securityContext:
@@ -74,9 +67,6 @@ spec:
     []
   serviceAccountName: 'RELEASE-NAME-worker-serviceaccount'
   volumes:
-    - name: dags
-      persistentVolumeClaim:
-        claimName: RELEASE-NAME-dags
     - emptyDir: {}
       name: airflow-logs
     - configMap:


### PR DESCRIPTION
For the case where dags should be in the image (the case for which this example is intended), we should not need to mount a dags volume.

I noticed this because there were actually duplicate mounts in this template.  But better to remove both in this instance.

