### PR TITLE
Fix whitespace error causing failing graphviz test

### DIFF
--- a/tests/utils/test_dot_renderer.py
+++ b/tests/utils/test_dot_renderer.py
@@ -141,7 +141,7 @@ class TestDotRenderer:
 
         dot = dot_renderer.render_dag(dag)
 
-        assert dot.source == '\n'.join(
+        assert dot.source.strip() == '\n'.join(
             [
                 'digraph example_task_group {',
                 '\tgraph [label=example_task_group labelloc=t rankdir=LR]',


### PR DESCRIPTION
The latest graphviz module subtly changed the output in a
non-significant way that was causing test failures.


