### PR TITLE
Chart: PgBouncer service enhancements

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -121,6 +121,9 @@ spec:
               mountPath: /etc/pgbouncer/server.key
               readOnly: true
 {{- end }}
+{{- if .Values.pgbouncer.extraVolumeMounts }}
+{{ toYaml .Values.pgbouncer.extraVolumeMounts | indent 12 }}
+{{- end }}
           lifecycle:
             preStop:
               exec:
@@ -158,7 +161,12 @@ spec:
         - name: pgbouncer-config
           secret:
             secretName: {{ template "pgbouncer_config_secret" . }}
+{{- if or .Values.pgbouncer.ssl.ca  .Values.pgbouncer.ssl.cert .Values.pgbouncer.ssl.key }}
         - name: pgbouncer-certificates
           secret:
             secretName: {{ template "pgbouncer_certificates_secret" . }}
+{{- end }}
+{{- if .Values.pgbouncer.extraVolumes }}
+{{ toYaml .Values.pgbouncer.extraVolumes | indent 8 }}
+{{- end }}
 {{- end }}

--- a/chart/templates/secrets/pgbouncer-stats-secret.yaml
+++ b/chart/templates/secrets/pgbouncer-stats-secret.yaml
@@ -34,5 +34,5 @@ metadata:
 {{- end }}
 type: Opaque
 data:
-  connection: {{ urlJoin (dict "scheme" "postgresql" "userinfo" (printf "%s:%s" (.Values.data.metadataConnection.user | urlquery) (.Values.data.metadataConnection.pass | urlquery) ) "host" (printf "127.0.0.1:%s" (.Values.ports.pgbouncer | toString)) "path" "/pgbouncer" "query" "sslmode=disable") | b64enc | quote }}
+  connection: {{ urlJoin (dict "scheme" "postgresql" "userinfo" (printf "%s:%s" (.Values.data.metadataConnection.user | urlquery) (.Values.data.metadataConnection.pass | urlquery) ) "host" (printf "127.0.0.1:%s" (.Values.ports.pgbouncer | toString)) "path" "/pgbouncer" "query" (printf "sslmode=%s" (.Values.pgbouncer.metricsExporterSidecar.sslmode | toString ))) | b64enc | quote }}
 {{- end }}

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -468,5 +468,5 @@ class PgbouncerExporterTest(unittest.TestCase):
         )
         assert (
             "postgresql://username%40123123:password%40%21%40%23$%5E&%2A%28%29@127.0.0.1:1111"
-            "/pgbouncer?sslmode=disable" == connection
+            "/pgbouncer?sslmode=require" == connection
         )

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -453,7 +453,7 @@ class PgbouncerExporterTest(unittest.TestCase):
     def test_exporter_secret_with_overrides(self):
         connection = self._get_connection(
             {
-                "pgbouncer": {"enabled": True, "metricsExporterSidecar": {"sslmode": "disable"}},
+                "pgbouncer": {"enabled": True, "metricsExporterSidecar": {"sslmode": "require"}},
                 "data": {
                     "metadataConnection": {
                         "user": "username@123123",

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -455,7 +455,7 @@ class PgbouncerExporterTest(unittest.TestCase):
     def test_exporter_secret_with_overrides(self):
         connection = self._get_connection(
             {
-                "pgbouncer": {"enabled": True, "metricsExporterSidecar": {"sslmode": "disable"}},
+                "pgbouncer": {"enabled": True, "metricsExporterSidecar": {"sslmode": "require"}},
                 "data": {
                     "metadataConnection": {
                         "user": "username@123123",

--- a/chart/tests/test_pgbouncer.py
+++ b/chart/tests/test_pgbouncer.py
@@ -285,8 +285,6 @@ class PgbouncerTest(unittest.TestCase):
             show_only=["templates/pgbouncer/pgbouncer-deployment.yaml"],
         )
 
-        print(docs[0])
-
         assert "pgbouncer-client-certificates" in jmespath.search(
             "spec.template.spec.volumes[*].name", docs[0]
         )
@@ -455,7 +453,7 @@ class PgbouncerExporterTest(unittest.TestCase):
     def test_exporter_secret_with_overrides(self):
         connection = self._get_connection(
             {
-                "pgbouncer": {"enabled": True, "metricsExporterSidecar": {"sslmode": "require"}},
+                "pgbouncer": {"enabled": True, "metricsExporterSidecar": {"sslmode": "disable"}},
                 "data": {
                     "metadataConnection": {
                         "user": "username@123123",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3015,7 +3015,10 @@
                 "extraVolumeMounts": {
                     "description": "Mount additional volumes into PgBouncer.",
                     "type": "array",
-                    "default": []
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volumemount-v1.json"
+                    }
                 },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3005,12 +3005,12 @@
                     "default": null
                 },
                 "extraVolumes": {
-                    "description": "Mount additional volumes into pgbouncer.",
+                    "description": "Mount additional volumes into PgBouncer.",
                     "type": "array",
                     "default": []
                 },
                 "extraVolumeMounts": {
-                    "description": "Mount additional volumes into pgbouncer.",
+                    "description": "Mount additional volumes into PgBouncer.",
                     "type": "array",
                     "default": []
                 },
@@ -3094,7 +3094,7 @@
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
                         },
                         "sslmode": {
-                            "description": "SSL mode for metricsExporterSidecar",
+                            "description": "SSL mode for ``metricsExporterSidecar``",
                             "type": "string",
                             "enum": [
                                 "disable",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3004,6 +3004,16 @@
                     ],
                     "default": null
                 },
+                "extraVolumes": {
+                    "description": "Mount additional volumes into pgbouncer.",
+                    "type": "array",
+                    "default": []
+                },
+                "extraVolumeMounts": {
+                    "description": "Mount additional volumes into pgbouncer.",
+                    "type": "array",
+                    "default": []
+                },
                 "serviceAccount": {
                     "description": "Create ServiceAccount.",
                     "type": "object",
@@ -3082,6 +3092,17 @@
                                 }
                             ],
                             "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/resourcerequirements-v1.json"
+                        },
+                        "sslmode": {
+                            "description": "SSL mode for metricsExporterSidecar",
+                            "type": "string",
+                            "enum": [
+                                "disable",
+                                "require",
+                                "verify-ca",
+                                "verify-full"
+                            ],
+                            "default": "disable"
                         }
                     }
                 }

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3007,7 +3007,10 @@
                 "extraVolumes": {
                     "description": "Mount additional volumes into PgBouncer.",
                     "type": "array",
-                    "default": []
+                    "default": [],
+                    "items": {
+                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/volume-v1.json"
+                    }
                 },
                 "extraVolumeMounts": {
                     "description": "Mount additional volumes into PgBouncer.",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1088,6 +1088,10 @@ pgbouncer:
   # Add extra general PgBouncer ini configuration: https://www.pgbouncer.org/config.html
   extraIni: ~
 
+  # Mount additional volumes into pgbouncer.
+  extraVolumes: []
+  extraVolumeMounts: []
+
   # Select certain nodes for PgBouncer pods.
   nodeSelector: {}
   affinity: {}
@@ -1103,6 +1107,7 @@ pgbouncer:
     #  requests:
     #   cpu: 100m
     #   memory: 128Mi
+    sslmode: "disable"
 
 # Configuration for the redis provisioned by the chart
 redis:


### PR DESCRIPTION
Problem:
pgbouncer does not support additional volume and volume mounts this lacks feature to add client side tls certificates.

Additionally pgbouncer MetricExporter sslmode is hardcoded at all times, this breaks if user tries to set sslmode=require

How does this PR fix the problem above:

This PR  below functionality to solve above issues

* Added support for extraVolumes and Volumemounts
* Added seperate sslmode for metrics exporter
* Fixed condition for pgbouncer volume mounts
* Added test cases

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
