### PR TITLE
Add more complete instruction for reproducing failed integration tests

### DIFF
--- a/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
+++ b/scripts/ci/testing/ci_run_single_airflow_test_in_docker.sh
@@ -25,6 +25,7 @@ export PRINT_INFO_FROM_SCRIPTS
 
 DOCKER_COMPOSE_LOCAL=()
 INTEGRATIONS=()
+INTEGRATION_BREEZE_FLAGS=()
 
 function prepare_tests() {
     DOCKER_COMPOSE_LOCAL+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/files.yml")
@@ -59,8 +60,8 @@ function prepare_tests() {
 
     for _INT in ${ENABLED_INTEGRATIONS}
     do
-        INTEGRATIONS+=("-f")
-        INTEGRATIONS+=("${SCRIPTS_CI_DIR}/docker-compose/integration-${_INT}.yml")
+        INTEGRATIONS+=("-f" "${SCRIPTS_CI_DIR}/docker-compose/integration-${_INT}.yml")
+        INTEGRATION_BREEZE_FLAGS+=("--integration" "${_INT}")
     done
 
     readonly INTEGRATIONS
@@ -146,8 +147,8 @@ function run_airflow_testing_in_docker() {
         echo "${COLOR_RED}***********************************************************************************************${COLOR_RESET}"
         echo
         echo "${COLOR_BLUE}***********************************************************************************************${COLOR_RESET}"
-        echo "${COLOR_BLUE}Reproduce the failed tests on your local machine:${COLOR_RESET}"
-        echo "${COLOR_YELLOW}./breeze --github-image-id ${GITHUB_REGISTRY_PULL_IMAGE_TAG=} --backend ${BACKEND} ${EXTRA_ARGS}--python ${PYTHON_MAJOR_MINOR_VERSION} --db-reset --skip-mounting-local-sources --test-type ${TEST_TYPE} shell${COLOR_RESET}"
+        echo "${COLOR_BLUE}Reproduce the failed tests on your local machine (note that you need to use docker-compose v1 rather than v2 to enable Kerberos integration):${COLOR_RESET}"
+        echo "${COLOR_YELLOW}./breeze --github-image-id ${GITHUB_REGISTRY_PULL_IMAGE_TAG=} --backend ${BACKEND} ${EXTRA_ARGS}--python ${PYTHON_MAJOR_MINOR_VERSION} --db-reset --skip-mounting-local-sources --test-type ${TEST_TYPE} ${INTEGRATION_BREEZE_FLAGS[*]} shell${COLOR_RESET}"
         echo "${COLOR_BLUE}Then you can run failed tests with:${COLOR_RESET}"
         echo "${COLOR_YELLOW}pytest [TEST_NAME]${COLOR_RESET}"
         echo "${COLOR_BLUE}***********************************************************************************************${COLOR_RESET}"


### PR DESCRIPTION
When integration tests are failing, breeze prints the exact
reproduction step to recreate the same environment. However when
integration tests were enabled it missed the --integration
flags that were necessary to enable the integrations.

This PR adds the --integration flags to the instructions and also
adds the comment that Kerberos integration currently does not work
with docker-compose v2.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
