### PR TITLE
Add missing description field to Pool schema(REST API)

### DIFF
--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -2357,6 +2357,13 @@ components:
           type: integer
           readOnly: true
           description: The number of free slots at the moment.
+        description:
+          type: string
+          description: |
+            The description of the pool.
+
+            *New in version 2.3.0*
+          nullable: true
 
     PoolCollection:
       type: object

--- a/airflow/api_connexion/schemas/pool_schema.py
+++ b/airflow/api_connexion/schemas/pool_schema.py
@@ -37,6 +37,7 @@ class PoolSchema(SQLAlchemySchema):
     running_slots = fields.Method("get_running_slots", dump_only=True)
     queued_slots = fields.Method("get_queued_slots", dump_only=True)
     open_slots = fields.Method("get_open_slots", dump_only=True)
+    description = auto_field()
 
     @staticmethod
     def get_occupied_slots(obj: Pool) -> int:

--- a/tests/api_connexion/endpoints/test_pool_endpoint.py
+++ b/tests/api_connexion/endpoints/test_pool_endpoint.py
@@ -79,6 +79,7 @@ class TestGetPools(TestBasePoolEndpoints):
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 128,
+                    "description": "Default pool",
                 },
                 {
                     "name": "test_pool_a",
@@ -87,6 +88,7 @@ class TestGetPools(TestBasePoolEndpoints):
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 3,
+                    "description": None,
                 },
             ],
             "total_entries": 2,
@@ -109,6 +111,7 @@ class TestGetPools(TestBasePoolEndpoints):
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 3,
+                    "description": None,
                 },
                 {
                     "name": "default_pool",
@@ -117,6 +120,7 @@ class TestGetPools(TestBasePoolEndpoints):
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 128,
+                    "description": "Default pool",
                 },
             ],
             "total_entries": 2,
@@ -214,6 +218,7 @@ class TestGetPool(TestBasePoolEndpoints):
             "running_slots": 0,
             "queued_slots": 0,
             "open_slots": 3,
+            "description": None,
         } == response.json
 
     def test_response_404(self):
@@ -274,7 +279,7 @@ class TestPostPool(TestBasePoolEndpoints):
     def test_response_200(self):
         response = self.client.post(
             "api/v1/pools",
-            json={"name": "test_pool_a", "slots": 3},
+            json={"name": "test_pool_a", "slots": 3, "description": "test pool"},
             environ_overrides={'REMOTE_USER': "test"},
         )
         assert response.status_code == 200
@@ -285,6 +290,7 @@ class TestPostPool(TestBasePoolEndpoints):
             "running_slots": 0,
             "queued_slots": 0,
             "open_slots": 3,
+            "description": "test pool",
         } == response.json
 
     def test_response_409(self, session):
@@ -366,6 +372,7 @@ class TestPatchPool(TestBasePoolEndpoints):
             "open_slots": 3,
             "running_slots": 0,
             "slots": 3,
+            "description": None,
         } == response.json
 
     @parameterized.expand(
@@ -459,6 +466,7 @@ class TestModifyDefaultPool(TestBasePoolEndpoints):
                     "open_slots": 3,
                     "running_slots": 0,
                     "slots": 3,
+                    "description": "Default pool",
                 },
             ),
             (
@@ -473,13 +481,17 @@ class TestModifyDefaultPool(TestBasePoolEndpoints):
                     "open_slots": 3,
                     "running_slots": 0,
                     "slots": 3,
+                    "description": "Default pool",
                 },
             ),
             (
                 "200 no update mask",
                 200,
                 "api/v1/pools/default_pool",
-                {"name": "default_pool", "slots": 3},
+                {
+                    "name": "default_pool",
+                    "slots": 3,
+                },
                 {
                     "occupied_slots": 0,
                     "queued_slots": 0,
@@ -487,6 +499,7 @@ class TestModifyDefaultPool(TestBasePoolEndpoints):
                     "open_slots": 3,
                     "running_slots": 0,
                     "slots": 3,
+                    "description": "Default pool",
                 },
             ),
         ]
@@ -541,6 +554,7 @@ class TestPatchPoolWithUpdateMask(TestBasePoolEndpoints):
             "running_slots": 0,
             "queued_slots": 0,
             "open_slots": expected_slots,
+            "description": None,
         } == response.json
 
     @parameterized.expand(

--- a/tests/api_connexion/schemas/test_pool_schemas.py
+++ b/tests/api_connexion/schemas/test_pool_schemas.py
@@ -44,6 +44,7 @@ class TestPoolSchema(unittest.TestCase):
             "running_slots": 0,
             "queued_slots": 0,
             "open_slots": 2,
+            "description": None,
         }
 
     @provide_session
@@ -73,6 +74,7 @@ class TestPoolCollectionSchema(unittest.TestCase):
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 3,
+                    "description": None,
                 },
                 {
                     "name": "test_pool_b",
@@ -81,6 +83,7 @@ class TestPoolCollectionSchema(unittest.TestCase):
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 3,
+                    "description": None,
                 },
             ],
             "total_entries": 2,

--- a/tests/api_connexion/test_basic_auth.py
+++ b/tests/api_connexion/test_basic_auth.py
@@ -75,6 +75,7 @@ class TestBasicAuth:
                     "running_slots": 0,
                     "queued_slots": 0,
                     "open_slots": 128,
+                    "description": "Default pool",
                 },
             ],
             "total_entries": 1,


### PR DESCRIPTION
The pool endpoint is missing the description field


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
