### PR TITLE
Fix `multiNamespaceMode` docs to also cover KPO

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3149,7 +3149,7 @@
             }
         },
         "multiNamespaceMode": {
-            "description": "Whether the KubernetesExecutor can launch workers and pods in multiple namespaces. If true, it creates ``ClusterRole``/``ClusterRolebinding`` (with access to entire cluster)",
+            "description": "Whether Airflow can launch workers and/or pods in multiple namespaces. If true, it creates ``ClusterRole``/``ClusterRolebinding`` (with access to entire cluster)",
             "x-docsSection": "Airflow",
             "type": "boolean",
             "default": false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1306,7 +1306,7 @@ config:
     multi_namespace_mode: '{{ if .Values.multiNamespaceMode }}True{{ else }}False{{ end }}'
 # yamllint enable rule:line-length
 
-# Whether the KubernetesExecutor can launch workers and pods in multiple namespaces
+# Whether Airflow can launch workers and/or pods in multiple namespaces
 # If true, it creates ClusterRole/ClusterRolebinding (with access to entire cluster)
 multiNamespaceMode: false
 


### PR DESCRIPTION
The `multiNamespaceMode` flag also controls whether KubernetesPodOperator can create pods in other namespaces, so generalize the docs for that param.