### PR TITLE
Change ParamsDict to a MutableMapping subclass

### DIFF
--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -135,7 +135,7 @@ class ParamsDict(MutableMapping[str, Any]):
         del self.__dict[v]
 
     def __iter__(self):
-        return self.__dict.__iter__()
+        return iter(self.__dict)
 
     def __setitem__(self, key: str, value: Any) -> None:
         """

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import Any, Dict, Optional
+from typing import Any, Dict, ItemsView, MutableMapping, Optional, ValuesView
 
 import jsonschema
 from jsonschema import FormatChecker
@@ -50,7 +50,7 @@ class Param:
     __NO_VALUE_SENTINEL = NoValueSentinel()
     CLASS_IDENTIFIER = '__class'
 
-    def __init__(self, default: Any = __NO_VALUE_SENTINEL, description: str = None, **kwargs):
+    def __init__(self, default: Any = __NO_VALUE_SENTINEL, description: Optional[str] = None, **kwargs):
         self.value = default
         self.description = description
         self.schema = kwargs.pop('schema') if 'schema' in kwargs else kwargs
@@ -99,16 +99,17 @@ class Param:
         return not isinstance(self.value, NoValueSentinel)
 
 
-class ParamsDict(dict):
+class ParamsDict(MutableMapping[str, Any]):
     """
     Class to hold all params for dags or tasks. All the keys are strictly string and values
     are converted into Param's object if they are not already. This class is to replace param's
     dictionary implicitly and ideally not needed to be used directly.
     """
 
+    __slots__ = ['__dict', 'suppress_exception']
+
     def __init__(self, dict_obj: Optional[Dict] = None, suppress_exception: bool = False):
         """
-        Init override for ParamsDict
         :param dict_obj: A dict or dict like object to init ParamsDict
         :type dict_obj: Optional[dict]
         :param suppress_exception: Flag to suppress value exceptions while initializing the ParamsDict
@@ -121,8 +122,20 @@ class ParamsDict(dict):
                 params_dict[k] = Param(v)
             else:
                 params_dict[k] = v
-        super().__init__(params_dict)
+        self.__dict = params_dict
         self.suppress_exception = suppress_exception
+
+    def __contains__(self, o: object) -> bool:
+        return o in self.__dict
+
+    def __len__(self) -> int:
+        return len(self.__dict)
+
+    def __delitem__(self, v: str) -> None:
+        del self.__dict[v]
+
+    def __iter__(self):
+        return self.__dict.__iter__()
 
     def __setitem__(self, key: str, value: Any) -> None:
         """
@@ -137,14 +150,17 @@ class ParamsDict(dict):
         """
         if isinstance(value, Param):
             param = value
-        elif key in self:
-            param = dict.__getitem__(self, key)
-            param.resolve(value=value, suppress_exception=self.suppress_exception)
+        elif key in self.__dict:
+            param = self.__dict[key]
+            try:
+                param.resolve(value=value, suppress_exception=self.suppress_exception)
+            except ValueError as ve:
+                raise ValueError(f'Invalid input for param {key}: {ve}') from None
         else:
             # if the key isn't there already and if the value isn't of Param type create a new Param object
             param = Param(value)
 
-        super().__setitem__(key, param)
+        self.__dict[key] = param
 
     def __getitem__(self, key: str) -> Any:
         """
@@ -154,30 +170,34 @@ class ParamsDict(dict):
         :param key: The key to fetch
         :type key: str
         """
-        param = super().__getitem__(key)
+        param = self.__dict[key]
         return param.resolve(suppress_exception=self.suppress_exception)
+
+    def get_param(self, key: str) -> Param:
+        """Get the internal :class:`.Param` object for this key"""
+        return self.__dict[key]
+
+    def items(self):
+        return ItemsView(self.__dict)
+
+    def values(self):
+        return ValuesView(self.__dict)
+
+    def update(self, *args, **kwargs) -> None:
+
+        if len(args) == 1 and isinstance(args[0], ParamsDict):
+            return super().update(args[0].__dict)
+        super().update(*args, **kwargs)
 
     def dump(self) -> dict:
         """Dumps the ParamsDict object as a dictionary, while suppressing exceptions"""
         return {k: v.resolve(suppress_exception=True) for k, v in self.items()}
 
-    def update(self, other_dict: dict) -> None:
-        """
-        Override for dictionary's update method.
-        :param other_dict: A dict type object which needs to be merged in the ParamsDict object
-        :type other_dict: dict
-        """
-        try:
-            for k, v in other_dict.items():
-                self.__setitem__(k, v)
-        except ValueError as ve:
-            raise ValueError(f'Invalid input for param {k}: {ve}') from None
-
     def validate(self) -> dict:
         """Validates & returns all the Params object stored in the dictionary"""
         resolved_dict = {}
         try:
-            for k, v in dict.items(self):
+            for k, v in self.items():
                 resolved_dict[k] = v.resolve(suppress_exception=self.suppress_exception)
         except ValueError as ve:
             raise ValueError(f'Invalid input for param {k}: {ve}') from None

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -184,8 +184,7 @@ class ParamsDict(MutableMapping[str, Any]):
         return ValuesView(self.__dict)
 
     def update(self, *args, **kwargs) -> None:
-
-        if len(args) == 1 and isinstance(args[0], ParamsDict):
+        if len(args) == 1 and not kwargs and isinstance(args[0], ParamsDict):
             return super().update(args[0].__dict)
         super().update(*args, **kwargs)
 

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -46,7 +46,7 @@ from airflow.exceptions import AirflowException, DuplicateTaskIdFound
 from airflow.models import DAG, DagModel, DagRun, DagTag, TaskFail, TaskInstance as TI
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import dag as dag_decorator
-from airflow.models.param import DagParam, Param
+from airflow.models.param import DagParam, Param, ParamsDict
 from airflow.operators.bash import BashOperator
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.subdag import SubDagOperator
@@ -115,7 +115,7 @@ class TestDag(unittest.TestCase):
         """
         dag = models.DAG('test-dag')
 
-        assert isinstance(dag.params, dict)
+        assert isinstance(dag.params, ParamsDict)
         assert 0 == len(dag.params)
 
     def test_params_passed_and_params_in_default_args_no_override(self):

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -141,23 +141,23 @@ class TestParam(unittest.TestCase):
         assert dump['schema'] == {'type': 'string', 'minLength': 2}
 
 
-class TestParamsDict(unittest.TestCase):
+class TestParamsDict:
     def test_params_dict(self):
         # Init with a simple dictionary
         pd = ParamsDict(dict_obj={'key': 'value'})
-        assert pd.get('key').__class__ == Param
+        assert isinstance(pd.get_param('key'), Param)
         assert pd['key'] == 'value'
         assert pd.suppress_exception is False
 
         # Init with a dict which contains Param objects
         pd2 = ParamsDict({'key': Param('value', type='string')}, suppress_exception=True)
-        assert pd2.get('key').__class__ == Param
+        assert isinstance(pd2.get_param('key'), Param)
         assert pd2['key'] == 'value'
         assert pd2.suppress_exception is True
 
         # Init with another object of another ParamsDict
         pd3 = ParamsDict(pd2)
-        assert pd3.get('key').__class__ == Param
+        assert isinstance(pd3.get_param('key'), Param)
         assert pd3['key'] == 'value'
         assert pd3.suppress_exception is False  # as it's not a deepcopy of pd2
 
@@ -167,17 +167,27 @@ class TestParamsDict(unittest.TestCase):
         assert pd3.dump() == {'key': 'value'}
 
         # Validate the ParamsDict
-        pd.validate()
+        plain_dict = pd.validate()
+        assert type(plain_dict) == dict
         pd2.validate()
         pd3.validate()
 
         # Update the ParamsDict
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r'Invalid input for param key: 1 is not'):
             pd3['key'] = 1
 
         # Should not raise an error as suppress_exception is True
         pd2['key'] = 1
         pd2.validate()
+
+    def test_update(self):
+        pd = ParamsDict({'key': Param('value', type='string')})
+
+        pd.update({'key': 'a'})
+        internal_value = pd.get_param('key')
+        assert isinstance(internal_value, Param)
+        with pytest.raises(ValueError, match=r'Invalid input for param key: 1 is not'):
+            pd.update({'key': 1})
 
 
 class TestDagParamRuntime:

--- a/tests/serialization/test_dag_serialization.py
+++ b/tests/serialization/test_dag_serialization.py
@@ -789,7 +789,7 @@ class TestStringifiedDAGs:
         dag = SerializedDAG.from_dict(serialized)
 
         assert dag.params["my_param"] == param.value
-        observed_param = dict.get(dag.params, 'my_param')
+        observed_param = dag.params.get_param('my_param')
         assert isinstance(observed_param, Param)
         assert observed_param.description == param.description
         assert observed_param.schema == param.schema
@@ -1475,7 +1475,7 @@ class TestStringifiedDAGs:
         dag = SerializedDAG.from_dict(serialized)
 
         assert dag.params["none"] is None
-        assert isinstance(dict.__getitem__(dag.params, "none"), Param)
+        assert isinstance(dag.params.get_param("none"), Param)
         assert dag.params["str"] == "str"
 
     def test_params_serialize_default_2_2_0(self):
@@ -1495,7 +1495,7 @@ class TestStringifiedDAGs:
         SerializedDAG.validate_schema(serialized)
         dag = SerializedDAG.from_dict(serialized)
 
-        assert isinstance(dict.__getitem__(dag.params, "str"), Param)
+        assert isinstance(dag.params.get_param("str"), Param)
         assert dag.params["str"] == "str"
 
     def test_params_serialize_default(self):
@@ -1520,7 +1520,7 @@ class TestStringifiedDAGs:
         dag = SerializedDAG.from_dict(serialized)
 
         assert dag.params["my_param"] == "a string value"
-        param = dict.get(dag.params, 'my_param')
+        param = dag.params.get_param('my_param')
         assert isinstance(param, Param)
         assert param.description == 'hello'
         assert param.schema == {'type': 'string'}


### PR DESCRIPTION
This is a little more work, and while it has no change in behaviour it
does make Mypy happier -- previously it was complaining about update's
signature not matching dict _or_ MutableMapping's

Part of #19891, but since this was a bigger change than just adding/changing some types it is its own PR for easier review.