### PR TITLE
Fix typos in Hive transfer operator docstrings

### DIFF
--- a/airflow/providers/apache/hive/transfers/hive_to_mysql.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_mysql.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module contains operator to move data from Hive to MySQL."""
+"""This module contains an operator to move data from Hive to MySQL."""
 from tempfile import NamedTemporaryFile
 from typing import Dict, Optional
 

--- a/airflow/providers/apache/hive/transfers/hive_to_samba.py
+++ b/airflow/providers/apache/hive/transfers/hive_to_samba.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module contains operator to move data from Hive to Samba."""
+"""This module contains an operator to move data from Hive to Samba."""
 
 from tempfile import NamedTemporaryFile
 

--- a/airflow/providers/apache/hive/transfers/mssql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mssql_to_hive.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module contains operator to move data from MSSQL to Hive."""
+"""This module contains an operator to move data from MSSQL to Hive."""
 
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile

--- a/airflow/providers/apache/hive/transfers/mysql_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/mysql_to_hive.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module contains operator to move data from MySQL to Druid."""
+"""This module contains an operator to move data from MySQL to Hive."""
 
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile

--- a/airflow/providers/apache/hive/transfers/s3_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/s3_to_hive.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module contains operator to move data from Hive to S3 bucket."""
+"""This module contains an operator to move data from an S3 bucket to Hive."""
 
 import bz2
 import gzip

--- a/airflow/providers/apache/hive/transfers/vertica_to_hive.py
+++ b/airflow/providers/apache/hive/transfers/vertica_to_hive.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"""This module contains operator to move data from Vertica to Hive."""
+"""This module contains an operator to move data from Vertica to Hive."""
 
 from collections import OrderedDict
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
