### PR TITLE
Add migration-wait-timeout to the helm chart

### DIFF
--- a/airflow/cli/cli_parser.py
+++ b/airflow/cli/cli_parser.py
@@ -448,7 +448,7 @@ ARG_MIGRATION_TIMEOUT = Arg(
     ("-t", "--migration-wait-timeout"),
     help="timeout to wait for db to migrate ",
     type=int,
-    default=0,
+    default=60,
 )
 
 # webserver

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -546,6 +546,7 @@ Create the name of the cleanup service account to use
   - airflow
   - db
   - check-migrations
+  - --migration-wait-timeout={{ .Values.images.migrationsWaitTimeout }}
   {{- else }}
   - python
   - -c

--- a/chart/tests/conftest.py
+++ b/chart/tests/conftest.py
@@ -22,7 +22,7 @@ import pytest
 from filelock import FileLock
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True, scope="module")
 def upgrade_helm(tmp_path_factory, worker_id):
     """
     Upgrade Helm repo

--- a/chart/tests/conftest.py
+++ b/chart/tests/conftest.py
@@ -22,7 +22,7 @@ import pytest
 from filelock import FileLock
 
 
-@pytest.fixture(autouse=True, scope="module")
+@pytest.fixture(autouse=True, scope="session")
 def upgrade_helm(tmp_path_factory, worker_id):
     """
     Upgrade Helm repo

--- a/chart/tests/test_webserver.py
+++ b/chart/tests/test_webserver.py
@@ -139,8 +139,8 @@ class WebserverDeploymentTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("2.0.0", ["airflow", "db", "check-migrations"]),
-            ("2.1.0", ["airflow", "db", "check-migrations"]),
+            ("2.0.0", ["airflow", "db", "check-migrations", "--migration-wait-timeout=60"]),
+            ("2.1.0", ["airflow", "db", "check-migrations", "--migration-wait-timeout=60"]),
             ("1.10.2", ["python", "-c"]),
         ],
     )

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -373,7 +373,7 @@
                     "default": false
                 },
                 "migrationsWaitTimeout": {
-                    "description": "The time to wait for the DB migrations to complete.",
+                    "description": "The time (in seconds) to wait for the DB migrations to complete.",
                     "type": "number",
                     "x-docsSection": "Images",
                     "default": 60

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -372,6 +372,12 @@
                     "x-docsSection": "Images",
                     "default": false
                 },
+                "migrationsWaitTimeout": {
+                    "description": "The time to wait for the DB migrations to complete.",
+                    "type": "number",
+                    "x-docsSection": "Images",
+                    "default": 60
+                },
                 "pod_template": {
                     "description": "Configuration of the pod_template image.",
                     "type": "object",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,6 +56,8 @@ images:
   # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
   # to run and wait for DB migrations .
   useDefaultImageForMigration: false
+  # timeout for airflow-migrations to complete
+  migrationsWaitTimeout: 60
   pod_template:
     repository: ~
     tag: ~

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,7 +56,7 @@ images:
   # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
   # to run and wait for DB migrations .
   useDefaultImageForMigration: false
-  # timeout for airflow-migrations to complete
+  # timeout (in seconds) for airflow-migrations to complete
   migrationsWaitTimeout: 60
   pod_template:
     repository: ~

--- a/tests/cli/commands/test_db_command.py
+++ b/tests/cli/commands/test_db_command.py
@@ -47,7 +47,7 @@ class TestCliDb(unittest.TestCase):
     def test_cli_check_migrations(self, mock_wait_for_migrations):
         db_command.check_migrations(self.parser.parse_args(['db', 'check-migrations']))
 
-        mock_wait_for_migrations.assert_called_once_with(timeout=0)
+        mock_wait_for_migrations.assert_called_once_with(timeout=60)
 
     @mock.patch("airflow.cli.commands.db_command.db.upgradedb")
     def test_cli_upgradedb(self, mock_upgradedb):


### PR DESCRIPTION
The `airflow db check-migrations` command is missing a migration wait timeout
value in the helm chart resulting in unexpected failures at times.

This PR adds a default timeout to the command


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
