### PR TITLE
Fix ``breeze kind-cluster shell``

### DIFF
--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -93,7 +93,7 @@ function create_virtualenv() {
         --constraint
         "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${HOST_PYTHON_VERSION}.txt"
     )
-    if [[ -n ${GITHUB_REGISTRY_PULL_IMAGE_TAG=} ]]; then
+    if [[ ${CI:=} == "true" ]]; then
         # Disable constraints when building in CI with specific version of sources
         # In case there will be conflicting constraints
         constraints=()

--- a/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
+++ b/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh
@@ -93,7 +93,7 @@ function create_virtualenv() {
         --constraint
         "https://raw.githubusercontent.com/${CONSTRAINTS_GITHUB_REPOSITORY}/${DEFAULT_CONSTRAINTS_BRANCH}/constraints-${HOST_PYTHON_VERSION}.txt"
     )
-    if [[ ${CI:=} == "true" ]]; then
+    if [[ ${CI:=} == "true" && -n ${GITHUB_REGISTRY_PULL_IMAGE_TAG=} ]]; then
         # Disable constraints when building in CI with specific version of sources
         # In case there will be conflicting constraints
         constraints=()


### PR DESCRIPTION
This was failing with following:

```
/Users/kaxilnaik/Documents/GitHub/astronomer/airflow/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh: line 102: constraints[@]: unbound variable
Exporting logs for cluster "airflow-python-3.7-v1.20.2" to:
/tmp/kind_logs_2021-12-03_0_0
```

and was caused by https://github.com/apache/airflow/pull/17290

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
