### PR TITLE
Check if job object is None before calling .is_alive()

### DIFF
--- a/airflow/cli/commands/standalone_command.py
+++ b/airflow/cli/commands/standalone_command.py
@@ -228,7 +228,10 @@ class StandaloneCommand:
         Checks if the given job name is running and heartbeating correctly
         (used to tell if scheduler is alive)
         """
-        return job.most_recent_job().is_alive()
+        recent = job.most_recent_job()
+        if not recent:
+            return False
+        return recent.is_alive()
 
     def print_ready(self):
         """


### PR DESCRIPTION
The method job_running raises an ArrtibuteError if
the job object passed to is is None. Adding a check
helps fix this (#19365).
