### PR TITLE
Databricks hook: fix expiration time check

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -176,7 +176,7 @@ class DatabricksHook(BaseHook):
         if resource in self.aad_tokens:
             d = self.aad_tokens[resource]
             now = int(time.time())
-            if d['expires_on'] > (now - TOKEN_REFRESH_LEAD_TIME):  # it expires in more than 5 minutes
+            if d['expires_on'] > (now + TOKEN_REFRESH_LEAD_TIME):  # it expires in more than 2 minutes
                 return d['token']
             self.log.info("Existing AAD token is expired, or going to expire soon. Refreshing...")
 


### PR DESCRIPTION
There was a logical error in the check of expiration time that could lead to authentication failures when executing long-running jobs (thank you to @eskarimov for pointing to it)

