### PR TITLE
Relax timetable clas validation

### DIFF
--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -146,7 +146,7 @@ def _encode_timetable(var: Timetable) -> Dict[str, Any]:
     """
     timetable_class = type(var)
     importable_string = as_importable_string(timetable_class)
-    if _get_registered_timetable(importable_string) != timetable_class:
+    if _get_registered_timetable(importable_string) is None:
         raise _TimetableNotRegistered(importable_string)
     return {Encoding.TYPE: importable_string, Encoding.VAR: var.serialize()}
 


### PR DESCRIPTION
Airflow regularly reloads `sys.modules`, which makes type identity comparison unreliable, because a class would obtain a second, different identity in the interpreter when imported after a reload.

This makes validation difficult because there isn't really a way to tell whether two class objects are indeed "the same". But this check is only for sanity to begin with, so the best we can do is to drop the check entirely ans trust the Plugin Manager is doing its job correctly.

Fix #19869.