### PR TITLE
Fix failures with recent moto library 2.2.15

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -532,7 +532,7 @@ devel_only = [
     'jira',
     'jsondiff',
     'mongomock',
-    'moto~=2.2, >=2.2.7',
+    'moto~=2.2, >=2.2.12',
     'mypy==0.770',
     'parameterized',
     'paramiko',

--- a/tests/providers/amazon/aws/hooks/test_cloud_formation.py
+++ b/tests/providers/amazon/aws/hooks/test_cloud_formation.py
@@ -23,7 +23,6 @@ from airflow.providers.amazon.aws.hooks.cloud_formation import AWSCloudFormation
 
 try:
     from moto import mock_cloudformation
-    from moto.ec2.models import NetworkInterface as some_model
 except ImportError:
     mock_cloudformation = None
 
@@ -39,10 +38,20 @@ class TestAWSCloudFormationHook(unittest.TestCase):
             {
                 'Resources': {
                     "myResource": {
-                        "Type": some_model.cloudformation_type(),
-                        "Properties": {"myProperty": "myPropertyValue"},
+                        "Type": "AWS::EC2::VPC",
+                        "Properties": {
+                            "CidrBlock": {"Ref": "VPCCidr"},
+                            "Tags": [{"Key": "Name", "Value": "Primary_CF_VPC"}],
+                        },
                     }
-                }
+                },
+                "Parameters": {
+                    "VPCCidr": {
+                        "Type": "String",
+                        "Default": "10.0.0.0/16",
+                        "Description": "Enter the CIDR block for the VPC. Default is 10.0.0.0/16.",
+                    }
+                },
             }
         )
 
@@ -51,7 +60,7 @@ class TestAWSCloudFormationHook(unittest.TestCase):
             params={
                 'TimeoutInMinutes': timeout,
                 'TemplateBody': template_body,
-                'Parameters': [{'ParameterKey': 'myParam', 'ParameterValue': 'myParamValue'}],
+                'Parameters': [{'ParameterKey': "VPCCidr", 'ParameterValue': '10.0.0.0/16'}],
             },
         )
 

--- a/tests/providers/amazon/aws/hooks/test_logs.py
+++ b/tests/providers/amazon/aws/hooks/test_logs.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+import time
 import unittest
 
 from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
@@ -49,7 +49,7 @@ class TestAwsLogsHook(unittest.TestCase):
         conn.create_log_group(logGroupName=log_group_name)
         conn.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)
 
-        input_events = [{'timestamp': 1, 'message': 'Test Message 1'}]
+        input_events = [{'timestamp': int(time.time()) * 1000, 'message': 'Test Message 1'}]
 
         conn.put_log_events(
             logGroupName=log_group_name, logStreamName=log_stream_name, logEvents=input_events


### PR DESCRIPTION
The recent moto library is more picky about parameters
passed to it:
* when you are sending too old logs they are rejected
* when you are passing cloud formation template they are parsed
  and validated for correctness

Our tests had artifficial values for those, which caused failures
with the recent moto version.

This PR provides realistic values in tests to pass moto validation

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
