### PR TITLE
Workaround occasional deadlocks with MSSQL

### DIFF
--- a/airflow/utils/retries.py
+++ b/airflow/utils/retries.py
@@ -21,7 +21,7 @@ from inspect import signature
 from typing import Any, Optional
 
 import tenacity
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError, OperationalError
 
 from airflow.configuration import conf
 
@@ -32,7 +32,7 @@ def run_with_db_retries(max_retries: int = MAX_DB_RETRIES, logger: Optional[logg
     """Return Tenacity Retrying object with project specific default"""
     # Default kwargs
     retry_kwargs = dict(
-        retry=tenacity.retry_if_exception_type(exception_types=OperationalError),
+        retry=tenacity.retry_if_exception_type(exception_types=(OperationalError, DBAPIError)),
         wait=tenacity.wait_random_exponential(multiplier=0.5, max=5),
         stop=tenacity.stop_after_attempt(max_retries),
         reraise=True,


### PR DESCRIPTION
We already have a mechanism to retry operations that could result
in temporary deadlocks - this have been helpful with handling MySQL
deadlocks - however similar problems occur occasionally in MSSQL and
there we get a DBAPIError rather than OperationalError:

`sqlalchemy.exc.DBAPIError: (pyodbc.Error) ('40001', '[40001]
[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Transaction
(Process ID 55) was deadlocked on lock resources with another process
and has been chosen as the deadlock victim. Rerun the transaction.
(1205) (SQLExecDirectW)');

This PR adds DBAPIError to the list of errors that are handled
by `run_with_db_retries` to mitigate such occasional deadlocks.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
