### PR TITLE
Fix extra links url in tree view

### DIFF
--- a/airflow/www/static/js/tree/renderTaskRows.jsx
+++ b/airflow/www/static/js/tree/renderTaskRows.jsx
@@ -93,6 +93,7 @@ const TaskInstances = ({ task, containerRef, dagRuns }) => (
             key={`${run.runId}-${task.id}`}
             instance={instance}
             containerRef={containerRef}
+            extraLinks={task.extraLinks}
             group={task}
           />
         )


### PR DESCRIPTION
Extra links were not fully plumbed through after the recent refactor of the tree view in #18675

### Testing 
I've tested this manually and the fix is working.

Some regression testing should be put in place to catch this in the future. I reckon we should at least check the mock of `callModal` in this [test module](https://github.com/apache/airflow/blob/e8b53545b48180ba3f698ba84365c5a2d4519c0d/airflow/www/static/js/tree/renderTaskRows.test.jsx#L30) and ensure that it was called with the extraLinks.

I played with this a little but didn't make any progress, FE development is not my specialty :) @bbovenzi can you weigh in on the testing aspect?
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
