### PR TITLE
Simplify ``KubernetesPodOperator``

### DIFF
--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -43,9 +43,13 @@ then you don't need to worry about this change.  If however you have subclassed 
 One of the principal goals of the refactor is to clearly separate the "get or create pod" and
 "wait for pod completion" phases.  Previously the "wait for pod completion" logic would be invoked
 differently depending on whether the operator were to  "attach to an existing pod" (e.g. after a
-worker failure) or "create a new pod".  With this refactor we encapsulate  the "get or create" step
-into method :meth:`~.KubernetesPodOperator.get_or_create_pod`. This method tries first to find an
-existing pod using labels specific to the task instance (see :meth:`~.KubernetesPodOperator.find_pod`).
+worker failure) or "create a new pod" and this resulted in some code duplication and a bit more
+nesting of logic.  With this refactor we encapsulate  the "get or create" step
+into method :meth:`~.KubernetesPodOperator.get_or_create_pod`, and pull the monitoring and XCom logic up
+into the top level of ``execute`` because it can be the same for "attached" pods and "new" pods.
+
+:meth:`~.KubernetesPodOperator.get_or_create_pod` tries first to find an existing pod using labels
+specific to the task instance (see :meth:`~.KubernetesPodOperator.find_pod`).
 If one does not exist it :meth:`creates a pod <~.PodLauncher.create_pod>`.
 
 The "waiting" part of execution has three components.  The first step is to wait for the pod to leave the

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -31,6 +31,57 @@ Breaking changes
     If you have subclassed :class:`~.KubernetesPodOperator` will need to update your subclass to reflect
     the new structure. Additionally ``PodStatus`` enum has been renamed to ``PodPhase``.
 
+Notes on changes KubernetesPodOperator and PodLauncher
+``````````````````````````````````````````````````````
+
+Overview
+========
+
+Generally speaking if you did not subclass ``KubernetesPodOperator`` and you didn't use the ``PodLauncher`` class directly,
+then you don't need to worry about this change.  If however you have subclassed ``KubernetesPodOperator, what follows are some notes on the changes in this release.
+
+One of the principal goals of the refactor is to clearly separate the "get or create pod" and
+"wait for pod completion" phases.  Previously the "wait for pod completion" logic would be invoked
+differently depending on whether the operator were to  "attach to an existing pod" (e.g. after a
+worker failure) or "create a new pod".  With this refactor we encapsulate  the "get or create" step
+into method :meth:`~.KubernetesPodOperator.get_or_create_pod`. This method tries first to find an
+existing pod using labels specific to the task instance (see :meth:`~.KubernetesPodOperator.find_pod`).
+If one does not exist it :meth:`creates a pod <~.PodLauncher.create_pod>`.
+
+The "waiting" part of execution has three components.  The first step is to wait for the pod to leave the
+``Pending`` phase (:meth:`~.KubernetesPodOperator.await_pod_start`). Next, if configured to do so,
+the operator will :meth:`follow the base container logs <~.KubernetesPodOperator.await_pod_start>`
+and forward these logs to the task logger until the ``base`` container is done. If not configured to harvest the
+logs, the operator will instead :meth:`poll for container completion until done <~.KubernetesPodOperator.await_container_completion>`;
+either way, we must await container completion before harvesting xcom. After (optionally) extracting the xcom
+value from the base container, we :meth:`await pod completion <~.PodLauncher.await_pod_completion>`.
+
+Previously, depending on whether the pod was "reattached to" (e.g. after a worker failure) or
+created anew, the waiting logic may have occurred in either ``handle_pod_overlap`` or ``create_new_pod_for_operator``.
+
+After the pod terminates, we execute different cleanup tasks depending on whether the pod terminated successfully.
+
+If the pod terminates *unsuccessfully*, we attempt to :meth:`log the pod events <~.PodLauncher.read_pod_events>`. If
+additionally the task is configured *not* to delete the pod after termination, :meth:`we apply a label <~.KubernetesPodOperator.patch_already_checked>`
+indicating that the pod failed and should not be "reattached to" in a retry.  If the task is configured
+to delete its pod, we :meth:`delete it <~.KubernetesPodOperator.process_pod_deletion>`.  Finally,
+we raise an AirflowException to fail the task instance.
+
+If the pod terminates successfully, we :meth:`delete the pod <~.KubernetesPodOperator.process_pod_deletion>`
+(if configured to delete the pod) and push XCom (if configured to push XCom).
+
+Details on method renames, refactors, and deletions
+===================================================
+
+* Method ``create_pod_launcher`` is converted to cached property ``launcher``
+* Construction of k8s ``CoreV1Api`` client is now encapsulated within cached property ``client``
+* Logic to search for an existing pod (e.g. after an airflow worker failure) is moved out of ``execute`` and into method ``find_pod``.
+* Method ``handle_pod_overlap`` is removed. Previously it monitored a "found" pod until completion.  With this change the pod monitoring (and log following) is orchestrated directly from ``execute`` and it is the same  whether it's a "found" pod or a "new" pod. See methods ``await_pod_start``, ``follow_container_logs``, ``await_container_completion`` and ``await_pod_completion``.
+* Method ``create_pod_request_obj`` is renamed ``build_pod_request_obj``.  It now takes argument ``context`` in order to add TI-specific pod labels; previously they were added after return.
+* Method ``create_labels_for_pod`` is renamed ``_get_ti_pod_labels``.  This method doesn't return *all* labels, but only those specific to the TI. We also add parameter ``include_try_number`` to control the inclusion of this label instead of possibly filtering it out later.
+* Method ``_get_pod_identifying_label_string`` is renamed ``_build_find_pod_label_selector``
+* Method ``_try_numbers_match`` is removed.
+* Method ``create_new_pod_for_operator`` is removed. Previously it would mutate the labels on ``self.pod``, launch the pod, monitor the pod to completion etc.  Now this logic is in part handled by ``get_or_create_pod``, where a new pod will be created if necessary. The monitoring etc is now orchestrated directly from ``execute``.  Again, see the calls to methods ``await_pod_start``, ``follow_container_logs``, ``await_container_completion`` and ``await_pod_completion``.
 
 2.2.0
 .....

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -19,6 +19,19 @@
 Changelog
 ---------
 
+3.0.0
+.....
+
+Breaking changes
+~~~~~~~~~~~~~~~~
+
+* ``Simplify KubernetesPodOperator (#19572)``
+
+.. warning:: Many methods in :class:`~.KubernetesPodOperator` and class:`~.PodLauncher` have been renamed.
+    If you have subclassed :class:`~.KubernetesPodOperator` will need to update your subclass to reflect
+    the new structure. Additionally ``PodStatus`` enum has been renamed to ``PodPhase``.
+
+
 2.2.0
 .....
 

--- a/airflow/providers/cncf/kubernetes/CHANGELOG.rst
+++ b/airflow/providers/cncf/kubernetes/CHANGELOG.rst
@@ -38,7 +38,8 @@ Overview
 ''''''''
 
 Generally speaking if you did not subclass ``KubernetesPodOperator`` and you didn't use the ``PodLauncher`` class directly,
-then you don't need to worry about this change.  If however you have subclassed ``KubernetesPodOperator, what follows are some notes on the changes in this release.
+then you don't need to worry about this change.  If however you have subclassed ``KubernetesPodOperator``, what
+follows are some notes on the changes in this release.
 
 One of the principal goals of the refactor is to clearly separate the "get or create pod" and
 "wait for pod completion" phases.  Previously the "wait for pod completion" logic would be invoked

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -425,11 +425,10 @@ class KubernetesPodOperator(BaseOperator):
                 pod=self.pod or self.pod_request_obj,
                 remote_pod=remote_pod,
             )
+        ti = context['ti']
+        ti.xcom_push(key='pod_name', value=self.pod.metadata.name)
+        ti.xcom_push(key='pod_namespace', value=self.pod.metadata.namespace)
         if self.do_xcom_push:
-            ti = context['ti']
-            if remote_pod:
-                ti.xcom_push(key='pod_name', value=remote_pod.metadata.name)
-                ti.xcom_push(key='pod_namespace', value=remote_pod.metadata.namespace)
             return result
 
     def cleanup(self, pod: k8s.V1Pod, remote_pod: k8s.V1Pod):

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -393,7 +393,7 @@ class KubernetesPodOperator(BaseOperator):
     def extract_xcom(self, pod):
         """Retrieves xcom value and kills xcom sidecar container"""
         result = self.launcher.extract_xcom(pod)
-        self.log.info(result)
+        self.log.info("xcom result: \n%s", result)
         return json.loads(result)
 
     def execute(self, context):

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -369,12 +369,8 @@ class KubernetesPodOperator(BaseOperator):
         elif num_pods == 1:
             pod = pod_list[0]
             self.log.info("Found matching pod %s with labels %s", pod.metadata.name, pod.metadata.labels)
-            if not pod.metadata.labels['try_number'] == context['ti'].try_number:
-                self.log.info(
-                    "`try_number` of current task instance is %s but pod has `try_number` %s",
-                    context['ti'].try_number,
-                    pod.metadata.labels['try_number'],
-                )
+            self.log.info("`try_number` of task_instance: %s", context['ti'].try_number)
+            self.log.info("`try_number` of pod: %s", pod.metadata.labels['try_number'])
             return pod
 
     def get_or_create_pod(self, pod_request_obj: k8s.V1Pod, context):

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 from kubernetes.client import CoreV1Api, models as k8s
 
-from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLaunchFailedException, PodStatus
+from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLaunchFailedException, PodPhase
 
 try:
     import airflow.utils.yaml as yaml
@@ -436,7 +436,7 @@ class KubernetesPodOperator(BaseOperator):
             self.process_pod_deletion(pod)
 
         pod_phase = remote_pod.status.phase if hasattr(remote_pod, 'status') else None
-        if pod_phase != PodStatus.SUCCEEDED:
+        if pod_phase != PodPhase.SUCCEEDED:
             if self.log_events_on_failure:
                 with _suppress(Exception):
                     for event in self.launcher.read_pod_events(pod).items:

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -448,7 +448,7 @@ class KubernetesPodOperator(BaseOperator):
 
     def process_pod_deletion(self, pod):
         if self.is_delete_operator_pod:
-            self.log.info("deleting pod: %s", pod.metadata.name)
+            self.log.info("Deleting pod: %s", pod.metadata.name)
             self.launcher.delete_pod(pod)
         else:
             self.log.info("skipping deleting pod: %s", pod.metadata.name)
@@ -563,7 +563,7 @@ class KubernetesPodOperator(BaseOperator):
             pod = xcom_sidecar.add_xcom_sidecar(pod)
 
         labels = self._create_labels_for_pod(context)
-        self.log.info("creating pod %s with labels: %s", pod.metadata.name, labels)
+        self.log.info("Creating pod %s with labels: %s", pod.metadata.name, labels)
 
         # Merge Pod Identifying labels with labels passed to operator
         pod.metadata.labels.update(labels)

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -436,7 +436,7 @@ class KubernetesPodOperator(BaseOperator):
                 ti.xcom_push(key='pod_namespace', value=remote_pod.metadata.namespace)
             return result
 
-    def cleanup(self, pod, remote_pod):
+    def cleanup(self, pod: k8s.V1Pod, remote_pod: k8s.V1Pod):
         with _suppress(Exception):
             self.process_pod_deletion(pod)
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -574,8 +574,11 @@ class KubernetesPodOperator(BaseOperator):
 
 class _suppress(AbstractContextManager):
     """
-    This behaves the same as contextlib.suppress but logs the suppressed
+    This behaves the same as ``contextlib.suppress`` but logs the suppressed
     exceptions as errors with traceback.
+
+    The caught exception is also stored on the context manager instance under
+    attribute ``exception``.
     """
 
     def __init__(self, *exceptions):

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -316,13 +316,16 @@ class KubernetesPodOperator(BaseOperator):
         super()._render_nested_template_fields(content, context, jinja_env, seen_oids)
 
     @staticmethod
-    def _create_labels_for_pod(context) -> dict:
+    def _create_labels_for_pod(context=None) -> dict:
         """
         Generate labels for the pod to track the pod in case of Operator crash
 
         :param context: task context provided by airflow DAG
         :return: dict
         """
+        if not context:
+            return {}
+
         labels = {
             'dag_id': context['dag'].dag_id,
             'task_id': context['task'].task_id,
@@ -485,7 +488,7 @@ class KubernetesPodOperator(BaseOperator):
                 kwargs.update(grace_period_seconds=self.termination_grace_period)
             self.client.delete_namespaced_pod(**kwargs)
 
-    def build_pod_request_obj(self, context):
+    def build_pod_request_obj(self, context=None):
         """
         Creates a V1Pod based on user parameters. Note that a `pod` or `pod_template_file`
         will supersede all other values.

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -18,13 +18,13 @@
 import json
 import math
 import time
+from contextlib import closing
 from datetime import datetime as dt
 from typing import Iterable, Optional, Tuple, Union
 
 import pendulum
 import tenacity
 from kubernetes import client, watch
-from kubernetes.client.models.v1_event import V1Event
 from kubernetes.client.models.v1_event_list import V1EventList
 from kubernetes.client.models.v1_pod import V1Pod
 from kubernetes.client.rest import ApiException
@@ -38,7 +38,10 @@ from airflow.kubernetes.kube_client import get_kube_client
 from airflow.kubernetes.pod_generator import PodDefaults
 from airflow.settings import pod_mutation_hook
 from airflow.utils.log.logging_mixin import LoggingMixin
-from airflow.utils.state import State
+
+
+class PodLaunchFailedException(AirflowException):
+    """When pod launching fails in KubernetesPodOperator."""
 
 
 def should_retry_start_pod(exception: Exception) -> bool:
@@ -51,10 +54,22 @@ def should_retry_start_pod(exception: Exception) -> bool:
 class PodStatus:
     """Status of the PODs"""
 
-    PENDING = 'pending'
-    RUNNING = 'running'
-    FAILED = 'failed'
-    SUCCEEDED = 'succeeded'
+    PENDING = 'Pending'
+    RUNNING = 'Running'
+    FAILED = 'Failed'
+    SUCCEEDED = 'Succeeded'
+
+    terminal_states = {FAILED, SUCCEEDED}
+
+
+def container_is_running(pod: V1Pod, container_name: str) -> bool:
+    container_statuses = pod.status.container_statuses if pod and pod.status else None
+    if not container_statuses:
+        return False
+    container_status = next(iter([x for x in container_statuses if x.name == container_name]), None)
+    if not container_status:
+        return False
+    return container_status.state.running is not None
 
 
 class PodLauncher(LoggingMixin):
@@ -65,7 +80,6 @@ class PodLauncher(LoggingMixin):
         kube_client: client.CoreV1Api = None,
         in_cluster: bool = True,
         cluster_context: Optional[str] = None,
-        extract_xcom: bool = False,
     ):
         """
         Creates the launcher.
@@ -73,12 +87,10 @@ class PodLauncher(LoggingMixin):
         :param kube_client: kubernetes client
         :param in_cluster: whether we are in cluster
         :param cluster_context: context of the cluster
-        :param extract_xcom: whether we should extract xcom
         """
         super().__init__()
         self._client = kube_client or get_kube_client(in_cluster=in_cluster, cluster_context=cluster_context)
         self._watch = watch.Watch()
-        self.extract_xcom = extract_xcom
 
     def run_pod_async(self, pod: V1Pod, **kwargs) -> V1Pod:
         """Runs POD asynchronously"""
@@ -117,79 +129,99 @@ class PodLauncher(LoggingMixin):
         reraise=True,
         retry=tenacity.retry_if_exception(should_retry_start_pod),
     )
-    def start_pod(self, pod: V1Pod, startup_timeout: int = 120) -> None:
+    def create_pod(self, pod: V1Pod) -> V1Pod:
+        """Launches the pod asynchronously."""
+        return self.run_pod_async(pod)
+
+    def await_pod_start(self, pod: V1Pod, startup_timeout: int = 120) -> None:
         """
-        Launches the pod synchronously and waits for completion.
+        Waits for the pod to reach phase other than ``Pending``
 
         :param pod:
         :param startup_timeout: Timeout (in seconds) for startup of the pod
             (if pod is pending for too long, fails task)
         :return:
         """
-        resp = self.run_pod_async(pod)
         curr_time = dt.now()
-        if resp.status.start_time is None:
-            while self.pod_not_started(pod):
-                self.log.warning("Pod not yet started: %s", pod.metadata.name)
-                delta = dt.now() - curr_time
-                if delta.total_seconds() >= startup_timeout:
-                    msg = (
-                        f"Pod took longer than {startup_timeout} seconds to start. "
-                        "Check the pod events in kubernetes to determine why."
-                    )
-                    raise AirflowException(msg)
-                time.sleep(1)
+        while True:
+            remote_pod = self.read_pod(pod)
+            if remote_pod.status.phase != PodStatus.PENDING:
+                break
+            self.log.warning("Pod not yet started: %s", pod.metadata.name)
+            delta = dt.now() - curr_time
+            if delta.total_seconds() >= startup_timeout:
+                msg = (
+                    f"Pod took longer than {startup_timeout} seconds to start. "
+                    "Check the pod events in kubernetes to determine why."
+                )
+                raise PodLaunchFailedException(msg)
+            time.sleep(1)
 
-    def monitor_pod(self, pod: V1Pod, get_logs: bool) -> Tuple[State, V1Pod, Optional[str]]:
+    def follow_container_logs(self, pod: V1Pod, container_name: str):
         """
-        Monitors a pod and returns the final state, pod and xcom result
+        Follows the logs of container and streams to airflow logging.
+        Returns when container exits.
+        """
+        container_stopped = False
+        read_logs_since_sec = None
+        last_log_time = None
+
+        # `read_pod_logs` follows the logs so we shouldn't necessarily _need_ to loop
+        # but in a long-running process we might lose connectivity and this way we
+        # can resume following the logs
+        while True:
+            try:
+                logs = self.read_pod_logs(
+                    pod=pod,
+                    container_name=container_name,
+                    timestamps=True,
+                    since_seconds=read_logs_since_sec,
+                )
+                for line in logs:  # type: bytes
+                    timestamp, message = self.parse_log_line(line.decode('utf-8'))
+                    self.log.info(message)
+                    if timestamp:
+                        last_log_time = timestamp
+            except BaseHTTPError:  # Catches errors like ProtocolError(TimeoutError).
+                self.log.warning(
+                    'Failed to read logs for pod %s',
+                    pod.metadata.name,
+                    exc_info=True,
+                )
+
+            if container_stopped is True:
+                break
+
+            if last_log_time:
+                delta = pendulum.now() - last_log_time
+                read_logs_since_sec = math.ceil(delta.total_seconds())
+
+            time.sleep(1)
+
+            if self.container_is_running(pod, container_name=container_name):
+                self.log.info('Container %s is running', pod.metadata.name)
+                self.log.warning('Pod %s log read interrupted', pod.metadata.name)
+            else:
+                container_stopped = True  # fetch logs once more and exit
+
+    def await_container_completion(self, pod: V1Pod, container_name: str) -> None:
+        while not self.container_is_running(pod=pod, container_name=container_name):
+            time.sleep(1)
+
+    def await_pod_completion(self, pod: V1Pod) -> V1Pod:
+        """
+        Monitors a pod and returns the final state
 
         :param pod: pod spec that will be monitored
-        :param get_logs: whether to read the logs locally
         :return:  Tuple[State, Optional[str]]
         """
-        if get_logs:
-            read_logs_since_sec = None
-            last_log_time = None
-            while True:
-                try:
-                    logs = self.read_pod_logs(pod, timestamps=True, since_seconds=read_logs_since_sec)
-                    for line in logs:
-                        timestamp, message = self.parse_log_line(line.decode('utf-8'))
-                        self.log.info(message)
-                        if timestamp:
-                            last_log_time = timestamp
-                except BaseHTTPError:
-                    # Catches errors like ProtocolError(TimeoutError).
-                    self.log.warning(
-                        'Failed to read logs for pod %s',
-                        pod.metadata.name,
-                        exc_info=True,
-                    )
-
-                time.sleep(1)
-
-                if not self.base_container_is_running(pod):
-                    break
-
-                self.log.warning('Pod %s log read interrupted', pod.metadata.name)
-                if last_log_time:
-                    delta = pendulum.now() - last_log_time
-                    # Prefer logs duplication rather than loss
-                    read_logs_since_sec = math.ceil(delta.total_seconds())
-        result = None
-        if self.extract_xcom:
-            while self.base_container_is_running(pod):
-                self.log.info('Container %s has state %s', pod.metadata.name, State.RUNNING)
-                time.sleep(2)
-            result = self._extract_xcom(pod)
-            self.log.info(result)
-            result = json.loads(result)
-        while self.pod_is_running(pod):
-            self.log.info('Pod %s has state %s', pod.metadata.name, State.RUNNING)
+        while True:
+            remote_pod = self.read_pod(pod)
+            if remote_pod.status.phase in PodStatus.terminal_states:
+                break
+            self.log.info('Pod %s has phase %s', pod.metadata.name, remote_pod.status.phase)
             time.sleep(2)
-        remote_pod = self.read_pod(pod)
-        return self._task_status(remote_pod), remote_pod, result
+        return remote_pod
 
     def parse_log_line(self, line: str) -> Tuple[Optional[Union[Date, Time, DateTime, Duration]], str]:
         """
@@ -212,35 +244,16 @@ class PodLauncher(LoggingMixin):
             return None, line
         return last_log_time, message
 
-    def _task_status(self, event: V1Event) -> str:
-        self.log.info('Event: %s had an event of type %s', event.metadata.name, event.status.phase)
-        status = self.process_status(event.metadata.name, event.status.phase)
-        return status
-
-    def pod_not_started(self, pod: V1Pod) -> bool:
-        """Tests if pod has not started"""
-        state = self._task_status(self.read_pod(pod))
-        return state == State.QUEUED
-
-    def pod_is_running(self, pod: V1Pod) -> bool:
-        """Tests if pod is running"""
-        state = self._task_status(self.read_pod(pod))
-        return state not in (State.SUCCESS, State.FAILED)
-
-    def base_container_is_running(self, pod: V1Pod) -> bool:
-        """Tests if base container is running"""
-        event = self.read_pod(pod)
-        if not (event and event.status and event.status.container_statuses):
-            return False
-        status = next(iter(filter(lambda s: s.name == 'base', event.status.container_statuses)), None)
-        if not status:
-            return False
-        return status.state.running is not None
+    def container_is_running(self, pod: V1Pod, container_name) -> bool:
+        """Reads pod and checks if container is running"""
+        remote_pod = self.read_pod(pod)
+        return container_is_running(pod=remote_pod, container_name=container_name)
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
     def read_pod_logs(
         self,
         pod: V1Pod,
+        container_name: str,
         tail_lines: Optional[int] = None,
         timestamps: bool = False,
         since_seconds: Optional[int] = None,
@@ -257,7 +270,7 @@ class PodLauncher(LoggingMixin):
             return self._client.read_namespaced_pod_log(
                 name=pod.metadata.name,
                 namespace=pod.metadata.namespace,
-                container='base',
+                container=container_name,
                 follow=True,
                 timestamps=timestamps,
                 _preload_content=False,
@@ -265,7 +278,6 @@ class PodLauncher(LoggingMixin):
             )
         except BaseHTTPError:
             self.log.exception('There was an error reading the kubernetes API.')
-            # Reraise to be caught by self.monitor_pod.
             raise
 
     @tenacity.retry(stop=tenacity.stop_after_attempt(3), wait=tenacity.wait_exponential(), reraise=True)
@@ -286,29 +298,29 @@ class PodLauncher(LoggingMixin):
         except BaseHTTPError as e:
             raise AirflowException(f'There was an error reading the kubernetes API: {e}')
 
-    def _extract_xcom(self, pod: V1Pod) -> str:
-        resp = kubernetes_stream(
-            self._client.connect_get_namespaced_pod_exec,
-            pod.metadata.name,
-            pod.metadata.namespace,
-            container=PodDefaults.SIDECAR_CONTAINER_NAME,
-            command=['/bin/sh'],
-            stdin=True,
-            stdout=True,
-            stderr=True,
-            tty=False,
-            _preload_content=False,
-        )
-        try:
+    def extract_xcom(self, pod: V1Pod) -> str:
+        """Retrieves xcom value using xcom value and kills xcom sidecar container"""
+        with closing(
+            kubernetes_stream(
+                self._client.connect_get_namespaced_pod_exec,
+                pod.metadata.name,
+                pod.metadata.namespace,
+                container=PodDefaults.SIDECAR_CONTAINER_NAME,
+                command=['/bin/sh'],
+                stdin=True,
+                stdout=True,
+                stderr=True,
+                tty=False,
+                _preload_content=False,
+            )
+        ) as resp:
             result = self._exec_pod_command(resp, f'cat {PodDefaults.XCOM_MOUNT_PATH}/return.json')
             self._exec_pod_command(resp, 'kill -s SIGINT 1')
-        finally:
-            resp.close()
         if result is None:
             raise AirflowException(f'Failed to extract xcom from pod: {pod.metadata.name}')
         return result
 
-    def _exec_pod_command(self, resp, command: str) -> None:
+    def _exec_pod_command(self, resp, command: str) -> Optional[str]:
         if resp.is_open():
             self.log.info('Running command... %s\n', command)
             resp.write_stdin(command + '\n')
@@ -320,20 +332,3 @@ class PodLauncher(LoggingMixin):
                     self.log.info(resp.read_stderr())
                     break
         return None
-
-    def process_status(self, job_id: str, status: str) -> str:
-        """Process status information for the JOB"""
-        status = status.lower()
-        if status == PodStatus.PENDING:
-            return State.QUEUED
-        elif status == PodStatus.FAILED:
-            self.log.error('Event with job id %s Failed', job_id)
-            return State.FAILED
-        elif status == PodStatus.SUCCEEDED:
-            self.log.info('Event with job id %s Succeeded', job_id)
-            return State.SUCCESS
-        elif status == PodStatus.RUNNING:
-            return State.RUNNING
-        else:
-            self.log.error('Event: Invalid state %s on job %s', status, job_id)
-            return State.FAILED

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -189,7 +189,7 @@ class PodLauncher(LoggingMixin):
                     exc_info=True,
                 )
 
-            if container_stopped is True:
+            if container_stopped:
                 break
 
             if last_log_time:
@@ -244,7 +244,7 @@ class PodLauncher(LoggingMixin):
             return None, line
         return last_log_time, message
 
-    def container_is_running(self, pod: V1Pod, container_name) -> bool:
+    def container_is_running(self, pod: V1Pod, container_name: str) -> bool:
         """Reads pod and checks if container is running"""
         remote_pod = self.read_pod(pod)
         return container_is_running(pod=remote_pod, container_name=container_name)
@@ -299,7 +299,7 @@ class PodLauncher(LoggingMixin):
             raise AirflowException(f'There was an error reading the kubernetes API: {e}')
 
     def extract_xcom(self, pod: V1Pod) -> str:
-        """Retrieves xcom value using xcom value and kills xcom sidecar container"""
+        """Retrieves XCom value and kills xcom sidecar container"""
         with closing(
             kubernetes_stream(
                 self._client.connect_get_namespaced_pod_exec,

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -63,6 +63,10 @@ class PodStatus:
 
 
 def container_is_running(pod: V1Pod, container_name: str) -> bool:
+    """
+    Examines V1Pod ``pod`` to determine whether ``container_name`` is running.
+    If that container is present and running, returns True.  Returns False otherwise.
+    """
     container_statuses = pod.status.container_statuses if pod and pod.status else None
     if not container_statuses:
         return False

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -51,8 +51,11 @@ def should_retry_start_pod(exception: Exception) -> bool:
     return False
 
 
-class PodStatus:
-    """Status of the PODs"""
+class PodPhase:
+    """
+    Possible pod phases
+    See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase.
+    """
 
     PENDING = 'Pending'
     RUNNING = 'Running'
@@ -149,7 +152,7 @@ class PodLauncher(LoggingMixin):
         curr_time = datetime.now()
         while True:
             remote_pod = self.read_pod(pod)
-            if remote_pod.status.phase != PodStatus.PENDING:
+            if remote_pod.status.phase != PodPhase.PENDING:
                 break
             self.log.warning("Pod not yet started: %s", pod.metadata.name)
             delta = datetime.now() - curr_time
@@ -230,7 +233,7 @@ class PodLauncher(LoggingMixin):
         """
         while True:
             remote_pod = self.read_pod(pod)
-            if remote_pod.status.phase in PodStatus.terminal_states:
+            if remote_pod.status.phase in PodPhase.terminal_states:
                 break
             self.log.info('Pod %s has phase %s', pod.metadata.name, remote_pod.status.phase)
             time.sleep(2)

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -329,6 +329,6 @@ class PodLauncher(LoggingMixin):
                 if resp.peek_stdout():
                     return resp.read_stdout()
                 if resp.peek_stderr():
-                    self.log.info(resp.read_stderr())
+                    self.log.info("stderr from command: %s", resp.read_stderr())
                     break
         return None

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1297,6 +1297,7 @@ storedInfoType
 str
 stringified
 subchart
+subclassed
 subclasses
 subclassing
 subcluster

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1410,6 +1410,7 @@ unpausing
 unpredicted
 unqueued
 unterminated
+untransformed
 unutilized
 updateMask
 updateonly

--- a/kubernetes_tests/test_kubernetes_pod_operator.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator.py
@@ -23,7 +23,7 @@ import sys
 import textwrap
 import unittest
 from unittest import mock
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
 import pendulum
 import pytest
@@ -34,7 +34,7 @@ from kubernetes.client.rest import ApiException
 from airflow.exceptions import AirflowException
 from airflow.kubernetes import kube_client
 from airflow.kubernetes.secret import Secret
-from airflow.models import DAG, DagRun, TaskInstance
+from airflow.models import DAG, XCOM_RETURN_KEY, DagRun, TaskInstance
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
@@ -156,6 +156,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             task_id="task" + self.get_current_task_name(),
             in_cluster=False,
             do_xcom_push=False,
+            is_delete_operator_pod=False,
             config_file=new_config_path,
         )
         context = create_context(k)
@@ -516,12 +517,10 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             startup_timeout_seconds=5,
             service_account_name=bad_service_account_name,
         )
-        with pytest.raises(ApiException):
-            context = create_context(k)
-            k.execute(context)
-            actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-            self.expected_pod['spec']['serviceAccountName'] = bad_service_account_name
-            assert self.expected_pod == actual_pod
+        context = create_context(k)
+        pod = k.build_pod_request_obj(context)
+        with pytest.raises(ApiException, match="error looking up service account default/foobar"):
+            k.get_or_create_pod(pod, context)
 
     def test_pod_failure(self):
         """
@@ -546,7 +545,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             self.expected_pod['spec']['containers'][0]['args'] = bad_internal_command
             assert self.expected_pod == actual_pod
 
-    def test_xcom_push(self):
+    @mock.patch("airflow.models.taskinstance.TaskInstance.xcom_push")
+    def test_xcom_push(self, xcom_push):
         return_value = '{"foo": "bar"\n, "buzz": 2}'
         args = [f'echo \'{return_value}\' > /airflow/xcom/return.json']
         k = KubernetesPodOperator(
@@ -561,7 +561,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             do_xcom_push=True,
         )
         context = create_context(k)
-        assert k.execute(context) == json.loads(return_value)
+        k.execute(context)
+        assert xcom_push.called_once_with(key=XCOM_RETURN_KEY, value=json.loads(return_value))
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
         volume = self.api_client.sanitize_for_serialization(PodDefaults.VOLUME)
         volume_mount = self.api_client.sanitize_for_serialization(PodDefaults.VOLUME_MOUNT)
@@ -572,12 +573,11 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_envs_from_secrets(self, mock_client, monitor_mock, start_mock):
+    def test_envs_from_secrets(self, mock_client, await_pod_completion_mock, create_pod):
         # GIVEN
-        from airflow.utils.state import State
 
         secret_ref = 'secret_name'
         secrets = [Secret('env', None, secret_ref)]
@@ -595,10 +595,11 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             do_xcom_push=False,
         )
         # THEN
-        monitor_mock.return_value = (State.SUCCESS, None, None)
+        await_pod_completion_mock.return_value = None
         context = create_context(k)
-        k.execute(context)
-        assert start_mock.call_args[0][0].spec.containers[0].env_from == [
+        with pytest.raises(AirflowException):
+            k.execute(context)
+        assert create_pod.call_args[1]['pod'].spec.containers[0].env_from == [
             k8s.V1EnvFromSource(secret_ref=k8s.V1SecretEnvSource(name=secret_ref))
         ]
 
@@ -625,12 +626,9 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             in_cluster=False,
             do_xcom_push=False,
         )
-
-        context = create_context(k)
-        k.execute(context)
-
         # THEN
-        actual_pod = self.api_client.sanitize_for_serialization(k.pod)
+        context = create_context(k)
+        actual_pod = self.api_client.sanitize_for_serialization(k.build_pod_request_obj(context))
         self.expected_pod['spec']['containers'][0]['env'] = [
             {'name': 'ENV1', 'value': 'val1'},
             {'name': 'ENV2', 'value': 'val2'},
@@ -741,6 +739,7 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             in_cluster=False,
             full_pod_spec=pod_spec,
             do_xcom_push=True,
+            is_delete_operator_pod=False,
         )
 
         context = create_context(k)
@@ -814,12 +813,12 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         ]
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.extract_xcom")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_pod_template_file(self, mock_client, monitor_mock, start_mock):
-        from airflow.utils.state import State
-
+    def test_pod_template_file(self, mock_client, await_pod_completion_mock, create_mock, extract_xcom_mock):
+        extract_xcom_mock.return_value = '{}'
         path = sys.path[0] + '/tests/kubernetes/pod.yaml'
         k = KubernetesPodOperator(
             task_id="task" + self.get_current_task_name(),
@@ -827,8 +826,9 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             pod_template_file=path,
             do_xcom_push=True,
         )
-
-        monitor_mock.return_value = (State.SUCCESS, None, None)
+        pod_mock = MagicMock()
+        pod_mock.status.phase = 'Succeeded'
+        await_pod_completion_mock.return_value = pod_mock
         context = create_context(k)
         with self.assertLogs(k.log, level=logging.DEBUG) as cm:
             k.execute(context)
@@ -899,12 +899,11 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         del actual_pod['metadata']['labels']['airflow_version']
         assert expected_dict == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_pod_priority_class_name(self, mock_client, monitor_mock, start_mock):
+    def test_pod_priority_class_name(self, mock_client, await_pod_completion_mock, create_mock):
         """Test ability to assign priorityClassName to pod"""
-        from airflow.utils.state import State
 
         priority_class_name = "medium-test"
         k = KubernetesPodOperator(
@@ -920,7 +919,9 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             priority_class_name=priority_class_name,
         )
 
-        monitor_mock.return_value = (State.SUCCESS, None, None)
+        pod_mock = MagicMock()
+        pod_mock.status.phase = 'Succeeded'
+        await_pod_completion_mock.return_value = pod_mock
         context = create_context(k)
         k.execute(context)
         actual_pod = self.api_client.sanitize_for_serialization(k.pod)
@@ -942,9 +943,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
                 do_xcom_push=False,
             )
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
-    def test_on_kill(self, monitor_mock):
-        from airflow.utils.state import State
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
+    def test_on_kill(self, await_pod_completion_mock):
 
         client = kube_client.get_kube_client(in_cluster=False)
         name = "test"
@@ -959,21 +959,20 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             task_id=name,
             in_cluster=False,
             do_xcom_push=False,
+            get_logs=False,
             termination_grace_period=0,
         )
         context = create_context(k)
-        monitor_mock.return_value = (State.SUCCESS, None, None)
-        k.execute(context)
+        with pytest.raises(AirflowException):
+            k.execute(context)
         name = k.pod.metadata.name
         pod = client.read_namespaced_pod(name=name, namespace=namespace)
         assert pod.status.phase == "Running"
         k.on_kill()
-        with pytest.raises(ApiException):
-            pod = client.read_namespaced_pod(name=name, namespace=namespace)
+        with pytest.raises(ApiException, match=r'pods \\"test.[a-z0-9]+\\" not found'):
+            client.read_namespaced_pod(name=name, namespace=namespace)
 
     def test_reattach_failing_pod_once(self):
-        from airflow.utils.state import State
-
         client = kube_client.get_kube_client(in_cluster=False)
         name = "test"
         namespace = "default"
@@ -993,24 +992,38 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
 
         context = create_context(k)
 
+        # launch pod
         with mock.patch(
-            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod"
-        ) as monitor_mock:
-            monitor_mock.return_value = (State.SUCCESS, None, None)
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion"
+        ) as await_pod_completion_mock:
+            pod_mock = MagicMock()
+
+            # we don't want failure because we don't want the pod to be patched as "already_checked"
+            pod_mock.status.phase = 'Succeeded'
+            await_pod_completion_mock.return_value = pod_mock
             k.execute(context)
             name = k.pod.metadata.name
             pod = client.read_namespaced_pod(name=name, namespace=namespace)
             while pod.status.phase != "Failed":
                 pod = client.read_namespaced_pod(name=name, namespace=namespace)
-        with pytest.raises(AirflowException):
-            k.execute(context)
-        pod = client.read_namespaced_pod(name=name, namespace=namespace)
-        assert pod.metadata.labels["already_checked"] == "True"
+            assert 'already_checked' not in pod.metadata.labels
+
+        # should not call `create_pod`, because there's a pod there it should find
+        # should use the found pod and patch as "already_checked" (in failure block)
         with mock.patch(
-            "airflow.providers.cncf.kubernetes"
-            ".operators.kubernetes_pod.KubernetesPodOperator"
-            ".create_new_pod_for_operator"
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod"
         ) as create_mock:
-            create_mock.return_value = ("success", {}, {})
-            k.execute(context)
+            with pytest.raises(AirflowException):
+                k.execute(context)
+            pod = client.read_namespaced_pod(name=name, namespace=namespace)
+            assert pod.metadata.labels["already_checked"] == "True"
+            create_mock.assert_not_called()
+
+        # `create_pod` should be called because though there's still a pod to be found,
+        # it will be `already_checked`
+        with mock.patch(
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod"
+        ) as create_mock:
+            with pytest.raises(AirflowException):
+                k.execute(context)
             create_mock.assert_called_once()

--- a/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
+++ b/kubernetes_tests/test_kubernetes_pod_operator_backcompat.py
@@ -19,7 +19,7 @@ import json
 import sys
 import unittest
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import kubernetes.client.models as k8s
 import pendulum
@@ -39,7 +39,6 @@ from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import Kubernete
 from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher
 from airflow.providers.cncf.kubernetes.utils.xcom_sidecar import PodDefaults
 from airflow.utils import timezone
-from airflow.utils.state import State
 from airflow.version import version as airflow_version
 
 # noinspection DuplicatedCode
@@ -118,10 +117,10 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         client = kube_client.get_kube_client(in_cluster=False)
         client.delete_collection_namespaced_pod(namespace="default")
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_image_pull_secrets_correctly_set(self, mock_client, monitor_mock, start_mock):
+    def test_image_pull_secrets_correctly_set(self, mock_client, await_pod_completion_mock, create_mock):
         fake_pull_secrets = "fakeSecret"
         k = KubernetesPodOperator(
             namespace='default',
@@ -136,10 +135,12 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             image_pull_secrets=fake_pull_secrets,
             cluster_context='default',
         )
-        monitor_mock.return_value = (State.SUCCESS, None, None)
+        mock_pod = MagicMock()
+        mock_pod.status.phase = 'Succeeded'
+        await_pod_completion_mock.return_value = mock_pod
         context = create_context(k)
         k.execute(context=context)
-        assert start_mock.call_args[0][0].spec.image_pull_secrets == [
+        assert create_mock.call_args[1]['pod'].spec.image_pull_secrets == [
             k8s.V1LocalObjectReference(name=fake_pull_secrets)
         ]
 
@@ -378,9 +379,11 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         assert self.expected_pod == actual_pod
 
     def test_faulty_service_account(self):
-        bad_service_account_name = "foobar"
+        """pod creation should fail when service account does not exist"""
+        service_account = "foobar"
+        namespace = "default"
         k = KubernetesPodOperator(
-            namespace='default',
+            namespace=namespace,
             image="ubuntu:16.04",
             cmds=["bash", "-cx"],
             arguments=["echo 10"],
@@ -390,14 +393,14 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             in_cluster=False,
             do_xcom_push=False,
             startup_timeout_seconds=5,
-            service_account_name=bad_service_account_name,
+            service_account_name=service_account,
         )
-        with pytest.raises(ApiException):
-            context = create_context(k)
-            k.execute(context)
-            actual_pod = self.api_client.sanitize_for_serialization(k.pod)
-            self.expected_pod['spec']['serviceAccountName'] = bad_service_account_name
-            assert self.expected_pod == actual_pod
+        context = create_context(k)
+        pod = k.build_pod_request_obj(context)
+        with pytest.raises(
+            ApiException, match=f"error looking up service account {namespace}/{service_account}"
+        ):
+            k.get_or_create_pod(pod, context)
 
     def test_pod_failure(self):
         """
@@ -448,8 +451,8 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
         self.expected_pod['spec']['containers'].append(container)
         assert self.expected_pod == actual_pod
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
     def test_envs_from_configmaps(self, mock_client, mock_monitor, mock_start):
         # GIVEN
@@ -468,17 +471,19 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             configmaps=[configmap],
         )
         # THEN
-        mock_monitor.return_value = (State.SUCCESS, None, None)
+        mock_pod = MagicMock()
+        mock_pod.status.phase = 'Succeeded'
+        mock_monitor.return_value = mock_pod
         context = create_context(k)
         k.execute(context)
-        assert mock_start.call_args[0][0].spec.containers[0].env_from == [
+        assert mock_start.call_args[1]['pod'].spec.containers[0].env_from == [
             k8s.V1EnvFromSource(config_map_ref=k8s.V1ConfigMapEnvSource(name=configmap))
         ]
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion")
     @mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-    def test_envs_from_secrets(self, mock_client, monitor_mock, start_mock):
+    def test_envs_from_secrets(self, mock_client, await_pod_completion_mock, create_mock):
         # GIVEN
         secret_ref = 'secret_name'
         secrets = [Secret('env', None, secret_ref)]
@@ -496,10 +501,13 @@ class TestKubernetesPodOperatorSystem(unittest.TestCase):
             do_xcom_push=False,
         )
         # THEN
-        monitor_mock.return_value = (State.SUCCESS, None, None)
+
+        mock_pod = MagicMock()
+        mock_pod.status.phase = 'Succeeded'
+        await_pod_completion_mock.return_value = mock_pod
         context = create_context(k)
         k.execute(context)
-        assert start_mock.call_args[0][0].spec.containers[0].env_from == [
+        assert create_mock.call_args[1]['pod'].spec.containers[0].env_from == [
             k8s.V1EnvFromSource(secret_ref=k8s.V1SecretEnvSource(name=secret_ref))
         ]
 

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -17,6 +17,7 @@
 import unittest
 from tempfile import NamedTemporaryFile
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pytest
 from kubernetes.client import ApiClient, models as k8s
@@ -25,27 +26,44 @@ from parameterized import parameterized
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.models.xcom import IN_MEMORY_DAGRUN_ID
-from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator, _suppress
 from airflow.utils import timezone
-from airflow.utils.state import State
 
 DEFAULT_DATE = timezone.datetime(2016, 1, 1, 1, 0, 0)
 
 
+def create_context(task):
+    dag = DAG(dag_id="dag")
+    task_instance = TaskInstance(task=task, run_id="kub_pod_test")
+    task_instance.dag_run = DagRun(run_id="kub_pod_test", execution_date=DEFAULT_DATE)
+    return {
+        "dag": dag,
+        "ts": DEFAULT_DATE.isoformat(),
+        "task": task,
+        "ti": task_instance,
+        "task_instance": task_instance,
+    }
+
+
 class TestKubernetesPodOperator(unittest.TestCase):
     def setUp(self):
-        self.start_patch = mock.patch(
-            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.start_pod"
+        self.create_pod_patch = mock.patch(
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.create_pod"
         )
-        self.monitor_patch = mock.patch(
-            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.monitor_pod"
+        self.await_pod_patch = mock.patch(
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_start"
+        )
+        self.await_pod_completion_patch = mock.patch(
+            "airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_pod_completion"
         )
         self.client_patch = mock.patch("airflow.kubernetes.kube_client.get_kube_client")
-        self.start_mock = self.start_patch.start()
-        self.monitor_mock = self.monitor_patch.start()
+        self.create_mock = self.create_pod_patch.start()
+        self.await_start_mock = self.await_pod_patch.start()
+        self.await_pod_mock = self.await_pod_completion_patch.start()
         self.client_mock = self.client_patch.start()
-        self.addCleanup(self.start_patch.stop)
-        self.addCleanup(self.monitor_patch.stop)
+        self.addCleanup(self.create_pod_patch.stop)
+        self.addCleanup(self.await_pod_patch.stop)
+        self.addCleanup(self.await_pod_completion_patch.stop)
         self.addCleanup(self.client_patch.stop)
 
     @staticmethod
@@ -62,10 +80,15 @@ class TestKubernetesPodOperator(unittest.TestCase):
         }
 
     def run_pod(self, operator) -> k8s.V1Pod:
-        self.monitor_mock.return_value = (State.SUCCESS, None, None)
-        context = self.create_context(operator)
+        context = create_context(operator)
+        pod_request_obj = operator.build_pod_request_obj(context)
+        remote_pod_mock = MagicMock()
+        remote_pod_mock.status.phase = 'Succeeded'
+        remote_pod_mock.metadata.name = pod_request_obj.metadata.name
+        remote_pod_mock.metadata.namespace = pod_request_obj.metadata.namespace
+        self.await_pod_mock.return_value = remote_pod_mock
         operator.execute(context=context)
-        return self.start_mock.call_args[0][0]
+        return self.await_start_mock.call_args[1]['pod']
 
     def sanitize_for_serialization(self, obj):
         return ApiClient().sanitize_for_serialization(obj)
@@ -85,9 +108,11 @@ class TestKubernetesPodOperator(unittest.TestCase):
             config_file=file_path,
             cluster_context="default",
         )
-        self.monitor_mock.return_value = (State.SUCCESS, None, None)
+        remote_pod_mock = MagicMock()
+        remote_pod_mock.status.phase = 'Succeeded'
+        self.await_pod_mock.return_value = remote_pod_mock
         self.client_mock.list_namespaced_pod.return_value = []
-        context = self.create_context(k)
+        context = create_context(k)
         k.execute(context=context)
         self.client_mock.assert_called_once_with(
             in_cluster=False,
@@ -170,7 +195,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             image_pull_secrets=[k8s.V1LocalObjectReference(fake_pull_secrets)],
             cluster_context="default",
         )
-        pod = k.create_pod_request_obj()
+
+        pod = k.build_pod_request_obj(create_context(k))
         assert pod.spec.image_pull_secrets == [k8s.V1LocalObjectReference(name=fake_pull_secrets)]
 
     def test_image_pull_policy_correctly_set(self):
@@ -187,7 +213,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             image_pull_policy="Always",
             cluster_context="default",
         )
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         assert pod.spec.containers[0].image_pull_policy == "Always"
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.delete_pod")
@@ -205,9 +231,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
             cluster_context="default",
             is_delete_operator_pod=True,
         )
-        self.monitor_mock.side_effect = AirflowException("fake failure")
+        self.await_pod_mock.side_effect = AirflowException("fake failure")
         with pytest.raises(AirflowException):
-            context = self.create_context(k)
+            context = create_context(k)
             k.execute(context=context)
         assert delete_pod_mock.called
 
@@ -225,7 +251,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             do_xcom_push=False,
             cluster_context="default",
         )
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
 
         if randomize_name:
             assert pod.metadata.name.startswith(name_base)
@@ -462,7 +488,9 @@ class TestKubernetesPodOperator(unittest.TestCase):
                 "execution_date": mock.ANY,
             }
 
-    def test_describes_pod_on_failure(self):
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.follow_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_container_completion")
+    def test_describes_pod_on_failure(self, await_container_mock, follow_container_mock):
         name_base = "test"
 
         k = KubernetesPodOperator(
@@ -477,22 +505,20 @@ class TestKubernetesPodOperator(unittest.TestCase):
             do_xcom_push=False,
             cluster_context="default",
         )
-        failed_pod_status = "read_pod_namespaced_result"
-        self.monitor_mock.return_value = (State.FAILED, failed_pod_status, None)
-        read_namespaced_pod_mock = self.client_mock.return_value.read_namespaced_pod
-        read_namespaced_pod_mock.return_value = failed_pod_status
+        follow_container_mock.return_value = None
+        remote_pod_mock = MagicMock()
+        remote_pod_mock.status.phase = 'Failed'
+        self.await_pod_mock.return_value = remote_pod_mock
 
-        with pytest.raises(AirflowException) as ctx:
-            context = self.create_context(k)
+        with pytest.raises(AirflowException, match=f"Pod {name_base}.[a-z0-9]+ returned a failure: .*"):
+            context = create_context(k)
             k.execute(context=context)
 
-        assert (
-            str(ctx.value)
-            == f"Pod Launching failed: Pod {k.pod.metadata.name} returned a failure: {failed_pod_status}"
-        )
         assert not self.client_mock.return_value.read_namespaced_pod.called
 
-    def test_no_need_to_describe_pod_on_success(self):
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.follow_container_logs")
+    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.await_container_completion")
+    def test_no_handle_failure_on_success(self, await_container_mock, follow_container_mock):
         name_base = "test"
 
         k = KubernetesPodOperator(
@@ -507,12 +533,16 @@ class TestKubernetesPodOperator(unittest.TestCase):
             do_xcom_push=False,
             cluster_context="default",
         )
-        self.monitor_mock.return_value = (State.SUCCESS, None, None)
 
-        context = self.create_context(k)
+        follow_container_mock.return_value = None
+        remote_pod_mock = MagicMock()
+        remote_pod_mock.status.phase = 'Succeeded'
+        self.await_pod_mock.return_value = remote_pod_mock
+
+        context = create_context(k)
+
+        # assert does not raise
         k.execute(context=context)
-
-        assert not self.client_mock.return_value.read_namespaced_pod.called
 
     def test_create_with_affinity(self):
         name_base = "test"
@@ -544,7 +574,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             affinity=affinity,
         )
 
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         sanitized_pod = self.sanitize_for_serialization(pod)
         assert isinstance(pod.spec.affinity, k8s.V1Affinity)
         assert sanitized_pod["spec"]["affinity"] == affinity
@@ -578,7 +608,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             affinity=k8s_api_affinity,
         )
 
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         sanitized_pod = self.sanitize_for_serialization(pod)
         assert isinstance(pod.spec.affinity, k8s.V1Affinity)
         assert sanitized_pod["spec"]["affinity"] == affinity
@@ -602,7 +632,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             tolerations=tolerations,
         )
 
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         sanitized_pod = self.sanitize_for_serialization(pod)
         assert isinstance(pod.spec.tolerations[0], k8s.V1Toleration)
         assert sanitized_pod["spec"]["tolerations"] == tolerations
@@ -621,7 +651,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             tolerations=k8s_api_tolerations,
         )
 
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         sanitized_pod = self.sanitize_for_serialization(pod)
         assert isinstance(pod.spec.tolerations[0], k8s.V1Toleration)
         assert sanitized_pod["spec"]["tolerations"] == tolerations
@@ -643,7 +673,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             node_selector=node_selector,
         )
 
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         sanitized_pod = self.sanitize_for_serialization(pod)
         assert isinstance(pod.spec.node_selector, dict)
         assert sanitized_pod["spec"]["nodeSelector"] == node_selector
@@ -666,12 +696,16 @@ class TestKubernetesPodOperator(unittest.TestCase):
                 node_selectors=node_selector,
             )
 
-        pod = k.create_pod_request_obj()
+        pod = k.build_pod_request_obj(create_context(k))
         sanitized_pod = self.sanitize_for_serialization(pod)
         assert isinstance(pod.spec.node_selector, dict)
         assert sanitized_pod["spec"]["nodeSelector"] == node_selector
 
-    def test_push_xcom_pod_info(self):
+    @mock.patch('airflow.kubernetes.pod_generator.PodGenerator.make_unique_pod_id')
+    @mock.patch('airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.extract_xcom')
+    def test_push_xcom_pod_info(self, extract_xcom_mock, make_unique_pod_id):
+        extract_xcom_mock.return_value = '{}'
+        make_unique_pod_id.return_value = 'test-pod-a1b2c3'
         k = KubernetesPodOperator(
             namespace="default",
             image="ubuntu:16.04",
@@ -679,7 +713,7 @@ class TestKubernetesPodOperator(unittest.TestCase):
             name="test",
             task_id="task",
             in_cluster=False,
-            do_xcom_push=False,
+            do_xcom_push=True,
         )
         pod = self.run_pod(k)
         ti = TaskInstance(task=k, run_id=IN_MEMORY_DAGRUN_ID)
@@ -719,8 +753,10 @@ class TestKubernetesPodOperator(unittest.TestCase):
             task_id="task",
             is_delete_operator_pod=False,
         )
-        self.monitor_mock.return_value = (State.FAILED, None, None)
-        context = self.create_context(k)
+        remote_pod_mock = MagicMock()
+        remote_pod_mock.status.phase = 'Failed'
+        self.await_pod_mock.return_value = remote_pod_mock
+        context = create_context(k)
         with pytest.raises(AirflowException):
             k.execute(context=context)
         mock_patch_already_checked.assert_called_once()
@@ -742,8 +778,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
             task_id="task",
             is_delete_operator_pod=False,
         )
-        self.monitor_mock.side_effect = AirflowException("oops")
-        context = self.create_context(k)
+        self.await_pod_mock.side_effect = AirflowException("oops")
+        context = create_context(k)
         with pytest.raises(AirflowException):
             k.execute(context=context)
         mock_patch_already_checked.assert_called_once()
@@ -751,8 +787,8 @@ class TestKubernetesPodOperator(unittest.TestCase):
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.delete_pod")
     @mock.patch(
-        "airflow.providers.cncf.kubernetes.operators.kubernetes_pod"
-        ".KubernetesPodOperator.patch_already_checked"
+        "airflow.providers.cncf.kubernetes.operators."
+        "kubernetes_pod.KubernetesPodOperator.patch_already_checked"
     )
     def test_mark_reattached_pod_if_not_deleted(self, mock_patch_already_checked, mock_delete_pod):
         """If we aren't deleting pods and have a failure, mark it so we don't reattach to it"""
@@ -763,17 +799,21 @@ class TestKubernetesPodOperator(unittest.TestCase):
             task_id="task",
             is_delete_operator_pod=False,
         )
-        # Run it first to easily get the pod
-        pod = self.run_pod(k)
+        remote_pod_mock = MagicMock()
+        remote_pod_mock.status.phase = 'Failed'
+        self.await_pod_mock.return_value = remote_pod_mock
 
-        # Now try and "reattach"
-        mock_patch_already_checked.reset_mock()
-        mock_delete_pod.reset_mock()
-        self.client_mock.return_value.list_namespaced_pod.return_value.items = [pod]
-        self.monitor_mock.return_value = (State.FAILED, None, None)
-
-        context = self.create_context(k)
+        context = create_context(k)
         with pytest.raises(AirflowException):
             k.execute(context=context)
         mock_patch_already_checked.assert_called_once()
         mock_delete_pod.assert_not_called()
+
+
+def test__suppress():
+    with mock.patch('logging.Logger.error') as mock_error:
+
+        with _suppress(ValueError):
+            raise ValueError("failure")
+
+        mock_error.assert_called_once_with("failure", exc_info=True)

--- a/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
+++ b/tests/providers/cncf/kubernetes/operators/test_kubernetes_pod.py
@@ -176,6 +176,25 @@ class TestKubernetesPodOperator:
             "execution_date": mock.ANY,
         }
 
+    def test_find_pod_labels(self):
+        k = KubernetesPodOperator(
+            namespace="default",
+            image="ubuntu:16.04",
+            cmds=["bash", "-cx"],
+            labels={"foo": "bar"},
+            name="test",
+            task_id="task",
+            in_cluster=False,
+            do_xcom_push=False,
+        )
+        self.run_pod(k)
+        self.client_mock.return_value.list_namespaced_pod.assert_called_once()
+        _, kwargs = self.client_mock.return_value.list_namespaced_pod.call_args
+        assert (
+            kwargs['label_selector']
+            == 'dag_id=dag,execution_date=2016-01-01T0100000000-26816529d,task_id=task,already_checked!=True'
+        )
+
     def test_image_pull_secrets_correctly_set(self):
         fake_pull_secrets = "fakeSecret"
         k = KubernetesPodOperator(

--- a/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
@@ -14,8 +14,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import unittest
 from unittest import mock
+from unittest.mock import MagicMock
 
 import pendulum
 import pytest
@@ -23,18 +23,18 @@ from kubernetes.client.rest import ApiException
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from airflow.exceptions import AirflowException
-from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher, PodStatus
+from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher, PodStatus, container_is_running
 
 
-class TestPodLauncher(unittest.TestCase):
-    def setUp(self):
+class TestPodLauncher:
+    def setup_method(self):
         self.mock_kube_client = mock.Mock()
         self.pod_launcher = PodLauncher(kube_client=self.mock_kube_client)
 
     def test_read_pod_logs_successfully_returns_logs(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.return_value = mock.sentinel.logs
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel)
+        logs = self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base')
         assert mock.sentinel.logs == logs
 
     def test_read_pod_logs_retries_successfully(self):
@@ -43,7 +43,7 @@ class TestPodLauncher(unittest.TestCase):
             BaseHTTPError('Boom'),
             mock.sentinel.logs,
         ]
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel)
+        logs = self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base')
         assert mock.sentinel.logs == logs
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls(
             [
@@ -74,12 +74,12 @@ class TestPodLauncher(unittest.TestCase):
             BaseHTTPError('Boom'),
         ]
         with pytest.raises(BaseHTTPError):
-            self.pod_launcher.read_pod_logs(mock.sentinel)
+            self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base')
 
     def test_read_pod_logs_successfully_with_tail_lines(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [mock.sentinel.logs]
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel, tail_lines=100)
+        logs = self.pod_launcher.read_pod_logs(pod=mock.sentinel, container_name='base', tail_lines=100)
         assert mock.sentinel.logs == logs
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls(
             [
@@ -98,7 +98,7 @@ class TestPodLauncher(unittest.TestCase):
     def test_read_pod_logs_successfully_with_since_seconds(self):
         mock.sentinel.metadata = mock.MagicMock()
         self.mock_kube_client.read_namespaced_pod_log.side_effect = [mock.sentinel.logs]
-        logs = self.pod_launcher.read_pod_logs(mock.sentinel, since_seconds=2)
+        logs = self.pod_launcher.read_pod_logs(mock.sentinel, 'base', since_seconds=2)
         assert mock.sentinel.logs == logs
         self.mock_kube_client.read_namespaced_pod_log.assert_has_calls(
             [
@@ -186,7 +186,7 @@ class TestPodLauncher(unittest.TestCase):
 
         self.mock_kube_client.read_namespaced_pod.side_effect = pod_state_gen()
         self.mock_kube_client.read_namespaced_pod_log.return_value = iter(())
-        self.pod_launcher.monitor_pod(mock.sentinel, get_logs=True)
+        self.pod_launcher.follow_container_logs(mock.sentinel, 'base')
 
     def test_monitor_pod_logs_failures_non_fatal(self):
         mock.sentinel.metadata = mock.MagicMock()
@@ -209,7 +209,7 @@ class TestPodLauncher(unittest.TestCase):
 
         self.mock_kube_client.read_namespaced_pod_log.side_effect = pod_log_gen()
 
-        self.pod_launcher.monitor_pod(mock.sentinel, get_logs=True)
+        self.pod_launcher.follow_container_logs(mock.sentinel, 'base')
 
     def test_read_pod_retries_fails(self):
         mock.sentinel.metadata = mock.MagicMock()
@@ -224,13 +224,13 @@ class TestPodLauncher(unittest.TestCase):
     def test_parse_log_line(self):
         log_message = "This should return no timestamp"
         timestamp, line = self.pod_launcher.parse_log_line(log_message)
-        self.assertEqual(timestamp, None)
-        self.assertEqual(line, log_message)
+        assert timestamp is None
+        assert line == log_message
 
         real_timestamp = "2020-10-08T14:16:17.793417674Z"
         timestamp, line = self.pod_launcher.parse_log_line(" ".join([real_timestamp, log_message]))
-        self.assertEqual(timestamp, pendulum.parse(real_timestamp))
-        self.assertEqual(line, log_message)
+        assert timestamp == pendulum.parse(real_timestamp)
+        assert line == log_message
 
         with pytest.raises(Exception):
             self.pod_launcher.parse_log_line('2020-10-08T14:16:17.793417674ZInvalidmessage\n')
@@ -241,14 +241,14 @@ class TestPodLauncher(unittest.TestCase):
             ApiException(status=409),
             mock.MagicMock(),
         ]
-        self.pod_launcher.start_pod(mock.sentinel)
+        self.pod_launcher.create_pod(mock.sentinel)
         assert mock_run_pod_async.call_count == 2
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.run_pod_async")
     def test_start_pod_fails_on_other_exception(self, mock_run_pod_async):
         mock_run_pod_async.side_effect = [ApiException(status=504)]
         with pytest.raises(ApiException):
-            self.pod_launcher.start_pod(mock.sentinel)
+            self.pod_launcher.create_pod(mock.sentinel)
 
     @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.run_pod_async")
     def test_start_pod_retries_three_times(self, mock_run_pod_async):
@@ -259,31 +259,83 @@ class TestPodLauncher(unittest.TestCase):
             ApiException(status=409),
         ]
         with pytest.raises(ApiException):
-            self.pod_launcher.start_pod(mock.sentinel)
+            self.pod_launcher.create_pod(mock.sentinel)
 
         assert mock_run_pod_async.call_count == 3
 
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.pod_not_started")
-    @mock.patch("airflow.providers.cncf.kubernetes.utils.pod_launcher.PodLauncher.run_pod_async")
-    def test_start_pod_raises_informative_error_on_timeout(self, mock_run_pod_async, mock_pod_not_started):
+    def test_start_pod_raises_informative_error_on_timeout(self):
         pod_response = mock.MagicMock()
-        pod_response.status.start_time = None
-        mock_run_pod_async.return_value = pod_response
-        mock_pod_not_started.return_value = True
+        pod_response.status.phase = 'Pending'
+        self.mock_kube_client.read_namespaced_pod.return_value = pod_response
         expected_msg = "Check the pod events in kubernetes"
+        mock_pod = MagicMock()
         with pytest.raises(AirflowException, match=expected_msg):
-            self.pod_launcher.start_pod(
-                pod=mock.sentinel,
+            self.pod_launcher.await_pod_start(
+                pod=mock_pod,
                 startup_timeout=0,
             )
 
-    def test_base_container_is_running_none_event(self):
-        event = mock.MagicMock()
-        event_status = mock.MagicMock()
-        event_status.status = None
-        event_container_statuses = mock.MagicMock()
-        event_container_statuses.status = mock.MagicMock()
-        event_container_statuses.status.container_statuses = None
-        for e in [event, event_status, event_container_statuses]:
-            self.pod_launcher.read_pod = mock.MagicMock(return_value=e)
-            assert self.pod_launcher.base_container_is_running(None) is False
+    @mock.patch('airflow.providers.cncf.kubernetes.utils.pod_launcher.container_is_running')
+    def test_container_is_running(self, container_is_running_mock):
+        mock_pod = MagicMock()
+        self.pod_launcher.read_pod = mock.MagicMock(return_value=mock_pod)
+        self.pod_launcher.container_is_running(None, 'base')
+        container_is_running_mock.assert_called_with(pod=mock_pod, container_name='base')
+
+
+def params_for_test_container_is_running():
+    """The `container_is_running` method is designed to handle an assortment of bad objects
+    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
+    an object `e` such that `e.status.container_statuses` is None, and so on.  This function
+    emits params used in `test_container_is_running` to verify this behavior.
+
+    We create mock classes not derived from MagicMock because with an instance `e` of MagicMock,
+    tests like `e.hello is not None` are always True.
+    """
+
+    class RemotePodMock:
+        pass
+
+    class ContainerStatusMock:
+        def __init__(self, name):
+            self.name = name
+
+    def remote_pod(running=None, not_running=None):
+        e = RemotePodMock()
+        e.status = RemotePodMock()
+        e.status.container_statuses = []
+        for r in not_running or []:
+            e.status.container_statuses.append(container(r, False))
+        for r in running or []:
+            e.status.container_statuses.append(container(r, True))
+        return e
+
+    def container(name, running):
+        c = ContainerStatusMock(name)
+        c.state = RemotePodMock()
+        c.state.running = {'a': 'b'} if running else None
+        return c
+
+    pod_mock_list = []
+    pod_mock_list.append(pytest.param(None, False, id='None remote_pod'))
+    p = RemotePodMock()
+    p.status = None
+    pod_mock_list.append(pytest.param(p, False, id='None remote_pod.status'))
+    p = RemotePodMock()
+    p.status = RemotePodMock()
+    p.status.container_statuses = []
+    pod_mock_list.append(pytest.param(p, False, id='empty remote_pod.status.container_statuses'))
+    pod_mock_list.append(pytest.param(remote_pod(), False, id='filter empty'))
+    pod_mock_list.append(pytest.param(remote_pod(None, ['base']), False, id='filter 0 running'))
+    pod_mock_list.append(pytest.param(remote_pod(['hello'], ['base']), False, id='filter 1 not running'))
+    pod_mock_list.append(pytest.param(remote_pod(['base'], ['hello']), True, id='filter 1 running'))
+    return pod_mock_list
+
+
+@pytest.mark.parametrize('remote_pod, result', params_for_test_container_is_running())
+def test_container_is_running(remote_pod, result):
+    """The `container_is_running` function is designed to handle an assortment of bad objects
+    returned from `read_pod`.  E.g. a None object, an object `e` such that `e.status` is None,
+    an object `e` such that `e.status.container_statuses` is None, and so on.  This test
+    verifies the expected behavior."""
+    assert container_is_running(remote_pod, 'base') is result

--- a/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
@@ -23,7 +23,7 @@ from kubernetes.client.rest import ApiException
 from urllib3.exceptions import HTTPError as BaseHTTPError
 
 from airflow.exceptions import AirflowException
-from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher, PodStatus, container_is_running
+from airflow.providers.cncf.kubernetes.utils.pod_launcher import PodLauncher, PodPhase, container_is_running
 
 
 class TestPodLauncher:
@@ -177,7 +177,7 @@ class TestPodLauncher:
         running_status = mock.MagicMock()
         running_status.configure_mock(**{'name': 'base', 'state.running': True})
         pod_info_running = mock.MagicMock(**{'status.container_statuses': [running_status]})
-        pod_info_succeeded = mock.MagicMock(**{'status.phase': PodStatus.SUCCEEDED})
+        pod_info_succeeded = mock.MagicMock(**{'status.phase': PodPhase.SUCCEEDED})
 
         def pod_state_gen():
             yield pod_info_running
@@ -193,7 +193,7 @@ class TestPodLauncher:
         running_status = mock.MagicMock()
         running_status.configure_mock(**{'name': 'base', 'state.running': True})
         pod_info_running = mock.MagicMock(**{'status.container_statuses': [running_status]})
-        pod_info_succeeded = mock.MagicMock(**{'status.phase': PodStatus.SUCCEEDED})
+        pod_info_succeeded = mock.MagicMock(**{'status.phase': PodPhase.SUCCEEDED})
 
         def pod_state_gen():
             yield pod_info_running


### PR DESCRIPTION
Refactor of KPO with the following goals:
* simpler, easier-to-follow `execute` method
* remove reliance on mutation of `pod` and `namespace` instance attributes
~* change the default to delete pods~
~* allow usage of kubernetes hook (waiting on https://github.com/apache/airflow/pull/19695 before implementing)~

## Notes on changes

### pod_launcher.py

#### changes to launcher

`start_pod` split up into two steps:

* `create_pod` asynchronously creates the pod
* `await_pod_start` waits for it to leave the `Pending` phase

`monitor_pod` split up into two components

* `follow_container_logs`: this bit of logic was previously in `monitor_pod` and invoked only if `get_logs` is true.  it also monitored for completion of the base container in this case.  here we pull that `if self.get_logs` decisionmaking up to the `execute` method for greater transparency, and we parameterize the `follow_container_logs` method so that it could be used for any container (and also make it more transparent which container it is following).
* `monitor_pod` remains and does two things: wait for pod to reach a phase that is terminal, and harvest xcom if applicable.

#### PodStatus -> PodPhase

I rename the `PodStatus` enums to have the same case the actual kubernetes phase values.  I do not think that we need to lower them and doing so introduces a need for more status evaluation methods.

I also do away with the way pod `phase` was always translated to task states.  It's more transparent to handle the phases directly.  In the old code sometimes you would look at the "task state" -- which the pod phase had been translated to -- in order to infer the pod phase; better to be more direct.  In any case these two changes allow us to chop a few methods.

#### misc

### kubernetes_pod.py

#### simplified `execute`

The main goal here was simplifying the execute method so it's easier to follow.  I tried to better reveal the key orchesration decisions that have to be made _(e.g. do we get logs or not; do we get xcom or not; do we find a pod or create one)_, and provide a clearer separation of the processess that can be separated.

#### other
I moved the "get client" logic to a cached property.

I did away with mutation of the `self.pod` attribute, and none of the methods reference the attribute directly -- the object is always passed to them in the method.  And I made a clear separation between the pod request object (which is used when a new pod is created) and pod -- the pod we're actually monitoring e.g. if we find a pod after failure and resume..

Similar for `self.namespace` which was mutated in the run without an obvious reason.  The reason was that sometimes operator namespace is none but through templates or whatever you have a namespace and when you go to find a pod you need the namespace.
