### PR TITLE
Revert "Added parentheses (#19853)"

### DIFF
--- a/airflow/_vendor/connexion/apis/flask_api.py
+++ b/airflow/_vendor/connexion/apis/flask_api.py
@@ -186,7 +186,7 @@ class FlaskApi(AbstractAPI):
     def _serialize_data(cls, data, mimetype):
         # TODO: harmonize flask and aiohttp serialization when mimetype=None or mimetype is not JSON
         #       (cases where it might not make sense to jsonify the data)
-        if isinstance(mimetype, str) and is_json_mimetype(mimetype):
+        if (isinstance(mimetype, str) and is_json_mimetype(mimetype)):
             body = cls.jsonifier.dumps(data)
         elif not (isinstance(data, bytes) or isinstance(data, str)):
             warnings.warn(

--- a/airflow/_vendor/connexion/decorators/uri_parsing.py
+++ b/airflow/_vendor/connexion/decorators/uri_parsing.py
@@ -108,7 +108,7 @@ class AbstractURIParser(BaseDecorator, metaclass=abc.ABCMeta):
                 # multiple values in a path is impossible
                 values = [values]
 
-            if param_schema is not None and param_schema['type'] == 'array':
+            if (param_schema is not None and param_schema['type'] == 'array'):
                 # resolve variable re-assignment, handle explode
                 values = self._resolve_param_duplicates(values, param_defn, _in)
                 # handle array styles
@@ -186,7 +186,7 @@ class OpenAPIURIParser(AbstractURIParser):
         """
         root_key = k.split("[", 1)[0]
         if k == root_key:
-            return k, v, False
+            return (k, v, False)
         key_path = re.findall(r'\[([^\[\]]*)\]', k)
         root = prev = node = {}
         for k in key_path:
@@ -194,7 +194,7 @@ class OpenAPIURIParser(AbstractURIParser):
             prev = node
             node = node[k]
         prev[k] = v[0]
-        return root_key, [root], True
+        return (root_key, [root], True)
 
     def _preprocess_deep_objects(self, query_data):
         """ deep objects provide a way of rendering nested objects using query

--- a/airflow/_vendor/connexion/operations/openapi.py
+++ b/airflow/_vendor/connexion/operations/openapi.py
@@ -210,7 +210,7 @@ class OpenAPIOperation(AbstractOperation):
             return (self._nested_example(deep_get(self._responses, schema_path)),
                     status_code)
         except KeyError:
-            return None, status_code
+            return (None, status_code)
 
     def _nested_example(self, schema):
         try:

--- a/airflow/_vendor/connexion/operations/swagger2.py
+++ b/airflow/_vendor/connexion/operations/swagger2.py
@@ -203,7 +203,7 @@ class Swagger2Operation(AbstractOperation):
             return (self._nested_example(deep_get(self._responses, schema_path)),
                     status_code)
         except KeyError:
-            return None, status_code
+            return (None, status_code)
 
     def _nested_example(self, schema):
         try:


### PR DESCRIPTION
Reverts apache/airflow#19854

We shouldn't really touch code in `_vendor` like this -- it makes it harder to update it in future.