### PR TITLE
Set X-Frame-Options header to DENY unless X_FRAME_ENABLED is set to true

### DIFF
--- a/airflow/www/extensions/init_security.py
+++ b/airflow/www/extensions/init_security.py
@@ -35,7 +35,8 @@ def init_xframe_protection(app):
         return
 
     def apply_caching(response):
-        response.headers["X-Frame-Options"] = "DENY"
+        if not x_frame_enabled:
+            response.headers["X-Frame-Options"] = "DENY"
         return response
 
     app.after_request(apply_caching)


### PR DESCRIPTION
Set X-Frame-Options header to DENY unless X_FRAME_ENABLED is set to true.

closes: #17255
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
