### PR TITLE
Bring back Core and Other tests to be run in parallel

### DIFF
--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -92,16 +92,6 @@ function run_all_test_types_in_parallel() {
             test_types_to_run="${test_types_to_run//Integration/}"
             sequential_tests+=("Integration")
         fi
-        if [[ ${test_types_to_run} == *"Core"* ]]; then
-            echo "${COLOR_YELLOW}Remove Core from tests_types_to_run and add them to sequential tests due to low memory.${COLOR_RESET}"
-            test_types_to_run="${test_types_to_run//Core/}"
-            sequential_tests+=("Core")
-        fi
-        if [[ ${test_types_to_run} == *"Other"* ]]; then
-            echo "${COLOR_YELLOW}Remove Other from tests_types_to_run and add them to sequential tests due to low memory.${COLOR_RESET}"
-            test_types_to_run="${test_types_to_run//Other/}"
-            sequential_tests+=("Other")
-        fi
         if [[ ${BACKEND} == "mssql" || ${BACKEND} == "mysql" ]]; then
             # For mssql/mysql - they take far more memory than postgres (or sqlite) - we skip the Provider
             # tests altogether as they take too much memory even if run sequentially.


### PR DESCRIPTION
After merging #19809 we can very likely come back to parallel
running of Core and Other tests as we separated them out
thinking that the parallel runs were the cause of the problems.

Those tests should be perfectly fine to run in parallel now.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
