### PR TITLE
Fix failing CI phase with unhealthy container issue

### DIFF
--- a/scripts/ci/docker-compose/integration-pinot.yml
+++ b/scripts/ci/docker-compose/integration-pinot.yml
@@ -18,7 +18,7 @@
 version: "3.7"
 services:
   pinot:
-    image: apachepinot/pinot:latest
+    image: apachepinot/pinot:0.8.0
     ports:
       - "9080:9080"
     volumes:

--- a/scripts/ci/docker-compose/integration-statsd.yml
+++ b/scripts/ci/docker-compose/integration-statsd.yml
@@ -25,7 +25,7 @@ services:
       - "29102:9102"
 
   grafana:
-    image: grafana/grafana
+    image: grafana/grafana:8.2.4
     ports:
       - "23000:3000"
 

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -126,6 +126,7 @@ function run_airflow_testing_in_docker() {
          run airflow "${@}"
     exit_code=$?
     docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
+        "${INTEGRATIONS[@]}" \
         --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
         down --remove-orphans \
         --volumes --timeout 10

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -117,13 +117,14 @@ function run_airflow_testing_in_docker() {
         --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
         down --remove-orphans \
         --volumes --timeout 10
-    docker-compose --log-level INFO \
+    docker-compose --log-level DEBUG \
       -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
       "${backend_docker_compose[@]}" \
       "${INTEGRATIONS[@]}" \
       "${DOCKER_COMPOSE_LOCAL[@]}" \
       --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
          run airflow "${@}"
+    docker ps
     exit_code=$?
     docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
         "${INTEGRATIONS[@]}" \

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -117,7 +117,7 @@ function run_airflow_testing_in_docker() {
         --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
         down --remove-orphans \
         --volumes --timeout 10
-    docker-compose --log-level DEBUG \
+    docker-compose --log-level INFO \
       -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
       "${backend_docker_compose[@]}" \
       "${INTEGRATIONS[@]}" \

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -113,6 +113,7 @@ function run_airflow_testing_in_docker() {
     echo "Making sure docker-compose is down and remnants removed"
     echo
     docker-compose -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
+        "${INTEGRATIONS[@]}" \
         --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
         down --remove-orphans \
         --volumes --timeout 10


### PR DESCRIPTION
This is to fix failing Integration tests with below error that can be seen in CI builds for most PRs.

` ERROR: for airflow  Container "f149d1742c3f" is unhealthy.`

It happens due to **openldap** integration. When container is started it expects some empty directories for ldap database and finds some data and fails the container entering **unhealthy** state. ([similar issue](https://github.com/osixia/docker-openldap/issues/326))
This directories are mapped from docker-compose and provided externally using volumes.

PR adds removal of integration related volumes as well prior executing of main docker-compose build.  


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
