### PR TITLE
Chart: Update default Airflow version to 2.2.2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -20,7 +20,7 @@
 apiVersion: v2
 name: airflow
 version: 1.4.0-dev
-appVersion: 2.2.1
+appVersion: 2.2.2
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows
 home: https://airflow.apache.org/

--- a/chart/UPDATING.rst
+++ b/chart/UPDATING.rst
@@ -35,8 +35,16 @@ assists users migrating to a new version.
 
 Run ``helm repo update`` before upgrading the chart to the latest version.
 
-Airflow Helm Chart 1.3.0 (dev)
+Airflow Helm Chart 1.4.0 (dev)
 ------------------------------
+
+Default Airflow image is updated to ``2.2.2``
+"""""""""""""""""""""""""""""""""""""""""""""
+
+The default Airflow image that is used with the Chart is now ``2.2.2``, previously it was ``2.2.1``.
+
+Airflow Helm Chart 1.3.0
+------------------------
 
 Default Airflow image is updated to ``2.2.1``
 """""""""""""""""""""""""""""""""""""""""""""

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -67,13 +67,13 @@
         "defaultAirflowTag": {
             "description": "Default airflow tag to deploy.",
             "type": "string",
-            "default": "2.2.1",
+            "default": "2.2.2",
             "x-docsSection": "Common"
         },
         "airflowVersion": {
             "description": "Airflow version (Used to make some decisions based on Airflow Version being deployed).",
             "type": "string",
-            "default": "2.2.1",
+            "default": "2.2.2",
             "x-docsSection": "Common"
         },
         "nodeSelector": {

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -40,10 +40,10 @@ airflowHome: /opt/airflow
 defaultAirflowRepository: apache/airflow
 
 # Default airflow tag to deploy
-defaultAirflowTag: "2.2.1"
+defaultAirflowTag: "2.2.2"
 
 # Airflow version (Used to make some decisions based on Airflow Version being deployed)
-airflowVersion: "2.2.1"
+airflowVersion: "2.2.2"
 
 # Images
 images:


### PR DESCRIPTION
Now that `2.2.2` is released, use it in the helm chart.