### PR TITLE
Cast macro datetime string inputs explicitly

### DIFF
--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -19,13 +19,17 @@ import time  # noqa
 import uuid  # noqa
 from datetime import datetime, timedelta
 from random import random  # noqa
+from typing import Any, Optional, Union
 
 import dateutil  # noqa
+import lazy_object_proxy
 
 from airflow.macros import hive  # noqa
 
+TemplateStringInput = Union[str, lazy_object_proxy.Proxy]
 
-def ds_add(ds, days):
+
+def ds_add(ds: TemplateStringInput, days: int) -> str:
     """
     Add or subtract days from a YYYY-MM-DD
 
@@ -39,13 +43,13 @@ def ds_add(ds, days):
     >>> ds_add('2015-01-06', -5)
     '2015-01-01'
     """
-    ds = datetime.strptime(ds, '%Y-%m-%d')
-    if days:
-        ds = ds + timedelta(days)
-    return ds.isoformat()[:10]
+    if not days:
+        return str(ds)
+    dt = datetime.strptime(str(ds), "%Y-%m-%d") + timedelta(days=days)
+    return dt.strftime("%Y-%m-%d")
 
 
-def ds_format(ds, input_format, output_format):
+def ds_format(ds: TemplateStringInput, input_format: str, output_format: str) -> str:
     """
     Takes an input string and outputs another string
     as specified in the output format
@@ -62,10 +66,10 @@ def ds_format(ds, input_format, output_format):
     >>> ds_format('1/5/2015', "%m/%d/%Y",  "%Y-%m-%d")
     '2015-01-05'
     """
-    return datetime.strptime(ds, input_format).strftime(output_format)
+    return datetime.strptime(str(ds), input_format).strftime(output_format)
 
 
-def datetime_diff_for_humans(dt, since=None):
+def datetime_diff_for_humans(dt: Any, since: Optional[datetime] = None) -> str:
     """
     Return a human-readable/approximate difference between two datetimes, or
     one and now.

--- a/tests/macros/test_macros.py
+++ b/tests/macros/test_macros.py
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import lazy_object_proxy
+import pendulum
+import pytest
+
+from airflow import macros
+from airflow.utils import timezone
+
+
+@pytest.mark.parametrize(
+    "ds, days, expected",
+    [
+        ("2015-01-01", 5, "2015-01-06"),
+        ("2015-01-02", 0, "2015-01-02"),
+        ("2015-01-06", -5, "2015-01-01"),
+        (lazy_object_proxy.Proxy(lambda: "2015-01-01"), 5, "2015-01-06"),
+        (lazy_object_proxy.Proxy(lambda: "2015-01-02"), 0, "2015-01-02"),
+        (lazy_object_proxy.Proxy(lambda: "2015-01-06"), -5, "2015-01-01"),
+    ],
+)
+def test_ds_add(ds, days, expected):
+    result = macros.ds_add(ds, days)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "ds, input_format, output_format, expected",
+    [
+        ("2015-01-02", "%Y-%m-%d", "%m-%d-%y", "01-02-15"),
+        ("2015-01-02", "%Y-%m-%d", "%Y-%m-%d", "2015-01-02"),
+        ("1/5/2015", "%m/%d/%Y", "%m-%d-%y", "01-05-15"),
+        ("1/5/2015", "%m/%d/%Y", "%Y-%m-%d", "2015-01-05"),
+        (lazy_object_proxy.Proxy(lambda: "2015-01-02"), "%Y-%m-%d", "%m-%d-%y", "01-02-15"),
+        (lazy_object_proxy.Proxy(lambda: "2015-01-02"), "%Y-%m-%d", "%Y-%m-%d", "2015-01-02"),
+        (lazy_object_proxy.Proxy(lambda: "1/5/2015"), "%m/%d/%Y", "%m-%d-%y", "01-05-15"),
+        (lazy_object_proxy.Proxy(lambda: "1/5/2015"), "%m/%d/%Y", "%Y-%m-%d", "2015-01-05"),
+    ],
+)
+def test_ds_format(ds, input_format, output_format, expected):
+    result = macros.ds_format(ds, input_format, output_format)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "dt, since, expected",
+    [
+        (
+            timezone.datetime(2017, 1, 2),
+            None,
+            pendulum.instance(timezone.datetime(2017, 1, 2)).diff_for_humans(),
+        ),
+        (timezone.datetime(2017, 1, 2), timezone.datetime(2017, 1, 3), "1 day before"),
+        (timezone.datetime(2017, 1, 2), timezone.datetime(2017, 1, 1), "1 day after"),
+        (
+            lazy_object_proxy.Proxy(lambda: timezone.datetime(2017, 1, 2)),
+            None,
+            pendulum.instance(timezone.datetime(2017, 1, 2)).diff_for_humans(),
+        ),
+        (
+            lazy_object_proxy.Proxy(lambda: timezone.datetime(2017, 1, 2)),
+            timezone.datetime(2017, 1, 3),
+            "1 day before",
+        ),
+        (
+            lazy_object_proxy.Proxy(lambda: timezone.datetime(2017, 1, 2)),
+            timezone.datetime(2017, 1, 1),
+            "1 day after",
+        ),
+    ],
+)
+def test_datetime_diff_for_humans(dt, since, expected):
+    result = macros.datetime_diff_for_humans(dt, since)
+    assert result == expected


### PR DESCRIPTION
Finishing and close #19249. Fix #19241.

This coerce template variables to strings to work around a limitation in lazy_object_proxy when used against built-in types.

Some tests against macro functions are added to ensure macro functions all work against lazy object proxy objects and avoid regression in the future.