### PR TITLE
Add note to restart runners when updating committers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,10 @@ jobs:
     # When changing this list, ensure that it is kept in sync with the
     # /runners/apache/airflow/configOverlay
     # parameter in AWS SSM ParameterStore (which is what the runner uses)
+    # and restart the self-hosted runners.
+    #
+    # This list of committers can be generated with:
+    #   https://github.com/apache/airflow-ci-infra/blob/main/scripts/list_committers
     runs-on: >-
       ${{ (
         (


### PR DESCRIPTION
So we don't accidentally miss it the next time around.