### PR TITLE
Skip masking airflow password for tests

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -48,7 +48,7 @@ DEFAULT_SENSITIVE_FIELDS = frozenset(
 )
 """Names of fields (Connection extra, Variable key name etc.) that are deemed sensitive"""
 
-UNMASKED_SECRETS = {'airflow'}
+SKIP_MASKING_FOR_TESTS = {'airflow'}
 
 
 @cache
@@ -240,7 +240,7 @@ class SecretsMasker(logging.Filter):
             for k, v in secret.items():
                 self.add_mask(v, k)
         elif isinstance(secret, str):
-            if not secret or (test_mode and secret in UNMASKED_SECRETS):
+            if not secret or (test_mode and secret in SKIP_MASKING_FOR_TESTS):
                 return
             pattern = re.escape(secret)
             if pattern not in self.patterns and (not name or should_hide_value_for_key(name)):

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -17,7 +17,6 @@
 """Mask sensitive information from logs"""
 import collections
 import logging
-import os
 import re
 from typing import TYPE_CHECKING, Iterable, Optional, Set, TypeVar, Union
 
@@ -236,7 +235,7 @@ class SecretsMasker(logging.Filter):
     def add_mask(self, secret: Union[str, dict, Iterable], name: str = None):
         """Add a new secret to be masked to this filter instance."""
         from airflow.configuration import conf
-        
+
         test_mode: bool = conf.getboolean('core', 'unit_test_mode')
         if isinstance(secret, dict):
             for k, v in secret.items():

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -235,7 +235,7 @@ class SecretsMasker(logging.Filter):
 
     def add_mask(self, secret: Union[str, dict, Iterable], name: str = None):
         """Add a new secret to be masked to this filter instance."""
-        test_mode = os.environ["AIRFLOW__CORE__UNIT_TEST_MODE"]
+        test_mode = os.environ.get("AIRFLOW__CORE__UNIT_TEST_MODE")
         if isinstance(secret, dict):
             for k, v in secret.items():
                 self.add_mask(v, k)

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 """Mask sensitive information from logs"""
-import os
 import collections
 import logging
+import os
 import re
 from typing import TYPE_CHECKING, Iterable, Optional, Set, TypeVar, Union
 

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -48,7 +48,7 @@ DEFAULT_SENSITIVE_FIELDS = frozenset(
 )
 """Names of fields (Connection extra, Variable key name etc.) that are deemed sensitive"""
 
-SKIP_MASKING_FOR_TESTS = {'airflow'}
+SECRETS_TO_SKIP_MASKING_FOR_TESTS = {'airflow'}
 
 
 @cache
@@ -240,7 +240,7 @@ class SecretsMasker(logging.Filter):
             for k, v in secret.items():
                 self.add_mask(v, k)
         elif isinstance(secret, str):
-            if not secret or (test_mode and secret in SKIP_MASKING_FOR_TESTS):
+            if not secret or (test_mode and secret in SECRETS_TO_SKIP_MASKING_FOR_TESTS):
                 return
             pattern = re.escape(secret)
             if pattern not in self.patterns and (not name or should_hide_value_for_key(name)):

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -235,7 +235,9 @@ class SecretsMasker(logging.Filter):
 
     def add_mask(self, secret: Union[str, dict, Iterable], name: str = None):
         """Add a new secret to be masked to this filter instance."""
-        test_mode = os.environ.get("AIRFLOW__CORE__UNIT_TEST_MODE")
+        from airflow.configuration import conf
+        
+        test_mode: bool = conf.getboolean('core', 'unit_test_mode')
         if isinstance(secret, dict):
             for k, v in secret.items():
                 self.add_mask(v, k)


### PR DESCRIPTION
Current "airflow" password gets masked whenever mentioned in the logs.
This causes word "airflow" to be replaced with *** in the logs including folder path etc.

This causes issue in some tests that read logs.  
For example:
Test case: **tests.cli.commands.test_task_command.TestLogsfromTaskRunCommand**
It asserts for this value:
```
"INFO - Running: ['airflow', 'tasks', 'run'...."
```
but gets
```
"INFO - Running: ['***', 'tasks', 'run'..."
```
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
