### PR TITLE
Cleanup dynamic `start_date` use for miscellaneous Google example DAGs

### DIFF
--- a/airflow/providers/google/ads/example_dags/example_ads.py
+++ b/airflow/providers/google/ads/example_dags/example_ads.py
@@ -19,11 +19,11 @@
 Example Airflow DAG that shows how to use GoogleAdsToGcsOperator.
 """
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.google.ads.operators.ads import GoogleAdsListAccountsOperator
 from airflow.providers.google.ads.transfers.ads_to_gcs import GoogleAdsToGcsOperator
-from airflow.utils import dates
 
 # [START howto_google_ads_env_variables]
 CLIENT_IDS = ["1111111111", "2222222222"]
@@ -67,7 +67,8 @@ FIELDS_TO_EXTRACT = [
 with models.DAG(
     "example_google_ads",
     schedule_interval=None,  # Override to match your needs
-    start_date=dates.days_ago(1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
 ) as dag:
     # [START howto_google_ads_to_gcs_operator]
     run_operator = GoogleAdsToGcsOperator(

--- a/airflow/providers/google/firebase/example_dags/example_firestore.py
+++ b/airflow/providers/google/firebase/example_dags/example_firestore.py
@@ -44,9 +44,11 @@ If you want to run this example, you must do the following:
 """
 
 import os
+from datetime import datetime
 from urllib.parse import urlparse
 
 from airflow import models
+from airflow.models.baseoperator import chain
 from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryCreateEmptyDatasetOperator,
     BigQueryCreateExternalTableOperator,
@@ -54,7 +56,6 @@ from airflow.providers.google.cloud.operators.bigquery import (
     BigQueryInsertJobOperator,
 )
 from airflow.providers.google.firebase.operators.firestore import CloudFirestoreExportDatabaseOperator
-from airflow.utils import dates
 
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID", "example-gcp-project")
 FIRESTORE_PROJECT_ID = os.environ.get("G_FIRESTORE_PROJECT_ID", "example-firebase-project")
@@ -72,8 +73,9 @@ if BUCKET_NAME is None:
 
 with models.DAG(
     "example_google_firestore",
-    default_args=dict(start_date=dates.days_ago(1)),
+    start_date=datetime(2021, 1, 1),
     schedule_interval='@once',
+    catchup=False,
     tags=["example"],
 ) as dag:
     # [START howto_operator_export_database_to_gcs]
@@ -134,10 +136,12 @@ with models.DAG(
         },
     )
 
-    # Firestore
-    export_database_to_gcs >> create_dataset
-
-    # BigQuery
-    create_dataset >> create_external_table_multiple_types
-    create_external_table_multiple_types >> read_data_from_gcs_multiple_types
-    read_data_from_gcs_multiple_types >> delete_dataset
+    chain(
+        # Firestore
+        export_database_to_gcs,
+        # BigQuery
+        create_dataset,
+        create_external_table_multiple_types,
+        read_data_from_gcs_multiple_types,
+        delete_dataset,
+    )

--- a/airflow/providers/google/leveldb/example_dags/example_leveldb.py
+++ b/airflow/providers/google/leveldb/example_dags/example_leveldb.py
@@ -19,29 +19,27 @@
 Example use of LevelDB operators.
 """
 
+from datetime import datetime
+
 from airflow import models
 from airflow.providers.google.leveldb.operators.leveldb import LevelDBOperator
-from airflow.utils.dates import days_ago
 
 with models.DAG(
     'example_leveldb',
-    start_date=days_ago(2),
+    start_date=datetime(2021, 1, 1),
     schedule_interval='@once',
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_leveldb_get_key]
-    get_key_leveldb_task = LevelDBOperator(
-        task_id='get_key_leveldb', leveldb_conn_id='leveldb_default', command='get', key=b'key', dag=dag
-    )
+    get_key_leveldb_task = LevelDBOperator(task_id='get_key_leveldb', command='get', key=b'key')
     # [END howto_operator_leveldb_get_key]
     # [START howto_operator_leveldb_put_key]
     put_key_leveldb_task = LevelDBOperator(
         task_id='put_key_leveldb',
-        leveldb_conn_id='leveldb_default',
         command='put',
         key=b'another_key',
         value=b'another_value',
-        dag=dag,
     )
     # [END howto_operator_leveldb_put_key]
     get_key_leveldb_task >> put_key_leveldb_task

--- a/airflow/providers/google/marketing_platform/example_dags/example_analytics.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_analytics.py
@@ -18,6 +18,7 @@
 Example Airflow DAG that shows how to use Google Analytics 360.
 """
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.google.marketing_platform.operators.analytics import (
@@ -28,7 +29,6 @@ from airflow.providers.google.marketing_platform.operators.analytics import (
     GoogleAnalyticsModifyFileHeadersDataImportOperator,
     GoogleAnalyticsRetrieveAdsLinksListOperator,
 )
-from airflow.utils import dates
 
 ACCOUNT_ID = os.environ.get("GA_ACCOUNT_ID", "123456789")
 
@@ -41,7 +41,8 @@ DATA_ID = "kjdDu3_tQa6n8Q1kXFtSmg"
 with models.DAG(
     "example_google_analytics",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=dates.days_ago(1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
 ) as dag:
     # [START howto_marketing_platform_list_accounts_operator]
     list_account = GoogleAnalyticsListAccountsOperator(task_id="list_account")

--- a/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
@@ -20,6 +20,7 @@ Example Airflow DAG that shows how to use CampaignManager.
 """
 import os
 import time
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.google.marketing_platform.operators.campaign_manager import (
@@ -33,7 +34,6 @@ from airflow.providers.google.marketing_platform.operators.campaign_manager impo
 from airflow.providers.google.marketing_platform.sensors.campaign_manager import (
     GoogleCampaignManagerReportSensor,
 )
-from airflow.utils import dates
 from airflow.utils.state import State
 
 PROFILE_ID = os.environ.get("MARKETING_PROFILE_ID", "123456789")
@@ -87,20 +87,21 @@ CONVERSION_UPDATE = {
 with models.DAG(
     "example_campaign_manager",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=dates.days_ago(1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
 ) as dag:
     # [START howto_campaign_manager_insert_report_operator]
     create_report = GoogleCampaignManagerInsertReportOperator(
         profile_id=PROFILE_ID, report=REPORT, task_id="create_report"
     )
-    report_id = "{{ task_instance.xcom_pull('create_report')['id'] }}"
+    report_id = create_report.output["report_id"]
     # [END howto_campaign_manager_insert_report_operator]
 
     # [START howto_campaign_manager_run_report_operator]
     run_report = GoogleCampaignManagerRunReportOperator(
         profile_id=PROFILE_ID, report_id=report_id, task_id="run_report"
     )
-    file_id = "{{ task_instance.xcom_pull('run_report')['id'] }}"
+    file_id = run_report.output["file_id"]
     # [END howto_campaign_manager_run_report_operator]
 
     # [START howto_campaign_manager_wait_for_operation]
@@ -131,6 +132,9 @@ with models.DAG(
 
     create_report >> run_report >> wait_for_report >> get_report >> delete_report
 
+    # Task dependencies created via `XComArgs`:
+    #   create_report >> run_report
+
     # [START howto_campaign_manager_insert_conversions]
     insert_conversion = GoogleCampaignManagerBatchInsertConversionsOperator(
         task_id="insert_conversion",
@@ -155,6 +159,7 @@ with models.DAG(
     # [END howto_campaign_manager_update_conversions]
 
     insert_conversion >> update_conversion
+
 
 if __name__ == "__main__":
     dag.clear(dag_run_state=State.NONE)

--- a/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_campaign_manager.py
@@ -130,10 +130,14 @@ with models.DAG(
     )
     # [END howto_campaign_manager_delete_report_operator]
 
-    create_report >> run_report >> wait_for_report >> get_report >> delete_report
+    wait_for_report >> get_report >> delete_report
 
     # Task dependencies created via `XComArgs`:
     #   create_report >> run_report
+    #   create_report >> wait_for_report
+    #   create_report >> get_report
+    #   run_report >> get_report
+    #   run_report >> wait_for_report
 
     # [START howto_campaign_manager_insert_conversions]
     insert_conversion = GoogleCampaignManagerBatchInsertConversionsOperator(

--- a/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_display_video.py
@@ -19,6 +19,7 @@
 Example Airflow DAG that shows how to use DisplayVideo.
 """
 import os
+from datetime import datetime
 from typing import Dict
 
 from airflow import models
@@ -38,7 +39,6 @@ from airflow.providers.google.marketing_platform.sensors.display_video import (
     GoogleDisplayVideo360GetSDFDownloadOperationSensor,
     GoogleDisplayVideo360ReportSensor,
 )
-from airflow.utils import dates
 
 # [START howto_display_video_env_variables]
 BUCKET = os.environ.get("GMP_DISPLAY_VIDEO_BUCKET", "gs://INVALID BUCKET NAME")
@@ -82,10 +82,13 @@ CREATE_SDF_DOWNLOAD_TASK_BODY_REQUEST: Dict = {
 DOWNLOAD_LINE_ITEMS_REQUEST: Dict = {"filterType": ADVERTISER_ID, "format": "CSV", "fileSpec": "EWF"}
 # [END howto_display_video_env_variables]
 
+START_DATE = datetime(2021, 1, 1)
+
 with models.DAG(
     "example_display_video",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=dates.days_ago(1),
+    start_date=START_DATE,
+    catchup=False,
 ) as dag1:
     # [START howto_google_display_video_createquery_report_operator]
     create_report = GoogleDisplayVideo360CreateReportOperator(body=REPORT, task_id="create_report")
@@ -127,7 +130,8 @@ with models.DAG(
 with models.DAG(
     "example_display_video_misc",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=dates.days_ago(1),
+    start_date=START_DATE,
+    catchup=False,
 ) as dag2:
     # [START howto_google_display_video_upload_multiple_entity_read_files_to_big_query]
     upload_erf_to_bq = GCSToBigQueryOperator(
@@ -160,7 +164,8 @@ with models.DAG(
 with models.DAG(
     "example_display_video_sdf",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=dates.days_ago(1),
+    start_date=START_DATE,
+    catchup=False,
 ) as dag3:
     # [START howto_google_display_video_create_sdf_download_task_operator]
     create_sdf_download_task = GoogleDisplayVideo360CreateSDFDownloadTaskOperator(

--- a/airflow/providers/google/marketing_platform/example_dags/example_search_ads.py
+++ b/airflow/providers/google/marketing_platform/example_dags/example_search_ads.py
@@ -19,6 +19,7 @@
 Example Airflow DAG that shows how to use SearchAds.
 """
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.google.marketing_platform.operators.search_ads import (
@@ -26,7 +27,6 @@ from airflow.providers.google.marketing_platform.operators.search_ads import (
     GoogleSearchAdsInsertReportOperator,
 )
 from airflow.providers.google.marketing_platform.sensors.search_ads import GoogleSearchAdsReportSensor
-from airflow.utils import dates
 
 # [START howto_search_ads_env_variables]
 AGENCY_ID = os.environ.get("GMP_AGENCY_ID")
@@ -47,7 +47,8 @@ REPORT = {
 with models.DAG(
     "example_search_ads",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=dates.days_ago(1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
 ) as dag:
     # [START howto_search_ads_generate_report_operator]
     generate_report = GoogleSearchAdsInsertReportOperator(report=REPORT, task_id="generate_report")

--- a/airflow/providers/google/suite/example_dags/example_gcs_to_gdrive.py
+++ b/airflow/providers/google/suite/example_dags/example_gcs_to_gdrive.py
@@ -19,17 +19,18 @@
 Example DAG using GoogleCloudStorageToGoogleDriveOperator.
 """
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.google.suite.transfers.gcs_to_gdrive import GCSToGoogleDriveOperator
-from airflow.utils.dates import days_ago
 
 GCS_TO_GDRIVE_BUCKET = os.environ.get("GCS_TO_DRIVE_BUCKET", "example-object")
 
 with models.DAG(
     "example_gcs_to_gdrive",
     schedule_interval=None,  # Override to match your needs,
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=['example'],
 ) as dag:
     # [START howto_operator_gcs_to_gdrive_copy_single_file]

--- a/airflow/providers/google/suite/example_dags/example_gcs_to_sheets.py
+++ b/airflow/providers/google/suite/example_dags/example_gcs_to_sheets.py
@@ -17,11 +17,11 @@
 # under the License.
 
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.providers.google.cloud.transfers.sheets_to_gcs import GoogleSheetsToGCSOperator
 from airflow.providers.google.suite.transfers.gcs_to_sheets import GCSToGoogleSheetsOperator
-from airflow.utils.dates import days_ago
 
 BUCKET = os.environ.get("GCP_GCS_BUCKET", "example-test-bucket3")
 SPREADSHEET_ID = os.environ.get("SPREADSHEET_ID", "example-spreadsheetID")
@@ -29,8 +29,9 @@ NEW_SPREADSHEET_ID = os.environ.get("NEW_SPREADSHEET_ID", "1234567890qwerty")
 
 with models.DAG(
     "example_gcs_to_sheets",
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     schedule_interval='@once',  # Override to match your needs
+    catchup=False,
     tags=["example"],
 ) as dag:
 

--- a/airflow/providers/google/suite/example_dags/example_sheets.py
+++ b/airflow/providers/google/suite/example_dags/example_sheets.py
@@ -17,13 +17,13 @@
 # under the License.
 
 import os
+from datetime import datetime
 
 from airflow import models
 from airflow.operators.bash import BashOperator
 from airflow.providers.google.cloud.transfers.sheets_to_gcs import GoogleSheetsToGCSOperator
 from airflow.providers.google.suite.operators.sheets import GoogleSheetsCreateSpreadsheetOperator
 from airflow.providers.google.suite.transfers.gcs_to_sheets import GCSToGoogleSheetsOperator
-from airflow.utils.dates import days_ago
 
 GCS_BUCKET = os.environ.get("SHEETS_GCS_BUCKET", "test28397ye")
 SPREADSHEET_ID = os.environ.get("SPREADSHEET_ID", "1234567890qwerty")
@@ -37,7 +37,8 @@ SPREADSHEET = {
 with models.DAG(
     "example_sheets_gcs",
     schedule_interval='@once',  # Override to match your needs,
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
     tags=["example"],
 ) as dag:
     # [START upload_sheet_to_gcs]

--- a/airflow/providers/google/suite/example_dags/example_sql_to_sheets.py
+++ b/airflow/providers/google/suite/example_dags/example_sql_to_sheets.py
@@ -16,17 +16,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime
+
 from airflow import models
 from airflow.providers.google.suite.transfers.sql_to_sheets import SQLToGoogleSheetsOperator
-from airflow.utils.dates import days_ago
 
 SQL = "select 1 as my_col"
 NEW_SPREADSHEET_ID = "123"
 
 with models.DAG(
     "example_sql_to_sheets",
-    start_date=days_ago(1),
+    start_date=datetime(2021, 1, 1),
     schedule_interval=None,  # Override to match your needs
+    catchup=False,
     tags=["example"],
 ) as dag:
 


### PR DESCRIPTION
There is an ongoing effort to enhance example DAGs by setting static values for `start_date`, ensuring `catchup=False` is set, cleaning up and/or implementing useful `default_args`, and removing/limiting the use of redundant, default connection ID values.

This PR mainly addresses the static `start_date` and `catchup` clean up areas in example DAGs in the across non-Google Cloud providers (e.g. Ads, Firebase, LevelDB, Marketing Platform, and Suite). 

The following additional (small) updates are also included:
-  The `example_campaign_manager` example DAG was updated to take advantage of `XComArgs` rather than the classic Jinja templating to pull `XComs`.
- Updated task-dependency notation in `example_firestore` to improve readability using `chain()`.
- Removed unnecessary setting of `dag=dag` in `example_leveldb`

> Note: There was an opportunity to consolidate task args to `default_args` for most, if not all, DAGs. However, these updates were not implemented as they would have conflicted too much with the operator documentation that references the example DAGs.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
