### PR TITLE
Fix IntegrityError in `DagFileProcessor.manage_slas`

### DIFF
--- a/airflow/dag_processing/processor.py
+++ b/airflow/dag_processing/processor.py
@@ -389,6 +389,12 @@ class DagFileProcessor(LoggingMixin):
             .group_by(TI.task_id)
             .subquery('sq')
         )
+        # get recorded SlaMiss
+        recorded_slas_query = set(
+            session.query(SlaMiss.dag_id, SlaMiss.task_id, SlaMiss.execution_date).filter(
+                SlaMiss.dag_id == dag.dag_id, SlaMiss.task_id.in_(dag.task_ids)
+            )
+        )
 
         max_tis: Iterator[TI] = (
             session.query(TI)
@@ -401,6 +407,7 @@ class DagFileProcessor(LoggingMixin):
         )
 
         ts = timezone.utcnow()
+
         for ti in max_tis:
             task = dag.get_task(ti.task_id)
             if not task.sla:
@@ -419,9 +426,13 @@ class DagFileProcessor(LoggingMixin):
             else:
                 while next_info.logical_date < ts:
                     next_info = dag.next_dagrun_info(next_info.data_interval, restricted=False)
+
                     if next_info is None:
                         break
+                    if (ti.dag_id, ti.task_id, next_info.logical_date) in recorded_slas_query:
+                        break
                     if next_info.logical_date + task.sla < ts:
+
                         sla_miss = SlaMiss(
                             task_id=ti.task_id,
                             dag_id=ti.dag_id,

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -197,7 +197,7 @@ class TestDagFileProcessor:
 
         sla_callback.assert_not_called()
 
-    def test_dag_file_processor_sla_miss_doesnot_have_integrity_error(self, dag_maker):
+    def test_dag_file_processor_sla_miss_doesnot_raise_integrity_error(self, dag_maker):
         """
         Test that the dag file processor does not try to insert already existing item into the database
         """
@@ -221,6 +221,15 @@ class TestDagFileProcessor:
 
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
         dag_file_processor.manage_slas(dag=dag, session=session)
+        sla_miss_count = (
+            session.query(SlaMiss)
+            .filter(
+                SlaMiss.dag_id == dag.dag_id,
+                SlaMiss.task_id == task.task_id,
+            )
+            .count()
+        )
+        assert sla_miss_count == 1
         # Now call manage_slas and see that it runs without errors
         # because of existing SlaMiss above.
         # Since this is run often, it's possible that it runs before another

--- a/tests/dag_processing/test_processor.py
+++ b/tests/dag_processing/test_processor.py
@@ -197,6 +197,36 @@ class TestDagFileProcessor:
 
         sla_callback.assert_not_called()
 
+    def test_dag_file_processor_sla_miss_doesnot_have_integrity_error(self, dag_maker):
+        """
+        Test that the dag file processor does not try to insert already existing item into the database
+        """
+        session = settings.Session()
+
+        # Create dag with a start of 2 days ago, but an sla of 1 day
+        # ago so we'll already have an sla_miss on the books
+        test_start_date = days_ago(2)
+        with dag_maker(
+            dag_id='test_sla_miss',
+            default_args={'start_date': test_start_date, 'sla': datetime.timedelta(days=1)},
+        ) as dag:
+            task = DummyOperator(task_id='dummy')
+
+        dag_maker.create_dagrun(execution_date=test_start_date, state=State.SUCCESS)
+
+        # Create a TaskInstance for two days ago
+        ti = TaskInstance(task=task, execution_date=test_start_date, state='success')
+        session.merge(ti)
+        session.flush()
+
+        dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
+        dag_file_processor.manage_slas(dag=dag, session=session)
+        # Now call manage_slas and see that it runs without errors
+        # because of existing SlaMiss above.
+        # Since this is run often, it's possible that it runs before another
+        # ti is successful thereby trying to insert a duplicate record.
+        dag_file_processor.manage_slas(dag=dag, session=session)
+
     def test_dag_file_processor_sla_miss_callback_exception(self, create_dummy_dag):
         """
         Test that the dag file processor gracefully logs an exception if there is a problem


### PR DESCRIPTION
The DagFileProcessor.manage_slas does not consider if an SlaMiss already exists in
DB while inserting slas.

If an SLA for a task is missed and recorded, on checking SLA again, this task
comes up again if there's no recent run of the task and we try to insert
the record into the SlaMiss table again, this results in Integrity error.

This PR fixes that by avoiding insert if the record already exists

```
[2021-11-12 11:56:11,159] {processor.py:567} ERROR - Error executing SlaCallbackRequest callback for file: /files/dags/example_sla_dag.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1257, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 912, in do_executemany
    cursor.executemany(statement, parameters)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "sla_miss_pkey"
DETAIL:  Key (task_id, dag_id, execution_date)=(sleep_20, example_sla_dag, 2021-11-12 11:56:00+00) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/airflow/airflow/dag_processing/processor.py", line 560, in execute_callbacks
    self.manage_slas(dagbag.dags.get(request.dag_id))
  File "/opt/airflow/airflow/utils/session.py", line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File "/opt/airflow/airflow/dag_processing/processor.py", line 434, in manage_slas
    session.commit()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 1046, in commit
    self.transaction.commit()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 504, in commit
    self._prepare_impl()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 483, in _prepare_impl
    self.session.flush()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2540, in flush
    self._flush(objects)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2682, in _flush
    transaction.rollback(_capture_exception=True)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 70, in __exit__
    with_traceback=exc_tb,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/session.py", line 2642, in _flush
    flush_context.execute()
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/unitofwork.py", line 422, in execute
    rec.execute(self)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/unitofwork.py", line 589, in execute
    uow,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/persistence.py", line 245, in save_obj
    insert,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/orm/persistence.py", line 1083, in _emit_insert_statements
    c = cached_connections[connection].execute(statement, multiparams)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1011, in execute
    return meth(self, multiparams, params)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/elements.py", line 298, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1130, in _execute_clauseelement
    distilled_params,
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1317, in _execute_context
    e, statement, parameters, cursor, context
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1511, in _handle_dbapi_exception
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1257, in _execute_context
    cursor, statement, parameters, context
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/dialects/postgresql/psycopg2.py", line 912, in do_executemany
    cursor.executemany(statement, parameters)
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "sla_miss_pkey"
DETAIL:  Key (task_id, dag_id, execution_date)=(sleep_20, example_sla_dag, 2021-11-12 11:56:00+00) already exists.
```


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
