### PR TITLE
Extend config window on UI

### DIFF
--- a/airflow/www/static/js/trigger.js
+++ b/airflow/www/static/js/trigger.js
@@ -17,13 +17,14 @@
  * under the License.
  */
 
-/* global document, CodeMirror */
+/* global document, CodeMirror, window */
 
 const textArea = document.getElementById('json');
+const height = window.innerHeight * 0.6;
 
 CodeMirror.fromTextArea(textArea, {
   lineNumbers: true,
   mode: { name: 'javascript', json: true },
   gutters: ['CodeMirror-lint-markers'],
   lint: true,
-});
+}).setSize(null, height);

--- a/airflow/www/static/js/trigger.js
+++ b/airflow/www/static/js/trigger.js
@@ -20,7 +20,9 @@
 /* global document, CodeMirror, window */
 
 const textArea = document.getElementById('json');
-const height = window.innerHeight * 0.6;
+const minHeight = 300;
+const maxHeight = window.innerHeight - 450;
+const height = maxHeight > minHeight ? maxHeight : minHeight;
 
 CodeMirror.fromTextArea(textArea, {
   lineNumbers: true,


### PR DESCRIPTION
Closes #17874.

This PR adjusts the size of the JSON config window on the UI, better utilizing the empty space between the Trigger button and the bottom of the page.

Before & after:
![ui](https://user-images.githubusercontent.com/50751110/144753942-ac6842db-9846-42db-b127-96b227cf09bc.JPG)
