### PR TITLE
Context class handles deprecation

### DIFF
--- a/airflow/macros/__init__.py
+++ b/airflow/macros/__init__.py
@@ -19,15 +19,14 @@ import time  # noqa
 import uuid  # noqa
 from datetime import datetime, timedelta
 from random import random  # noqa
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import dateutil  # noqa
-import lazy_object_proxy
 
 from airflow.macros import hive  # noqa
 
 
-def ds_add(ds: Union[str, lazy_object_proxy.Proxy], days: int) -> str:
+def ds_add(ds: str, days: int) -> str:
     """
     Add or subtract days from a YYYY-MM-DD
 
@@ -47,7 +46,7 @@ def ds_add(ds: Union[str, lazy_object_proxy.Proxy], days: int) -> str:
     return dt.strftime("%Y-%m-%d")
 
 
-def ds_format(ds: Union[str, lazy_object_proxy.Proxy], input_format: str, output_format: str) -> str:
+def ds_format(ds: str, input_format: str, output_format: str) -> str:
     """
     Takes an input string and outputs another string
     as specified in the output format

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -118,7 +118,7 @@ if TYPE_CHECKING:
 
 
 @contextlib.contextmanager
-def set_current_context(context: Context):
+def set_current_context(context: Context) -> None:
     """
     Sets the current execution context to the provided context object.
     This method should be called once per Task execution, before calling operator.execute.

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -114,6 +114,7 @@ log = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
     from airflow.models.dag import DAG, DagModel, DagRun
 
 
@@ -1779,7 +1780,7 @@ class TaskInstance(Base, LoggingMixin):
         # Do not use provide_session here -- it expunges everything on exit!
         if not session:
             session = settings.Session()
-        task = self.task
+        task: "BaseOperator" = self.task
         dag: DAG = task.dag
         from airflow import macros
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -32,6 +32,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
 from airflow.models.skipmixin import SkipMixin
 from airflow.models.taskinstance import _CURRENT_CONTEXT
+from airflow.utils.context import Context
 from airflow.utils.operator_helpers import determine_kwargs
 from airflow.utils.process_utils import execute_in_subprocess
 from airflow.utils.python_virtualenv import prepare_virtualenv, write_python_script
@@ -399,8 +400,9 @@ class PythonVirtualenvOperator(PythonOperator):
                 self.requirements.append('dill')
         self.pickling_library = dill if self.use_dill else pickle
 
-    def execute(self, context: Dict):
-        serializable_context = {key: context[key] for key in self._get_serializable_context_keys()}
+    def execute(self, context: Context):
+        serializable_keys = self._get_serializable_context_keys()
+        serializable_context = context.copy_only(serializable_keys)
         return super().execute(context=serializable_context)
 
     def execute_callable(self):

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -24,7 +24,7 @@ import types
 import warnings
 from tempfile import TemporaryDirectory
 from textwrap import dedent
-from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+from typing import Callable, Dict, Iterable, List, Optional, Union
 
 import dill
 
@@ -489,7 +489,7 @@ class PythonVirtualenvOperator(PythonOperator):
         return super().__deepcopy__(memo)
 
 
-def get_current_context() -> Dict[str, Any]:
+def get_current_context() -> Context:
     """
     Obtain the execution context for the currently executing operator without
     altering user method's signature.

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -394,8 +394,6 @@ class PythonVirtualenvOperator(PythonOperator):
         self.use_dill = use_dill
         self.system_site_packages = system_site_packages
         if not self.system_site_packages:
-            if 'lazy-object-proxy' not in self.requirements:
-                self.requirements.append('lazy-object-proxy')
             if self.use_dill and 'dill' not in self.requirements:
                 self.requirements.append('dill')
         self.pickling_library = dill if self.use_dill else pickle

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -61,6 +61,9 @@ class Context(MutableMapping[str, Any]):
         self._context = context
         self._deprecation_replacements = self._DEPRECATION_REPLACEMENTS.copy()
 
+    def __repr__(self) -> str:
+        return repr(self._context)
+
     def __getitem__(self, key: str) -> Any:
         with contextlib.suppress(KeyError):
             warnings.warn(_create_deprecation_warning(key, self._deprecation_replacements[key]), stacklevel=2)

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -64,6 +64,15 @@ class Context(MutableMapping[str, Any]):
     def __repr__(self) -> str:
         return repr(self._context)
 
+    def __reduce_ex__(self, protocol: int) -> Tuple[Any, ...]:
+        """Pickle the context as a dict.
+
+        We are intentionally going through ``__getitem__`` in this function,
+        instead of using ``items()``, to trigger deprecation warnings.
+        """
+        items = [(key, self[key]) for key in self._context]
+        return dict, (items,)
+
     def __getitem__(self, key: str) -> Any:
         with contextlib.suppress(KeyError):
             warnings.warn(_create_deprecation_warning(key, self._deprecation_replacements[key]), stacklevel=2)

--- a/airflow/utils/context.pyi
+++ b/airflow/utils/context.pyi
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This stub exists to "fake" the Context class as a TypedDict to provide
+# better typehint and editor support.
+
+from typing import Any, Optional
+
+from pendulum import DateTime
+
+from airflow.configuration import AirflowConfigParser
+from airflow.models.baseoperator import BaseOperator
+from airflow.models.dag import DAG
+from airflow.models.dagrun import DagRun
+from airflow.models.param import ParamsDict
+from airflow.models.taskinstance import TaskInstance
+from airflow.typing_compat import Protocol, TypedDict
+
+class _Macros(Protocol):
+    def ds_add(self, ds: str, days: int) -> str: ...
+    def ds_format(self, ds: str, input_format: str, output_format: str) -> str: ...
+
+class _Var(TypedDict):
+    json: Any
+    value: Any
+
+class Context(TypedDict, total=False):
+    conf: AirflowConfigParser
+    dag: DAG
+    dag_run: DagRun
+    data_interval_end: DateTime
+    data_interval_start: DateTime
+    ds: str
+    ds_nodash: str
+    execution_date: DateTime
+    inlets: list
+    logical_date: DateTime
+    macros: _Macros
+    next_ds: Optional[str]
+    next_ds_nodash: Optional[str]
+    next_execution_date: Optional[DateTime]
+    outlets: list
+    params: ParamsDict
+    prev_data_interval_start_success: Optional[DateTime]
+    prev_data_interval_end_success: Optional[DateTime]
+    prev_ds: Optional[str]
+    prev_ds_nodash: Optional[str]
+    prev_execution_date: Optional[DateTime]
+    prev_execution_date_success: Optional[DateTime]
+    prev_start_date_success: Optional[DateTime]
+    run_id: str
+    task: BaseOperator
+    task_instance: TaskInstance
+    task_instance_key_str: str
+    test_mode: bool
+    ti: TaskInstance
+    tomorrow_ds: str
+    tomorrow_ds_nodash: str
+    ts: str
+    ts_nodash: str
+    ts_nodash_with_tz: str
+    var: _Var
+    conn: Any
+    yesterday_ds: str
+    yesterday_ds_nodash: str

--- a/airflow/utils/context.pyi
+++ b/airflow/utils/context.pyi
@@ -18,6 +18,12 @@
 
 # This stub exists to "fake" the Context class as a TypedDict to provide
 # better typehint and editor support.
+#
+# Unfortunately 'conn', 'macros', 'var.json', and 'var.value' need to be
+# annotated as Any and loose discoverability because we don't know what
+# attributes are injected at runtime, and giving them a class would trigger
+# undefined attribute errors from Mypy. Hopefully there will be a mechanism to
+# declare "these are defined, but don't error if others are accessed" someday.
 
 from typing import Any, Optional
 
@@ -29,18 +35,15 @@ from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
 from airflow.models.param import ParamsDict
 from airflow.models.taskinstance import TaskInstance
-from airflow.typing_compat import Protocol, TypedDict
+from airflow.typing_compat import TypedDict
 
-class _Macros(Protocol):
-    def ds_add(self, ds: str, days: int) -> str: ...
-    def ds_format(self, ds: str, input_format: str, output_format: str) -> str: ...
-
-class _Var(TypedDict):
+class _VariableAccessors(TypedDict):
     json: Any
     value: Any
 
 class Context(TypedDict, total=False):
     conf: AirflowConfigParser
+    conn: Any
     dag: DAG
     dag_run: DagRun
     data_interval_end: DateTime
@@ -50,7 +53,7 @@ class Context(TypedDict, total=False):
     execution_date: DateTime
     inlets: list
     logical_date: DateTime
-    macros: _Macros
+    macros: Any
     next_ds: Optional[str]
     next_ds_nodash: Optional[str]
     next_execution_date: Optional[DateTime]
@@ -74,7 +77,6 @@ class Context(TypedDict, total=False):
     ts: str
     ts_nodash: str
     ts_nodash_with_tz: str
-    var: _Var
-    conn: Any
+    var: _VariableAccessors
     yesterday_ds: str
     yesterday_ds_nodash: str

--- a/airflow/utils/operator_helpers.py
+++ b/airflow/utils/operator_helpers.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 from datetime import datetime
-from typing import Callable, Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Mapping, Tuple, Union
 
 AIRFLOW_VAR_NAME_FORMAT_MAPPING = {
     'AIRFLOW_CONTEXT_DAG_ID': {'default': 'airflow.ctx.dag_id', 'env_var_format': 'AIRFLOW_CTX_DAG_ID'},
@@ -88,7 +88,7 @@ def context_to_airflow_vars(context, in_env_var_format=False):
     return params
 
 
-def determine_kwargs(func: Callable, args: Union[Tuple, List], kwargs: Dict) -> Dict:
+def determine_kwargs(func: Callable, args: Union[Tuple, List], kwargs: Mapping) -> Dict:
     """
     Inspect the signature of a given callable to determine which arguments in kwargs need
     to be passed to the callable.

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -2118,14 +2118,7 @@ class TestRunRawTaskQueriesCount:
     def teardown_method(self) -> None:
         self._clean()
 
-    @pytest.mark.parametrize(
-        "expected_query_count, mark_success",
-        [
-            # Expected queries, mark_success
-            (10, False),
-            (5, True),
-        ],
-    )
+    @pytest.mark.parametrize("expected_query_count, mark_success", [(12, False), (5, True)])
     @provide_session
     def test_execute_queries_count(
         self, expected_query_count, mark_success, create_task_instance, session=None

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -1074,7 +1074,7 @@ class MyContextAssertOperator(BaseOperator):
 
 def get_all_the_context(**context):
     current_context = get_current_context()
-    assert context == current_context
+    assert context == current_context._context
 
 
 @pytest.fixture()

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -969,9 +969,7 @@ class TestPythonVirtualenvOperator(unittest.TestCase):
         ):
             pass
 
-        self._run_as_operator(
-            f, use_dill=True, system_site_packages=False, requirements=['pendulum', 'lazy_object_proxy']
-        )
+        self._run_as_operator(f, use_dill=True, system_site_packages=False, requirements=['pendulum'])
 
     def test_base_context(self):
         def f(

--- a/tests/providers/amazon/aws/sensors/test_s3_key.py
+++ b/tests/providers/amazon/aws/sensors/test_s3_key.py
@@ -17,7 +17,6 @@
 # under the License.
 
 import unittest
-from datetime import datetime
 from unittest import mock
 
 import pytest
@@ -27,6 +26,7 @@ from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.models.variable import Variable
 from airflow.providers.amazon.aws.sensors.s3_key import S3KeySensor, S3KeySizeSensor
+from airflow.utils import timezone
 
 
 class TestS3KeySensor(unittest.TestCase):
@@ -79,7 +79,7 @@ class TestS3KeySensor(unittest.TestCase):
 
         Variable.set("test_bucket_key", "s3://bucket/key")
 
-        execution_date = datetime(2020, 1, 1)
+        execution_date = timezone.datetime(2020, 1, 1)
 
         dag = DAG("test_s3_key", start_date=execution_date)
         op = S3KeySensor(

--- a/tests/providers/papermill/operators/test_papermill.py
+++ b/tests/providers/papermill/operators/test_papermill.py
@@ -16,13 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 import unittest
-from datetime import datetime
 from unittest.mock import patch
 
 from airflow.models import DAG, DagRun, TaskInstance
 from airflow.providers.papermill.operators.papermill import PapermillOperator
+from airflow.utils import timezone
 
-DEFAULT_DATE = datetime(2021, 1, 1)
+DEFAULT_DATE = timezone.datetime(2021, 1, 1)
 
 
 class TestPapermillOperator(unittest.TestCase):


### PR DESCRIPTION
Fix #19716, close #19734.

Fortunately (?) we don’t really set up Mypy with enough information to catch typing errors this introduces to `def execute(self, context: Dict):`. I still intend to fix those eventually, but this helps producing a cleaner diff to run against CI.

Now that we have a class (and a separate module), I also want to move more logic from the giant `TaskInstance.get_template_context()` (currently ~250 lines).