### PR TITLE
Add DAG run details page

### DIFF
--- a/airflow/www/static/js/dag.js
+++ b/airflow/www/static/js/dag.js
@@ -227,6 +227,10 @@ export function callModalDag(dag) {
     dag_id: dag && dag.dag_id,
     execution_date: dag && dag.execution_date,
   });
+  updateButtonUrl(buttons.dagrun_details, {
+    dag_id: dag && dag.dag_id,
+    run_id: dag && dag.run_id,
+  });
 }
 
 // Task Instance Modal actions

--- a/airflow/www/static/js/tree/dagRuns/Bar.jsx
+++ b/airflow/www/static/js/tree/dagRuns/Bar.jsx
@@ -43,7 +43,7 @@ const DagRunBar = ({
       pb="2px"
       px="3px"
       onClick={() => {
-        callModalDag({ execution_date: run.executionDate, dag_id: run.dagId });
+        callModalDag({ execution_date: run.executionDate, dag_id: run.dagId, run_id: run.runId });
       }}
     >
       <Tooltip

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -403,6 +403,10 @@
               </a>
             </span>
           </div>
+          <hr style="margin-bottom: 8px;">
+          <a id="btn_dagrun_details" class="btn" data-base-url="{{ url_for('Airflow.dagrun_details') }}">
+            DAG Run details
+          </a>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>

--- a/airflow/www/templates/airflow/dagrun_details.html
+++ b/airflow/www/templates/airflow/dagrun_details.html
@@ -1,0 +1,44 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+{% extends "airflow/dag.html" %}
+{% block page_title %}{{ dag_id }} - {{ run_id }} - DAG Run details - {{ appbuilder.app_name }}{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <hr>
+  <br>
+  <h4>
+    <span class="text-muted">DAG Run details:</span> <span>{{ dag_id }}</span>
+    <span class="text-muted">run id</span> <span>{{ run_id }}</span>
+    <span class="text-muted">at</span> <time datetime="{{ execution_date }}">{{ execution_date }}</time>
+  </h4>
+  <table class="table table-striped table-bordered">
+    <tr>
+      <th>Attribute</th>
+      <th>Value</th>
+    </tr>
+    {% for attribute, value in dagrun_attributes %}
+      <tr>
+        <td class="text-nowrap">{{ attribute }}</td>
+        <td>{{ value }}</td>
+      </tr>
+    {% endfor %}
+  </table>
+{% endblock %}

--- a/airflow/www/utils.py
+++ b/airflow/www/utils.py
@@ -321,16 +321,21 @@ def datetime_f(attr_name):
 
     def dt(attr):
         f = attr.get(attr_name)
-        as_iso = f.isoformat() if f else ''
-        if not as_iso:
-            return Markup('')
-        f = as_iso
-        if timezone.utcnow().isoformat()[:4] == f[:4]:
-            f = f[5:]
-        # The empty title will be replaced in JS code when non-UTC dates are displayed
-        return Markup('<nobr><time title="" datetime="{}">{}</time></nobr>').format(as_iso, f)
+        return datetime_html(f)
 
     return dt
+
+
+def datetime_html(dttm: Optional[DateTime]) -> str:
+    """Return an HTML formatted string with time element to support timezone changes in UI"""
+    as_iso = dttm.isoformat() if dttm else ''
+    if not as_iso:
+        return Markup('')
+    dttm = as_iso
+    if timezone.utcnow().isoformat()[:4] == dttm[:4]:
+        dttm = dttm[5:]
+    # The empty title will be replaced in JS code when non-UTC dates are displayed
+    return Markup('<nobr><time title="" datetime="{}">{}</time></nobr>').format(as_iso, dttm)
 
 
 def json_f(attr_name):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -130,7 +130,6 @@ from airflow.www.forms import (
     DateTimeWithNumRunsWithDagRunsForm,
     TaskInstanceEditForm,
 )
-from airflow.www.utils import json_render
 from airflow.www.widgets import AirflowModelListWidget
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
@@ -2087,7 +2086,7 @@ class Airflow(AirflowBaseView):
                 ("Current state", wwwutils.state_token(dag_run.state)),
                 ("Run type", dag_run.run_type),
                 ("Externally triggered", dag_run.external_trigger),
-                ("Config", json_render(dag_run.conf, lexers.JsonLexer)),
+                ("Config", wwwutils.json_render(dag_run.conf, lexers.JsonLexer)),
             ]
 
             return self.render_template(

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -130,6 +130,7 @@ from airflow.www.forms import (
     DateTimeWithNumRunsWithDagRunsForm,
     TaskInstanceEditForm,
 )
+from airflow.www.utils import json_render
 from airflow.www.widgets import AirflowModelListWidget
 
 PAGE_SIZE = conf.getint('webserver', 'page_size')
@@ -2047,6 +2048,56 @@ class Airflow(AirflowBaseView):
         confirmed = request.form.get('confirmed') == 'true'
         origin = get_safe_url(request.form.get('origin'))
         return self._mark_dagrun_state_as_success(dag_id, execution_date, confirmed, origin)
+
+    @expose("/dagrun_details")
+    @auth.has_access(
+        [
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG_RUN),
+        ]
+    )
+    @action_logging
+    @provide_session
+    def dagrun_details(self, session=None):
+        """Retrieve DAG Run details."""
+        dag_id = request.args.get("dag_id")
+        run_id = request.args.get("run_id")
+
+        dag = current_app.dag_bag.get_dag(dag_id)
+        dag_run: Optional[DagRun] = (
+            session.query(DagRun).filter(DagRun.dag_id == dag_id, DagRun.run_id == run_id).one_or_none()
+        )
+
+        if dag_run is None:
+            flash(f"No DAG run found for DAG id {dag_id} and run id {run_id}", "error")
+            return redirect(request.referrer or url_for('Airflow.index'))
+        else:
+            try:
+                duration = dag_run.end_date - dag_run.start_date
+            except TypeError:
+                # Raised if end_date is None e.g. when DAG is still running
+                duration = None
+
+            dagrun_attributes = [
+                ("Logical date", dag_run.execution_date.isoformat()),
+                ("Queued at", dag_run.queued_at),
+                ("Start date", dag_run.start_date),
+                ("End date", dag_run.end_date),
+                ("Duration", duration),
+                ("Current state", wwwutils.state_token(dag_run.state)),
+                ("Run type", dag_run.run_type),
+                ("Externally triggered", dag_run.external_trigger),
+                ("Config", json_render(dag_run.conf, lexers.JsonLexer)),
+            ]
+
+            return self.render_template(
+                "airflow/dagrun_details.html",
+                dag=dag,
+                dag_id=dag_id,
+                run_id=run_id,
+                execution_date=dag_run.execution_date.isoformat(),
+                dagrun_attributes=dagrun_attributes,
+            )
 
     def _mark_task_instance_state(
         self,

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2078,11 +2078,11 @@ class Airflow(AirflowBaseView):
                 duration = None
 
             dagrun_attributes = [
-                ("Logical date", dag_run.execution_date.isoformat()),
-                ("Queued at", dag_run.queued_at),
-                ("Start date", dag_run.start_date),
-                ("End date", dag_run.end_date),
-                ("Duration", duration),
+                ("Logical date", wwwutils.datetime_html(dag_run.execution_date)),
+                ("Queued at", wwwutils.datetime_html(dag_run.queued_at)),
+                ("Start date", wwwutils.datetime_html(dag_run.start_date)),
+                ("End date", wwwutils.datetime_html(dag_run.end_date)),
+                ("Duration", str(duration)),
                 ("Current state", wwwutils.state_token(dag_run.state)),
                 ("Run type", dag_run.run_type),
                 ("Externally triggered", dag_run.external_trigger),


### PR DESCRIPTION
This PR adds a DAG run details page showing information about one single DAG run.

I have a couple of DAGs where every run is triggered with parameters and found it difficult to trace which parameters were used to trigger a DAG in the Airflow UI. The current flow is:

1. Hover over DAG run in tree view
2. Memorize a property to identify specific DAG run, usually the run id (memorize because toolbox disappears when cursor leaves the DAG run circle)
3. Go to Browse -> DAG runs
4. Filter using property from step 2

This PR adds a new button to the modal clicking on a DAG run bar in the tree view:
![image](https://user-images.githubusercontent.com/6249654/142614378-e0702ad7-5e87-40ed-86e9-93e93724e056.png)

That brings you to the DAG run details page:
![image](https://user-images.githubusercontent.com/6249654/142614767-3116bfb4-c9fd-4cac-8b3f-666bbfdf6169.png)
