### PR TITLE
Update production Helm guide database section to use k8s secret

### DIFF
--- a/docs/helm-chart/production-guide.rst
+++ b/docs/helm-chart/production-guide.rst
@@ -23,25 +23,32 @@ The following are things to consider when using this Helm chart in a production 
 Database
 --------
 
-You will want to use an external database instead of the one deployed with the chart by default.
-Both **PostgreSQL** and **MySQL** are supported. Supported versions can be
-found on the :doc:`Set up a Database Backend <apache-airflow:howto/set-up-database>` page.
+It is advised to set up an external database for the Airflow metastore. The default Helm chart deploys a
+Postgres database running in a container. For production usage, a database running on a dedicated machine or
+leveraging a cloud provider's database service such as AWS RDS is advised. Supported databases and versions
+can be found at :doc:`Set up a Database Backend <apache-airflow:howto/set-up-database>`.
+
+First disable the Postgres in Docker container:
 
 .. code-block:: yaml
 
-  # Don't deploy postgres
   postgresql:
     enabled: false
 
-  # Use an external database
+To provide the database credentials to Airflow, store the credentials in a Kubernetes secret. Note that
+special characters in the username/password must be URL encoded.
+
+.. code-block:: bash
+
+  kubectl create secret generic mydatabase --from-literal=connection=postgresql://user:pass@host:5432/db
+
+Helm defaults to fetching the value from a secret named ``[RELEASE NAME]-airflow-metadata``, but you can
+configure the secret name:
+
+.. code-block:: yaml
+
   data:
-    metadataConnection:
-      user: ...
-      pass: ...
-      protocol: postgresql  # or 'mysql'
-      host: ...
-      port: ...
-      db: ...
+    metadataSecretName: mydatabase
 
 .. _production-guide:pgbouncer:
 


### PR DESCRIPTION
The Helm docs currently show how to configure the Postgres secret in values.yaml. I'd say you don't want your secrets in there and a safer approach would be to store the connection URL in a K8S secret. I updated the section to explain this.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
