### PR TITLE
Add Helm Chart 1.3.0 as an option in airflow_helmchart_bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml
@@ -28,7 +28,8 @@ body:
         What Apache Airflow Helm Chart version are you using?
       multiple: false
       options:
-        - "1.2.0 (latest released)"
+        - "1.3.0 (latest released)"
+        - "1.2.0"
         - "1.1.0"
         - "1.0.0"
         - "main (development)"


### PR DESCRIPTION
Include Helm Chart 1.3.0 as a drop down option in `.github/ISSUE_TEMPLATE/airflow_helmchart_bug_report.yml`.