### PR TITLE
Implement task-level include/exclude time filter

### DIFF
--- a/airflow/serialization/schema.json
+++ b/airflow/serialization/schema.json
@@ -47,6 +47,9 @@
         }
       }
     },
+    "timefilter": {
+      "type": "object"
+    },
     "timezone": {
       "anyOf": [
         { "type": "string" },
@@ -173,6 +176,8 @@
         "owner": { "type": "string" },
         "start_date": { "$ref": "#/definitions/datetime" },
         "end_date": { "$ref": "#/definitions/datetime" },
+        "include_date": { "$ref": "#/definitions/timefilter" },
+        "exclude_date": { "$ref": "#/definitions/timefilter" },
         "trigger_rule": { "type": "string" },
         "depends_on_past": { "type": "boolean" },
         "wait_for_downstream": { "type": "boolean" },

--- a/airflow/timefilters/__init__.py
+++ b/airflow/timefilters/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,39 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-"""Enums for DAG serialization."""
-
-from enum import Enum, unique
-
-
-# Fields of an encoded object in serialization.
-@unique
-class Encoding(str, Enum):
-    """Enum of encoding constants."""
-
-    TYPE = '__type'
-    VAR = '__var'
-
-
-# Supported types for encoding. primitives and list are not encoded.
-@unique
-class DagAttributeTypes(str, Enum):
-    """Enum of supported attribute types of DAG."""
-
-    DAG = 'dag'
-    OP = 'operator'
-    DATETIME = 'datetime'
-    TIMEDELTA = 'timedelta'
-    TIMEZONE = 'timezone'
-    RELATIVEDELTA = 'relativedelta'
-    DICT = 'dict'
-    SET = 'set'
-    TUPLE = 'tuple'
-    POD = 'k8s.V1Pod'
-    TASK_GROUP = 'taskgroup'
-    EDGE_INFO = 'edgeinfo'
-    PARAM = 'param'
-    CRON = 'cron'
-    ANY = 'any'
-    ALL = 'all'

--- a/airflow/timefilters/base.py
+++ b/airflow/timefilters/base.py
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from abc import abstractmethod
+from typing import NamedTuple
+
+from pendulum import DateTime
+
+from airflow.typing_compat import Protocol
+
+
+class AbstractTimeFilter(Protocol):
+    """Protocol that all time filters are expected to implement."""
+
+    @abstractmethod
+    def match(self, date: DateTime) -> bool:
+        """Return true if the provided date matches the condition."""
+
+
+class TimeFilter(AbstractTimeFilter):
+    """Base class that all built-in time filters inherit from."""
+
+    def __eq__(self, other: AbstractTimeFilter) -> bool:
+        return type(self) is type(other) and self.__dict__ == other.__dict__
+
+    def __and__(self, other: AbstractTimeFilter) -> "TimeFilter":
+        return AllTimeFilter(self, other)
+
+    def __or__(self, other: AbstractTimeFilter) -> "TimeFilter":
+        return AnyTimeFilter(self, other)
+
+
+class OperatorTimeFilter(TimeFilter):
+    """Time filter class used internally to combine other filters."""
+
+    def __init__(self, *timefilters):
+        self.timefilters = timefilters
+
+    def match(self, date: DateTime) -> bool:
+        class Wrapper(NamedTuple):
+            timefilter: TimeFilter
+
+            def __bool__(self):
+                return self.timefilter.match(date)
+
+        return self.operator(map(Wrapper, self.timefilters))
+
+
+class AllTimeFilter(OperatorTimeFilter):
+    """Matches when all filters match."""
+
+    operator = staticmethod(all)
+
+
+class AnyTimeFilter(OperatorTimeFilter):
+    """Matches when any one filter matches."""
+
+    operator = staticmethod(any)

--- a/airflow/timefilters/cron.py
+++ b/airflow/timefilters/cron.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,38 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Enums for DAG serialization."""
+from croniter import croniter
+from pendulum.tz.timezone import Timezone
 
-from enum import Enum, unique
-
-
-# Fields of an encoded object in serialization.
-@unique
-class Encoding(str, Enum):
-    """Enum of encoding constants."""
-
-    TYPE = '__type'
-    VAR = '__var'
+from airflow.timefilters.base import TimeFilter
+from airflow.utils.timezone import make_naive
 
 
-# Supported types for encoding. primitives and list are not encoded.
-@unique
-class DagAttributeTypes(str, Enum):
-    """Enum of supported attribute types of DAG."""
+class CronTimeFilter(TimeFilter):
+    """Time filter that match on a cron expression."""
 
-    DAG = 'dag'
-    OP = 'operator'
-    DATETIME = 'datetime'
-    TIMEDELTA = 'timedelta'
-    TIMEZONE = 'timezone'
-    RELATIVEDELTA = 'relativedelta'
-    DICT = 'dict'
-    SET = 'set'
-    TUPLE = 'tuple'
-    POD = 'k8s.V1Pod'
-    TASK_GROUP = 'taskgroup'
-    EDGE_INFO = 'edgeinfo'
-    PARAM = 'param'
-    CRON = 'cron'
-    ANY = 'any'
-    ALL = 'all'
+    def __init__(self, expression: str, timezone: Timezone):
+        self.expression = expression
+        self.timezone = timezone
+
+    def match(self, date):
+        naive = make_naive(date, self.timezone)
+        return croniter.match(self.expression, naive)

--- a/tests/models/test_baseoperator.py
+++ b/tests/models/test_baseoperator.py
@@ -574,6 +574,32 @@ class TestBaseOperator:
         op = BaseOperator(task_id="test_task", weight_rule="upstream")
         assert WeightRule.UPSTREAM == op.weight_rule
 
+    @pytest.mark.parametrize(
+        ("include", "exclude", "expectation"),
+        [
+            (None, None, True),
+            (None, False, True),
+            (True, None, True),
+            (True, False, True),
+            (None, True, False),
+            (False, None, False),
+            (False, False, False),
+            (False, True, False),
+        ],
+    )
+    def test_include_in_dagrun(self, include, exclude, expectation):
+        include_date = mock.Mock()
+        include_date.match.side_effect = lambda d: include
+        exclude_date = mock.Mock()
+        exclude_date.match.side_effect = lambda d: exclude
+        task = BaseOperator(
+            task_id="dummy",
+            include_date=include_date if include is not None else None,
+            exclude_date=exclude_date if exclude is not None else None,
+        )
+        date = mock.Mock()
+        assert task.include_in_dagrun(date) == expectation
+
 
 def test_init_subclass_args():
     class InitSubclassOp(BaseOperator):

--- a/tests/timefilters/__init__.py
+++ b/tests/timefilters/__init__.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,39 +14,3 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-"""Enums for DAG serialization."""
-
-from enum import Enum, unique
-
-
-# Fields of an encoded object in serialization.
-@unique
-class Encoding(str, Enum):
-    """Enum of encoding constants."""
-
-    TYPE = '__type'
-    VAR = '__var'
-
-
-# Supported types for encoding. primitives and list are not encoded.
-@unique
-class DagAttributeTypes(str, Enum):
-    """Enum of supported attribute types of DAG."""
-
-    DAG = 'dag'
-    OP = 'operator'
-    DATETIME = 'datetime'
-    TIMEDELTA = 'timedelta'
-    TIMEZONE = 'timezone'
-    RELATIVEDELTA = 'relativedelta'
-    DICT = 'dict'
-    SET = 'set'
-    TUPLE = 'tuple'
-    POD = 'k8s.V1Pod'
-    TASK_GROUP = 'taskgroup'
-    EDGE_INFO = 'edgeinfo'
-    PARAM = 'param'
-    CRON = 'cron'
-    ANY = 'any'
-    ALL = 'all'

--- a/tests/timefilters/test_cron.py
+++ b/tests/timefilters/test_cron.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,38 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""Enums for DAG serialization."""
+from pendulum import DateTime
 
-from enum import Enum, unique
+from airflow.settings import TIMEZONE
+from airflow.timefilters.cron import CronTimeFilter
 
-
-# Fields of an encoded object in serialization.
-@unique
-class Encoding(str, Enum):
-    """Enum of encoding constants."""
-
-    TYPE = '__type'
-    VAR = '__var'
+DATE = DateTime(1970, 1, 1, tzinfo=TIMEZONE)
 
 
-# Supported types for encoding. primitives and list are not encoded.
-@unique
-class DagAttributeTypes(str, Enum):
-    """Enum of supported attribute types of DAG."""
+def test_match():
+    assert CronTimeFilter("* * * * THU", TIMEZONE).match(DATE)
 
-    DAG = 'dag'
-    OP = 'operator'
-    DATETIME = 'datetime'
-    TIMEDELTA = 'timedelta'
-    TIMEZONE = 'timezone'
-    RELATIVEDELTA = 'relativedelta'
-    DICT = 'dict'
-    SET = 'set'
-    TUPLE = 'tuple'
-    POD = 'k8s.V1Pod'
-    TASK_GROUP = 'taskgroup'
-    EDGE_INFO = 'edgeinfo'
-    PARAM = 'param'
-    CRON = 'cron'
-    ANY = 'any'
-    ALL = 'all'
+
+def test_not_match():
+    assert not CronTimeFilter("* * * * FRI", TIMEZONE).match(DATE)


### PR DESCRIPTION
This adds support for including or excluding a task execution during a DAG run based on a filtering mechanism that matches on the execution date.

The changeset adds two optional parameters `include_date` and `exclude_date` to the base operator class – along with a new method `include_in_dagrun(execution_date)` which determines whether or not to _schedule_ a task instance or immediately mark it as _skipped_.

The time filters are instances of classes under `airflow.timefilters` and can be combined using the bitwise and/or operators.

Currently implemented time filters:

- `airflow.timefilters.cron.CronTimeFilter` – matches on a cron expression

### Limitations

At this time, only built-in time filters (and combinations) are possible. This is not a design limitation as such, but an implementation decision. It would be possible to provide a registration mechanism similar to time tables to allow using custom classes.

### FAQ

1. Why not just use `BranchOperator` – ?

    Executing a task simply to evaluate on DAG metadata (i.e., execution date) is wasteful, similar to how we don't need to "execute" a `DummyOperator` in the common case.

    Filtering on a declarative basis makes it possible to provide a better user experience as well, helping to make it clear when a particular task will be skipped (e.g. "Sundays").

    In addition, a `BranchOperator` needs a task id which will probably be a variation on the filtering requirement itself such as "my_task_skip_sundays", violating the DRY principle.