### PR TITLE
Improve automation for docker image release

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -759,15 +759,11 @@ previously released RC candidates in "${AIRFLOW_SOURCES}/dist":
 ./scripts/ci/tools/prepare_prod_docker_images.sh ${VERSION}
 ```
 
-This will wipe Breeze cache and docker-context-files in order to make sure the build is "clean". It
-also performs image verification before pushing the images.
-
-If this is the newest image released, push the latest image as well.
-
-```shell script
-docker tag "apache/airflow:${VERSION}" "apache/airflow:latest"
-docker push "apache/airflow:latest"
-```
+If you release 'official' (non-rc) version you will be asked if you want to
+tag the images as latest - if you are releasing the latest stable branch, you
+should answer y and tags will be created and pushed. If you are releasing a
+patch release from an older branch, you should answer n and creating tags will
+be skipped.
 
 ## Publish documentation
 

--- a/scripts/ci/tools/prepare_prod_docker_images.sh
+++ b/scripts/ci/tools/prepare_prod_docker_images.sh
@@ -18,6 +18,8 @@
 AIRFLOW_SOURCES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../../ && pwd)"
 export AIRFLOW_SOURCES_DIR
 
+CURRENT_PYTHON_MAJOR_MINOR_VERSIONS=("3.7" "3.8" "3.9" "3.6")
+
 usage() {
     local cmdname
     cmdname="$(basename -- "$0")"
@@ -38,8 +40,35 @@ fi
 
 export INSTALL_AIRFLOW_VERSION="${1}"
 
-for python_version in "3.6" "3.7" "3.8" "3.9"
+for python_version in "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}"
 do
   export PYTHON_MAJOR_MINOR_VERSION=${python_version}
-  "${AIRFLOW_SOURCES_DIR}/scripts/ci/tools/build_dockerhub.sh"
+  echo "${AIRFLOW_SOURCES_DIR}/scripts/ci/tools/build_dockerhub.sh"
 done
+
+if [[ ${INSTALL_AIRFLOW_VERSION} =~ .*rc.* ]]; then
+    echo
+    echo "Skipping tagging latest as this is an rc version"
+    echo
+    exit
+fi
+
+echo "Should we tag version ${1} with latest tag [y/N]"
+read -r RESPONSE
+
+if [[ ${RESPONSE} == 'n' || ${RESPONSE} = 'N' ]]; then
+    echo
+    echo "Skip tagging the image with latest tag."
+    echo
+    exit
+fi
+
+for python_version in "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}"
+do
+    echo docker tag "apache/airflow:${INSTALL_AIRFLOW_VERSION}-python${python_version}" \
+        "apache/airflow:latest-python${python_version}"
+    echo docker push "apache/airflow:latest-python${python_version}"
+done
+
+echo docker tag "apache/airflow:${INSTALL_AIRFLOW_VERSION}" "apache/airflow:latest"
+echo docker push "apache/airflow:latest"


### PR DESCRIPTION
The "latest" tags for docker images were not applied in recent
releases - mainly because the process of doing it was not followed,
but this was also not obvious as preparing the rc image and final
images was different - the latest images required extra manual
step.

This PR modifies the "image preparation" script to ask a question
whether the latest images should be tagged when non-RC build
is being prepared.

Fixes: #19569

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
