### PR TITLE
Update Databricks operators to match latest version of API 2.0

### DIFF
--- a/docs/apache-airflow-providers-databricks/operators.rst
+++ b/docs/apache-airflow-providers-databricks/operators.rst
@@ -19,11 +19,12 @@
 
 .. _howto/operator:DatabricksSubmitRunOperator:
 
+
 DatabricksSubmitRunOperator
 ===========================
 
 Use the :class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` to submit
-an existing Spark job run to Databricks api/2.0/jobs/runs/submit <https://docs.databricks.com/api/latest/jobs.html#runs-submit> API endpoint.
+a new Databricks job via Databricks `api/2.0/jobs/runs/submit <https://docs.databricks.com/api/latest/jobs.html#runs-submit>`_ API endpoint.
 
 
 Using the Operator
@@ -42,13 +43,15 @@ one named parameter for each top level parameter in the ``runs/submit`` endpoint
    * - Parameter
      - Input
    * - spark_jar_task: dict
-     - main class and parameters for the JAR task
+     - `main class and parameters for the JAR task <https://docs.databricks.com/dev-tools/api/2.0/jobs.html#jobssparkjartask>`_
    * - notebook_task: dict
-     - notebook path and parameters for the task
+     - `notebook path and parameters for the task <https://docs.databricks.com/dev-tools/api/2.0/jobs.html#jobsnotebooktask>`_
    * - spark_python_task: dict
-     - python file path and parameters to run the python file with
+     - `python file path and parameters to run the python file with <https://docs.databricks.com/dev-tools/api/2.0/jobs.html#jobssparkpythontask>`_
    * - spark_submit_task: dict
-     - parameters needed to run a spark-submit command
+     - `parameters needed to run a spark-submit command <https://docs.databricks.com/dev-tools/api/2.0/jobs.html#jobssparksubmittask>`_
+   * - pipeline_task: dict
+     - `parameters needed to run a Delta Live Tables pipeline <https://docs.databricks.com/dev-tools/api/2.0/jobs.html#jobspipelinetask>`_
    * - new_cluster: dict
      - specs for a new cluster on which this task will be run
    * - existing_cluster_id: string
@@ -83,3 +86,49 @@ You can also use named parameters to initialize the operator and run the job.
     :language: python
     :start-after: [START howto_operator_databricks_named]
     :end-before: [END howto_operator_databricks_named]
+
+
+DatabricksRunNowOperator
+===========================
+
+Use the :class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` to trigger run of existing Databricks job
+via `api/2.0/jobs/runs/run-now <https://docs.databricks.com/dev-tools/api/2.0/jobs.html#run-now>`_ API endpoint.
+
+
+Using the Operator
+^^^^^^^^^^^^^^^^^^
+
+There are two ways to instantiate this operator. In the first way, you can take the JSON payload that you typically use
+to call the ``api/2.0/jobs/run-now`` endpoint and pass it directly to our ``DatabricksRunNowOperator`` through the ``json`` parameter.
+
+Another way to accomplish the same thing is to use the named parameters of the ``DatabricksRunNowOperator`` directly.
+Note that there is exactly one named parameter for each top level parameter in the ``jobs/run-now`` endpoint.
+
+.. list-table:: Databricks Airflow Connection Metadata
+   :widths: 15 25
+   :header-rows: 1
+
+   * - Parameter
+     - Input
+   * - job_id: str
+     - ID of the existing Databricks jobs (required)
+   * - jar_params: list[str]
+     - A list of parameters for jobs with JAR tasks, e.g. ``"jar_params": ["john doe", "35"]``. The parameters will be passed to JAR file as command line parameters. If specified upon run-now, it would        overwrite the parameters specified in job setting. The json representation of this field (i.e. ``{"jar_params":["john doe","35"]}``) cannot exceed 10,000 bytes. This field will be templated.
+   * - notebook_params: dict[str,str]
+     - A dict from keys to values for jobs with notebook task, e.g.``"notebook_params": {"name": "john doe", "age":  "35"}```. The map is passed to the notebook and will be accessible through the ``dbutils.widgets.get function``. See `Widgets <https://docs.databricks.com/notebooks/widgets.html>`_ for more information. If not specified upon run-now, the triggered run will use the job’s base parameters. ``notebook_params`` cannot be specified in conjunction with ``jar_params``. The json representation of this field (i.e. ``{"notebook_params":{"name":"john doe","age":"35"}}``) cannot exceed 10,000 bytes. This field will be templated.
+   * - python_params: list[str]
+     - A list of parameters for jobs with python tasks, e.g. ``"python_params": ["john doe", "35"]``. The parameters will be passed to python file as command line parameters. If specified upon run-now, it would overwrite the parameters specified in job setting. The json representation of this field (i.e. ``{"python_params":["john doe","35"]}``) cannot exceed 10,000 bytes. This field will be templated.
+   * - spark_submit_params: list[str]
+     - A list of parameters for jobs with spark submit task,  e.g. ``"spark_submit_params": ["--class", "org.apache.spark.examples.SparkPi"]``. The parameters will be passed to spark-submit script as command line parameters. If specified upon run-now, it would overwrite the parameters specified in job setting. The json representation of this field cannot exceed 10,000 bytes. This field will be templated.
+   * - timeout_seconds: int
+     - The timeout for this run. By default a value of 0 is used  which means to have no timeout. This field will be templated.
+   * - databricks_conn_id: string
+     - the name of the Airflow connection to use
+   * - polling_period_seconds: integer
+     - controls the rate which we poll for the result of this run
+   * - databricks_retry_limit: integer
+     - amount of times retry if the Databricks backend is unreachable
+   * - databricks_retry_delay: decimal
+     - number of seconds to wait between retries
+   * - do_xcom_push: boolean
+     - whether we should push run_id and run_page_url to xcom

--- a/tests/providers/databricks/operators/test_databricks.py
+++ b/tests/providers/databricks/operators/test_databricks.py
@@ -46,7 +46,7 @@ NEW_CLUSTER = {'spark_version': '2.0.x-scala2.10', 'node_type_id': 'development-
 EXISTING_CLUSTER_ID = 'existing-cluster-id'
 RUN_NAME = 'run-name'
 RUN_ID = 1
-JOB_ID = 42
+JOB_ID = "42"
 NOTEBOOK_PARAMS = {"dry-run": "true", "oldest-time-to-consider": "1457570074236"}
 JAR_PARAMS = ["param1", "param2"]
 RENDERED_TEMPLATED_JAR_PARAMS = [f'/test-{DATE}']
@@ -134,6 +134,18 @@ class TestDatabricksSubmitRunOperator(unittest.TestCase):
         op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
         expected = databricks_operator._deep_string_coerce(
             {'new_cluster': NEW_CLUSTER, 'notebook_task': NOTEBOOK_TASK, 'run_name': RUN_NAME}
+        )
+        assert expected == op.json
+
+    def test_pipeline_task(self):
+        """
+        Test the initializer with a specified run_name.
+        """
+        pipeline_task = {"pipeline_id": "test-dlt"}
+        json = {'new_cluster': NEW_CLUSTER, 'run_name': RUN_NAME, "pipeline_task": pipeline_task}
+        op = DatabricksSubmitRunOperator(task_id=TASK_ID, json=json)
+        expected = databricks_operator._deep_string_coerce(
+            {'new_cluster': NEW_CLUSTER, "pipeline_task": pipeline_task, 'run_name': RUN_NAME}
         )
         assert expected == op.json
 
@@ -301,7 +313,8 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
         provided. The named parameters should override top level keys in the
         json dict.
         """
-        override_notebook_params = {'workers': 999}
+        override_notebook_params = {'workers': "999"}
+        override_jar_params = ['workers', "998"]
         json = {'notebook_params': NOTEBOOK_PARAMS, 'jar_params': JAR_PARAMS}
 
         op = DatabricksRunNowOperator(
@@ -310,13 +323,14 @@ class TestDatabricksRunNowOperator(unittest.TestCase):
             job_id=JOB_ID,
             notebook_params=override_notebook_params,
             python_params=PYTHON_PARAMS,
+            jar_params=override_jar_params,
             spark_submit_params=SPARK_SUBMIT_PARAMS,
         )
 
         expected = databricks_operator._deep_string_coerce(
             {
                 'notebook_params': override_notebook_params,
-                'jar_params': JAR_PARAMS,
+                'jar_params': override_jar_params,
                 'python_params': PYTHON_PARAMS,
                 'spark_submit_params': SPARK_SUBMIT_PARAMS,
                 'job_id': JOB_ID,


### PR DESCRIPTION
This includes:
- added support for `jar_params` in the `DatabricksRunNowOperator`
- added support for `pipeline_task` in the `DatabricksSubmitRunOperator`

Also, added documentation for `DatabricksRunNowOperator`

closes: #10786