### PR TITLE
Add missed deprecations for cncf

### DIFF
--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`."""
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements` and :mod:`kubernetes.client.models.V1ContainerPort`."""
 
 import warnings
 

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -15,8 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1Volume`."""
+
+import warnings
 
 from kubernetes.client import models as k8s
+
+warnings.warn(
+    "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class Resources:

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -28,7 +28,7 @@ from kubernetes.client import models as k8s
 warnings.warn(
     (
         "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements`"
-        "and `kubernetes.client.models.V1ContainerPort`."
+        " and `kubernetes.client.models.V1ContainerPort`."
     ),
     DeprecationWarning,
     stacklevel=2,

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -14,9 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Classes for interacting with Kubernetes API
+"""
+Classes for interacting with Kubernetes API.
+
 This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements`
-and :mod:`kubernetes.client.models.V1ContainerPort`."""
+and :mod:`kubernetes.client.models.V1ContainerPort`.
+"""
 
 import warnings
 
@@ -33,7 +36,7 @@ warnings.warn(
 
 
 class Resources:
-    """backwards compat for Resources"""
+    """backwards compat for Resources."""
 
     __slots__ = (
         'request_memory',

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -15,14 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements` and :mod:`kubernetes.client.models.V1ContainerPort`."""
-
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements`
+and :mod:`kubernetes.client.models.V1ContainerPort`."""
 import warnings
 
 from kubernetes.client import models as k8s
 
 warnings.warn(
-    "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`.",
+    (
+        "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements`"
+        "and `kubernetes.client.models.V1ContainerPort`."
+    ),
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements` and and `kubernetes.client.models.V1ContainerPort`."""
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`."""
 
 import warnings
 

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements`
+"""Classes for interacting with Kubernetes API
+This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements`
 and :mod:`kubernetes.client.models.V1ContainerPort`."""
+
 import warnings
 
 from kubernetes.client import models as k8s

--- a/airflow/providers/cncf/kubernetes/backcompat/pod.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1Volume`."""
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1ResourceRequirements` and and `kubernetes.client.models.V1ContainerPort`."""
 
 import warnings
 

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -15,8 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1Volume`."""
+
+import warnings
 
 import kubernetes.client.models as k8s
+
+warnings.warn(
+    "This module is deprecated. Please use `kubernetes.client.models.V1EnvVar`.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 
 class PodRuntimeInfoEnv:

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -14,8 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1EnvVar`."""
+"""Classes for interacting with Kubernetes API
+This module is deprecated. Please use :mod:`kubernetes.client.models.V1EnvVar`.
+"""
+
 import warnings
 
 import kubernetes.client.models as k8s

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -16,7 +16,6 @@
 # under the License.
 """Classes for interacting with Kubernetes API"""
 """This module is deprecated. Please use :mod:`kubernetes.client.models.V1EnvVar`."""
-
 import warnings
 
 import kubernetes.client.models as k8s

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -27,7 +27,7 @@ import kubernetes.client.models as k8s
 warnings.warn(
     "This module is deprecated. Please use `kubernetes.client.models.V1EnvVar`.",
     DeprecationWarning,
-    stacklevel=3,
+    stacklevel=2,
 )
 
 

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -27,7 +27,7 @@ import kubernetes.client.models as k8s
 warnings.warn(
     "This module is deprecated. Please use `kubernetes.client.models.V1EnvVar`.",
     DeprecationWarning,
-    stacklevel=2,
+    stacklevel=3,
 )
 
 

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -14,7 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Classes for interacting with Kubernetes API
+"""
+Classes for interacting with Kubernetes API.
+
 This module is deprecated. Please use :mod:`kubernetes.client.models.V1EnvVar`.
 """
 
@@ -30,7 +32,7 @@ warnings.warn(
 
 
 class PodRuntimeInfoEnv:
-    """Defines Pod runtime information as environment variable"""
+    """Defines Pod runtime information as environment variable."""
 
     def __init__(self, name, field_path):
         """

--- a/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
+++ b/airflow/providers/cncf/kubernetes/backcompat/pod_runtime_info_env.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Classes for interacting with Kubernetes API"""
-"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1Volume`."""
+"""This module is deprecated. Please use :mod:`kubernetes.client.models.V1EnvVar`."""
 
 import warnings
 

--- a/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/kubernetes_pod.py
@@ -42,7 +42,6 @@ from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters im
     convert_volume,
     convert_volume_mount,
 )
-from airflow.providers.cncf.kubernetes.backcompat.pod_runtime_info_env import PodRuntimeInfoEnv
 from airflow.providers.cncf.kubernetes.utils import xcom_sidecar
 from airflow.providers.cncf.kubernetes.utils.pod_manager import PodLaunchFailedException, PodManager, PodPhase
 from airflow.settings import pod_mutation_hook
@@ -196,7 +195,7 @@ class KubernetesPodOperator(BaseOperator):
         do_xcom_push: bool = False,
         pod_template_file: Optional[str] = None,
         priority_class_name: Optional[str] = None,
-        pod_runtime_info_envs: Optional[List[PodRuntimeInfoEnv]] = None,
+        pod_runtime_info_envs: Optional[List[k8s.V1EnvVar]] = None,
         termination_grace_period: Optional[int] = None,
         configmaps: Optional[List[str]] = None,
         **kwargs,

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2166,6 +2166,7 @@ KNOWN_DEPRECATED_DIRECT_IMPORTS: Set[str] = {
     "This module is deprecated. Please use `kubernetes.client.models.V1Volume`.",
     "This module is deprecated. Please use `kubernetes.client.models.V1VolumeMount`.",
     "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`.",
+    "This module is deprecated. Please use `kubernetes.client.models.V1EnvVar`.",
     'numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header,'
     ' got 216 from PyObject',
     "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.step_function`.",

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2165,7 +2165,10 @@ KNOWN_DEPRECATED_DIRECT_IMPORTS: Set[str] = {
     "This module is deprecated. Please use `airflow.providers.tableau.hooks.tableau`.",
     "This module is deprecated. Please use `kubernetes.client.models.V1Volume`.",
     "This module is deprecated. Please use `kubernetes.client.models.V1VolumeMount`.",
-    "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`.",
+    (
+        "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements`"
+        " and `kubernetes.client.models.V1ContainerPort`."
+    ),
     "This module is deprecated. Please use `kubernetes.client.models.V1EnvVar`.",
     'numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header,'
     ' got 216 from PyObject',

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2165,6 +2165,7 @@ KNOWN_DEPRECATED_DIRECT_IMPORTS: Set[str] = {
     "This module is deprecated. Please use `airflow.providers.tableau.hooks.tableau`.",
     "This module is deprecated. Please use `kubernetes.client.models.V1Volume`.",
     "This module is deprecated. Please use `kubernetes.client.models.V1VolumeMount`.",
+    "This module is deprecated. Please use `kubernetes.client.models.V1ResourceRequirements` and `kubernetes.client.models.V1ContainerPort`.",
     'numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header,'
     ' got 216 from PyObject',
     "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.step_function`.",


### PR DESCRIPTION
This just adds deprecation warnings to backcompat classes for:
* V1EnvVar
* V1ResourceRequirements
* V1ContainerPort

This was split from https://github.com/apache/airflow/pull/19726#issuecomment-982085070

@jedcunningham 