### PR TITLE
env: Add support for different value keys

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -196,8 +196,9 @@ If release name contains chart name it will be used as a full name.
       value: "true"
     {{- end }}
     {{- range $i, $config := .Values.dags.gitSync.env }}
+    {{- $values := omit $config "name" }}
     - name: {{ $config.name }}
-      value: {{ $config.value | quote }}
+      {{- toYaml $values | nindent 6 }}
     {{- end }}
   resources: {{ toYaml .Values.dags.gitSync.resources | nindent 6 }}
   volumeMounts:

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -94,11 +94,12 @@ If release name contains chart name it will be used as a full name.
 {{- define "custom_airflow_environment" }}
   # Dynamically created environment variables
   {{- range $i, $config := .Values.env }}
+  {{- $values := omit $config "name" }}
   - name: {{ $config.name }}
-    value: {{ $config.value | quote }}
+    {{- toYaml $values | nindent 4 }}
     {{- if or (eq $.Values.executor "KubernetesExecutor") (eq $.Values.executor "CeleryKubernetesExecutor") }}
   - name: AIRFLOW__KUBERNETES_ENVIRONMENT_VARIABLES__{{ $config.name }}
-    value: {{ $config.value | quote }}
+    {{- toYaml $values | nindent 4 }}
     {{- end }}
   {{- end }}
   # Dynamically created secret envs


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This expands the functionality of the top level `env` (and `gitSync.env`) values to support different value keys supported by the Kubernetes env spec. For example:
```
env:
  - name: AIRFLOW__SCHEDULER__STATSD_HOST
    valueFrom:
      fieldRef:
        fieldPath: status.hostIP
```
instead of just:
```
env:
  - name: AIRFLOW__SCHEDULER__STATSD_HOST
    value: localhost
```
---
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
