### PR TITLE
Fix race condition when running mssql tests

### DIFF
--- a/scripts/ci/docker-compose/backend-mssql.yml
+++ b/scripts/ci/docker-compose/backend-mssql.yml
@@ -49,6 +49,12 @@ services:
     entrypoint:
       - bash
       - -c
-      - opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P Airflow123 -i /mssql_create_airflow_db.sql || true
+      - >
+        for i in {1..10};
+        do
+            /opt/mssql-tools/bin/sqlcmd -S mssql -U sa -P Airflow123 -i /mssql_create_airflow_db.sql &&
+                exit 0;
+            sleep 1;
+        done
     volumes:
       - ./mssql_create_airflow_db.sql:/mssql_create_airflow_db.sql:ro


### PR DESCRIPTION
There is a race condition where initialization of Airlfow DB
for mssql might be executed when the server is started but it is
not yet initialized with a model db needed to create airflow db.

In such case mssql database intialization will fail as it will
not be able to obtain a locl on the `model` database. The error
in the mssqlsetup container will be similar to:

```
Msg 1807, Level 16, State 3, Server d2888dd467fe, Line 20
Could not obtain exclusive lock on database 'model'. Retry the operation later.
Msg 1802, Level 16, State 4, Server d2888dd467fe, Line 20
CREATE DATABASE failed. Some file names listed could not be created. Check related errors.
Msg 5011, Level 14, State 5, Server d2888dd467fe, Line 21
User does not have permission to alter database 'airflow', the database does not exist, or the database is not in a state that allows access checks.
Msg 5069, Level 16, State 1, Server d2888dd467fe, Line 21
ALTER DATABASE statement failed.
```

This PR alters the setup job to try to create airflow db
several times and wait a second before every retry.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
