### PR TITLE
Update Airflow versions in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_bug_report.yml
@@ -25,6 +25,7 @@ body:
         discuss Airflow 1.10, open [Discussion](https://github.com/apache/airflow/discussions) instead!
       multiple: false
       options:
+        - "2.2.2rc1 (release candidate)"
         - "2.2.1 (latest released)"
         - "2.2.0"
         - "2.1.4"

--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -42,7 +42,10 @@ body:
         discuss Airflow 1.10, open [Discussion](https://github.com/apache/airflow/discussions) instead!
       multiple: false
       options:
-        - "2.1.4 (latest released)"
+        - "2.2.2rc1 (release candidate)"
+        - "2.2.1 (latest released)"
+        - "2.2.0"
+        - "2.1.4"
         - "2.1.3"
         - "2.1.2"
         - "2.1.1"

--- a/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_providers_bug_report.yml
@@ -109,6 +109,7 @@ body:
         discuss Airflow 1.10, open [Discussion](https://github.com/apache/airflow/discussions) instead!
       multiple: false
       options:
+        - "2.2.2rc1 (release candidate)"
         - "2.2.1 (latest released)"
         - "2.2.0"
         - "2.1.4"


### PR DESCRIPTION
Add `2.2.2rc1` across the board, and bring the helm chart template up to date with core Airflow releases.