### PR TITLE
Change logLevel as debug for XCOM returned value message

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -123,6 +123,9 @@ class PythonOperator(BaseOperator):
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
+    :param show_return_value_in_logs: a bool value whether to show return_value
+        logs
+    :type show_return_value_in_logs: str
     """
 
     template_fields = ('templates_dict', 'op_args', 'op_kwargs')
@@ -145,6 +148,7 @@ class PythonOperator(BaseOperator):
         op_kwargs: Optional[Dict] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
+        show_return_value_in_logs: Optional[bool] = True,
         **kwargs,
     ) -> None:
         if kwargs.get("provide_context"):
@@ -163,6 +167,7 @@ class PythonOperator(BaseOperator):
         self.templates_dict = templates_dict
         if templates_exts:
             self.template_ext = templates_exts
+        self.show_return_value_in_logs = show_return_value_in_logs
 
     def execute(self, context: Dict):
         context.update(self.op_kwargs)
@@ -171,7 +176,8 @@ class PythonOperator(BaseOperator):
         self.op_kwargs = determine_kwargs(self.python_callable, self.op_args, context)
 
         return_value = self.execute_callable()
-        self.log.debug("Done. Returned value was: %s", return_value)
+        if self.show_return_value_in_logs:
+            self.log.debug("Done. Returned value was: %s", return_value)
         return return_value
 
     def execute_callable(self):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -126,7 +126,7 @@ class PythonOperator(BaseOperator):
     :param show_return_value_in_logs: a bool value whether to show return_value
         logs. Defaults to True, which allows return value log output.
         It can be set to False to prevent log output of return value when you return huge data
-        such as sending a large amount of XCom to TaskAPI.
+        such as transmission a large amount of XCom to TaskAPI.
     :type show_return_value_in_logs: bool
     """
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -180,6 +180,9 @@ class PythonOperator(BaseOperator):
         return_value = self.execute_callable()
         if self.show_return_value_in_logs:
             self.log.info("Done. Returned value was: %s", return_value)
+        else:
+            self.log.info("Done. Returned value not shown")
+
         return return_value
 
     def execute_callable(self):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -150,7 +150,7 @@ class PythonOperator(BaseOperator):
         op_kwargs: Optional[Dict] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
-        show_return_value_in_logs: Optional[bool] = True,
+        show_return_value_in_logs: bool = True,
         **kwargs,
     ) -> None:
         if kwargs.get("provide_context"):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -179,7 +179,7 @@ class PythonOperator(BaseOperator):
 
         return_value = self.execute_callable()
         if self.show_return_value_in_logs:
-            self.log.debug("Done. Returned value was: %s", return_value)
+            self.log.info("Done. Returned value was: %s", return_value)
         return return_value
 
     def execute_callable(self):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -124,8 +124,10 @@ class PythonOperator(BaseOperator):
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
     :param show_return_value_in_logs: a bool value whether to show return_value
-        logs
-    :type show_return_value_in_logs: str
+        logs.
+        It can be set to False to prevent log output of return value when you want to prevent huge log output
+        from returning excessive data, such as sending a large amount of XCom to TaskAPI.
+    :type show_return_value_in_logs: bool
     """
 
     template_fields = ('templates_dict', 'op_args', 'op_kwargs')

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -171,7 +171,7 @@ class PythonOperator(BaseOperator):
         self.op_kwargs = determine_kwargs(self.python_callable, self.op_args, context)
 
         return_value = self.execute_callable()
-        self.log.info("Done. Returned value was: %s", return_value)
+        self.log.debug("Done. Returned value was: %s", return_value)
         return return_value
 
     def execute_callable(self):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -125,8 +125,8 @@ class PythonOperator(BaseOperator):
     :type templates_exts: list[str]
     :param show_return_value_in_logs: a bool value whether to show return_value
         logs.
-        It can be set to False to prevent log output of return value when you want to prevent huge log output
-        from returning excessive data, such as sending a large amount of XCom to TaskAPI.
+        It can be set to False to prevent log output of return value when you return huge data
+        such as sending a large amount of XCom to TaskAPI.
     :type show_return_value_in_logs: bool
     """
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -124,7 +124,7 @@ class PythonOperator(BaseOperator):
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
     :param show_return_value_in_logs: a bool value whether to show return_value
-        logs.
+        logs. Defaults to True, which allows return value log output.
         It can be set to False to prevent log output of return value when you return huge data
         such as sending a large amount of XCom to TaskAPI.
     :type show_return_value_in_logs: bool

--- a/airflow/providers/google/leveldb/operators/leveldb.py
+++ b/airflow/providers/google/leveldb/operators/leveldb.py
@@ -92,7 +92,7 @@ class LevelDBOperator(BaseOperator):
             keys=self.keys,
             values=self.values,
         )
-        self.log.info("Done. Returned value was: %s", str(value))
+        self.log.debug("Done. Returned value was: %s", str(value))
         leveldb_hook.close_conn()
         value = value if value is None else value.decode()
         return value

--- a/airflow/providers/google/leveldb/operators/leveldb.py
+++ b/airflow/providers/google/leveldb/operators/leveldb.py
@@ -92,7 +92,7 @@ class LevelDBOperator(BaseOperator):
             keys=self.keys,
             values=self.values,
         )
-        self.log.debug("Done. Returned value was: %s", str(value))
+        self.log.info("Done. Returned value was: %s", str(value))
         leveldb_hook.close_conn()
         value = value if value is None else value.decode()
         return value

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -326,15 +326,14 @@ class TestPythonOperator(TestPythonBase):
         def func():
             return 'test_return_value'
 
-        python_operator = PythonOperator(
-            task_id='python_operator', python_callable=func, dag=self.dag
-        )
+        python_operator = PythonOperator(task_id='python_operator', python_callable=func, dag=self.dag)
 
         with self.assertLogs('airflow.task.operators', level=logging.INFO) as cm:
             python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
-        assert 'INFO:airflow.task.operators:Done. Returned value was: test_return_value' in cm.output, \
-            'Return value should be shown'
+        assert (
+            'INFO:airflow.task.operators:Done. Returned value was: test_return_value' in cm.output
+        ), 'Return value should be shown'
 
     def test_return_value_log_with_show_return_value_in_logs_false(self):
         self.dag.create_dagrun(
@@ -358,10 +357,12 @@ class TestPythonOperator(TestPythonBase):
         with self.assertLogs('airflow.task.operators', level=logging.INFO) as cm:
             python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
-        assert 'INFO:airflow.task.operators:Done. Returned value was: test_return_value' not in cm.output, \
-            'Return value should not be shown'
-        assert 'INFO:airflow.task.operators:Done. Returned value not shown' in cm.output, \
-            'Log message that the option is turned off should be shown'
+        assert (
+            'INFO:airflow.task.operators:Done. Returned value was: test_return_value' not in cm.output
+        ), 'Return value should not be shown'
+        assert (
+            'INFO:airflow.task.operators:Done. Returned value not shown' in cm.output
+        ), 'Log message that the option is turned off should be shown'
 
 
 class TestBranchOperator(unittest.TestCase):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -314,6 +314,55 @@ class TestPythonOperator(TestPythonBase):
         )
         python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
+    def test_return_value_log_with_show_return_value_in_logs_default(self):
+        self.dag.create_dagrun(
+            run_type=DagRunType.MANUAL,
+            execution_date=DEFAULT_DATE,
+            start_date=DEFAULT_DATE,
+            state=State.RUNNING,
+            external_trigger=False,
+        )
+
+        def func():
+            return 'test_return_value'
+
+        python_operator = PythonOperator(
+            task_id='python_operator', python_callable=func, dag=self.dag
+        )
+
+        with self.assertLogs('airflow.task.operators', level=logging.DEBUG) as cm:
+            python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+            assert (
+                'DEBUG:airflow.task.operators:Done. Returned value was: test_return_value' in cm.output,
+                'Return value should be shown'
+            )
+
+    def test_return_value_log_with_show_return_value_in_logs_false(self):
+        self.dag.create_dagrun(
+            run_type=DagRunType.MANUAL,
+            execution_date=DEFAULT_DATE,
+            start_date=DEFAULT_DATE,
+            state=State.RUNNING,
+            external_trigger=False,
+        )
+
+        def func():
+            return 'test_return_value'
+
+        python_operator = PythonOperator(
+            task_id='python_operator',
+            python_callable=func,
+            dag=self.dag,
+            show_return_value_in_logs=False,
+        )
+
+        with self.assertLogs('airflow.task.operators', level=logging.DEBUG) as cm:
+            python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+            assert (
+                'DEBUG:airflow.task.operators:Done. Returned value was: test_return_value' not in cm.output,
+                'Return value should not be shown'
+            )
+
 
 class TestBranchOperator(unittest.TestCase):
     @classmethod

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -355,16 +355,13 @@ class TestPythonOperator(TestPythonBase):
             show_return_value_in_logs=False,
         )
 
-        try:
-            with self.assertLogs('airflow.task.operators', level=logging.INFO) as cm:
-                python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        except AssertionError as e:
-            # ignore when the log is not captured.
-            if e.args[0] != 'no logs of level INFO or higher triggered on airflow.task.operators':
-                raise e
+        with self.assertLogs('airflow.task.operators', level=logging.INFO) as cm:
+            python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
-        assert 'INFO:airflow.task.operators:Done. Returned value was: test_return_value' not in cm.records, \
+        assert 'INFO:airflow.task.operators:Done. Returned value was: test_return_value' not in cm.output, \
             'Return value should not be shown'
+        assert 'INFO:airflow.task.operators:Done. Returned value not shown' in cm.output, \
+            'Log message that the option is turned off should be shown'
 
 
 class TestBranchOperator(unittest.TestCase):

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -330,7 +330,7 @@ class TestPythonOperator(TestPythonBase):
             task_id='python_operator', python_callable=func, dag=self.dag
         )
 
-        with self.assertLogs('airflow.task.operators', level=logging.DEBUG) as cm:
+        with self.assertLogs('airflow.task.operators', level=logging.INFO) as cm:
             python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
             assert (
                 'DEBUG:airflow.task.operators:Done. Returned value was: test_return_value' in cm.output,
@@ -356,7 +356,7 @@ class TestPythonOperator(TestPythonBase):
             show_return_value_in_logs=False,
         )
 
-        with self.assertLogs('airflow.task.operators', level=logging.DEBUG) as cm:
+        with self.assertLogs('airflow.task.operators', level=logging.INFO) as cm:
             python_operator.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
             assert (
                 'DEBUG:airflow.task.operators:Done. Returned value was: test_return_value' not in cm.output,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

related: #18264

---

The current Airflow version (2.x.x) supports [Custom XCom Backends](https://www.astronomer.io/guides/custom-xcom-backends). and It means that the data from XCom could be larger than we think. (e.g. over `100GB`)

However, `PythonOperator` and `LevelDBOperator` will try to show all of those data from XCom as a log message. This issue can cause web issues such as breaking the web page (due to browser memory issue or rendering speed issue). and It also will make it difficult to see the other log message from the task.

This PR suggests changing the logLevel `info` to `debug`, Because XCom returned value can be treated `debug purpose

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
