### PR TITLE
Add params dag_id, task_id etc to XCom.serialize_value

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -478,8 +478,8 @@ class BaseXCom(Base, LoggingMixin):
 
     @staticmethod
     def serialize_value(
-        value: Any,
         *,
+        value: Any,
         key=None,
         task_id=None,
         dag_id=None,

--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -478,8 +478,8 @@ class BaseXCom(Base, LoggingMixin):
 
     @staticmethod
     def serialize_value(
-        *,
         value: Any,
+        *,
         key=None,
         task_id=None,
         dag_id=None,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3577,12 +3577,24 @@ class XComModelView(AirflowModelView):
     def pre_add(self, item):
         """Pre add hook."""
         item.execution_date = timezone.make_aware(item.execution_date)
-        item.value = XCom.serialize_value(item.value)
+        item.value = XCom.serialize_value(
+            value=item.value,
+            key=item.key,
+            task_id=item.task_id,
+            dag_id=item.dag_id,
+            run_id=item.run_id,
+        )
 
     def pre_update(self, item):
         """Pre update hook."""
         item.execution_date = timezone.make_aware(item.execution_date)
-        item.value = XCom.serialize_value(item.value)
+        item.value = XCom.serialize_value(
+            value=item.value,
+            key=item.key,
+            task_id=item.task_id,
+            dag_id=item.dag_id,
+            run_id=item.run_id,
+        )
 
 
 def lazy_add_provider_discovered_options_to_connection_form():


### PR DESCRIPTION
When implementing a custom XCom backend, in order to store XCom objects organized by dag_id, run_id etc, we need to pass those params to `serialize_value`.
