### PR TITLE
Don't use CREATE TABLE AS SELECT ... with mySQL

### DIFF
--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -737,13 +737,24 @@ def _move_dangling_table(session, source_table: "Table", target_table_name: str,
             )
         )
     else:
-        # Postgres, MySQL and SQLite all have the same CREATE TABLE a AS SELECT ... syntax
-        session.execute(
-            text(
-                f"create table {target_table_name} as select source.* from {source_table} as source "
-                + where_clause
+        if dialect_name == "mysql":
+            # CREATE TABLE AS SELECT must be broken into two queries in mySQL for GTID consistency.
+            # More info: https://github.com/apache/airflow/issues/19988
+            session.execute(text(f"create table {target_table_name} like {source_table}"))
+            session.execute(
+                text(
+                    f"INSERT INTO {target_table_name} select source.* from {source_table} as source "
+                    + where_clause
+                )
             )
-        )
+        # Postgres and SQLite have the same CREATE TABLE a AS SELECT ... syntax
+        else:
+            session.execute(
+                text(
+                    f"create table {target_table_name} as select source.* from {source_table} as source "
+                    + where_clause
+                )
+            )
 
         # But different join-delete syntax.
         if dialect_name == "mysql":

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -738,8 +738,8 @@ def _move_dangling_table(session, source_table: "Table", target_table_name: str,
         )
     else:
         if dialect_name == "mysql":
-            # CREATE TABLE AS SELECT must be broken into two queries in mySQL for GTID consistency.
-            # More info: https://github.com/apache/airflow/issues/19988
+            # CREATE TABLE AS SELECT must be broken into two queries for  MySQL as the single query
+            # approach fails when replication is enabled ("Statement violates GTID consistency")```
             session.execute(text(f"create table {target_table_name} like {source_table}"))
             session.execute(
                 text(


### PR DESCRIPTION
Closes: https://github.com/apache/airflow/issues/19988

Splitting this `CREATE TABLE AS SELECT` query into two queries (`CREATE TABLE LIKE ..` followed by `INSERT INTO`) because the former doesn't play nicely with MySQL.

This PR is inherently difficult to test/validate, but I ran the proposed queries against the metadata database in our development environment (where we first ran into this issue) and was able to replicate the issue and verify the fix:

```
// replicating the issue:

MySQL [airflow] > create table _airflow_moved__2_2__task_instance as select source.* from task_instance as source;
ERROR 1786 (HY000): Statement violates GTID consistency: CREATE TABLE ... SELECT.

// Validating that splitting the query fixes the issue

MySQL [airflow] > create table _airflow_moved__2_2__task_instance like task_instance;
Query OK, 0 rows affected (0.063 sec)

MySQL [airflow] > INSERT INTO _airflow_moved__2_2__task_instance select source.* from task_instance as source left join dag_run as dr on (source.dag_id = dr.dag_id and source.execution_date = dr.execution_date) where dr.id is null;
Query OK, 22900 rows affected (2.110 sec)
```

Tomorrow I can create a patched image with these changes and validate the fix in our development environment.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
