### PR TITLE
Bug fix in AWS glue operator when specifying the WorkerType & NumberOfWorkers

### DIFF
--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -74,10 +74,10 @@ class AwsGlueJobHook(AwsBaseHook):
         self.role_name = iam_role_name
         self.s3_glue_logs = 'logs/glue-logs/'
         self.create_job_kwargs = create_job_kwargs or {}
-        
+
         worker_type_exists = "WorkerType" in self.create_job_kwargs
         num_workers_exists = "NumberOfWorkers" in self.create_job_kwargs
-        
+
         if worker_type_exists and num_workers_exists:
             if num_of_dpus is not None:
                 raise ValueError("Cannot specify num_of_dpus with custom WorkerType")
@@ -89,7 +89,7 @@ class AwsGlueJobHook(AwsBaseHook):
             self.num_of_dpus = 10
         else:
             self.num_of_dpus = num_of_dpus
-        
+
         kwargs['client_type'] = 'glue'
         super().__init__(*args, **kwargs)
 

--- a/airflow/providers/amazon/aws/hooks/glue.py
+++ b/airflow/providers/amazon/aws/hooks/glue.py
@@ -75,12 +75,15 @@ class AwsGlueJobHook(AwsBaseHook):
         self.s3_glue_logs = 'logs/glue-logs/'
         self.create_job_kwargs = create_job_kwargs or {}
         
-        if "WorkerType" in self.create_job_kwargs and "NumberOfWorkers" in self.create_job_kwargs:
+        worker_type_exists = "WorkerType" in self.create_job_kwargs
+        num_workers_exists = "NumberOfWorkers" in self.create_job_kwargs
+        
+        if worker_type_exists and num_workers_exists:
             if num_of_dpus is not None:
                 raise ValueError("Cannot specify num_of_dpus with custom WorkerType")
-        elif "WorkerType" not in self.create_job_kwargs and "NumberOfWorkers" in self.create_job_kwargs:
+        elif not worker_type_exists and num_workers_exists:
             raise ValueError("Need to specify custom WorkerType when specifying NumberOfWorkers")
-        elif "WorkerType" in self.create_job_kwargs and "NumberOfWorkers" not in self.create_job_kwargs:
+        elif worker_type_exists and not num_workers_exists:
             raise ValueError("Need to specify NumberOfWorkers when specifying custom WorkerType")
         elif num_of_dpus is None:
             self.num_of_dpus = 10

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -93,7 +93,7 @@ class TestGlueJobHook(unittest.TestCase):
             create_job_kwargs={'WorkerType': 'G.2X', 'NumberOfWorkers': 60},
         ).get_or_create_glue_job()
         assert glue_job == mock_glue_job
-        
+
     @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
     @mock.patch.object(AwsGlueJobHook, "get_conn")
     def test_init_worker_type_value_error(self, mock_get_conn, mock_get_iam_execution_role):
@@ -101,8 +101,8 @@ class TestGlueJobHook(unittest.TestCase):
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
         some_s3_bucket = "my-includes"
 
-        try:
-            glue_hook = AwsGlueJobHook(
+        with self.assertRaises(ValueError, msg="Expected error message here"):
+            AwsGlueJobHook(
                 job_name='aws_test_glue_job',
                 desc='This is test case job from Airflow',
                 script_location=some_script,
@@ -112,10 +112,6 @@ class TestGlueJobHook(unittest.TestCase):
                 num_of_dpus=20,
                 create_job_kwargs={'WorkerType': 'G.2X', 'NumberOfWorkers': 60},
             )
-        except ValueError as e:
-            self.assertEqual(type(e), ValueError)
-        else:
-            raise AssertionError("ValueError was not raised")
 
     @mock.patch.object(AwsGlueJobHook, "get_job_state")
     @mock.patch.object(AwsGlueJobHook, "get_or_create_glue_job")

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -103,7 +103,7 @@ class TestGlueJobHook(unittest.TestCase):
 
         with self.assertRaises(
             ValueError,
-            msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
+            msg="ValueError should be raised for specifying the num_of_dpus and worker type together.",
         ):
             AwsGlueJobHook(
                 job_name='aws_test_glue_job',

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -103,7 +103,7 @@ class TestGlueJobHook(unittest.TestCase):
 
         with self.assertRaises(
             ValueError,
-            msg="ValueError should be raised for specifying the num_of_dpus and worker type together.",
+            msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
         ):
             AwsGlueJobHook(
                 job_name='aws_test_glue_job',

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -101,7 +101,10 @@ class TestGlueJobHook(unittest.TestCase):
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
         some_s3_bucket = "my-includes"
 
-        with self.assertRaises(ValueError, msg="ValueError should be raised for specifying the num_of_dpus and worker type together!"):
+        with self.assertRaises(
+            ValueError,
+            msg="ValueError should be raised for specifying the num_of_dpus and worker type together!",
+        ):
             AwsGlueJobHook(
                 job_name='aws_test_glue_job',
                 desc='This is test case job from Airflow',

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -93,6 +93,29 @@ class TestGlueJobHook(unittest.TestCase):
             create_job_kwargs={'WorkerType': 'G.2X', 'NumberOfWorkers': 60},
         ).get_or_create_glue_job()
         assert glue_job == mock_glue_job
+        
+    @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
+    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    def test_init_worker_type_value_error(self, mock_get_conn, mock_get_iam_execution_role):
+        mock_get_iam_execution_role.return_value = mock.MagicMock(Role={'RoleName': 'my_test_role'})
+        some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
+        some_s3_bucket = "my-includes"
+
+        try:
+            glue_hook = AwsGlueJobHook(
+                job_name='aws_test_glue_job',
+                desc='This is test case job from Airflow',
+                script_location=some_script,
+                iam_role_name='my_test_role',
+                s3_bucket=some_s3_bucket,
+                region_name=self.some_aws_region,
+                num_of_dpus=20,
+                create_job_kwargs={'WorkerType': 'G.2X', 'NumberOfWorkers': 60},
+            )
+        except ValueError as e:
+            self.assertEqual(type(e), ValueError)
+        else:
+            raise AssertionError("ValueError was not raised")
 
     @mock.patch.object(AwsGlueJobHook, "get_job_state")
     @mock.patch.object(AwsGlueJobHook, "get_or_create_glue_job")

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -101,7 +101,7 @@ class TestGlueJobHook(unittest.TestCase):
         some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
         some_s3_bucket = "my-includes"
 
-        with self.assertRaises(ValueError, msg="Expected error message here"):
+        with self.assertRaises(ValueError, msg="ValueError should be raised for specifying the num_of_dpus and worker type together!"):
             AwsGlueJobHook(
                 job_name='aws_test_glue_job',
                 desc='This is test case job from Airflow',

--- a/tests/providers/amazon/aws/hooks/test_glue.py
+++ b/tests/providers/amazon/aws/hooks/test_glue.py
@@ -75,6 +75,25 @@ class TestGlueJobHook(unittest.TestCase):
         ).get_or_create_glue_job()
         assert glue_job == mock_glue_job
 
+    @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
+    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    def test_get_or_create_glue_job_worker_type(self, mock_get_conn, mock_get_iam_execution_role):
+        mock_get_iam_execution_role.return_value = mock.MagicMock(Role={'RoleName': 'my_test_role'})
+        some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
+        some_s3_bucket = "my-includes"
+
+        mock_glue_job = mock_get_conn.return_value.get_job()['Job']['Name']
+        glue_job = AwsGlueJobHook(
+            job_name='aws_test_glue_job',
+            desc='This is test case job from Airflow',
+            script_location=some_script,
+            iam_role_name='my_test_role',
+            s3_bucket=some_s3_bucket,
+            region_name=self.some_aws_region,
+            create_job_kwargs={'WorkerType': 'G.2X', 'NumberOfWorkers': 60},
+        ).get_or_create_glue_job()
+        assert glue_job == mock_glue_job
+
     @mock.patch.object(AwsGlueJobHook, "get_job_state")
     @mock.patch.object(AwsGlueJobHook, "get_or_create_glue_job")
     @mock.patch.object(AwsGlueJobHook, "get_conn")


### PR DESCRIPTION
<!--

Existing issue:

closes: #19207
related: #19207

This commit is to fix a bug in the AWS Glue Job operator. In the case when we specify the `WorkerType` and `NumberOfWorkers` as the parameters in the `create_job_kwargs`, the glue job creation would fail. This is because AWS Glue API does not allow to use "AllocatedCapacity" or "MaxCapacity" parameters when the 'WorkerType' and 'NumberOfWorkers' are being assigned. This is the issue which I have addressed and fixed in this commit. 

I have removed the "AllocatedCapacity" or "MaxCapacity" parameters from the `glue_client.create_job` function call if the `WorkerType` and `NumberOfWorkers` are given.

--> 

---
Existing issue:

closes: #19207
related: #19207

This commit is to fix a bug in the AWS Glue Job operator. In the case when we specify the `WorkerType` and `NumberOfWorkers` as the parameters in the `create_job_kwargs`, the glue job creation would fail. This is because AWS Glue API does not allow to use "AllocatedCapacity" or "MaxCapacity" parameters when the 'WorkerType' and 'NumberOfWorkers' are being assigned. This is the issue which I have addressed and fixed in this commit. 

I have removed the "AllocatedCapacity" or "MaxCapacity" parameters from the `glue_client.create_job` function call if the `WorkerType` and `NumberOfWorkers` are specified.
