### PR TITLE
Fix badly merged impersonation in GKEPodOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -365,7 +365,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
                 if isinstance(self.impersonation_chain, str):
                     impersonation_account = self.impersonation_chain
                 elif len(self.impersonation_chain) == 1:
-                    impersonation_account = self.impersonation_chain[:-1]
+                    impersonation_account = self.impersonation_chain[0]
                 else:
                     raise AirflowException(
                         "Chained list of accounts is not supported, please specify only one service account"

--- a/tests/providers/google/cloud/operators/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/operators/test_kubernetes_engine.py
@@ -313,7 +313,7 @@ class TestGKEPodOperator(unittest.TestCase):
         type(file_mock.return_value.__enter__.return_value).name = PropertyMock(
             side_effect=[FILE_NAME, '/path/to/new-file']
         )
-        self.gke_op.impersonation_service_account = "test_account@example.com"
+        self.gke_op.impersonation_chain = "test_account@example.com"
         self.gke_op.execute(None)
 
         mock_gcp_hook.return_value.provide_authorized_gcloud.assert_called_once()
@@ -335,3 +335,75 @@ class TestGKEPodOperator(unittest.TestCase):
         )
 
         assert self.gke_op.config_file == FILE_NAME
+
+    @mock.patch.dict(os.environ, {})
+    @mock.patch(
+        "airflow.hooks.base.BaseHook.get_connections",
+        return_value=[
+            Connection(
+                extra=json.dumps(
+                    {"extra__google_cloud_platform__keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}
+                )
+            )
+        ],
+    )
+    @mock.patch('airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
+    @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.GoogleBaseHook')
+    @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.execute_in_subprocess')
+    @mock.patch('tempfile.NamedTemporaryFile')
+    def test_execute_with_impersonation_service_chain_one_element(
+        self, file_mock, mock_execute_in_subprocess, mock_gcp_hook, exec_mock, get_con_mock
+    ):
+        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(
+            side_effect=[FILE_NAME, '/path/to/new-file']
+        )
+        self.gke_op.impersonation_chain = ["test_account@example.com"]
+        self.gke_op.execute(None)
+
+        mock_gcp_hook.return_value.provide_authorized_gcloud.assert_called_once()
+
+        mock_execute_in_subprocess.assert_called_once_with(
+            [
+                'gcloud',
+                'container',
+                'clusters',
+                'get-credentials',
+                CLUSTER_NAME,
+                '--zone',
+                PROJECT_LOCATION,
+                '--project',
+                TEST_GCP_PROJECT_ID,
+                '--impersonate-service-account',
+                'test_account@example.com',
+            ]
+        )
+
+        assert self.gke_op.config_file == FILE_NAME
+
+    @mock.patch.dict(os.environ, {})
+    @mock.patch(
+        "airflow.hooks.base.BaseHook.get_connections",
+        return_value=[
+            Connection(
+                extra=json.dumps(
+                    {"extra__google_cloud_platform__keyfile_dict": '{"private_key": "r4nd0m_k3y"}'}
+                )
+            )
+        ],
+    )
+    @mock.patch('airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
+    @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.GoogleBaseHook')
+    @mock.patch('airflow.providers.google.cloud.operators.kubernetes_engine.execute_in_subprocess')
+    @mock.patch('tempfile.NamedTemporaryFile')
+    def test_execute_with_impersonation_service_chain_more_elements(
+        self, file_mock, mock_execute_in_subprocess, mock_gcp_hook, exec_mock, get_con_mock
+    ):
+        type(file_mock.return_value.__enter__.return_value).name = PropertyMock(
+            side_effect=[FILE_NAME, '/path/to/new-file']
+        )
+        self.gke_op.impersonation_chain = ["test_account@example.com", "test_account1@example.com"]
+        with pytest.raises(
+            AirflowException,
+            match="Chained list of accounts is not supported, please specify only one service account",
+        ):
+            self.gke_op.execute(None)


### PR DESCRIPTION
The #19518 was merged while we had false-positive test results
due to testing memory optmisation in CI - test failures went
unnoticed for the change.

This PR fixes the problem (both in tests and in the code) and
adds more tests to cover all scenarios

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
