### PR TITLE
Move scripts for prod image preparation to dev

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -332,7 +332,7 @@ is not supposed to be used by and advertised to the end-users who do not read th
 Production Docker images should be manually prepared and pushed by the release manager.
 
 ```shell script
-./scripts/ci/tools/prepare_prod_docker_images.sh ${VERSION}
+./dev/prepare_prod_docker_images.sh ${VERSION}
 ```
 
 This will wipe Breeze cache and docker-context-files in order to make sure the build is "clean". It
@@ -785,7 +785,7 @@ previously released RC candidates in "${AIRFLOW_SOURCES}/dist":
 
 
 ```shell script
-./scripts/ci/tools/prepare_prod_docker_images.sh ${VERSION}
+./dev/prepare_prod_docker_images.sh ${VERSION}
 ```
 
 If you release 'official' (non-rc) version you will be asked if you want to

--- a/dev/prepare_prod_docker_images.sh
+++ b/dev/prepare_prod_docker_images.sh
@@ -15,7 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-AIRFLOW_SOURCES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../../../ && pwd)"
+AIRFLOW_SOURCES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
 export AIRFLOW_SOURCES_DIR
 
 CURRENT_PYTHON_MAJOR_MINOR_VERSIONS=("3.7" "3.8" "3.9" "3.6")
@@ -43,7 +43,7 @@ export INSTALL_AIRFLOW_VERSION="${1}"
 for python_version in "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}"
 do
   export PYTHON_MAJOR_MINOR_VERSION=${python_version}
-  echo "${AIRFLOW_SOURCES_DIR}/scripts/ci/tools/build_dockerhub.sh"
+  "${AIRFLOW_SOURCES_DIR}/scripts/ci/tools/build_dockerhub.sh"
 done
 
 if [[ ${INSTALL_AIRFLOW_VERSION} =~ .*rc.* ]]; then
@@ -65,10 +65,10 @@ fi
 
 for python_version in "${CURRENT_PYTHON_MAJOR_MINOR_VERSIONS[@]}"
 do
-    echo docker tag "apache/airflow:${INSTALL_AIRFLOW_VERSION}-python${python_version}" \
+    docker tag "apache/airflow:${INSTALL_AIRFLOW_VERSION}-python${python_version}" \
         "apache/airflow:latest-python${python_version}"
-    echo docker push "apache/airflow:latest-python${python_version}"
+    docker push "apache/airflow:latest-python${python_version}"
 done
 
-echo docker tag "apache/airflow:${INSTALL_AIRFLOW_VERSION}" "apache/airflow:latest"
-echo docker push "apache/airflow:latest"
+docker tag "apache/airflow:${INSTALL_AIRFLOW_VERSION}" "apache/airflow:latest"
+docker push "apache/airflow:latest"


### PR DESCRIPTION
The script belongs to dev. Also it had `echo` debug commands left
after testing that are removed now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
