### PR TITLE
Fix `airflow db check-migrations`

### DIFF
--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -29,7 +29,7 @@ from sqlalchemy import MetaData
 
 from airflow.models import Base as airflow_base
 from airflow.settings import engine
-from airflow.utils.db import create_default_connections
+from airflow.utils.db import check_migrations, create_default_connections
 
 
 class TestDb(unittest.TestCase):
@@ -103,3 +103,7 @@ class TestDb(unittest.TestCase):
         source = inspect.getsource(create_default_connections)
         src = pattern.findall(source)
         assert sorted(src) == src
+
+    def test_check_migrations(self):
+        # Should run without error. Can't easily test the behaviour, but we can check it works
+        check_migrations(1)


### PR DESCRIPTION
This command broke after [Define datetime and StringID column types centrally in migrations #19408](https://github.com/apache/airflow/pull/19408) was merged, but we didn't notice as Github styles timedout checks badly.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).