### PR TITLE
Fix Volume/VolumeMount KPO DeprecationWarning

### DIFF
--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -72,7 +72,6 @@ def convert_resources(resources) -> k8s.V1ResourceRequirements:
     """
     if isinstance(resources, dict):
         from airflow.providers.cncf.kubernetes.backcompat.pod import Resources
-        
         resources = Resources(**resources)
     return _convert_kube_model_object(resources, "Resources", k8s.V1ResourceRequirements)
 

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -21,8 +21,6 @@ from typing import List
 from kubernetes.client import ApiClient, models as k8s
 
 from airflow.exceptions import AirflowException
-from airflow.providers.cncf.kubernetes.backcompat.pod import Port, Resources
-from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
 
 
 def _convert_kube_model_object(obj, old_class_name, new_class):
@@ -73,6 +71,7 @@ def convert_resources(resources) -> k8s.V1ResourceRequirements:
     :return: k8s.V1ResourceRequirements
     """
     if isinstance(resources, dict):
+        from airflow.providers.cncf.kubernetes.backcompat.pod import Resources
         resources = Resources(**resources)
     return _convert_kube_model_object(resources, "Resources", k8s.V1ResourceRequirements)
 

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -23,14 +23,14 @@ from kubernetes.client import ApiClient, models as k8s
 from airflow.exceptions import AirflowException
 
 
-def _convert_kube_model_object(obj, old_class_name, new_class):
+def _convert_kube_model_object(obj, new_class):
     convert_op = getattr(obj, "to_k8s_client_obj", None)
     if callable(convert_op):
         return obj.to_k8s_client_obj()
     elif isinstance(obj, new_class):
         return obj
     else:
-        raise AirflowException(f"Expected {old_class_name} or {new_class}, got {type(obj)}")
+        raise AirflowException(f"Expected {new_class}, got {type(obj)}")
 
 
 def _convert_from_dict(obj, new_class):
@@ -50,7 +50,7 @@ def convert_volume(volume) -> k8s.V1Volume:
     :param volume:
     :return: k8s.V1Volume
     """
-    return _convert_kube_model_object(volume, "Volume", k8s.V1Volume)
+    return _convert_kube_model_object(volume, k8s.V1Volume)
 
 
 def convert_volume_mount(volume_mount) -> k8s.V1VolumeMount:
@@ -60,7 +60,7 @@ def convert_volume_mount(volume_mount) -> k8s.V1VolumeMount:
     :param volume_mount:
     :return: k8s.V1VolumeMount
     """
-    return _convert_kube_model_object(volume_mount, "VolumeMount", k8s.V1VolumeMount)
+    return _convert_kube_model_object(volume_mount, k8s.V1VolumeMount)
 
 
 def convert_resources(resources) -> k8s.V1ResourceRequirements:
@@ -74,7 +74,7 @@ def convert_resources(resources) -> k8s.V1ResourceRequirements:
         from airflow.providers.cncf.kubernetes.backcompat.pod import Resources
 
         resources = Resources(**resources)
-    return _convert_kube_model_object(resources, "Resources", k8s.V1ResourceRequirements)
+    return _convert_kube_model_object(resources, k8s.V1ResourceRequirements)
 
 
 def convert_port(port) -> k8s.V1ContainerPort:
@@ -84,7 +84,7 @@ def convert_port(port) -> k8s.V1ContainerPort:
     :param port:
     :return: k8s.V1ContainerPort
     """
-    return _convert_kube_model_object(port, "Port", k8s.V1ContainerPort)
+    return _convert_kube_model_object(port, k8s.V1ContainerPort)
 
 
 def convert_env_vars(env_vars) -> List[k8s.V1EnvVar]:
@@ -112,7 +112,7 @@ def convert_pod_runtime_info_env(pod_runtime_info_envs) -> k8s.V1EnvVar:
     :param pod_runtime_info_envs:
     :return:
     """
-    return _convert_kube_model_object(pod_runtime_info_envs, "PodRuntimeInfoEnv", k8s.V1EnvVar)
+    return _convert_kube_model_object(pod_runtime_info_envs, k8s.V1EnvVar)
 
 
 def convert_image_pull_secrets(image_pull_secrets) -> List[k8s.V1LocalObjectReference]:

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -72,6 +72,7 @@ def convert_resources(resources) -> k8s.V1ResourceRequirements:
     """
     if isinstance(resources, dict):
         from airflow.providers.cncf.kubernetes.backcompat.pod import Resources
+        
         resources = Resources(**resources)
     return _convert_kube_model_object(resources, "Resources", k8s.V1ResourceRequirements)
 

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -72,6 +72,7 @@ def convert_resources(resources) -> k8s.V1ResourceRequirements:
     """
     if isinstance(resources, dict):
         from airflow.providers.cncf.kubernetes.backcompat.pod import Resources
+
         resources = Resources(**resources)
     return _convert_kube_model_object(resources, "Resources", k8s.V1ResourceRequirements)
 

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -25,14 +25,14 @@ from airflow.providers.cncf.kubernetes.backcompat.pod import Port, Resources
 from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
 
 
-def _convert_kube_model_object(obj, old_class, new_class):
+def _convert_kube_model_object(obj, old_class_name, new_class):
     convert_op = getattr(obj, "to_k8s_client_obj", None)
     if callable(convert_op):
         return obj.to_k8s_client_obj()
     elif isinstance(obj, new_class):
         return obj
     else:
-        raise AirflowException(f"Expected {old_class} or {new_class}, got {type(obj)}")
+        raise AirflowException(f"Expected {old_class_name} or {new_class}, got {type(obj)}")
 
 
 def _convert_from_dict(obj, new_class):
@@ -74,7 +74,7 @@ def convert_resources(resources) -> k8s.V1ResourceRequirements:
     """
     if isinstance(resources, dict):
         resources = Resources(**resources)
-    return _convert_kube_model_object(resources, Resources, k8s.V1ResourceRequirements)
+    return _convert_kube_model_object(resources, "Resources", k8s.V1ResourceRequirements)
 
 
 def convert_port(port) -> k8s.V1ContainerPort:
@@ -84,7 +84,7 @@ def convert_port(port) -> k8s.V1ContainerPort:
     :param port:
     :return: k8s.V1ContainerPort
     """
-    return _convert_kube_model_object(port, Port, k8s.V1ContainerPort)
+    return _convert_kube_model_object(port, "Port", k8s.V1ContainerPort)
 
 
 def convert_env_vars(env_vars) -> List[k8s.V1EnvVar]:
@@ -112,7 +112,7 @@ def convert_pod_runtime_info_env(pod_runtime_info_envs) -> k8s.V1EnvVar:
     :param pod_runtime_info_envs:
     :return:
     """
-    return _convert_kube_model_object(pod_runtime_info_envs, PodRuntimeInfoEnv, k8s.V1EnvVar)
+    return _convert_kube_model_object(pod_runtime_info_envs, "PodRuntimeInfoEnv", k8s.V1EnvVar)
 
 
 def convert_image_pull_secrets(image_pull_secrets) -> List[k8s.V1LocalObjectReference]:

--- a/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py
@@ -52,9 +52,7 @@ def convert_volume(volume) -> k8s.V1Volume:
     :param volume:
     :return: k8s.V1Volume
     """
-    from airflow.providers.cncf.kubernetes.backcompat.volume import Volume
-
-    return _convert_kube_model_object(volume, Volume, k8s.V1Volume)
+    return _convert_kube_model_object(volume, "Volume", k8s.V1Volume)
 
 
 def convert_volume_mount(volume_mount) -> k8s.V1VolumeMount:
@@ -64,9 +62,7 @@ def convert_volume_mount(volume_mount) -> k8s.V1VolumeMount:
     :param volume_mount:
     :return: k8s.V1VolumeMount
     """
-    from airflow.providers.cncf.kubernetes.backcompat.volume_mount import VolumeMount
-
-    return _convert_kube_model_object(volume_mount, VolumeMount, k8s.V1VolumeMount)
+    return _convert_kube_model_object(volume_mount, "VolumeMount", k8s.V1VolumeMount)
 
 
 def convert_resources(resources) -> k8s.V1ResourceRequirements:


### PR DESCRIPTION
What is this?
This is to resolve incomplete solution of this commit https://github.com/apache/airflow/commit/42e13e1a5a4c97a2085ddf96f7d93e7bf71949b8 (#17900)
The deprecation warning was previously shown always, but with above commit the scope was reduced. Unfortunately, its not doing what its intended to do - show this warning only when legacy Volume and VolumeMount classes are being used with KubernetesPodOperator. Instead, it now shows up always when you use Volume or VolumeMount of ANY implementation (old or new).

The reason for that is next:
1. The "conversion" methods are called on KPO always whenever there's any Volume/VolumeMount
https://github.com/apache/airflow/blob/1e570229533c4bbf5d3c901d5db21261fa4b1137/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py#L246-L247
2. While those methods will convert only if necessary, inside of them we're doing imports of legacy class, which immediately shows message of deprecation upon import, rather than upon validation of underline class (so that we know if we have to import it in the first place...). In other words, we have a chicken-and-egg problem that might have been solved incorrectly.
https://github.com/apache/airflow/blob/1e570229533c4bbf5d3c901d5db21261fa4b1137/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py#L55-L57
https://github.com/apache/airflow/blob/1e570229533c4bbf5d3c901d5db21261fa4b1137/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py#L67-L69

So what do we do about it?
One of the approaches that I decided to take was to inspect the method `_convert_kube_model_object`. To my surprise, it doesn't use old class for anything but basically print of exception in "catch-all-other-scenarios" way.
https://github.com/apache/airflow/blob/1e570229533c4bbf5d3c901d5db21261fa4b1137/airflow/providers/cncf/kubernetes/backcompat/backwards_compat_converters.py#L28-L35
The minimal effort solution is to avoid import of legacy classes in backcompat altogether, while passing just the "string" name of those classes. This way the behavior of underline method is not changing, we still get the deprecation warnings when user is trying to import legacy classes separately in his code (while constructing the KPO), but there won't be warning shown during "processing" of KPO itself (on scheduler I assume?).

The proposed solution is potentially anti-pattern, as we pass literally the wrong type to defined function, but I'm ready to listen for constructive "better" solutions that will introduce minimal regressions to existing airflow codebase. That might come with extra overhead of validation of incoming type above the call to `_convert_kube_model_object` or such. In proposed solution should be no such extra overhead.