### PR TITLE
Update Databricks API from 2.0 to 2.1

### DIFF
--- a/airflow/providers/databricks/CHANGELOG.rst
+++ b/airflow/providers/databricks/CHANGELOG.rst
@@ -19,6 +19,13 @@
 Changelog
 ---------
 
+2.0.3
+.....
+
+Misc
+~~~~
+   * ``Update API version from 2.0 to 2.1``
+
 2.0.2
 .....
 

--- a/airflow/providers/databricks/CHANGELOG.rst
+++ b/airflow/providers/databricks/CHANGELOG.rst
@@ -19,13 +19,6 @@
 Changelog
 ---------
 
-2.0.3
-.....
-
-Misc
-~~~~
-   * ``Update API version from 2.0 to 2.1``
-
 2.0.2
 .....
 

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -34,7 +34,6 @@ from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
-
 RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.1/clusters/restart")
 START_CLUSTER_ENDPOINT = ("POST", "api/2.1/clusters/start")
 TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.1/clusters/delete")

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -33,18 +33,18 @@ from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.hooks.base import BaseHook
 
-RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/restart")
-START_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/start")
-TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.0/clusters/delete")
+RESTART_CLUSTER_ENDPOINT = ("POST", "api/2.1/clusters/restart")
+START_CLUSTER_ENDPOINT = ("POST", "api/2.1/clusters/start")
+TERMINATE_CLUSTER_ENDPOINT = ("POST", "api/2.1/clusters/delete")
 
-RUN_NOW_ENDPOINT = ('POST', 'api/2.0/jobs/run-now')
-SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/submit')
-GET_RUN_ENDPOINT = ('GET', 'api/2.0/jobs/runs/get')
-CANCEL_RUN_ENDPOINT = ('POST', 'api/2.0/jobs/runs/cancel')
+RUN_NOW_ENDPOINT = ('POST', 'api/2.1/jobs/run-now')
+SUBMIT_RUN_ENDPOINT = ('POST', 'api/2.1/jobs/runs/submit')
+GET_RUN_ENDPOINT = ('GET', 'api/2.1/jobs/runs/get')
+CANCEL_RUN_ENDPOINT = ('POST', 'api/2.1/jobs/runs/cancel')
 USER_AGENT_HEADER = {'user-agent': f'airflow-{__version__}'}
 
-INSTALL_LIBS_ENDPOINT = ('POST', 'api/2.0/libraries/install')
-UNINSTALL_LIBS_ENDPOINT = ('POST', 'api/2.0/libraries/uninstall')
+INSTALL_LIBS_ENDPOINT = ('POST', 'api/2.1/libraries/install')
+UNINSTALL_LIBS_ENDPOINT = ('POST', 'api/2.1/libraries/uninstall')
 
 
 class RunState:

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -66,63 +66,63 @@ def run_now_endpoint(host):
     """
     Utility function to generate the run now endpoint given the host.
     """
-    return f'https://{host}/api/2.0/jobs/run-now'
+    return f'https://{host}/api/2.1/jobs/run-now'
 
 
 def submit_run_endpoint(host):
     """
     Utility function to generate the submit run endpoint given the host.
     """
-    return f'https://{host}/api/2.0/jobs/runs/submit'
+    return f'https://{host}/api/2.1/jobs/runs/submit'
 
 
 def get_run_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
     """
-    return f'https://{host}/api/2.0/jobs/runs/get'
+    return f'https://{host}/api/2.1/jobs/runs/get'
 
 
 def cancel_run_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
     """
-    return f'https://{host}/api/2.0/jobs/runs/cancel'
+    return f'https://{host}/api/2.1/jobs/runs/cancel'
 
 
 def start_cluster_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
     """
-    return f'https://{host}/api/2.0/clusters/start'
+    return f'https://{host}/api/2.1/clusters/start'
 
 
 def restart_cluster_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
     """
-    return f'https://{host}/api/2.0/clusters/restart'
+    return f'https://{host}/api/2.1/clusters/restart'
 
 
 def terminate_cluster_endpoint(host):
     """
     Utility function to generate the get run endpoint given the host.
     """
-    return f'https://{host}/api/2.0/clusters/delete'
+    return f'https://{host}/api/2.1/clusters/delete'
 
 
 def install_endpoint(host):
     """
     Utility function to generate the install endpoint given the host.
     """
-    return f'https://{host}/api/2.0/libraries/install'
+    return f'https://{host}/api/2.1/libraries/install'
 
 
 def uninstall_endpoint(host):
     """
     Utility function to generate the uninstall endpoint given the host.
     """
-    return f'https://{host}/api/2.0/libraries/uninstall'
+    return f'https://{host}/api/2.1/libraries/uninstall'
 
 
 def create_valid_response_mock(content):
@@ -256,7 +256,7 @@ class TestDatabricksHook(unittest.TestCase):
     def test_do_api_call_patch(self, mock_requests):
         mock_requests.patch.return_value.json.return_value = {'cluster_name': 'new_name'}
         data = {'cluster_name': 'new_name'}
-        patched_cluster_name = self.hook._do_api_call(('PATCH', 'api/2.0/jobs/runs/submit'), data)
+        patched_cluster_name = self.hook._do_api_call(('PATCH', 'api/2.1/jobs/runs/submit'), data)
 
         assert patched_cluster_name['cluster_name'] == 'new_name'
         mock_requests.patch.assert_called_once_with(


### PR DESCRIPTION
This PR updates the Databricks API version from 2.0 to 2.1. Of the nine available endpoints in the DatabricksHook, these seven are not in use and do not map to any operators.

```
[NOT IN USE] api/2.1/clusters/restart => None
[NOT IN USE] api/2.1/clusters/start => None
[NOT IN USE] api/2.1/clusters/delete => None
[NOT IN USE] api/2.1/jobs/runs/get => None
[NOT IN USE] api/2.1/jobs/runs/cancel => None
[NOT IN USE] api/2.1/libraries/install => None
[NOT IN USE] api/2.1/libraries/uninstall => None
```

The remaining two endpoints map to a single operator each and the request structure is either unchanged or compatible when moving from version 2.0 to 2.1 according to this doc https://docs.databricks.com/data-engineering/jobs/jobs-api-updates.html#api-client-guide

```
[COMPATIABLE] api/2.1/jobs/runs/submit => DatabricksSubmitRunOperator
[UNCHANGED] api/2.1/jobs/run-now  => DatabricksRunNowOperator
```