### PR TITLE
Declare data interval fields as serializable

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -303,6 +303,7 @@ class PythonVirtualenvOperator(PythonOperator):
     """
 
     BASE_SERIALIZABLE_CONTEXT_KEYS = {
+        'ds',
         'ds_nodash',
         'inlets',
         'next_ds',
@@ -322,8 +323,13 @@ class PythonVirtualenvOperator(PythonOperator):
         'yesterday_ds_nodash',
     }
     PENDULUM_SERIALIZABLE_CONTEXT_KEYS = {
+        'data_interval_end',
+        'data_interval_start',
         'execution_date',
+        'logical_date',
         'next_execution_date',
+        'prev_data_interval_end_success',
+        'prev_data_interval_start_success',
         'prev_execution_date',
         'prev_execution_date_success',
         'prev_start_date_success',


### PR DESCRIPTION
So they are available in PythonVirtualenvOperator. Also added a few more keys that are trivially serializable but was missing previously.

A test is added to make sure we declare all keys so this does not happen again in the future.

See #9394

I’m not really sure why exactly `ti` and `task_instance` are not being serialised. Those exist back when #9394 was implemented so they seem to be omitted intentionally? But I didn’t see any discussion on the decision.

`ds` was also omitted for some reason, but it’s just a string so I just added it.

cc @eladkal 