### PR TITLE
Refactor f-string and update docstring

### DIFF
--- a/airflow/api/common/experimental/pool.py
+++ b/airflow/api/common/experimental/pool.py
@@ -42,7 +42,7 @@ def get_pools(session=None):
 
 @provide_session
 def create_pool(name, slots, description, session=None):
-    """Create a pool with a given parameters."""
+    """Create a pool with given parameters."""
     if not (name and name.strip()):
         raise AirflowBadRequest("Pool name shouldn't be empty")
 
@@ -54,7 +54,7 @@ def create_pool(name, slots, description, session=None):
     # Get the length of the pool column
     pool_name_length = Pool.pool.property.columns[0].type.length
     if len(name) > pool_name_length:
-        raise AirflowBadRequest("Pool name can't be more than %d characters" % pool_name_length)
+        raise AirflowBadRequest(f"Pool name can't be more than {pool_name_length} characters")
 
     session.expire_on_commit = False
     pool = session.query(Pool).filter_by(pool=name).first()


### PR DESCRIPTION
_ Update the f-string for the case when pool_name_length exceed, for coherent and consistent of the file.
_ Fix the docstring grammar  """Create a pool with a given parameters.""" -> """Create a pool with given parameters."""

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
