### PR TITLE
Chart: Allow overriding redis's ``runAsUser`` option (#19681)

### DIFF
--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -71,8 +71,10 @@ spec:
         - name: redis
           image: {{ template "redis_image" . }}
           imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
+          {{- if .Values.redis.uid }}
           securityContext:
-            runAsUser: {{ .Values.uid }}
+            runAsUser: {{ .Values.redis.uid }}
+          {{- end }}
           command: ["/bin/sh"]
           resources:
 {{ toYaml .Values.redis.resources | indent 12 }}

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -71,6 +71,8 @@ spec:
         - name: redis
           image: {{ template "redis_image" . }}
           imagePullPolicy: {{ .Values.images.redis.pullPolicy }}
+          securityContext:
+            runAsUser: {{ .Values.uid }}
           command: ["/bin/sh"]
           resources:
 {{ toYaml .Values.redis.resources | indent 12 }}

--- a/chart/tests/test_redis.py
+++ b/chart/tests/test_redis.py
@@ -320,3 +320,18 @@ class RedisTest(unittest.TestCase):
         )
         annotations = jmespath.search("metadata.annotations", docs[0])
         assert annotations["helm.sh/hook-weight"] == "0"
+
+    def test_redis_uid_is_not_added_by_default(self):
+        docs = render_chart(
+            show_only=["templates/redis/redis-statefulset.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].securityContext", docs[0]) is None
+
+    def test_redis_uid(self):
+        docs = render_chart(
+            values={
+                "redis": {"uid": 1001},
+            },
+            show_only=["templates/redis/redis-statefulset.yaml"],
+        )
+        assert jmespath.search("spec.template.spec.containers[0].securityContext", docs[0]) == 1001

--- a/chart/tests/test_redis.py
+++ b/chart/tests/test_redis.py
@@ -334,4 +334,4 @@ class RedisTest(unittest.TestCase):
             },
             show_only=["templates/redis/redis-statefulset.yaml"],
         )
-        assert jmespath.search("spec.template.spec.containers[0].securityContext", docs[0]) == 1001
+        assert jmespath.search("spec.template.spec.containers[0].securityContext.runAsUser", docs[0]) == 1001

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3190,6 +3190,11 @@
                         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/toleration-v1.json"
                     }
                 },
+                "uid": {
+                    "description": "Redis run as user parameter.",
+                    "type": "integer",
+                    "default": 1001
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3192,8 +3192,11 @@
                 },
                 "uid": {
                     "description": "Redis run as user parameter.",
-                    "type": "integer",
-                    "default": 1001
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "default": null
                 },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1153,6 +1153,8 @@ redis:
   affinity: {}
   tolerations: []
 
+  uid: 1001
+
 # Auth secret for a private registry
 # This is used if pulling airflow images from a private registry
 registry:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1153,7 +1153,7 @@ redis:
   affinity: {}
   tolerations: []
 
-  uid: null
+  uid: ~
 
 # Auth secret for a private registry
 # This is used if pulling airflow images from a private registry

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1153,7 +1153,7 @@ redis:
   affinity: {}
   tolerations: []
 
-  uid: 1001
+  uid: null
 
 # Auth secret for a private registry
 # This is used if pulling airflow images from a private registry


### PR DESCRIPTION
closes: #19681

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
