### PR TITLE
Fix the link to the Graph view in the Tree view DAGRun modal

### DIFF
--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -43,7 +43,7 @@ const DagRunBar = ({
       pb="2px"
       px="3px"
       onClick={() => {
-        callModalDag({ execution_date: run.executionDate, dagId: run.dagId });
+        callModalDag({ execution_date: run.executionDate, dag_id: run.dagId });
       }}
     >
       <Tooltip


### PR DESCRIPTION
The Graph link in the DAG run modal in the new Tree view is broken because the DAG id is passed in a parameter named `dagId` and the URL is built assuming a parameter named `dag_id` ([link](https://github.com/apache/airflow/blob/main/airflow/www/static/js/dag.js#L227)). As a result, the user is forwarded to the main page and gets an error:

![image](https://user-images.githubusercontent.com/6249654/142418855-5f104594-0ade-4141-81da-183258e6f45c.png)

This PR fixes the URL.