### PR TITLE
Fix dumping container logs on error

### DIFF
--- a/scripts/ci/libraries/_start_end.sh
+++ b/scripts/ci/libraries/_start_end.sh
@@ -71,21 +71,6 @@ function start_end::script_start {
     fi
 }
 
-function start_end::dump_container_logs() {
-    start_end::group_start "${COLOR_BLUE}Dumping container logs ${container}${COLOR_RESET}"
-    local container="${1}"
-    local dump_file
-    dump_file=${AIRFLOW_SOURCES}/files/container_logs_${container}_$(date "+%Y-%m-%d")_${CI_BUILD_ID}_${CI_JOB_ID}.log
-    echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
-    echo "                   Dumping logs from ${container} container"
-    echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
-    docker_v logs "${container}" > "${dump_file}"
-    echo "                   Container ${container} logs dumped to ${dump_file}"
-    echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
-    start_end::group_end
-}
-
-
 #
 # Trap function executed always at the end of the script. In case of verbose output it also
 # Prints the exit code that the script exits with. Removes verbosity of commands in case it was run with
@@ -106,13 +91,6 @@ function start_end::script_end {
         echo
         echo "${COLOR_RED}ERROR: The previous step completed with error. Please take a look at output above ${COLOR_RESET}"
         echo
-        if [[ ${CI} == "true" ]]; then
-            local container
-            for container in $(docker ps --format '{{.Names}}')
-            do
-                start_end::dump_container_logs "${container}"
-            done
-        fi
         verbosity::print_info "${COLOR_RED}###########################################################################################${COLOR_RESET}"
         verbosity::print_info "${COLOR_RED}                   EXITING WITH STATUS CODE ${exit_code}${COLOR_RESET}"
         verbosity::print_info "${COLOR_RED}###########################################################################################${COLOR_RESET}"

--- a/scripts/ci/libraries/_testing.sh
+++ b/scripts/ci/libraries/_testing.sh
@@ -114,3 +114,17 @@ function testing::get_test_types_to_run() {
     fi
     readonly TEST_TYPES
 }
+
+function testing::dump_container_logs() {
+    start_end::group_start "${COLOR_BLUE}Dumping container logs ${container}${COLOR_RESET}"
+    local container="${1}"
+    local dump_file
+    dump_file=${AIRFLOW_SOURCES}/files/container_logs_${container}_$(date "+%Y-%m-%d")_${CI_BUILD_ID}_${CI_JOB_ID}.log
+    echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
+    echo "                   Dumping logs from ${container} container"
+    echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
+    docker_v logs "${container}" > "${dump_file}"
+    echo "                   Container ${container} logs dumped to ${dump_file}"
+    echo "${COLOR_BLUE}###########################################################################################${COLOR_RESET}"
+    start_end::group_end
+}

--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -124,6 +124,15 @@ function run_airflow_testing_in_docker() {
       --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
          run airflow "${@}"
     exit_code=$?
+    if [[ ${exit_code} != "0" && ${CI} == "true" ]]; then
+        docker ps --all
+        local container
+        for container in $(docker ps --all --format '{{.Names}}')
+        do
+            testing::dump_container_logs "${container}"
+        done
+    fi
+
     docker-compose --log-level INFO -f "${SCRIPTS_CI_DIR}/docker-compose/base.yml" \
         --project-name "airflow-${TEST_TYPE}-${BACKEND}" \
         down --remove-orphans \


### PR DESCRIPTION
When we optimized tests for memory use we added cleanup of all
containers after each test suite. Unfortunately it caused
dumping container logs to stop working because this dumping was
done only only when the script was exiting.

This PR moves dumping container logs to between the test run and
cleanup, so that we can see the logs when there is a test failure.

Related to: #19633 where the logs were not dumped and it made the
analysis much more difficult.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
