### PR TITLE
Update upgrading.rst with detailed code example of how to resolve post-upgrade warning

### DIFF
--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -87,7 +87,6 @@ Alternatively, you can drop the table by following the steps below:
 2. Run the following commands in the python shell:
 
  .. code-block:: python
- 
    from airflow.settings import Session
    session = Session()
    session.execute("DROP TABLE _airflow_moved__2_2__task_instance")

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -87,11 +87,11 @@ How to drop the table using Kubernetes:
 2. Run the following commands in the python shell:
 
  .. code-block:: python
-   from airflow.settings import Session
+     from airflow.settings import Session
 
-   session = Session()
-   session.execute("DROP TABLE _airflow_moved__2_2__task_instance")
-   session.commit()
+     session = Session()
+     session.execute("DROP TABLE _airflow_moved__2_2__task_instance")
+     session.commit()
 
 Please replace ``<table>`` in the examples with the actual table name as printed in the warning message.
 

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -79,7 +79,7 @@ table or rename it or move it to another database using those tools. If you don'
 can use the ``airflow db shell`` command - this will drop you in the db shell tool for your database and you
 will be able to both inspect and delete the table.
 
-Alternatively, you can drop the table by following the steps below:
+How to drop the table using Kubernetes:
 
 
 1. Exec into any of the Airflow pods - webserver or scheduler: ``kubectl exec -it <your-webserver-pod> python``

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -88,6 +88,7 @@ Alternatively, you can drop the table by following the steps below:
 
  .. code-block:: python
    from airflow.settings import Session
+
    session = Session()
    session.execute("DROP TABLE _airflow_moved__2_2__task_instance")
    session.commit()

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -87,6 +87,7 @@ How to drop the table using Kubernetes:
 2. Run the following commands in the python shell:
 
  .. code-block:: python
+
      from airflow.settings import Session
 
      session = Session()

--- a/docs/apache-airflow/installation/upgrading.rst
+++ b/docs/apache-airflow/installation/upgrading.rst
@@ -79,6 +79,20 @@ table or rename it or move it to another database using those tools. If you don'
 can use the ``airflow db shell`` command - this will drop you in the db shell tool for your database and you
 will be able to both inspect and delete the table.
 
+Alternatively, you can drop the table by following the steps below:
+
+
+1. Exec into any of the Airflow pods - webserver or scheduler: ``kubectl exec -it <your-webserver-pod> python``
+
+2. Run the following commands in the python shell:
+
+ .. code-block:: python
+ 
+   from airflow.settings import Session
+   session = Session()
+   session.execute("DROP TABLE _airflow_moved__2_2__task_instance")
+   session.commit()
+
 Please replace ``<table>`` in the examples with the actual table name as printed in the warning message.
 
 Inspecting a table:


### PR DESCRIPTION
Give a detailed code example for how to drop the _airflow_moved__2_2__task_instance table to resolve post-upgrade warning

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
