### PR TITLE
Fix link in post-upgrade warnings message

### DIFF
--- a/airflow/www/templates/airflow/dags.html
+++ b/airflow/www/templates/airflow/dags.html
@@ -58,7 +58,7 @@
       metadatabase, and has moved them to <code>{{ moved_table_name }}</code> during the database migration
       to upgrade. Please inspect the moved data to decide whether you need to keep them, and manually drop
       the <code>{{ moved_table_name }}</code> table to dismiss this warning. Read more about it
-      in <a href={{ get_docs_url("installing/upgrading.html") }}><b>Upgrading</b></a>.
+      in <a href={{ get_docs_url("installation/upgrading.html") }}><b>Upgrading</b></a>.
     {% endcall %}
   {% endfor %}
   {{ super() }}


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
This PR fixes the link in the error message you get when Airflow finds incompatible data in the metadata database during upgrades.

The link to the docs pointed to a 404:
https://airflow.apache.org/docs/apache-airflow/2.2.2/installing/upgrading.html

The correct link should be:
https://airflow.apache.org/docs/apache-airflow/2.2.2/installation/upgrading.html


![image](https://user-images.githubusercontent.com/135472/143554206-ae44ffc6-a286-4f6d-b75c-24a7decc9376.png)

---

