### PR TITLE
Add sensor for AWS Batch (#19850)

### DIFF
--- a/airflow/providers/amazon/aws/sensors/batch.py
+++ b/airflow/providers/amazon/aws/sensors/batch.py
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Dict, Optional
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
+from airflow.sensors.base import BaseSensorOperator
+
+
+class BatchSensor(BaseSensorOperator):
+    """
+    Asks for the state of the Batch Job execution until it reaches a failure state or success state.
+    If the job fails, the task will fail.
+
+    :param job_id: Batch job_id to check the state for
+    :type job_id: str
+    :param aws_conn_id: aws connection to use, defaults to 'aws_default'
+    :type aws_conn_id: str
+    """
+
+    INTERMEDIATE_STATES = (
+        'SUBMITTED',
+        'PENDING',
+        'RUNNABLE',
+        'STARTING',
+        'RUNNING',
+    )
+    FAILURE_STATES = ('FAILED',)
+    SUCCESS_STATES = ('SUCCEEDED',)
+
+    template_fields = ['job_id']
+    template_ext = ()
+    ui_color = '#66c3ff'
+
+    def __init__(
+        self,
+        *,
+        job_id: str,
+        aws_conn_id: str = 'aws_default',
+        region_name: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.job_id = job_id
+        self.aws_conn_id = aws_conn_id
+        self.region_name = region_name
+        self.hook: Optional[AwsBatchClientHook] = None
+
+    def poke(self, context: Dict) -> bool:
+        job_description = self.get_hook().get_job_description(self.job_id)
+        state = job_description['status']
+
+        if state in self.FAILURE_STATES:
+            raise AirflowException(f'Batch sensor failed. Batch Job Status: {state}')
+
+        if state in self.INTERMEDIATE_STATES:
+            return False
+
+        return True
+
+    def get_hook(self) -> AwsBatchClientHook:
+        """Create and return a AwsBatchClientHook"""
+        if self.hook:
+            return self.hook
+
+        self.hook = AwsBatchClientHook(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.region_name,
+        )
+        return self.hook

--- a/airflow/providers/amazon/provider.yaml
+++ b/airflow/providers/amazon/provider.yaml
@@ -251,6 +251,9 @@ sensors:
   - integration-name: Amazon Athena
     python-modules:
       - airflow.providers.amazon.aws.sensors.athena
+  - integration-name: AWS Batch
+    python-modules:
+      - airflow.providers.amazon.aws.sensors.batch
   - integration-name: Amazon CloudFormation
     python-modules:
       - airflow.providers.amazon.aws.sensors.cloud_formation

--- a/tests/providers/amazon/aws/sensors/test_batch.py
+++ b/tests/providers/amazon/aws/sensors/test_batch.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from airflow.exceptions import AirflowException
+from airflow.providers.amazon.aws.sensors.batch import BatchSensor
+
+TASK_ID = 'batch_job_sensor'
+JOB_ID = '8222a1c2-b246-4e19-b1b8-0039bb4407c0'
+
+
+class TestBatchSensor(unittest.TestCase):
+    def setUp(self):
+        self.batch_sensor = BatchSensor(
+            task_id='batch_job_sensor',
+            job_id=JOB_ID,
+        )
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.batch.AwsBatchClientHook')
+    def test_poke_on_success_state(self, mock_batch_client_hook):
+        mock_job_description = {'status': 'SUCCEEDED'}
+
+        hook_instance = mock_batch_client_hook.return_value
+        hook_instance.get_job_description.return_value = mock_job_description
+
+        self.assertTrue(self.batch_sensor.poke(None))
+        hook_instance.get_job_description.assert_called_once_with(JOB_ID)
+
+    @mock.patch('airflow.providers.amazon.aws.sensors.batch.AwsBatchClientHook')
+    def test_poke_on_failure_state(self, mock_batch_client_hook):
+        mock_job_description = {'status': 'FAILED'}
+
+        hook_instance = mock_batch_client_hook.return_value
+        hook_instance.get_job_description.return_value = mock_job_description
+
+        with self.assertRaises(AirflowException) as e:
+            self.batch_sensor.poke(None)
+        self.assertEqual('Batch sensor failed. Batch Job Status: FAILED', str(e.exception))
+        hook_instance.get_job_description.assert_called_once_with(JOB_ID)
+
+    @parameterized.expand(
+        [
+            ('SUBMITTED',),
+            ('PENDING',),
+            ('RUNNABLE',),
+            ('STARTING',),
+            ('RUNNING',),
+        ]
+    )
+    @mock.patch('airflow.providers.amazon.aws.sensors.batch.AwsBatchClientHook')
+    def test_poke_on_intermediate_state(self, job_status, mock_batch_client_hook):
+        mock_job_description = {'status': job_status}
+
+        hook_instance = mock_batch_client_hook.return_value
+        hook_instance.get_job_description.return_value = mock_job_description
+
+        self.assertFalse(self.batch_sensor.poke(None))
+        hook_instance.get_job_description.assert_called_once_with(JOB_ID)


### PR DESCRIPTION
Adds a sensor implementation to ask for the status of an
AWS Batch job. The sensor will enable DAGs to wait for the
batch job to reach a terminal state before proceeding to the
downstream tasks.

closes: #19850

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
