### PR TITLE
Fix dynamic queue loss

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1053,9 +1053,12 @@ class SchedulerJob(BaseJob):
     def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session=None):
         """Only run DagRun.verify integrity if Serialized DAG has changed since it is slow"""
         latest_version = SerializedDagModel.get_latest_version_hash(dag_run.dag_id, session=session)
-        if dag_run.dag_hash == latest_version:
-            self.log.debug("DAG %s not changed structure, skipping dagrun.verify_integrity", dag_run.dag_id)
-            return
+
+        # TODO: If the following code exists, ``task_instance_mutation_hook`` will
+        # not be triggered when the dag is not changed, it is in ``verify_integrity``
+        # if dag_run.dag_hash == latest_version:
+        #     self.log.debug("DAG %s not changed structure, skipping dagrun.verify_integrity", dag_run.dag_id)
+        #     return
 
         dag_run.dag_hash = latest_version
 


### PR DESCRIPTION
I use ``task_instance_mutation_hook`` in Airflow ``2.2.1`` to dynamically assign ``queue``:

```python
def task_instance_mutation_hook(task_instance: TaskInstance):

    from airflow.settings import Session
    session = Session()
    dag_run = task_instance.get_dagrun(session)
    conf = dag_run.conf
    if conf and conf.get('queue'):
        task_instance.queue = conf.get('queue')
```

Doing so allows me to specify the queue normally.

This is my database data:

![pic_2021-11-11 224552](https://user-images.githubusercontent.com/12382013/141326133-163e1305-b078-488d-8708-cf01327479fe.png)

But when I click on ``Instance Details`` or ``Clear`` in the UI, the ``queue`` is restored to its ``default`` value.

![pic_2021-11-11 224648](https://user-images.githubusercontent.com/12382013/141326489-1f048b77-1f48-4c0f-bc85-a9b75fcd2cad.png)

This is the database data that was restored after I clicked on ``one's Instance Details``:

![pic_2021-11-11 225112](https://user-images.githubusercontent.com/12382013/141326810-0cf740d5-13fb-451d-9a9c-5c061fdd10ea.png)

I found that the problem is that both ``Instance Details`` and ``Clear`` call the ``refresh_from_task`` and the current ``queue`` is overwritten.

https://github.com/apache/airflow/blob/7622f5e08261afe5ab50a08a6ca0804af8c7c7fe/airflow/models/taskinstance.py#L763-L773

If the ``queue`` is overwritten but the dag here is not changed, ``task_instance_mutation_hook`` will not be triggered, it is in ``verify_integrity``.

https://github.com/apache/airflow/blob/9519bf664b1c20ebec940fc1c3daa097eca351b4/airflow/jobs/scheduler_job.py#L1053-L1066

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
