### PR TITLE
Fix mypy tests providers - part 1

### DIFF
--- a/tests/providers/amazon/aws/utils/eks_test_constants.py
+++ b/tests/providers/amazon/aws/utils/eks_test_constants.py
@@ -76,21 +76,21 @@ VERSION: Tuple[str, str] = ("version", "1")
 class ResponseAttributes:
     """Key names for the dictionaries returned by API calls."""
 
-    CLUSTER: slice = "cluster"
-    CLUSTERS: slice = "clusters"
-    FARGATE_PROFILE_NAMES: slice = "fargateProfileNames"
-    FARGATE_PROFILE: slice = "fargateProfile"
-    NEXT_TOKEN: slice = "nextToken"
-    NODEGROUP: slice = "nodegroup"
-    NODEGROUPS: slice = "nodegroups"
+    CLUSTER = "cluster"
+    CLUSTERS = "clusters"
+    FARGATE_PROFILE_NAMES = "fargateProfileNames"
+    FARGATE_PROFILE = "fargateProfile"
+    NEXT_TOKEN = "nextToken"
+    NODEGROUP = "nodegroup"
+    NODEGROUPS = "nodegroups"
 
 
 class ErrorAttributes:
     """Key names for the dictionaries representing error messages."""
 
-    CODE: slice = "Code"
-    ERROR: slice = "Error"
-    MESSAGE: slice = "Message"
+    CODE = "Code"
+    ERROR = "Error"
+    MESSAGE = "Message"
 
 
 class ClusterInputs:
@@ -137,37 +137,37 @@ class PossibleTestResults(Enum):
 class ClusterAttributes:
     """Key names for the dictionaries representing EKS Clusters."""
 
-    ARN: slice = "arn"
-    CLUSTER_NAME: slice = "clusterName"
-    CREATED_AT: slice = "createdAt"
-    ENDPOINT: slice = "endpoint"
-    IDENTITY: slice = "identity"
-    ISSUER: slice = "issuer"
-    NAME: slice = "name"
-    OIDC: slice = "oidc"
+    ARN = "arn"
+    CLUSTER_NAME = "clusterName"
+    CREATED_AT = "createdAt"
+    ENDPOINT = "endpoint"
+    IDENTITY = "identity"
+    ISSUER = "issuer"
+    NAME = "name"
+    OIDC = "oidc"
 
 
 class FargateProfileAttributes:
-    ARN: slice = "fargateProfileArn"
-    CREATED_AT: slice = "createdAt"
-    FARGATE_PROFILE_NAME: slice = "fargateProfileName"
-    LABELS: slice = "labels"
-    NAMESPACE: slice = "namespace"
-    SELECTORS: slice = "selectors"
+    ARN = "fargateProfileArn"
+    CREATED_AT = "createdAt"
+    FARGATE_PROFILE_NAME = "fargateProfileName"
+    LABELS = "labels"
+    NAMESPACE = "namespace"
+    SELECTORS = "selectors"
 
 
 class NodegroupAttributes:
     """Key names for the dictionaries representing EKS Managed Nodegroups."""
 
-    ARN: slice = "nodegroupArn"
-    AUTOSCALING_GROUPS: slice = "autoScalingGroups"
-    CREATED_AT: slice = "createdAt"
-    MODIFIED_AT: slice = "modifiedAt"
-    NAME: slice = "name"
-    NODEGROUP_NAME: slice = "nodegroupName"
-    REMOTE_ACCESS_SG: slice = "remoteAccessSecurityGroup"
-    RESOURCES: slice = "resources"
-    TAGS: slice = "tags"
+    ARN = "nodegroupArn"
+    AUTOSCALING_GROUPS = "autoScalingGroups"
+    CREATED_AT = "createdAt"
+    MODIFIED_AT = "modifiedAt"
+    NAME = "name"
+    NODEGROUP_NAME = "nodegroupName"
+    REMOTE_ACCESS_SG = "remoteAccessSecurityGroup"
+    RESOURCES = "resources"
+    TAGS = "tags"
 
 
 class BatchCountSize:

--- a/tests/providers/elasticsearch/log/elasticmock/__init__.py
+++ b/tests/providers/elasticsearch/log/elasticmock/__init__.py
@@ -42,7 +42,7 @@ from functools import wraps
 from typing import Dict
 from unittest.mock import patch
 
-from elasticsearch.client import _normalize_hosts  # type: ignore
+from elasticsearch.client.utils import _normalize_hosts
 
 from .fake_elasticsearch import FakeElasticsearch
 

--- a/tests/providers/elasticsearch/log/elasticmock/__init__.py
+++ b/tests/providers/elasticsearch/log/elasticmock/__init__.py
@@ -42,7 +42,7 @@ from functools import wraps
 from typing import Dict
 from unittest.mock import patch
 
-from elasticsearch.client import _normalize_hosts
+from elasticsearch.client import _normalize_hosts  # type: ignore
 
 from .fake_elasticsearch import FakeElasticsearch
 

--- a/tests/providers/mongo/hooks/test_mongo.py
+++ b/tests/providers/mongo/hooks/test_mongo.py
@@ -15,7 +15,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import importlib
 import unittest
+from types import ModuleType
+from typing import Optional
 
 import pymongo
 
@@ -23,8 +26,10 @@ from airflow.models import Connection
 from airflow.providers.mongo.hooks.mongo import MongoHook
 from airflow.utils import db
 
+mongomock: Optional[ModuleType]
+
 try:
-    import mongomock
+    mongomock = importlib.import_module("mongomock")
 except ImportError:
     mongomock = None
 

--- a/tests/providers/snowflake/hooks/test_snowflake.py
+++ b/tests/providers/snowflake/hooks/test_snowflake.py
@@ -129,13 +129,15 @@ class TestPytestSnowflakeHook:
             (
                 {
                     **BASE_CONNECTION_KWARGS,
-                    'extra': {
-                        'extra__snowflake__database': 'db',
-                        'extra__snowflake__account': 'airflow',
-                        'extra__snowflake__warehouse': 'af_wh',
-                        'extra__snowflake__region': 'af_region',
-                        'extra__snowflake__role': 'af_role',
-                        'extra__snowflake__insecure_mode': 'True',
+                    **{
+                        'extra': {
+                            'extra__snowflake__database': 'db',
+                            'extra__snowflake__account': 'airflow',
+                            'extra__snowflake__warehouse': 'af_wh',
+                            'extra__snowflake__region': 'af_region',
+                            'extra__snowflake__role': 'af_role',
+                            'extra__snowflake__insecure_mode': 'True',
+                        },
                     },
                 },
                 (
@@ -160,13 +162,15 @@ class TestPytestSnowflakeHook:
             (
                 {
                     **BASE_CONNECTION_KWARGS,
-                    'extra': {
-                        'extra__snowflake__database': 'db',
-                        'extra__snowflake__account': 'airflow',
-                        'extra__snowflake__warehouse': 'af_wh',
-                        'extra__snowflake__region': 'af_region',
-                        'extra__snowflake__role': 'af_role',
-                        'extra__snowflake__insecure_mode': 'False',
+                    **{
+                        'extra': {
+                            'extra__snowflake__database': 'db',
+                            'extra__snowflake__account': 'airflow',
+                            'extra__snowflake__warehouse': 'af_wh',
+                            'extra__snowflake__region': 'af_region',
+                            'extra__snowflake__role': 'af_role',
+                            'extra__snowflake__insecure_mode': 'False',
+                        }
                     },
                 },
                 (


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/19891

Fixed following providers subfolders:
- amazon
- elasticsearch
- mongo
- azure datafactory

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
