### PR TITLE
Avoid using Proxy in subscript type alias

### DIFF
--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -26,10 +26,8 @@ import lazy_object_proxy
 
 from airflow.macros import hive  # noqa
 
-TemplateStringInput = Union[str, lazy_object_proxy.Proxy]
 
-
-def ds_add(ds: TemplateStringInput, days: int) -> str:
+def ds_add(ds: Union[str, lazy_object_proxy.Proxy], days: int) -> str:
     """
     Add or subtract days from a YYYY-MM-DD
 
@@ -49,7 +47,7 @@ def ds_add(ds: TemplateStringInput, days: int) -> str:
     return dt.strftime("%Y-%m-%d")
 
 
-def ds_format(ds: TemplateStringInput, input_format: str, output_format: str) -> str:
+def ds_format(ds: Union[str, lazy_object_proxy.Proxy], input_format: str, output_format: str) -> str:
     """
     Takes an input string and outputs another string
     as specified in the output format


### PR DESCRIPTION
This should fix main.

Python's pickle module (or typing?) seems to have a bug when `lazy_object_proxy.Proxy` is used in a subscript type (such as Union). `pickle` would somehow incorrectly try to look up the Proxy type in
`builtin` during pickling, causing an exception.

Since this global variable being pickled is only a type alias and not really functionally significant, we can work around the bug by simply not introducing that alias in the first place.

I’ll try to come up with a more minimal example to reproduce the issue and report this to CPython. :)
