### PR TITLE
Simple class to make attribute reference obvious

### DIFF
--- a/tests/cluster_policies/__init__.py
+++ b/tests/cluster_policies/__init__.py
@@ -15,6 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from abc import ABC
 from datetime import timedelta
 from typing import Callable, List
 
@@ -77,8 +78,12 @@ def dag_policy(dag: DAG):
 # [END example_dag_cluster_policy]
 
 
+class TimedOperator(BaseOperator, ABC):
+    timeout: timedelta
+
+
 # [START example_task_cluster_policy]
-def task_policy(task: BaseOperator):
+def task_policy(task: TimedOperator):
     if task.task_type == 'HivePartitionSensor':
         task.queue = "sensor_queue"
     if task.timeout > timedelta(hours=48):


### PR DESCRIPTION
Part of #19891
MyPy complaining as "timeout" attribute is not part BaseOperator class but used some other type of operators (e.g. Google)

This simple class definition should make it cleaner

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
