### PR TITLE
Add state details to EMR container failure reason

### DIFF
--- a/airflow/providers/amazon/aws/hooks/emr_containers.py
+++ b/airflow/providers/amazon/aws/hooks/emr_containers.py
@@ -123,7 +123,9 @@ class EMRContainerHook(AwsBaseHook):
                 virtualClusterId=self.virtual_cluster_id,
                 id=job_id,
             )
-            reason = response['jobRun']['failureReason']
+            failure_reason = response['jobRun']['failureReason']
+            state_details = response["jobRun"]["stateDetails"]
+            reason = f"{failure_reason} - {state_details}"
         except KeyError:
             self.log.error('Could not get status of the EMR on EKS job')
         except ClientError as ex:

--- a/tests/providers/amazon/aws/operators/test_emr_containers.py
+++ b/tests/providers/amazon/aws/operators/test_emr_containers.py
@@ -96,11 +96,13 @@ class TestEMRContainerOperator(unittest.TestCase):
     ):
         mock_submit_job.return_value = "jobid_123456"
         mock_check_query_status.return_value = 'FAILED'
-        mock_get_job_failure_reason.return_value = "CLUSTER_UNAVAILABLE"
+        mock_get_job_failure_reason.return_value = (
+            "CLUSTER_UNAVAILABLE - Cluster EKS eks123456 does not exist."
+        )
         with pytest.raises(AirflowException) as ctx:
             self.emr_container.execute(None)
         assert 'EMR Containers job failed' in str(ctx.value)
-        assert 'Error: CLUSTER_UNAVAILABLE' in str(ctx.value)
+        assert 'Error: CLUSTER_UNAVAILABLE - Cluster EKS eks123456 does not exist.' in str(ctx.value)
 
     @mock.patch.object(
         EMRContainerHook,


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add **stateDetails** to `EMRContainerHook.get_job_failure_reason`.
There are various details in failureReason. [Ref. EMR-on-EKS Docs](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/emr-eks-jobs-error.html)
So the user cannot understand the error with only failureReason.

<br>

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
