### PR TITLE
Clean up dynamic `start_date` values from docs

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -165,8 +165,9 @@ Similarly, `DAG.concurrency` has been renamed to `DAG.max_active_tasks`.
 ```python
 dag = DAG(
     dag_id="example_dag",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
     concurrency=3,
-    start_date=days_ago(2),
 )
 ```
 
@@ -175,8 +176,9 @@ dag = DAG(
 ```python
 dag = DAG(
     dag_id="example_dag",
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
     max_active_tasks=3,
-    start_date=days_ago(2),
 )
 ```
 

--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -19,29 +19,29 @@
 """Example DAG demonstrating the usage of the SubDagOperator."""
 
 # [START example_subdag_operator]
+from datetime import datetime
+
 from airflow import DAG
 from airflow.example_dags.subdags.subdag import subdag
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.subdag import SubDagOperator
-from airflow.utils.dates import days_ago
 
 DAG_NAME = 'example_subdag_operator'
 
-args = {
-    'owner': 'airflow',
-}
-
 with DAG(
-    dag_id=DAG_NAME, default_args=args, start_date=days_ago(2), schedule_interval="@once", tags=['example']
+    dag_id=DAG_NAME,
+    default_args={'retries': 1},
+    start_date=datetime(2021, 1, 1),
+    schedule_interval="@once",
+    catchup=False,
+    tags=['example'],
 ) as dag:
 
-    start = DummyOperator(
-        task_id='start',
-    )
+    start = DummyOperator(task_id='start')
 
     section_1 = SubDagOperator(
         task_id='section-1',
-        subdag=subdag(DAG_NAME, 'section-1', args),
+        subdag=subdag(DAG_NAME, 'section-1', args=dag.default_args),
     )
 
     some_other_task = DummyOperator(
@@ -50,12 +50,10 @@ with DAG(
 
     section_2 = SubDagOperator(
         task_id='section-2',
-        subdag=subdag(DAG_NAME, 'section-2', args),
+        subdag=subdag(DAG_NAME, 'section-2', args=dag.default_args),
     )
 
-    end = DummyOperator(
-        task_id='end',
-    )
+    end = DummyOperator(task_id='end')
 
     start >> section_1 >> some_other_task >> section_2 >> end
 # [END example_subdag_operator]

--- a/airflow/example_dags/example_subdag_operator.py
+++ b/airflow/example_dags/example_subdag_operator.py
@@ -19,29 +19,29 @@
 """Example DAG demonstrating the usage of the SubDagOperator."""
 
 # [START example_subdag_operator]
-from datetime import datetime
-
 from airflow import DAG
 from airflow.example_dags.subdags.subdag import subdag
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.subdag import SubDagOperator
+from airflow.utils.dates import days_ago
 
 DAG_NAME = 'example_subdag_operator'
 
+args = {
+    'owner': 'airflow',
+}
+
 with DAG(
-    dag_id=DAG_NAME,
-    default_args={'retries': 1},
-    start_date=datetime(2021, 1, 1),
-    schedule_interval="@once",
-    catchup=False,
-    tags=['example'],
+    dag_id=DAG_NAME, default_args=args, start_date=days_ago(2), schedule_interval="@once", tags=['example']
 ) as dag:
 
-    start = DummyOperator(task_id='start')
+    start = DummyOperator(
+        task_id='start',
+    )
 
     section_1 = SubDagOperator(
         task_id='section-1',
-        subdag=subdag(DAG_NAME, 'section-1', args=dag.default_args),
+        subdag=subdag(DAG_NAME, 'section-1', args),
     )
 
     some_other_task = DummyOperator(
@@ -50,10 +50,12 @@ with DAG(
 
     section_2 = SubDagOperator(
         task_id='section-2',
-        subdag=subdag(DAG_NAME, 'section-2', args=dag.default_args),
+        subdag=subdag(DAG_NAME, 'section-2', args),
     )
 
-    end = DummyOperator(task_id='end')
+    end = DummyOperator(
+        task_id='end',
+    )
 
     start >> section_1 >> some_other_task >> section_2 >> end
 # [END example_subdag_operator]

--- a/airflow/smart_sensor_dags/smart_sensor_group.py
+++ b/airflow/smart_sensor_dags/smart_sensor_group.py
@@ -17,16 +17,11 @@
 # under the License.
 
 """Smart sensor DAGs managing all smart sensor tasks."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from airflow.configuration import conf
 from airflow.models import DAG
 from airflow.sensors.smart_sensor import SmartSensorOperator
-from airflow.utils.dates import days_ago
-
-args = {
-    'owner': 'airflow',
-}
 
 num_smart_sensor_shard = conf.getint("smart_sensor", "shards")
 shard_code_upper_limit = conf.getint('smart_sensor', 'shard_code_upper_limit')
@@ -38,13 +33,12 @@ for i in range(num_smart_sensor_shard):
     dag_id = f'smart_sensor_group_shard_{i}'
     dag = DAG(
         dag_id=dag_id,
-        default_args=args,
         schedule_interval=timedelta(minutes=5),
         max_active_tasks=1,
         max_active_runs=1,
         catchup=False,
         dagrun_timeout=timedelta(hours=24),
-        start_date=days_ago(2),
+        start_date=datetime(2021, 1, 1),
     )
 
     SmartSensorOperator(

--- a/docs/apache-airflow/best-practices.rst
+++ b/docs/apache-airflow/best-practices.rst
@@ -239,7 +239,12 @@ Then you can import and use the ``ALL_TASKS`` constant in all your DAGs like tha
 
     from my_company_utils.common import ALL_TASKS
 
-    with DAG(dag_id="my_dag", schedule_interval=None, start_date=days_ago(2)) as dag:
+    with DAG(
+        dag_id="my_dag",
+        schedule_interval=None,
+        start_date=datetime(2021, 1, 1),
+        catchup=False,
+    ) as dag:
         for task in ALL_TASKS:
             # create your operators and relations here
             pass

--- a/docs/apache-airflow/concepts/dags.rst
+++ b/docs/apache-airflow/concepts/dags.rst
@@ -37,18 +37,20 @@ Declaring a DAG
 There are three ways to declare a DAG - either you can use a context manager,
 which will add the DAG to anything inside it implicitly::
 
-    with DAG("my_dag_name") as dag:
+    with DAG(
+        "my_dag_name", start_date=datetime(2021, 1, 1), schedule_interval="@daily", catchup=False
+    ) as dag:
         op = DummyOperator(task_id="task")
 
 Or, you can use a standard constructor, passing the dag into any
 operators you use::
 
-    my_dag = DAG("my_dag_name")
+    my_dag = DAG("my_dag_name", start_date=datetime(2021, 1, 1), schedule_interval="@daily", catchup=False)
     op = DummyOperator(task_id="task", dag=my_dag)
 
 Or, you can use the ``@dag`` decorator to :ref:`turn a function into a DAG generator <concepts:dag-decorator>`::
 
-    @dag(start_date=days_ago(2))
+    @dag(start_date=datetime(2021, 1, 1), schedule_interval="@daily", catchup=False)
     def generate_dag():
         op = DummyOperator(task_id="task")
 

--- a/docs/apache-airflow/concepts/operators.rst
+++ b/docs/apache-airflow/concepts/operators.rst
@@ -175,7 +175,8 @@ you can pass ``render_template_as_native_obj=True`` to the DAG as follows:
     dag = DAG(
         dag_id="example_template_as_python_object",
         schedule_interval=None,
-        start_date=days_ago(2),
+        start_date=datetime(2021, 1, 1),
+        catchup=False,
         render_template_as_native_obj=True,
     )
 

--- a/docs/apache-airflow/dag-run.rst
+++ b/docs/apache-airflow/dag-run.rst
@@ -229,11 +229,17 @@ Example of a parameterized DAG:
 
 .. code-block:: python
 
+    from datetime import datetime
+
     from airflow import DAG
     from airflow.operators.bash import BashOperator
-    from airflow.utils.dates import days_ago
 
-    dag = DAG("example_parameterized_dag", schedule_interval=None, start_date=days_ago(2))
+    dag = DAG(
+        "example_parameterized_dag",
+        schedule_interval=None,
+        start_date=datetime(2021, 1, 1),
+        catchup=False,
+    )
 
     parameterized_task = BashOperator(
         task_id="parameterized_task",

--- a/docs/apache-airflow/lineage.rst
+++ b/docs/apache-airflow/lineage.rst
@@ -30,22 +30,21 @@ works.
 
 .. code-block:: python
 
+    from datetime import datetime, timedelta
+
     from airflow.operators.bash import BashOperator
     from airflow.operators.dummy import DummyOperator
     from airflow.lineage import AUTO
     from airflow.lineage.entities import File
     from airflow.models import DAG
-    from airflow.utils.dates import days_ago
-    from datetime import timedelta
 
     FILE_CATEGORIES = ["CAT1", "CAT2", "CAT3"]
 
-    args = {"owner": "airflow", "start_date": days_ago(2)}
-
     dag = DAG(
         dag_id="example_lineage",
-        default_args=args,
+        start_date=datetime(2021, 1, 1),
         schedule_interval="0 0 * * *",
+        catchup=False,
         dagrun_timeout=timedelta(minutes=60),
     )
 

--- a/docs/apache-airflow/tutorial.rst
+++ b/docs/apache-airflow/tutorial.rst
@@ -487,7 +487,8 @@ Lets look at our DAG:
 
   @dag(
       schedule_interval="0 0 * * *",
-      start_date=datetime.today() - timedelta(days=2),
+      start_date=datetime(2021, 1, 1),
+      catchup=False,
       dagrun_timeout=timedelta(minutes=60),
   )
   def Etl():

--- a/docs/docker-stack/docker-examples/extending/embedding-dags/test_dag.py
+++ b/docs/docker-stack/docker-examples/extending/embedding-dags/test_dag.py
@@ -21,15 +21,19 @@ from datetime import datetime, timedelta
 
 from airflow.models.dag import DAG
 from airflow.operators.dummy import DummyOperator
-from airflow.utils.dates import days_ago
 
 now = datetime.now()
 now_to_the_hour = (now - timedelta(0, 0, 0, 0, 0, 3)).replace(minute=0, second=0, microsecond=0)
 START_DATE = now_to_the_hour
 DAG_NAME = 'test_dag_v1'
 
-default_args = {'owner': 'airflow', 'depends_on_past': True, 'start_date': days_ago(2)}
-dag = DAG(DAG_NAME, schedule_interval='*/10 * * * *', default_args=default_args)
+dag = DAG(
+    DAG_NAME,
+    schedule_interval='*/10 * * * *',
+    default_args={'depends_on_past': True},
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+)
 
 run_this_1 = DummyOperator(task_id='run_this_1', dag=dag)
 run_this_2 = DummyOperator(task_id='run_this_2', dag=dag)


### PR DESCRIPTION
This PR attempts to remove the remaining instances of uses dynamic values for `start_date` across the existing docs and added `catchup=False` where applicable as it is the latest best practice for examples (see thread [here](https://github.com/apache/airflow/pull/19237#discussion_r737875169)).

Also included a trivial `default_args` cleanup that was missing earlier example DAG updates.

> The removal of the dynamic `start_date` value used in `airflow/example_dags/example_subdag_operator.py` was reverted as it affects a number of tests and requires a larger change that's outside the scope of this PR.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
