### PR TITLE
Add option to run PRs on public runners by maintainers.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,17 +171,6 @@ jobs:
       pullRequestLabels: ${{ steps.source-run-info.outputs.pullRequestLabels }}
       runsOn: ${{ steps.set-runs-on.outputs.runsOn }}
     steps:
-      # Avoid having to specify the runs-on logic every time. We use the custom
-      # env var AIRFLOW_SELF_HOSTED_RUNNER set only on our runners, but never
-      # on the public runners
-      - name: Set runs-on
-        id: set-runs-on
-        run: |
-          if [[ ${AIRFLOW_SELF_HOSTED_RUNNER} != "" ]]; then
-            echo "::set-output name=runsOn::\"self-hosted\""
-          else
-            echo "::set-output name=runsOn::\"ubuntu-20.04\""
-          fi
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
         uses: actions/checkout@v2
         with:
@@ -218,6 +207,24 @@ jobs:
           else
             # Run all checks
             ./scripts/ci/selective_ci_checks.sh
+          fi
+      # Avoid having to specify the runs-on logic every time. We use the custom
+      # env var AIRFLOW_SELF_HOSTED_RUNNER set only on our runners, but never
+      # on the public runners
+      - name: Set runs-on
+        id: set-runs-on
+        env:
+          PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
+        run: |
+          if [[ ${PR_LABELS=} == *"use public runners"* ]]; then
+            echo "Forcing running the on Public Runners via `use public runners` label"
+            echo "::set-output name=runsOn::\"ubuntu-20.04\""
+          elif [[ ${AIRFLOW_SELF_HOSTED_RUNNER} == "" ]]; then
+            echo "Regular PR running with Public Runner"
+            echo "::set-output name=runsOn::\"ubuntu-20.04\""
+          else
+            echo "Maintainer or main run running with self-hosted runner"
+            echo "::set-output name=runsOn::\"self-hosted\""
           fi
 
   tests-ui:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
           PR_LABELS: "${{ steps.source-run-info.outputs.pullRequestLabels }}"
         run: |
           if [[ ${PR_LABELS=} == *"use public runners"* ]]; then
-            echo "Forcing running the on Public Runners via `use public runners` label"
+            echo "Forcing running on Public Runners via `use public runners` label"
             echo "::set-output name=runsOn::\"ubuntu-20.04\""
           elif [[ ${AIRFLOW_SELF_HOSTED_RUNNER} == "" ]]; then
             echo "Regular PR running with Public Runner"

--- a/PULL_REQUEST_WORKFLOW.rst
+++ b/PULL_REQUEST_WORKFLOW.rst
@@ -81,13 +81,9 @@ We approached the problem by:
    More about it can be found in `Approval workflow and Matrix tests <#approval-workflow-and-matrix-tests>`_
    chapter.
 
-4) We've also applied (and received) funds to run self-hosted runners. This is not yet implemented, due to
-   discussions about security of self-hosted runners for public repositories. Running self-hosted runners by
-   public repositories is currently (as of end of October 2020)
-   `Discouraged by GitHub <https://docs.github.com/en/free-pro-team@latest/actions/hosting-your-own-runners/about-self-hosted-runners#self-hosted-runner-security-with-public-repositories>`_
-   and we are working on solving the problem - also involving Apache Software Foundation infrastructure team.
-   This document does not describe this part of the approach. Most likely we will add soon a document
-   describing details of the approach taken there.
+4) We've also applied (and received) funds to run self-hosted runners. They are used for ``main`` runs
+   and whenever the PRs are done by one of the maintainers. Maintainers can force using Public GitHub runners
+   by applying "use public runners" label to the PR before submitting it.
 
 Selective CI Checks
 -------------------


### PR DESCRIPTION
When `use public runners` label is applied to a PR, that PR will
run on Public Runners even if it is created by the maintainer.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
