### PR TITLE
Handle more patterns in `restrict-start_date` pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -459,7 +459,7 @@ repos:
       - id: restrict-start_date
         language: pygrep
         name: "'start_date' should not be defined in default_args in example_dags"
-        entry: "default_args\\s*=\\s*{\\s*(\"|')start_date(\"|')|(\"|')start_date(\"|'):"
+        entry: "default_args\\s*=\\s*(({|dict\\()+|.+,+)\\s*(\"|')*start_date(=|\"|')*\\s*(:|=)"
         files: \.*example_dags.*\.py$
         exclude: ^airflow/_vendor/
         pass_filenames: true


### PR DESCRIPTION
The current `restrict-start_date` does not catch defining `start_date` in `default_args` of example DAGs like `default_args=dict(start_date=dates.days_ago(1))` as seen in the Google provider.

This PR updates the pre-commit hook's regex to catch patterns like the above and others.

For example, the new regex will capture:
- `default_args=dict(owner=airflow, retries=1, start_date=`
- `default_args=dict( owner: airflow, start_date =:`
- `default_args={'owner': 'airflow', 'start_date' :`
- `default_args={'owner': 'airflow','retries': 1, 'start_date':`
- `default_args=dict(owner= "airflow", start_date=`
- `default_args=dict( owner= "airflow",start_date:`
- `default_args={'owner': 'airflow','start_date' :`
- `default_args=dict(start_date=dates.days_ago(1)),`
- `default_args=dict( start_date=dates.days_ago(1)),`
- `default_args=dict(start_date =dates.days_ago(1)),`
- `default_args=dict( start_date =dates.days_ago(1)),`
- `default_args={'start_date':`
- `default_args = {'start_date':`
- `default_args={ 'start_date':`
- `default_args = { 'start_date':`
- `default_args={"start_date":`
- `default_args = {"start_date":`
- `default_args={ "start_date":`
- `default_args = { "start_date":`
- `default_args={'start_date' :`
- `default_args = {'start_date' :`
- `default_args={ 'start_date' :`
- `default_args = { 'start_date' :`
- `default_args={ "start_date" :`
- `default_args = { "start_date" :`

But **not** these patterns (as expected):
- `default_args=dict('owner': 'airflow', _start_date=`
- `default_args=dict( 'owner': 'airflow', my_start_date=`
- `default_args=dict(owner='airflow', my_start_date=`
- `default_args=dict( 'owner': 'airflow', my_start_date=`
- `default_args={'owner': 'airflow', my_start_date=`
- `default_args={"start_date " :`
- `default_args = {"start_date " :`
- `default_args={'my_start_date':`
- `default_args = {'ystart_date':`
- `default_args={ '_start_date':`
- `default_args = { 'oistart_date':`
- `default_args = {"estart_date":`
- `default_args={ ",start_dates":`
- `default_args = { "|start_date":`
- `default_args={' start_dates' :`
- `default_args = {'67start_date' :`
- `default_args={" start_date" :`
- `default_args = {" start_date" :`
- `default_args={ "start_datee" :`
- `default_args = { "start_date " :`

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
