### PR TITLE
Define datetime and StringID column types centrally in migrations

### DIFF
--- a/airflow/migrations/db_types.py
+++ b/airflow/migrations/db_types.py
@@ -1,0 +1,86 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import sys
+
+import sqlalchemy as sa
+from alembic import context
+from lazy_object_proxy import Proxy
+
+######################################
+# Note about this module:
+#
+# It loads the specific type dynamically at runtime. For IDE/typing support
+# there is an associated db_types.pyi. If you add a new type in here, add a
+# simple version in there too.
+######################################
+
+
+def _mssql_use_date_time2():
+    conn = context.get_bind()
+    result = conn.execute(
+        """SELECT CASE WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion'))
+        like '8%' THEN '2000' WHEN CONVERT(VARCHAR(128), SERVERPROPERTY ('productversion'))
+        like '9%' THEN '2005' ELSE '2005Plus' END AS MajorVersion"""
+    ).fetchone()
+    mssql_version = result[0]
+    return mssql_version not in ("2000", "2005")
+
+
+MSSQL_USE_DATE_TIME2 = Proxy(_mssql_use_date_time2)
+
+
+def _mssql_TIMESTAMP():
+    from sqlalchemy.dialects import mssql
+
+    return mssql.DATETIME2(precision=6) if MSSQL_USE_DATE_TIME2 else mssql.DATETIME
+
+
+def _mysql_TIMESTAMP():
+    from sqlalchemy.dialects import mysql
+
+    return mysql.TIMESTAMP(fsp=6, timezone=True)
+
+
+def _sa_TIMESTAMP():
+    return sa.TIMESTAMP(timezone=True)
+
+
+def _sa_StringID():
+    from airflow.models.base import StringID
+
+    return StringID
+
+
+def __getattr__(name):
+    if name in ["TIMESTAMP", "StringID"]:
+        dialect = context.get_bind().dialect.name
+        module = globals()
+
+        # Lookup the type based on the dialect specific type, or fallback to the generic type
+        type_ = module.get(f'_{dialect}_{name}', None) or module.get(f'_sa_{name}')
+        val = module[name] = type_()
+        return val
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+if sys.version_info < (3, 7):
+    from pep562 import Pep562
+
+    Pep562(__name__)

--- a/airflow/migrations/db_types.pyi
+++ b/airflow/migrations/db_types.pyi
@@ -15,36 +15,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#
 
-"""add dag_stats table
-
-Revision ID: f2ca10b85618
-Revises: 64de9cddf6c9
-Create Date: 2016-07-20 15:08:28.247537
-
-"""
 import sqlalchemy as sa
-from alembic import op
 
-from airflow.migrations.db_types import StringID
+TIMESTAMP = sa.TIMESTAMP
+"""Database specific timestamp with timezone"""
 
-# revision identifiers, used by Alembic.
-revision = 'f2ca10b85618'
-down_revision = '64de9cddf6c9'
-branch_labels = None
-depends_on = None
+StringID = sa.String
+"""String column type with correct DB collation applied"""
 
-
-def upgrade():
-    op.create_table(
-        'dag_stats',
-        sa.Column('dag_id', StringID(), nullable=False),
-        sa.Column('state', sa.String(length=50), nullable=False),
-        sa.Column('count', sa.Integer(), nullable=False, default=0),
-        sa.Column('dirty', sa.Boolean(), nullable=False, default=False),
-        sa.PrimaryKeyConstraint('dag_id', 'state'),
-    )
-
-
-def downgrade():
-    op.drop_table('dag_stats')
+MSSQL_USE_DATE_TIME2: bool

--- a/airflow/migrations/versions/03afc6b6f902_increase_length_of_fab_ab_view_menu_.py
+++ b/airflow/migrations/versions/03afc6b6f902_increase_length_of_fab_ab_view_menu_.py
@@ -28,7 +28,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.engine.reflection import Inspector
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = '03afc6b6f902'
@@ -63,7 +63,7 @@ def upgrade():
             op.alter_column(
                 table_name='ab_view_menu',
                 column_name='name',
-                type_=sa.String(length=250, **COLLATION_ARGS),
+                type_=StringID(length=250),
                 nullable=False,
             )
 

--- a/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
+++ b/airflow/migrations/versions/1b38cef5b76e_add_dagrun.py
@@ -27,7 +27,7 @@ Create Date: 2015-10-27 08:31:48.475140
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = '1b38cef5b76e'
@@ -40,10 +40,10 @@ def upgrade():
     op.create_table(
         'dag_run',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+        sa.Column('dag_id', StringID(), nullable=True),
         sa.Column('execution_date', sa.DateTime(), nullable=True),
         sa.Column('state', sa.String(length=50), nullable=True),
-        sa.Column('run_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+        sa.Column('run_id', StringID(), nullable=True),
         sa.Column('external_trigger', sa.Boolean(), nullable=True),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('dag_id', 'execution_date'),

--- a/airflow/migrations/versions/3c20cacc0044_add_dagrun_run_type.py
+++ b/airflow/migrations/versions/3c20cacc0044_add_dagrun_run_type.py
@@ -31,7 +31,7 @@ from sqlalchemy import Boolean, Column, Integer, PickleType, String
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.models.base import ID_LEN
+from airflow.migrations.db_types import StringID
 from airflow.utils import timezone
 from airflow.utils.sqlalchemy import UtcDateTime
 from airflow.utils.state import State
@@ -55,12 +55,12 @@ class DagRun(Base):  # type: ignore
     __tablename__ = "dag_run"
 
     id = Column(Integer, primary_key=True)
-    dag_id = Column(String(ID_LEN))
+    dag_id = Column(StringID())
     execution_date = Column(UtcDateTime, default=timezone.utcnow)
     start_date = Column(UtcDateTime, default=timezone.utcnow)
     end_date = Column(UtcDateTime)
     _state = Column('state', String(50), default=State.RUNNING)
-    run_id = Column(String(ID_LEN))
+    run_id = Column(StringID())
     external_trigger = Column(Boolean, default=True)
     run_type = Column(String(50), nullable=False)
     conf = Column(PickleType)
@@ -96,7 +96,9 @@ def upgrade():
 
         # Make run_type not nullable
         with op.batch_alter_table("dag_run") as batch_op:
-            batch_op.alter_column("run_type", type_=run_type_col_type, nullable=False)
+            batch_op.alter_column(
+                "run_type", existing_type=run_type_col_type, type_=run_type_col_type, nullable=False
+            )
 
 
 def downgrade():

--- a/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
+++ b/airflow/migrations/versions/64de9cddf6c9_add_task_fails_journal_table.py
@@ -26,7 +26,7 @@ Create Date: 2016-08-03 14:02:59.203021
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = '64de9cddf6c9'
@@ -39,8 +39,8 @@ def upgrade():
     op.create_table(
         'task_fail',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('task_id', StringID(), nullable=False),
+        sa.Column('dag_id', StringID(), nullable=False),
         sa.Column('execution_date', sa.DateTime(), nullable=False),
         sa.Column('start_date', sa.DateTime(), nullable=True),
         sa.Column('end_date', sa.DateTime(), nullable=True),

--- a/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
+++ b/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
@@ -30,7 +30,7 @@ from alembic import op
 from sqlalchemy import Column, Float, Integer, PickleType, String
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 from airflow.utils.session import create_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
@@ -60,8 +60,8 @@ class TaskInstance(Base):  # type: ignore
 
     __tablename__ = "task_instance"
 
-    task_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
-    dag_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    task_id = Column(StringID(), primary_key=True)
+    dag_id = Column(StringID(), primary_key=True)
     execution_date = Column(UtcDateTime, primary_key=True)
     start_date = Column(UtcDateTime)
     end_date = Column(UtcDateTime)

--- a/airflow/migrations/versions/7939bcff74ba_add_dagtags_table.py
+++ b/airflow/migrations/versions/7939bcff74ba_add_dagtags_table.py
@@ -27,7 +27,7 @@ Create Date: 2020-01-07 19:39:01.247442
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = '7939bcff74ba'
@@ -41,7 +41,7 @@ def upgrade():
     op.create_table(
         'dag_tag',
         sa.Column('name', sa.String(length=100), nullable=False),
-        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('dag_id', StringID(), nullable=False),
         sa.ForeignKeyConstraint(
             ['dag_id'],
             ['dag.dag_id'],

--- a/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
+++ b/airflow/migrations/versions/852ae6c715af_add_rendered_task_instance_fields_table.py
@@ -27,7 +27,7 @@ Create Date: 2020-03-10 22:19:18.034961
 import sqlalchemy as sa
 from alembic import op
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = '852ae6c715af'
@@ -53,8 +53,8 @@ def upgrade():
 
     op.create_table(
         TABLE_NAME,
-        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-        sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('dag_id', StringID(), nullable=False),
+        sa.Column('task_id', StringID(), nullable=False),
         sa.Column('execution_date', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.Column('rendered_fields', json_type(), nullable=False),
         sa.PrimaryKeyConstraint('dag_id', 'task_id', 'execution_date'),

--- a/airflow/migrations/versions/8646922c8a04_change_default_pool_slots_to_1.py
+++ b/airflow/migrations/versions/8646922c8a04_change_default_pool_slots_to_1.py
@@ -30,7 +30,7 @@ from alembic import op
 from sqlalchemy import Column, Float, Integer, PickleType, String
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -41,7 +41,6 @@ depends_on = None
 
 Base = declarative_base()
 BATCH_SIZE = 5000
-ID_LEN = 250
 
 
 class TaskInstance(Base):  # type: ignore
@@ -49,8 +48,8 @@ class TaskInstance(Base):  # type: ignore
 
     __tablename__ = "task_instance"
 
-    task_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
-    dag_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    task_id = Column(StringID(), primary_key=True)
+    dag_id = Column(StringID(), primary_key=True)
     execution_date = Column(UtcDateTime, primary_key=True)
     start_date = Column(UtcDateTime)
     end_date = Column(UtcDateTime)
@@ -70,7 +69,7 @@ class TaskInstance(Base):  # type: ignore
     queued_by_job_id = Column(Integer)
     pid = Column(Integer)
     executor_config = Column(PickleType(pickler=dill))
-    external_executor_id = Column(String(ID_LEN, **COLLATION_ARGS))
+    external_executor_id = Column(StringID())
 
 
 def upgrade():

--- a/airflow/migrations/versions/97cdd93827b8_add_queued_at_column_to_dagrun_table.py
+++ b/airflow/migrations/versions/97cdd93827b8_add_queued_at_column_to_dagrun_table.py
@@ -26,7 +26,8 @@ Create Date: 2021-06-29 21:53:48.059438
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import mssql
+
+from airflow.migrations.db_types import TIMESTAMP
 
 # revision identifiers, used by Alembic.
 revision = '97cdd93827b8'
@@ -37,11 +38,7 @@ depends_on = None
 
 def upgrade():
     """Apply Add queued_at column to dagrun table"""
-    conn = op.get_bind()
-    if conn.dialect.name == "mssql":
-        op.add_column('dag_run', sa.Column('queued_at', mssql.DATETIME2(precision=6), nullable=True))
-    else:
-        op.add_column('dag_run', sa.Column('queued_at', sa.DateTime(), nullable=True))
+    op.add_column('dag_run', sa.Column('queued_at', TIMESTAMP, nullable=True))
 
 
 def downgrade():

--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -25,13 +25,13 @@ Create Date: 2017-06-19 16:53:12.851141
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import Column, Integer, String
+from sqlalchemy import Column, Integer
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow import settings
+from airflow.migrations.db_types import StringID
 from airflow.models import DagBag
-from airflow.models.base import COLLATION_ARGS
 
 # revision identifiers, used by Alembic.
 revision = 'cc1e65623dc7'
@@ -41,7 +41,6 @@ depends_on = None
 
 Base = declarative_base()
 BATCH_SIZE = 5000
-ID_LEN = 250
 
 
 class TaskInstance(Base):  # type: ignore
@@ -49,8 +48,8 @@ class TaskInstance(Base):  # type: ignore
 
     __tablename__ = "task_instance"
 
-    task_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
-    dag_id = Column(String(ID_LEN, **COLLATION_ARGS), primary_key=True)
+    task_id = Column(StringID(), primary_key=True)
+    dag_id = Column(StringID(), primary_key=True)
     execution_date = Column(sa.DateTime, primary_key=True)
     max_tries = Column(Integer)
     try_number = Column(Integer, default=0)

--- a/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
+++ b/airflow/migrations/versions/d38e04c12aa2_add_serialized_dag_table.py
@@ -27,7 +27,7 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import mysql
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = 'd38e04c12aa2'
@@ -51,7 +51,7 @@ def upgrade():
 
     op.create_table(
         'serialized_dag',
-        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+        sa.Column('dag_id', StringID(), nullable=False),
         sa.Column('fileloc', sa.String(length=2000), nullable=False),
         sa.Column('fileloc_hash', sa.Integer(), nullable=False),
         sa.Column('data', json_type(), nullable=False),

--- a/airflow/migrations/versions/e38be357a868_update_schema_for_smart_sensor.py
+++ b/airflow/migrations/versions/e38be357a868_update_schema_for_smart_sensor.py
@@ -26,28 +26,15 @@ Create Date: 2019-06-07 04:03:17.003939
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import func
-from sqlalchemy.dialects import mysql
 from sqlalchemy.engine.reflection import Inspector
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import TIMESTAMP, StringID
 
 # revision identifiers, used by Alembic.
 revision = 'e38be357a868'
 down_revision = '8d48763f6d53'
 branch_labels = None
 depends_on = None
-
-
-def mssql_timestamp():
-    return sa.DateTime()
-
-
-def mysql_timestamp():
-    return mysql.TIMESTAMP(fsp=6)
-
-
-def sa_timestamp():
-    return sa.TIMESTAMP(timezone=True)
 
 
 def upgrade():
@@ -58,30 +45,23 @@ def upgrade():
     if 'sensor_instance' in tables:
         return
 
-    if conn.dialect.name == 'mysql':
-        timestamp = mysql_timestamp
-    elif conn.dialect.name == 'mssql':
-        timestamp = mssql_timestamp
-    else:
-        timestamp = sa_timestamp
-
     op.create_table(
         'sensor_instance',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-        sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-        sa.Column('execution_date', timestamp(), nullable=False),
+        sa.Column('task_id', StringID(), nullable=False),
+        sa.Column('dag_id', StringID(), nullable=False),
+        sa.Column('execution_date', TIMESTAMP, nullable=False),
         sa.Column('state', sa.String(length=20), nullable=True),
         sa.Column('try_number', sa.Integer(), nullable=True),
-        sa.Column('start_date', timestamp(), nullable=True),
+        sa.Column('start_date', TIMESTAMP, nullable=True),
         sa.Column('operator', sa.String(length=1000), nullable=False),
         sa.Column('op_classpath', sa.String(length=1000), nullable=False),
         sa.Column('hashcode', sa.BigInteger(), nullable=False),
         sa.Column('shardcode', sa.Integer(), nullable=False),
         sa.Column('poke_context', sa.Text(), nullable=False),
         sa.Column('execution_context', sa.Text(), nullable=True),
-        sa.Column('created_at', timestamp(), default=func.now(), nullable=False),
-        sa.Column('updated_at', timestamp(), default=func.now(), nullable=False),
+        sa.Column('created_at', TIMESTAMP, default=func.now(), nullable=False),
+        sa.Column('updated_at', TIMESTAMP, default=func.now(), nullable=False),
         sa.PrimaryKeyConstraint('id'),
     )
     op.create_index('ti_primary_key', 'sensor_instance', ['dag_id', 'task_id', 'execution_date'], unique=True)

--- a/airflow/migrations/versions/e3a246e0dc1_current_schema.py
+++ b/airflow/migrations/versions/e3a246e0dc1_current_schema.py
@@ -29,7 +29,7 @@ from alembic import op
 from sqlalchemy import func
 from sqlalchemy.engine.reflection import Inspector
 
-from airflow.models.base import COLLATION_ARGS
+from airflow.migrations.db_types import StringID
 
 # revision identifiers, used by Alembic.
 revision = 'e3a246e0dc1'
@@ -47,7 +47,7 @@ def upgrade():
         op.create_table(
             'connection',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('conn_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+            sa.Column('conn_id', StringID(), nullable=True),
             sa.Column('conn_type', sa.String(length=500), nullable=True),
             sa.Column('host', sa.String(length=500), nullable=True),
             sa.Column('schema', sa.String(length=500), nullable=True),
@@ -60,7 +60,7 @@ def upgrade():
     if 'dag' not in tables:
         op.create_table(
             'dag',
-            sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+            sa.Column('dag_id', StringID(), nullable=False),
             sa.Column('is_paused', sa.Boolean(), nullable=True),
             sa.Column('is_subdag', sa.Boolean(), nullable=True),
             sa.Column('is_active', sa.Boolean(), nullable=True),
@@ -112,8 +112,8 @@ def upgrade():
             'log',
             sa.Column('id', sa.Integer(), nullable=False),
             sa.Column('dttm', sa.DateTime(), nullable=True),
-            sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
-            sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+            sa.Column('dag_id', StringID(), nullable=True),
+            sa.Column('task_id', StringID(), nullable=True),
             sa.Column('event', sa.String(length=30), nullable=True),
             sa.Column('execution_date', sa.DateTime(), nullable=True),
             sa.Column('owner', sa.String(length=500), nullable=True),
@@ -122,8 +122,8 @@ def upgrade():
     if 'sla_miss' not in tables:
         op.create_table(
             'sla_miss',
-            sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-            sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+            sa.Column('task_id', StringID(), nullable=False),
+            sa.Column('dag_id', StringID(), nullable=False),
             sa.Column('execution_date', sa.DateTime(), nullable=False),
             sa.Column('email_sent', sa.Boolean(), nullable=True),
             sa.Column('timestamp', sa.DateTime(), nullable=True),
@@ -134,7 +134,7 @@ def upgrade():
         op.create_table(
             'slot_pool',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('pool', sa.String(length=50, **COLLATION_ARGS), nullable=True),
+            sa.Column('pool', StringID(length=50), nullable=True),
             sa.Column('slots', sa.Integer(), nullable=True),
             sa.Column('description', sa.Text(), nullable=True),
             sa.PrimaryKeyConstraint('id'),
@@ -143,8 +143,8 @@ def upgrade():
     if 'task_instance' not in tables:
         op.create_table(
             'task_instance',
-            sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-            sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+            sa.Column('task_id', StringID(), nullable=False),
+            sa.Column('dag_id', StringID(), nullable=False),
             sa.Column('execution_date', sa.DateTime(), nullable=False),
             sa.Column('start_date', sa.DateTime(), nullable=True),
             sa.Column('end_date', sa.DateTime(), nullable=True),
@@ -169,7 +169,7 @@ def upgrade():
         op.create_table(
             'user',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('username', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+            sa.Column('username', StringID(), nullable=True),
             sa.Column('email', sa.String(length=500), nullable=True),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('username'),
@@ -178,7 +178,7 @@ def upgrade():
         op.create_table(
             'variable',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('key', sa.String(length=250, **COLLATION_ARGS), nullable=True),
+            sa.Column('key', StringID(), nullable=True),
             sa.Column('val', sa.Text(), nullable=True),
             sa.PrimaryKeyConstraint('id'),
             sa.UniqueConstraint('key'),
@@ -211,12 +211,12 @@ def upgrade():
         op.create_table(
             'xcom',
             sa.Column('id', sa.Integer(), nullable=False),
-            sa.Column('key', sa.String(length=512, **COLLATION_ARGS), nullable=True),
+            sa.Column('key', StringID(length=512), nullable=True),
             sa.Column('value', sa.PickleType(), nullable=True),
             sa.Column('timestamp', sa.DateTime(), default=func.now(), nullable=False),
             sa.Column('execution_date', sa.DateTime(), nullable=False),
-            sa.Column('task_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
-            sa.Column('dag_id', sa.String(length=250, **COLLATION_ARGS), nullable=False),
+            sa.Column('task_id', StringID(), nullable=False),
+            sa.Column('dag_id', StringID(), nullable=False),
             sa.PrimaryKeyConstraint('id'),
         )
 

--- a/airflow/models/base.py
+++ b/airflow/models/base.py
@@ -16,9 +16,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any
+import functools
+from typing import Any, Type
 
-from sqlalchemy import MetaData
+from sqlalchemy import MetaData, String
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow.configuration import conf
@@ -61,3 +62,5 @@ def get_id_collation_args():
 
 
 COLLATION_ARGS = get_id_collation_args()
+
+StringID: Type[String] = functools.partial(String, length=ID_LEN, **COLLATION_ARGS)


### PR DESCRIPTION
We have various flavours of the code all over the place in many
migration files -- which leads to duplication and things not being in
sync.

This pulls them once in to a central location.

I had to make a slight change to the DB test to ensure that the migrations are evaluted/loaded with an active Alembic context given the changed way of detecting the current engine type in db_types.