### PR TITLE
Fix log endpoint for same task

### DIFF
--- a/airflow/api_connexion/endpoints/log_endpoint.py
+++ b/airflow/api_connexion/endpoints/log_endpoint.py
@@ -62,7 +62,11 @@ def get_log(session, dag_id, dag_run_id, task_id, task_try_number, full_content=
 
     ti = (
         session.query(TaskInstance)
-        .filter(TaskInstance.task_id == task_id, TaskInstance.run_id == dag_run_id)
+        .filter(
+            TaskInstance.task_id == task_id,
+            TaskInstance.dag_id == dag_id,
+            TaskInstance.run_id == dag_run_id,
+        )
         .join(TaskInstance.dag_run)
         .one_or_none()
     )

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -59,7 +59,6 @@ def configured_app(minimal_app_for_api):
 class TestGetLog:
     DAG_ID = 'dag_for_testing_log_endpoint'
     TASK_ID = 'task_for_testing_log_endpoint'
-    RUN_ID = 'TEST_DAG_RUN_ID'
     TRY_NUMBER = 1
 
     default_time = "2020-06-10T20:00:00+00:00"
@@ -74,7 +73,7 @@ class TestGetLog:
         with dag_maker(self.DAG_ID, start_date=timezone.parse(self.default_time), session=session) as dag:
             DummyOperator(task_id=self.TASK_ID)
         dr = dag_maker.create_dagrun(
-            run_id=self.RUN_ID,
+            run_id='TEST_DAG_RUN_ID',
             run_type=DagRunType.SCHEDULED,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
@@ -87,7 +86,7 @@ class TestGetLog:
         ) as dummy_dag:
             DummyOperator(task_id=self.TASK_ID)
         dag_maker.create_dagrun(
-            run_id=self.RUN_ID,
+            run_id='TEST_DAG_RUN_ID',
             run_type=DagRunType.SCHEDULED,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
@@ -129,7 +128,7 @@ class TestGetLog:
         serializer = URLSafeSerializer(key)
         token = serializer.dumps({"download_logs": False})
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'application/json'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -151,7 +150,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'text/plain'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -177,7 +176,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'text/plain'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -197,7 +196,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/Invalid-Task-ID/logs/1?token={token}",
             environ_overrides={'REMOTE_USER': "test"},
         )
@@ -218,7 +217,7 @@ class TestGetLog:
             read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
 
             response = self.client.get(
-                f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+                f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
                 f"taskInstances/{self.TASK_ID}/logs/1?full_content=True",
                 headers={"Accept": 'text/plain'},
                 environ_overrides={'REMOTE_USER': "test"},
@@ -239,7 +238,7 @@ class TestGetLog:
 
         # check guessing
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Content-Type': 'application/jso'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -251,7 +250,7 @@ class TestGetLog:
         token = {"download_logs": False}
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'application/json'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -284,7 +283,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": False})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'application/json'},
         )
@@ -297,7 +296,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'text/plain'},
             environ_overrides={'REMOTE_USER': "test_no_permissions"},

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -81,6 +81,18 @@ class TestGetLog:
 
         configured_app.dag_bag.bag_dag(dag, root_dag=dag)
 
+        with dag_maker(
+            f'{self.DAG_ID}_copy', start_date=timezone.parse(self.default_time), session=session
+        ) as dummy_dag:
+            DummyOperator(task_id=self.TASK_ID)
+        dag_maker.create_dagrun(
+            run_id='TEST_DAG_RUN_ID',
+            run_type=DagRunType.SCHEDULED,
+            execution_date=timezone.parse(self.default_time),
+            start_date=timezone.parse(self.default_time),
+        )
+        configured_app.dag_bag.bag_dag(dummy_dag, root_dag=dummy_dag)
+
         self.ti = dr.task_instances[0]
         self.ti.try_number = 1
 

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -81,6 +81,7 @@ class TestGetLog:
 
         configured_app.dag_bag.bag_dag(dag, root_dag=dag)
 
+        # Add dummy dag for checking picking correct log with same task_id and different dag_id case.
         with dag_maker(
             f'{self.DAG_ID}_copy', start_date=timezone.parse(self.default_time), session=session
         ) as dummy_dag:

--- a/tests/api_connexion/endpoints/test_log_endpoint.py
+++ b/tests/api_connexion/endpoints/test_log_endpoint.py
@@ -59,6 +59,7 @@ def configured_app(minimal_app_for_api):
 class TestGetLog:
     DAG_ID = 'dag_for_testing_log_endpoint'
     TASK_ID = 'task_for_testing_log_endpoint'
+    RUN_ID = 'TEST_DAG_RUN_ID'
     TRY_NUMBER = 1
 
     default_time = "2020-06-10T20:00:00+00:00"
@@ -73,7 +74,7 @@ class TestGetLog:
         with dag_maker(self.DAG_ID, start_date=timezone.parse(self.default_time), session=session) as dag:
             DummyOperator(task_id=self.TASK_ID)
         dr = dag_maker.create_dagrun(
-            run_id='TEST_DAG_RUN_ID',
+            run_id=self.RUN_ID,
             run_type=DagRunType.SCHEDULED,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
@@ -86,7 +87,7 @@ class TestGetLog:
         ) as dummy_dag:
             DummyOperator(task_id=self.TASK_ID)
         dag_maker.create_dagrun(
-            run_id='TEST_DAG_RUN_ID',
+            run_id=self.RUN_ID,
             run_type=DagRunType.SCHEDULED,
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
@@ -128,7 +129,7 @@ class TestGetLog:
         serializer = URLSafeSerializer(key)
         token = serializer.dumps({"download_logs": False})
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'application/json'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -150,7 +151,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'text/plain'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -176,7 +177,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'text/plain'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -196,7 +197,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/Invalid-Task-ID/logs/1?token={token}",
             environ_overrides={'REMOTE_USER': "test"},
         )
@@ -217,7 +218,7 @@ class TestGetLog:
             read_mock.side_effect = [first_return, second_return, third_return, fourth_return]
 
             response = self.client.get(
-                f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+                f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
                 f"taskInstances/{self.TASK_ID}/logs/1?full_content=True",
                 headers={"Accept": 'text/plain'},
                 environ_overrides={'REMOTE_USER': "test"},
@@ -238,7 +239,7 @@ class TestGetLog:
 
         # check guessing
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Content-Type': 'application/jso'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -250,7 +251,7 @@ class TestGetLog:
         token = {"download_logs": False}
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'application/json'},
             environ_overrides={'REMOTE_USER': "test"},
@@ -283,7 +284,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": False})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'application/json'},
         )
@@ -296,7 +297,7 @@ class TestGetLog:
         token = serializer.dumps({"download_logs": True})
 
         response = self.client.get(
-            f"api/v1/dags/{self.DAG_ID}/dagRuns/TEST_DAG_RUN_ID/"
+            f"api/v1/dags/{self.DAG_ID}/dagRuns/{self.RUN_ID}/"
             f"taskInstances/{self.TASK_ID}/logs/1?token={token}",
             headers={'Accept': 'text/plain'},
             environ_overrides={'REMOTE_USER': "test_no_permissions"},


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Log endpoint API raise exception when same `task_id` with different `dag_id`.

```
Traceback (most recent call last):
  File &#34;/opt/app-root/lib64/python3.8/site-packages/flask/app.py&#34;, line 2447, in wsgi_app
    response = self.full_dispatch_request()
  File &#34;/opt/app-root/lib64/python3.8/site-packages/flask/app.py&#34;, line 1952, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/flask/app.py&#34;, line 1821, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/flask/_compat.py&#34;, line 39, in reraise
    raise value
  File &#34;/opt/app-root/lib64/python3.8/site-packages/flask/app.py&#34;, line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File &#34;/opt/app-root/lib64/python3.8/site-packages/flask/app.py&#34;, line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/_vendor/connexion/decorators/decorator.py&#34;, line 48, in wrapper
    response = function(request)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/_vendor/connexion/decorators/uri_parsing.py&#34;, line 144, in wrapper
    response = function(request)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/_vendor/connexion/decorators/validation.py&#34;, line 384, in wrapper
    return function(request)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/_vendor/connexion/decorators/response.py&#34;, line 103, in wrapper
    response = function(request)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/_vendor/connexion/decorators/parameter.py&#34;, line 121, in wrapper
    return function(**kwargs)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/api_connexion/security.py&#34;, line 47, in decorated
    return func(*args, **kwargs)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/utils/session.py&#34;, line 70, in wrapper
    return func(*args, session=session, **kwargs)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/airflow/api_connexion/endpoints/log_endpoint.py&#34;, line 64, in get_log
    session.query(TaskInstance)
  File &#34;/opt/app-root/lib64/python3.8/site-packages/sqlalchemy/orm/query.py&#34;, line 3467, in one_or_none
    raise orm_exc.MultipleResultsFound(
sqlalchemy.orm.exc.MultipleResultsFound: Multiple rows were found for one_or_none()
```

So, I add `dag_id` filter to get unique task_instance.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
