### PR TITLE
Handle stuck queued tasks in Celery for db backend

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1681,7 +1681,7 @@
     - name: stuck_queued_task_check_interval
       description: |
         How often to check for stuck queued task (in seconds)
-      version_added: 2.2.3
+      version_added: 2.3.0
       type: integer
       example: ~
       default: "300"

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1678,6 +1678,13 @@
       type: string
       example: ~
       default: "False"
+    - name: stuck_queued_task_check_interval
+      description: |
+        How often to check for stuck queued task (in seconds)
+      version_added: 2.2.3
+      type: integer
+      example: ~
+      default: "300"
 - name: celery_broker_transport_options
   description: |
     This section is for specifying options which can be passed to the

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -837,6 +837,9 @@ task_publish_max_retries = 3
 # Worker initialisation check to validate Metadata Database connection
 worker_precheck = False
 
+# How often to check for stuck queued task (in seconds)
+stuck_queued_task_check_interval = 300
+
 [celery_broker_transport_options]
 
 # This section is for specifying options which can be passed to the

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -391,9 +391,8 @@ class CeleryExecutor(BaseExecutor):
     def _clear_stuck_queued_tasks(self, session=None):
         """
         Tasks can get stuck in queued state in DB while still not in
-        self.queued_tasks and not in self.running_tasks. This usually happens
-        when the worker is autoscaled down and the task has not been picked up
-        by any worker(we think).
+        worker. This happens when the worker is autoscaled down and
+        the task is queued but has not been picked up by any worker prior to the scaling.
 
         In such situation, we update the task instance state to scheduled so that
         it can be queued again. We chose to use task_adoption_timeout to decide

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -243,9 +243,6 @@ class CeleryExecutor(BaseExecutor):
 
     def start(self) -> None:
         self.log.debug('Starting Celery Executor using %s processes for syncing', self._sync_parallelism)
-        # Clear stuck queued tasks at startup
-        self._clear_stuck_queued_tasks()
-        self.stuck_tasks_last_check_time = time.time()
 
     def _num_tasks_per_send_process(self, to_send_count: int) -> int:
         """

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -393,7 +393,8 @@ class CeleryExecutor(BaseExecutor):
         the task is queued but has not been picked up by any worker prior to the scaling.
 
         In such situation, we update the task instance state to scheduled so that
-        it can be queued again. We chose to use task_adoption_timeout to decide
+        it can be queued again. We chose to use task_adoption_timeout to decide when
+        a queued task is considered stuck and should be reschelduled.
         """
         if not isinstance(app.backend, DatabaseBackend):
             # We only want to do this for database backends where

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -413,7 +413,6 @@ class CeleryExecutor(BaseExecutor):
             TaskInstance.state == State.QUEUED, TaskInstance.queued_dttm < max_allowed_time
         ):
 
-            self.log.info("Checking task %s", task)
 
             if task.key in self.queued_tasks or task.key in self.running:
                 continue

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -40,6 +40,7 @@ from celery.backends.database import DatabaseBackend, Task as TaskDb, session_cl
 from celery.result import AsyncResult
 from celery.signals import import_modules as celery_import_modules
 from setproctitle import setproctitle
+from sqlalchemy.orm.session import Session
 
 import airflow.settings as settings
 from airflow.config_templates.default_celery import DEFAULT_CELERY_CONFIG
@@ -50,7 +51,7 @@ from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.net import get_hostname
-from airflow.utils.session import provide_session
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State
 from airflow.utils.timeout import timeout
 from airflow.utils.timezone import utcnow
@@ -385,7 +386,7 @@ class CeleryExecutor(BaseExecutor):
                 self.change_state(key, State.FAILED)
 
     @provide_session
-    def _clear_stuck_queued_tasks(self: Session = NEW_SESSION) -> None:
+    def _clear_stuck_queued_tasks(self, session: Session = NEW_SESSION) -> None:
         """
         Tasks can get stuck in queued state in DB while still not in
         worker. This happens when the worker is autoscaled down and

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -390,8 +390,10 @@ class CeleryExecutor(BaseExecutor):
     @provide_session
     def _clear_stuck_queued_tasks(self, session=None):
         """
-        For some reasons, tasks can get stuck in queued state in DB while still not in
-        self.queued_tasks and not in self.running_tasks.
+        Tasks can get stuck in queued state in DB while still not in
+        self.queued_tasks and not in self.running_tasks. This usually happens
+        when the worker is autoscaled down and the task has not been picked up
+        by any worker(we think).
 
         In such situation, we update the task instance state to scheduled so that
         it can be queued again. We chose to use task_adoption_timeout to decide

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -385,7 +385,7 @@ class CeleryExecutor(BaseExecutor):
                 self.change_state(key, State.FAILED)
 
     @provide_session
-    def _clear_stuck_queued_tasks(self, session=None):
+    def _clear_stuck_queued_tasks(self: Session = NEW_SESSION) -> None:
         """
         Tasks can get stuck in queued state in DB while still not in
         worker. This happens when the worker is autoscaled down and

--- a/airflow/executors/celery_executor.py
+++ b/airflow/executors/celery_executor.py
@@ -412,8 +412,6 @@ class CeleryExecutor(BaseExecutor):
         for task in session.query(TaskInstance).filter(
             TaskInstance.state == State.QUEUED, TaskInstance.queued_dttm < max_allowed_time
         ):
-
-
             if task.key in self.queued_tasks or task.key in self.running:
                 continue
 

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -445,6 +445,7 @@ class TestCeleryExecutor:
         executor._clear_stuck_queued_tasks()
         session.flush()
         ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
+        assert executor.queued_tasks == {ti.key: AsyncResult("231")}
         assert ti.state == State.QUEUED
 
     @pytest.mark.backend("mysql", "postgres")
@@ -462,6 +463,7 @@ class TestCeleryExecutor:
         executor._clear_stuck_queued_tasks()
         session.flush()
         ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
+        assert executor.running == {ti.key: AsyncResult("231")}
         assert ti.state == State.QUEUED
 
     @pytest.mark.backend("mysql", "postgres")
@@ -483,6 +485,7 @@ class TestCeleryExecutor:
                 ti = session.query(TaskInstance).filter(TaskInstance.task_id == ti.task_id).one()
                 # Not cleared
                 assert ti.state == State.QUEUED
+                assert executor.tasks == {ti.key: AsyncResult("231")}
 
     @mock.patch("celery.backends.database.DatabaseBackend.ResultSession")
     @pytest.mark.backend("mysql", "postgres")

--- a/tests/executors/test_celery_executor.py
+++ b/tests/executors/test_celery_executor.py
@@ -493,8 +493,8 @@ class TestCeleryExecutor:
     @pytest.mark.parametrize(
         "last_check_time, state",
         [
-            (time.time() - 300, State.SCHEDULED),
-            (time.time() - 290, State.QUEUED),
+            (time.time() - 400, State.SCHEDULED),
+            (time.time() - 200, State.QUEUED),
         ],
     )
     def test_the_check_interval_to_clear_stuck_queued_task_is_correct(


### PR DESCRIPTION
Move the state of stuck queued tasks in Celery to Scheduled so that
the Scheduler can queue them again
Closes: https://github.com/apache/airflow/issues/19699

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
