### PR TITLE
Add more filtering options for TI's in the UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -4373,13 +4373,16 @@ class TaskInstanceModelView(AirflowPrivilegeVerifierModelView):
         'task_id',
         'run_id',
         'execution_date',
-        'hostname',
-        'queue',
-        'pool',
         'operator',
         'start_date',
         'end_date',
+        'hostname',
+        'priority_weight',
+        'queue',
         'queued_dttm',
+        'try_number',
+        'pool',
+        'queued_by_job_id',
     ]
 
     edit_columns = [


### PR DESCRIPTION
Allow TI's to be filtered by `priority_weight`, `try_number`,
and `queued_by_job_id`.

This also reorders the list to match the `list_columns` order to make it the order consistent.

![Screen Shot 2021-11-30 at 5 56 31 PM](https://user-images.githubusercontent.com/66968678/144152446-e7ab881e-583a-4baa-b35b-42be323d3575.png)

![Screen Shot 2021-11-30 at 5 57 29 PM](https://user-images.githubusercontent.com/66968678/144152456-18e37afa-4701-4ed9-a9ba-5f950998f5a3.png)

