### PR TITLE
Fix message on "Mark as" confirmation page

### DIFF
--- a/airflow/www/templates/airflow/_messages.html
+++ b/airflow/www/templates/airflow/_messages.html
@@ -16,9 +16,9 @@
  specific language governing permissions and limitations
  under the License.
 #}
-{%- macro message(content, category='info', dismissable=true) -%}
+{%- macro show_message(content, category='info', dismissible=true) -%}
   <div class="alert alert-{{ category }}">
-    {%- if dismissable -%}
+    {%- if dismissible -%}
     <button type="button" class="close" data-dismiss="alert">&times;</button>
     {%- endif -%}
     {%- if caller is defined -%}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -50,10 +50,10 @@
 
 {% block messages %}
   {% for m in dashboard_alerts %}
-    {{ message(m.message, m.category) }}
+    {{ show_message(m.message, m.category) }}
   {% endfor %}
   {% for original_table_name, moved_table_name in migration_moved_data_alerts %}
-    {% call message(category='error', dismissable=false) %}
+    {% call show_message(category='error', dismissible=false) %}
       Airflow found incompatible data in the <code>{{ original_table_name }}</code> table in the
       metadatabase, and has moved them to <code>{{ moved_table_name }}</code> during the database migration
       to upgrade. Please inspect the moved data to decide whether you need to keep them, and manually drop
@@ -62,14 +62,14 @@
   {% endfor %}
   {{ super() }}
   {% if sqlite_warning | default(true) %}
-    {% call message(category='warning', dismissable=false)  %}
+    {% call show_message(category='warning', dismissible=false)  %}
       Do not use <b>SQLite</b> as metadata DB in production &#8211; it should only be used for dev/testing
       We recommend using Postgres or MySQL.
       <a href={{ get_docs_url("howto/set-up-database.html") }}><b>Click here</b></a> for more information.
     {% endcall %}
   {% endif %}
   {% if sequential_executor_warning | default(false) %}
-    {% call message(category='warning', dismissable=false)  %}
+    {% call show_message(category='warning', dismissible=false)  %}
       Do not use <b>SequentialExecutor</b> in production.
       <a href={{ get_docs_url("executor/index.html") }}><b>Click here</b></a> for more information.
     {% endcall %}

--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -19,7 +19,7 @@
 
 {% extends base_template %}
 {% from 'appbuilder/loading_dots.html' import loading_dots %}
-{% from 'airflow/_messages.html' import message %}
+{% from 'airflow/_messages.html' import show_message %}
 
 {% block page_title %}
   {% if search_query %}"{{ search_query }}" - {% endif %}DAGs - {{ appbuilder.app_name }}

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -18,7 +18,7 @@
 #}
 
 {% extends 'appbuilder/baselayout.html' %}
-{% from 'airflow/_messages.html' import message %}
+{% from 'airflow/_messages.html' import show_message %}
 
 {% block page_title -%}
   {% if title is defined -%}

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -67,7 +67,7 @@
     {% endcall %}
   {% endif %}
   {% if triggerer_job is defined and (not triggerer_job or not triggerer_job.is_alive()) %}
-    {% call show_message(category='warning', dismissabie=false) %}
+    {% call show_message(category='warning', dismissible=false) %}
       <p>The triggerer does not appear to be running.
       {% if triggerer_job %}
       Last heartbeat was received

--- a/airflow/www/templates/airflow/main.html
+++ b/airflow/www/templates/airflow/main.html
@@ -52,7 +52,7 @@
 {% block messages %}
   {% include 'appbuilder/flash.html' %}
   {% if scheduler_job is defined and (not scheduler_job or not scheduler_job.is_alive()) %}
-    {% call message(category='warning', dismissable=false) %}
+    {% call show_message(category='warning', dismissible=false) %}
       <p>The scheduler does not appear to be running.
       {% if scheduler_job %}
       Last heartbeat was received
@@ -67,7 +67,7 @@
     {% endcall %}
   {% endif %}
   {% if triggerer_job is defined and (not triggerer_job or not triggerer_job.is_alive()) %}
-    {% call message(category='warning', dismissable=false) %}
+    {% call show_message(category='warning', dismissabie=false) %}
       <p>The triggerer does not appear to be running.
       {% if triggerer_job %}
       Last heartbeat was received

--- a/airflow/www/templates/appbuilder/flash.html
+++ b/airflow/www/templates/appbuilder/flash.html
@@ -35,7 +35,7 @@
         {{ dag_import_errors.append((category, m)) if dag_import_errors.append((category, m)) != None else '' }}
       {% elif not (request.path == appbuilder.get_url_for_login and 'access is denied' in m.lower()) %}
       {# Don't show 'Access is Denied' alert if user is logged out and on the login page. #}
-        {{ message(m, category) }}
+        {{ show_message(m, category) }}
       {% endif %}
     {% endfor %}
   {% endif %}


### PR DESCRIPTION
In an earlier refactor I created a macro called `message` which
"stomped" on the variable of the same name set in the view, meaning the
page shows `<Macro message>` instead of the string we meant to set.

This "fixes" it by using a less-likely-to-clash name for the macro (and
fixing the typo in `dismissible` parameter.)
