### PR TITLE
Fix missing dagruns when catchup=True

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -630,6 +630,7 @@ class DAG(LoggingMixin):
         data_interval = dag_model.next_dagrun_data_interval
         if data_interval is not None:
             return data_interval
+
         # Compatibility: A run was scheduled without an explicit data interval.
         # This means the run was scheduled before AIP-39 implementation. Try to
         # infer from the logical date.


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/19461
There's a bug that when the max_active_runs is reached, run dates could skip.
This PR fixes it



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
