### PR TITLE
Add retagging images accross repos

### DIFF
--- a/dev/retag_docker_images.py
+++ b/dev/retag_docker_images.py
@@ -33,28 +33,35 @@ import click
 
 PYTHON_VERSIONS = ["3.6", "3.7", "3.8", "3.9"]
 
-GHCR_IO_PREFIX = "ghcr.io/apache/airflow"
+GHCR_IO_PREFIX = "ghcr.io"
+
 
 GHCR_IO_IMAGES = [
-    "{prefix}/{branch}/ci-manifest/python{python_version}:latest",
-    "{prefix}/{branch}/ci/python{python_version}:latest",
-    "{prefix}/{branch}/prod-build/python{python_version}-build:latest",
-    "{prefix}/{branch}/prod/python{python_version}-build:latest",
-    "{prefix}/{branch}/python:{python_version}-slim-buster",
+    "{prefix}/{repo}/{branch}/ci-manifest/python{python_version}:latest",
+    "{prefix}/{repo}/{branch}/ci/python{python_version}:latest",
+    "{prefix}/{repo}/{branch}/prod-build/python{python_version}:latest",
+    "{prefix}/{repo}/{branch}/prod/python{python_version}:latest",
+    "{prefix}/{repo}/{branch}/python:{python_version}-slim-buster",
 ]
 
 
 # noinspection StrFormat
 def pull_push_all_images(
-    source_prefix: str, target_prefix: str, images: List[str], source_branch: str, target_branch: str
+    source_prefix: str,
+    target_prefix: str,
+    images: List[str],
+    source_branch: str,
+    source_repo: str,
+    target_branch: str,
+    target_repo: str,
 ):
     for python_version in PYTHON_VERSIONS:
         for image in images:
             source_image = image.format(
-                prefix=source_prefix, branch=source_branch, python_version=python_version
+                prefix=source_prefix, branch=source_branch, repo=source_repo, python_version=python_version
             )
             target_image = image.format(
-                prefix=target_prefix, branch=target_branch, python_version=python_version
+                prefix=target_prefix, branch=target_branch, repo=target_repo, python_version=python_version
             )
             print(f"Copying image: {source_image} -> {target_image}")
             subprocess.run(["docker", "pull", source_image], check=True)
@@ -65,11 +72,17 @@ def pull_push_all_images(
 @click.group(invoke_without_command=True)
 @click.option("--source-branch", type=str, default="main", help="Source branch name [main]")
 @click.option("--target-branch", type=str, default="main", help="Target branch name [main]")
+@click.option("--source-repo", type=str, default="apache/airflow", help="Source repo")
+@click.option("--target-repo", type=str, default="apache/airflow", help="Target repo")
 def main(
     source_branch: str,
     target_branch: str,
+    source_repo: str,
+    target_repo: str,
 ):
-    pull_push_all_images(GHCR_IO_PREFIX, GHCR_IO_PREFIX, GHCR_IO_IMAGES, source_branch, target_branch)
+    pull_push_all_images(
+        GHCR_IO_PREFIX, GHCR_IO_PREFIX, GHCR_IO_IMAGES, source_branch, source_repo, target_branch, target_repo
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Useful to refresh cache images to a different repository - in
order to speed up builds there.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
