### PR TITLE
Reduce logs from imported/vendored FAB class

### DIFF
--- a/airflow/www/extensions/init_appbuilder.py
+++ b/airflow/www/extensions/init_appbuilder.py
@@ -44,7 +44,8 @@ from flask_appbuilder.views import IndexView, UtilView
 from airflow import settings
 from airflow.configuration import conf
 
-log = logging.getLogger(__name__)
+# This module contains code imported from FlaskAppbuilder, so lets use _its_ logger name
+log = logging.getLogger("flask_appbuilder.base")
 
 
 def dynamic_class_import(class_path):


### PR DESCRIPTION
When we imported/vendored this class from FAB in #19667, we unintentionally changed the logger name it was using, which caused more logs to appear (the default level for FAB was warning, but this changed it to info)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).