### PR TITLE
hive provider: restore HA support for metastore

### DIFF
--- a/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst
+++ b/docs/apache-airflow-providers-apache-hive/connections/hive_metastore.rst
@@ -42,7 +42,7 @@ Configuring the Connection
 --------------------------
 
 Host (optional)
-    The host of your Hive Metastore node.
+    The host of your Hive Metastore node. It is possible to specify multiple hosts as a comma-separated list.
 
 Port (optional)
     Your Hive Metastore port number.

--- a/tests/providers/apache/hive/hooks/test_hive.py
+++ b/tests/providers/apache/hive/hooks/test_hive.py
@@ -59,7 +59,9 @@ class TestHiveEnvironment(unittest.TestCase):
         self.table = 'static_babynames_partitioned'
         with mock.patch(
             'airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_metastore_client'
-        ) as get_metastore_mock:
+        ) as get_metastore_mock, mock.patch(
+            'airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_connection'
+        ):
             get_metastore_mock.return_value = mock.MagicMock()
 
             self.hook = HiveMetastoreHook()
@@ -400,19 +402,33 @@ class TestHiveMetastoreHook(TestHiveEnvironment):
         assert isinstance(max_partition, str)
 
     @mock.patch(
-        "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_connection",
-        return_value=Connection(host="localhost", port=9802),
+        "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook._find_valid_host",
+        return_value="localhost",
     )
     @mock.patch("airflow.providers.apache.hive.hooks.hive.socket")
-    def test_error_metastore_client(self, socket_mock, _find_valid_server_mock):
+    def test_error_metastore_client(self, socket_mock, _find_valid_host_mock):
         socket_mock.socket.return_value.connect_ex.return_value = 0
         self.hook.get_metastore_client()
 
+    @mock.patch(
+        "airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_connection",
+        return_value=Connection(host="metastore1.host,metastore2.host", port=9802),
+    )
+    @mock.patch("airflow.providers.apache.hive.hooks.hive.socket")
+    def test_ha_hosts(self, socket_mock, get_connection_mock):
+        socket_mock.socket.return_value.connect_ex.return_value = 1
+        with pytest.raises(AirflowException):
+            HiveMetastoreHook()
+        assert socket_mock.socket.call_count == 2
+
     def test_get_conn(self):
         with mock.patch(
-            'airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook._find_valid_server'
-        ) as find_valid_server:
-            find_valid_server.return_value = mock.MagicMock(return_value={})
+            'airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook._find_valid_host'
+        ) as find_valid_host, mock.patch(
+            'airflow.providers.apache.hive.hooks.hive.HiveMetastoreHook.get_connection'
+        ) as get_connection:
+            find_valid_host.return_value = mock.MagicMock(return_value="")
+            get_connection.return_value = mock.MagicMock(return_value="")
             metastore_hook = HiveMetastoreHook()
 
         assert isinstance(metastore_hook.get_conn(), HMSClient)


### PR DESCRIPTION
HA support for hivemetastore was added in #4708 , but stopped working when conn_id became unique in #8608 . This PR fixes it by allowing to specify more than one host for metastore connection via `,`. This is a similar PR to #19711 where the same problem is fixed for webhdfs connection.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
