### PR TITLE
Add hour and minute to time format on x-axis of all charts using nvd3.lineChart

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -139,7 +139,7 @@ FILTER_STATUS_COOKIE = 'dag_status_filter'
 LINECHART_X_AXIS_TICKFORMAT = (
     "function (d, i) { let xLabel;"
     "if (i === undefined) {xLabel = d3.time.format('%H:%M, %d %b %Y')(new Date(parseInt(d)));"
-    "} else {xLabel = d3.time.format('%H:%M')(new Date(parseInt(d)));} return xLabel;}"
+    "} else {xLabel = d3.time.format('%H:%M, %d %b')(new Date(parseInt(d)));} return xLabel;}"
 )
 
 

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -2561,10 +2561,18 @@ class Airflow(AirflowBaseView):
             dag = dag.partial_subset(task_ids_or_regex=root, include_upstream=True, include_downstream=False)
         chart_height = wwwutils.get_chart_height(dag)
         chart = nvd3.lineChart(
-            name="lineChart", x_is_date=True, height=chart_height, chart_attr=self.line_chart_attr
+            name="lineChart",
+            x_is_date=True,
+            x_axis_format="%d %b %Y, %H:%M",
+            height=chart_height,
+            chart_attr=self.line_chart_attr
         )
         cum_chart = nvd3.lineChart(
-            name="cumLineChart", x_is_date=True, height=chart_height, chart_attr=self.line_chart_attr
+            name="cumLineChart",
+            x_is_date=True,
+            x_axis_format="%d %b %Y, %H:%M",
+            height=chart_height,
+            chart_attr=self.line_chart_attr
         )
 
         y_points = defaultdict(list)
@@ -2691,6 +2699,7 @@ class Airflow(AirflowBaseView):
         chart = nvd3.lineChart(
             name="lineChart",
             x_is_date=True,
+            x_axis_format="%d %b %Y, %H:%M",
             y_axis_format='d',
             height=chart_height,
             chart_attr=self.line_chart_attr,
@@ -2767,7 +2776,11 @@ class Airflow(AirflowBaseView):
 
         chart_height = wwwutils.get_chart_height(dag)
         chart = nvd3.lineChart(
-            name="lineChart", x_is_date=True, height=chart_height, chart_attr=self.line_chart_attr
+            name="lineChart",
+            x_is_date=True,
+            x_axis_format="%d %b %Y, %H:%M",
+            height=chart_height,
+            chart_attr=self.line_chart_attr
         )
         y_points = {}
         x_points = {}

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -136,6 +136,11 @@ from airflow.www.widgets import AirflowModelListWidget
 PAGE_SIZE = conf.getint('webserver', 'page_size')
 FILTER_TAGS_COOKIE = 'tags_filter'
 FILTER_STATUS_COOKIE = 'dag_status_filter'
+LINECHART_X_AXIS_TICKFORMAT = (
+    "function (d, i) { let xLabel;"
+    "if (i === undefined) {xLabel = d3.time.format('%H:%M, %d %b %Y')(new Date(parseInt(d)));"
+    "} else {xLabel = d3.time.format('%H:%M')(new Date(parseInt(d)));} return xLabel;}"
+)
 
 
 def truncate_task_duration(task_duration):
@@ -2562,17 +2567,19 @@ class Airflow(AirflowBaseView):
         chart_height = wwwutils.get_chart_height(dag)
         chart = nvd3.lineChart(
             name="lineChart",
-            x_is_date=True,
-            x_axis_format="%d %b %Y, %H:%M",
+            x_custom_format=True,
+            x_axis_date=True,
+            x_axis_format=LINECHART_X_AXIS_TICKFORMAT,
             height=chart_height,
-            chart_attr=self.line_chart_attr
+            chart_attr=self.line_chart_attr,
         )
         cum_chart = nvd3.lineChart(
             name="cumLineChart",
-            x_is_date=True,
-            x_axis_format="%d %b %Y, %H:%M",
+            x_custom_format=True,
+            x_axis_date=True,
+            x_axis_format=LINECHART_X_AXIS_TICKFORMAT,
             height=chart_height,
-            chart_attr=self.line_chart_attr
+            chart_attr=self.line_chart_attr,
         )
 
         y_points = defaultdict(list)
@@ -2698,9 +2705,9 @@ class Airflow(AirflowBaseView):
         chart_height = wwwutils.get_chart_height(dag)
         chart = nvd3.lineChart(
             name="lineChart",
-            x_is_date=True,
-            x_axis_format="%d %b %Y, %H:%M",
-            y_axis_format='d',
+            x_custom_format=True,
+            x_axis_date=True,
+            x_axis_format=LINECHART_X_AXIS_TICKFORMAT,
             height=chart_height,
             chart_attr=self.line_chart_attr,
         )
@@ -2777,10 +2784,11 @@ class Airflow(AirflowBaseView):
         chart_height = wwwutils.get_chart_height(dag)
         chart = nvd3.lineChart(
             name="lineChart",
-            x_is_date=True,
-            x_axis_format="%d %b %Y, %H:%M",
+            x_custom_format=True,
+            x_axis_date=True,
+            x_axis_format=LINECHART_X_AXIS_TICKFORMAT,
             height=chart_height,
-            chart_attr=self.line_chart_attr
+            chart_attr=self.line_chart_attr,
         )
         y_points = {}
         x_points = {}


### PR DESCRIPTION
This PR adds a new date and time format for x axis where all `nvd3.lineChart` classes are initialized in order to see time of execution_date as well as date.

![image](https://user-images.githubusercontent.com/16971553/144526638-dda95c0a-27f0-4a96-bd93-8475e23e7843.png)

closes: #19955 


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
