### PR TITLE
Upload provider distribution artifacts during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -608,7 +608,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         uses: actions/upload-artifact@v2
         with:
           name: airflow-provider-packages
-          path: "./dist/apache_airflow_providers_*.tar.gz"
+          path: "./dist/apache-airflow-providers-*.tar.gz"
           retention-days: 1
 
   tests-helm:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,6 @@ jobs:
       - run: yarn --cwd airflow/ui/ install --frozen-lockfile --non-interactive
       - run: yarn --cwd airflow/ui/ run test
 
-
   tests-www:
     timeout-minutes: 10
     name: React WWW tests
@@ -283,6 +282,7 @@ jobs:
           key: ${{ runner.os }}-ui-node-modules-${{ hashFiles('airflow/ui/**/yarn.lock') }}
       - run: yarn --cwd airflow/www/ install --frozen-lockfile --non-interactive
       - run: yarn --cwd airflow/www/ run test
+
 
   test-openapi-client-generation:
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,6 +260,7 @@ jobs:
       - run: yarn --cwd airflow/ui/ install --frozen-lockfile --non-interactive
       - run: yarn --cwd airflow/ui/ run test
 
+
   tests-www:
     timeout-minutes: 10
     name: React WWW tests
@@ -282,7 +283,6 @@ jobs:
           key: ${{ runner.os }}-ui-node-modules-${{ hashFiles('airflow/ui/**/yarn.lock') }}
       - run: yarn --cwd airflow/www/ install --frozen-lockfile --non-interactive
       - run: yarn --cwd airflow/www/ run test
-
 
   test-openapi-client-generation:
     timeout-minutes: 10
@@ -563,7 +563,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         env:
           USE_AIRFLOW_VERSION: "2.1.0"
           PACKAGE_FORMAT: "wheel"
-          
+
   prepare-test-provider-packages-sdist:
     timeout-minutes: 40
     name: "Build and test provider packages sdist"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,12 +563,6 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         env:
           USE_AIRFLOW_VERSION: "2.1.0"
           PACKAGE_FORMAT: "wheel"
-      - name: "Upload wheel artifacts"
-        uses: actions/upload-artifact@v2
-        with:
-          name: airflow-wheels
-          path: "./dist/*.whl"
-          retention-days: 1
           
   prepare-test-provider-packages-sdist:
     timeout-minutes: 40
@@ -610,6 +604,12 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         env:
           USE_AIRFLOW_VERSION: "sdist"
           PACKAGE_FORMAT: "sdist"
+      - name: "Upload provider distribution artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: airflow-provider-packages
+          path: "./dist/apache_airflow_providers_*.tar.gz"
+          retention-days: 1
 
   tests-helm:
     timeout-minutes: 40

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,13 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         env:
           USE_AIRFLOW_VERSION: "2.1.0"
           PACKAGE_FORMAT: "wheel"
-
+      - name: "Upload wheel artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: airflow-wheels
+          path: "./dist/*.whl"
+          retention-days: 1
+          
   prepare-test-provider-packages-sdist:
     timeout-minutes: 40
     name: "Build and test provider packages sdist"


### PR DESCRIPTION
This adds "./dist/apache_airflow_providers_*.tar.gz" into a build artifact bundle "airflow-providers".

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
