### PR TITLE
Fixing failing quarantined test cases in test_task_command

### DIFF
--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -541,24 +541,23 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
     def test_log_file_template_with_run_task(self):
         """Verify that the taskinstance has the right context for log_filename_template"""
 
-        with mock.patch.object(task_command, "_run_task_by_selected_method"):
-            with conf_vars({('core', 'dags_folder'): self.dag_path}):
-                # increment the try_number of the task to be run
-                with create_session() as session:
-                    ti = session.query(TaskInstance).filter_by(run_id=self.run_id)
-                    ti.try_number = 1
+        with conf_vars({('core', 'dags_folder'): self.dag_path}):
+            # increment the try_number of the task to be run
+            with create_session() as session:
+                ti = session.query(TaskInstance).filter_by(run_id=self.run_id).first()
+                ti.try_number = 1
 
-                log_file_path = os.path.join(os.path.dirname(self.ti_log_file_path), "2.log")
+            log_file_path = os.path.join(os.path.dirname(self.ti_log_file_path), "2.log")
 
+            try:
+                task_command.task_run(self.parser.parse_args(self.task_args))
+
+                assert os.path.exists(log_file_path)
+            finally:
                 try:
-                    task_command.task_run(self.parser.parse_args(self.task_args))
-
-                    assert os.path.exists(log_file_path)
-                finally:
-                    try:
-                        os.remove(log_file_path)
-                    except OSError:
-                        pass
+                    os.remove(log_file_path)
+                except OSError:
+                    pass
 
     @mock.patch.object(task_command, "_run_task_by_selected_method")
     def test_root_logger_restored(self, run_task_mock):

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -444,23 +444,10 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
 
     @mock.patch("airflow.cli.commands.task_command.LocalTaskJob")
     def test_external_executor_id_present_for_fork_run_task(self, mock_local_job):
-        naive_date = datetime(2016, 1, 1)
-        dag_id = 'test_run_fork_has_external_executor_id'
-        task0_id = 'test_run_fork_task'
-
-        dag = self.dagbag.get_dag(dag_id)
-        args_list = [
-            'tasks',
-            'run',
-            '--local',
-            dag_id,
-            task0_id,
-            naive_date.isoformat(),
-        ]
-        args = self.parser.parse_args(args_list)
+        args = self.parser.parse_args(self.task_args)
         args.external_executor_id = "ABCD12345"
 
-        task_command.task_run(args, dag=dag)
+        task_command.task_run(args)
         mock_local_job.assert_called_once_with(
             task_instance=mock.ANY,
             mark_success=False,
@@ -522,7 +509,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
         assert "standard_task_runner.py" in logs
         assert (
             f"INFO - Running: ['airflow', 'tasks', 'run', '{self.dag_id}', "
-            f"'{self.task_id}', '{self.execution_date_str}'," in logs
+            f"'{self.task_id}', '{self.run_id}'," in logs
         )
 
         self.assert_log_line("Log from DAG Logger", logs_list)

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -462,22 +462,11 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
 
     @mock.patch("airflow.cli.commands.task_command.LocalTaskJob")
     def test_external_executor_id_present_for_process_run_task(self, mock_local_job):
-        naive_date = datetime(2016, 1, 1)
-        dag_id = 'test_run_process_has_external_executor_id'
-        task0_id = 'test_run_process_task'
+        args = self.parser.parse_args(self.task_args)
+        args.external_executor_id = "ABCD12345"
 
-        dag = self.dagbag.get_dag(dag_id)
-        args_list = [
-            'tasks',
-            'run',
-            '--local',
-            dag_id,
-            task0_id,
-            naive_date.isoformat(),
-        ]
-        args = self.parser.parse_args(args_list)
         with mock.patch.dict(os.environ, {"external_executor_id": "12345FEDCBA"}):
-            task_command.task_run(args, dag=dag)
+            task_command.task_run(args)
             mock_local_job.assert_called_once_with(
                 task_instance=mock.ANY,
                 mark_success=False,

--- a/tests/cli/commands/test_task_command.py
+++ b/tests/cli/commands/test_task_command.py
@@ -379,8 +379,6 @@ class TestCliTasks(unittest.TestCase):
         task_command.task_clear(args)
 
 
-# For this test memory spins out of control on Python 3.6. TODO(potiuk): FIXME")
-@pytest.mark.quarantined
 class TestLogsfromTaskRunCommand(unittest.TestCase):
     def setUp(self) -> None:
         self.dag_id = "test_logging_dag"
@@ -510,6 +508,8 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
             f"task_id={self.task_id}, execution_date=20170101T000000" in logs
         )
 
+    # For this test memory spins out of control on Python 3.6. TODO(potiuk): FIXME")
+    @pytest.mark.quarantined
     @mock.patch("airflow.task.task_runner.standard_task_runner.CAN_FORK", False)
     def test_logging_with_run_task_subprocess(self):
         # We are not using self.assertLogs as we want to verify what actually is stored in the Log file
@@ -585,6 +585,7 @@ class TestLogsfromTaskRunCommand(unittest.TestCase):
 
         assert self.root_logger.handlers == self.root_handlers
 
+    @pytest.mark.quarantined
     @mock.patch.object(task_command, "_run_task_by_selected_method")
     def test_disable_handler_modifying(self, run_task_mock):
         """If [core] donot_modify_handlers is set to True, the root logger is untouched"""


### PR DESCRIPTION
These test (first 2) cases were broken due to missing self.dagbag and dag_id=test_run_fork_has_external_executor_id.

This PR fixes the issues and makes the test inline with the suite logic/setup and preserves test case's objective.

Test cases fixed in this PR:

- test_external_executor_id_present_for_fork_run_task
- test_external_executor_id_present_for_process_run_task
- test_logging_with_run_task
- test_log_file_template_with_run_task


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
