### PR TITLE
Remove unnecessary connection form customizations in Azure

### DIFF
--- a/airflow/providers/microsoft/azure/hooks/container_volume.py
+++ b/airflow/providers/microsoft/azure/hooks/container_volume.py
@@ -57,8 +57,6 @@ class AzureContainerVolumeHook(BaseHook):
     @staticmethod
     def get_ui_field_behaviour() -> Dict:
         """Returns custom field behaviour"""
-        import json
-
         return {
             "hidden_fields": ['schema', 'port', 'host', "extra"],
             "relabeling": {
@@ -66,13 +64,6 @@ class AzureContainerVolumeHook(BaseHook):
                 'password': 'Azure Secret',
             },
             "placeholders": {
-                'extra': json.dumps(
-                    {
-                        "key_path": "path to json file for auth",
-                        "key_json": "specifies json dict for auth",
-                    },
-                    indent=1,
-                ),
                 'login': 'client_id (token credentials auth)',
                 'password': 'secret (token credentials auth)',
                 'extra__azure_container_volume__connection_string': 'connection string auth',

--- a/airflow/providers/microsoft/azure/hooks/fileshare.py
+++ b/airflow/providers/microsoft/azure/hooks/fileshare.py
@@ -71,12 +71,10 @@ class AzureFileShareHook(BaseHook):
             "relabeling": {
                 'login': 'Blob Storage Login (optional)',
                 'password': 'Blob Storage Key (optional)',
-                'host': 'Account Name (Active Directory Auth)',
             },
             "placeholders": {
                 'login': 'account name',
                 'password': 'secret',
-                'host': 'account url',
                 'extra__azure_fileshare__sas_token': 'account url or token (optional)',
                 'extra__azure_fileshare__connection_string': 'account url or token (optional)',
                 'extra__azure_fileshare__protocol': 'account url or token (optional)',


### PR DESCRIPTION
In the `Azure FileShare` connection form, the `extra` field is being hidden; no need to add a placeholder for the field.

In the `Azure Container Volume` connection form, the `host` field is being hidden; no need to relabel nor add a placeholder.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
