### PR TITLE
Remove duplicate get_connection in SnowflakeHook

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -268,8 +268,7 @@ class SnowflakeHook(DbApiHook):
         """
         self.query_ids = []
 
-        with self.get_conn() as conn:
-            conn = self.get_conn()
+        with closing(self.get_conn()) as conn:
             self.set_autocommit(conn, autocommit)
 
             if isinstance(sql, str):


### PR DESCRIPTION
Each time the SnowflakeHook was being used, the code was opening the connection to Snowflake twice. This removes the duplicate call to `get_connection()` and adds the `closing()` to automatically close connection at the end of the block to match the run method of the `DbApi`. All existing unit tests in `tests/providers/snowflake/hooks/test_snowflake.py` pass.

closes: #19503 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
