### PR TITLE
Add more dagrun centered view in UI

### DIFF
--- a/airflow/www/dagrun_table_formatters.py
+++ b/airflow/www/dagrun_table_formatters.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Dict, Sequence
+
+from markupsafe import Markup
+
+from airflow.models import DAG, DagRun, TaskInstance, XCom
+from airflow.www import utils as wwwutils
+
+DagRunTableFormatRegistry = []
+
+
+def get_formatter(dag: DAG):
+    for f in DagRunTableFormatRegistry:
+        if f.supports_dag(dag):
+            return f
+    return DefaultDagRunFormatter
+
+
+def add_formatter_to_registry(f):
+    DagRunTableFormatRegistry.append(f)
+
+
+class DefaultDagRunFormatter:
+    @staticmethod
+    def labels(original_labels: Dict[str, str]):
+        return {**original_labels, "conf": "Conf"}
+
+    @staticmethod
+    def extra_dagrun_fields(dr: DagRun, ti: Sequence[TaskInstance], session):
+        return {"conf": dr.conf}
+
+    @staticmethod
+    def formatters():
+        return {"conf": wwwutils.json_f('conf')}
+
+
+class ExampleDagRunFormatter:
+    """
+    This formatter will provide two extra columns in the /dag_dagruns view,
+      - One that extracts a value ('revision') from the conf that was used to start the dag
+      - One that extracts a xcom return_value from a task in the dagrun
+    """
+
+    @staticmethod
+    def supports_dag(dag: DAG):
+        return dag.dag_id in ["example_xcom_args"]
+
+    @staticmethod
+    def labels(original_labels):
+        return {
+            **original_labels,
+            "revision": "Revision",
+            "return_value": "Generate Value Output",
+            "logs": "Logs",
+        }
+
+    @staticmethod
+    def extra_dagrun_fields(dr: DagRun, ti: Sequence[TaskInstance], session):
+        wanted_tasks = [t for t in ti if t.task_id == "generate_value"]
+        xcom_return_value = ""
+        if len(wanted_tasks) > 0:
+            wanted_task = wanted_tasks[0]
+            try:
+                xcom_return_value = (
+                    session.query(XCom)
+                    .filter(
+                        XCom.dag_id == dr.dag_id,
+                        XCom.task_id == wanted_task.task_id,
+                        XCom.execution_date == wanted_task.execution_date,
+                        XCom.key == "return_value",
+                    )
+                    .one()
+                    .value
+                )
+            except Exception as e:
+                xcom_return_value = str(e)
+
+        return {"revision": dr.conf.get("revision"), "return_value": xcom_return_value}
+
+    @staticmethod
+    def formatters():
+        def rev_formatter(attr):
+            r = attr.get("revision") or ""
+            return r[0:8]
+
+        def log_formatter(attr):
+            return Markup(
+                '<a href="{url}"><span class="material-icons" aria-hidden="true">reorder</span></a>'
+            ).format(url="http://example.com")
+
+        return {"revision": rev_formatter, "logs": log_formatter}
+
+
+add_formatter_to_registry(ExampleDagRunFormatter)

--- a/airflow/www/templates/airflow/dag.html
+++ b/airflow/www/templates/airflow/dag.html
@@ -109,6 +109,9 @@
             <span class="material-icons" aria-hidden="true">nature</span>
             Tree
           </a></li>
+          <li><a href="{{ url_for('Airflow.dagruns', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg) }}">
+            <span class="material-icons" aria-hidden="true">fact_check</span>
+            Dag Runs</a></li>
           <li><a href="{{ url_for('Airflow.graph', dag_id=dag.dag_id, root=root, num_runs=num_runs_arg, base_date=base_date_arg, execution_date=execution_date_arg) }}">
             <span class="material-icons" aria-hidden="true">account_tree</span>
             Graph</a></li>

--- a/airflow/www/templates/airflow/dagruns.html
+++ b/airflow/www/templates/airflow/dagruns.html
@@ -1,0 +1,50 @@
+{#
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+#}
+
+{% extends "airflow/dag.html" %}
+{% block page_title %}{{ dag.dag_id }} - Tree - {{ appbuilder.app_name }}{% endblock %}
+{% from 'appbuilder/loading_dots.html' import loading_dots %}
+
+{% block head_meta %}
+  {{ super() }}
+  <meta name="num_runs" content="{{ num_runs }}">
+  <meta name="root" content="{{ root if root else '' }}">
+  <meta name="base_date" content="{{ request.args.get('base_date') if request.args.get('base_date') else '' }}">
+{% endblock %}
+
+{% block content %}
+  {{ super() }}
+  <div>
+    <a href="{{ url_for('DagRunModelView.list') }}?_flt_3_dag_id={{ dag.dag_id }}">
+      Advanced filtering
+    </a>
+
+    {{ dagrun_list() | safe  }}
+  </div>
+
+{% endblock %}
+
+
+{% block tail_js %}
+  {{ super() }}
+{% endblock %}
+
+{% block tail %}
+  {{ super() }}
+{% endblock %}


### PR DESCRIPTION
This adds a new view under each dag that provides
quick access to a table of the most recent dag runs
and their status.

The previous views providing similar functionality are
- Tree, which can be a bit hard to navigate for new users and
  if you are looking for one specific dagrun where you care
  more about input arguments or results, rather than execution date.
- DAG Runs under the browse menu, which can be very hard to reach
  and requires user to fill in the dag id as search parameter
  each time to not get too many results.

This new view is intended to provide a middle ground, containing all
the details (and more) of that under DAG Runs, but with equally easy
access as the tree view.

Included is also a proof of concept for allow DAG authors to provide
custom formatters to add arbitary columns in this new dagrun table.
As example, you can provide links to downlaod results or logs, and
can visualize the most important values of their specific dag, such
as the input config. For dags which are more depending on user input,
rather than the logical date and time tables.
The idea is that adding new columns should be equally easy as writing
a DAG and not require rebuilding webserver or providers.
**This final step is not finalized and is left open for suggestions
on how to best proceed, given AIP-38 is in progress this might
not be worth pursuing further.**

**How it looks:**

![image](https://user-images.githubusercontent.com/89977373/144283492-e4791b7a-7c1e-4592-8c68-1f07e64695f8.png)

