### PR TITLE
Add test_connection method for sftp hook

### DIFF
--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -320,3 +320,11 @@ class SFTPHook(SSHHook):
         )
 
         return files, dirs, unknowns
+
+    def test_connection(self) -> Tuple[bool, str]:
+        """Test the SFTP connection by checking if remote entity '/some/path' exists"""
+        try:
+            self.path_exists('/some/path')
+            return True, "Connection successfully tested"
+        except Exception as e:
+            return False, str(e)

--- a/airflow/providers/sftp/hooks/sftp.py
+++ b/airflow/providers/sftp/hooks/sftp.py
@@ -324,7 +324,8 @@ class SFTPHook(SSHHook):
     def test_connection(self) -> Tuple[bool, str]:
         """Test the SFTP connection by checking if remote entity '/some/path' exists"""
         try:
-            self.path_exists('/some/path')
+            conn = self.get_conn()
+            conn.pwd
             return True, "Connection successfully tested"
         except Exception as e:
             return False, str(e)

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -306,9 +306,9 @@ class TestSFTPHook(unittest.TestCase):
 
     @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
     @mock.patch(
-        'airflow.providers.sftp.hooks.sftp.SFTPHook.path_exists', side_effect=Exception('Connection Error')
+        'airflow.providers.sftp.hooks.sftp.SFTPHook.get_conn.pwd', side_effect=Exception('Connection Error')
     )
-    def test_connection_failure(self, mock_get_connection, mock_path_exists):
+    def test_connection_failure(self, mock_get_connection, mock_pwd):
         connection = Connection(
             login='login',
             host='host',
@@ -321,14 +321,14 @@ class TestSFTPHook(unittest.TestCase):
         assert msg == 'Connection Error'
 
     @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
-    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.path_exists')
-    def test_connection_success(self, mock_get_connection, mock_path_exists):
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_conn.pwd')
+    def test_connection_success(self, mock_get_connection, mock_pwd):
         connection = Connection(
             login='login',
             host='host',
         )
         mock_get_connection.return_value = connection
-        mock_path_exists.return_value = True
+        mock_pwd.return_value = '/home/some_user'
 
         hook = SFTPHook()
         status, msg = hook.test_connection()

--- a/tests/providers/sftp/hooks/test_sftp.py
+++ b/tests/providers/sftp/hooks/test_sftp.py
@@ -304,6 +304,37 @@ class TestSFTPHook(unittest.TestCase):
         assert dirs == [os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS, SUB_DIR)]
         assert unknowns == []
 
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
+    @mock.patch(
+        'airflow.providers.sftp.hooks.sftp.SFTPHook.path_exists', side_effect=Exception('Connection Error')
+    )
+    def test_connection_failure(self, mock_get_connection, mock_path_exists):
+        connection = Connection(
+            login='login',
+            host='host',
+        )
+        mock_get_connection.return_value = connection
+
+        hook = SFTPHook()
+        status, msg = hook.test_connection()
+        assert status is False
+        assert msg == 'Connection Error'
+
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.get_connection')
+    @mock.patch('airflow.providers.sftp.hooks.sftp.SFTPHook.path_exists')
+    def test_connection_success(self, mock_get_connection, mock_path_exists):
+        connection = Connection(
+            login='login',
+            host='host',
+        )
+        mock_get_connection.return_value = connection
+        mock_path_exists.return_value = True
+
+        hook = SFTPHook()
+        status, msg = hook.test_connection()
+        assert status is True
+        assert msg == 'Connection successfully tested'
+
     def tearDown(self):
         shutil.rmtree(os.path.join(TMP_PATH, TMP_DIR_FOR_TESTS))
         os.remove(os.path.join(TMP_PATH, TMP_FILE_FOR_TESTS))


### PR DESCRIPTION
This PR is to add a `test_connection` method to the SFTPHook. To test connectivity to a remote entity, we check to see if `/some/path` exists in the sftp server. 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
