### PR TITLE
Fix DruidOperator rendering problem

### DIFF
--- a/airflow/providers/apache/druid/operators/druid.py
+++ b/airflow/providers/apache/druid/operators/druid.py
@@ -37,6 +37,7 @@ class DruidOperator(BaseOperator):
 
     template_fields = ('json_index_file',)
     template_ext = ('.json',)
+    template_fields_renderers = {'json_index_file': 'json'}
 
     def __init__(
         self,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In airflow 2.2.0, `DruidOperator` can not render `json_index_file` field properly  at "rendered templates" page.

![image](https://user-images.githubusercontent.com/8676247/140459134-26bba895-faf4-422a-bf2a-fad4c01d34d7.png)

So I specify `template_fields_renderers` field to prettify `json_index_file` field.
![image](https://user-images.githubusercontent.com/8676247/140459606-e3a5cd38-d759-41a8-abaa-8a079f5bee95.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
