### PR TITLE
Add cli command for 'airflow dags reserialize`

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -769,6 +769,22 @@ ARG_CAPACITY = Arg(
     help="The maximum number of triggers that a Triggerer will run at one time.",
 )
 
+# reserialize
+ARG_CLEAR_ONLY = Arg(
+    ("--clear-only",),
+    action="store_true",
+    help="If passed, serialized DAGs will be cleared but not reserialized.",
+)
+ARG_RESERIALIZE_TIMEOUT = Arg(
+    ("--timeout",), type=int, help="Timeout in minutes for the serialization process. Default 10"
+)
+
+ARG_RESERIALIZE_PICKLE = Arg(
+    ("--pickle",),
+    action="store_true",
+    help="Store the serialized representations of the DAGs as pickle instead of JSON",
+)
+
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE,
     ARG_CONN_DESCRIPTION,
@@ -986,7 +1002,7 @@ DAGS_COMMANDS = (
             "version of Airflow that you are running."
         ),
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_reserialize'),
-        args=(),
+        args=(ARG_CLEAR_ONLY, ARG_RESERIALIZE_TIMEOUT, ARG_RESERIALIZE_PICKLE),
     ),
 )
 TASKS_COMMANDS = (

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -977,6 +977,17 @@ DAGS_COMMANDS = (
             ARG_SAVE_DAGRUN,
         ),
     ),
+    ActionCommand(
+        name='reserialize',
+        help="Reserialize all DAGs by parsing the DagBag files",
+        description=(
+            "Drop all serialized dags from the metadata DB. This will cause all DAGs to be reserialized "
+            "from the DagBag folder. This can be helpful if your serialized DAGs get out of sync with the "
+            "version of Airflow that you are running."
+        ),
+        func=lazy_load_command('airflow.cli.commands.dag_command.dag_reserialize'),
+        args=(),
+    ),
 )
 TASKS_COMMANDS = (
     ActionCommand(

--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -775,15 +775,6 @@ ARG_CLEAR_ONLY = Arg(
     action="store_true",
     help="If passed, serialized DAGs will be cleared but not reserialized.",
 )
-ARG_RESERIALIZE_TIMEOUT = Arg(
-    ("--timeout",), type=int, help="Timeout in minutes for the serialization process. Default 10"
-)
-
-ARG_RESERIALIZE_PICKLE = Arg(
-    ("--pickle",),
-    action="store_true",
-    help="Store the serialized representations of the DAGs as pickle instead of JSON",
-)
 
 ALTERNATIVE_CONN_SPECS_ARGS = [
     ARG_CONN_TYPE,
@@ -1002,7 +993,7 @@ DAGS_COMMANDS = (
             "version of Airflow that you are running."
         ),
         func=lazy_load_command('airflow.cli.commands.dag_command.dag_reserialize'),
-        args=(ARG_CLEAR_ONLY, ARG_RESERIALIZE_TIMEOUT, ARG_RESERIALIZE_PICKLE),
+        args=(ARG_CLEAR_ONLY,),
     ),
 )
 TASKS_COMMANDS = (

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -449,3 +449,8 @@ def dag_test(args, session=None):
 def dag_reserialize(args, session=None):
     session.query(SerializedDagModel).delete()
     session.commit()
+
+    if not args.clear_only:
+        dagbag = DagBag()
+        dagbag.collect_dags(only_if_updated=False, safe_mode=False)
+        dagbag.sync_to_db()

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -37,6 +37,7 @@ from airflow.executors.debug_executor import DebugExecutor
 from airflow.jobs.base_job import BaseJob
 from airflow.models import DagBag, DagModel, DagRun, TaskInstance
 from airflow.models.dag import DAG
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import (
     get_dag,
@@ -441,3 +442,10 @@ def dag_test(args, session=None):
             _display_dot_via_imgcat(dot_graph)
         if show_dagrun:
             print(dot_graph.source)
+
+
+@provide_session
+@cli_utils.action_logging
+def dag_reserialize(args, session=None):
+    session.query(SerializedDagModel).delete()
+    session.commit()

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -447,8 +447,7 @@ def dag_test(args, session=None):
 @provide_session
 @cli_utils.action_logging
 def dag_reserialize(args, session=None):
-    session.query(SerializedDagModel).delete()
-    session.commit()
+    session.query(SerializedDagModel).delete(synchronize_session=False)
 
     if not args.clear_only:
         dagbag = DagBag()

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -302,6 +302,7 @@ Redhat
 ReidentifyContentResponse
 Reinitialising
 Remoting
+Reserialize
 ResourceRequirements
 Roadmap
 Robinhood
@@ -1167,6 +1168,8 @@ replicaSet
 repo
 repos
 reqs
+reserialize
+reserialized
 resetdb
 resourceVersion
 resultset


### PR DESCRIPTION
Dag serialization is currently out of the hands of the user. Whenever dag reserialization is required, I run this python script:

```
from airflow.models.serialized_dag import SerializedDagModel
from airflow.settings import Session
session = Session()
session.query(SerializedDagModel).delete()
session.commit()
```

This PR makes running that script as simple as `airflow dags reserialize`.

closes: #19432 


