### PR TITLE
Fix PATH export in breeze tmux sessions

### DIFF
--- a/scripts/in_container/bin/run_tmux
+++ b/scripts/in_container/bin/run_tmux
@@ -33,6 +33,11 @@ fi
 mkdir -p ~/.tmux/tmp
 chmod 777 -R ~/.tmux/tmp
 
+# Creating a new tmux session (below) will start a new login shell and /etc/profile
+# will overwrite the custom Dockerfile PATH variable. Adding the custom PATH export
+# to home directory profile here will take precedence.
+echo "export PATH=$PATH" >> ~/.profile
+
 # Set Session Name
 export TMUX_SESSION="Airflow"
 


### PR DESCRIPTION
## Issue
I went to use the `install_aws.sh` script inside breeze (see [docs here](https://github.com/apache/airflow/blob/main/BREEZE.rst#additional-tools)) which are supposed to be on the PATH within breeze to easily execute them:
> Each script is also available in $PATH, so just type install_<TAB> to get a list of tools.

Though when I attempted to use the script it was not found on the PATH. The PATH should be what's exported [here in Dockerfile.ci](https://github.com/apache/airflow/blob/adc6bbfee397ce7f2cc3206ef8e77bf0f74715d6/Dockerfile.ci#L374). 
The below screenshot shows what was actually present in Breeze (as well as a snippet of the `/etc/profile` script which is overwriting it), this is not the exported value from Dockerfile.ci:
![Screenshot from 2021-11-23 19-48-07](https://user-images.githubusercontent.com/65743084/143171726-1ef1f69a-a858-4032-8f84-6f8242ba7b05.png)

## Fix
In the start_tmux script, export the PATH (which is correctly set within the container when executing the start_tmux script) into the ~/.profile file (so that it is shell agnostic).
With this change the correct path is present in Breeze:
![Screenshot from 2021-11-23 20-06-33](https://user-images.githubusercontent.com/65743084/143173177-83b64d3c-51b4-452c-be9b-aa126bb893b4.png)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---


**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
