### PR TITLE
Allow the use of Stable API in the CLI

### DIFF
--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -28,13 +28,13 @@ class Client:
         if auth:
             self._session.auth = auth
 
-    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None):
+    def trigger_dag(self, *, dag_id, run_id=None, conf=None, execution_date=None, **kwargs):
         """Create a dag run for the specified dag.
 
-        :param dag_id:
-        :param run_id:
-        :param conf:
-        :param execution_date:
+        :param dag_id: The ID of the dag to run
+        :param run_id: The DagRun ID for the dag, generated if not specified
+        :param conf: a dictionary of configuration items to be passed into the DAG
+        :param execution_date: The execution date of the dag to run
         :return:
         """
         raise NotImplementedError()
@@ -42,7 +42,7 @@ class Client:
     def delete_dag(self, dag_id):
         """Delete all DB records related to the specified dag.
 
-        :param dag_id:
+        :param dag_id: the ID of the dag to be deleted
         """
         raise NotImplementedError()
 

--- a/airflow/api/client/stable_api_client.py
+++ b/airflow/api/client/stable_api_client.py
@@ -1,0 +1,114 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from json.decoder import JSONDecodeError
+from typing import Optional
+from urllib.parse import urljoin
+
+from airflow.api.client import api_client
+from airflow.models import DagRun
+from airflow.utils.state import State
+
+
+class AirflowClient(api_client.Client):
+    """API Client using the stable REST API"""
+
+    def _request(self, url, method='GET', json=None):
+        params = {
+            'url': url,
+        }
+        if json is not None:
+            params['json'] = json
+        resp = getattr(self._session, method.lower())(**params)
+        if resp.is_error:
+            # It is justified here because there might be many resp types.
+            try:
+                data = resp.json()
+            except Exception:
+                data = {}
+            raise OSError(data.get('error', 'Server error'))
+        try:  # DELETE requests doesn't return a value
+            return resp.json()
+        except JSONDecodeError:
+            return resp.text
+
+    def trigger_dag(
+        self, *, dag_id, run_id=None, conf=None, execution_date=None, logical_date=None, state=State.QUEUED
+    ):
+        endpoint = f'/api/v1/dags/{dag_id}/dagRuns'
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(
+            url,
+            method='POST',
+            json={
+                "dag_run_id": run_id,
+                "conf": conf or {},
+                "execution_date": execution_date,
+                "state": state,
+                "logical_date": logical_date,
+            },
+        )
+        return data
+
+    def delete_dag(self, dag_id):
+        endpoint = f'/api/v1/dags/{dag_id}'
+        url = urljoin(self._api_base_url, endpoint)
+        self._request(url, method='DELETE')
+        return f"DAG with dag_id: {dag_id} deleted"
+
+    def get_pool(self, name):
+        endpoint = f'/api/v1/pools/{name}'
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(url)
+        return data
+
+    def get_pools(self):
+        endpoint = '/api/v1/pools'
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(url)
+        return data
+
+    def create_pool(self, name, slots, description):
+        endpoint = '/api/v1/pools'
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(
+            url,
+            method='POST',
+            json={
+                'name': name,
+                'slots': slots,
+                'description': description,
+            },
+        )
+        return data
+
+    def delete_pool(self, name):
+        endpoint = f'/api/v1/pools/{name}'
+        url = urljoin(self._api_base_url, endpoint)
+        self._request(url, method='DELETE')
+        return f"Pool with name: {name} deleted"
+
+    def get_lineage(self, dag_id: str, execution_date: Optional[str] = None, run_id: Optional[str] = None):
+        if execution_date:
+            dr = DagRun.find(dag_id=dag_id, execution_date=execution_date, run_id=run_id)
+            if not dr:
+                raise ValueError(f"DagRun with dag_id={dag_id}, execution_date={execution_date} not found ")
+            run_id = dr.run_id
+        endpoint = f"/api/v1/dags/{dag_id}/dagRuns/{run_id}/lineage"
+        url = urljoin(self._api_base_url, endpoint)
+        data = self._request(url, method='GET')
+        return data

--- a/airflow/api_connexion/openapi/v1.yaml
+++ b/airflow/api_connexion/openapi/v1.yaml
@@ -749,6 +749,29 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
+  /dags/{dag_id}/dagRuns/{dag_run_id}/lineage:
+    parameters:
+      - $ref: '#/components/parameters/DAGID'
+      - $ref: '#/components/parameters/DAGRunID'
+    get:
+      summary: Get DAG lineage
+      x-openapi-router-controller: airflow.api_connexion.endpoints.dag_run_endpoint
+      operationId: getlineage
+      tags: [DAGRun]
+      responses:
+        '200':
+          description: Success.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lineage'
+        '401':
+          $ref: '#/components/responses/Unauthenticated'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
   /eventLogs:
     get:
       summary: List log entries
@@ -2203,6 +2226,17 @@ components:
               items:
                 $ref: '#/components/schemas/DAGRun'
         - $ref: '#/components/schemas/CollectionInfo'
+
+    Lineage:
+      type: object
+      description: |
+        Lineage of a DAG.
+
+        *New in version 2.3.0*
+      properties:
+        task_ids:
+          type: object
+          description: The lineage object.
 
     EventLog:
       type: object

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -146,7 +146,14 @@ class DagRunsBatchFormSchema(Schema):
     end_date_lte = fields.DateTime(load_default=None, validate=validate_istimezone)
 
 
+class LineageSchema(Schema):
+    """Lineage Schema"""
+
+    task_ids = fields.Dict(fields.Str(), fields.Dict())
+
+
 dagrun_schema = DAGRunSchema()
 dagrun_collection_schema = DAGRunCollectionSchema()
 set_dagrun_state_form_schema = SetDagRunStateFormSchema()
 dagruns_batch_form_schema = DagRunsBatchFormSchema()
+lineage_schema = LineageSchema()

--- a/tests/api/client/test_stable_api_client.py
+++ b/tests/api/client/test_stable_api_client.py
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pytest_httpx import HTTPXMock
+
+from airflow.api.client.stable_api_client import AirflowClient
+
+
+class TestStableAPIClient:
+    def setup_method(self):
+        self.client = AirflowClient(api_base_url='http://localhost:8080', auth=None)
+        self.base_url = 'http://localhost:8080/api/v1'
+
+    def test_trigger_dag(self, httpx_mock: HTTPXMock):
+        test_dag_id = "example_bash_operator"
+        run_id = "Test_Run_ID"
+        data = {"dag_run_id": run_id, "dag_id": test_dag_id, "conf": {}}
+        httpx_mock.add_response(url=f'{self.base_url}/dags/{test_dag_id}/dagRuns', json=data, method='POST')
+
+        # no execution date, execution date should be set automatically
+        assert self.client.trigger_dag(dag_id=test_dag_id) == data
+        assert self.client.trigger_dag(dag_id=test_dag_id, run_id=run_id) == data
+
+    def test_delete_dag(self, httpx_mock: HTTPXMock):
+        test_dag_id = "example_bash_operator"
+        text = f"DAG with dag_id: {test_dag_id} deleted"
+        httpx_mock.add_response(
+            url=f'{self.base_url}/dags/{test_dag_id}', method='DELETE', status_code=204, text=text
+        )
+        assert self.client.delete_dag(dag_id=test_dag_id) == text
+
+    def test_get_pool(self, httpx_mock: HTTPXMock):
+        name = "test_pool"
+        data = {'name': name, 'slots': 1, 'description': 'test pool'}
+        httpx_mock.add_response(url=f'{self.base_url}/pools/{name}', json=data, method='GET')
+        assert self.client.get_pool(name=name) == data
+
+    def test_get_pools(self, httpx_mock: HTTPXMock):
+        name = "test_pool"
+        data = [{'name': name, 'slots': 1, 'description': 'test pool'}]
+        httpx_mock.add_response(url=f'{self.base_url}/pools', json=data, method='GET')
+        assert self.client.get_pools() == data
+
+    def test_create_pool(self, httpx_mock: HTTPXMock):
+        name = "test_pool"
+        data = {'name': name, 'slots': 1, 'description': 'test pool'}
+        httpx_mock.add_response(url=f'{self.base_url}/pools', json=data, method='POST')
+        assert self.client.create_pool(name=name, slots=1, description='test pool') == data
+
+    def test_delete_pool(self, httpx_mock: HTTPXMock):
+        name = "test_pool"
+        text = f"Pool with name: {name} deleted"
+        httpx_mock.add_response(
+            url=f'{self.base_url}/pools/{name}', method='DELETE', status_code=204, text=text
+        )
+        assert self.client.delete_pool(name=name) == text
+
+    def test_lineage(self, httpx_mock: HTTPXMock):
+        dag_id = "example_bash_operator"
+        dag_run_id = "test_run_id"
+        httpx_mock.add_response(
+            url=f'{self.base_url}/dags/{dag_id}/dagRuns/{dag_run_id}/lineage', json={}, method='GET'
+        )
+        assert self.client.get_lineage(dag_id=dag_id, run_id=dag_run_id) == {}


### PR DESCRIPTION
The stable REST API is not used in the CLI while the deprecated experimental API
is. This PR adds a client for the stable REST API.

Also, `lineage` endpoint was added to the Stable REST API in the process.


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
