### PR TITLE
Increase timeouts even longer for on_kill test

### DIFF
--- a/tests/task/task_runner/test_standard_task_runner.py
+++ b/tests/task/task_runner/test_standard_task_runner.py
@@ -222,7 +222,7 @@ class TestStandardTaskRunner:
             processes = list(self._procs_in_pgroup(runner_pgid))
 
             logging.info("Waiting for the task to start")
-            with timeout(seconds=4):
+            with timeout(seconds=20):
                 while True:
                     if os.path.exists(path_on_kill_running):
                         break


### PR DESCRIPTION
Seems that when the system is busy, the timeouts we had to
wait for tasks to start were a bit to short. Increasing them.

Related to #20054

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
