### PR TITLE
Chart: Fix Helm Hooks Weight for K8s Jobs

### DIFF
--- a/chart/templates/jobs/create-user-job.yaml
+++ b/chart/templates/jobs/create-user-job.yaml
@@ -38,7 +38,7 @@ metadata:
   {{- $annotations := dict }}
   {{- if .Values.createUserJob.useHelmHooks }}
     {{- $_ := set $annotations "helm.sh/hook" "post-install,post-upgrade" }}
-    {{- $_ := set $annotations "helm.sh/hook-weight" "1" }}
+    {{- $_ := set $annotations "helm.sh/hook-weight" "2" }}
     {{- $_ := set $annotations "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" }}
   {{- end }}
   {{- with $annotations := merge $annotations .Values.createUserJob.jobAnnotations }}

--- a/chart/tests/test_airflow_common.py
+++ b/chart/tests/test_airflow_common.py
@@ -123,3 +123,10 @@ class TestAirflowCommon:
 
         for doc in docs:
             assert expected_image == jmespath.search("spec.template.spec.initContainers[0].image", doc)
+
+    def test_should_set_correct_helm_hooks_weight(self):
+        docs = render_chart(
+            show_only=["templates/secrets/fernetkey-secret.yaml"],
+        )
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert annotations["helm.sh/hook-weight"] == "0"

--- a/chart/tests/test_create_user_job.py
+++ b/chart/tests/test_create_user_job.py
@@ -114,3 +114,12 @@ class CreateUserJobTest(unittest.TestCase):
         )
         annotations = jmespath.search("spec.template.metadata.annotations", docs[0])
         assert annotations is None
+
+    def test_should_set_correct_helm_hooks_weight(self):
+        docs = render_chart(
+            show_only=[
+                "templates/jobs/create-user-job.yaml",
+            ],
+        )
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert annotations["helm.sh/hook-weight"] == "2"

--- a/chart/tests/test_migrate_database_job.py
+++ b/chart/tests/test_migrate_database_job.py
@@ -161,5 +161,14 @@ class TestMigrateDatabaseJob:
             values={"migrateDatabaseJob": {"useHelmHooks": False}},
             show_only=["templates/jobs/migrate-database-job.yaml"],
         )
-        annotations = jmespath.search("spec.template.metadata.annotations", docs[0])
+        annotations = jmespath.search("metadata.annotations", docs[0])
         assert annotations is None
+
+    def test_should_set_correct_helm_hooks_weight(self):
+        docs = render_chart(
+            show_only=[
+                "templates/jobs/migrate-database-job.yaml",
+            ],
+        )
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert annotations["helm.sh/hook-weight"] == "1"

--- a/chart/tests/test_redis.py
+++ b/chart/tests/test_redis.py
@@ -310,3 +310,13 @@ class RedisTest(unittest.TestCase):
             show_only=["templates/redis/redis-statefulset.yaml"],
         )
         assert jmespath.search("spec.template.spec.containers[0].resources", docs[0]) == {}
+
+    def test_should_set_correct_helm_hooks_weight(self):
+        docs = render_chart(
+            values={
+                "executor": "CeleryExecutor",
+            },
+            show_only=["templates/secrets/redis-secrets.yaml"],
+        )
+        annotations = jmespath.search("metadata.annotations", docs[0])
+        assert annotations["helm.sh/hook-weight"] == "0"


### PR DESCRIPTION
https://github.com/apache/airflow/pull/18776 introduced a bug where it changed the Helm Hook weight for Create User job from 2 to 1. It needs to be 2 as we want to run migrations first even before create-user-job

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
