### PR TITLE
Databricks Provider: Allow authentication via Azure Service Principals 

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -171,8 +171,10 @@ class DatabricksHook(BaseHook):
         :param tenant_id: The ID of the azure tenant the applications ia located in
         """
         if not tenant_id:
-            raise AirflowException("tenant_id has to be supplied as a connection extra when using azure service "
-                                   "principals as authentication method.")
+            raise AirflowException(
+                "tenant_id has to be supplied as a connection extra when using azure service "
+                "principals as authentication method."
+            )
         attempt_num = 1
         while True:
             try:
@@ -182,7 +184,7 @@ class DatabricksHook(BaseHook):
                         "grant_type": "client_credentials",
                         "client_id": client_id,
                         "resource": AZURE_AUTHENTICATION_RESOURCE,
-                        "client_secret": client_secret
+                        "client_secret": client_secret,
                     },
                     headers=USER_AGENT_HEADER,
                     timeout=self.timeout_seconds,
@@ -233,9 +235,11 @@ class DatabricksHook(BaseHook):
 
         elif self._get_bool(self.databricks_conn.extra_dejson.get('use_azure_service_principal', 'False')):
             self.log.info('Using azure service principal auth. ')
-            token = self._token_from_azure_service_principal(self.databricks_conn.login,
-                                                             self.databricks_conn.password,
-                                                             self.databricks_conn.extra_dejson.get('tenant_id'))
+            token = self._token_from_azure_service_principal(
+                self.databricks_conn.login,
+                self.databricks_conn.password,
+                self.databricks_conn.extra_dejson.get('tenant_id'),
+            )
             auth = _TokenAuth(token)
         else:
             self.log.info('Using basic auth. ')

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -27,13 +27,18 @@ The Databricks connection type enables the Databricks Integration.
 Authenticating to Databricks
 ----------------------------
 
-There are two ways to connect to Databricks using Airflow.
+There are three ways to connect to Databricks using Airflow.
 
 1. Use a `Personal Access Token (PAT)
    <https://docs.databricks.com/dev-tools/api/latest/authentication.html>`_
    i.e. add a token to the Airflow connection. This is the recommended method.
 2. Use Databricks login credentials
    i.e. add the username and password used to login to the Databricks account to the Airflow connection.
+3. Use a `service principal
+   <https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/aad/service-prin-aad-token>`_
+   on Azure Databricks
+   i.e. add the Client ID as username, the application secret as password to the Airflow connection and set
+   ``use_azure_service_principal`` as well as ``tenant_id`` in the connection extras of the connection.
 
 
 Default Connection IDs
@@ -60,6 +65,10 @@ Extra (optional)
     This parameter is necessary if using the *PAT* authentication method (recommended):
 
     * ``token``: Specify PAT to use.
+    * ``use_azure_service_principal``: Set to ``false`` if login and password are an azure client id and
+      client secret.
+    * ``tenant_id``: Specify the id of the tenant the azure service principal is defined in. Only used and required
+      if ``use_azure_service_principal`` is set to true.
 
 When specifying the connection using an environment variable you should specify
 it using URI syntax.

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -65,8 +65,8 @@ Extra (optional)
     This parameter is necessary if using the *PAT* authentication method (recommended):
 
     * ``token``: Specify PAT to use.
-    * ``use_azure_service_principal``: Set to ``false`` if login and password are an azure client id and
-      client secret.
+    * ``use_azure_service_principal``: Set to ``True`` if login and password are an azure client id and
+      client secret. Defaults to ``False``
     * ``tenant_id``: Specify the id of the tenant the azure service principal is defined in. Only used and required
       if ``use_azure_service_principal`` is set to true.
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -28,12 +28,12 @@ from requests import exceptions as requests_exceptions
 from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
-from airflow.providers.databricks.hooks.databricks import ( 
-    AZURE_AUTHENTICATION_ENDPOINT, 
+from airflow.providers.databricks.hooks.databricks import (
+    AZURE_AUTHENTICATION_ENDPOINT,
     AZURE_AUTHENTICATION_RESOURCE,
     AZURE_LOGIN_URL,
-    SUBMIT_RUN_ENDPOINT, 
-    DatabricksHook, 
+    SUBMIT_RUN_ENDPOINT,
+    DatabricksHook,
     RunState,
 )
 from airflow.utils.session import provide_session
@@ -639,7 +639,6 @@ class TestDatabricksAzureServicePrincipal(unittest.TestCase):
     @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
     def test_token_from_azure_service_principal(self, mock_requests):
         mock_requests.post.return_value = create_valid_response_mock({'access_token': TOKEN})
-        data = {'cluster_name': 'new_name'}
         patched_cluster_name = self.hook._token_from_azure_service_principal(LOGIN, PASSWORD, TENANT_ID)
 
         assert patched_cluster_name == TOKEN
@@ -654,7 +653,6 @@ class TestDatabricksAzureServicePrincipal(unittest.TestCase):
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds,
         )
-
 
 
 class TestRunState(unittest.TestCase):

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -28,8 +28,14 @@ from requests import exceptions as requests_exceptions
 from airflow import __version__
 from airflow.exceptions import AirflowException
 from airflow.models import Connection
-from airflow.providers.databricks.hooks.databricks import SUBMIT_RUN_ENDPOINT, DatabricksHook, RunState, \
-    AZURE_LOGIN_URL, AZURE_AUTHENTICATION_ENDPOINT, AZURE_AUTHENTICATION_RESOURCE
+from airflow.providers.databricks.hooks.databricks import ( 
+    AZURE_AUTHENTICATION_ENDPOINT, 
+    AZURE_AUTHENTICATION_RESOURCE,
+    AZURE_LOGIN_URL,
+    SUBMIT_RUN_ENDPOINT, 
+    DatabricksHook, 
+    RunState,
+)
 from airflow.utils.session import provide_session
 
 TASK_ID = 'databricks-operator'
@@ -524,12 +530,11 @@ class TestDatabricksHookTokenWhenNoHostIsProvidedInExtra(TestDatabricksHookToken
         self.hook = DatabricksHook()
 
 
-
-
 class TestDatabricksAzureServicePrincipal(unittest.TestCase):
     """
     Tests for DatabricksHook when auth is done via Azure Service Principal.
     """
+
     @provide_session
     def setUp(self, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
@@ -551,7 +556,7 @@ class TestDatabricksAzureServicePrincipal(unittest.TestCase):
         with mock.patch.object(self.hook, "_token_from_azure_service_principal") as mock_sp:
             mock_sp.return_value = TOKEN
             run_id = self.hook.submit_run(data)
-            
+
             mock_sp.assert_called_once_with(LOGIN, PASSWORD, TENANT_ID)
 
         assert run_id == '1'
@@ -644,7 +649,7 @@ class TestDatabricksAzureServicePrincipal(unittest.TestCase):
                 "grant_type": "client_credentials",
                 "client_id": LOGIN,
                 "resource": AZURE_AUTHENTICATION_RESOURCE,
-                "client_secret": PASSWORD
+                "client_secret": PASSWORD,
             },
             headers=USER_AGENT_HEADER,
             timeout=self.hook.timeout_seconds,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Currently, the databricks provider does allow authentication either via Personal Access Tokens or with plain user / password combinations. On Azure Databricks, both authentication methods are only available for human users, but not for service principals.

This PR adds the possibility to use service principal based authentication by first calling the Microsoft authentication API and requesting a short-lived login token for the service principal.

The documentation of the added login method is provided as well. 

