### PR TITLE
Api add support bulk pause resume

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -404,16 +404,7 @@ paths:
         - $ref: '#/components/parameters/PageOffset'
         - $ref: '#/components/parameters/OrderBy'
         - $ref: '#/components/parameters/FilterTags'
-        - name: only_active
-          in: query
-          schema:
-            type: boolean
-            default: true
-          required: false
-          description: |
-            Only return active DAGs.
-
-            *New in version 2.1.1*
+        - $ref: '#/components/parameters/OnlyActive'
         - name: dag_id_pattern
           in: query
           schema:
@@ -421,8 +412,6 @@ paths:
           required: false
           description: |
             If set, only return DAGs with dag_ids matching this pattern.
-
-            *New in version 2.3.0*
       responses:
         '200':
           description: Success.
@@ -432,6 +421,46 @@ paths:
                 $ref: '#/components/schemas/DAGCollection'
         '401':
           $ref: '#/components/responses/Unauthenticated'
+
+    patch:
+      summary: Update DAGs
+      x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint
+      operationId: patch_dags
+      parameters:
+        - $ref: '#/components/parameters/PageLimit'
+        - $ref: '#/components/parameters/PageOffset'
+        - $ref: '#/components/parameters/FilterTags'
+        - $ref: '#/components/parameters/UpdateMask'
+        - $ref: '#/components/parameters/OnlyActive'
+        - name: dag_id_pattern
+          in: query
+          schema:
+            type: string
+          required: true
+          description: |
+            If set, only return DAGs with dag_ids matching this pattern.
+      tags: [DAG]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DAG'
+            example:
+              is_paused: true
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DAGCollection'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /dags/{dag_id}:
     parameters:
@@ -3803,6 +3832,16 @@ components:
         Prefix a field name with `-` to reverse the sort order.
 
         *New in version 2.1.0*
+
+    OnlyActive:
+      in: query
+      name: only_active
+      schema:
+        type: boolean
+        default: true
+      required: false
+      description: |
+        Only filter active DAGs.
 
     # Other parameters
 

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -431,7 +431,7 @@ paths:
       description: >
        Update DAGs of a given dag_id_pattern using UpdateMask.
 
-       This endpoint allows specifying `~` as the dag_id_pattern to retrieve DAG runs for all DAGs.
+       This endpoint allows specifying `~` as the dag_id_pattern to update all DAGs.
 
        *New in version 2.3.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -396,6 +396,10 @@ paths:
   /dags:
     get:
       summary: List DAGs
+      description: >
+       List DAGs in the database.
+
+       `dag_id_pattern` can be set to match dags of a specific pattern
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint
       operationId: get_dags
       tags: [DAG]
@@ -424,6 +428,12 @@ paths:
 
     patch:
       summary: Update DAGs
+      description: >
+       Update DAGs of a given dag_id_pattern using UpdateMask.
+
+       This endpoint allows specifying `~` as the dag_id_pattern to retrieve DAG runs for all DAGs.
+
+       *New in version 2.3.0*
       x-openapi-router-controller: airflow.api_connexion.endpoints.dag_endpoint
       operationId: patch_dags
       parameters:
@@ -438,7 +448,7 @@ paths:
             type: string
           required: true
           description: |
-            If set, only return DAGs with dag_ids matching this pattern.
+            If set, only update DAGs with dag_ids matching this pattern.
       tags: [DAG]
       requestBody:
         required: true
@@ -3842,6 +3852,8 @@ components:
       required: false
       description: |
         Only filter active DAGs.
+
+        *New in version 2.1.1*
 
     # Other parameters
 

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -834,3 +834,415 @@ class TestPatchDag(TestDagEndpoint):
         )
 
         assert response.status_code == 403
+
+
+class TestPatchDags(TestDagEndpoint):
+
+    file_token = SERIALIZER.dumps("/tmp/dag_1.py")
+    file_token2 = SERIALIZER.dumps("/tmp/dag_2.py")
+
+    @provide_session
+    def test_should_respond_200_on_patch_is_paused(self, session):
+        self._create_dag_models(2)
+        self._create_deactivated_dag()
+
+        dags_query = session.query(DagModel).filter(~DagModel.is_subdag)
+        assert len(dags_query.all()) == 3
+
+        response = self.client.patch(
+            "/api/v1/dags?dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+
+        assert response.status_code == 200
+        assert {
+            "dags": [
+                {
+                    "dag_id": "TEST_DAG_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_1.py",
+                    "file_token": self.file_token,
+                    "is_paused": False,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+                {
+                    "dag_id": "TEST_DAG_2",
+                    "description": None,
+                    "fileloc": "/tmp/dag_2.py",
+                    "file_token": self.file_token2,
+                    "is_paused": False,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+            ],
+            "total_entries": 2,
+        } == response.json
+
+    def test_only_active_true_returns_active_dags(self):
+        self._create_dag_models(1)
+        self._create_deactivated_dag()
+        response = self.client.patch(
+            "/api/v1/dags?only_active=True&dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 200
+        assert {
+            "dags": [
+                {
+                    "dag_id": "TEST_DAG_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_1.py",
+                    "file_token": self.file_token,
+                    "is_paused": False,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                }
+            ],
+            "total_entries": 1,
+        } == response.json
+
+    def test_only_active_false_returns_all_dags(self):
+        self._create_dag_models(1)
+        self._create_deactivated_dag()
+        response = self.client.patch(
+            "/api/v1/dags?only_active=False&dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+
+        file_token_2 = SERIALIZER.dumps("/tmp/dag_del_1.py")
+        assert response.status_code == 200
+        assert {
+            "dags": [
+                {
+                    "dag_id": "TEST_DAG_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_1.py",
+                    "file_token": self.file_token,
+                    "is_paused": False,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+                {
+                    "dag_id": "TEST_DAG_DELETED_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_del_1.py",
+                    "file_token": file_token_2,
+                    "is_paused": False,
+                    "is_active": False,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+            ],
+            "total_entries": 2,
+        } == response.json
+
+    @parameterized.expand(
+        [
+            ("api/v1/dags?tags=t1&dag_id_pattern=~", ['TEST_DAG_1', 'TEST_DAG_3']),
+            ("api/v1/dags?tags=t2&dag_id_pattern=~", ['TEST_DAG_2', 'TEST_DAG_3']),
+            ("api/v1/dags?tags=t1,t2&dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_2", "TEST_DAG_3"]),
+            ("api/v1/dags?dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_2", "TEST_DAG_3", "TEST_DAG_4"]),
+        ]
+    )
+    def test_filter_dags_by_tags_works(self, url, expected_dag_ids):
+        # test filter by tags
+        dag1 = DAG(dag_id="TEST_DAG_1", tags=['t1'])
+        dag2 = DAG(dag_id="TEST_DAG_2", tags=['t2'])
+        dag3 = DAG(dag_id="TEST_DAG_3", tags=['t1', 't2'])
+        dag4 = DAG(dag_id="TEST_DAG_4")
+        dag1.sync_to_db()
+        dag2.sync_to_db()
+        dag3.sync_to_db()
+        dag4.sync_to_db()
+        response = self.client.patch(
+            url,
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 200
+        dag_ids = [dag["dag_id"] for dag in response.json["dags"]]
+
+        assert expected_dag_ids == dag_ids
+
+    @parameterized.expand(
+        [
+            ("api/v1/dags?dag_id_pattern=DAG_1", {'TEST_DAG_1', 'SAMPLE_DAG_1'}),
+            ("api/v1/dags?dag_id_pattern=SAMPLE_DAG", {'SAMPLE_DAG_1', 'SAMPLE_DAG_2'}),
+            (
+                "api/v1/dags?dag_id_pattern=_DAG_",
+                {"TEST_DAG_1", "TEST_DAG_2", 'SAMPLE_DAG_1', 'SAMPLE_DAG_2'},
+            ),
+        ]
+    )
+    def test_filter_dags_by_dag_id_works(self, url, expected_dag_ids):
+        # test filter by tags
+        dag1 = DAG(dag_id="TEST_DAG_1")
+        dag2 = DAG(dag_id="TEST_DAG_2")
+        dag3 = DAG(dag_id="SAMPLE_DAG_1")
+        dag4 = DAG(dag_id="SAMPLE_DAG_2")
+        dag1.sync_to_db()
+        dag2.sync_to_db()
+        dag3.sync_to_db()
+        dag4.sync_to_db()
+
+        response = self.client.patch(
+            url,
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 200
+        dag_ids = {dag["dag_id"] for dag in response.json["dags"]}
+
+        assert expected_dag_ids == dag_ids
+
+    def test_should_respond_200_with_granular_dag_access(self):
+        self._create_dag_models(3)
+        response = self.client.patch(
+            "api/v1/dags?dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test_granular_permissions"},
+        )
+        assert response.status_code == 200
+        assert len(response.json['dags']) == 1
+        assert response.json['dags'][0]['dag_id'] == 'TEST_DAG_1'
+
+    @parameterized.expand(
+        [
+            ("api/v1/dags?limit=1&dag_id_pattern=~", ["TEST_DAG_1"]),
+            ("api/v1/dags?limit=2&dag_id_pattern=~", ["TEST_DAG_1", "TEST_DAG_10"]),
+            (
+                "api/v1/dags?offset=5&dag_id_pattern=~",
+                ["TEST_DAG_5", "TEST_DAG_6", "TEST_DAG_7", "TEST_DAG_8", "TEST_DAG_9"],
+            ),
+            (
+                "api/v1/dags?offset=0&dag_id_pattern=~",
+                [
+                    "TEST_DAG_1",
+                    "TEST_DAG_10",
+                    "TEST_DAG_2",
+                    "TEST_DAG_3",
+                    "TEST_DAG_4",
+                    "TEST_DAG_5",
+                    "TEST_DAG_6",
+                    "TEST_DAG_7",
+                    "TEST_DAG_8",
+                    "TEST_DAG_9",
+                ],
+            ),
+            ("api/v1/dags?limit=1&offset=5&dag_id_pattern=~", ["TEST_DAG_5"]),
+            ("api/v1/dags?limit=1&offset=1&dag_id_pattern=~", ["TEST_DAG_10"]),
+            ("api/v1/dags?limit=2&offset=2&dag_id_pattern=~", ["TEST_DAG_2", "TEST_DAG_3"]),
+        ]
+    )
+    def test_should_respond_200_and_handle_pagination(self, url, expected_dag_ids):
+        self._create_dag_models(10)
+
+        response = self.client.patch(
+            url,
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+
+        assert response.status_code == 200
+
+        dag_ids = [dag["dag_id"] for dag in response.json["dags"]]
+
+        assert expected_dag_ids == dag_ids
+        assert 10 == response.json["total_entries"]
+
+    def test_should_respond_200_default_limit(self):
+        self._create_dag_models(101)
+
+        response = self.client.patch(
+            "api/v1/dags?dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+
+        assert response.status_code == 200
+
+        assert 100 == len(response.json["dags"])
+        assert 101 == response.json["total_entries"]
+
+    def test_should_raises_401_unauthenticated(self):
+        response = self.client.patch(
+            "api/v1/dags?dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+        )
+
+        assert_401(response)
+
+    def test_should_respond_403_unauthorized(self):
+        self._create_dag_models(1)
+        response = self.client.patch(
+            "api/v1/dags?dag_id_pattern=~",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test_no_permissions"},
+        )
+
+        assert response.status_code == 403
+
+    def test_should_respond_200_and_pause_dags(self):
+        self._create_dag_models(2)
+
+        response = self.client.patch(
+            "/api/v1/dags?dag_id_pattern=~",
+            json={
+                "is_paused": True,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+
+        assert response.status_code == 200
+        assert {
+            "dags": [
+                {
+                    "dag_id": "TEST_DAG_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_1.py",
+                    "file_token": self.file_token,
+                    "is_paused": True,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+                {
+                    "dag_id": "TEST_DAG_2",
+                    "description": None,
+                    "fileloc": "/tmp/dag_2.py",
+                    "file_token": self.file_token2,
+                    "is_paused": True,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+            ],
+            "total_entries": 2,
+        } == response.json
+
+    @provide_session
+    def test_should_respond_200_and_pause_dag_pattern(self, session):
+        self._create_dag_models(10)
+        file_token10 = SERIALIZER.dumps("/tmp/dag_10.py")
+
+        response = self.client.patch(
+            "/api/v1/dags?dag_id_pattern=TEST_DAG_1",
+            json={
+                "is_paused": True,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+
+        assert response.status_code == 200
+        assert {
+            "dags": [
+                {
+                    "dag_id": "TEST_DAG_1",
+                    "description": None,
+                    "fileloc": "/tmp/dag_1.py",
+                    "file_token": self.file_token,
+                    "is_paused": True,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+                {
+                    "dag_id": "TEST_DAG_10",
+                    "description": None,
+                    "fileloc": "/tmp/dag_10.py",
+                    "file_token": file_token10,
+                    "is_paused": True,
+                    "is_active": True,
+                    "is_subdag": False,
+                    "owners": [],
+                    "root_dag_id": None,
+                    "schedule_interval": {
+                        "__type": "CronExpression",
+                        "value": "2 2 * * *",
+                    },
+                    "tags": [],
+                },
+            ],
+            "total_entries": 2,
+        } == response.json
+
+        dags_not_updated = session.query(DagModel).filter(~DagModel.is_paused)
+        assert len(dags_not_updated.all()) == 8
+        dags_updated = session.query(DagModel).filter(DagModel.is_paused)
+        assert len(dags_updated.all()) == 2

--- a/tests/api_connexion/endpoints/test_dag_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_endpoint.py
@@ -1246,3 +1246,14 @@ class TestPatchDags(TestDagEndpoint):
         assert len(dags_not_updated.all()) == 8
         dags_updated = session.query(DagModel).filter(DagModel.is_paused)
         assert len(dags_updated.all()) == 2
+
+    def test_should_respons_400_dag_id_pattern_missing(self):
+        self._create_dag_models(1)
+        response = self.client.patch(
+            "/api/v1/dags?only_active=True",
+            json={
+                "is_paused": False,
+            },
+            environ_overrides={'REMOTE_USER': "test"},
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
Endpoint for Bulk Updates to DAGs
---
Currently the Airflow REST API only allows us to pause/resume (update) one DAG per request. We often need to pause/resume DAGs in bulk. To avoid maintaining a separate set of custom endpoints that will be fragile, it makes sense to update the `patch_dag` endpoint to handle bulk requests.

**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
