### PR TITLE
Fix Daylight Saving Time issue in test case

### DIFF
--- a/airflow/ui/test/TimezoneDropdown.test.tsx
+++ b/airflow/ui/test/TimezoneDropdown.test.tsx
@@ -41,14 +41,14 @@ describe('test timezone dropdown', () => {
     fireEvent.click(button);
     const focusedElement = document.activeElement;
     if (focusedElement) {
-      fireEvent.change(focusedElement, { target: { value: 'Anch' } });
+      fireEvent.change(focusedElement, { target: { value: 'Baku' } });
     }
-    const optionText = '-08:00 America/Anchorage';
+    const optionText = '+04:00 Asia/Baku';
     const option = getByText(optionText);
     expect(option).toBeInTheDocument();
     fireEvent.click(option);
 
     expect(queryByText(optionText)).toBeNull();
-    expect(getByText('-08:00', { exact: false })).toBeInTheDocument();
+    expect(getByText('+04:00', { exact: false })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This is to fix "Tests / React UI tests (pull_request) " failing CI step. 
Due to Daylight Saving Time change this test has started to fail as it uses timezone that is changing from -08:00 to -09:00 on 7th November and back in March.
This PR changes testing timezone to a DST neutral one and will make it DST agnostic.

PS. Baku abolished time changing since 2016.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
