### PR TITLE
Doc: Fix the parameter name 'deploy-mode' in spark.rst (#19403)

### DIFF
--- a/docs/apache-airflow-providers-apache-spark/connections/spark.rst
+++ b/docs/apache-airflow-providers-apache-spark/connections/spark.rst
@@ -56,4 +56,4 @@ For example:
 
 .. code-block:: bash
 
-   export AIRFLOW_CONN_SPARK_DEFAULT='spark://mysparkcluster.com:80?deploy_mode=cluster&spark_binary=command&namespace=kube+namespace'
+   export AIRFLOW_CONN_SPARK_DEFAULT='spark://mysparkcluster.com:80?deploy-mode=cluster&spark_binary=command&namespace=kube+namespace'


### PR DESCRIPTION
A parameter name deploy_mode is incorrect in spark.rst. deploy-mode is correct.
closes: #19403 
