### PR TITLE
Add ShortCircuitOperator configurability for respecting downstream trigger rules

### DIFF
--- a/airflow/example_dags/example_short_circuit_operator.py
+++ b/airflow/example_dags/example_short_circuit_operator.py
@@ -23,6 +23,7 @@ from airflow import DAG
 from airflow.models.baseoperator import chain
 from airflow.operators.dummy import DummyOperator
 from airflow.operators.python import ShortCircuitOperator
+from airflow.utils.trigger_rule import TriggerRule
 
 with DAG(
     dag_id='example_short_circuit_operator',
@@ -30,6 +31,7 @@ with DAG(
     catchup=False,
     tags=['example'],
 ) as dag:
+    # [START howto_operator_short_circuit]
     cond_true = ShortCircuitOperator(
         task_id='condition_is_True',
         python_callable=lambda: True,
@@ -45,3 +47,18 @@ with DAG(
 
     chain(cond_true, *ds_true)
     chain(cond_false, *ds_false)
+    # [END howto_operator_short_circuit]
+
+    # [START howto_operator_short_circuit_trigger_rules]
+    [task_1, task_2, task_3, task_4, task_5, task_6] = [
+        DummyOperator(task_id=f"task_{i}") for i in range(1, 7)
+    ]
+
+    task_7 = DummyOperator(task_id="task_7", trigger_rule=TriggerRule.ALL_DONE)
+
+    short_circuit = ShortCircuitOperator(
+        task_id="short_circuit", ignore_downstream_trigger_rules=False, python_callable=lambda: False
+    )
+
+    chain(task_1, [task_2, short_circuit], [task_3, task_4], [task_5, task_6], task_7)
+    # [END howto_operator_short_circuit_trigger_rules]

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -26,11 +26,6 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 from typing import Any, Callable, Collection, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
-try:
-    from typing import Literal
-except ImportError:
-    from typing_extensions import Literal
-
 import dill
 
 from airflow.exceptions import AirflowException
@@ -277,11 +272,6 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
                 # Explicitly setting the state of the direct, downstream task(s) to "skipped" and letting the
                 # Scheduler handle the remaining downstream task(s) appropriately.
                 self.skip(dag_run, execution_date, context["task"].get_direct_relatives(upstream=False))
-            else:
-                raise ValueError(
-                    f"The provided short-circuiting mode value, '{self.mode}', is not supported. "
-                    + "Please use either 'hard' or 'soft'."
-                )
 
         self.log.info("Done.")
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -26,6 +26,11 @@ from tempfile import TemporaryDirectory
 from textwrap import dedent
 from typing import Any, Callable, Collection, Dict, Iterable, List, Mapping, Optional, Sequence, Union
 
+try:
+    from typing import Literal
+except ImportError:
+    from typing_extensions import Literal
+
 import dill
 
 from airflow.exceptions import AirflowException
@@ -272,6 +277,11 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
                 # Explicitly setting the state of the direct, downstream task(s) to "skipped" and letting the
                 # Scheduler handle the remaining downstream task(s) appropriately.
                 self.skip(dag_run, execution_date, context["task"].get_direct_relatives(upstream=False))
+            else:
+                raise ValueError(
+                    f"The provided short-circuiting mode value, '{self.mode}', is not supported. "
+                    + "Please use either 'hard' or 'soft'."
+                )
 
         self.log.info("Done.")
 

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -262,7 +262,7 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
 
         if downstream_tasks:
             dag_run = context["dag_run"]
-            execution_date = context["ti"].execution_date
+            execution_date = dag_run.execution_date
 
             if self.ignore_downstream_trigger_rules is True:
                 self.log.info("Skipping all downstream tasks...")

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -239,10 +239,6 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:ShortCircuitOperator`
 
-    .. seealso::
-        For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:ShortCircuitOperator`
-
     :param ignore_downstream_trigger_rules: If set to True, all downstream tasks from this operator task will
         be skipped. This is the default behavior. If set to False, the direct, downstream task(s) will be
         skipped but the ``trigger_rule`` defined for a other downstream tasks will be respected.

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -222,10 +222,12 @@ class BranchPythonOperator(PythonOperator, SkipMixin):
 
 class ShortCircuitOperator(PythonOperator, SkipMixin):
     """
+    Allows a pipeline to continue based on the result of a ``python_callable``.
+
     The ShortCircuitOperator is derived from the PythonOperator and evaluates the result of a
-    ``python_callable``. If the returned result is False or a Falsy value, the pipeline will be
+    ``python_callable``. If the returned result is False or a falsy value, the pipeline will be
     short-circuited. Downstream tasks will be marked with a state of "skipped" based on the short-circuiting
-    mode configured. If the returned result is True or a Truthy value, downstream tasks proceed as normal and
+    mode configured. If the returned result is True or a truthy value, downstream tasks proceed as normal and
     an ``XCom`` of the returned result is pushed.
 
     The short-circuiting can be configured to either respect or ignore the ``trigger_rule`` set for
@@ -242,7 +244,6 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
     :param ignore_downstream_trigger_rules: If set to True, all downstream tasks from this operator task will
         be skipped. This is the default behavior. If set to False, the direct, downstream task(s) will be
         skipped but the ``trigger_rule`` defined for a other downstream tasks will be respected.
-    :type ignore_downstream_trigger_rules: bool
     """
 
     def __init__(self, *, ignore_downstream_trigger_rules: bool = True, **kwargs) -> None:
@@ -258,7 +259,7 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
             return condition
 
         downstream_tasks = context['task'].get_flat_relatives(upstream=False)
-        self.log.debug("Downstream tasks %s", downstream_tasks)
+        self.log.debug("Downstream task IDs %s", downstream_tasks)
 
         if downstream_tasks:
             dag_run = context["dag_run"]

--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -239,6 +239,10 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
         For more information on how to use this operator, take a look at the guide:
         :ref:`howto/operator:ShortCircuitOperator`
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:ShortCircuitOperator`
+
     :param ignore_downstream_trigger_rules: If set to True, all downstream tasks from this operator task will
         be skipped. This is the default behavior. If set to False, the direct, downstream task(s) will be
         skipped but the ``trigger_rule`` defined for a other downstream tasks will be respected.

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -96,10 +96,10 @@ ShortCircuitOperator
 ========================
 
 Use the :class:`~airflow.operators.python.ShortCircuitOperator` to control whether a pipeline continues
-if a condition is satisfied or a Truthy value is obtained. The evaluation of this condition and Truthy value
-is done via the output of a ``python_callable``. If the ``python_callable`` returns True or a Truthy value,
+if a condition is satisfied or a truthy value is obtained. The evaluation of this condition and truthy value
+is done via the output of a ``python_callable``. If the ``python_callable`` returns True or a truthy value,
 the pipeline is allowed to continue and an :ref:`XCom <concepts:xcom>` of the output will be pushed. If the
-output is False or a Falsy value, the pipeline will be short-circuited based on the configured
+output is False or a falsy value, the pipeline will be short-circuited based on the configured
 short-circuiting (more on this later). In the example below, the tasks that follow the "condition_is_True"
 ShortCircuitOperator will execute while the tasks downstream of the "condition_is_False" ShortCircuitOperator
 will be skipped.

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -112,7 +112,7 @@ execute while the tasks downstream of the "condition_is_False" ShortCircuitOpera
 The "short-circuiting" can be configured to either respect or ignore the ``trigger_rule`` defined
 for downstream tasks. If ``ignore_downstream_trigger_rules`` is set to True, the default configuration, all
 downstream tasks are skipped without considering the ``trigger_rule`` defined for tasks.  If this parameter is
-set to False, the direct, downstream tasks are skipped but the specified ``trigger_rule`` for other subsequent
+set to False, the direct downstream tasks are skipped but the specified ``trigger_rule`` for other subsequent
 downstream tasks are respected. In this mode, the operator assumes the direct, downstream task(s) were
 purposely meant to be skipped but perhaps not other subsequent tasks.
 

--- a/docs/apache-airflow/howto/operator/python.rst
+++ b/docs/apache-airflow/howto/operator/python.rst
@@ -90,7 +90,52 @@ If additional parameters for package installation are needed pass them in ``requ
 All supported options are listed in the `requirements file format <https://pip.pypa.io/en/stable/reference/requirements-file-format/#supported-options>`_.
 
 
+.. _howto/operator:ShortCircuitOperator:
+
+ShortCircuitOperator
+========================
+
+Use the :class:`~airflow.operators.python.ShortCircuitOperator` to control whether a pipeline continues only
+if a condition is satisfied. The evaluation of this condition is done via the output of a ``python_callable``.
+If the ``python_callable`` returns True, the condition is considered satisfied and the pipeline is allowed to
+continue. In the example below, the tasks that follow the "condition_is_True" ShortCircuitOperator will
+execute while the tasks downstream of the "condition_is_False" ShortCircuitOperator will be skipped.
+
+
+.. exampleinclude:: /../../airflow/example_dags/example_short_circuit_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_short_circuit]
+    :end-before: [END howto_operator_short_circuit]
+
+
+The "short-circuiting" can be configured to either respect or ignore the ``trigger_rule`` defined
+for downstream tasks. If ``ignore_downstream_trigger_rules`` is set to True, the default configuration, all
+downstream tasks are skipped without considering the ``trigger_rule`` defined for tasks.  If this parameter is
+set to False, the direct, downstream tasks are skipped but the specified ``trigger_rule`` for other subsequent
+downstream tasks are respected. In this mode, the operator assumes the direct, downstream task(s) were
+purposely meant to be skipped but perhaps not other subsequent tasks.
+
+In the example below, notice that the ShortCircuitOperator task is configured to respect downstream trigger
+rules. This means while the tasks that follow the "short_circuit" ShortCircuitOperator task will be skipped
+since the ``python_callable`` returns False, "task_7" will still execute as its set to execute when upstream
+tasks have completed running regardless of status.
+
+.. exampleinclude:: /../../airflow/example_dags/example_short_circuit_operator.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_short_circuit_trigger_rules]
+    :end-before: [END howto_operator_short_circuit_trigger_rules]
+
+
+
+Passing in arguments
+^^^^^^^^^^^^^^^^^^^^
+
+Both the ``op_args`` and ``op_kwargs`` arguments can be used in same way as described for the PythonOperator.
+
+
 Templating
 ^^^^^^^^^^
 
-You can use jinja Templating the same way you use it in PythonOperator.
+Jinja templating can be used in same way as described for the PythonOperator.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -141,7 +141,6 @@ EventBufferValueType
 ExaConnection
 Exasol
 Failover
-Falsy
 Fargate
 Fernet
 FileSensor
@@ -385,7 +384,6 @@ Tez
 Thinknear
 ToC
 Tooltip
-Truthy
 Tunables
 UA
 Umask

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -762,6 +762,7 @@ exts
 faas
 facebook
 failover
+falsy
 faq
 fargate
 fbee
@@ -1396,6 +1397,7 @@ triggerer
 triggerers
 trino
 trojan
+truthy
 tsv
 ttl
 tunables

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -383,9 +383,9 @@ Terraform
 TextToSpeechClient
 Tez
 Thinknear
-Truthy
 ToC
 Tooltip
+Truthy
 Tunables
 UA
 Umask

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -141,6 +141,7 @@ EventBufferValueType
 ExaConnection
 Exasol
 Failover
+Falsy
 Fargate
 Fernet
 FileSensor
@@ -382,6 +383,7 @@ Terraform
 TextToSpeechClient
 Tez
 Thinknear
+Truthy
 ToC
 Tooltip
 Tunables

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -704,16 +704,13 @@ class TestShortCircuitOperator(unittest.TestCase):
     def test_invalid_short_mode(self):
         """Checking a ValueError is raised when an invalid ``mode`` value is provided."""
 
-        self.short_circuit = ShortCircuitOperator(
-            task_id="short_circuit",
-            python_callable=lambda: False,
-            mode="medium",
-            dag=self.dag,
-        )
-        self.short_circuit.set_downstream(self.op1)
-
         with pytest.raises(ValueError):
-            self.short_circuit.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+            self.short_circuit = ShortCircuitOperator(
+                task_id="short_circuit",
+                python_callable=lambda: False,
+                mode="medium",
+                dag=self.dag,
+            )
 
     def test_clear_skipped_downstream_task(self):
         """

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -701,6 +701,20 @@ class TestShortCircuitOperator(unittest.TestCase):
 
         self._assert_expected_task_states(dagrun, expected_task_states)
 
+    def test_invalid_short_mode(self):
+        """Checking a ValueError is raised when an invalid ``mode`` value is provided."""
+
+        self.short_circuit = ShortCircuitOperator(
+            task_id="short_circuit",
+            python_callable=lambda: False,
+            mode="medium",
+            dag=self.dag,
+        )
+        self.short_circuit.set_downstream(self.op1)
+
+        with pytest.raises(ValueError):
+            self.short_circuit.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
     def test_clear_skipped_downstream_task(self):
         """
         After a downstream task is skipped by ShortCircuitOperator, clearing the skipped task

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -634,13 +634,13 @@ class TestShortCircuitOperator(unittest.TestCase):
             # Skip downstream tasks, do not respect trigger rules, default trigger rule on all downstream
             # tasks
             (False, True, TriggerRule.ALL_SUCCESS, all_downstream_skipped_states),
-            # Skip downstream tasks via a Falsey value, do not respect trigger rules, default trigger rule on
+            # Skip downstream tasks via a Falsy value, do not respect trigger rules, default trigger rule on
             # all downstream tasks
             ([], True, TriggerRule.ALL_SUCCESS, all_downstream_skipped_states),
             # Skip downstream tasks, do not respect trigger rules, non-default trigger rule on a downstream
             # task
             (False, True, TriggerRule.ALL_DONE, all_downstream_skipped_states),
-            # Skip downstream tasks via a Falsey value, do not respect trigger rules, non-default trigger rule
+            # Skip downstream tasks via a Falsy value, do not respect trigger rules, non-default trigger rule
             # on a downstream task
             ([], True, TriggerRule.ALL_DONE, all_downstream_skipped_states),
             # Skip downstream tasks, respect trigger rules, default trigger rule on all downstream tasks
@@ -650,7 +650,7 @@ class TestShortCircuitOperator(unittest.TestCase):
                 TriggerRule.ALL_SUCCESS,
                 {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.NONE},
             ),
-            # Skip downstream tasks via a Falsey value, respect trigger rules, default trigger rule on all
+            # Skip downstream tasks via a Falsy value, respect trigger rules, default trigger rule on all
             # downstream tasks
             (
                 [],
@@ -665,7 +665,7 @@ class TestShortCircuitOperator(unittest.TestCase):
                 TriggerRule.ALL_DONE,
                 {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.SUCCESS},
             ),
-            # Skip downstream tasks via a Falsey value, respect trigger rules, non-default trigger rule on a
+            # Skip downstream tasks via a Falsy value, respect trigger rules, non-default trigger rule on a
             # downstream task
             (
                 [],

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -640,14 +640,14 @@ class TestShortCircuitOperator(unittest.TestCase):
             # Skip downstream tasks, respect trigger rules, default trigger rule on all downstream tasks
             (
                 False,
-                "soft",
+                False,
                 TriggerRule.ALL_SUCCESS,
                 {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.NONE},
             ),
             # Skip downstream tasks, respect trigger rules, non-default trigger rule on a downstream task
             (
                 False,
-                "soft",
+                False,
                 TriggerRule.ALL_DONE,
                 {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.SUCCESS},
             ),
@@ -700,17 +700,6 @@ class TestShortCircuitOperator(unittest.TestCase):
         assert self.op2.trigger_rule == test_trigger_rule
 
         self._assert_expected_task_states(dagrun, expected_task_states)
-
-    def test_invalid_short_mode(self):
-        """Checking a ValueError is raised when an invalid ``mode`` value is provided."""
-
-        with pytest.raises(ValueError):
-            self.short_circuit = ShortCircuitOperator(
-                task_id="short_circuit",
-                python_callable=lambda: False,
-                mode="medium",
-                dag=self.dag,
-            )
 
     def test_clear_skipped_downstream_task(self):
         """

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -640,14 +640,14 @@ class TestShortCircuitOperator(unittest.TestCase):
             # Skip downstream tasks, respect trigger rules, default trigger rule on all downstream tasks
             (
                 False,
-                False,
+                "soft",
                 TriggerRule.ALL_SUCCESS,
                 {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.NONE},
             ),
             # Skip downstream tasks, respect trigger rules, non-default trigger rule on a downstream task
             (
                 False,
-                False,
+                "soft",
                 TriggerRule.ALL_DONE,
                 {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.SUCCESS},
             ),

--- a/tests/operators/test_python.py
+++ b/tests/operators/test_python.py
@@ -27,6 +27,7 @@ from subprocess import CalledProcessError
 from typing import List
 
 import pytest
+from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
 from airflow.models import DAG, DagRun, TaskInstance as TI
@@ -45,6 +46,7 @@ from airflow.utils.context import AirflowContextDeprecationWarning, Context
 from airflow.utils.dates import days_ago
 from airflow.utils.session import create_session
 from airflow.utils.state import State
+from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
 from tests.test_utils import AIRFLOW_MAIN_FOLDER
 from tests.test_utils.db import clear_db_runs
@@ -587,147 +589,164 @@ class TestBranchOperator(unittest.TestCase):
 class TestShortCircuitOperator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
-
         with create_session() as session:
             session.query(DagRun).delete()
             session.query(TI).delete()
 
-    def tearDown(self):
-        super().tearDown()
-
-        with create_session() as session:
-            session.query(DagRun).delete()
-            session.query(TI).delete()
-
-    def test_with_dag_run(self):
-        value = False
-        dag = DAG(
-            'shortcircuit_operator_test_with_dag_run',
-            default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE},
+    def setUp(self):
+        self.dag = DAG(
+            "short_circuit_op_test",
+            start_date=DEFAULT_DATE,
             schedule_interval=INTERVAL,
         )
-        short_op = ShortCircuitOperator(task_id='make_choice', dag=dag, python_callable=lambda: value)
-        branch_1 = DummyOperator(task_id='branch_1', dag=dag)
-        branch_1.set_upstream(short_op)
-        branch_2 = DummyOperator(task_id='branch_2', dag=dag)
-        branch_2.set_upstream(branch_1)
-        upstream = DummyOperator(task_id='upstream', dag=dag)
-        upstream.set_downstream(short_op)
-        dag.clear()
 
-        logging.error("Tasks %s", dag.tasks)
-        dr = dag.create_dagrun(
+        with self.dag:
+            self.op1 = DummyOperator(task_id="op1")
+            self.op2 = DummyOperator(task_id="op2")
+            self.op1.set_downstream(self.op2)
+
+    def tearDown(self):
+        with create_session() as session:
+            session.query(DagRun).delete()
+            session.query(TI).delete()
+
+    def _assert_expected_task_states(self, dagrun, expected_states):
+        """Helper function that asserts `TaskInstances` of a given `task_id` are in a given state."""
+
+        tis = dagrun.get_task_instances()
+        for ti in tis:
+            try:
+                expected_state = expected_states[ti.task_id]
+            except KeyError:
+                raise ValueError(f"Invalid task id {ti.task_id} found!")
+            else:
+                assert ti.state == expected_state
+
+    all_downstream_skipped_states = {
+        "short_circuit": State.SUCCESS,
+        "op1": State.SKIPPED,
+        "op2": State.SKIPPED,
+    }
+    all_success_states = {"short_circuit": State.SUCCESS, "op1": State.SUCCESS, "op2": State.SUCCESS}
+
+    @parameterized.expand(
+        [
+            # Skip downstream tasks, do not respect trigger rules, default trigger rule on all downstream
+            # tasks
+            (False, True, TriggerRule.ALL_SUCCESS, all_downstream_skipped_states),
+            # Skip downstream tasks, do not respect trigger rules, non-default trigger rule on a downstream
+            # task
+            (False, True, TriggerRule.ALL_DONE, all_downstream_skipped_states),
+            # Skip downstream tasks, respect trigger rules, default trigger rule on all downstream tasks
+            (
+                False,
+                False,
+                TriggerRule.ALL_SUCCESS,
+                {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.NONE},
+            ),
+            # Skip downstream tasks, respect trigger rules, non-default trigger rule on a downstream task
+            (
+                False,
+                False,
+                TriggerRule.ALL_DONE,
+                {"short_circuit": State.SUCCESS, "op1": State.SKIPPED, "op2": State.SUCCESS},
+            ),
+            # Do not skip downstream tasks, do not respect trigger rules, default trigger rule on all
+            # downstream tasks
+            (True, True, TriggerRule.ALL_SUCCESS, all_success_states),
+            # Do not skip downstream tasks, do not respect trigger rules, non-default trigger rule on a
+            # downstream task
+            (True, True, TriggerRule.ALL_DONE, all_success_states),
+            # Do not skip downstream tasks, respect trigger rules, default trigger rule on all downstream
+            # tasks
+            (True, False, TriggerRule.ALL_SUCCESS, all_success_states),
+            # Do not skip downstream tasks, respect trigger rules, non-default trigger rule on a downstream
+            # task
+            (True, False, TriggerRule.ALL_DONE, all_success_states),
+        ],
+    )
+    def test_short_circuiting(
+        self, callable_return, test_ignore_downstream_trigger_rules, test_trigger_rule, expected_task_states
+    ):
+        """
+        Checking the behavior of the ShortCircuitOperator in several scenarios enabling/disabling the skipping
+        of downstream tasks, both short-circuiting modes, and various trigger rules of downstream tasks.
+        """
+
+        self.short_circuit = ShortCircuitOperator(
+            task_id="short_circuit",
+            python_callable=lambda: callable_return,
+            ignore_downstream_trigger_rules=test_ignore_downstream_trigger_rules,
+            dag=self.dag,
+        )
+        self.short_circuit.set_downstream(self.op1)
+        self.op2.trigger_rule = test_trigger_rule
+        self.dag.clear()
+
+        dagrun = self.dag.create_dagrun(
             run_type=DagRunType.MANUAL,
             start_date=timezone.utcnow(),
             execution_date=DEFAULT_DATE,
             state=State.RUNNING,
         )
 
-        upstream.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        short_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self.short_circuit.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self.op1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self.op2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
-        tis = dr.get_task_instances()
-        assert len(tis) == 4
-        for ti in tis:
-            if ti.task_id == 'make_choice':
-                assert ti.state == State.SUCCESS
-            elif ti.task_id == 'upstream':
-                assert ti.state == State.SUCCESS
-            elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
-                assert ti.state == State.SKIPPED
-            else:
-                raise ValueError(f'Invalid task id {ti.task_id} found!')
+        assert self.short_circuit.ignore_downstream_trigger_rules == test_ignore_downstream_trigger_rules
+        assert self.short_circuit.trigger_rule == TriggerRule.ALL_SUCCESS
+        assert self.op1.trigger_rule == TriggerRule.ALL_SUCCESS
+        assert self.op2.trigger_rule == test_trigger_rule
 
-        value = True
-        dag.clear()
-        dr.verify_integrity()
-        upstream.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        short_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-        tis = dr.get_task_instances()
-        assert len(tis) == 4
-        for ti in tis:
-            if ti.task_id == 'make_choice':
-                assert ti.state == State.SUCCESS
-            elif ti.task_id == 'upstream':
-                assert ti.state == State.SUCCESS
-            elif ti.task_id == 'branch_1' or ti.task_id == 'branch_2':
-                assert ti.state == State.NONE
-            else:
-                raise ValueError(f'Invalid task id {ti.task_id} found!')
+        self._assert_expected_task_states(dagrun, expected_task_states)
 
     def test_clear_skipped_downstream_task(self):
         """
         After a downstream task is skipped by ShortCircuitOperator, clearing the skipped task
         should not cause it to be executed.
         """
-        dag = DAG(
-            'shortcircuit_clear_skipped_downstream_task',
-            default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE},
-            schedule_interval=INTERVAL,
+
+        self.short_circuit = ShortCircuitOperator(
+            task_id="short_circuit",
+            python_callable=lambda: False,
+            dag=self.dag,
         )
-        short_op = ShortCircuitOperator(task_id='make_choice', dag=dag, python_callable=lambda: False)
-        downstream = DummyOperator(task_id='downstream', dag=dag)
+        self.short_circuit.set_downstream(self.op1)
+        self.op2.trigger_rule = TriggerRule.ALL_SUCCESS
+        self.dag.clear()
 
-        short_op >> downstream
-
-        dag.clear()
-
-        dr = dag.create_dagrun(
+        dagrun = self.dag.create_dagrun(
             run_type=DagRunType.MANUAL,
             start_date=timezone.utcnow(),
             execution_date=DEFAULT_DATE,
             state=State.RUNNING,
         )
 
-        short_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        downstream.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self.short_circuit.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self.op1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self.op2.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
 
-        tis = dr.get_task_instances()
+        assert self.short_circuit.ignore_downstream_trigger_rules
+        assert self.short_circuit.trigger_rule == TriggerRule.ALL_SUCCESS
+        assert self.op1.trigger_rule == TriggerRule.ALL_SUCCESS
+        assert self.op2.trigger_rule == TriggerRule.ALL_SUCCESS
 
-        for ti in tis:
-            if ti.task_id == 'make_choice':
-                assert ti.state == State.SUCCESS
-            elif ti.task_id == 'downstream':
-                assert ti.state == State.SKIPPED
-            else:
-                raise ValueError(f'Invalid task id {ti.task_id} found!')
+        expected_states = {
+            "short_circuit": State.SUCCESS,
+            "op1": State.SKIPPED,
+            "op2": State.SKIPPED,
+        }
+        self._assert_expected_task_states(dagrun, expected_states)
 
-        # Clear downstream
+        # Clear downstream task "op1" that was previously executed.
+        tis = dagrun.get_task_instances()
+
         with create_session() as session:
-            clear_task_instances([t for t in tis if t.task_id == "downstream"], session=session, dag=dag)
+            clear_task_instances([ti for ti in tis if ti.task_id == "op1"], session=session, dag=self.dag)
 
-        # Run downstream again
-        downstream.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-
-        # Check if the states are correct.
-        for ti in dr.get_task_instances():
-            if ti.task_id == 'make_choice':
-                assert ti.state == State.SUCCESS
-            elif ti.task_id == 'downstream':
-                assert ti.state == State.SKIPPED
-            else:
-                raise ValueError(f'Invalid task id {ti.task_id} found!')
-
-    def test_xcom_push(self):
-        dag = DAG(
-            'shortcircuit_operator_test_xcom_push',
-            default_args={'owner': 'airflow', 'start_date': DEFAULT_DATE},
-            schedule_interval=INTERVAL,
-        )
-        short_op = ShortCircuitOperator(task_id='make_choice', dag=dag, python_callable=lambda: 'signature')
-        dag.clear()
-        dr = dag.create_dagrun(
-            run_type=DagRunType.MANUAL,
-            start_date=timezone.utcnow(),
-            execution_date=DEFAULT_DATE,
-            state=State.RUNNING,
-        )
-        short_op.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
-        tis = dr.get_task_instances()
-        xcom_value = tis[0].xcom_pull(task_ids='make_choice', key='return_value')
-        assert xcom_value == 'signature'
+        self.op1.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+        self._assert_expected_task_states(dagrun, expected_states)
 
 
 virtualenv_string_args: List[str] = []


### PR DESCRIPTION
Closes: #7858

Adding the ability to configure the `ShortCircuitOperator` to respect trigger rules for downstream tasks.  Currently this operator ignores all trigger rules and forcibly skips all downstream tasks.  However, there are use cases in which downstream tasks from the `ShortCircuitOperator` have trigger rules applied such that said tasks should execute even if upstream tasks are skipped by the operator (e.g. multiple branches that execute in parallel, one branch can be short-circuited at some point, and the branches converge).

This PR adds a new parameter, `ignore_downstream_trigger_rules`, which allows users to have the `ShortCircuitOperator` perform a "hard short" (i.e. blindly skip all downstream tasks; the current behavior) or a "soft short" (i.e. the immediate, downstream task(s) are skipped only and the Scheduler is left to handle the trigger rules appropriately).

The unit tests for the `ShortCircuitOperator` were refactored as part of this change as well.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
