### PR TITLE
Remove deprecated template_fields and add update tests (#19977)

### DIFF
--- a/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
+++ b/airflow/providers/google/cloud/transfers/gdrive_to_gcs.py
@@ -67,8 +67,6 @@ class GoogleDriveToGCSOperator(BaseOperator):
     template_fields = [
         "bucket_name",
         "object_name",
-        "destination_bucket",
-        "destination_object",
         "folder_id",
         "file_name",
         "drive_id",

--- a/tests/providers/google/cloud/transfers/test_gdrive_to_gcs.py
+++ b/tests/providers/google/cloud/transfers/test_gdrive_to_gcs.py
@@ -59,3 +59,5 @@ class TestGoogleDriveToGCSOperator:
         mock_gcs_hook.return_value.provide_file_and_upload.assert_called_once_with(
             bucket_name=BUCKET, object_name=OBJECT
         )
+
+        assert op.dry_run() is None


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #19977
related: #19977 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
In the issue #19977, I've described a scenario in which calling `op.dry_run()` on the `GoogleDriveToGCSOperator` raises
an `AttributeError` because of the following deprecated template_fields:

* `destination_bucket`
* `destination_object`

These attributes are not set on the instance, and instead are only used in the constructor for backwards compatibility.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
