### PR TITLE
hdfs provider: fix HA support for webhdfs

### DIFF
--- a/docs/apache-airflow-providers-apache-hdfs/connections.rst
+++ b/docs/apache-airflow-providers-apache-hdfs/connections.rst
@@ -31,7 +31,7 @@ parameter as ``webhdfs_default`` by default.
 Configuring the Connection
 --------------------------
 Host
-    The host to connect to, it can be ``local``, ``yarn`` or an URL.
+    The host to connect to, it can be ``local``, ``yarn`` or an URL. For Web HDFS Hook it is possible to specify multiple hosts as a comma-separated list.
 
 Port
     Specify the port in case of host be an URL.


### PR DESCRIPTION
HA support for webHDFS was actually added in #7454 , but stopped working when conn_id became unique in #8608 . This PR fixes it by allowing to specify more than one host for webhdfs connection via `,`.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
