### PR TITLE
Revert "Work around change in GH Actions concurrency expression evaluation"

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -50,7 +50,7 @@ env:
   GITHUB_REGISTRY_PUSH_IMAGE_TAG: ${{ github.event.pull_request.head.sha || github.sha }}
 
 concurrency:
-  group: build-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || github.ref }}
+  group: build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ env:
   GITHUB_REGISTRY_WAIT_FOR_IMAGE: ${{ secrets.AIRFLOW_GITHUB_REGISTRY_WAIT_FOR_IMAGE != 'false' }}
 
 concurrency:
-  group: ci-${{ (github.event_name == 'pull_request' && github.event.pull_request.number) || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Reverts apache/airflow#20023

This alternate syntax puts everythign at "main" group, and the old way works again

Closes #20024 