### PR TITLE
Mounted airflow_local_settings in helm jobs.

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -114,6 +114,12 @@ spec:
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
+            {{- if .Values.airflowLocalSettings }}
+            - name: config
+              mountPath: {{ template"airflow_local_setting_path" . }}
+              subPath: airflow_local_settings.py
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml .Values.createUserJob.resources | indent 12 }}
       volumes:

--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -115,11 +115,11 @@ spec:
               subPath: airflow.cfg
               readOnly: true
             {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template"airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
-              readOnly: true
-            {{- end }}
+            - name: config
+              mountPath: {{ template "airflow_local_setting_path" . }}
+              subPath: airflow_local_settings.py
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml .Values.createUserJob.resources | indent 12 }}
       volumes:

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -98,6 +98,12 @@ spec:
               mountPath: {{ template "airflow_config_path" . }}
               subPath: airflow.cfg
               readOnly: true
+            {{- if .Values.airflowLocalSettings }}
+            - name: config
+              mountPath: {{ template"airflow_local_setting_path" . }}
+              subPath: airflow_local_settings.py
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml .Values.migrateDatabaseJob.resources | indent 12 }}
 {{- if .Values.migrateDatabaseJob.extraContainers }}

--- a/chart/templates/jobs/migrate-database-job.yaml
+++ b/chart/templates/jobs/migrate-database-job.yaml
@@ -99,11 +99,11 @@ spec:
               subPath: airflow.cfg
               readOnly: true
             {{- if .Values.airflowLocalSettings }}
-            - name: config
-              mountPath: {{ template"airflow_local_setting_path" . }}
-              subPath: airflow_local_settings.py
-              readOnly: true
-            {{- end }}
+            - name: config
+              mountPath: {{ template "airflow_local_setting_path" . }}
+              subPath: airflow_local_settings.py
+              readOnly: true
+            {{- end }}
           resources:
 {{ toYaml .Values.migrateDatabaseJob.resources | indent 12 }}
 {{- if .Values.migrateDatabaseJob.extraContainers }}


### PR DESCRIPTION
Currently, the create-users as well as the run-airflow-migrations job of the helm chart do not mount the airflow_local_settings file. In all deployments, this mount is provided. 
Depending on the use of the airflow_local_settings it is helpful to have those settings available in the jobs as well. Example: If one uses custom logging settings that are loaded via the airflow config, airflow does not start if the local settings file is not available. 

This PR adds the mount to those two jobs. 