### PR TITLE
Update doc reference links in Google's provider.yaml

### DIFF
--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -82,7 +82,7 @@ integrations:
     logo: /integration-logos/gcp/Cloud-Bigtable.png
     tags: [gcp]
   - integration-name: Google Cloud Build
-    external-doc-url: https://cloud.google.com/cloud-build/
+    external-doc-url: https://cloud.google.com/build/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/cloud_build.rst
     logo: /integration-logos/gcp/Cloud-Build.png
@@ -106,7 +106,7 @@ integrations:
     logo: /integration-logos/gcp/Cloud-Functions.png
     tags: [gcp]
   - integration-name: Google Cloud Key Management Service (KMS)
-    external-doc-url: https://cloud.google.com/kms/
+    external-doc-url: https://cloud.google.com/security-key-management/
     logo: /integration-logos/gcp/Key-Management-Service.png
     tags: [gcp]
   - integration-name: Google Cloud Life Sciences
@@ -156,13 +156,13 @@ integrations:
     logo: /integration-logos/gcp/Cloud-SQL.png
     tags: [gcp]
   - integration-name: Google Cloud Stackdriver
-    external-doc-url: https://cloud.google.com/stackdriver
+    external-doc-url: https://cloud.google.com/products/operations/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/stackdriver.rst
     logo: /integration-logos/gcp/Google-Cloud-Stackdriver.png
     tags: [gcp]
   - integration-name: Google Cloud Storage (GCS)
-    external-doc-url: https://cloud.google.com/gcs/
+    external-doc-url: https://cloud.google.com/storage/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/gcs.rst
     logo: /integration-logos/gcp/Cloud-Storage.png
@@ -185,7 +185,7 @@ integrations:
     logo: /integration-logos/gcp/Cloud-Translation-API.png
     tags: [gcp]
   - integration-name: Google Cloud Video Intelligence
-    external-doc-url: https://cloud.google.com/video_intelligence/
+    external-doc-url: https://cloud.google.com/video-intelligence/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/video_intelligence.rst
     logo: /integration-logos/gcp/Cloud-Video-Intelligence-API.png
@@ -204,11 +204,11 @@ integrations:
     logo: /integration-logos/gcp/Compute-Engine.png
     tags: [gcp]
   - integration-name: Google Data Proc
-    external-doc-url: https://cloud.yandex.com/services/data-proc
+    external-doc-url: https://cloud.google.com/dataproc/
     logo: /integration-logos/gcp/Google-Data-Proc.png
     tags: [gcp]
   - integration-name: Google Data Catalog
-    external-doc-url: https://cloud.google.com/data-catalog
+    external-doc-url: https://cloud.google.com/data-catalog/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/datacatalog.rst
     logo: /integration-logos/gcp/Google-Data-Catalog.png
@@ -253,7 +253,7 @@ integrations:
     logo: /integration-logos/gcp/Google-Deployment-Manager.png
     tags: [gcp]
   - integration-name: Google API Python Client
-    external-doc-url: https://github.com/googleapis/google-api-python-client
+    external-doc-url: https://github.com/googleapis/google-api-python-client/
     logo: /integration-logos/gcp/Google-API-Python-Client.png
     tags: [google]
   - integration-name: Google Campaign Manager
@@ -267,7 +267,7 @@ integrations:
     logo: /integration-logos/gcp/Google-Cloud.png
     tags: [gcp]
   - integration-name: Google Discovery API
-    external-doc-url: https://developers.google.com/discovery
+    external-doc-url: https://developers.google.com/discovery/
     logo: /integration-logos/gcp/Google-Cloud-Generic.png
     tags: [google]
   - integration-name: Google Display&Video 360
@@ -297,19 +297,19 @@ integrations:
     logo: /integration-logos/gcp/Google-Spreadsheet.png
     tags: [google]
   - integration-name: Google Cloud Storage Transfer Service
-    external-doc-url: https://cloud.google.com/storage/transfer/
+    external-doc-url: https://cloud.google.com/storage-transfer-service/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/cloud_storage_transfer_service.rst
     logo: /integration-logos/gcp/Cloud-Storage.png
     tags: [gcp]
   - integration-name: Google Kubernetes Engine
-    external-doc-url: https://cloud.google.com/kubernetes_engine/
+    external-doc-url: https://cloud.google.com/kubernetes-engine/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/kubernetes_engine.rst
     logo: /integration-logos/gcp/Kubernetes-Engine.png
     tags: [gcp]
   - integration-name: Google Machine Learning Engine
-    external-doc-url: https://cloud.google.com/ai-platform/
+    external-doc-url: https://cloud.google.com/vertex-ai/
     how-to-guide:
       - /docs/apache-airflow-providers-google/operators/cloud/mlengine.rst
     logo: /integration-logos/gcp/AI-Platform.png


### PR DESCRIPTION
Fixed links to the documentation.

Need some comments from provider developers about the following lines:
https://github.com/apache/airflow/blob/15a9d7910cc0d2ca0ed97e3535a6b85edcf16af8/airflow/providers/google/provider.yaml#L206
and
https://github.com/apache/airflow/blob/15a9d7910cc0d2ca0ed97e3535a6b85edcf16af8/airflow/providers/google/provider.yaml#L239
