### PR TITLE
Fix parsing of Cloudwatch log group arn containing slashes (#14667)

### DIFF
--- a/airflow/config_templates/airflow_local_settings.py
+++ b/airflow/config_templates/airflow_local_settings.py
@@ -194,12 +194,13 @@ if REMOTE_LOGGING:
 
         DEFAULT_LOGGING_CONFIG['handlers'].update(S3_REMOTE_HANDLERS)
     elif REMOTE_BASE_LOG_FOLDER.startswith('cloudwatch://'):
+        url_parts = urlparse(REMOTE_BASE_LOG_FOLDER)
         CLOUDWATCH_REMOTE_HANDLERS: Dict[str, Dict[str, str]] = {
             'task': {
                 'class': 'airflow.providers.amazon.aws.log.cloudwatch_task_handler.CloudwatchTaskHandler',
                 'formatter': 'airflow',
                 'base_log_folder': str(os.path.expanduser(BASE_LOG_FOLDER)),
-                'log_group_arn': urlparse(REMOTE_BASE_LOG_FOLDER).netloc,
+                'log_group_arn': url_parts.netloc + url_parts.path,
                 'filename_template': FILENAME_TEMPLATE,
             },
         }

--- a/tests/core/test_logging_config.py
+++ b/tests/core/test_logging_config.py
@@ -26,6 +26,7 @@ import unittest
 from unittest.mock import patch
 
 import pytest
+from parameterized import parameterized
 
 from airflow.configuration import conf
 from tests.test_utils.config import conf_vars
@@ -277,3 +278,40 @@ class TestLoggingSettings(unittest.TestCase):
 
         logger = logging.getLogger('airflow.task')
         assert isinstance(logger.handlers[0], WasbTaskHandler)
+
+    @parameterized.expand(
+        [
+            (
+                'cloudwatch://arn:aws:logs:aaaa:bbbbb:log-group:ccccc',
+                'arn:aws:logs:aaaa:bbbbb:log-group:ccccc',
+            ),
+            (
+                'cloudwatch://arn:aws:logs:aaaa:bbbbb:log-group:aws/ccccc',
+                'arn:aws:logs:aaaa:bbbbb:log-group:aws/ccccc',
+            ),
+            (
+                'cloudwatch://arn:aws:logs:aaaa:bbbbb:log-group:/aws/ecs/ccccc',
+                'arn:aws:logs:aaaa:bbbbb:log-group:/aws/ecs/ccccc',
+            ),
+        ]
+    )
+    def test_log_group_arns_remote_logging_with_cloudwatch_handler(
+        self, remote_base_log_folder, log_group_arn
+    ):
+        """Test if the correct ARNs are configured for Cloudwatch"""
+        from airflow.config_templates import airflow_local_settings
+        from airflow.logging_config import configure_logging
+
+        with conf_vars(
+            {
+                ('logging', 'remote_logging'): 'True',
+                ('logging', 'remote_log_conn_id'): 'some_cloudwatch',
+                ('logging', 'remote_base_log_folder'): remote_base_log_folder,
+            }
+        ):
+            importlib.reload(airflow_local_settings)
+            configure_logging()
+            assert (
+                airflow_local_settings.DEFAULT_LOGGING_CONFIG['handlers']['task']['log_group_arn']
+                == log_group_arn
+            )


### PR DESCRIPTION
When the log group arn contains slashes, the urlparse function parses
the group name as part of the 'path' instead of including it as part of
the 'netloc'. This fix concatenates both the 'netloc' and 'path' fields
together to use as the group arn. For group names without slashes, the
functionality remains the same as the group name is still parsed as part
of the 'netloc' field and the 'path' field will be empty.

Fix #19783.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
