### PR TITLE
Clarify behaviour of test_backfill_depends_on_past

### DIFF
--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -24,7 +24,6 @@ import threading
 from unittest.mock import patch
 
 import pytest
-from parameterized import parameterized
 
 from airflow import settings
 from airflow.cli import cli_parser
@@ -798,7 +797,7 @@ class TestBackfillJob:
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("ignore_depends_on_past", [True, False])
     def test_backfill_depends_on_past_works_independently_on_ignore_depends_on_past(
         self, ignore_depends_on_past
     ):

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -24,6 +24,7 @@ import threading
 from unittest.mock import patch
 
 import pytest
+from parameterized import parameterized
 
 from airflow import settings
 from airflow.cli import cli_parser
@@ -797,25 +798,20 @@ class TestBackfillJob:
         ti.refresh_from_db()
         assert ti.state == State.SUCCESS
 
-    @pytest.mark.quarantined
-    def test_backfill_depends_on_past(self):
-        """
-        Test that backfill respects ignore_depends_on_past
-        """
+    @parameterized.expand([(True,), (False,)])
+    def test_backfill_depends_on_past_works_independently_on_ignore_depends_on_past(
+        self, ignore_depends_on_past
+    ):
         dag = self.dagbag.get_dag('test_depends_on_past')
         dag.clear()
         run_date = DEFAULT_DATE + datetime.timedelta(days=5)
-
-        # backfill should deadlock
-        with pytest.raises(AirflowException, match='BackfillJob is deadlocked'):
-            BackfillJob(dag=dag, start_date=run_date, end_date=run_date).run()
 
         BackfillJob(
             dag=dag,
             start_date=run_date,
             end_date=run_date,
             executor=MockExecutor(),
-            ignore_first_depends_on_past=True,
+            ignore_first_depends_on_past=ignore_depends_on_past,
         ).run()
 
         # ti should have succeeded


### PR DESCRIPTION
It used to be that the backfill job deadlocked when a task had
"depends_on_past" set. This was because it depended on past,
non-existing and not succesful task.

You needed to set `ignore_first_depends_on_past' set in order to
avoid the deadlock. This test was quarantined but I think
the behaviour has changed.

It looks like currently Airflow behaves differently: when checking
dependencies, it actually retrieves the previous dag-run and
if there is none available it does not deadlock no matter if
depends_on_past is set. That makes much more sense and likely
was fixed during the recent changes involved in timetable
implementation.

This PR updates the tests to show that backfill will behave
properly, regardless from `ignore_first_depends_on_past`.

Fixes: #14755

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
