### PR TITLE
Ensure Spark driver response is valid before setting UNKNOWN status

### DIFF
--- a/airflow/providers/apache/spark/hooks/spark_submit.py
+++ b/airflow/providers/apache/spark/hooks/spark_submit.py
@@ -520,9 +520,14 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
         :param itr: An iterator which iterates over the input of the subprocess
         """
         driver_found = False
+        valid_response = False
         # Consume the iterator
         for line in itr:
             line = line.strip()
+
+            # A valid Spark status response should contain a submissionId
+            if "submissionId" in line:
+                valid_response = True
 
             # Check if the log line is about the driver status and extract the status.
             if "driverState" in line:
@@ -531,7 +536,7 @@ class SparkSubmitHook(BaseHook, LoggingMixin):
 
             self.log.debug("spark driver status log: %s", line)
 
-        if not driver_found:
+        if valid_response and not driver_found:
             self._driver_status = "UNKNOWN"
 
     def _start_driver_status_tracking(self) -> None:

--- a/tests/providers/apache/spark/hooks/test_spark_submit.py
+++ b/tests/providers/apache/spark/hooks/test_spark_submit.py
@@ -728,6 +728,21 @@ class TestSparkSubmitHook(unittest.TestCase):
 
         assert hook._driver_status == 'RUNNING'
 
+    def test_process_spark_driver_status_log_bad_response(self):
+        # Given
+        hook = SparkSubmitHook(conn_id='spark_standalone_cluster')
+        log_lines = [
+            'curl: Failed to connect to http://spark-standalone-master:6066'
+            'This is an invalid Spark response',
+            'Timed out',
+        ]
+        # When
+        hook._process_spark_status_log(log_lines)
+
+        # Then
+
+        assert hook._driver_status is None
+
     @patch('airflow.providers.apache.spark.hooks.spark_submit.renew_from_kt')
     @patch('airflow.providers.apache.spark.hooks.spark_submit.subprocess.Popen')
     def test_yarn_process_on_kill(self, mock_popen, mock_renew_from_kt):


### PR DESCRIPTION
Closes #19897.

This PR ensures an invalid `curl` response from Spark driver won't change the driver status to "UNKNOWN", which will lead to a task retry.