### PR TITLE
Adjust built-in base_aws methods to avoid Deprecation warnings

### DIFF
--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -539,9 +539,9 @@ class AwsBaseHook(BaseHook):
         if "/" in role:
             return role
         else:
-            session, endpoint_url = self._get_credentials(None)
-            _client_type = session.client('iam', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
-            return _client_type.get_role(RoleName=role)["Role"]["Arn"]
+            session, endpoint_url = self._get_credentials()
+            _client = session.client('iam', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
+            return _client.get_role(RoleName=role)["Role"]["Arn"]
 
     @staticmethod
     def retry(should_retry: Callable[[Exception], bool]):

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -493,7 +493,7 @@ class AwsBaseHook(BaseHook):
         if self.client_type:
             return self.get_client_type(region_name=self.region_name)
         elif self.resource_type:
-            return self.get_resource_type(None, region_name=self.region_name)
+            return self.get_resource_type(region_name=self.region_name)
         else:
             # Rare possibility - subclasses have not specified a client_type or resource_type
             raise NotImplementedError('Could not get boto3 connection!')

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -441,7 +441,7 @@ class AwsBaseHook(BaseHook):
         """Get the underlying boto3 client using boto3 session"""
         session, endpoint_url = self._get_credentials(region_name)
 
-        if client_type and client_type != 'iam':
+        if client_type:
             warnings.warn(
                 "client_type is deprecated. Set client_type from class attribute.",
                 DeprecationWarning,
@@ -539,7 +539,9 @@ class AwsBaseHook(BaseHook):
         if "/" in role:
             return role
         else:
-            return self.get_client_type("iam").get_role(RoleName=role)["Role"]["Arn"]
+            session, endpoint_url = self._get_credentials(None)
+            _client_type = session.client('iam', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
+            return _client_type.get_role(RoleName=role)["Role"]["Arn"]
 
     @staticmethod
     def retry(should_retry: Callable[[Exception], bool]):

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -491,7 +491,7 @@ class AwsBaseHook(BaseHook):
         :rtype: Union[boto3.client, boto3.resource]
         """
         if self.client_type:
-            return self.get_client_type(None, region_name=self.region_name)
+            return self.get_client_type(region_name=self.region_name)
         elif self.resource_type:
             return self.get_resource_type(None, region_name=self.region_name)
         else:

--- a/airflow/providers/amazon/aws/hooks/base_aws.py
+++ b/airflow/providers/amazon/aws/hooks/base_aws.py
@@ -441,7 +441,7 @@ class AwsBaseHook(BaseHook):
         """Get the underlying boto3 client using boto3 session"""
         session, endpoint_url = self._get_credentials(region_name)
 
-        if client_type:
+        if client_type and client_type != 'iam':
             warnings.warn(
                 "client_type is deprecated. Set client_type from class attribute.",
                 DeprecationWarning,
@@ -491,9 +491,9 @@ class AwsBaseHook(BaseHook):
         :rtype: Union[boto3.client, boto3.resource]
         """
         if self.client_type:
-            return self.get_client_type(self.client_type, region_name=self.region_name)
+            return self.get_client_type(None, region_name=self.region_name)
         elif self.resource_type:
-            return self.get_resource_type(self.resource_type, region_name=self.region_name)
+            return self.get_resource_type(None, region_name=self.region_name)
         else:
             # Rare possibility - subclasses have not specified a client_type or resource_type
             raise NotImplementedError('Could not get boto3 connection!')

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -85,7 +85,8 @@ class AwsGlueJobHook(AwsBaseHook):
 
     def get_iam_execution_role(self) -> Dict:
         """:return: iam role for job execution"""
-        iam_client = self.get_client_type('iam', self.region_name)
+        session, endpoint_url = self._get_credentials(self.region_name)
+        iam_client = session.client('iam', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
 
         try:
             glue_execution_role = iam_client.get_role(RoleName=self.role_name)

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -173,7 +173,7 @@ class S3Hook(AwsBaseHook):
         :return: the bucket object to the bucket name.
         :rtype: boto3.S3.Bucket
         """
-        session, endpoint_url = self._get_credentials(region_name)
+        session, endpoint_url = self._get_credentials()
         s3_resource = session.client('s3', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
         return s3_resource.Bucket(bucket_name)
 
@@ -341,7 +341,7 @@ class S3Hook(AwsBaseHook):
         :return: the key object from the bucket
         :rtype: boto3.s3.Object
         """
-        session, endpoint_url = self._get_credentials(region_name)
+        session, endpoint_url = self._get_credentials()
         s3_resource = session.client('s3', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
         obj = s3_resource.Object(bucket_name, key)
         obj.load()

--- a/airflow/providers/amazon/aws/hooks/s3.py
+++ b/airflow/providers/amazon/aws/hooks/s3.py
@@ -173,7 +173,8 @@ class S3Hook(AwsBaseHook):
         :return: the bucket object to the bucket name.
         :rtype: boto3.S3.Bucket
         """
-        s3_resource = self.get_resource_type('s3')
+        session, endpoint_url = self._get_credentials(region_name)
+        s3_resource = session.client('s3', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
         return s3_resource.Bucket(bucket_name)
 
     @provide_bucket_name
@@ -340,7 +341,9 @@ class S3Hook(AwsBaseHook):
         :return: the key object from the bucket
         :rtype: boto3.s3.Object
         """
-        obj = self.get_resource_type('s3').Object(bucket_name, key)
+        session, endpoint_url = self._get_credentials(region_name)
+        s3_resource = session.client('s3', endpoint_url=endpoint_url, config=self.config, verify=self.verify)
+        obj = s3_resource.Object(bucket_name, key)
         obj.load()
         return obj
 

--- a/airflow/providers/postgres/hooks/postgres.py
+++ b/airflow/providers/postgres/hooks/postgres.py
@@ -184,7 +184,8 @@ class PostgresHook(DbApiHook):
             # Pull the custer-identifier from the beginning of the Redshift URL
             # ex. my-cluster.ccdre4hpd39h.us-east-1.redshift.amazonaws.com returns my-cluster
             cluster_identifier = conn.extra_dejson.get('cluster-identifier', conn.host.split('.')[0])
-            client = aws_hook.get_client_type('redshift')
+            session, endpoint_url = aws_hook._get_credentials()
+            client = session.client('redshift', endpoint_url=endpoint_url, config=aws_hook.config, verify=aws_hook.verify)
             cluster_creds = client.get_cluster_credentials(
                 DbUser=conn.login,
                 DbName=self.schema or conn.schema,


### PR DESCRIPTION
What is this?
This PR is to help with consequences of https://github.com/apache/airflow/commit/867e9305f08bf9580f25430d8b6e84071c59f9e6 (#17987)

Currently out of the box base_aws implementation is going to show warnings whenever connection cache is invoked (that is potentially always when you use any AWS-based resource in Airflow like S3 as storage for logging or sensors)

Why?
Newly added warning for deprecation is shown every time anyone is passing `not None` value `client_type` to `get_client_type` method. Same is happening with `not None` value `resource_type` being passed to `get_resource_type`.
While this new deprecation warning might have been created with good intentions, the out of the box calls to mentioned methods weren't modified accordingly (missed during review?), so right now Airflow is barking on its own code for deprecation on any AWS-hook based component.

Condition 1:
https://github.com/apache/airflow/blob/aa2cb5545f09d694b9143b323efcd4f6b6c66e60/airflow/providers/amazon/aws/hooks/base_aws.py#L444-L449

Calls:
https://github.com/apache/airflow/blob/aa2cb5545f09d694b9143b323efcd4f6b6c66e60/airflow/providers/amazon/aws/hooks/base_aws.py#L493-L494
https://github.com/apache/airflow/blob/aa2cb5545f09d694b9143b323efcd4f6b6c66e60/airflow/providers/amazon/aws/hooks/base_aws.py#L541-L542

(for `iam` call please read the notes on the very end of this PR message)

Condition 2:
https://github.com/apache/airflow/blob/aa2cb5545f09d694b9143b323efcd4f6b6c66e60/airflow/providers/amazon/aws/hooks/base_aws.py#L469-L474

Calls:
https://github.com/apache/airflow/blob/aa2cb5545f09d694b9143b323efcd4f6b6c66e60/airflow/providers/amazon/aws/hooks/base_aws.py#L495-L496

---

Now, to mitigate this I took next approach: I pass temporarily None in mentioned arguments until the code is refactored to get rid of entire argument in method (I assume somewhen in the future?).

Few notes:
1. One piece of code that I randomly noticed is that IAM request is not standard (see call 2 in above mentioned cuts, and is using special hardcoded value "iam"). As I'm not certain about all the specifics of Airflow internals I have added "iam" to list of exceptions for deprecation for time being. Feel free to modify to proper approach.
2. There might be other invocations of mentioned methods with "not None" being passed by Airflow codebase, but unfortunately, I haven't done deep inspection of entire codebase to verify.