### PR TITLE
Introduce DagRun action to change state to queued.

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4001,7 +4001,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         """This routine only supports Running and Queued state."""
         try:
             count = 0
-            for dr in session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all():
+            for dr in session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])):
                 count += 1
                 if state == State.RUNNING:
                     dr.start_date = timezone.utcnow()

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3991,19 +3991,18 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     @action_has_dag_edit_access
     def action_set_queued(self, drs: List[DagRun]):
         """Set state to queued."""
-        return self.action_set_dag_run_to_active_state(drs, State.QUEUED)
+        return self.set_dag_runs_to_active_state(drs, State.QUEUED)
 
     @action('set_running', "Set state to 'running'", '', single=False)
     @action_has_dag_edit_access
     def action_set_running(self, drs: List[DagRun]):
         """Set state to running."""
-        return self.action_set_dag_run_to_active_state(drs, State.RUNNING)
+        return self.set_dag_runs_to_active_state(drs, State.RUNNING)
 
     @provide_session
-    def action_set_dag_run_to_active_state(self, drs: List[DagRun], state: str, *, session: "Session"):
+    def set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, *, session: "Session"):
         if state not in [State.RUNNING, State.QUEUED]:
             raise ValueError("This routine only supports Running and Queued.")
-
         try:
             count = 0
             for dr in session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all():

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3998,7 +3998,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
     @provide_session
     def _set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, session=None):
-        """This routine only support Running and Queued state."""
+        """This routine only supports Running and Queued state."""
         try:
             count = 0
             for dr in session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all():

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -30,7 +30,7 @@ from datetime import timedelta
 from functools import wraps
 from json import JSONDecodeError
 from operator import itemgetter
-from typing import Any, Callable, Iterable, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Set, Tuple, Union
 from urllib.parse import parse_qsl, unquote, urlencode, urlparse
 
 import lazy_object_proxy
@@ -131,6 +131,9 @@ from airflow.www.forms import (
     TaskInstanceEditForm,
 )
 from airflow.www.widgets import AirflowModelListWidget
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
 FILTER_TAGS_COOKIE = 'tags_filter'
@@ -3920,6 +3923,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'list': 'read',
         'action_clear': 'edit',
         'action_muldelete': 'delete',
+        'action_set_queued': 'edit',
         'action_set_running': 'edit',
         'action_set_failed': 'edit',
         'action_set_success': 'edit',
@@ -3977,26 +3981,38 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
     @action('muldelete', "Delete", "Are you sure you want to delete selected records?", single=False)
     @action_has_dag_edit_access
-    @provide_session
-    def action_muldelete(self, items, session=None):
+    def action_muldelete(self, items: List[DagRun]):
         """Multiple delete."""
         self.datamodel.delete_all(items)
         self.update_redirect()
         return redirect(self.get_redirect())
 
+    @action('set_queued', "Set state to 'queued'", '', single=False)
+    @action_has_dag_edit_access
+    def action_set_queued(self, drs: List[DagRun]):
+        """Set state to queued."""
+        return self.action_set_dag_run_to_active_state(drs, State.QUEUED)
+
     @action('set_running', "Set state to 'running'", '', single=False)
     @action_has_dag_edit_access
-    @provide_session
-    def action_set_running(self, drs, session=None):
+    def action_set_running(self, drs: List[DagRun]):
         """Set state to running."""
+        return self.action_set_dag_run_to_active_state(drs, State.RUNNING)
+
+    @provide_session
+    def action_set_dag_run_to_active_state(self, drs: List[DagRun], state: str, *, session: "Session"):
+        if state not in [State.RUNNING, State.QUEUED]:
+            raise ValueError("This routine only supports Running and Queued.")
+
         try:
             count = 0
             for dr in session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all():
                 count += 1
-                dr.start_date = timezone.utcnow()
-                dr.state = State.RUNNING
+                if state == State.RUNNING:
+                    dr.start_date = timezone.utcnow()
+                dr.state = state
             session.commit()
-            flash(f"{count} dag runs were set to running")
+            flash(f"{count} dag runs were set to {state}.")
         except Exception as ex:
             flash(str(ex), 'error')
             flash('Failed to set state', 'error')
@@ -4010,7 +4026,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
-    def action_set_failed(self, drs, session=None):
+    def action_set_failed(self, drs: List[DagRun], *, session: "Session"):
         """Set state to failed."""
         try:
             count = 0
@@ -4034,7 +4050,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
-    def action_set_success(self, drs, session=None):
+    def action_set_success(self, drs: List[DagRun], *, session: "Session"):
         """Set state to success."""
         try:
             count = 0
@@ -4053,7 +4069,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     @action('clear', "Clear the state", "All task instances would be cleared, are you sure?", single=False)
     @action_has_dag_edit_access
     @provide_session
-    def action_clear(self, drs, session=None):
+    def action_clear(self, drs: List[DagRun], *, session: "Session"):
         """Clears the state."""
         try:
             count = 0

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3988,18 +3988,17 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     @action_has_dag_edit_access
     def action_set_queued(self, drs: List[DagRun]):
         """Set state to queued."""
-        return self.set_dag_runs_to_active_state(drs, State.QUEUED)
+        return self._set_dag_runs_to_active_state(drs, State.QUEUED)
 
     @action('set_running', "Set state to 'running'", '', single=False)
     @action_has_dag_edit_access
     def action_set_running(self, drs: List[DagRun]):
         """Set state to running."""
-        return self.set_dag_runs_to_active_state(drs, State.RUNNING)
+        return self._set_dag_runs_to_active_state(drs, State.RUNNING)
 
     @provide_session
-    def set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, session=None):
-        if state not in [State.RUNNING, State.QUEUED]:
-            raise ValueError("This routine only supports Running and Queued.")
+    def _set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, session=None):
+        """This routine only support Running and Queued state."""
         try:
             count = 0
             for dr in session.query(DagRun).filter(DagRun.id.in_([dagrun.id for dagrun in drs])).all():

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -30,7 +30,7 @@ from datetime import timedelta
 from functools import wraps
 from json import JSONDecodeError
 from operator import itemgetter
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Optional, Set, Tuple, Union
+from typing import Any, Callable, Iterable, List, Optional, Set, Tuple, Union
 from urllib.parse import parse_qsl, unquote, urlencode, urlparse
 
 import lazy_object_proxy
@@ -131,9 +131,6 @@ from airflow.www.forms import (
     TaskInstanceEditForm,
 )
 from airflow.www.widgets import AirflowModelListWidget
-
-if TYPE_CHECKING:
-    from sqlalchemy.orm import Session
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
 FILTER_TAGS_COOKIE = 'tags_filter'
@@ -4000,7 +3997,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         return self.set_dag_runs_to_active_state(drs, State.RUNNING)
 
     @provide_session
-    def set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, *, session: "Session"):
+    def set_dag_runs_to_active_state(self, drs: List[DagRun], state: str, session=None):
         if state not in [State.RUNNING, State.QUEUED]:
             raise ValueError("This routine only supports Running and Queued.")
         try:
@@ -4025,7 +4022,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
-    def action_set_failed(self, drs: List[DagRun], *, session: "Session"):
+    def action_set_failed(self, drs: List[DagRun], session=None):
         """Set state to failed."""
         try:
             count = 0
@@ -4049,7 +4046,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     )
     @action_has_dag_edit_access
     @provide_session
-    def action_set_success(self, drs: List[DagRun], *, session: "Session"):
+    def action_set_success(self, drs: List[DagRun], session=None):
         """Set state to success."""
         try:
             count = 0
@@ -4068,7 +4065,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     @action('clear', "Clear the state", "All task instances would be cleared, are you sure?", single=False)
     @action_has_dag_edit_access
     @provide_session
-    def action_clear(self, drs: List[DagRun], *, session: "Session"):
+    def action_clear(self, drs: List[DagRun], session=None):
         """Clears the state."""
         try:
             count = 0

--- a/tests/www/views/test_views_dagrun.py
+++ b/tests/www/views/test_views_dagrun.py
@@ -145,8 +145,13 @@ def test_delete_dagrun_permission_denied(session, client_dr_without_dag_edit, ru
             {"success", "failed"},  # Unchanged.
             "1 dag runs were set to running",
         ),
+        (
+            "set_queued",
+            {"success", "failed"},
+            "1 dag runs were set to queued",
+        ),
     ],
-    ids=["clear", "success", "failed", "running"],
+    ids=["clear", "success", "failed", "running", "queued"],
 )
 def test_set_dag_runs_action(
     session,
@@ -172,8 +177,9 @@ def test_set_dag_runs_action(
         ("set_success", "Failed to set state"),
         ("set_failed", "Failed to set state"),
         ("set_running", "Failed to set state"),
+        ("set_queued", "Failed to set state"),
     ],
-    ids=["clear", "success", "failed", "running"],
+    ids=["clear", "success", "failed", "running", "queued"],
 )
 def test_set_dag_runs_action_fails(admin_client, action, expected_message):
     resp = admin_client.post(


### PR DESCRIPTION
When a DAG has been running for a bit, it often occurs in our workflow that a task is added.
Often, people want to run these tasks for historical dates.
However, when there are more TaskInstances you want to run than the `max_active_runs` DagRuns, you might cross the limit.
Therefore, I felt we should add the option to mark the DagRun immediately as Queued.

For now, the work around I did was mark the tasks I wanted to run as success first, then clear them. 
This yields the same result but requires more click, and Airflow is of course all about efficiency :)

Love to hear some feedback on what you think about what I've done with the refactoring. In particulair:
- Added the typing information to all args/kwargs
- Instead of providing session with None, we use the asterix (*) to indicate it's a keyword and give it correct typing info.
- Instead of repeating ourselves, I extracted a function that we can use for Queued and Running DagRun state changes. 