### PR TITLE
Add Databricks Deferrable Operators

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -25,6 +25,7 @@ operators talk to the
 or the ``api/2.1/jobs/runs/submit``
 `endpoint <https://docs.databricks.com/dev-tools/api/latest/jobs.html#operation/JobsRunsSubmit>`_.
 """
+import json
 from typing import Any, Dict, List, Optional
 
 from requests import exceptions as requests_exceptions
@@ -91,6 +92,13 @@ class RunState:
 
     def __repr__(self) -> str:
         return str(self.__dict__)
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__)
+
+    @classmethod
+    def from_json(cls, data: str) -> 'RunState':
+        return RunState(**json.loads(data))
 
 
 class DatabricksHook(BaseDatabricksHook):
@@ -198,6 +206,16 @@ class DatabricksHook(BaseDatabricksHook):
         response = self._do_api_call(GET_RUN_ENDPOINT, json)
         return response['run_page_url']
 
+    async def a_get_run_page_url(self, run_id: int) -> str:
+        """
+        Async version of `get_run_page_url()`.
+        :param run_id: id of the run
+        :return: URL of the run page
+        """
+        json = {'run_id': run_id}
+        response = await self._a_do_api_call(GET_RUN_ENDPOINT, json)
+        return response['run_page_url']
+
     def get_job_id(self, run_id: int) -> int:
         """
         Retrieves job_id from run_id.
@@ -226,6 +244,17 @@ class DatabricksHook(BaseDatabricksHook):
         """
         json = {'run_id': run_id}
         response = self._do_api_call(GET_RUN_ENDPOINT, json)
+        state = response['state']
+        return RunState(**state)
+
+    async def a_get_run_state(self, run_id: int) -> RunState:
+        """
+        Async version of `get_run_state()`.
+        :param run_id: id of the run
+        :return: state of the run
+        """
+        json = {'run_id': run_id}
+        response = await self._a_do_api_call(GET_RUN_ENDPOINT, json)
         state = response['state']
         return RunState(**state)
 

--- a/airflow/providers/databricks/triggers/__init__.py
+++ b/airflow/providers/databricks/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/databricks/triggers/databricks.py
+++ b/airflow/providers/databricks/triggers/databricks.py
@@ -1,0 +1,77 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import asyncio
+import logging
+from typing import Any, Dict, Tuple
+
+from airflow.providers.databricks.hooks.databricks import DatabricksHook
+
+try:
+    from airflow.triggers.base import BaseTrigger, TriggerEvent
+except ImportError:
+    logging.getLogger(__name__).warning(
+        'Deferrable Operators only work starting Airflow 2.2',
+        exc_info=True,
+    )
+    BaseTrigger = object  # type: ignore
+    TriggerEvent = None  # type: ignore
+
+
+class DatabricksExecutionTrigger(BaseTrigger):
+    """
+    The trigger handles the logic of async communication with DataBricks API.
+
+    :param run_id: id of the run
+    :param databricks_conn_id: Reference to the :ref:`Databricks connection <howto/connection:databricks>`.
+    :param polling_period_seconds: Controls the rate of the poll for the result of this run.
+        By default, the trigger will poll every 30 seconds.
+    """
+
+    def __init__(self, run_id: int, databricks_conn_id: str, polling_period_seconds: int = 30) -> None:
+        super().__init__()
+        self.run_id = run_id
+        self.databricks_conn_id = databricks_conn_id
+        self.polling_period_seconds = polling_period_seconds
+        self.hook = DatabricksHook(databricks_conn_id)
+
+    def serialize(self) -> Tuple[str, Dict[str, Any]]:
+        return (
+            'airflow.providers.databricks.triggers.databricks.DatabricksExecutionTrigger',
+            {
+                'run_id': self.run_id,
+                'databricks_conn_id': self.databricks_conn_id,
+                'polling_period_seconds': self.polling_period_seconds,
+            },
+        )
+
+    async def run(self):
+        async with self.hook:
+            run_page_url = await self.hook.a_get_run_page_url(self.run_id)
+            while True:
+                run_state = await self.hook.a_get_run_state(self.run_id)
+                if run_state.is_terminal:
+                    yield TriggerEvent(
+                        {
+                            'run_id': self.run_id,
+                            'run_state': run_state.to_json(),
+                            'run_page_url': run_page_url,
+                        }
+                    )
+                    break
+                else:
+                    await asyncio.sleep(self.polling_period_seconds)

--- a/airflow/providers/databricks/utils/__init__.py
+++ b/airflow/providers/databricks/utils/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/airflow/providers/databricks/utils/databricks.py
+++ b/airflow/providers/databricks/utils/databricks.py
@@ -1,0 +1,69 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from typing import Union
+
+from airflow.exceptions import AirflowException
+from airflow.providers.databricks.hooks.databricks import RunState
+
+
+def deep_string_coerce(content, json_path: str = 'json') -> Union[str, list, dict]:
+    """
+    Coerces content or all values of content if it is a dict to a string. The
+    function will throw if content contains non-string or non-numeric types.
+    The reason why we have this function is because the ``self.json`` field must be a
+    dict with only string values. This is because ``render_template`` will fail
+    for numerical values.
+    """
+    coerce = deep_string_coerce
+    if isinstance(content, str):
+        return content
+    elif isinstance(
+        content,
+        (
+            int,
+            float,
+        ),
+    ):
+        # Databricks can tolerate either numeric or string types in the API backend.
+        return str(content)
+    elif isinstance(content, (list, tuple)):
+        return [coerce(e, f'{json_path}[{i}]') for i, e in enumerate(content)]
+    elif isinstance(content, dict):
+        return {k: coerce(v, f'{json_path}[{k}]') for k, v in list(content.items())}
+    else:
+        param_type = type(content)
+        msg = f'Type {param_type} used for parameter {json_path} is not a number or a string'
+        raise AirflowException(msg)
+
+
+def validate_trigger_event(event: dict):
+    """
+    Validates correctness of the event
+    received from :class:`~airflow.providers.databricks.triggers.databricks.DatabricksExecutionTrigger`
+    """
+    keys_to_check = ['run_id', 'run_page_url', 'run_state']
+    for key in keys_to_check:
+        if key not in event:
+            raise AirflowException(f'Could not find `{key}` in the event: {event}')
+
+    try:
+        RunState.from_json(event['run_state'])
+    except Exception:
+        raise AirflowException(f'Run state returned by the Trigger is incorrect: {event["run_state"]}')

--- a/docs/apache-airflow-providers-databricks/operators/run_now.rst
+++ b/docs/apache-airflow-providers-databricks/operators/run_now.rst
@@ -45,3 +45,10 @@ All other parameters are optional and described in documentation for ``Databrick
 * ``python_named_parameters``
 * ``jar_params``
 * ``spark_submit_params``
+
+DatabricksRunNowDeferrableOperator
+==================================
+
+Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksRunNowOperator` operator.
+
+It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_

--- a/docs/apache-airflow-providers-databricks/operators/submit_run.rst
+++ b/docs/apache-airflow-providers-databricks/operators/submit_run.rst
@@ -75,3 +75,10 @@ You can also use named parameters to initialize the operator and run the job.
     :language: python
     :start-after: [START howto_operator_databricks_named]
     :end-before: [END howto_operator_databricks_named]
+
+DatabricksSubmitRunDeferrableOperator
+=====================================
+
+Deferrable version of the :class:`~airflow.providers.databricks.operators.DatabricksSubmitRunOperator` operator.
+
+It allows to utilize Airflow workers more effectively using `new functionality introduced in Airflow 2.2.0 <https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#triggering-deferral>`_

--- a/setup.py
+++ b/setup.py
@@ -265,6 +265,7 @@ dask = [
 databricks = [
     'requests>=2.26.0, <3',
     'databricks-sql-connector>=2.0.0, <3.0.0',
+    'aiohttp>=3.6.3, <4',
 ]
 datadog = [
     'datadog>=0.14.0',
@@ -602,6 +603,7 @@ mypy_dependencies = [
 
 # Dependencies needed for development only
 devel_only = [
+    'asynctest~=0.13',
     'aws_xray_sdk',
     'beautifulsoup4>=4.7.1',
     'black',

--- a/tests/providers/databricks/triggers/__init__.py
+++ b/tests/providers/databricks/triggers/__init__.py
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/databricks/triggers/test_databricks.py
+++ b/tests/providers/databricks/triggers/test_databricks.py
@@ -1,0 +1,153 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import sys
+
+import pytest
+
+from airflow.models import Connection
+from airflow.providers.databricks.hooks.databricks import RunState
+from airflow.providers.databricks.triggers.databricks import DatabricksExecutionTrigger
+from airflow.triggers.base import TriggerEvent
+from airflow.utils.session import provide_session
+
+if sys.version_info < (3, 8):
+    from asynctest import mock
+else:
+    from unittest import mock
+
+DEFAULT_CONN_ID = 'databricks_default'
+HOST = 'xx.cloud.databricks.com'
+LOGIN = 'login'
+PASSWORD = 'password'
+POLLING_INTERVAL_SECONDS = 30
+RETRY_DELAY = 10
+RETRY_LIMIT = 3
+RUN_ID = 1
+JOB_ID = 42
+RUN_PAGE_URL = 'https://XX.cloud.databricks.com/#jobs/1/runs/1'
+
+RUN_LIFE_CYCLE_STATES = ['PENDING', 'RUNNING', 'TERMINATING', 'TERMINATED', 'SKIPPED', 'INTERNAL_ERROR']
+
+LIFE_CYCLE_STATE_PENDING = 'PENDING'
+LIFE_CYCLE_STATE_TERMINATED = 'TERMINATED'
+
+STATE_MESSAGE = 'Waiting for cluster'
+
+GET_RUN_RESPONSE_PENDING = {
+    'job_id': JOB_ID,
+    'run_page_url': RUN_PAGE_URL,
+    'state': {
+        'life_cycle_state': LIFE_CYCLE_STATE_PENDING,
+        'state_message': STATE_MESSAGE,
+        'result_state': None,
+    },
+}
+GET_RUN_RESPONSE_TERMINATED = {
+    'job_id': JOB_ID,
+    'run_page_url': RUN_PAGE_URL,
+    'state': {
+        'life_cycle_state': LIFE_CYCLE_STATE_TERMINATED,
+        'state_message': None,
+        'result_state': 'SUCCESS',
+    },
+}
+
+
+class TestDatabricksExecutionTrigger:
+    @provide_session
+    def setup_method(self, method, session=None):
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.host = HOST
+        conn.login = LOGIN
+        conn.password = PASSWORD
+        conn.extra = None
+        session.commit()
+
+        self.trigger = DatabricksExecutionTrigger(
+            run_id=RUN_ID,
+            databricks_conn_id=DEFAULT_CONN_ID,
+            polling_period_seconds=POLLING_INTERVAL_SECONDS,
+        )
+
+    def test_serialize(self):
+        assert self.trigger.serialize() == (
+            'airflow.providers.databricks.triggers.databricks.DatabricksExecutionTrigger',
+            {
+                'run_id': RUN_ID,
+                'databricks_conn_id': DEFAULT_CONN_ID,
+                'polling_period_seconds': POLLING_INTERVAL_SECONDS,
+            },
+        )
+
+    @pytest.mark.asyncio
+    @mock.patch('airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_page_url')
+    @mock.patch('airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_state')
+    async def test_run_return_success(self, mock_get_run_state, mock_get_run_page_url):
+        mock_get_run_page_url.return_value = RUN_PAGE_URL
+        mock_get_run_state.return_value = RunState(
+            life_cycle_state=LIFE_CYCLE_STATE_TERMINATED,
+            state_message='',
+            result_state='SUCCESS',
+        )
+
+        trigger_event = self.trigger.run()
+        async for event in trigger_event:
+            assert event == TriggerEvent(
+                {
+                    'run_id': RUN_ID,
+                    'run_state': RunState(
+                        life_cycle_state=LIFE_CYCLE_STATE_TERMINATED, state_message='', result_state='SUCCESS'
+                    ).to_json(),
+                    'run_page_url': RUN_PAGE_URL,
+                }
+            )
+
+    @pytest.mark.asyncio
+    @mock.patch('airflow.providers.databricks.triggers.databricks.asyncio.sleep')
+    @mock.patch('airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_page_url')
+    @mock.patch('airflow.providers.databricks.hooks.databricks.DatabricksHook.a_get_run_state')
+    async def test_sleep_between_retries(self, mock_get_run_state, mock_get_run_page_url, mock_sleep):
+        mock_get_run_page_url.return_value = RUN_PAGE_URL
+        mock_get_run_state.side_effect = [
+            RunState(
+                life_cycle_state=LIFE_CYCLE_STATE_PENDING,
+                state_message='',
+                result_state='',
+            ),
+            RunState(
+                life_cycle_state=LIFE_CYCLE_STATE_TERMINATED,
+                state_message='',
+                result_state='SUCCESS',
+            ),
+        ]
+
+        trigger_event = self.trigger.run()
+        async for event in trigger_event:
+            assert event == TriggerEvent(
+                {
+                    'run_id': RUN_ID,
+                    'run_state': RunState(
+                        life_cycle_state=LIFE_CYCLE_STATE_TERMINATED, state_message='', result_state='SUCCESS'
+                    ).to_json(),
+                    'run_page_url': RUN_PAGE_URL,
+                }
+            )
+            mock_sleep.assert_called_once()
+            mock_sleep.assert_called_with(POLLING_INTERVAL_SECONDS)

--- a/tests/providers/databricks/utils/__init__.py
+++ b/tests/providers/databricks/utils/__init__.py
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/tests/providers/databricks/utils/databricks.py
+++ b/tests/providers/databricks/utils/databricks.py
@@ -1,0 +1,62 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+
+import pytest
+
+from airflow.exceptions import AirflowException
+from airflow.providers.databricks.hooks.databricks import RunState
+from airflow.providers.databricks.utils.databricks import deep_string_coerce, validate_trigger_event
+
+RUN_ID = 1
+RUN_PAGE_URL = 'run-page-url'
+
+
+class TestDatabricksOperatorSharedFunctions(unittest.TestCase):
+    def test_deep_string_coerce(self):
+        test_json = {
+            'test_int': 1,
+            'test_float': 1.0,
+            'test_dict': {'key': 'value'},
+            'test_list': [1, 1.0, 'a', 'b'],
+            'test_tuple': (1, 1.0, 'a', 'b'),
+        }
+
+        expected = {
+            'test_int': '1',
+            'test_float': '1.0',
+            'test_dict': {'key': 'value'},
+            'test_list': ['1', '1.0', 'a', 'b'],
+            'test_tuple': ['1', '1.0', 'a', 'b'],
+        }
+        assert deep_string_coerce(test_json) == expected
+
+    def test_validate_trigger_event_success(self):
+        event = {
+            'run_id': RUN_ID,
+            'run_page_url': RUN_PAGE_URL,
+            'run_state': RunState('TERMINATED', 'SUCCESS', '').to_json(),
+        }
+        self.assertIsNone(validate_trigger_event(event))
+
+    def test_validate_trigger_event_failure(self):
+        event = {}
+        with pytest.raises(AirflowException):
+            validate_trigger_event(event)


### PR DESCRIPTION
closes: #18999 

The PR intends to add deferrable versions of `DatabricksSubmitRunOperator` and `DatabricksRunNowOperator`, which are using [new Airflow functionality introduced with the version 2.2.0](https://airflow.apache.org/docs/apache-airflow/2.2.0/concepts/deferring.html#deferrable-operators-triggers).

There're not so many examples of deferrable operators at the moment, so I'd appreciate if we discuss the following:
- Should we update existing operators or create new?
  If we update existing operators right away, we'll break backward compatibility for Airflow versions prior 2.2.0, so I thought it'd be better to introduce new operators at the moment.
- Execution timeout for deferrable operators not handled correctly at the moment, will investigate separately under #19382 