### PR TITLE
Fix log timezone in task log view (#19342)

### DIFF
--- a/airflow/www/static/js/ti_log.js
+++ b/airflow/www/static/js/ti_log.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-/* global document, window, $, */
+/* global document, window, $, moment, Airflow */
 import { escapeHtml } from './main';
 import getMetaValue from './meta_value';
 import { formatDateTime } from './datetime_utils';
@@ -115,9 +115,10 @@ function autoTailingLog(tryNumber, metadata = null, autoTailing = false) {
 
         // The message may contain HTML, so either have to escape it or write it as text.
         const escapedMessage = escapeHtml(item[1]);
+        const tzOffset = moment().tz(Airflow.serverTimezone).format('Z');
         const linkifiedMessage = escapedMessage
           .replace(urlRegex, (url) => `<a href="${url}" target="_blank">${url}</a>`)
-          .replaceAll(dateRegex, (date) => `<time datetime="${date}+00:00">${formatDateTime(`${date}+00:00`)}</time>`);
+          .replaceAll(dateRegex, (date) => `<time datetime="${date}${tzOffset}">${formatDateTime(`${date}${tzOffset}`)}</time>`);
         logBlock.innerHTML += `${linkifiedMessage}\n`;
       });
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

related: #19342

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



Fix #19342 such that when using non-UTC timezone (change `default_timezone` and airflow server's timezone), task's log in web interface will give incorrect log times.

Since python logging module saves `asctime` without timezone, the solution is simply add server's timezone offset (e.g. "Europe/Moscow" => "+03:00") to every `asctime` in the log file.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
