### PR TITLE
Add a proper example to the "patch DAG" API documentation

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -481,6 +481,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/DAG'
+            example:
+              is_paused: true
       responses:
         '200':
           description: Success.


### PR DESCRIPTION
Since redoc seems to have a bug affecting the autogen documentation , and there's no ETA for fixing it, I propose a solution based on the workaround described in https://github.com/Redocly/redoc/issues/1238

related: #19402 
related: #15917
