### PR TITLE
Fix mypy typing issues for airflow.executors

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -55,7 +55,7 @@ class BaseExecutor(LoggingMixin):
         ``0`` for infinity
     """
 
-    job_id: Optional[str] = None
+    job_id: Optional[int] = None
 
     def __init__(self, parallelism: int = PARALLELISM):
         super().__init__()

--- a/airflow/executors/celery_kubernetes_executor.py
+++ b/airflow/executors/celery_kubernetes_executor.py
@@ -40,7 +40,7 @@ class CeleryKubernetesExecutor(LoggingMixin):
 
     def __init__(self, celery_executor: CeleryExecutor, kubernetes_executor: KubernetesExecutor):
         super().__init__()
-        self._job_id: Optional[str] = None
+        self._job_id: Optional[int] = None
         self.celery_executor = celery_executor
         self.kubernetes_executor = kubernetes_executor
 
@@ -58,7 +58,7 @@ class CeleryKubernetesExecutor(LoggingMixin):
         return self.celery_executor.running.union(self.kubernetes_executor.running)
 
     @property
-    def job_id(self) -> Optional[str]:
+    def job_id(self) -> Optional[int]:
         """
         This is a class attribute in BaseExecutor but since this is not really an executor, but a wrapper
         of executors we implement as property so we can have custom setter.
@@ -66,7 +66,7 @@ class CeleryKubernetesExecutor(LoggingMixin):
         return self._job_id
 
     @job_id.setter
-    def job_id(self, value: Optional[str]) -> None:
+    def job_id(self, value: Optional[int]) -> None:
         """job_id is manipulated by SchedulerJob.  We must propagate the job_id to wrapped executors."""
         self._job_id = value
         self.kubernetes_executor.job_id = value

--- a/airflow/executors/kubernetes_executor.py
+++ b/airflow/executors/kubernetes_executor.py
@@ -81,7 +81,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         multi_namespace_mode: bool,
         watcher_queue: 'Queue[KubernetesWatchType]',
         resource_version: Optional[str],
-        scheduler_job_id: Optional[str],
+        scheduler_job_id: Optional[int],
         kube_config: Configuration,
     ):
         super().__init__()
@@ -120,7 +120,7 @@ class KubernetesJobWatcher(multiprocessing.Process, LoggingMixin):
         self,
         kube_client: client.CoreV1Api,
         resource_version: Optional[str],
-        scheduler_job_id: str,
+        scheduler_job_id: int,
         kube_config: Any,
     ) -> Optional[str]:
         self.log.info('Event: and now my watch begins starting at resource_version: %s', resource_version)
@@ -232,7 +232,7 @@ class AirflowKubernetesScheduler(LoggingMixin):
         task_queue: 'Queue[KubernetesJobType]',
         result_queue: 'Queue[KubernetesResultsType]',
         kube_client: client.CoreV1Api,
-        scheduler_job_id: str,
+        scheduler_job_id: int,
     ):
         super().__init__()
         self.log.debug("Creating Kubernetes executor")
@@ -431,9 +431,9 @@ class KubernetesExecutor(BaseExecutor):
         self.result_queue: 'Queue[KubernetesResultsType]' = self._manager.Queue()
         self.kube_scheduler: Optional[AirflowKubernetesScheduler] = None
         self.kube_client: Optional[client.CoreV1Api] = None
-        self.scheduler_job_id: Optional[str] = None
+        self.scheduler_job_id: Optional[int] = None
         self.event_scheduler: Optional[EventScheduler] = None
-        self.last_handled: Dict[TaskInstanceKey, int] = {}
+        self.last_handled: Dict[TaskInstanceKey, float] = {}
         super().__init__(parallelism=self.kube_config.parallelism)
 
     @provide_session
@@ -565,6 +565,8 @@ class KubernetesExecutor(BaseExecutor):
         if not self.result_queue:
             raise AirflowException(NOT_STARTED_MESSAGE)
         if not self.task_queue:
+            raise AirflowException(NOT_STARTED_MESSAGE)
+        if not self.event_scheduler:
             raise AirflowException(NOT_STARTED_MESSAGE)
         self.kube_scheduler.sync()
 


### PR DESCRIPTION
This fixes all the issue in `airflow.executors` except for 2 in `airflow.executors.celery_executor.py`, which will be fixed as part of #20000.

Related to #19891.