### PR TITLE
Fix infinite recursion on redact log

### DIFF
--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -213,11 +213,13 @@ class SecretsMasker(logging.Filter):
             else:
                 return item
         # I think this should never happen, but it does not hurt to leave it just in case
+        # Well. It happened (see https://github.com/apache/airflow/issues/19816#issuecomment-983311373)
+        # but it caused infinite recursion, so we need to cast it to str first.
         except Exception as e:
             log.warning(
-                "Unable to redact %r, please report this via <https://github.com/apache/airflow/issues>. "
+                "Unable to redact %s, please report this via <https://github.com/apache/airflow/issues>. "
                 "Error was: %s: %s",
-                item,
+                item.repr(),
                 type(e).__name__,
                 str(e),
             )

--- a/airflow/utils/log/secrets_masker.py
+++ b/airflow/utils/log/secrets_masker.py
@@ -219,7 +219,7 @@ class SecretsMasker(logging.Filter):
             log.warning(
                 "Unable to redact %s, please report this via <https://github.com/apache/airflow/issues>. "
                 "Error was: %s: %s",
-                item.repr(),
+                repr(item),
                 type(e).__name__,
                 str(e),
             )


### PR DESCRIPTION
When redact warning log on "unredactable" item is printed, the
log entered an infinite recursion, because the item was attempted
to be redacted again in the log.

This PR converts the item to str() - in the worst case the str
converstion will fail and raise exception - but this will be about
right - but it will not attempt to redact the item again.

Fixes: #19816

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
