### PR TITLE
Disable yarn-dev in start-airflow command

### DIFF
--- a/airflow/www/ask_for_recompile_assets_if_needed.sh
+++ b/airflow/www/ask_for_recompile_assets_if_needed.sh
@@ -30,12 +30,19 @@ NO_COLOR='\033[0m'
 md5sum=$(find package.json yarn.lock static/css static/js -type f | sort | xargs md5sum)
 old_md5sum=$(cat "${MD5SUM_FILE}" 2>/dev/null || true)
 if [[ ${old_md5sum} != "${md5sum}" ]]; then
-    echo
-    echo -e "${YELLOW}WARNING: It seems that the generated assets files do not match the content of the sources.${NO_COLOR}"
-    echo "To recompile assets, run:"
-    echo ""
-    echo "   ./airflow/www/compile_assets.sh"
-    echo ""
+    if [[ ${START_AIRFLOW} == "true" && ${USE_AIRFLOW_VERSION} == "" ]]; then
+        echo
+        echo -e "${YELLOW}Recompiling assets as they have changed and you need them for 'start_airflow' command${NO_COLOR}"
+        echo
+        ./compile_assets.sh
+    else
+        echo
+        echo -e "${YELLOW}WARNING: It seems that the generated assets files do not match the content of the sources.${NO_COLOR}"
+        echo "To recompile assets, run:"
+        echo ""
+        echo "   ./airflow/www/compile_assets.sh"
+        echo ""
+    fi
 else
     echo
     echo -e "${GREEN}No need for www assets recompilation.${NO_COLOR}"

--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -56,12 +56,6 @@ tmux split-window -h
 tmux select-pane -t 2
 tmux send-keys 'airflow webserver' C-m
 
-if [[ -z "${USE_AIRFLOW_VERSION=}" ]]; then
-    tmux select-pane -t 0
-    tmux split-window -h
-    tmux send-keys 'cd /opt/airflow/airflow/www/; yarn install --frozen-lockfile; yarn dev' C-m
-fi
-
 if python -c 'import sys; sys.exit(sys.version_info < (3, 7))'; then
     tmux select-pane -t 0
     tmux split-window -h

--- a/scripts/in_container/run_tmux_welcome.sh
+++ b/scripts/in_container/run_tmux_welcome.sh
@@ -19,5 +19,7 @@ cd /opt/airflow/ || exit
 clear
 echo "Welcome to your tmux based running Airflow environment (courtesy of Breeze)."
 echo
-echo "     To stop Airflow and exit tmux just type 'stop_airflow'."
+echo "     To stop Airflow and exit tmux, just type 'stop_airflow'."
+echo
+echo "     If you want to rebuild webserver assets dynamically, run 'cd airflow/www; yarn && yarn dev' and restart airflow webserver with '-d' flag."
 echo


### PR DESCRIPTION
When you run start-airflow, by default it also run `yarn dev`
command, however if you've never built assets before, yarn dev
is very slow first time and the webserver started before the dist
folder was even created which caused asset-less airflow experience.

There was another race condition even if you did build the
assets before. If you run start-airflow on MacOS or Windows when
the filesystem was slow, there could be a case that yarn dev
cleaned up the dist folder while webserver was starting and
it could lead again to asset-less experience if you were unlucky.

Also running `yarn dev` has the side effect of removing the checksum
file which is used to see if any of the assets changed and whether
they need recompilation. As the result after running `start-airflow`
you always got the warning that the assets need recompilation.

This PR disables automated start of `yarn dev` and suggests to run
it manually instead if there is a need for dynamic asset
recompilation. Also when `start-airflow` is run and we are starting
airflow from sources rather than PyPI, asset compilation is
executed if the checksum is missing or does not match the source
files.

Related to: #19566


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
