### PR TITLE
Speed up webserver start up in Kube tests

### DIFF
--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -270,6 +270,8 @@ COPY airflow/example_dags/ \${AIRFLOW_HOME}/dags/
 
 COPY airflow/kubernetes_executor_templates/ \${AIRFLOW_HOME}/pod_templates/
 
+ENV GUNICORN_CMD_ARGS='--preload' AIRFLOW__WEBSERVER__WORKER_REFRESH_INTERVAL=0
+
 EOF
     echo "The ${AIRFLOW_IMAGE_KUBERNETES}:${image_tag} is prepared for test kubernetes deployment."
 }


### PR DESCRIPTION
Thanks to a previous change (https://github.com/apache/airflow/pull/19709) to not load provider hooks too early we can take advantage of the "preload-app" feature of Gunicorn to load the application once in the main gunicorn process before the workers are forked off.

This change makes the webserver start up (time to serving first request) go from 20s to 5s.

(The reason we don't just do this blindly everywhere is that it would mean plugins are loaded at start only, and is a change in behaviour. But in tests this is fine.)