### PR TITLE
Task should fail immediately when pod is unprocessable

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -599,6 +599,9 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                 try:
                     self.kube_scheduler.run_next(task)
                 except ApiException as e:
+
+                    # These codes indicate something is wrong with pod definition; otherwise we assume pod
+                    # definition is ok, and that retrying may work
                     if e.status in (400, 422):
                         self.log.error("Pod creation failed with reason %r. Failing task", e.reason)
                         key, _, _, _ = task

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -600,7 +600,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                     self.kube_scheduler.run_next(task)
                 except ApiException as e:
                     if e.reason in ("BadRequest", "Unprocessable Entity"):
-                        self.log.error(f"Pod creation failed with reason {e.reason!r}. Failing task")
+                        self.log.error("Pod creation failed with reason %r. Failing task", e.reason)
                         key, _, _, _ = task
                         self.change_state(key, State.FAILED, e)
                     else:

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -599,7 +599,7 @@ class KubernetesExecutor(BaseExecutor, LoggingMixin):
                 try:
                     self.kube_scheduler.run_next(task)
                 except ApiException as e:
-                    if e.reason in ("BadRequest", "Unprocessable Entity"):
+                    if e.status in (400, 422):
                         self.log.error("Pod creation failed with reason %r. Failing task", e.reason)
                         key, _, _, _ = task
                         self.change_state(key, State.FAILED, e)

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -200,8 +200,8 @@ class TestKubernetesExecutor:
         [
             ('Forbidden', 403, True),
             ('fake-unhandled-reason', 12345, True),
-            ('Unprocessable Entity',422, False),
-            ('BadRequest',400, False),
+            ('Unprocessable Entity', 422, False),
+            ('BadRequest', 400, False),
         ],
     )
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -251,9 +251,8 @@ class TestKubernetesExecutor:
                 command=['airflow', 'tasks', 'run', 'true', 'some_parameter'],
             )
             kubernetes_executor.sync()
-            kubernetes_executor.sync()
 
-            assert mock_kube_client.create_namespaced_pod.called
+            assert mock_kube_client.create_namespaced_pod.call_count == 1
 
             if should_requeue:
                 assert not kubernetes_executor.task_queue.empty()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -215,6 +215,13 @@ class TestKubernetesExecutor:
         and be attempted on a subsequent executor sync.  When reason is 'Unprocessable Entity'
         or 'BadRequest', the task should be failed without being re-queued.
 
+        Note on error scenarios:
+
+        - 403 Forbidden will be returned when your request exceeds namespace quota.
+        - 422 Unprocessable Entity is returned when your parameters are valid but unsupported
+            e.g. limits lower than requests.
+        - 400 BadRequest is returned when your parameters are invalid e.g. asking for cpu=100ABC123.
+
         """
         import sys
 

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -269,6 +269,7 @@ class TestKubernetesExecutor:
                 mock_kube_client.create_namespaced_pod.side_effect = None
 
                 # Execute the task without errors should empty the queue
+                mock_kube_client.create_namespaced_pod.reset_mock()
                 kubernetes_executor.sync()
                 assert mock_kube_client.create_namespaced_pod.called
                 assert kubernetes_executor.task_queue.empty()

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -196,18 +196,18 @@ class TestKubernetesExecutor:
         AirflowKubernetesScheduler is None, reason='kubernetes python package is not installed'
     )
     @pytest.mark.parametrize(
-        'reason, status, should_requeue',
+        'status, should_requeue',
         [
-            ('Forbidden', 403, True),
-            ('fake-unhandled-reason', 12345, True),
-            ('Unprocessable Entity', 422, False),
-            ('BadRequest', 400, False),
+            pytest.param(403, True, id='403 Forbidden'),
+            pytest.param(12345, True, id='12345 fake-unhandled-reason'),
+            pytest.param(422, False, id='422 Unprocessable Entity'),
+            pytest.param(400, False, id='400 BadRequest'),
         ],
     )
     @mock.patch('airflow.executors.kubernetes_executor.KubernetesJobWatcher')
     @mock.patch('airflow.executors.kubernetes_executor.get_kube_client')
     def test_run_next_exception_requeue(
-        self, mock_get_kube_client, mock_kubernetes_job_watcher, reason, status, should_requeue
+        self, mock_get_kube_client, mock_kubernetes_job_watcher, status, should_requeue
     ):
         """
         When pod scheduling fails with either reason 'Forbidden', or any reason not yet

--- a/tests/executors/test_kubernetes_executor.py
+++ b/tests/executors/test_kubernetes_executor.py
@@ -225,9 +225,16 @@ class TestKubernetesExecutor:
         """
         import sys
 
+        reason_status_map = {
+            'BadRequest': 400,
+            'Forbidden': 403,
+            'Unprocessable Entity': 422,
+        }
+
         path = sys.path[0] + '/tests/kubernetes/pod_generator_base_with_secrets.yaml'
 
-        response = HTTPResponse(body='{"message": "any message"}', reason=reason)
+        status = reason_status_map.get(reason, 12345)
+        response = HTTPResponse(body='{"message": "any message"}', status=status)
 
         # A mock kube_client that throws errors when making a pod
         mock_kube_client = mock.patch('kubernetes.client.CoreV1Api', autospec=True)


### PR DESCRIPTION
When pod has invalid requirements, e.g. resource limit < resource request,
the kubernetes api may return "Unprocessable Entity".  In this scenario,
the kubernetes executor should fail the task immediately, rather than set
it to be attempted again

closes https://github.com/apache/airflow/issues/19320
