### PR TITLE
Fixed MyPy issues in tests decorators and hooks

### DIFF
--- a/tests/decorators/test_python.py
+++ b/tests/decorators/test_python.py
@@ -139,8 +139,8 @@ class TestAirflowTaskDecorator(TestPythonBase):
 
     def test_manual_multiple_outputs_false_with_typings(self):
         @task_decorator(multiple_outputs=False)
-        def identity2(x: int, y: int) -> Dict[int, int]:
-            return (x, y)
+        def identity2(x: int, y: int) -> Tuple[int, int]:
+            return x, y
 
         with self.dag:
             res = identity2(8, 4)

--- a/tests/hooks/test_subprocess.py
+++ b/tests/hooks/test_subprocess.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from subprocess import PIPE, STDOUT
 from tempfile import TemporaryDirectory
 from unittest import mock
+from unittest.mock import MagicMock
 
 from parameterized import parameterized
 
@@ -77,14 +78,11 @@ class TestSubprocessHook(unittest.TestCase):
     @mock.patch.dict('os.environ', clear=True)
     @mock.patch(
         "airflow.hooks.subprocess.TemporaryDirectory",
-        **{'return_value.__enter__.return_value': '/tmp/airflowtmpcatcat'},  # type: ignore
+        return_value=MagicMock(__enter__=MagicMock(return_value='/tmp/airflowtmpcatcat')),
     )
     @mock.patch(
         "airflow.hooks.subprocess.Popen",
-        **{  # type: ignore
-            'return_value.stdout.readline.side_effect': [b'BAR', b'BAZ'],
-            'return_value.returncode': 0,
-        },
+        return_value=MagicMock(stdout=MagicMock(readline=MagicMock(side_effect=StopIteration), returncode=0)),
     )
     def test_should_exec_subprocess(self, mock_popen, mock_temporary_directory):
         hook = SubprocessHook()


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/19891
Fixed MyPy issues inside tests for decorator and hooks folders

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
