### PR TITLE
Allow session properties for trino connection

### DIFF
--- a/airflow/providers/trino/hooks/trino.py
+++ b/airflow/providers/trino/hooks/trino.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import ast
 import os
 from typing import Any, Iterable, Optional
 
@@ -92,6 +93,7 @@ class TrinoHook(DbApiHook):
             auth=auth,
             isolation_level=self.get_isolation_level(),  # type: ignore[func-returns-value]
             verify=_boolify(extra.get('verify', True)),
+            session_properties=ast.literal_eval(extra.get('session_properties')),
         )
 
         return trino_conn


### PR DESCRIPTION
Hi, I was using the Trino provider package of airflow. While using I found out that I am not able to set `session_properties` for the Trino connector.  So I am creating this PR to fix this. This way if the user needs to add session_properties from Airflow UI they can add it like below

```
{"catalog": "hive", "protocol": "https", "session_properties": "{'hive.insert_existing_partitions_behavior':'OVERWRITE', 'scale_writers':'true','task_writer_count':'1','writer_min_size':'32MB'}"}
```

![image](https://user-images.githubusercontent.com/14219201/142755452-28c0a44b-ac7c-4059-adff-453d35b4d5e9.png)


Let me know if any changes or additional work is required