### PR TITLE
Fix OOM error in tests when using public Github Runners.

### DIFF
--- a/tests/dag_processing/test_manager.py
+++ b/tests/dag_processing/test_manager.py
@@ -26,6 +26,7 @@ import sys
 import threading
 import unittest
 from datetime import datetime, timedelta
+from logging.config import dictConfig
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 from unittest import mock
@@ -34,6 +35,7 @@ from unittest.mock import MagicMock, PropertyMock
 import pytest
 from freezegun import freeze_time
 
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.configuration import conf
 from airflow.dag_processing.manager import (
     DagFileProcessorAgent,
@@ -111,6 +113,7 @@ class FakeDagFileProcessorRunner(DagFileProcessorProcess):
 
 class TestDagFileProcessorManager:
     def setup_method(self):
+        dictConfig(DEFAULT_LOGGING_CONFIG)
         clear_db_runs()
         clear_db_serialized_dags()
         clear_db_dags()

--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -24,6 +24,7 @@ from unittest import mock
 import psutil
 import pytest
 
+from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
 from airflow.jobs.local_task_job import LocalTaskJob
 from airflow.models.dagbag import DagBag
 from airflow.models.taskinstance import TaskInstance
@@ -69,6 +70,7 @@ class TestStandardTaskRunner:
         airflow_logger = logging.getLogger('airflow')
         airflow_logger.handlers = []
         clear_db_runs()
+        dictConfig(DEFAULT_LOGGING_CONFIG)
 
     def test_start_and_terminate(self):
         local_task_job = mock.Mock()


### PR DESCRIPTION
There was a side effect caused by th TestStandardRunner 
test that caused broken logging configuration,
which in turn created OutOfMemory condition for our Public
GitHubRunners.

The problem was that the test overrode the configuration of
logging with some simple test configuration, but never restored
the default configuration, which resulted in `airflow.processor`
logger that was created before contain empty handlers. Since
the `airflow.processor` logger has "propagate" set to False,
empty handlers normally cause a lastResort handler call, which
by default redirects everything to Stderr and this is what
happened in DagFile Processor tests. However, DagFileProcessor
uses `stderr_redirect` which replaces `sys.stderr` with provided
stream. In this case however the stream set (StreamLogWriter)
redirected the output to "airflow.processor" logger - which in
turn (as last resort) redirected everything to sys.stderr which
in turn redirected everything to "airflow.processor" logger etc.

This resulted in:

* OOM condition in Public GitHub Runners
* DagFileProcessor failing with exceeded recursion depth when
  there was enough memory to get there.

The condition was triggered by two preceding tests:

1) First test_plugins_manger.py initialized logging for
   `airflow.processor` and stored it in logging manager
2) The TestStandardTaskRunner test applied simpler configuration
   but the way configure() works - it did not remove the
   "airflow.processor" logger, but it REMOVED all handlers
   registered for it - and never restored the default configuration
3) The DagFileProcessor logs caused infinite recursion

The fix is two-fold:

* the TestStandardTaskRunner restores default config after test
* the DagFileProcessor sets default config before starting

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
