### PR TITLE
Clarify Helm behaviour when it comes to loading default connections

### DIFF
--- a/docs/helm-chart/airflow-configuration.rst
+++ b/docs/helm-chart/airflow-configuration.rst
@@ -67,3 +67,12 @@ configuration prior to installing and deploying the service.
   The recommended way to load example DAGs using the official Docker image and chart is to configure the ``AIRFLOW__CORE__LOAD_EXAMPLES`` environment variable
   in ``extraEnv`` (see :doc:`Parameters reference <parameters-ref>`). Because the official Docker image has ``AIRFLOW__CORE__LOAD_EXAMPLES=False``
   set within the image, so you need to override it when deploying the chart.
+
+.. note::
+
+  The  ``AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS`` variable is not used by the Chart. Airflow Helm Chart is
+  intended to be used as production deployment and loading default connections is not supposed to be handled
+  during Chart installation. The Chart is intended to install and configure the Apache Airflow software
+  and create database structure, but not to fill-in the data which should be managed by the users.
+  The default connections are only meaningful when you want to have a ``quick start`` with Airflow or
+  do some development and adding the data via Helm Chart installation is not a good idea.


### PR DESCRIPTION
Users find it surprising that our Helm Chart does not load the
default connections. This is deliberate choice because Helm Chart
should not manage the database content and the default connections
are just "quick start" type of data, but this should be explicitly
stated in the documentaiton of Helm's configuration.

This PR fixes it. See also discussion in #19688

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
