### PR TITLE
Track completed triggers until deleted from database

### DIFF
--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -158,6 +158,7 @@ class TriggererJob(BaseJob):
             trigger_id, event = self.runner.events.popleft()
             # Tell the model to wake up its tasks
             Trigger.submit_event(trigger_id=trigger_id, event=event)
+            self.runner.triggers[trigger_id]["is_submitted"] = True
             # Emit stat event
             Stats.incr('triggers.succeeded')
 
@@ -183,6 +184,7 @@ class TriggerDetails(TypedDict):
     task: asyncio.Task
     name: str
     events: int
+    is_submitted: bool
 
 
 class TriggerRunner(threading.Thread, LoggingMixin):
@@ -260,10 +262,11 @@ class TriggerRunner(threading.Thread, LoggingMixin):
         while self.to_create:
             trigger_id, trigger_instance = self.to_create.popleft()
             if trigger_id not in self.triggers:
-                self.triggers[trigger_id] = {
+                self.triggers[trigger_id]: TriggerDetails = {
                     "task": create_task(self.run_trigger(trigger_id, trigger_instance)),
                     "name": f"{trigger_instance!r} (ID {trigger_id})",
                     "events": 0,
+                    "is_submitted": False,
                 }
             else:
                 self.log.warning("Trigger %s had insertion attempted twice", trigger_id)
@@ -315,7 +318,8 @@ class TriggerRunner(threading.Thread, LoggingMixin):
                         details["name"],
                     )
                     self.failed_triggers.append(trigger_id)
-                del self.triggers[trigger_id]
+                if details['is_submitted'] is True:
+                    del self.triggers[trigger_id]
             await asyncio.sleep(0)
 
     async def block_watchdog(self):

--- a/airflow/jobs/triggerer_job.py
+++ b/airflow/jobs/triggerer_job.py
@@ -283,8 +283,6 @@ class TriggerRunner(threading.Thread, LoggingMixin):
         """
         while self.to_create:
             trigger_id, trigger_instance = self.to_create.popleft()
-            if trigger_id in self.completed_triggers:
-                continue
             if trigger_id not in self.triggers:
                 self.triggers[trigger_id] = {
                     "task": create_task(self.run_trigger(trigger_id, trigger_instance)),


### PR DESCRIPTION
Commonly a trigger will complete and be deleted from the `TriggerRunner.triggers` dictionary attr before the the TriggerJob has had a chance to `submit_event`.  So TriggerRunner thinks it needs to create the trigger [again], which it does.

One way to resolve this is to have TriggerJob mark `is_submitted` after successful complletion of `submit_event`, and then have the cleanup process wait for this.  But I'm not sure if perhaps we will need to implement monitoring / timeouts if for some reason the event is never submitted; in that case we'd want to ensure that the trigger is re-run.

Should fix https://github.com/apache/airflow/issues/18392

If you think this approach looks OK I'll proceed with tests.


