### PR TITLE
Bump chart version to 1.4.0-dev

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: airflow
-version: 1.3.0-dev
+version: 1.4.0-dev
 appVersion: 2.2.1
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows


### PR DESCRIPTION
Now that `1.3.0` has been released, time to bump the chart version.