### PR TITLE
Disclaimer in Kubernetes executor pod template example

### DIFF
--- a/docs/apache-airflow/executor/kubernetes.rst
+++ b/docs/apache-airflow/executor/kubernetes.rst
@@ -91,6 +91,14 @@ Example pod templates
 
 With these requirements in mind, here are some examples of basic ``pod_template_file`` YAML files.
 
+.. note::
+
+    The examples below should work when using default airflow configuration values. However, many custom
+    configuration values need to be explicitly passed to the pod via this template too. This includes,
+    but is not limited to, sql configuration, required Airflow connections, dag folder path and
+    logging settings. See
+    https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html for details.
+
 Storing DAGs in the image:
 
 .. exampleinclude:: /../../airflow/kubernetes/pod_template_file_examples/dags_in_image_template.yaml


### PR DESCRIPTION
This came in when upgrading from 2.1.4 to 2.2.x, and using non-default dag folder.

Because of https://github.com/apache/airflow/issues/8061
all dags stopped working.

Add a note that the examples for pod template are not final,
and require more configuration variables to be passed explicitly.