### PR TITLE
Fixing '-' to '_' in task_instance_created metric

### DIFF
--- a/docs/apache-airflow/logging-monitoring/metrics.rst
+++ b/docs/apache-airflow/logging-monitoring/metrics.rst
@@ -109,7 +109,7 @@ Name                                        Description
 ``task_removed_from_dag.<dagid>``           Number of tasks removed for a given dag (i.e. task no longer exists in DAG)
 ``task_restored_to_dag.<dagid>``            Number of tasks restored for a given dag (i.e. task instance which was
                                             previously in REMOVED state in the DB is added to DAG file)
-``task_instance_created-<operator_name>``   Number of tasks instances created for a given Operator
+``task_instance_created_<operator_name>``   Number of tasks instances created for a given Operator
 ``triggers.blocked_main_thread``            Number of triggers that blocked the main thread (likely due to not being
                                             fully asynchronous)
 ``triggers.failed``                         Number of triggers that errored before they could fire an event


### PR DESCRIPTION
Saw that this was misnamed when writing my statsd mappers.