### PR TITLE
Databricks: add more methods to represent run state information

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -429,7 +429,7 @@ class DatabricksHook(BaseHook):
 
     def get_run_state_str(self, run_id: str) -> str:
         """
-        Returns string representation of RunState
+        Return the string representation of RunState.
 
         :param run_id: id of the run
         :return: string describing run state

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -407,6 +407,14 @@ class DatabricksHook(BaseHook):
         """
         Retrieves run state of the run.
 
+        Please note that any Airflow tasks that call the ``get_run_state`` method will result in
+        failure unless you have enabled xcom pickling.  This can be done using the following
+        environment variable: ``AIRLFOW_CORE_ENABLE_XCOM_PICKLING=TRUE``
+
+        If you do not want to enable xcom pickling then use the ``get_run_state_str`` method to get
+        string describing state, or ``get_run_state_lifecycle``, ``get_run_state_result``, or
+        ``get_run_state_message`` to get individual components of the run state.
+
         :param run_id: id of the run
         :return: state of the run
         """
@@ -418,6 +426,46 @@ class DatabricksHook(BaseHook):
         result_state = state.get('result_state', None)
         state_message = state['state_message']
         return RunState(life_cycle_state, result_state, state_message)
+
+    def get_run_state_str(self, run_id: str) -> str:
+        """
+        Returns string representation of RunState
+
+        :param run_id: id of the run
+        :return: string describing run state
+        """
+        state = self.get_run_state(run_id)
+        run_state_str = (
+            f"State: {state.life_cycle_state}. Result: {state.result_state}. {state.state_message}"
+        )
+        return run_state_str
+
+    def get_run_state_lifecycle(self, run_id: str) -> str:
+        """
+        Returns lifecycle state of the run
+
+        :param run_id: id of the run
+        :return: string with lifecycle state
+        """
+        return self.get_run_state(run_id).life_cycle_state
+
+    def get_run_state_result(self, run_id: str) -> str:
+        """
+        Returns resulting state of the run
+
+        :param run_id: id of the run
+        :return: string with resulting state
+        """
+        return self.get_run_state(run_id).result_state
+
+    def get_run_state_message(self, run_id: str) -> str:
+        """
+        Returns state message for the run
+
+        :param run_id: id of the run
+        :return: string with state message
+        """
+        return self.get_run_state(run_id).state_message
 
     def cancel_run(self, run_id: str) -> None:
         """

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -411,8 +411,8 @@ class DatabricksHook(BaseHook):
         failure unless you have enabled xcom pickling.  This can be done using the following
         environment variable: ``AIRLFOW_CORE_ENABLE_XCOM_PICKLING=TRUE``
 
-        If you do not want to enable xcom pickling then use the ``get_run_state_str`` method to get
-        string describing state, or ``get_run_state_lifecycle``, ``get_run_state_result``, or
+        If you do not want to enable xcom pickling, use the ``get_run_state_str`` method to get
+        a string describing state, or ``get_run_state_lifecycle``, ``get_run_state_result``, or
         ``get_run_state_message`` to get individual components of the run state.
 
         :param run_id: id of the run

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -409,7 +409,7 @@ class DatabricksHook(BaseHook):
 
         Please note that any Airflow tasks that call the ``get_run_state`` method will result in
         failure unless you have enabled xcom pickling.  This can be done using the following
-        environment variable: ``AIRLFOW_CORE_ENABLE_XCOM_PICKLING=TRUE``
+        environment variable: ``AIRFLOW__CORE__ENABLE_XCOM_PICKLING``
 
         If you do not want to enable xcom pickling then use the ``get_run_state_str`` method to get
         string describing state, or ``get_run_state_lifecycle``, ``get_run_state_result``, or

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -442,7 +442,7 @@ class DatabricksHook(BaseHook):
 
     def get_run_state_lifecycle(self, run_id: str) -> str:
         """
-        Returns lifecycle state of the run
+        Returns the lifecycle state of the run
 
         :param run_id: id of the run
         :return: string with lifecycle state
@@ -451,7 +451,7 @@ class DatabricksHook(BaseHook):
 
     def get_run_state_result(self, run_id: str) -> str:
         """
-        Returns resulting state of the run
+        Returns the resulting state of the run
 
         :param run_id: id of the run
         :return: string with resulting state
@@ -460,7 +460,7 @@ class DatabricksHook(BaseHook):
 
     def get_run_state_message(self, run_id: str) -> str:
         """
-        Returns state message for the run
+        Returns the state message for the run
 
         :param run_id: id of the run
         :return: string with state message

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -390,6 +390,30 @@ class TestDatabricksHook(unittest.TestCase):
         )
 
     @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_get_run_state_str(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+        run_state_str = self.hook.get_run_state_str(RUN_ID)
+        assert run_state_str == f"State: {LIFE_CYCLE_STATE}. Result: {RESULT_STATE}. {STATE_MESSAGE}"
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_get_run_state_lifecycle(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+        lifecycle_state = self.hook.get_run_state_lifecycle(RUN_ID)
+        assert lifecycle_state == LIFE_CYCLE_STATE
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_get_run_state_result(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+        result_state = self.hook.get_run_state_result(RUN_ID)
+        assert result_state == RESULT_STATE
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_get_run_state_cycle(self, mock_requests):
+        mock_requests.get.return_value.json.return_value = GET_RUN_RESPONSE
+        state_message = self.hook.get_run_state_message(RUN_ID)
+        assert state_message == STATE_MESSAGE
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
     def test_cancel_run(self, mock_requests):
         mock_requests.post.return_value.json.return_value = GET_RUN_RESPONSE
 


### PR DESCRIPTION
This PR adds a warning about need to use XCOM if `get_run_state` function is used, plus adds more methods to retrieve information about run state

closes: #19357
