### PR TITLE
Fix S3ToRedshiftOperator

### DIFF
--- a/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
+++ b/airflow/providers/amazon/aws/transfers/s3_to_redshift.py
@@ -149,12 +149,7 @@ class S3ToRedshiftOperator(BaseOperator):
         copy_statement = self._build_copy_query(copy_destination, credentials_block, copy_options)
 
         if self.method == 'REPLACE':
-            sql = f"""
-            BEGIN;
-            DELETE FROM {destination};
-            {copy_statement}
-            COMMIT
-            """
+            sql = ["BEGIN;", f"DELETE FROM {destination};", copy_statement, "COMMIT"]
         elif self.method == 'UPSERT':
             keys = self.upsert_keys or redshift_hook.get_table_primary_key(self.table, self.schema)
             if not keys:
@@ -162,14 +157,16 @@ class S3ToRedshiftOperator(BaseOperator):
                     f"No primary key on {self.schema}.{self.table}. Please provide keys on 'upsert_keys'"
                 )
             where_statement = ' AND '.join([f'{self.table}.{k} = {copy_destination}.{k}' for k in keys])
-            sql = f"""
-            CREATE TABLE {copy_destination} (LIKE {destination});
-            {copy_statement}
-            BEGIN;
-            DELETE FROM {destination} USING {copy_destination} WHERE {where_statement};
-            INSERT INTO {destination} SELECT * FROM {copy_destination};
-            COMMIT
-            """
+
+            sql = [
+                f"CREATE TABLE {copy_destination} (LIKE {destination});",
+                copy_statement,
+                "BEGIN;",
+                f"DELETE FROM {destination} USING {copy_destination} WHERE {where_statement};",
+                f"INSERT INTO {destination} SELECT * FROM {copy_destination};",
+                "COMMIT",
+            ]
+
         else:
             sql = copy_statement
 

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -170,7 +170,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     {copy_statement}
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], transaction)
+        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0].join("\n"), transaction)
 
         assert mock_run.call_count == 1
 
@@ -222,7 +222,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     {copy_statement}
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], transaction)
+        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0].join("\n"), transaction)
 
         assert mock_run.call_count == 1
 
@@ -277,7 +277,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     INSERT INTO {schema}.{table} SELECT * FROM #{table};
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0], transaction)
+        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0].join("\n"), transaction)
 
         assert mock_run.call_count == 1
 

--- a/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
+++ b/tests/providers/amazon/aws/transfers/test_s3_to_redshift.py
@@ -170,7 +170,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     {copy_statement}
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0].join("\n"), transaction)
+        assert_equal_ignore_multiple_spaces(self, "\n".join(mock_run.call_args[0][0]), transaction)
 
         assert mock_run.call_count == 1
 
@@ -222,7 +222,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     {copy_statement}
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0].join("\n"), transaction)
+        assert_equal_ignore_multiple_spaces(self, "\n".join(mock_run.call_args[0][0]), transaction)
 
         assert mock_run.call_count == 1
 
@@ -277,7 +277,7 @@ class TestS3ToRedshiftTransfer(unittest.TestCase):
                     INSERT INTO {schema}.{table} SELECT * FROM #{table};
                     COMMIT
                     """
-        assert_equal_ignore_multiple_spaces(self, mock_run.call_args[0][0].join("\n"), transaction)
+        assert_equal_ignore_multiple_spaces(self, "\n".join(mock_run.call_args[0][0]), transaction)
 
         assert mock_run.call_count == 1
 


### PR DESCRIPTION
Bug happens on S3ToRedshiftOperator with specific configuration. By using "UPSERT" or "REPLACE" is generate an sql block with multiple queries. The RedshiftSQLHook don't support execute multiple queries in a single call of execute. To fix it just need to convert the single query string to a list of queries.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
