### PR TITLE
PSRP improvements

### DIFF
--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -233,7 +233,15 @@ class PsrpHook(BaseHook):
             except BaseException as exc:
                 # See https://github.com/jborean93/pypsrp/pull/130
                 message = str(exc)
-            log(level, "%s: %s", record.command_name, message)
+
+            # Sometimes a message will have a trailing \r\n sequence such as
+            # the tracing output of the Set-PSDebug cmdlet.
+            message = message.rstrip()
+
+            if record.command_name is None:
+                log(level, "%s", message)
+            else:
+                log(level, "%s: %s", record.command_name, message)
         elif message_type == MessageType.INFORMATION_RECORD:
             log(INFO, "%s (%s): %s", record.computer, record.user, record.message_data)
         elif message_type == MessageType.PROGRESS_RECORD:

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -37,7 +37,7 @@ INFORMATIONAL_RECORD_LEVEL_MAP = {
 }
 
 
-class PSRPHook(BaseHook):
+class PsrpHook(BaseHook):
     """
     Hook for PowerShell Remoting Protocol execution.
 

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -19,7 +19,7 @@
 from contextlib import contextmanager
 from copy import copy
 from logging import DEBUG, ERROR, INFO, WARNING
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Iterator, Optional
 from weakref import WeakKeyDictionary
 
 from pypsrp.messages import MessageType
@@ -84,7 +84,7 @@ class PsrpHook(BaseHook):
         self,
         psrp_conn_id: str,
         logging_level: int = DEBUG,
-        operation_timeout: Optional[float] = None,
+        operation_timeout: Optional[int] = None,
         runspace_options: Optional[Dict[str, Any]] = None,
         wsman_options: Optional[Dict[str, Any]] = None,
         on_output_callback: Optional[OutputCallback] = None,
@@ -156,7 +156,7 @@ class PsrpHook(BaseHook):
         return pool
 
     @contextmanager
-    def invoke(self) -> PowerShell:
+    def invoke(self) -> Iterator[PowerShell]:
         """
         Context manager that yields a PowerShell object to which commands can be
         added. Upon exit, the commands will be invoked.
@@ -167,6 +167,7 @@ class PsrpHook(BaseHook):
         if local_context:
             self.__enter__()
         try:
+            assert self._conn is not None
             ps = PowerShell(self._conn)
             yield ps
             ps.begin_invoke()

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -53,6 +53,10 @@ class PSRPHook(BaseHook):
         :py:class:`~pypsrp.powershell.RunspacePool` for a description of the
         available options.
     :type runspace_options: dict
+    :param exchange_keys:
+        If true (default), automatically initiate a session key exchange when the
+        hook is used as a context manager.
+    :type exchange_keys: bool
 
     You can provide an alternative `configuration_name` using either `runspace_options`
     or by setting this key as the extra fields of your connection.
@@ -68,16 +72,20 @@ class PSRPHook(BaseHook):
         logging: bool = True,
         operation_timeout: Optional[float] = None,
         runspace_options: Optional[Dict[str, Any]] = None,
+        exchange_keys: bool = True,
     ):
         self.conn_id = psrp_conn_id
         self._logging = logging
         self._operation_timeout = operation_timeout
         self._runspace_options = runspace_options or {}
+        self._exchange_keys = exchange_keys
 
     def __enter__(self):
         conn = self.get_conn()
         self._wsman_ref[conn].__enter__()
         conn.__enter__()
+        if self._exchange_keys:
+            conn.exchange_keys()
         self._conn = conn
         return self
 

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -106,11 +106,8 @@ class PSRPHook(BaseHook):
         """
         Returns a runspace pool.
 
-        If the hook context has already been entered into, this will return the
-        active pool.
+        The returned object must be used as a context manager.
         """
-        if self._conn is not None:
-            return self._conn
         conn = self.get_connection(self.conn_id)
         self.log.info("Establishing WinRM connection %s to host: %s", self.conn_id, conn.host)
         wsman = WSMan(

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -53,6 +53,10 @@ class PSRPHook(BaseHook):
         :py:class:`~pypsrp.powershell.RunspacePool` for a description of the
         available options.
     :type runspace_options: dict
+    :param wsman_options:
+        Optional dictionary which is passed when creating the `WSMan` client. See
+        :py:class:`~pypsrp.wsman.WSMan` for a description of the available options.
+    :type wsman_options: dict
     :param exchange_keys:
         If true (default), automatically initiate a session key exchange when the
         hook is used as a context manager.
@@ -72,12 +76,14 @@ class PSRPHook(BaseHook):
         logging: bool = True,
         operation_timeout: Optional[float] = None,
         runspace_options: Optional[Dict[str, Any]] = None,
+        wsman_options: Optional[Dict[str, Any]] = None,
         exchange_keys: bool = True,
     ):
         self.conn_id = psrp_conn_id
         self._logging = logging
         self._operation_timeout = operation_timeout
         self._runspace_options = runspace_options or {}
+        self._wsman_options = wsman_options or {}
         self._exchange_keys = exchange_keys
 
     def __enter__(self):
@@ -109,12 +115,9 @@ class PSRPHook(BaseHook):
         self.log.info("Establishing WinRM connection %s to host: %s", self.conn_id, conn.host)
         wsman = WSMan(
             conn.host,
-            ssl=True,
-            auth="ntlm",
-            encryption="never",
             username=conn.login,
             password=conn.password,
-            cert_validation=False,
+            **self._wsman_options,
         )
         runspace_options = self._runspace_options.copy()
         configuration_name = conn.extra_dejson.get('configuration_name')

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -31,6 +31,9 @@ class PSRPHook(BaseHook):
     Hook for PowerShell Remoting Protocol execution.
 
     The hook must be used as a context manager.
+
+    :param psrp_conn_id: Required. The name of the PSRP connection.
+    :type psrp_conn_id: str
     """
 
     _client = None

--- a/airflow/providers/microsoft/psrp/hooks/psrp.py
+++ b/airflow/providers/microsoft/psrp/hooks/psrp.py
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import re
 from contextlib import contextmanager
 from copy import copy
 from logging import DEBUG, ERROR, INFO, WARNING
@@ -229,15 +228,7 @@ class PsrpHook(BaseHook):
         return ps
 
     def _log_record(self, log, record):
-        message_type = getattr(record, "MESSAGE_TYPE", None)
-
-        # There seems to be a problem with some record types; we'll assume
-        # that the class name matches a message type.
-        if message_type is None:
-            message_type = getattr(
-                MessageType, re.sub('(?!^)([A-Z]+)', r'_\1', type(record).__name__).upper()
-            )
-
+        message_type = record.MESSAGE_TYPE
         if message_type == MessageType.ERROR_RECORD:
             log(INFO, "%s: %s", record.reason, record)
             if record.script_stacktrace:

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -25,7 +25,12 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.psrp.hooks.psrp import PsrpHook
 from airflow.settings import json
-from airflow.utils.helpers import exactly_one
+
+
+# TODO: Replace with airflow.utils.helpers.exactly_one in Airflow 2.3.
+def exactly_one(*args):
+    return len(set(filter(None, args))) == 1
+
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -44,6 +44,10 @@ class PSRPOperator(BaseOperator):
         Optional dictionary which is passed when creating the runspace pool. See
         :py:class:`~pypsrp.powershell.RunspacePool` for a description of the
         available options.
+    :param wsman_options:
+        Optional dictionary which is passed when creating the `WSMan` client. See
+        :py:class:`~pypsrp.wsman.WSMan` for a description of the available options.
+    :type wsman_options: dict
     """
 
     template_fields: Sequence[str] = (
@@ -64,6 +68,7 @@ class PSRPOperator(BaseOperator):
         parameters: Optional[Dict[str, str]] = None,
         logging: bool = True,
         runspace_options: Optional[Dict[str, Any]] = None,
+        wsman_options: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
         args = {command, powershell, cmdlet}
@@ -81,9 +86,15 @@ class PSRPOperator(BaseOperator):
         self.parameters = parameters or {}
         self.logging = logging
         self.runspace_options = runspace_options
+        self.wsman_options = wsman_options
 
     def execute(self, context: "Context") -> List[str]:
-        with PSRPHook(self.conn_id, logging=self.logging, runspace_options=self.runspace_options) as hook:
+        with PSRPHook(
+            self.conn_id,
+            logging=self.logging,
+            runspace_options=self.runspace_options,
+            wsman_options=self.wsman_options,
+        ) as hook:
             ps = (
                 hook.invoke_cmdlet(self.cmdlet, **self.parameters)
                 if self.cmdlet

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -23,7 +23,7 @@ from pypsrp.serializer import TaggedValue
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
-from airflow.providers.microsoft.psrp.hooks.psrp import PSRPHook
+from airflow.providers.microsoft.psrp.hooks.psrp import PsrpHook
 from airflow.settings import json
 from airflow.utils.helpers import exactly_one
 
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class PSRPOperator(BaseOperator):
+class PsrpOperator(BaseOperator):
     """PowerShell Remoting Protocol operator.
 
     Use one of the 'command', 'cmdlet', or 'powershell' arguments.
@@ -102,7 +102,7 @@ class PSRPOperator(BaseOperator):
         self.wsman_options = wsman_options
 
     def execute(self, context: "Context") -> List[Any]:
-        with PSRPHook(
+        with PsrpHook(
             self.conn_id,
             logging=self.logging,
             runspace_options=self.runspace_options,

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -24,6 +24,7 @@ from pypsrp.serializer import TaggedValue
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.providers.microsoft.psrp.hooks.psrp import PSRPHook
+from airflow.settings import json
 from airflow.utils.helpers import exactly_one
 
 if TYPE_CHECKING:
@@ -39,6 +40,9 @@ class PSRPOperator(BaseOperator):
     serialization into a `System.Security.SecureString` (applicable only
     for DAGs which have `render_template_as_native_obj=True`).
 
+    The command output is converted to JSON by PowerShell such that the operator
+    return value is serializable to an XCom value.
+
     :param psrp_conn_id: connection id
     :param command: command to execute on remote host. (templated)
     :param powershell: powershell to execute on remote host. (templated)
@@ -50,11 +54,11 @@ class PSRPOperator(BaseOperator):
         the `cmdlet` parameter is also given.
     :param logging: whether to log command output and streams during execution
     :param runspace_options:
-        Optional dictionary which is passed when creating the runspace pool. See
+        optional dictionary which is passed when creating the runspace pool. See
         :py:class:`~pypsrp.powershell.RunspacePool` for a description of the
         available options.
     :param wsman_options:
-        Optional dictionary which is passed when creating the `WSMan` client. See
+        optional dictionary which is passed when creating the `WSMan` client. See
         :py:class:`~pypsrp.wsman.WSMan` for a description of the available options.
     """
 
@@ -97,25 +101,26 @@ class PSRPOperator(BaseOperator):
         self.runspace_options = runspace_options
         self.wsman_options = wsman_options
 
-    def execute(self, context: "Context") -> List[str]:
+    def execute(self, context: "Context") -> List[Any]:
         with PSRPHook(
             self.conn_id,
             logging=self.logging,
             runspace_options=self.runspace_options,
             wsman_options=self.wsman_options,
-        ) as hook:
-            ps = (
-                hook.invoke_cmdlet(self.cmdlet, **self.parameters)
-                if self.cmdlet
-                else (
-                    hook.invoke_powershell(
-                        f"cmd.exe /c @'\n{self.command}\n'@" if self.command else self.powershell
-                    )
-                )
-            )
+        ) as hook, hook.invoke() as ps:
+            if self.cmdlet:
+                ps.add_cmdlet(self.cmdlet)
+                ps.add_parameters(self.parameters)
+            elif self.command:
+                ps.add_script(f"cmd.exe /c @'\n{self.command}\n'@")
+            else:
+                ps.add_script(self.powershell)
+            ps.add_cmdlet("ConvertTo-Json")
+
         if ps.had_errors:
             raise AirflowException("Process failed")
-        return ps.output
+
+        return [json.loads(output) for output in ps.output]
 
     def get_template_env(self):
         # Create a template environment overlay in order to leave the underlying

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -65,7 +65,7 @@ class PSRPOperator(BaseOperator):
         "powershell",
     )
     template_fields_renderers = {"command": "powershell", "powershell": "powershell"}
-    ui_color = "#901dd2"
+    ui_color = "#c2e2ff"
 
     def __init__(
         self,

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from logging import DEBUG
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
 from jinja2.nativetypes import NativeEnvironment
@@ -57,7 +58,9 @@ class PsrpOperator(BaseOperator):
     :param parameters:
         parameters to provide to cmdlet (templated). This is allowed only if
         the `cmdlet` parameter is also given.
-    :param logging: whether to log command output and streams during execution
+    :param logging_level:
+        Logging level for message streams which are received during remote execution.
+        The default is to include all messages in the task log.
     :param runspace_options:
         optional dictionary which is passed when creating the runspace pool. See
         :py:class:`~pypsrp.powershell.RunspacePool` for a description of the
@@ -84,7 +87,7 @@ class PsrpOperator(BaseOperator):
         powershell: Optional[str] = None,
         cmdlet: Optional[str] = None,
         parameters: Optional[Dict[str, str]] = None,
-        logging: bool = True,
+        logging_level: int = DEBUG,
         runspace_options: Optional[Dict[str, Any]] = None,
         wsman_options: Optional[Dict[str, Any]] = None,
         **kwargs,
@@ -102,14 +105,14 @@ class PsrpOperator(BaseOperator):
         self.powershell = powershell
         self.cmdlet = cmdlet
         self.parameters = parameters or {}
-        self.logging = logging
+        self.logging_level = logging_level
         self.runspace_options = runspace_options
         self.wsman_options = wsman_options
 
     def execute(self, context: "Context") -> List[Any]:
         with PsrpHook(
             self.conn_id,
-            logging=self.logging,
+            logging_level=self.logging_level,
             runspace_options=self.runspace_options,
             wsman_options=self.wsman_options,
         ) as hook, hook.invoke() as ps:

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -130,7 +130,6 @@ class PsrpOperator(BaseOperator):
         ) as hook, hook.invoke() as ps:
             if self.psrp_session_init is not None:
                 ps.add_command(self.psrp_session_init)
-                ps.add_statement()
             if self.command:
                 ps.add_script(f"cmd.exe /c @'\n{self.command}\n'@")
             else:

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -51,9 +51,10 @@ class PSRPOperator(BaseOperator):
     """
 
     template_fields: Sequence[str] = (
-        "command",
-        "powershell",
         "cmdlet",
+        "command",
+        "parameters",
+        "powershell",
     )
     template_fields_renderers = {"command": "powershell", "powershell": "powershell"}
     ui_color = "#901dd2"

--- a/airflow/providers/microsoft/psrp/operators/psrp.py
+++ b/airflow/providers/microsoft/psrp/operators/psrp.py
@@ -33,8 +33,12 @@ class PSRPOperator(BaseOperator):
     :param psrp_conn_id: connection id
     :param command: command to execute on remote host. (templated)
     :param powershell: powershell to execute on remote host. (templated)
-    :param cmdlet: cmdlet to execute on remote host. (templated)
-    :param parameters: parameters to provide to cmdlet. (templated)
+    :param cmdlet:
+        cmdlet to execute on remote host (templated). Also used as the default
+        value for `task_id`.
+    :param parameters:
+        parameters to provide to cmdlet (templated). This is allowed only if
+        the `cmdlet` parameter is also given.
     :param logging: whether to log command output and streams during execution
     :param runspace_options:
         Optional dictionary which is passed when creating the runspace pool. See
@@ -62,12 +66,14 @@ class PSRPOperator(BaseOperator):
         runspace_options: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
-        super().__init__(**kwargs)
         args = {command, powershell, cmdlet}
         if not exactly_one(*args):
             raise ValueError("Must provide exactly one of 'command', 'powershell', or 'cmdlet'")
         if parameters and not cmdlet:
             raise ValueError("Parameters only allowed with 'cmdlet'")
+        if cmdlet:
+            kwargs.setdefault('task_id', cmdlet)
+        super().__init__(**kwargs)
         self.conn_id = psrp_conn_id
         self.command = command
         self.powershell = powershell

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -19,8 +19,9 @@
 package-name: apache-airflow-providers-microsoft-psrp
 name: PowerShell Remoting Protocol (PSRP)
 description: |
+    This package provides remote execution capabilities via the
     `PowerShell Remoting Protocol (PSRP)
-    <https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/>`__
+    <https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/>`__.
 
 versions:
   - 1.0.1

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -27,7 +27,7 @@ versions:
   - 1.0.0
 
 additional-dependencies:
-  - pypsrp>=0.5.0
+  - pypsrp>=0.7.0
 
 integrations:
   - integration-name: Windows PowerShell Remoting Protocol

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -27,7 +27,7 @@ versions:
   - 1.0.0
 
 additional-dependencies:
-  - pypsrp>=0.7.0
+  - pypsrp>=0.5.0
 
 integrations:
   - integration-name: Windows PowerShell Remoting Protocol

--- a/airflow/providers/microsoft/psrp/provider.yaml
+++ b/airflow/providers/microsoft/psrp/provider.yaml
@@ -28,7 +28,7 @@ versions:
   - 1.0.0
 
 additional-dependencies:
-  - pypsrp>=0.5.0
+  - pypsrp>=0.8.0
 
 integrations:
   - integration-name: Windows PowerShell Remoting Protocol

--- a/docs/apache-airflow-providers-microsoft-psrp/index.rst
+++ b/docs/apache-airflow-providers-microsoft-psrp/index.rst
@@ -24,6 +24,12 @@ Content
 
 .. toctree::
     :maxdepth: 1
+    :caption: Guides
+
+    Operators <operators/index>
+
+.. toctree::
+    :maxdepth: 1
     :caption: References
 
     Python API <_api/airflow/providers/microsoft/psrp/index>

--- a/docs/apache-airflow-providers-microsoft-psrp/index.rst
+++ b/docs/apache-airflow-providers-microsoft-psrp/index.rst
@@ -78,8 +78,8 @@ PIP requirements
 =============  ==================
 PIP package    Version required
 =============  ==================
-``pypsrp``     ``>=0.5.0``
-``pypsrp``     ``~=0.5``
+``pypsrp``     ``>=0.8.0``
+``pypsrp``     ``~=0.8``
 =============  ==================
 
 .. include:: ../../airflow/providers/microsoft/psrp/CHANGELOG.rst

--- a/docs/apache-airflow-providers-microsoft-psrp/operators/index.rst
+++ b/docs/apache-airflow-providers-microsoft-psrp/operators/index.rst
@@ -1,0 +1,99 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+Microsoft PSRP Operators
+=======================================
+
+The
+`PowerShell Remoting Protocol (PSRP)
+<https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-psrp/>`__
+protocol is required whenever a user wants to execute commands on a Windows
+server from a client using a native PowerShell runspace.
+
+The :class:`~airflow.providers.microsoft.psrp.operators.psrp.PsrpOperator`
+operator implements such client capabilities, enabling the
+scheduling of Windows jobs from Airflow. Internally, it makes use of
+the `pypsrp <https://pypi.org/project/pypsrp/>`__ client library.
+
+Compared to
+:class:`~airflow.providers.microsoft.winrm.operators.winrm.WinRMOperator`,
+using PSRP extends the remoting capabilities in Windows, providing
+better session control and close integration with the PowerShell
+ecosystem (i.e., .NET Runspace interface):
+
+* Run multiple commands in a single session
+* Reuse the runspace to create multiple sessions
+* Work with PowerShell objects instead of just text
+* Use constrained endpoints using JEA (Just-Enough-Administration)
+* Ability to use the .NET Runspace interface
+
+
+Using the Operator
+^^^^^^^^^^^^^^^^^^
+
+When instantiating the
+:class:`~airflow.providers.microsoft.psrp.operators.psrp.PsrpOperator`
+operator, you must provide a cmdlet, command or script using one of the
+following named arguments:
+
+.. list-table:: Provide one of the following arguments to the operator
+   :widths: 10 15 20
+   :header-rows: 1
+
+   * - Argument name
+     - Description
+     - Examples
+   * - cmdlet
+     - Invoke a PowerShell cmdlet.
+     - ``Copy-Item``, ``Restart-Computer``
+   * - command
+     - Carries out the specified command using the
+       `cmd <https://docs.microsoft.com/en-us/windows-server/
+       administration/windows-commands/cmd>`__ command interpreter.
+     - ``robocopy C:\Logfiles\* C:\Drawings /S /E``
+   * - powershell
+     - Run a PowerShell script.
+     - ``Copy-Item -Path "C:\Logfiles\*" -Destination "C:\Drawings" -Recurse``
+
+
+Output
+######
+
+When using one of the PowerShell arguments (i.e., ``cmdlet`` or
+``powershell``), the session output is converted to JSON using the
+``ConvertTo-Json`` cmdlet and then decodes on the client-side such that
+the value is compatible with :doc:`XComs
+<apache-airflow:concepts/xcoms>`.
+
+
+Secure strings
+##############
+
+The operator adds a template filter ``securestring`` which will encrypt
+the value and make it available in the remote session as a
+`SecureString
+<https://docs.microsoft.com/en-us/dotnet/api/system.security.securestring>`__
+type. This ensures for example that the value is not accidentally
+logged.
+
+Using the template filter requires the DAG to be configured to
+:ref:`render fields as native objects
+<concepts:templating-native-objects>` (the default is to coerce all
+values into strings which won't work here because we need a value
+which has been tagged to be serialized as a secure string). Use
+``render_template_as_native_obj=True`` to enable this.

--- a/docs/apache-airflow-providers-microsoft-psrp/operators/index.rst
+++ b/docs/apache-airflow-providers-microsoft-psrp/operators/index.rst
@@ -74,11 +74,23 @@ following named arguments:
 Output
 ######
 
-When using one of the PowerShell arguments (i.e., ``cmdlet`` or
-``powershell``), the session output is converted to JSON using the
-``ConvertTo-Json`` cmdlet and then decodes on the client-side such that
-the value is compatible with :doc:`XComs
-<apache-airflow:concepts/xcoms>`.
+PowerShell provides multiple output streams.
+
+In general, the operator logs a record using the built-in logging
+mechanism for records that arrive on these streams using a job status
+polling mechanism. The success stream (i.e., stdout or shell output)
+is handled differently, as explained in the following:
+
+When :doc:`XComs <apache-airflow:concepts/xcoms>` are enabled and when
+the operator is used with a native PowerShell cmdlet or script, the
+shell output is converted to JSON using the ``ConvertTo-Json`` cmdlet
+and then decoded on the client-side by the operator such that the
+operator's return value is compatible with the serialization required
+by XComs.
+
+When XComs are not enabled (that is, ``do_xcom_push`` is set to
+false), the shell output is instead logged like the other output
+streams and will appear in the task instance log.
 
 
 Secure strings

--- a/docs/apache-airflow/concepts/operators.rst
+++ b/docs/apache-airflow/concepts/operators.rst
@@ -148,6 +148,8 @@ You can pass custom options to the Jinja ``Environment`` when creating your DAG.
 
 See the `Jinja documentation <https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment>`_ to find all available options.
 
+.. _concepts:templating-native-objects:
+
 Rendering Fields as Native Python Objects
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1196,6 +1196,7 @@ reidentify
 reinit
 reinitialization
 relativedelta
+remoting
 renewer
 replicaSet
 repo

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1224,6 +1224,7 @@ rtype
 ru
 runAsUser
 runnable
+runspace
 runtime
 sagemaker
 salesforce

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1245,6 +1245,7 @@ sdk
 secretRef
 secretRefs
 securable
+securestring
 securityManager
 seealso
 seedlist

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -575,6 +575,7 @@ cloudwatch
 cls
 cmake
 cmd
+cmdlet
 cmdline
 cmds
 cname

--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,7 @@ presto = [
     pandas_requirement,
 ]
 psrp = [
-    'pypsrp~=0.5',
+    'pypsrp~=0.7',
 ]
 qubole = [
     'qds-sdk>=1.10.4',

--- a/setup.py
+++ b/setup.py
@@ -450,7 +450,7 @@ presto = [
     pandas_requirement,
 ]
 psrp = [
-    'pypsrp~=0.7',
+    'pypsrp~=0.8',
 ]
 qubole = [
     'qds-sdk>=1.10.4',

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -73,7 +73,8 @@ def mock_powershell_factory():
 class TestPSRPHook(TestCase):
     @parameterized.expand([(False,), (True,)])
     def test_invoke(self, log_info, runspace_pool, powershell, ws_man, logging):
-        with PSRPHook(CONNECTION_ID, logging=logging) as hook:
+        runspace_options = {"connection_name": "foo"}
+        with PSRPHook(CONNECTION_ID, logging=logging, runspace_options=runspace_options) as hook:
             with hook.invoke() as ps:
                 assert ps.state == PSInvocationState.NOT_STARTED
             assert ps.state == PSInvocationState.COMPLETED
@@ -82,6 +83,7 @@ class TestPSRPHook(TestCase):
         assert not (logging ^ (call('%s', '<output>') in log_info.mock_calls))
         assert not (logging ^ (call('Information: %s', '<message>') in log_info.mock_calls))
         assert call('Invocation state: %s', 'Completed') in log_info.mock_calls
+        assert runspace_pool.call_args == call(ws_man.return_value, connection_name='foo')
 
     def test_invoke_cmdlet(self, *mocks):
         with PSRPHook(CONNECTION_ID, logging=False) as hook:

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -35,7 +35,7 @@ class MockPowerShell(MagicMock):
         super().__init__(*args, **kwargs)
         self.state = PSInvocationState.NOT_STARTED
 
-    def poll_invoke(self):
+    def poll_invoke(self, timeout=None):
         self.output.append("<output>")
         self.streams.debug.append(MagicMock(spec=InformationRecord, message_data="<message>"))
         self.state = PSInvocationState.COMPLETED

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -69,15 +69,9 @@ class MockPowerShell(MagicMock):
         )
 
         if self.had_errors:
-            # There seems to be cases where an error record does not have a
-            # message type; in this case, we match on the class name as a
-            # workaround.
-            class ErrorRecord(Mock):
-                pass
-
             self.streams.error.append(
-                ErrorRecord(
-                    MESSAGE_TYPE=None,
+                Mock(
+                    MESSAGE_TYPE=MessageType.ERROR_RECORD,
                     command_name="command",
                     message="error",
                     reason="reason",

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -141,3 +141,8 @@ class TestPSRPHook(TestCase):
         with PSRPHook(CONNECTION_ID, logging=False) as hook:
             ps = hook.invoke_powershell('foo')
             assert call('foo') in ps.add_script.mock_calls
+
+    def test_invoke_local_context(self, *mocks):
+        hook = PSRPHook(CONNECTION_ID, logging=False)
+        ps = hook.invoke_powershell('foo')
+        assert call('foo') in ps.add_script.mock_calls

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -142,8 +142,14 @@ class TestPsrpHook(TestCase):
         if logging_level is not None:
             options["logging_level"] = logging_level
 
+        on_output_callback = Mock()
+
         with PsrpHook(
-            CONNECTION_ID, runspace_options=runspace_options, wsman_options=wsman_options, **options
+            CONNECTION_ID,
+            runspace_options=runspace_options,
+            wsman_options=wsman_options,
+            on_output_callback=on_output_callback,
+            **options,
         ) as hook, patch.object(type(hook), "log") as logger:
             try:
                 with hook.invoke() as ps:
@@ -159,6 +165,7 @@ class TestPsrpHook(TestCase):
                 self.fail("Expected an error")
             assert ps.state == PSInvocationState.COMPLETED
 
+        assert on_output_callback.mock_calls == [call('output')]
         assert runspace_pool.return_value.__exit__.mock_calls == [call(None, None, None)]
         assert ws_man().__exit__.mock_calls == [call(None, None, None)]
         assert ws_man.call_args_list[0][1]["encryption"] == "auto"

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -102,7 +102,10 @@ class TestPSRPHook(TestCase):
         self, logging, log_debug, log_error, log_info, log_warning, runspace_pool, powershell, ws_man
     ):
         runspace_options = {"connection_name": "foo"}
-        with PSRPHook(CONNECTION_ID, logging=logging, runspace_options=runspace_options) as hook:
+        wsman_options = {"encryption": "auto"}
+        with PSRPHook(
+            CONNECTION_ID, logging=logging, runspace_options=runspace_options, wsman_options=wsman_options
+        ) as hook:
             with hook.invoke() as ps:
                 assert ps.state == PSInvocationState.NOT_STARTED
             assert ps.state == PSInvocationState.COMPLETED
@@ -113,6 +116,7 @@ class TestPSRPHook(TestCase):
 
         assert runspace_pool.return_value.__exit__.mock_calls == [call(None, None, None)]
         assert ws_man().__exit__.mock_calls == [call(None, None, None)]
+        assert ws_man.call_args_list[0][1]["encryption"] == "auto"
 
         def assert_log(f, *args):
             assert not (logging ^ (call(*args) in f.mock_calls))

--- a/tests/providers/microsoft/psrp/hooks/test_psrp.py
+++ b/tests/providers/microsoft/psrp/hooks/test_psrp.py
@@ -49,9 +49,11 @@ class MockPowerShell(MagicMock):
         self.output.append("output")
 
         def informational(message_type, message, **kwargs):
-            return Mock(MESSAGE_TYPE=message_type, command_name="command", message=message, **kwargs)
+            kwargs.setdefault("command_name", "command")
+            return Mock(MESSAGE_TYPE=message_type, message=message, **kwargs)
 
-        self.streams.debug.append(informational(MessageType.DEBUG_RECORD, "debug"))
+        self.streams.debug.append(informational(MessageType.DEBUG_RECORD, "debug1"))
+        self.streams.debug.append(informational(MessageType.DEBUG_RECORD, "debug2\r\n", command_name=None))
         self.streams.verbose.append(informational(MessageType.VERBOSE_RECORD, "verbose"))
         self.streams.warning.append(informational(MessageType.WARNING_RECORD, "warning"))
         self.streams.information.append(
@@ -165,7 +167,8 @@ class TestPsrpHook(TestCase):
         def assert_log(level, *args):
             assert call.log(level, *args) in logger.method_calls
 
-        assert_log(DEBUG, '%s: %s', 'command', 'debug')
+        assert_log(DEBUG, '%s: %s', 'command', 'debug1')
+        assert_log(DEBUG, '%s', 'debug2')
         assert_log(ERROR, '%s: %s', 'command', 'error')
         assert_log(INFO, '%s: %s', 'command', 'verbose')
         assert_log(WARNING, '%s: %s', 'command', 'warning')

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -68,7 +68,7 @@ class TestPsrpOperator(TestCase):
     @patch(f"{PsrpOperator.__module__}.PsrpHook")
     def test_execute(self, parameter, had_errors, do_xcom_push, hook):
         kwargs = {parameter.name: "foo"}
-        if parameter[2]:
+        if parameter.expected_parameters:
             kwargs["parameters"] = parameter.expected_parameters
         psrp_session_init = Mock(spec=Command)
         op = PsrpOperator(
@@ -92,11 +92,11 @@ class TestPsrpOperator(TestCase):
         expected_ps_calls = [
             call.add_command(psrp_session_init),
             call.add_statement(),
-            parameter[1],
+            parameter.expected_method,
         ]
         if parameter.expected_parameters:
             expected_ps_calls.extend([call.add_parameters({'bar': 'baz'})])
-        if do_xcom_push:
+        if parameter.name in ("cmdlet", "powershell") and do_xcom_push:
             expected_ps_calls.append(
                 call.add_cmdlet('ConvertTo-Json'),
             )

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -91,7 +91,6 @@ class TestPsrpOperator(TestCase):
             assert output == [json.loads(output) for output in ps.output] if do_xcom_push else ps.output
         expected_ps_calls = [
             call.add_command(psrp_session_init),
-            call.add_statement(),
             parameter.expected_method,
         ]
         if parameter.expected_parameters:

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -35,6 +35,10 @@ class TestPSRPOperator(TestCase):
         with pytest.raises(ValueError, match=exception_msg):
             PSRPOperator(task_id='test_task_id', psrp_conn_id=CONNECTION_ID)
 
+    def test_cmdlet_task_id_default(self):
+        operator = PSRPOperator(cmdlet='Invoke-Foo', psrp_conn_id=CONNECTION_ID)
+        assert operator.task_id == 'Invoke-Foo'
+
     @parameterized.expand(
         list(
             product(

--- a/tests/providers/microsoft/psrp/operators/test_psrp.py
+++ b/tests/providers/microsoft/psrp/operators/test_psrp.py
@@ -89,7 +89,7 @@ class TestPsrpOperator(TestCase):
         else:
             output = op.execute(None)
             assert output == [json.loads(output) for output in ps.output] if do_xcom_push else ps.output
-            is_logged = hook_impl.mock_calls[0].kwargs["on_output_callback"] == op.log.info
+            is_logged = hook_impl.call_args[1]['on_output_callback'] == op.log.info
             assert do_xcom_push ^ is_logged
         expected_ps_calls = [
             call.add_command(psrp_session_init),


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

## Overview

This pull request represents a significant increment in the functionality of the PSRP provider.

## Hook

A method `invoke_cmdlet` has been added in addition to the existing `invoke_powershell` to `PsrpHook` – but it also provides a more general `invoke` method which works as a context manager such that you can build up your own command pipelines.
```python
with PsrpHook(...) as hook, hook.invoke() as ps:
    # Use `ps` to build up commands; upon exiting the context,
    # the commands will be sent to the host for execution.
```

The hook now logs records arriving in all six streams (see `pypsrp.powershell.PSDataStreams`).

- DEBUG
- ERROR
- INFORMATION
- PROGRESS
- VERBOSE
- WARNING

## Operator

A "cmdlet" parameter has also been added to `PsrpOperator` for convenience.

This is useful in particular when the session type is "RestrictedRemoteServer" (i.e., "NoLanguage" mode) where typically only a constrained et of cmdlets (e.g., "Restart-Server") are configured as _visible_.

### JSON result

When using XComs (and for PowerShell commands only, i.e., `cmdlet` and `script`), the operator always pipes the result via `ConvertTo-Json` in order to return a result that is compatible with XCom serialization.

If not using XComs, the output is just logged like any of the other streams.

### Template support for secure string

A template filter `securestring` has been added to the operator to conveniently tag a secret value for serialization into the `System.SecureString` PowerShell native type. Note that this works only with the native environment – see [rendering fields as native Python objects](https://airflow.apache.org/docs/apache-airflow/stable/concepts/operators.html#rendering-fields-as-native-python-objects).

Example:
```python
{{ conn.test_conn.password | securestring }}
```

## Additional changes

- Configuration of WSMan and Runspace settings via connection profile
- Documentation
- Improved docstrings
- Ability to configure logging level for streams (defaults to include everything)
- Exchanges session keys by default to enable transfer of secure strings
- Optional session initialization hook