### PR TITLE
Only update label when adopting to prevent new pods

### DIFF
--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -709,7 +709,7 @@ class KubernetesExecutor(BaseExecutor):
             kube_client.patch_namespaced_pod(
                 name=pod.metadata.name,
                 namespace=pod.metadata.namespace,
-                body=PodGenerator.serialize_pod(pod),
+                body={"metadata": {"labels": {"airflow-worker": pod.metadata.labels['airflow-worker']}}},
             )
             pod_ids.pop(pod_id)
             self.running.add(pod_id)
@@ -737,7 +737,7 @@ class KubernetesExecutor(BaseExecutor):
                 kube_client.patch_namespaced_pod(
                     name=pod.metadata.name,
                     namespace=pod.metadata.namespace,
-                    body=PodGenerator.serialize_pod(pod),
+                    body={"metadata": {"labels": {"airflow-worker": pod.metadata.labels['airflow-worker']}}},
                 )
             except ApiException as e:
                 self.log.info("Failed to adopt pod %s. Reason: %s", pod.metadata.name, e)


### PR DESCRIPTION
Background:
We run a lot of dags/tasks (~600 dags with 50 tasks in each) on kubernetes, and the scheduler tends to crash from so many. Adoption is common.
On adoption, it would patch the pod, but when a specific field would get re-written (I'm not sure which, sorry) that would cause a new pod to be created instead.
This new pod would then change the status of the task instance, causing the pod to die with SIGTERM, and the task to fail.

This patch asks it to only update the label, which has removed the symptom (from 300+ daily failures to 0).
I only needed to do this for `adopt_launched_task`, but also did it for `adopt_finished_task` for consistency.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
