### PR TITLE
Avoid littering postgres server logs with "could not obtain lock" with HA schedulers

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -244,7 +244,7 @@ class SchedulerJob(BaseJob):
             # COMMIT/ROLLBACK)
             lock_acquired = session.execute(
                 text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
-                    id=DBLocks.SCHEDULER_CRITICAL_SECTION
+                    id=DBLocks.SCHEDULER_CRITICAL_SECTION.value
                 )
             ).scalar()
             if not lock_acquired:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import Collection, DefaultDict, Dict, Iterator, List, Optional, Tuple
 
-from sqlalchemy import and_, func, not_, or_, tuple_
+from sqlalchemy import and_, func, not_, or_, text, tuple_
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import load_only, selectinload
 from sqlalchemy.orm.session import Session, make_transient
@@ -234,7 +234,24 @@ class SchedulerJob(BaseJob):
         :type max_tis: int
         :return: list[airflow.models.TaskInstance]
         """
+        from airflow.utils.db import DBLocks
+
         executable_tis: List[TI] = []
+
+        if session.get_bind().dialect.name == "postgresql":
+            # Optimization: to avoid littering the DB errors of "ERROR: canceling statement due to lock
+            # timeout", try to take out a transactional advisory lock (unlocks automatically on
+            # COMMIT/ROLLBACK)
+            lock_acquired = session.execute(
+                text("SELECT pg_try_advisory_xact_lock(:id)").bindparams(
+                    id=DBLocks.SCHEDULER_CRITICAL_SECTION
+                )
+            ).scalar()
+            if not lock_acquired:
+                # Throw an error like the one that would happen with NOWAIT
+                raise OperationalError(
+                    "Failed to acquire advisory lock", params=None, orig=RuntimeError('55P03')
+                )
 
         # Get the pool settings. We get a lock on the pool rows, treating this as a "critical section"
         # Throws an exception if lock cannot be obtained, rather than blocking

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -995,8 +995,8 @@ class DBLocks(enum.IntEnum):
     """
     Cross-db Identifiers for advisory global database locks.
 
-    Postgres uses int64 lock ids so we use the integer value, MySQL uses names, so we use the ``_name_``
-    field.
+    Postgres uses int64 lock ids so we use the integer value, MySQL uses names, so we
+    call ``str()`, which is implemented using the ``_name_`` field.
     """
 
     MIGRATIONS = enum.auto()
@@ -1018,7 +1018,7 @@ def create_global_lock(session, lock: DBLocks, lock_timeout=1800):
         elif dialect.name == 'mysql' and dialect.server_version_info >= (5, 6):
             conn.execute(text("SELECT GET_LOCK(:id, :timeout)"), id=str(lock), timeout=lock_timeout)
         elif dialect.name == 'mssql':
-            # TODO: make locking works for MSSQL
+            # TODO: make locking work for MSSQL
             pass
 
         yield
@@ -1031,5 +1031,5 @@ def create_global_lock(session, lock: DBLocks, lock_timeout=1800):
         elif dialect.name == 'mysql' and dialect.server_version_info >= (5, 6):
             conn.execute(text("select RELEASE_LOCK(:id)"), id=str(lock))
         elif dialect.name == 'mssql':
-            # TODO: make locking works for MSSQL
+            # TODO: make locking work for MSSQL
             pass

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1001,6 +1001,7 @@ class DBLocks(enum.IntEnum):
 
     INIT = enum.auto()
     MIGRATIONS = enum.auto()
+    SCHEDULER_CRITICAL_SECTION = enum.auto()
 
     def __str__(self):
         return f"airflow_{self._name_}"

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -596,7 +596,7 @@ def initdb(session=None):
     if conf.getboolean('core', 'LOAD_DEFAULT_CONNECTIONS'):
         create_default_connections(session=session)
 
-    with create_global_lock(session=session, lock=DBLocks.INIT):
+    with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
 
         dagbag = DagBag()
         # Save DAGs in the ORM
@@ -999,7 +999,6 @@ class DBLocks(enum.IntEnum):
     field.
     """
 
-    INIT = enum.auto()
     MIGRATIONS = enum.auto()
     SCHEDULER_CRITICAL_SECTION = enum.auto()
 

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -1024,6 +1024,9 @@ def create_global_lock(session, lock: DBLocks, lock_timeout=1800):
 
         yield None
     finally:
+        # The session may have been "closed" (which is fine, the lock lasts more than a transaction) -- ensure
+        # we get a usable connection
+        conn = session.connection()
         if dialect.name == 'postgresql':
             conn.execute('SET LOCK_TIMEOUT TO DEFAULT')
             conn.execute(text('SELECT pg_advisory_unlock(:id)'), id=lock.value)

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -15,6 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import contextlib
+import enum
 import logging
 import os
 import time
@@ -52,7 +54,7 @@ from airflow.models import (  # noqa: F401
 from airflow.models.serialized_dag import SerializedDagModel  # noqa: F401
 
 # TODO: remove create_session once we decide to break backward compatibility
-from airflow.utils.session import create_global_lock, create_session, provide_session  # noqa: F401
+from airflow.utils.session import create_session, provide_session  # noqa: F401
 
 log = logging.getLogger(__name__)
 
@@ -594,7 +596,7 @@ def initdb(session=None):
     if conf.getboolean('core', 'LOAD_DEFAULT_CONNECTIONS'):
         create_default_connections(session=session)
 
-    with create_global_lock(session=session):
+    with create_global_lock(session=session, lock=DBLocks.INIT):
 
         dagbag = DagBag()
         # Save DAGs in the ORM
@@ -910,7 +912,7 @@ def upgradedb(session=None):
     if errors_seen:
         exit(1)
 
-    with create_global_lock(session=session, pg_lock_id=2, lock_name="upgrade"):
+    with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
         log.info("Creating tables")
         command.upgrade(config, 'heads')
     add_default_pool_if_not_exists()
@@ -923,7 +925,7 @@ def resetdb(session=None):
 
     connection = settings.engine.connect()
 
-    with create_global_lock(session=session, pg_lock_id=4, lock_name="reset"):
+    with create_global_lock(session=session, lock=DBLocks.MIGRATIONS):
         drop_airflow_models(connection)
         drop_flask_models(connection)
 
@@ -986,3 +988,46 @@ def check(session=None):
     """
     session.execute('select 1 as is_alive;')
     log.info("Connection successful.")
+
+
+@enum.unique
+class DBLocks(enum.IntEnum):
+    """
+    Cross-db Identifiers for advisory global database locks.
+
+    Postgres uses int64 lock ids so we use the integer value, MySQL uses names, so we use the ``_name_``
+    field.
+    """
+
+    INIT = enum.auto()
+    MIGRATIONS = enum.auto()
+
+    def __str__(self):
+        return f"airflow_{self._name_}"
+
+
+@contextlib.contextmanager
+def create_global_lock(session, lock: DBLocks, lock_timeout=1800):
+    """Contextmanager that will create and teardown a global db lock."""
+    conn = session.connection()
+    dialect = conn.dialect
+    try:
+        if dialect.name == 'postgresql':
+            conn.execute(text('SET LOCK_TIMEOUT to :timeout'), timeout=lock_timeout)
+            conn.execute(text('SELECT pg_advisory_lock(:id)'), id=lock.value)
+        elif dialect.name == 'mysql' and dialect.server_version_info >= (5, 6):
+            conn.execute(text("SELECT GET_LOCK(:id, :timeout)"), id=str(lock), timeout=lock_timeout)
+        elif dialect.name == 'mssql':
+            # TODO: make locking works for MSSQL
+            pass
+
+        yield None
+    finally:
+        if dialect.name == 'postgresql':
+            conn.execute('SET LOCK_TIMEOUT TO DEFAULT')
+            conn.execute(text('SELECT pg_advisory_unlock(:id)'), id=lock.value)
+        elif dialect.name == 'mysql' and dialect.server_version_info >= (5, 6):
+            conn.execute(text("select RELEASE_LOCK(:id)"), id=str(lock))
+        elif dialect.name == 'mssql':
+            # TODO: make locking works for MSSQL
+            pass


### PR DESCRIPTION
If you are running multiple schedulers on PostgreSQL, it is likely that sooner or later you will have one scheduler fail the race to enter the critical section (which is fine, and expected).

However this can end up spamming the DB logs with errors like this:

```
Nov 26 14:08:48 sinope postgres[709953]: 2021-11-26 14:08:48.672 GMT [709953] ERROR:  could not obtain lock on row in relation "slot_pool"
Nov 26 14:08:48 sinope postgres[709953]: 2021-11-26 14:08:48.672 GMT [709953] STATEMENT:  SELECT slot_pool.pool AS slot_pool_pool, slot_pool.slots AS slot_pool_slots
Nov 26 14:08:48 sinope postgres[709953]:         FROM slot_pool FOR UPDATE NOWAIT
Nov 26 14:08:49 sinope postgres[709954]: 2021-11-26 14:08:49.730 GMT [709954] ERROR:  could not obtain lock on row in relation "slot_pool"
Nov 26 14:08:49 sinope postgres[709954]: 2021-11-26 14:08:49.730 GMT [709954] STATEMENT:  SELECT slot_pool.pool AS slot_pool_pool, slot_pool.slots AS slot_pool_slots
Nov 26 14:08:49 sinope postgres[709954]:         FROM slot_pool FOR UPDATE NOWAIT
```

If you are really unlucky that can end up happening over and over and over again.

So to avoid this error, for PostgreSQL only, we first try to acquire an "advisory lock" (advisory because it's up to the application to respect it), and if we cannot raise an error _like_ would have happened from the `FOR UPDATE NOWAIT`.

(We still obtain the exclusive log on the pool rows so that the rows are locked.)

This PR is split in to two commits, the second obtains the lock, and the first commit refactors the existing global locks to use enums to remove magic constants as these (integer for postgres) lock ids are "global", so we need to be sure the scheduler's lock doesn't clash with the `db upgrade` lock.