### PR TITLE
Remove reference to deprecated operator in example_dataproc

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_dataproc.py
+++ b/airflow/providers/google/cloud/example_dags/example_dataproc.py
@@ -24,7 +24,6 @@ import os
 from datetime import datetime
 
 from airflow import models
-from airflow.contrib.operators.dataproc_operator import DataprocClusterCreateOperator
 from airflow.providers.google.cloud.operators.dataproc import (
     ClusterGenerator,
     DataprocCreateClusterOperator,
@@ -66,11 +65,11 @@ CLUSTER_CONFIG = {
 
 # [END how_to_cloud_dataproc_create_cluster]
 
-# Cluster definition: Generating Cluster Config for DataprocClusterCreateOperator
+# Cluster definition: Generating Cluster Config for DataprocCreateClusterOperator
 # [START how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 path = "gs://goog-dataproc-initialization-actions-us-central1/python/pip-install.sh"
 
-CLUSTER_CONFIG = ClusterGenerator(
+CLUSTER_GENERATOR_CONFIG = ClusterGenerator(
     project_id="test",
     zone="us-central1-a",
     master_machine_type="n1-standard-4",
@@ -81,12 +80,12 @@ CLUSTER_CONFIG = ClusterGenerator(
     metadata={'PIP_PACKAGES': 'pyyaml requests pandas openpyxl'},
 ).make()
 
-create_cluster_operator = DataprocClusterCreateOperator(
+create_cluster_operator = DataprocCreateClusterOperator(
     task_id='create_dataproc_cluster',
     cluster_name="test",
     project_id="test",
     region="us-central1",
-    cluster_config=CLUSTER_CONFIG,
+    cluster_config=CLUSTER_GENERATOR_CONFIG,
 )
 # [END how_to_cloud_dataproc_create_cluster_generate_cluster_config]
 


### PR DESCRIPTION
An earlier merge of the `example_dataproc` DAG in the Google provider references a deprecated operator and is causing `main` to fail.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
