### PR TITLE
Capture container logs and upload as artficats when failed

### DIFF
--- a/scripts/ci/libraries/_parallel.sh
+++ b/scripts/ci/libraries/_parallel.sh
@@ -21,7 +21,7 @@
 
 
 function parallel::initialize_monitoring() {
-    PARALLEL_MONITORED_DIR="$(mktemp -d)"
+    PARALLEL_MONITORED_DIR="$(pwd)/files/container_logs$(mktemp -d)"
     export PARALLEL_MONITORED_DIR
 
     PARALLEL_TAIL_LENGTH=${PARALLEL_TAIL_LENGTH:=2}


### PR DESCRIPTION
When CI containers crashed logs are not captured. 
This will make default container output directory  to `files/container_logs` that is uploaded as a next step in the CI when failed.
It will ensure that even containers are failed the latest progress from parallel runs are available for investigation.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
