### PR TITLE
Add import serialized dag model

### DIFF
--- a/airflow/models/__init__.py
+++ b/airflow/models/__init__.py
@@ -29,6 +29,7 @@ from airflow.models.param import Param
 from airflow.models.pool import Pool
 from airflow.models.renderedtifields import RenderedTaskInstanceFields
 from airflow.models.sensorinstance import SensorInstance  # noqa: F401
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.slamiss import SlaMiss
 from airflow.models.taskfail import TaskFail

--- a/airflow/ti_deps/dependencies_deps.py
+++ b/airflow/ti_deps/dependencies_deps.py
@@ -55,6 +55,7 @@ RUNNING_DEPS = {
     TaskConcurrencyDep(),
     PoolSlotsAvailableDep(),
     TaskNotRunningDep(),
+    DagrunRunningDep(),
 }
 
 BACKFILL_QUEUED_DEPS = {


### PR DESCRIPTION
There are two changes here:
1. Let see this case:

- i use sequential executor, and use sqlite as db
- the dag has two task(as the pic shown below), and there is NO dependeny between them
![image](https://user-images.githubusercontent.com/4498225/142868986-4294b24f-0cb9-45d8-aef6-e2a0cd97a2da.png)

Then, whent i start a dag run, both tasks [sleep_1] and [sleep_2] will be added to sequential executor in the same schduler loop.

When i stop the dagrun when the first taskinstance(let's assume the is the [sleep_1] step) is running, using set_dag_run_state_to_failed function from airflow.api.common.experimental.mark_tasks. I can see the state of dagrun and the state of taskinstance of task [sleep_1] will be changed into FAILED, BUT the taskinstance of [sleep_2] will be left unchanged(queued)

Then, something weired happend, the task instance of [sleep_2] will be executed as usual. That's NOT what i want!

I check the code, and find the sequential executor will still run all the taskintance in command_to_run list, even if some taskinstance of the same dagrun has already failed.

And, even when running [airflow task run] command, the check_and_change_state_before_execution function in model/taskinstance.py will not check whether the dagrun of the taskinstance has failed or not.

So i add the add DagrunRunningDep into RUNNING_DEPS, and things go right again.

2. models/__init__.py has not import SerializedDagModel serialized_dag.py, so add it. I changed airflow(in site-packages) in my local enviroment, and it works, so I want to open a pull request.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
