### PR TITLE
Add information about supported OS-es for Apache Airflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ using the latest stable version of SQLite for local development.
 
 **Note**: Python v3.10 is not supported yet. For details, see [#19059](https://github.com/apache/airflow/issues/19059).
 
+**Note**: Airflow currently can be run on POSIX-compliant Operating Systems. For development it is regularly
+tested on fairly modern Linux Distros and recent versions of MacOS.
+On Windows you can run it via WSL2 (Windows Subsystem for Linux 2) or via Linux Containers.
+The work to add Windows support is tracked via [#10388](https://github.com/apache/airflow/issues/10388) but
+it is not a high priority. You should only use Linux-based distros as "Production" execution environment
+as this is the only environment that is supported. The only distro that is used in our CI tests and that
+is used in the [Community managed DockerHub image](https://hub.docker.com/p/apache/airflow) is
+`Debian Buster`.
+
 ## Getting started
 
 Visit the official Airflow website documentation (latest **stable** release) for help with

--- a/docs/apache-airflow/installation/prerequisites.rst
+++ b/docs/apache-airflow/installation/prerequisites.rst
@@ -43,3 +43,12 @@ Starting with Airflow 2.1.2, Airflow is tested with Python 3.6, 3.7, 3.8, and 3.
 
 The minimum memory required we recommend Airflow to run with is 4GB, but the actual requirements depends
 wildly on the deployment options you have
+
+**Note**: Airflow currently can be run on POSIX-compliant Operating Systems. For development it is regularly
+tested on fairly modern Linux Distros and recent versions of MacOS.
+On Windows you can run it via WSL2 (Windows Subsystem for Linux 2) or via Linux Containers.
+The work to add Windows support is tracked via `#10388 <https://github.com/apache/airflow/issues/10388>`__ but
+it is not a high priority. You should only use Linux-based distros as "Production" execution environment
+as this is the only environment that is supported. The only distro that is used in our CI tests and that
+is used in the `Community managed DockerHub image <https://hub.docker.com/p/apache/airflow>`__ is
+``Debian Buster``.


### PR DESCRIPTION
While answering some Stack Overflow questions I found and was
generally very surprised that we do not mention POSIX compliance
and "only use Linux for production" in our prerequisites.

This PR adds a note about it - both in GitHub and in our installation
prerequisites.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
