### PR TITLE
Add test case for views connections muldelete function

### DIFF
--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -194,7 +194,7 @@ def connection():
     yield connection
     with create_session() as session:
         session.query(Connection).filter(Connection.conn_id == CONNECTION["conn_id"]).delete()
-    
+
 
 def test_connection_muldelete(admin_client, connection):
     conn_id = connection.id

--- a/tests/www/views/test_views_connection.py
+++ b/tests/www/views/test_views_connection.py
@@ -180,3 +180,26 @@ def test_duplicate_connection_error(admin_client):
     assert resp.status_code == 200
     response = {conn[0] for conn in session.query(Connection.conn_id).all()}
     assert expected_result == response
+
+
+@pytest.fixture()
+def connection():
+    connection = Connection(
+        conn_id='conn1',
+        conn_type='Conn 1',
+        description='Conn 1 description',
+    )
+    with create_session() as session:
+        session.add(connection)
+    yield connection
+    with create_session() as session:
+        session.query(Connection).filter(Connection.conn_id == CONNECTION["conn_id"]).delete()
+    
+
+def test_connection_muldelete(admin_client, connection):
+    conn_id = connection.id
+    data = {"action": "muldelete", "rowid": [conn_id]}
+    resp = admin_client.post('/connection/action_post', data=data, follow_redirects=True)
+    assert resp.status_code == 200
+    with create_session() as session:
+        assert session.query(Connection).filter(Connection.id == conn_id).count() == 0


### PR DESCRIPTION
related: #15525

Adds one test case to test the [muldelete function in views](https://github.com/apache/airflow/blob/7a676a148f94f0dcf0bf86789d2684295798bd16/airflow/www/views.py#L3400).

Testing:
<img width="1440" alt="Screen Shot 2021-11-19 at 5 39 45 PM" src="https://user-images.githubusercontent.com/5105282/142742354-24a82692-e195-4651-ac6f-8785cc93c14e.png">

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
