### PR TITLE
Added namespace as a template field in the KPO.

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -173,6 +173,7 @@ class KubernetesPodOperator(BaseOperator):
         'labels',
         'config_file',
         'pod_template_file',
+        'namespace',
     )
 
     # fmt: off


### PR DESCRIPTION
Adding `namespace` as a template field in the KPO. This allows users to use the `namespace` configuration from the `airflow.cfg` at task run time via `{{ conf }}`, and removes the need to use top-level code in their DAG file. For example:

```
from airflow import configuration as conf

namespace = conf.get("kubernetes", "NAMESPACE")
```