### PR TITLE
Lower the recommended disk space requirements

### DIFF
--- a/scripts/in_container/run_resource_check.sh
+++ b/scripts/in_container/run_resource_check.sh
@@ -46,9 +46,9 @@ function resource_check() {
     else
         echo "* CPUs available ${cpus_available}. ${COLOR_GREEN}OK.${COLOR_RESET}"
     fi
-    if (( disk_available < one_meg*40 )); then
+    if (( disk_available < one_meg*20 )); then
         echo "${COLOR_YELLOW}WARNING!!!: Not enough Disk space available for Docker.${COLOR_RESET}"
-        echo "At least 40 GBs recommended. You have ${human_readable_disk}"
+        echo "At least 20 GBs recommended. You have ${human_readable_disk}"
         warning_resources="true"
     else
         echo "* Disk available ${human_readable_disk}. ${COLOR_GREEN}OK.${COLOR_RESET}"


### PR DESCRIPTION
The recommended disk space requirements for Breeze were set to
40GB which is way to high (and our Public Runners do not have that
much of a disk space - this generated false warnings).

Lowering it to 20GB should be quite enough for most "casual" users.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
