### PR TITLE
Add back-compat to db migrations for helm chart < 1.4

### DIFF
--- a/airflow/migrations/db_types.py
+++ b/airflow/migrations/db_types.py
@@ -48,17 +48,32 @@ MSSQL_USE_DATE_TIME2 = Proxy(_mssql_use_date_time2)
 def _mssql_TIMESTAMP():
     from sqlalchemy.dialects import mssql
 
-    return mssql.DATETIME2(precision=6) if MSSQL_USE_DATE_TIME2 else mssql.DATETIME
+    if MSSQL_USE_DATE_TIME2:
+
+        class DATETIME2(mssql.DATETIME2):
+            def __init__(self, *args, precision=6, **kwargs):
+                super().__init__(*args, precision=precision, **kwargs)
+
+        return DATETIME2
+    return mssql.DATETIME
 
 
 def _mysql_TIMESTAMP():
     from sqlalchemy.dialects import mysql
 
-    return mysql.TIMESTAMP(fsp=6, timezone=True)
+    class TIMESTAMP(mysql.TIMESTAMP):
+        def __init__(self, *args, fsp=6, timezone=True, **kwargs):
+            super().__init__(*args, fsp=fsp, timezone=timezone, **kwargs)
+
+    return TIMESTAMP
 
 
 def _sa_TIMESTAMP():
-    return sa.TIMESTAMP(timezone=True)
+    class TIMESTAMP(sa.TIMESTAMP):
+        def __init__(self, *args, timezone=True, **kwargs):
+            super().__init__(*args, timezone=timezone, **kwargs)
+
+    return TIMESTAMP
 
 
 def _sa_StringID():

--- a/airflow/migrations/versions/3c20cacc0044_add_dagrun_run_type.py
+++ b/airflow/migrations/versions/3c20cacc0044_add_dagrun_run_type.py
@@ -27,14 +27,10 @@ Create Date: 2020-04-08 13:35:25.671327
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import Boolean, Column, Integer, PickleType, String
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.migrations.db_types import StringID
-from airflow.utils import timezone
-from airflow.utils.sqlalchemy import UtcDateTime
-from airflow.utils.state import State
 from airflow.utils.types import DagRunType
 
 # revision identifiers, used by Alembic.
@@ -47,23 +43,13 @@ Base = declarative_base()
 
 
 class DagRun(Base):  # type: ignore
-    """
-    DagRun describes an instance of a Dag. It can be created
-    by the scheduler (for regular runs) or by an external trigger
-    """
+    """Minimal model definition for migrations"""
 
     __tablename__ = "dag_run"
 
     id = Column(Integer, primary_key=True)
-    dag_id = Column(StringID())
-    execution_date = Column(UtcDateTime, default=timezone.utcnow)
-    start_date = Column(UtcDateTime, default=timezone.utcnow)
-    end_date = Column(UtcDateTime)
-    _state = Column('state', String(50), default=State.RUNNING)
-    run_id = Column(StringID())
-    external_trigger = Column(Boolean, default=True)
+    run_id = Column(String())
     run_type = Column(String(50), nullable=False)
-    conf = Column(PickleType)
 
 
 def upgrade():

--- a/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
+++ b/airflow/migrations/versions/6e96a59344a4_make_taskinstance_pool_not_nullable.py
@@ -24,13 +24,11 @@ Create Date: 2019-06-13 21:51:32.878437
 
 """
 
-import dill
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import Column, Float, Integer, PickleType, String
+from sqlalchemy import Column, String
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.migrations.db_types import StringID
 from airflow.utils.session import create_session
 from airflow.utils.sqlalchemy import UtcDateTime
 
@@ -45,40 +43,14 @@ ID_LEN = 250
 
 
 class TaskInstance(Base):  # type: ignore
-    """
-    Task instances store the state of a task instance. This table is the
-    authority and single source of truth around what tasks have run and the
-    state they are in.
-
-    The SqlAlchemy model doesn't have a SqlAlchemy foreign key to the task or
-    dag model deliberately to have more control over transactions.
-
-    Database transactions on this table should insure double triggers and
-    any confusion around what task instances are or aren't ready to run
-    even while multiple schedulers may be firing task instances.
-    """
+    """Minimal model definition for migrations"""
 
     __tablename__ = "task_instance"
 
-    task_id = Column(StringID(), primary_key=True)
-    dag_id = Column(StringID(), primary_key=True)
+    task_id = Column(String(), primary_key=True)
+    dag_id = Column(String(), primary_key=True)
     execution_date = Column(UtcDateTime, primary_key=True)
-    start_date = Column(UtcDateTime)
-    end_date = Column(UtcDateTime)
-    duration = Column(Float)
-    state = Column(String(20))
-    _try_number = Column('try_number', Integer, default=0)
-    max_tries = Column(Integer)
-    hostname = Column(String(1000))
-    unixname = Column(String(1000))
-    job_id = Column(Integer)
     pool = Column(String(50), nullable=False)
-    queue = Column(String(256))
-    priority_weight = Column(Integer)
-    operator = Column(String(1000))
-    queued_dttm = Column(UtcDateTime)
-    pid = Column(Integer)
-    executor_config = Column(PickleType(pickler=dill))
 
 
 def upgrade():

--- a/airflow/migrations/versions/8646922c8a04_change_default_pool_slots_to_1.py
+++ b/airflow/migrations/versions/8646922c8a04_change_default_pool_slots_to_1.py
@@ -24,13 +24,11 @@ Create Date: 2021-02-23 23:19:22.409973
 
 """
 
-import dill
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import Column, Float, Integer, PickleType, String
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 
-from airflow.migrations.db_types import StringID
 from airflow.utils.sqlalchemy import UtcDateTime
 
 # revision identifiers, used by Alembic.
@@ -44,32 +42,14 @@ BATCH_SIZE = 5000
 
 
 class TaskInstance(Base):  # type: ignore
-    """Task instance class."""
+    """Minimal model definition for migrations"""
 
     __tablename__ = "task_instance"
 
-    task_id = Column(StringID(), primary_key=True)
-    dag_id = Column(StringID(), primary_key=True)
+    task_id = Column(String(), primary_key=True)
+    dag_id = Column(String(), primary_key=True)
     execution_date = Column(UtcDateTime, primary_key=True)
-    start_date = Column(UtcDateTime)
-    end_date = Column(UtcDateTime)
-    duration = Column(Float)
-    state = Column(String(20))
-    _try_number = Column('try_number', Integer, default=0)
-    max_tries = Column(Integer)
-    hostname = Column(String(1000))
-    unixname = Column(String(1000))
-    job_id = Column(Integer)
-    pool = Column(String(50), nullable=False)
     pool_slots = Column(Integer, default=1)
-    queue = Column(String(256))
-    priority_weight = Column(Integer)
-    operator = Column(String(1000))
-    queued_dttm = Column(UtcDateTime)
-    queued_by_job_id = Column(Integer)
-    pid = Column(Integer)
-    executor_config = Column(PickleType(pickler=dill))
-    external_executor_id = Column(StringID())
 
 
 def upgrade():

--- a/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
+++ b/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py
@@ -25,12 +25,11 @@ Create Date: 2017-06-19 16:53:12.851141
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy import Column, Integer
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.ext.declarative import declarative_base
 
 from airflow import settings
-from airflow.migrations.db_types import StringID
 from airflow.models import DagBag
 
 # revision identifiers, used by Alembic.
@@ -48,8 +47,8 @@ class TaskInstance(Base):  # type: ignore
 
     __tablename__ = "task_instance"
 
-    task_id = Column(StringID(), primary_key=True)
-    dag_id = Column(StringID(), primary_key=True)
+    task_id = Column(String(), primary_key=True)
+    dag_id = Column(String(), primary_key=True)
     execution_date = Column(sa.DateTime, primary_key=True)
     max_tries = Column(Integer)
     try_number = Column(Integer, default=0)


### PR DESCRIPTION
Prior to 1.4 of the helm-chart we "inlined"/hard-coded the
wait-for-migrations command (as a `python -c` command) and that version
didn't correctly initialize the alembic context, meaning that anything
triggering a context.get_bind() at migration version import time caused
an error.

This fixes that problem by:

- Making StringID and TIMESTAMP lazy objects, so that just importing
  them at the top level doesn't trigger the problem
- Stop calling it at the top level where it doesn't matter -- we have a
  few migrations that create a "copy" of TaskInstance/DagRun model to do
  an update, and those have been changed to
    a. just use `String()` (as the exact type doesn't matter for UDPATE)
    b. to only define the PK+columns being updated, as that is enough

