### PR TITLE
Add "access_key" to DEFAULT_SENSITIVE_FIELDS

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -34,6 +34,7 @@ log = logging.getLogger(__name__)
 DEFAULT_SENSITIVE_FIELDS = frozenset(
     {
         'access_token',
+        'access_key',
         'api_key',
         'apikey',
         'authorization',


### PR DESCRIPTION
**Inspiration for this change:**
Users who call the `WasbHook` and authenticate with a Shared Access Key to Azure Blob Storage will see their Shared Access Key in plain text within the Task Instance logs. Unfortunately since `Host` is not masked and is required to authenticate with a Shared Access Key, the entirety of the supplied credentials are written in the log.

**Sample log entry before**
```shell
[2021-11-09, 20:49:52 UTC] {base.py:79} INFO - Using connection to: id: wasb_default. Host: https://myAccountBlahBlah.blob.core.windows.net/, Port: None, Schema: , Login: , Password: None, extra: {'extra__wasb__connection_string': '', 'extra__wasb__sas_token': '***', 'extra__wasb__shared_access_key': 'KEa1QvMjxMNLuzTgVZFvS6PpQv087Ls0Oq+7Ic/fa9Lu3RQwunHi61yZTCJSCIo1gZBNLuzTgVZFvS6PpQv087Ls0Oq+7Ic/fa9Lu3RQwunHi61yZTCJSCIo1gZBH1cc/KZb3EAKXrqWXXXXXXXXXXXXXXXXXXXXXX==', 'extra__wasb__tenant_id': ''}
```


**Sample log entry after**
```shell
[2021-11-09, 20:56:37 UTC] {base.py:79} INFO - Using connection to: id: wasb_default. Host: https://myAccountBlahBlah.blob.core.windows.net/, Port: None, Schema: , Login: , Password: None, extra: {'extra__wasb__connection_string': '', 'extra__wasb__sas_token': '***', 'extra__wasb__shared_access_key': '***', 'extra__wasb__tenant_id': ''}
```

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
