### PR TITLE
Do not require all extras for SalesforceHook

### DIFF
--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -27,6 +27,11 @@ import logging
 import time
 from typing import Any, Dict, Iterable, List, Optional
 
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
+
 import pandas as pd
 from requests import Session
 from simple_salesforce import Salesforce, api
@@ -75,7 +80,6 @@ class SalesforceHook(BaseHook):
     ) -> None:
         super().__init__()
         self.conn_id = salesforce_conn_id
-        self.conn = None
         self.session_id = session_id
         self.session = session
 
@@ -126,45 +130,45 @@ class SalesforceHook(BaseHook):
             },
         }
 
+    @cached_property
+    def conn(self) -> api.Salesforce:
+        """Returns a Salesforce instance. (cached)"""
+        connection = self.get_connection(self.conn_id)
+        extras = connection.extra_dejson
+        # all extras below (besides the version one) are explicitly defaulted to None
+        # because simple-salesforce has a built-in authentication-choosing method that
+        # relies on which arguments are None and without "or None" setting this connection
+        # in the UI will result in the blank extras being empty strings instead of None,
+        # which would break the connection if "get" was used on its own.
+        conn = Salesforce(
+            username=connection.login,
+            password=connection.password,
+            security_token=extras.get('security_token')
+            or extras.get('extra__salesforce__security_token')
+            or None,
+            domain=extras.get('domain') or extras.get('extra__salesforce__domain') or None,
+            session_id=self.session_id,
+            instance=extras.get('instance') or extras.get('extra__salesforce__instance') or None,
+            instance_url=extras.get('instance_url') or extras.get('extra__salesforce__instance_url') or None,
+            organizationId=extras.get('organization_id')
+            or extras.get('extra__salesforce__organization_id')
+            or None,
+            version=extras.get('version')
+            or extras.get('extra__salesforce__version')
+            or api.DEFAULT_API_VERSION,
+            proxies=extras.get('proxies') or extras.get('extra__salesforce__proxies') or None,
+            session=self.session,
+            client_id=extras.get('client_id') or extras.get('extra__salesforce__client_id') or None,
+            consumer_key=extras.get('consumer_key') or extras.get('extra__salesforce__consumer_key') or None,
+            privatekey_file=extras.get('private_key_file_path')
+            or extras.get('extra__salesforce__private_key_file_path')
+            or None,
+            privatekey=extras.get('private_key') or extras.get('extra__salesforce__private_key') or None,
+        )
+        return conn
+
     def get_conn(self) -> api.Salesforce:
-        """Sign into Salesforce, only if we are not already signed in."""
-        if not self.conn:
-            connection = self.get_connection(self.conn_id)
-            extras = connection.extra_dejson
-            # all extras below (besides the version one) are explicitly defaulted to None
-            # because simple-salesforce has a built-in authentication-choosing method that
-            # relies on which arguments are None and without "or None" setting this connection
-            # in the UI will result in the blank extras being empty strings instead of None,
-            # which would break the connection if "get" was used on its own.
-            self.conn = Salesforce(
-                username=connection.login,
-                password=connection.password,
-                security_token=extras.get('security_token')
-                or extras.get('extra__salesforce__security_token')
-                or None,
-                domain=extras.get('domain') or extras.get('extra__salesforce__domain') or None,
-                session_id=self.session_id,
-                instance=extras.get('instance') or extras.get('extra__salesforce__instance') or None,
-                instance_url=extras.get('instance_url')
-                or extras.get('extra__salesforce__instance_url')
-                or None,
-                organizationId=extras.get('organization_id')
-                or extras.get('extra__salesforce__organization_id')
-                or None,
-                version=extras.get('version')
-                or extras.get('extra__salesforce__version')
-                or api.DEFAULT_API_VERSION,
-                proxies=extras.get('proxies') or extras.get('extra__salesforce__proxies') or None,
-                session=self.session,
-                client_id=extras.get('client_id') or extras.get('extra__salesforce__client_id') or None,
-                consumer_key=extras.get('consumer_key')
-                or extras.get('extra__salesforce__consumer_key')
-                or None,
-                privatekey_file=extras.get('private_key_file_path')
-                or extras.get('extra__salesforce__private_key_file_path')
-                or None,
-                privatekey=extras.get('private_key') or extras.get('extra__salesforce__private_key') or None,
-            )
+        """Returns a Salesforce instance. (cached)"""
         return self.conn
 
     def make_query(

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -27,15 +27,11 @@ import logging
 import time
 from typing import Any, Dict, Iterable, List, Optional
 
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
-
 import pandas as pd
 from requests import Session
 from simple_salesforce import Salesforce, api
 
+from airflow.compat.functools import cached_property
 from airflow.hooks.base import BaseHook
 
 log = logging.getLogger(__name__)

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -143,27 +143,19 @@ class SalesforceHook(BaseHook):
         conn = Salesforce(
             username=connection.login,
             password=connection.password,
-            security_token=extras.get('security_token')
-            or extras.get('extra__salesforce__security_token')
-            or None,
-            domain=extras.get('domain') or extras.get('extra__salesforce__domain') or None,
+            security_token=extras.get('extra__salesforce__security_token') or None,
+            domain=extras.get('extra__salesforce__domain') or None,
             session_id=self.session_id,
-            instance=extras.get('instance') or extras.get('extra__salesforce__instance') or None,
-            instance_url=extras.get('instance_url') or extras.get('extra__salesforce__instance_url') or None,
-            organizationId=extras.get('organization_id')
-            or extras.get('extra__salesforce__organization_id')
-            or None,
-            version=extras.get('version')
-            or extras.get('extra__salesforce__version')
-            or api.DEFAULT_API_VERSION,
-            proxies=extras.get('proxies') or extras.get('extra__salesforce__proxies') or None,
+            instance=extras.get('extra__salesforce__instance') or None,
+            instance_url=extras.get('extra__salesforce__instance_url') or None,
+            organizationId=extras.get('extra__salesforce__organization_id') or None,
+            version=extras.get('extra__salesforce__version') or api.DEFAULT_API_VERSION,
+            proxies=extras.get('extra__salesforce__proxies') or None,
             session=self.session,
-            client_id=extras.get('client_id') or extras.get('extra__salesforce__client_id') or None,
-            consumer_key=extras.get('consumer_key') or extras.get('extra__salesforce__consumer_key') or None,
-            privatekey_file=extras.get('private_key_file_path')
-            or extras.get('extra__salesforce__private_key_file_path')
-            or None,
-            privatekey=extras.get('private_key') or extras.get('extra__salesforce__private_key') or None,
+            client_id=extras.get('extra__salesforce__client_id') or None,
+            consumer_key=extras.get('extra__salesforce__consumer_key') or None,
+            privatekey_file=extras.get('extra__salesforce__private_key_file_path') or None,
+            privatekey=extras.get('extra__salesforce__private_key') or None,
         )
         return conn
 

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -27,11 +27,15 @@ import logging
 import time
 from typing import Any, Dict, Iterable, List, Optional
 
+try:
+    from functools import cached_property
+except ImportError:
+    from cached_property import cached_property
+
 import pandas as pd
 from requests import Session
 from simple_salesforce import Salesforce, api
 
-from airflow.compat.functools import cached_property
 from airflow.hooks.base import BaseHook
 
 log = logging.getLogger(__name__)

--- a/airflow/providers/salesforce/hooks/salesforce.py
+++ b/airflow/providers/salesforce/hooks/salesforce.py
@@ -131,22 +131,39 @@ class SalesforceHook(BaseHook):
         if not self.conn:
             connection = self.get_connection(self.conn_id)
             extras = connection.extra_dejson
+            # all extras below (besides the version one) are explicitly defaulted to None
+            # because simple-salesforce has a built-in authentication-choosing method that
+            # relies on which arguments are None and without "or None" setting this connection
+            # in the UI will result in the blank extras being empty strings instead of None,
+            # which would break the connection if "get" was used on its own.
             self.conn = Salesforce(
                 username=connection.login,
                 password=connection.password,
-                security_token=extras["extra__salesforce__security_token"] or None,
-                domain=extras["extra__salesforce__domain"] or None,
+                security_token=extras.get('security_token')
+                or extras.get('extra__salesforce__security_token')
+                or None,
+                domain=extras.get('domain') or extras.get('extra__salesforce__domain') or None,
                 session_id=self.session_id,
-                instance=extras["extra__salesforce__instance"] or None,
-                instance_url=extras["extra__salesforce__instance_url"] or None,
-                organizationId=extras["extra__salesforce__organization_id"] or None,
-                version=extras["extra__salesforce__version"] or api.DEFAULT_API_VERSION,
-                proxies=extras["extra__salesforce__proxies"] or None,
+                instance=extras.get('instance') or extras.get('extra__salesforce__instance') or None,
+                instance_url=extras.get('instance_url')
+                or extras.get('extra__salesforce__instance_url')
+                or None,
+                organizationId=extras.get('organization_id')
+                or extras.get('extra__salesforce__organization_id')
+                or None,
+                version=extras.get('version')
+                or extras.get('extra__salesforce__version')
+                or api.DEFAULT_API_VERSION,
+                proxies=extras.get('proxies') or extras.get('extra__salesforce__proxies') or None,
                 session=self.session,
-                client_id=extras["extra__salesforce__client_id"] or None,
-                consumer_key=extras["extra__salesforce__consumer_key"] or None,
-                privatekey_file=extras["extra__salesforce__private_key_file_path"] or None,
-                privatekey=extras["extra__salesforce__private_key"] or None,
+                client_id=extras.get('client_id') or extras.get('extra__salesforce__client_id') or None,
+                consumer_key=extras.get('consumer_key')
+                or extras.get('extra__salesforce__consumer_key')
+                or None,
+                privatekey_file=extras.get('private_key_file_path')
+                or extras.get('extra__salesforce__private_key_file_path')
+                or None,
+                privatekey=extras.get('private_key') or extras.get('extra__salesforce__private_key') or None,
             )
         return self.conn
 

--- a/tests/providers/salesforce/hooks/test_salesforce.py
+++ b/tests/providers/salesforce/hooks/test_salesforce.py
@@ -80,17 +80,6 @@ class TestSalesforceHook(unittest.TestCase):
                 }
                 ''',
             ),
-            (
-                "required extras no prefix",
-                '''
-                {
-                    "client_id": "my_client",
-                    "domain": "test",
-                    "security_token": "token",
-                    "version": "42.0"
-                }
-                ''',
-            ),
         ]
     )
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
@@ -117,16 +106,16 @@ class TestSalesforceHook(unittest.TestCase):
         mock_salesforce.assert_called_once_with(
             username=password_auth_conn.login,
             password=password_auth_conn.password,
-            security_token=extras.get('extra__salesforce__security_token') or extras.get('security_token'),
-            domain=extras.get('extra__salesforce__domain') or extras.get('domain'),
+            security_token=extras.get('extra__salesforce__security_token'),
+            domain=extras.get('extra__salesforce__domain'),
             session_id=None,
             instance=None,
             instance_url=None,
             organizationId=None,
-            version=extras.get('extra__salesforce__version') or extras.get('version'),
+            version=extras.get('extra__salesforce__version'),
             proxies=None,
             session=None,
-            client_id=extras.get('extra__salesforce__client_id') or extras.get('client_id'),
+            client_id=extras.get('extra__salesforce__client_id'),
             consumer_key=None,
             privatekey_file=None,
             privatekey=None,
@@ -160,17 +149,6 @@ class TestSalesforceHook(unittest.TestCase):
                     "extra__salesforce__domain": "test",
                     "extra__salesforce__instance_url": "https://my.salesforce.com",
                     "extra__salesforce__version": "29.0"
-                }
-                ''',
-            ),
-            (
-                "required extras no prefix",
-                '''
-                {
-                    "client_id": "my_client2",
-                    "domain": "test",
-                    "instance_url": "https://my.salesforce.com",
-                    "version": "29.0"
                 }
                 ''',
             ),
@@ -206,15 +184,15 @@ class TestSalesforceHook(unittest.TestCase):
             username=direct_access_conn.login,
             password=direct_access_conn.password,
             security_token=None,
-            domain=extras.get('extra__salesforce__domain') or extras.get('domain'),
+            domain=extras.get('extra__salesforce__domain'),
             session_id=self.salesforce_hook.session_id,
             instance=None,
-            instance_url=extras.get('extra__salesforce__instance_url') or extras.get('instance_url'),
+            instance_url=extras.get('extra__salesforce__instance_url'),
             organizationId=None,
-            version=extras.get('extra__salesforce__version') or extras.get('version'),
+            version=extras.get('extra__salesforce__version'),
             proxies=None,
             session=self.salesforce_hook.session,
-            client_id=extras.get('extra__salesforce__client_id') or extras.get('client_id'),
+            client_id=extras.get('extra__salesforce__client_id'),
             consumer_key=None,
             privatekey_file=None,
             privatekey=None,
@@ -252,18 +230,6 @@ class TestSalesforceHook(unittest.TestCase):
                 }
                 ''',
             ),
-            (
-                "required extras no prefix",
-                '''
-                {
-                    "client_id": "my_client3",
-                    "consumer_key": "consumer_key",
-                    "domain": "login",
-                    "private_key": "private_key",
-                    "version": "34.0"
-                }
-                ''',
-            ),
         ]
     )
     @patch("airflow.providers.salesforce.hooks.salesforce.Salesforce")
@@ -292,18 +258,18 @@ class TestSalesforceHook(unittest.TestCase):
             username=jwt_auth_conn.login,
             password=jwt_auth_conn.password,
             security_token=None,
-            domain=extras.get('extra__salesforce__domain') or extras.get('domain'),
+            domain=extras.get('extra__salesforce__domain'),
             session_id=None,
             instance=None,
             instance_url=None,
             organizationId=None,
-            version=extras.get('extra__salesforce__version') or extras.get('version'),
+            version=extras.get('extra__salesforce__version'),
             proxies=None,
             session=None,
-            client_id=extras.get('extra__salesforce__client_id') or extras.get('client_id'),
-            consumer_key=extras.get('extra__salesforce__consumer_key') or extras.get('consumer_key'),
+            client_id=extras.get('extra__salesforce__client_id'),
+            consumer_key=extras.get('extra__salesforce__consumer_key'),
             privatekey_file=None,
-            privatekey=extras.get('extra__salesforce__private_key') or extras.get('private_key'),
+            privatekey=extras.get('extra__salesforce__private_key'),
         )
 
     @parameterized.expand(
@@ -331,14 +297,6 @@ class TestSalesforceHook(unittest.TestCase):
                 '''
                 {
                     "extra__salesforce__organization_id": "my_organization",
-                }
-                ''',
-            ),
-            (
-                "required extras no prefix",
-                '''
-                {
-                    "organization_id": "my_organization",
                 }
                 ''',
             ),
@@ -374,7 +332,7 @@ class TestSalesforceHook(unittest.TestCase):
             session_id=None,
             instance=None,
             instance_url=None,
-            organizationId=extras.get('extra__salesforce__organization_id') or extras.get('organization_id'),
+            organizationId=extras.get('extra__salesforce__organization_id'),
             version=api.DEFAULT_API_VERSION,
             proxies=None,
             session=None,


### PR DESCRIPTION
The `SalesforceHook` was previously requiring all connection extras, however with secrets backends it is now possible to provide one extra at a time. The current setup was directly accessing keys of the extras json which would result in a `KeyError` if you leave out one of them.

This PR allows for just the minimum required extras to be provided for each Salesforce connection method as defined in the docstring of the `SalesforceHook`: https://github.com/apache/airflow/blob/e9a72a4e95e6d23bae010ad92499cd7b06d50037/airflow/providers/salesforce/hooks/salesforce.py#L55-L60

In addition to allowing for only the required extras it also still allows for all of the extras to be provided, such as the case currently when the connection is added via the UI.

When making the connection the hook will explicitly default to `None` for all extras except for "version" (which defaults to the default API version). The reason for this is because `simple-salesforce` already has built-in authentication-choosing methods that relies on which arguments are `None` and without having `or None` in the code then setting this connection in the UI will result in the blank extras being empty strings instead of None, which would break the connection if `get` was used on its own.

The tests for the hook are also updated to only test for the required connection params when testing connections and also test that if all extras are empty strings they will be defaulted to `None`.

Also, a thank you @gigatexal, @dstandish, @josh-fell for prior PRs and PR discussions regarding this fix. This PRs incorporates the discussed points.

closes: #19506
completes PR #18929 by adding tests

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
