### PR TITLE
#16691 Providing more information in docs for DataprocCreateCluster operator migration

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1899,6 +1899,8 @@ create_cluster = DataprocClusterCreateOperator(
 After upgrading to **v2.x.x** and using **CLUSTER_CONFIG**, it will look like followed:
 
 ```python
+path = f"gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
+
 CLUSTER_CONFIG = ClusterGenerator(
                     project_id="test",
                     zone="us-central1-a",

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1868,6 +1868,60 @@ https://cloud.google.com/compute/docs/disks/performance
 
 Hence, the default value for `master_disk_size` in `DataprocCreateClusterOperator` has been changed from 500GB to 1TB.
 
+##### Generating Cluster Config
+If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG**,
+You can easily generate config using **make()** of `airflow.providers.google.cloud.operators.dataproc.ClusterGenerator`
+
+this is been proved specially useful if you are using **metadata** argument from older API, refer [AIRFLOW-16911](https://github.com/apache/airflow/issues/16911) for details.
+
+eg. your cluster creation may look like this in **v1.10.x**
+
+```python
+path = f"gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
+
+create_cluster = DataprocClusterCreateOperator(
+                      task_id='create_dataproc_cluster',
+                      cluster_name="test",
+                      project_id="test",
+                      zone="us-central1-a",
+                      region="us-central1",
+                      master_machine_type="n1-standard-4",
+                      worker_machine_type="n1-standard-4",
+                      num_workers=2,
+                      storage_bucket="test_bucket",
+                      init_actions_uris=[
+                        path
+                      ],
+                      metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
+)
+```
+
+After upgrading to **v2.x.x** and using **CLUSTER_CONFIG**, it will look like followed:
+
+```python
+CLUSTER_CONFIG = ClusterGenerator(
+                    project_id="test",
+                    zone="us-central1-a",
+                    master_machine_type="n1-standard-4",
+                    worker_machine_type="n1-standard-4",
+                    num_workers=2,
+                    storage_bucket="test",
+                    init_actions_uris=[
+                        path
+                    ],
+                    metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
+                ).make()
+
+create_cluster_operator = DataprocClusterCreateOperator(
+                    task_id='create_dataproc_cluster',
+                    cluster_name="test",
+                    project_id="test",
+                    region="us-central1",
+                    cluster_config=CLUSTER_CONFIG,
+                )
+
+```
+
 #### `airflow.providers.google.cloud.operators.bigquery.BigQueryGetDatasetTablesOperator`
 
 We changed signature of `BigQueryGetDatasetTablesOperator`.

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -1869,10 +1869,11 @@ https://cloud.google.com/compute/docs/disks/performance
 Hence, the default value for `master_disk_size` in `DataprocCreateClusterOperator` has been changed from 500GB to 1TB.
 
 ##### Generating Cluster Config
+
 If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG**,
 You can easily generate config using **make()** of `airflow.providers.google.cloud.operators.dataproc.ClusterGenerator`
 
-this is been proved specially useful if you are using **metadata** argument from older API, refer [AIRFLOW-16911](https://github.com/apache/airflow/issues/16911) for details.
+This has been proved specially useful if you are using **metadata** argument from older API, refer [AIRFLOW-16911](https://github.com/apache/airflow/issues/16911) for details.
 
 eg. your cluster creation may look like this in **v1.10.x**
 
@@ -1880,19 +1881,17 @@ eg. your cluster creation may look like this in **v1.10.x**
 path = f"gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
 
 create_cluster = DataprocClusterCreateOperator(
-                      task_id='create_dataproc_cluster',
-                      cluster_name="test",
-                      project_id="test",
-                      zone="us-central1-a",
-                      region="us-central1",
-                      master_machine_type="n1-standard-4",
-                      worker_machine_type="n1-standard-4",
-                      num_workers=2,
-                      storage_bucket="test_bucket",
-                      init_actions_uris=[
-                        path
-                      ],
-                      metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
+    task_id="create_dataproc_cluster",
+    cluster_name="test",
+    project_id="test",
+    zone="us-central1-a",
+    region="us-central1",
+    master_machine_type="n1-standard-4",
+    worker_machine_type="n1-standard-4",
+    num_workers=2,
+    storage_bucket="test_bucket",
+    init_actions_uris=[path],
+    metadata={"PIP_PACKAGES": "pyyaml requests pandas openpyxl"},
 )
 ```
 
@@ -1902,26 +1901,23 @@ After upgrading to **v2.x.x** and using **CLUSTER_CONFIG**, it will look like fo
 path = f"gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
 
 CLUSTER_CONFIG = ClusterGenerator(
-                    project_id="test",
-                    zone="us-central1-a",
-                    master_machine_type="n1-standard-4",
-                    worker_machine_type="n1-standard-4",
-                    num_workers=2,
-                    storage_bucket="test",
-                    init_actions_uris=[
-                        path
-                    ],
-                    metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
-                ).make()
+    project_id="test",
+    zone="us-central1-a",
+    master_machine_type="n1-standard-4",
+    worker_machine_type="n1-standard-4",
+    num_workers=2,
+    storage_bucket="test",
+    init_actions_uris=[path],
+    metadata={"PIP_PACKAGES": "pyyaml requests pandas openpyxl"},
+).make()
 
 create_cluster_operator = DataprocClusterCreateOperator(
-                    task_id='create_dataproc_cluster',
-                    cluster_name="test",
-                    project_id="test",
-                    region="us-central1",
-                    cluster_config=CLUSTER_CONFIG,
-                )
-
+    task_id="create_dataproc_cluster",
+    cluster_name="test",
+    project_id="test",
+    region="us-central1",
+    cluster_config=CLUSTER_CONFIG,
+)
 ```
 
 #### `airflow.providers.google.cloud.operators.bigquery.BigQueryGetDatasetTablesOperator`

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -65,51 +65,31 @@ CLUSTER_CONFIG = {
 
 # [END how_to_cloud_dataproc_create_cluster]
 
-# Cluster definition upgrading from Airflow 1.10.x ( before using CLUSTER_CONFIG )
-# [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
+# Cluster definition: Generating Cluster Config for DataprocClusterCreateOperator
+# [START how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 path = f"gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
 
-create_cluster = DataprocClusterCreateOperator(
-                    task_id='create_dataproc_cluster',
-                    cluster_name="test",
-                    project_id="test",
-                    zone="us-central1-a",
-                    region="us-central1",
-                    master_machine_type="n1-standard-4",
-                    worker_machine_type="n1-standard-4",
-                    num_workers=2,
-                    storage_bucket="test_bucket",
-                    init_actions_uris=[
-                        path
-                    ],
-                    metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
-                )
-# [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
-
-# Cluster definition upgrading from Airflow 1.10.x ( after using CLUSTER_CONFIG )
-# [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_2]
-cluster_config = ClusterGenerator(
-                    project_id="test",
-                    zone="us-central1-a",
-                    master_machine_type="n1-standard-4",
-                    worker_machine_type="n1-standard-4",
-                    num_workers=2,
-                    storage_bucket="test",
-                    init_actions_uris=[
-                        path
-                    ],
-                    metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
-                ).make()
+CLUSTER_CONFIG = ClusterGenerator(
+                        project_id="test",
+                        zone="us-central1-a",
+                        master_machine_type="n1-standard-4",
+                        worker_machine_type="n1-standard-4",
+                        num_workers=2,
+                        storage_bucket="test",
+                        init_actions_uris=[
+                            path
+                        ],
+                        metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
+                    ).make()
 
 create_cluster_operator = DataprocClusterCreateOperator(
-                    task_id='create_dataproc_cluster',
-                    cluster_name="test",
-                    project_id="test",
-                    region="us-central1",
-                    cluster_config=cluster_config,
-                )
-# [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_2]
-
+                        task_id='create_dataproc_cluster',
+                        cluster_name="test",
+                        project_id="test",
+                        region="us-central1",
+                        cluster_config=CLUSTER_CONFIG,
+                    )
+# [END how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 
 # Update options
 # [START how_to_cloud_dataproc_updatemask_cluster_operator]

--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -25,12 +25,13 @@ import os
 from airflow import models
 from airflow.contrib.operators.dataproc_operator import DataprocClusterCreateOperator
 from airflow.providers.google.cloud.operators.dataproc import (
+    ClusterGenerator,
     DataprocCreateClusterOperator,
     DataprocCreateWorkflowTemplateOperator,
     DataprocDeleteClusterOperator,
     DataprocInstantiateWorkflowTemplateOperator,
     DataprocSubmitJobOperator,
-    DataprocUpdateClusterOperator, ClusterGenerator,
+    DataprocUpdateClusterOperator,
 )
 from airflow.providers.google.cloud.sensors.dataproc import DataprocJobSensor
 from airflow.utils.dates import days_ago
@@ -67,28 +68,26 @@ CLUSTER_CONFIG = {
 
 # Cluster definition: Generating Cluster Config for DataprocClusterCreateOperator
 # [START how_to_cloud_dataproc_create_cluster_generate_cluster_config]
-path = f"gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
+path = "gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
 
 CLUSTER_CONFIG = ClusterGenerator(
-                        project_id="test",
-                        zone="us-central1-a",
-                        master_machine_type="n1-standard-4",
-                        worker_machine_type="n1-standard-4",
-                        num_workers=2,
-                        storage_bucket="test",
-                        init_actions_uris=[
-                            path
-                        ],
-                        metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
-                    ).make()
+    project_id="test",
+    zone="us-central1-a",
+    master_machine_type="n1-standard-4",
+    worker_machine_type="n1-standard-4",
+    num_workers=2,
+    storage_bucket="test",
+    init_actions_uris=[path],
+    metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
+).make()
 
 create_cluster_operator = DataprocClusterCreateOperator(
-                        task_id='create_dataproc_cluster',
-                        cluster_name="test",
-                        project_id="test",
-                        region="us-central1",
-                        cluster_config=CLUSTER_CONFIG,
-                    )
+    task_id='create_dataproc_cluster',
+    cluster_name="test",
+    project_id="test",
+    region="us-central1",
+    cluster_config=CLUSTER_CONFIG,
+)
 # [END how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 
 # Update options

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -62,14 +62,17 @@ Generating Cluster Config
 If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG** or you would like to generate it using functional API,
 You can easily generate config using **make()** of
 :class:`~airflow.providers.google.cloud.operators.dataproc.ClusterGenerator`
+
 this is been proved specially useful if you are using **metadata** argument from older API, refer `AIRFLOW#16911 <https://github.com/apache/airflow/issues/16911>`__
 
 eg. your cluster creation may look like this in **v1.10.x**
+
 .. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_dataproc.py
     :language: python
     :dedent: 0
     :start-after: [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
     :end-before: [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
+
 
 After upgrading to **v2.x.x** and using **CLUSTER_CONFIG**, it will look like followed:
 

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -59,28 +59,16 @@ With this configuration we can create the cluster:
 
 Generating Cluster Config
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG** or you would like to generate it using functional API,
-You can easily generate config using **make()** of
+You can also generate **CLUSTER_CONFIG** using functional API,
+this could be easily done using **make()** of
 :class:`~airflow.providers.google.cloud.operators.dataproc.ClusterGenerator`
-
-this is been proved specially useful if you are using **metadata** argument from older API, refer `AIRFLOW#16911 <https://github.com/apache/airflow/issues/16911>`__
-
-eg. your cluster creation may look like this in **v1.10.x**
+You can generate and use config as followed:
 
 .. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_dataproc.py
     :language: python
     :dedent: 0
-    :start-after: [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
-    :end-before: [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
-
-
-After upgrading to **v2.x.x** and using **CLUSTER_CONFIG**, it will look like followed:
-
-.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_dataproc.py
-    :language: python
-    :dedent: 0
-    :start-after: [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_2]
-    :end-before: [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_2]
+    :start-after: [START how_to_cloud_dataproc_create_cluster_generate_cluster_config]
+    :end-before: [END how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 
 Update a cluster
 ----------------

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -59,15 +59,12 @@ With this configuration we can create the cluster:
 
 Generating Cluster Config
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG** or you would like to generate CLUSTER_CONFIG using functional API,
-You can easily refactor your operator usage to use **CLUSTER_CONFIG**,
-Config can be generated using **make()** of
+If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG** or you would like to generate it using functional API,
+You can easily generate config using **make()** of
 :class:`~airflow.providers.google.cloud.operators.dataproc.ClusterGenerator`
-
 this is been proved specially useful if you are using **metadata** argument from older API, refer `AIRFLOW#16911 <https://github.com/apache/airflow/issues/16911>`__
 
 eg. your cluster creation may look like this in **v1.10.x**
-
 .. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_dataproc.py
     :language: python
     :dedent: 0

--- a/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/dataproc.rst
@@ -57,6 +57,31 @@ With this configuration we can create the cluster:
     :start-after: [START how_to_cloud_dataproc_create_cluster_operator]
     :end-before: [END how_to_cloud_dataproc_create_cluster_operator]
 
+Generating Cluster Config
+^^^^^^^^^^^^^^^^^^^^^^^^^
+If you are upgrading from Airflow 1.10.x and are not using **CLUSTER_CONFIG** or you would like to generate CLUSTER_CONFIG using functional API,
+You can easily refactor your operator usage to use **CLUSTER_CONFIG**,
+Config can be generated using **make()** of
+:class:`~airflow.providers.google.cloud.operators.dataproc.ClusterGenerator`
+
+this is been proved specially useful if you are using **metadata** argument from older API, refer `AIRFLOW#16911 <https://github.com/apache/airflow/issues/16911>`__
+
+eg. your cluster creation may look like this in **v1.10.x**
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_dataproc.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
+    :end-before: [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_1]
+
+After upgrading to **v2.x.x** and using **CLUSTER_CONFIG**, it will look like followed:
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_dataproc.py
+    :language: python
+    :dedent: 0
+    :start-after: [START how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_2]
+    :end-before: [END how_to_cloud_dataproc_create_cluster_upgrading_from_v1_10_2]
+
 Update a cluster
 ----------------
 You can scale the cluster up or down by providing a cluster config and a updateMask.


### PR DESCRIPTION
closes: #16911


### Add meaningful description above
I am proposing to add a bit more information in the documentation regarding usage of **DataprocClusterCreateOperator()** as per refactoring in #6371, users find it a bit difficult to generate **CLUSTER_CONFIG**.

