### PR TITLE
Fix: Use seconds for schedule_delay metric when using dogstatsd

### DIFF
--- a/tests/core/test_stats.py
+++ b/tests/core/test_stats.py
@@ -181,8 +181,13 @@ class TestDogStats(unittest.TestCase):
         self.dogstatsd_client.timed.assert_not_called()
 
     def test_timing(self):
+        import datetime
+
         self.dogstatsd.timing("dummy_timer", 123)
         self.dogstatsd_client.timing.assert_called_once_with(metric='dummy_timer', value=123, tags=[])
+
+        self.dogstatsd.timing("dummy_timer", datetime.timedelta(seconds=123))
+        self.dogstatsd_client.timing.assert_called_with(metric='dummy_timer', value=123.0, tags=[])
 
     def test_gauge(self):
         self.dogstatsd.gauge("dummy", 123)


### PR DESCRIPTION
closes: #18599, #18622

This PR just fixes the failing test from a previos PR: https://github.com/apache/airflow/pull/18622

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
