### PR TITLE
Clean up incorrect class names of Google system tests

### DIFF
--- a/tests/providers/google/cloud/operators/test_datacatalog_system.py
+++ b/tests/providers/google/cloud/operators/test_datacatalog_system.py
@@ -22,7 +22,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 
 @pytest.mark.credential_file(GCP_DATACATALOG_KEY)
-class CloudDataflowExampleDagsSystemTest(GoogleSystemTest):
+class CloudDataCatalogExampleDagsSystemTest(GoogleSystemTest):
     def setUp(self):
         super().setUp()
 

--- a/tests/providers/google/cloud/operators/test_gcs_timespan_file_transform_system.py
+++ b/tests/providers/google/cloud/operators/test_gcs_timespan_file_transform_system.py
@@ -33,7 +33,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 
 @pytest.mark.credential_file(GCP_GCS_KEY)
-class GoogleCloudStorageExampleDagsTest(GoogleSystemTest):
+class GCSTimespanFileTransformExampleDagsTest(GoogleSystemTest):
     helper = GcsSystemTestHelper()
     testfile_content = ["This is a test file"]
 

--- a/tests/providers/google/cloud/operators/test_speech_to_text_system.py
+++ b/tests/providers/google/cloud/operators/test_speech_to_text_system.py
@@ -25,7 +25,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 @pytest.mark.backend("mysql", "postgres")
 @pytest.mark.credential_file(GCP_GCS_KEY)
-class GCPTextToSpeechExampleDagSystemTest(GoogleSystemTest):
+class GCPSpeechToTextExampleDagSystemTest(GoogleSystemTest):
     @provide_gcp_context(GCP_GCS_KEY)
     def setUp(self):
         super().setUp()

--- a/tests/providers/google/cloud/operators/test_stackdriver_system.py
+++ b/tests/providers/google/cloud/operators/test_stackdriver_system.py
@@ -24,7 +24,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 @pytest.mark.backend("mysql", "postgres")
 @pytest.mark.credential_file(GCP_STACKDRIVER)
-class GCPTextToSpeechExampleDagSystemTest(GoogleSystemTest):
+class GCPStackdriverExampleDagSystemTest(GoogleSystemTest):
     def setUp(self):
         super().setUp()
 

--- a/tests/providers/google/cloud/operators/test_translate_speech_system.py
+++ b/tests/providers/google/cloud/operators/test_translate_speech_system.py
@@ -25,7 +25,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 @pytest.mark.backend("mysql", "postgres")
 @pytest.mark.credential_file(GCP_GCS_KEY)
-class GCPTextToSpeechExampleDagSystemTest(GoogleSystemTest):
+class GCPTranslateSpeechExampleDagSystemTest(GoogleSystemTest):
     @provide_gcp_context(GCP_GCS_KEY)
     def setUp(self):
         super().setUp()

--- a/tests/providers/google/cloud/operators/test_workflows_system.py
+++ b/tests/providers/google/cloud/operators/test_workflows_system.py
@@ -23,7 +23,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 @pytest.mark.system("google.cloud")
 @pytest.mark.credential_file(GCP_WORKFLOWS_KEY)
-class CloudVisionExampleDagsSystemTest(GoogleSystemTest):
+class WorkflowsExampleDagsSystemTest(GoogleSystemTest):
     def setUp(self):
         super().setUp()
 

--- a/tests/providers/google/cloud/transfers/test_bigquery_to_gcs_system.py
+++ b/tests/providers/google/cloud/transfers/test_bigquery_to_gcs_system.py
@@ -26,7 +26,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 @pytest.mark.backend("mysql", "postgres")
 @pytest.mark.system("google.cloud")
 @pytest.mark.credential_file(GCP_BIGQUERY_KEY)
-class BigQueryExampleDagsSystemTest(GoogleSystemTest):
+class BigQueryToGCSExampleDagsSystemTest(GoogleSystemTest):
     @provide_gcp_context(GCP_BIGQUERY_KEY)
     def setUp(self):
         super().setUp()

--- a/tests/providers/google/cloud/transfers/test_gcs_to_local_system.py
+++ b/tests/providers/google/cloud/transfers/test_gcs_to_local_system.py
@@ -30,7 +30,7 @@ from tests.test_utils.gcp_system_helpers import CLOUD_DAG_FOLDER, GoogleSystemTe
 
 @pytest.mark.backend("mysql", "postgres")
 @pytest.mark.credential_file(GCP_GCS_KEY)
-class GoogleCloudStorageExampleDagsTest(GoogleSystemTest):
+class GoogleCloudStorageToLocalExampleDagsTest(GoogleSystemTest):
     @provide_gcp_context(GCP_GCS_KEY)
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Some system tests in the Google provider were duplicated and/or were referencing a different service than what was being tested. This PR simply aligns the class names of these system tests to what's being tested.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
