### PR TITLE
Move to watchtower 2.0.1 - Fixes Watchtower crash when logging empty line 

### DIFF
--- a/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
+++ b/airflow/providers/amazon/aws/log/cloudwatch_task_handler.py
@@ -81,7 +81,7 @@ class CloudwatchTaskHandler(FileTaskHandler, LoggingMixin):
         self.handler = watchtower.CloudWatchLogHandler(
             log_group=self.log_group,
             stream_name=self._render_filename(ti, ti.try_number),
-            boto3_session=self.hook.get_session(self.region_name),
+            boto3_client=self.hook.get_conn(),
         )
 
     def close(self):

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ alibaba = [
 ]
 amazon = [
     'boto3>=1.15.0,<1.19.0',
-    'watchtower~=1.0.6',
+    'watchtower~=2.0.1',
     'jsonpath_ng>=1.5.3',
     'redshift_connector~=2.0.888',
     'sqlalchemy_redshift~=0.8.6',


### PR DESCRIPTION
## Overview
This version of watchtower contains patches (submitted by myself and Andrey the maintainer) that fixes #15279 where empty log lines would crash Watchtower.

## Testing 
I wrote a dag with the following benchmarks:
- Log a single line from a task
- Log an empty line
- Log 1000 lines
- Log 10,000 lines
- Log 100,000 lines

I detected no noticeable regression in task run time, and as expected the new watchtower version does not crash when logging an empty line.

**Note**: The logic, as Andrey wrote it, ignores empty log lines and emits a warning message (see snippet below). The warning messages could be a nuisance if you're logging empty lines frequently, and it is possible to remove them, but I think it's a also a good indicator to the user that their remote logs will look different than they expect due to the empty messages being filtered. Let me know what you folks think.
Example output from my empty line benchmark task:
```
...
[2021-11-30, 19:22:45 UTC] Running command: ['bash', '-c', "echo ''"]
[2021-11-30, 19:22:45 UTC] Output:
[2021-11-30, 19:22:45 UTC] /usr/local/lib/python3.6/site-packages/watchtower/__init__.py:349 WatchtowerWarning: Received empty message. Empty messages cannot be sent to CloudWatch Logs
[2021-11-30, 19:22:45 UTC] Command exited with return code 0
...
```



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
