### PR TITLE
Do not check for S3 key before attempting download

### DIFF
--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -809,7 +809,7 @@ class S3Hook(AwsBaseHook):
         try:
             s3_obj = self.get_key(key, bucket_name)
         except ClientError as e:
-            if e.response.get('Error', {}).get('Code', {}) == 404:
+            if e.response.get('Error', {}).get('Code') == 404:
                 raise AirflowException(
                     f'The source file in Bucket {bucket_name} with path {key} does not exist'
                 )

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -806,10 +806,15 @@ class S3Hook(AwsBaseHook):
         """
         self.log.info('Downloading source S3 file from Bucket %s with path %s', bucket_name, key)
 
-        if not self.check_for_key(key, bucket_name):
-            raise AirflowException(f'The source file in Bucket {bucket_name} with path {key} does not exist')
-
-        s3_obj = self.get_key(key, bucket_name)
+        try:
+            s3_obj = self.get_key(key, bucket_name)
+        except ClientError as e:
+            if e.response.get('Error', {}).get('Code', {}) == 404:
+                raise AirflowException(
+                    f'The source file in Bucket {bucket_name} with path {key} does not exist'
+                )
+            else:
+                raise e
 
         with NamedTemporaryFile(dir=local_path, prefix='airflow_tmp_', delete=False) as local_tmp_file:
             s3_obj.download_fileobj(local_tmp_file)

--- a/tests/providers/amazon/aws/hooks/test_s3.py
+++ b/tests/providers/amazon/aws/hooks/test_s3.py
@@ -444,7 +444,6 @@ class TestAwsS3Hook:
 
         s3_hook.download_file(key=key, bucket_name=bucket)
 
-        s3_hook.check_for_key.assert_called_once_with(key, bucket)
         s3_hook.get_key.assert_called_once_with(key, bucket)
         s3_obj.download_fileobj.assert_called_once_with(mock_temp_file)
 


### PR DESCRIPTION
When you download a key that exists, notice that it retrieves creds twice:

```
[2021-11-09 22:25:18,736] {s3.py:807} INFO - Downloading source S3 file from Bucket oss-test-xcom with path test-dag/test-task/2021-01-01T00:00:00+00:00/hellodf
[2021-11-09 22:25:18,736] {base_aws.py:401} INFO - Airflow Connection: aws_conn_id=aws_default
[2021-11-09 22:25:18,752] {credentials.py:1224} INFO - Found credentials in shared credentials file: ~/.aws/credentials
[2021-11-09 22:25:19,049] {base_aws.py:424} WARNING - Unable to use Airflow Connection for credentials.
[2021-11-09 22:25:19,049] {base_aws.py:425} INFO - Fallback on boto3 credential strategy
[2021-11-09 22:25:19,049] {base_aws.py:428} INFO - Creating session using boto3 credential strategy region_name=None
/Users/dstandish/code/airflow/airflow/providers/amazon/aws/hooks/base_aws.py:494 DeprecationWarning: client_type is deprecated. Set client_type from class attribute.
[2021-11-09 22:25:19,066] {credentials.py:1224} INFO - Found credentials in shared credentials file: ~/.aws/credentials
[2021-11-09 22:25:19,526] {base_aws.py:401} INFO - Airflow Connection: aws_conn_id=aws_default
[2021-11-09 22:25:19,594] {base_aws.py:424} WARNING - Unable to use Airflow Connection for credentials.
[2021-11-09 22:25:19,594] {base_aws.py:425} INFO - Fallback on boto3 credential strategy
[2021-11-09 22:25:19,594] {base_aws.py:428} INFO - Creating session using boto3 credential strategy region_name=None
/Users/dstandish/code/airflow/airflow/providers/amazon/aws/hooks/s3.py:343 DeprecationWarning: resource_type is deprecated. Set resource_type from class attribute.
[2021-11-09 22:25:19,628] {credentials.py:1224} INFO - Found credentials in shared credentials file: ~/.aws/credentials
```

The first is for checking existence and the second is retrieving the object.

We don't need to check for existence.  We can just ask for the object and if it's not there, the api will let is know.  And when the object _is_ there, we'll only have retrieved creds once.



