### PR TITLE
Change the name of link to ASF downloads

### DIFF
--- a/docs/apache-airflow/installation/index.rst
+++ b/docs/apache-airflow/installation/index.rst
@@ -62,7 +62,7 @@ More details: :doc:`installing-from-sources`
 
 * This option is best if you expect to build all your software from sources.
 * Apache Airflow is one of the projects that belong to the `Apache Software Foundation <https://www.apache.org/>`__ .
-  It is a requirement for all ASF projects that they can be installed using official sources released via `Official Apache Mirrors <http://ws.apache.org/mirrors.cgi/>`__ .
+  It is a requirement for all ASF projects that they can be installed using official sources released via `Official Apache Downloads <http://ws.apache.org/mirrors.cgi/>`__ .
 * This is the best choice if you have a strong need to `verify the integrity and provenance of the software <https://www.apache.org/dyn/closer.cgi#verify>`__
 
 **Intended users**

--- a/docs/apache-airflow/installation/installing-from-sources.rst
+++ b/docs/apache-airflow/installation/installing-from-sources.rst
@@ -32,7 +32,7 @@ Released packages
 The ``source``, ``sdist`` and ``whl`` packages released are the "official" sources of installation that you
 can use if you want to verify the origin of the packages and want to verify checksums and signatures of
 the packages. The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`_
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 
 The |version| downloads are available at:

--- a/docs/helm-chart/installing-helm-chart-from-sources.rst
+++ b/docs/helm-chart/installing-helm-chart-from-sources.rst
@@ -34,7 +34,7 @@ Released packages
 The sources and packages released are the "official" sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`_
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`_
 
 The downloads are available at:
 

--- a/docs/installing-providers-from-sources.rst
+++ b/docs/installing-providers-from-sources.rst
@@ -34,7 +34,7 @@ Released packages
 The ``sdist`` and ``whl`` packages released are the "official" sources of installation that you can use if
 you want to verify the origin of the packages and want to verify checksums and signatures of the packages.
 The packages are available via the
-`Official Apache Software Foundations Mirrors <http://ws.apache.org/mirrors.cgi>`__
+`Official Apache Software Foundations Downloads <http://ws.apache.org/mirrors.cgi>`__
 
 The downloads are available at:
 


### PR DESCRIPTION
The ASF used to use mirrors to distribute their software, however
recently they changed to use CDN. The mechanism might change in
the future (even if currently CDN is used the ASF 'mirrors' page
and closer.lua script provide a fully ASF-controlled mechanism to
switch to the right mechanism, however technically speaking the
current solution is not 'mirrors' but it is CDN, therefore it makes
sense to rename it to generic downloads.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
