### PR TITLE
Fix broken anchors & syntax in MD files

### DIFF
--- a/airflow/providers/apache/beam/README.md
+++ b/airflow/providers/apache/beam/README.md
@@ -26,11 +26,9 @@ Release: 1.0.0
 
 - [Provider package](#provider-package)
 - [Installation](#installation)
-- [PIP requirements](#pip-requirements)
 - [Cross provider package dependencies](#cross-provider-package-dependencies)
 - [Provider class summary](#provider-classes-summary)
     - [Operators](#operators)
-    - [Transfer operators](#transfer-operators)
     - [Hooks](#hooks)
 - [Releases](#releases)
 

--- a/airflow/ui/README.md
+++ b/airflow/ui/README.md
@@ -68,4 +68,4 @@ yarn test
 
 ## Contributing
 
-Be sure to check out our [contribution guide](/docs/CONTRIBUTING.md)
+Be sure to check out our [contribution guide](docs/CONTRIBUTING.md)

--- a/airflow/ui/docs/CONTRIBUTING.md
+++ b/airflow/ui/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ the more confidence they can give you." Keep their [cheatsheet](https://testing-
 
 - Neutrino handles our App's configuration and Webpack build. Check out their [docs](https://neutrinojs.org/api/) if you need to customize it.
 
-- State management is handled with [Context](https://reactjs.org/docs/context.html) and [react-query](https://react-query.tanstack.com/). Context is used for App-level state that doesn't often change (authentication, dark/light mode). React Query handles all the state and side effects (loading, error, caching, etc.) of async data from the API.
+- State management is handled with [Context](https://reactjs.org/docs/context.html) and [react-query](https://react-query.tanstack.com/). Context is used for App-level state that doesn't change frequently (authentication, dark/light mode). React Query handles all the state and side effects (loading, error, caching, etc.) of async data from the API.
 
 ## Project Structure
 

--- a/airflow/ui/docs/CONTRIBUTING.md
+++ b/airflow/ui/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@ If you're new to modern frontend development or parts of our stack, you may want
 
 - TypeScript is an extension of javascript to add type-checking to our app. Files ending in `.ts` or `.tsx` will be type-checked. Check out the [handbook](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes-func.html) for an introduction or feel free to keep this [cheatsheet](https://github.com/typescript-cheatsheets/react) open while developing.
 
-- React powers our entire app so it would be valuable to learn JSX, the html-in-js templates React utilizes. Files that contain JSX will end in `.tsx` instead of `.ts`. Check out their official [tutorial](https://reactjs.org/tutorial/tutorial.html#overview) for a basic overview.
+- React powers our entire app, so it would be valuable to learn JSX, the html-in-js templates React utilizes. Files that contain JSX will end in `.tsx` instead of `.ts`. Check out their official [tutorial](https://reactjs.org/tutorial/tutorial.html#overview) for a basic overview.
 
 - Chakra-UI is our component library and theming system. You'll notice we have no traditional css nor html tags. This is all handled in Chakra with importing standard components like `<Box>` or `<Text>` that are styled globally in `src/theme.ts` file and then by passing styles as component props. Check out their [docs](https://chakra-ui.com/docs/getting-started) to see all the included components and hooks.
 
@@ -34,7 +34,7 @@ the more confidence they can give you." Keep their [cheatsheet](https://testing-
 
 - Neutrino handles our App's configuration and Webpack build. Check out their [docs](https://neutrinojs.org/api/) if you need to customize it.
 
-- State management is handled with [Context](https://reactjs.org/docs/context.html) and [react-query](https://react-query.tanstack.com/). Context is used for App-level state that doesn't change often (authentication, dark/light mode). React Query handles all the state and side effects (loading, error, caching, etc) of async data from the API.
+- State management is handled with [Context](https://reactjs.org/docs/context.html) and [react-query](https://react-query.tanstack.com/). Context is used for App-level state that doesn't often change (authentication, dark/light mode). React Query handles all the state and side effects (loading, error, caching, etc.) of async data from the API.
 
 ## Project Structure
 


### PR DESCRIPTION
`airflow/providers/apache/beam/README.md`: [PIP requirements] and [Transfer operators] don't have a section to connect to

`airflow/ui/README.md`: anchor had the wrong path leading to 404

`airflow/ui/docs/CONTRIBUTING.md`: minor syntax improvements