### PR TITLE
Databricks: allow to specify PAT in Password field

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -270,8 +270,13 @@ class DatabricksHook(BaseHook):
             host = self.databricks_conn.host
 
         if 'token' in self.databricks_conn.extra_dejson:
-            self.log.info('Using token auth.')
+            self.log.info(
+                'Using token auth. For security reasons, please set token in Password field instead of extra'
+            )
             auth = _TokenAuth(self.databricks_conn.extra_dejson['token'])
+        elif not self.databricks_conn.login and self.databricks_conn.password:
+            self.log.info('Using token auth.')
+            auth = _TokenAuth(self.databricks_conn.password)
         elif 'azure_tenant_id' in self.databricks_conn.extra_dejson:
             if self.databricks_conn.login == "" or self.databricks_conn.password == "":
                 raise AirflowException("Azure SPN credentials aren't provided")

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -58,7 +58,7 @@ Login (optional)
 Password (optional)
     * If authentication with *Databricks login credentials*  is used then specify the ``password`` used to login to Databricks.
     * If authentication with *Azure Service Principal* is used then specify the secret of the Azure Service Principal
-    * if authentication with *PAT* is used, then specify PAT (recommended)
+    * if authentication with *PAT* is used, then specify PAT and leave login empty (recommended)
 
 Extra (optional)
     Specify the extra parameter (as json dictionary) that can be used in the Databricks connection.

--- a/docs/apache-airflow-providers-databricks/connections/databricks.rst
+++ b/docs/apache-airflow-providers-databricks/connections/databricks.rst
@@ -57,14 +57,15 @@ Login (optional)
 
 Password (optional)
     * If authentication with *Databricks login credentials*  is used then specify the ``password`` used to login to Databricks.
-    * If *authentication with Azure Service Principal* is used then specify the secret of the Azure Service Principal
+    * If authentication with *Azure Service Principal* is used then specify the secret of the Azure Service Principal
+    * if authentication with *PAT* is used, then specify PAT (recommended)
 
 Extra (optional)
     Specify the extra parameter (as json dictionary) that can be used in the Databricks connection.
 
-    Following parameter is necessary if using the *PAT* authentication method (recommended):
+    Following parameter could be used if using the *PAT* authentication method:
 
-    * ``token``: Specify PAT to use.
+    * ``token``: Specify PAT to use. (it's better to put PAT into Password field so it won't be seen as plain text)
 
     Following parameters are necessary if using authentication with AAD token:
 

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -524,6 +524,37 @@ class TestDatabricksHookToken(unittest.TestCase):
         assert kwargs['auth'].token == TOKEN
 
 
+class TestDatabricksHookTokenInPassword(unittest.TestCase):
+    """
+    Tests for DatabricksHook.
+    """
+
+    @provide_session
+    def setUp(self, session=None):
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.host = HOST
+        conn.login = None
+        conn.password = TOKEN
+        conn.extra = None
+        session.commit()
+
+        self.hook = DatabricksHook(retry_delay=0)
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_submit_run(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.post.return_value.json.return_value = {'run_id': '1'}
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+        data = {'notebook_task': NOTEBOOK_TASK, 'new_cluster': NEW_CLUSTER}
+        run_id = self.hook.submit_run(data)
+
+        assert run_id == '1'
+        args = mock_requests.post.call_args
+        kwargs = args[1]
+        assert kwargs['auth'].token == TOKEN
+
+
 class TestDatabricksHookTokenWhenNoHostIsProvidedInExtra(TestDatabricksHookToken):
     @provide_session
     def setUp(self, session=None):
@@ -578,10 +609,10 @@ class TestDatabricksHookAadToken(unittest.TestCase):
     @provide_session
     def setUp(self, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.login = '9ff815a6-4404-4ab8-85cb-cd0e6f879c1d'
+        conn.password = 'secret'
         conn.extra = json.dumps(
             {
-                'azure_client_id': '9ff815a6-4404-4ab8-85cb-cd0e6f879c1d',
-                'azure_client_secret': 'secret',
                 'host': HOST,
                 'azure_tenant_id': '3ff810a6-5504-4ab8-85cb-cd0e6f879c1d',
             }
@@ -615,11 +646,11 @@ class TestDatabricksHookAadTokenSpOutside(unittest.TestCase):
     @provide_session
     def setUp(self, session=None):
         conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.login = '9ff815a6-4404-4ab8-85cb-cd0e6f879c1d'
+        conn.password = 'secret'
+        conn.host = HOST
         conn.extra = json.dumps(
             {
-                'azure_client_id': '9ff815a6-4404-4ab8-85cb-cd0e6f879c1d',
-                'azure_client_secret': 'secret',
-                'host': HOST,
                 'azure_resource_id': '/Some/resource',
                 'azure_tenant_id': '3ff810a6-5504-4ab8-85cb-cd0e6f879c1d',
             }


### PR DESCRIPTION
Currently, the PAT is specified in the extra section, where it's visible, so it's less secure. This PR allows to put PAT into Password field where it will be masked when editing the existing connection
