### PR TITLE
Clarify dag-not-found error message

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -177,7 +177,7 @@ def get_dag_by_file_location(dag_id: str):
     dag_model = DagModel.get_current(dag_id)
     if dag_model is None:
         raise AirflowException(
-            f'dag_id could not be found: {dag_id}. Either the dag did not exist or it failed to parse.'
+            f"Dag '{dag_id}' could not be found; either it does not exist or it failed to parse."
         )
     dagbag = DagBag(dag_folder=dag_model.fileloc)
     return dagbag.dags[dag_id]
@@ -190,7 +190,7 @@ def get_dag(subdir: Optional[str], dag_id: str) -> "DAG":
     dagbag = DagBag(process_subdir(subdir))
     if dag_id not in dagbag.dags:
         raise AirflowException(
-            f'dag_id could not be found: {dag_id}. Either the dag did not exist or it failed to parse.'
+            f"Dag '{dag_id}' could not be found; either it does not exist or it failed to parse."
         )
     return dagbag.dags[dag_id]
 

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -177,7 +177,7 @@ def get_dag_by_file_location(dag_id: str):
     dag_model = DagModel.get_current(dag_id)
     if dag_model is None:
         raise AirflowException(
-            f"Dag '{dag_id}' could not be found; either it does not exist or it failed to parse."
+            f"Dag {dag_id!r} could not be found; either it does not exist or it failed to parse."
         )
     dagbag = DagBag(dag_folder=dag_model.fileloc)
     return dagbag.dags[dag_id]
@@ -190,7 +190,7 @@ def get_dag(subdir: Optional[str], dag_id: str) -> "DAG":
     dagbag = DagBag(process_subdir(subdir))
     if dag_id not in dagbag.dags:
         raise AirflowException(
-            f"Dag '{dag_id}' could not be found; either it does not exist or it failed to parse."
+            f"Dag {dag_id!r} could not be found; either it does not exist or it failed to parse."
         )
     return dagbag.dags[dag_id]
 


### PR DESCRIPTION
In this context, what's really happening is, we can't find the dag.  From a user
perspective, when you encounter this error, 'could not find the dag' is
a more intuitive representation of the problem than 'could not find the dag_id'.
