### PR TITLE
Checking event.status.container_statuses before filtering

### DIFF
--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -230,7 +230,7 @@ class PodLauncher(LoggingMixin):
     def base_container_is_running(self, pod: V1Pod) -> bool:
         """Tests if base container is running"""
         event = self.read_pod(pod)
-        if not (event.status and event.status.container_statuses):
+        if not (event and event.status and event.status.container_statuses):
             return False
         status = next(iter(filter(lambda s: s.name == 'base', event.status.container_statuses)), None)
         if not status:

--- a/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
+++ b/airflow/providers/cncf/kubernetes/utils/pod_launcher.py
@@ -230,6 +230,8 @@ class PodLauncher(LoggingMixin):
     def base_container_is_running(self, pod: V1Pod) -> bool:
         """Tests if base container is running"""
         event = self.read_pod(pod)
+        if not (event.status and event.status.container_statuses):
+            return False
         status = next(iter(filter(lambda s: s.name == 'base', event.status.container_statuses)), None)
         if not status:
             return False

--- a/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
@@ -276,3 +276,15 @@ class TestPodLauncher(unittest.TestCase):
                 pod=mock.sentinel,
                 startup_timeout=0,
             )
+
+    def test_base_container_is_running_none_event(self):
+        event = mock.MagicMock()
+        event_status = mock.MagicMock()
+        event_status.status = None
+        event_container_statuses = mock.MagicMock()
+        event_container_statuses.status = mock.MagicMock()
+        event_container_statuses.status.container_statuses = None
+        for e in [event, event_status, event_container_statuses]:
+            self.pod_launcher.read_pod = mock.MagicMock(return_value=e)
+            assert self.pod_launcher.base_container_is_running(None) == False
+

--- a/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
+++ b/tests/providers/cncf/kubernetes/utils/test_pod_launcher.py
@@ -286,5 +286,4 @@ class TestPodLauncher(unittest.TestCase):
         event_container_statuses.status.container_statuses = None
         for e in [event, event_status, event_container_statuses]:
             self.pod_launcher.read_pod = mock.MagicMock(return_value=e)
-            assert self.pod_launcher.base_container_is_running(None) == False
-
+            assert self.pod_launcher.base_container_is_running(None) is False


### PR DESCRIPTION
Fix for issue https://github.com/apache/airflow/issues/19369
related: #19369

Checking list before calling built-in filter.
The bug happens because *event.status.container_statuses* is None when filter is called.
