### PR TITLE
Do not crash with stacktrace when task instance is missing

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1558,6 +1558,13 @@ class Airflow(AirflowBaseView):
 
         dag_run = dag.get_dagrun(execution_date=execution_date)
         ti = dag_run.get_task_instance(task_id=task.task_id)
+        if not ti:
+            flash(
+                "Could not queue task instance for execution, task instance is missing",
+                "error",
+            )
+            return redirect(origin)
+
         ti.refresh_from_task(task)
 
         # Make sure the task instance can be run


### PR DESCRIPTION
When task instance was missing (because old dag runs did not have
it) trying to run the missing task from the UI resulted in
stacktrace rather than nice error message.

Fixes: #19477

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
