### PR TITLE
Also terminate LocalTaskJob when taskrunner is being terminated

### DIFF
--- a/airflow/jobs/local_task_job.py
+++ b/airflow/jobs/local_task_job.py
@@ -221,6 +221,12 @@ class LocalTaskJob(BaseJob):
                 error = self.task_runner.deserialize_run_error() or "task marked as failed externally"
             ti._run_finished_callback(error=error)
             self.terminating = True
+            # Set the Job state to terminating too otherwise
+            # this job will still be in running state till
+            # DagFileProcessorManager._find_zombie kills it.
+            # See BaseJob.heartbeat
+            self.state = State.SHUTDOWN
+            session.merge(self)
 
     @provide_session
     @Sentry.enrich_errors


### PR DESCRIPTION
While troubleshooting another issue, I found that when a task is mark
failed in the UI, the LocalTaskJob will still be in the running state
for a long time.

This is not a problem but when you mark many task instances as failed
you will have a lot of hanging LocalTaskJob waiting for Zombie killer
to kill it. I got to a point that Scheduler crashes with FATAL:too-many-clients error

In this PR, I set the LocalTaskJob state to terminating so that the next
heartbeat will do the clean-up.

Not sure how to test, any guidance will be highly appreciated. I only tested on the webserver by marking tasks as failed

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
