### PR TITLE
Add pip proxy to PythonVirtualEnvOperator

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -343,6 +343,7 @@ class PythonVirtualenvOperator(PythonOperator):
         string_args: Optional[Iterable[str]] = None,
         templates_dict: Optional[Dict] = None,
         templates_exts: Optional[List[str]] = None,
+        pip_proxy: Optional[str] = None,
         **kwargs,
     ):
         if (
@@ -381,6 +382,7 @@ class PythonVirtualenvOperator(PythonOperator):
             if self.use_dill and 'dill' not in self.requirements:
                 self.requirements.append('dill')
         self.pickling_library = dill if self.use_dill else pickle
+        self.pip_proxy = pip_proxy
 
     def execute(self, context: Dict):
         serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
@@ -401,6 +403,7 @@ class PythonVirtualenvOperator(PythonOperator):
                 python_bin=f'python{self.python_version}' if self.python_version else None,
                 system_site_packages=self.system_site_packages,
                 requirements=self.requirements,
+                pip_proxy=self.pip_proxy,
             )
 
             self._write_args(input_filename)

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -300,6 +300,9 @@ class PythonVirtualenvOperator(PythonOperator):
     :param templates_exts: a list of file extensions to resolve while
         processing templated fields, for examples ``['.sql', '.hql']``
     :type templates_exts: list[str]
+    :param pip_proxy: The proxy server to use as when performing `pip install --proxy` to
+        create the virtual environment.
+    :type Optional[str]
     """
 
     BASE_SERIALIZABLE_CONTEXT_KEYS = {

--- a/airflow/utils/python_virtualenv.py
+++ b/airflow/utils/python_virtualenv.py
@@ -36,11 +36,13 @@ def _generate_virtualenv_cmd(tmp_dir: str, python_bin: str, system_site_packages
     return cmd
 
 
-def _generate_pip_install_cmd(tmp_dir: str, requirements: List[str]) -> Optional[List[str]]:
+def _generate_pip_install_cmd(tmp_dir: str, requirements: List[str], pip_proxy: Optional[str] = None) -> Optional[List[str]]:
     if not requirements:
         return None
     # direct path alleviates need to activate
     cmd = [f'{tmp_dir}/bin/pip', 'install']
+    if pip_proxy:
+        cmd.append(f"--proxy={pip_proxy}")
     return cmd + requirements
 
 
@@ -75,7 +77,7 @@ def remove_task_decorator(python_source: str, task_decorator_name: str) -> str:
 
 
 def prepare_virtualenv(
-    venv_directory: str, python_bin: str, system_site_packages: bool, requirements: List[str]
+    venv_directory: str, python_bin: str, system_site_packages: bool, requirements: List[str], pip_proxy: Optional[str] = None
 ) -> str:
     """
     Creates a virtual environment and installs the additional python packages
@@ -94,7 +96,7 @@ def prepare_virtualenv(
     """
     virtualenv_cmd = _generate_virtualenv_cmd(venv_directory, python_bin, system_site_packages)
     execute_in_subprocess(virtualenv_cmd)
-    pip_cmd = _generate_pip_install_cmd(venv_directory, requirements)
+    pip_cmd = _generate_pip_install_cmd(venv_directory, requirements, pip_proxy)
     if pip_cmd:
         execute_in_subprocess(pip_cmd)
 

--- a/tests/utils/test_python_virtualenv.py
+++ b/tests/utils/test_python_virtualenv.py
@@ -60,6 +60,20 @@ class TestPrepareVirtualenv(unittest.TestCase):
 
         mock_execute_in_subprocess.assert_called_with(['/VENV/bin/pip', 'install', 'apache-beam[gcp]'])
 
+    @mock.patch('airflow.utils.python_virtualenv.execute_in_subprocess')
+    def test_should_create_virtualenv_with_pip_proxy(self, mock_execute_in_subprocess):
+        python_bin = prepare_virtualenv(
+            venv_directory="/VENV",
+            python_bin="pythonVER",
+            system_site_packages=False,
+            requirements=[],
+            pip_proxy=""
+        )
+        assert "/VENV/bin/python" == python_bin
+        mock_execute_in_subprocess.assert_called_once_with(
+            [sys.executable, '-m', 'virtualenv', '/VENV', '--python=pythonVER']
+        )
+
     def test_remove_task_decorator(self):
 
         py_source = "@task.virtualenv(use_dill=True)\ndef f():\nimport funcsigs"


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #19522 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Add pip proxy to PythonVirtualEnvOperator
---
Added `pip_proxy` to the `PythonVirtualEnvOperator` init args and propagated to underlying functions. Defaulted to `None` and only adds `--proxy={pip_proxy}` when provided with a value. Helps alleviate issues when creating a virtualenv on clusters behind corporate proxies without the need to broadly apply environment variable proxies. 