### PR TITLE
Fix field relabeling when switching between conn types

### DIFF
--- a/airflow/www/static/js/connection_form.js
+++ b/airflow/www/static/js/connection_form.js
@@ -67,7 +67,7 @@ function getControlsContainer() {
    * well-known state during the change of connection types.
    */
 function restoreFieldBehaviours() {
-  Array.from(document.querySelectorAll('label[data-origText]')).forEach((elem) => {
+  Array.from(document.querySelectorAll('label[data-orig-text]')).forEach((elem) => {
     elem.innerText = elem.dataset.origText;
     delete elem.dataset.origText;
   });


### PR DESCRIPTION
Closes: #19386

The `restoreFieldBehaviours()` function was querying for the incorrect `label` attribute when attempting to relabel fields in the Connection form when switching between Conn Types. This PR corrects the `label` attribute name to be queried.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
