### PR TITLE
Allow generating DAGs from JSON/YAML files using given builder python code

### DIFF
--- a/airflow/example_dags/example_yaml_builder.py
+++ b/airflow/example_dags/example_yaml_builder.py
@@ -1,0 +1,17 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils import dates
+
+
+def make_dag(yaml_config):
+
+    with DAG(
+        dag_id=f"example_yaml_dag_{yaml_config['id']}",
+        start_date=dates.days_ago(1),
+        schedule_interval=yaml_config['schedule']
+    ) as dag:
+        bash_task = BashOperator(
+            task_id='bash_task',
+            bash_command=yaml_config['command']
+        )
+    return dag

--- a/airflow/example_dags/example_yaml_dag.yaml
+++ b/airflow/example_dags/example_yaml_dag.yaml
@@ -1,0 +1,4 @@
+builder: example_yaml_builder.py
+id: 1
+command: sleep 5
+schedule: "* */2 * * *"

--- a/tests/dags/test_builder.py
+++ b/tests/dags/test_builder.py
@@ -1,0 +1,17 @@
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+from airflow.utils import dates
+
+
+def make_dag(config):
+
+    with DAG(
+        dag_id=f"generated_dag_{config['id']}",
+        start_date=dates.days_ago(1),
+        schedule_interval=config['schedule']
+    ) as dag:
+        bash_task = BashOperator(
+            task_id='bash_task',
+            bash_command=config['command']
+        )
+    return dag

--- a/tests/dags/test_json_dag.json
+++ b/tests/dags/test_json_dag.json
@@ -1,0 +1,6 @@
+{
+  "builder": "test_builder.py",
+  "id": "2",
+  "command": "sleep 10",
+  "schedule": "*/20 * * * *"
+}

--- a/tests/dags/test_yaml_dag.yaml
+++ b/tests/dags/test_yaml_dag.yaml
@@ -1,0 +1,4 @@
+builder: test_builder.py
+id: 1
+command: sleep 5
+schedule: "* */2 * * *"


### PR DESCRIPTION
Adds support for dynamically generating DAGs from configuration in JSON or YAML format. The JSON/YAML contains the mandatory `builder` parameter with the path to the python "template" file which would parse the configuration to emit a DAG.

This improves scalability of dynamic DAG loading methods, as Airflow now considers each config file in separate process (earlier if a single python script was reading multiple json/yaml files, they were all being processed in a single process, limiting scalability). If the json/yaml fails to parse, it's registered as an import error. It's the json/yaml content which shows up in webserver's Code view.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
