### PR TITLE
[19458] Added column duration to DAG runs view

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3942,7 +3942,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'end_date',
         'external_trigger',
         'conf',
-        'duration'
+        'duration',
     ]
     search_columns = [
         'state',
@@ -3959,7 +3959,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
     }
     edit_columns = ['state', 'dag_id', 'execution_date', 'start_date', 'end_date', 'run_id', 'conf']
 
-    #duration is not a column, its derived
+    # duration is not a DB column, its derived
     order_columns = [
         'state',
         'dag_id',
@@ -3986,7 +3986,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
 
         difference = 0
         if start_date and end_date:
-            difference =  (end_date - start_date).total_seconds()
+            difference = (end_date - start_date).total_seconds()
 
         return difference
 
@@ -3999,7 +3999,7 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         'dag_id': wwwutils.dag_link,
         'run_id': wwwutils.dag_run_link,
         'conf': wwwutils.json_f('conf'),
-        'duration': duration_f
+        'duration': duration_f,
     }
 
     @action('muldelete', "Delete", "Are you sure you want to delete selected records?", single=False)

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3984,9 +3984,9 @@ class DagRunModelView(AirflowPrivilegeVerifierModelView):
         end_date = self.get('end_date')
         start_date = self.get('start_date')
 
-        difference = 0
+        difference = '0.0'
         if start_date and end_date:
-            difference = (end_date - start_date).total_seconds()
+            difference = str(end_date - start_date)
 
         return difference
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -26,7 +26,7 @@ import socket
 import sys
 import traceback
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import timedelta
 from functools import wraps
 from json import JSONDecodeError
 from operator import itemgetter


### PR DESCRIPTION
Added column duration(derived) to DAG runs view
closes: #19458 
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
