### PR TITLE
Refactor DatabricksHook

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -256,6 +256,20 @@ class DatabricksHook(BaseHook):
         return headers
 
     @staticmethod
+    def _is_aad_token_valid(aad_token: dict) -> bool:
+        """
+        Utility function to check AAD token hasn't expired yet
+        :param aad_token: dict with properties of AAD token
+        :type aad_token: dict
+        :return: true if token is valid, false otherwise
+        :rtype: bool
+        """
+        now = int(time.time())
+        if aad_token['expires_on'] > (now + TOKEN_REFRESH_LEAD_TIME):
+            return True
+        return False
+
+    @staticmethod
     def _check_azure_metadata_service() -> None:
         """
         Check for Azure Metadata Service
@@ -519,20 +533,6 @@ class DatabricksHook(BaseHook):
         :type json: dict
         """
         self._do_api_call(UNINSTALL_LIBS_ENDPOINT, json)
-
-    @staticmethod
-    def _is_aad_token_valid(aad_token: dict) -> bool:
-        """
-        Utility function to check AAD token hasn't expired yet
-        :param aad_token: dict with properties of AAD token
-        :type aad_token: dict
-        :return: true if token is valid, false otherwise
-        :rtype: bool
-        """
-        now = int(time.time())
-        if aad_token['expires_on'] > (now + TOKEN_REFRESH_LEAD_TIME):
-            return True
-        return False
 
 
 def _retryable_error(exception) -> bool:

--- a/tests/providers/databricks/hooks/test_databricks.py
+++ b/tests/providers/databricks/hooks/test_databricks.py
@@ -32,6 +32,7 @@ from airflow.models import Connection
 from airflow.providers.databricks.hooks.databricks import (
     AZURE_DEFAULT_AD_ENDPOINT,
     AZURE_MANAGEMENT_ENDPOINT,
+    AZURE_METADATA_SERVICE_TOKEN_URL,
     AZURE_TOKEN_SERVICE_URL,
     DEFAULT_DATABRICKS_SCOPE,
     SUBMIT_RUN_ENDPOINT,
@@ -772,3 +773,46 @@ class TestDatabricksHookAadTokenSpOutside(unittest.TestCase):
         assert kwargs['auth'].token == TOKEN
         assert kwargs['headers']['X-Databricks-Azure-Workspace-Resource-Id'] == '/Some/resource'
         assert kwargs['headers']['X-Databricks-Azure-SP-Management-Token'] == TOKEN
+
+
+class TestDatabricksHookAadTokenManagedIdentity(unittest.TestCase):
+    """
+    Tests for DatabricksHook when auth is done with AAD leveraging Managed Identity authentication
+    """
+
+    @provide_session
+    def setUp(self, session=None):
+        conn = session.query(Connection).filter(Connection.conn_id == DEFAULT_CONN_ID).first()
+        conn.host = HOST
+        conn.extra = json.dumps(
+            {
+                'use_azure_managed_identity': True,
+            }
+        )
+        session.commit()
+        self.hook = DatabricksHook()
+
+    @mock.patch('airflow.providers.databricks.hooks.databricks.requests')
+    def test_submit_run(self, mock_requests):
+        mock_requests.codes.ok = 200
+        mock_requests.get.side_effect = [
+            create_successful_response_mock({'compute': {'azEnvironment': 'AZUREPUBLICCLOUD'}}),
+            create_successful_response_mock(create_aad_token_for_resource(DEFAULT_DATABRICKS_SCOPE)),
+        ]
+        mock_requests.post.side_effect = [
+            create_successful_response_mock({'run_id': '1'}),
+        ]
+        status_code_mock = mock.PropertyMock(return_value=200)
+        type(mock_requests.post.return_value).status_code = status_code_mock
+        data = {'notebook_task': NOTEBOOK_TASK, 'new_cluster': NEW_CLUSTER}
+        run_id = self.hook.submit_run(data)
+
+        ad_call_args = mock_requests.method_calls[0]
+        assert ad_call_args[1][0] == AZURE_METADATA_SERVICE_TOKEN_URL
+        assert ad_call_args[2]['params']['api-version'] > '2018-02-01'
+        assert ad_call_args[2]['headers']['Metadata'] == 'true'
+
+        assert run_id == '1'
+        args = mock_requests.post.call_args
+        kwargs = args[1]
+        assert kwargs['auth'].token == TOKEN


### PR DESCRIPTION
related: PR #19736 and feature request #18999 

The PR intends to refactor `DatabricksHook` and related classes as a preparation step before introducing Deferrable Operator for Databricks.

Main points:
- Use `int` type for `run_id` and `job_id`. Databricks docs specifies it as integer. Also, actual responses from Databricks API return integer, not string.
- Fix filling AAD headers.
- Move AAD token validation into a separate function, covered with tests.
- Change initialisation of `RunState` - make it explicit that `run_state` might be None. Currently there's a tiny comment in the code telling that result_state might be None in case a job is still running.