### PR TITLE
Lock TI when decrementing try_number for sensor

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1650,7 +1650,7 @@ class TaskInstance(Base, LoggingMixin):
         # Don't record reschedule request in test mode
         if test_mode:
             return
-        self.refresh_from_db(session)
+        self.refresh_from_db(session, lock_for_update=True)
 
         self.end_date = timezone.utcnow()
         self.set_duration()


### PR DESCRIPTION
We have a bug where try_number can go negative for sensors and I figured
that we don't lock the task instance when handling the reschedule exception.

This problem only happens with a multi-scheduler setup. 

This PR applies a Lock on the TI during reschedule handling to allow only one scheduler access to the instance at a time


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
