### PR TITLE
Dynamically enable "Test Connection" button by connection type

### DIFF
--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -173,7 +173,7 @@ class HookInfo(NamedTuple):
     package_name: str
     hook_name: str
     connection_type: str
-    is_connection_type_testable: bool
+    connection_testable: bool
 
 
 class ConnectionFormWidgetInfo(NamedTuple):
@@ -675,7 +675,6 @@ class ProvidersManager(LoggingMixin):
         connection_type = hook_connection_type
         connection_id_attribute_name: str = self._get_attr(hook_class, 'conn_name_attr')
         hook_name: str = self._get_attr(hook_class, 'hook_name')
-        is_connection_type_testable: bool = hasattr(hook_class, 'test_connection')
 
         if not connection_type or not connection_id_attribute_name or not hook_name:
             log.warning(
@@ -693,7 +692,7 @@ class ProvidersManager(LoggingMixin):
             package_name=package_name,
             hook_name=hook_name,
             connection_type=connection_type,
-            is_connection_type_testable=is_connection_type_testable,
+            connection_testable=hasattr(hook_class, 'test_connection'),
         )
 
     def _add_widgets(self, package_name: str, hook_class: type, widgets: Dict[str, Any]):

--- a/airflow/providers_manager.py
+++ b/airflow/providers_manager.py
@@ -173,6 +173,7 @@ class HookInfo(NamedTuple):
     package_name: str
     hook_name: str
     connection_type: str
+    is_connection_type_testable: bool
 
 
 class ConnectionFormWidgetInfo(NamedTuple):
@@ -674,6 +675,7 @@ class ProvidersManager(LoggingMixin):
         connection_type = hook_connection_type
         connection_id_attribute_name: str = self._get_attr(hook_class, 'conn_name_attr')
         hook_name: str = self._get_attr(hook_class, 'hook_name')
+        is_connection_type_testable: bool = hasattr(hook_class, 'test_connection')
 
         if not connection_type or not connection_id_attribute_name or not hook_name:
             log.warning(
@@ -691,6 +693,7 @@ class ProvidersManager(LoggingMixin):
             package_name=package_name,
             hook_name=hook_name,
             connection_type=connection_type,
+            is_connection_type_testable=is_connection_type_testable,
         )
 
     def _add_widgets(self, package_name: str, hook_class: type, widgets: Dict[str, Any]):

--- a/airflow/www/templates/airflow/conn_create.html
+++ b/airflow/www/templates/airflow/conn_create.html
@@ -29,4 +29,5 @@
   {{ super() }}
   <script src="{{ url_for_asset('connectionForm.js') }}"></script>
   <script id="field_behaviours" type="text/json">{{ widgets["add"].field_behaviours }}</script>
+  <script id="testable_connection_types" type="text/json">{{ widgets["add"].testable_connection_types }}</script>
 {% endblock %}

--- a/airflow/www/templates/airflow/conn_edit.html
+++ b/airflow/www/templates/airflow/conn_edit.html
@@ -29,4 +29,5 @@
   {{ super() }}
   <script src="{{ url_for_asset(filename='connectionForm.js') }}"></script>
   <script id="field_behaviours" type="text/json">{{ widgets["edit"].field_behaviours }}</script>
+  <script id="testable_connection_types" type="text/json">{{ widgets["edit"].testable_connection_types }}</script>
 {% endblock %}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3378,12 +3378,23 @@ def lazy_add_provider_discovered_options_to_connection_form():
 # fields in ConnectionForm based on type of connection chosen
 # See airflow.hooks.base_hook.DiscoverableHook for details on how to customize your Hooks.
 # those field behaviours are rendered as scripts in the conn_create.html and conn_edit.html templates
+#
+# Additionally, a list of connection types that support testing via Airflow REST API is stored to dynamically
+# enable/disable the Test Connection button.
 class ConnectionFormWidget(FormWidget):
     """Form widget used to display connection"""
 
     @cached_property
     def field_behaviours(self):
         return json.dumps(ProvidersManager().field_behaviours)
+
+    @cached_property
+    def testable_connection_types(self):
+        return [
+            connection_type
+            for connection_type, provider_info in ProvidersManager().hooks.items()
+            if provider_info.is_connection_type_testable is True
+        ]
 
 
 class ConnectionModelView(AirflowModelView):

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3377,10 +3377,12 @@ def lazy_add_provider_discovered_options_to_connection_form():
 # Used to store a dictionary of field behaviours used to dynamically change available
 # fields in ConnectionForm based on type of connection chosen
 # See airflow.hooks.base_hook.DiscoverableHook for details on how to customize your Hooks.
-# those field behaviours are rendered as scripts in the conn_create.html and conn_edit.html templates
 #
 # Additionally, a list of connection types that support testing via Airflow REST API is stored to dynamically
 # enable/disable the Test Connection button.
+#
+# These field behaviours and testable connection types are rendered as scripts in the conn_create.html and
+# conn_edit.html templates.
 class ConnectionFormWidget(FormWidget):
     """Form widget used to display connection"""
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -3395,7 +3395,7 @@ class ConnectionFormWidget(FormWidget):
         return [
             connection_type
             for connection_type, provider_info in ProvidersManager().hooks.items()
-            if provider_info.is_connection_type_testable is True
+            if provider_info.connection_testable
         ]
 
 


### PR DESCRIPTION
The current implementation of the Test Connection button in the UI is either enabled/disabled relative only to the enablement of Airflow REST APIs within an environment. Meaning if REST APIs are enabled, the Test Connection button is enabled for _all_ connection types even if a selected type doesn't actually support testing connectivity in this way. This can be confusing for users.

This PR adds functionality to dynamically enable (or disable) the Test Connection button based on if the selected connection type supports testing via the Airflow REST API. (Note that if Airflow REST APIs are disabled for an environment, this configuration will take precedence over this logic.) Also, when disabling the button, the element will now be functionally disabled rather than just the appearance of being disabled.

**Example of dynamically disabled Test Connection button:**
![image](https://user-images.githubusercontent.com/48934154/143132472-27d9edfe-5726-40b4-8969-e4b828f79b5e.png)


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
