### PR TITLE
Allow DockerOperator's image to be templated

### DIFF
--- a/airflow/providers/docker/operators/docker.py
+++ b/airflow/providers/docker/operators/docker.py
@@ -58,7 +58,7 @@ class DockerOperator(BaseOperator):
     be provided with the parameter ``docker_conn_id``.
 
     :param image: Docker image from which to create the container.
-        If image tag is omitted, "latest" will be used.
+        If image tag is omitted, "latest" will be used. (templated)
     :type image: str
     :param api_version: Remote API version. Set to ``auto`` to automatically
         detect the server's version.
@@ -152,7 +152,7 @@ class DockerOperator(BaseOperator):
     :type retrieve_output_path: Optional[str]
     """
 
-    template_fields = ('command', 'environment', 'container_name')
+    template_fields = ('image', 'command', 'environment', 'container_name')
     template_ext = (
         '.sh',
         '.bash',


### PR DESCRIPTION
Users may want to use templating when specifying the image to run.