### PR TITLE
Ensure catchup=False is used in example dags

### DIFF
--- a/airflow/example_dags/example_external_task_marker_dag.py
+++ b/airflow/example_dags/example_external_task_marker_dag.py
@@ -43,11 +43,12 @@ from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 from airflow.sensors.external_task import ExternalTaskMarker, ExternalTaskSensor
 
-start_date = datetime.datetime(2015, 1, 1)
+start_date = datetime.datetime(2021, 1, 1)
 
 with DAG(
     dag_id="example_external_task_marker_parent",
     start_date=start_date,
+    catchup=False,
     schedule_interval=None,
     tags=['example2'],
 ) as parent_dag:
@@ -63,6 +64,7 @@ with DAG(
     dag_id="example_external_task_marker_child",
     start_date=start_date,
     schedule_interval=None,
+    catchup=False,
     tags=['example2'],
 ) as child_dag:
     # [START howto_operator_external_task_sensor]

--- a/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_fileshare.py
@@ -43,5 +43,10 @@ def delete_fileshare():
     hook.delete_share(NAME)
 
 
-with DAG("example_fileshare", schedule_interval="@once", start_date=datetime(2021, 1, 1)) as dag:
+with DAG(
+    "example_fileshare",
+    schedule_interval="@once",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+) as dag:
     create_fileshare() >> delete_fileshare()

--- a/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_local_to_adls.py
@@ -28,6 +28,7 @@ REMOTE_FILE_PATH = os.environ.get("REMOTE_LOCAL_PATH", 'remote.txt')
 with models.DAG(
     "example_local_to_adls",
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     schedule_interval=None,
     tags=['example'],
 ) as dag:

--- a/airflow/providers/microsoft/azure/example_dags/example_local_to_wasb.py
+++ b/airflow/providers/microsoft/azure/example_dags/example_local_to_wasb.py
@@ -28,6 +28,7 @@ with DAG(
     "example_local_to_wasb",
     schedule_interval="@once",
     start_date=datetime(2021, 1, 1),
+    catchup=False,
     default_args={"container_name": "mycontainer", "blob_name": "myblob"},
 ) as dag:
     upload = LocalFilesystemToWasbOperator(task_id="upload_file", file_path=PATH_TO_UPLOAD_FILE)


### PR DESCRIPTION
Along with the effort to move to static start times, use catchup=False to avoid users inadvertently causing a large backlog of tasks as discussed [here](https://github.com/apache/airflow/pull/19237) and [here](https://github.com/apache/airflow/pull/18071/files)

This PR covers Azure example dags (plus moving one Airflow example dag to the start time used elsewhere). 

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
