### PR TITLE
Run CLI tests sequentially for Public GitHub runners

### DIFF
--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -97,6 +97,11 @@ function run_all_test_types_in_parallel() {
             test_types_to_run="${test_types_to_run//Core/}"
             sequential_tests+=("Core")
         fi
+        if [[ ${test_types_to_run} == *"Other"* ]]; then
+            echo "${COLOR_YELLOW}Remove Other from tests_types_to_run and add them to sequential tests due to low memory.${COLOR_RESET}"
+            test_types_to_run="${test_types_to_run//Other/}"
+            sequential_tests+=("Other")
+        fi
         if [[ ${BACKEND} == "mssql" || ${BACKEND} == "mysql" ]]; then
             # For mssql/mysql - they take far more memory than postgres (or sqlite) - we skip the Provider
             # tests altogether as they take too much memory even if run sequentially.


### PR DESCRIPTION
The CLI tests take a lot of memory (> 1GB when tests of
webserver are running). This causes OOM issues for Public GitHub
runners when those tests are run in parallel to other tests.

This PR add CLI to sequentially run tests which will make sure
they are not run in parallel with any other tests.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
