### PR TITLE
Fix CI warnings when importing Google provider example DAGs

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_functions.py
+++ b/airflow/providers/google/cloud/example_dags/example_functions.py
@@ -72,7 +72,7 @@ body = {"name": FUNCTION_NAME, "entryPoint": GCF_ENTRYPOINT, "runtime": GCF_RUNT
 # [END howto_operator_gcf_deploy_body]
 
 # [START howto_operator_gcf_default_args]
-default_args = {'retries': '3'}
+default_args = {'retries': 3}
 # [END howto_operator_gcf_default_args]
 
 # [START howto_operator_gcf_deploy_variants]


### PR DESCRIPTION
As part of #19803 the `retries` value in `default_args` for the "example_functions" DAG within the Google provider was improperly added as a string rather than an integer. This update yields the below warnings in CI when importing all Airflow classes:
```
 Importing package: airflow.providers.google.cloud.example_dags
  [2021-11-28 18:30:01,419] {baseoperator.py:607} WARNING - Implicitly converting 'retries' for <Task(CloudFunctionDeployFunctionOperator): gcf_deploy_task> from '\x1b[01m3\x1b[22m' to int
  [2021-11-28 18:30:01,421] {baseoperator.py:607} WARNING - Implicitly converting 'retries' for <Task(CloudFunctionDeployFunctionOperator): gcf_deploy2_task> from '\x1b[01m3\x1b[22m' to int
  [2021-11-28 18:30:01,422] {baseoperator.py:607} WARNING - Implicitly converting 'retries' for <Task(CloudFunctionInvokeFunctionOperator): invoke_task> from '\x1b[01m3\x1b[22m' to int
  [2021-11-28 18:30:01,424] {baseoperator.py:607} WARNING - Implicitly converting 'retries' for <Task(CloudFunctionDeleteFunctionOperator): gcf_delete_task> from '\x1b[01m3\x1b[22m' to int
```
This PR updates the datatype of the `retries` value.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
