### PR TITLE
Validate DagRun state is valid on assignment

### DIFF
--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -161,7 +161,8 @@ class DagRun(Base, LoggingMixin):
         self.start_date = start_date
         self.external_trigger = external_trigger
         self.conf = conf or {}
-        self.state = state
+        if state is not None:
+            self.state = state
         if queued_at is self.__NO_VALUE:
             self.queued_at = timezone.utcnow() if state == State.QUEUED else None
         else:

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -189,6 +189,8 @@ class DagRun(Base, LoggingMixin):
         return self._state
 
     def set_state(self, state: DagRunState):
+        if state not in State.dag_states:
+            raise ValueError(f"invalid DagRun state: {state}")
         if self._state != state:
             self._state = state
             self.end_date = timezone.utcnow() if self._state in State.finished else None

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -1370,7 +1370,7 @@ class TestDag(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (State.NONE,),
+            (State.QUEUED,),
             (State.RUNNING,),
         ]
     )
@@ -1455,7 +1455,7 @@ class TestDag(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (State.NONE,),
+            (State.QUEUED,),
             (State.RUNNING,),
         ]
     )
@@ -1485,7 +1485,7 @@ class TestDag(unittest.TestCase):
 
     @parameterized.expand(
         [
-            (State.NONE,),
+            (State.QUEUED,),
             (State.RUNNING,),
         ]
     )

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -331,7 +331,7 @@ class TestTaskInstance:
         ti = create_task_instance(
             dag_id='test_mark_non_runnable_task_as_success',
             task_id='test_mark_non_runnable_task_as_success_op',
-            dagrun_state=non_runnable_state,
+            state=non_runnable_state,
         )
         ti.run(mark_success=True)
         assert ti.state == State.SUCCESS


### PR DESCRIPTION
This should avoid the most obvious user errors without too much overhead to the overall system. Nowhere near perfect, but if the user goes even lower level than this, they are obviously on their own.

Ref: #19836 