### PR TITLE
BaseOperator.on_kill should optionally accept airflow context

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -1006,7 +1006,7 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
         if self._post_execute_hook is not None:
             self._post_execute_hook(context, result)
 
-    def on_kill(self) -> None:
+    def on_kill(self, context=None) -> None:
         """
         Override this method to cleanup subprocesses when a task instance
         gets killed. Any use of the threading, subprocess or multiprocessing

--- a/airflow/utils/parameters.py
+++ b/airflow/utils/parameters.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import inspect
+from collections import namedtuple
+
+InspectSignatureResult = namedtuple('InspectSignatureResult', ['bound_arguments', 'has_kwargs'])
+
+
+def inspect_function_arguments(function) -> InspectSignatureResult:
+    """
+    Returns the list of variables names of a function and if it
+    accepts keyword arguments.
+    :param function: The function to inspect
+    :type function: Callable
+    :rtype: InspectSignatureResult
+    """
+    parameters = inspect.signature(function).parameters
+    bound_arguments = [
+        name for name, p in parameters.items() if p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    ]
+    has_kwargs = any(p.kind == p.VAR_KEYWORD for p in parameters.values())
+    return InspectSignatureResult(list(bound_arguments), has_kwargs)


### PR DESCRIPTION
There are times, particularly as we incomporate more deferrable operators, when the on_kill logic would benefit from access to the airflow context.  For example in the kubernetes context we might need to use context information to look up the pod name.  Having context available in on_kill frees us from having to ensure in all possible entrypoints that we set instance attributes that on_kill would need in order to do a proper cleanup.
