### PR TITLE
ShortCircuitOperator pushs XCom

### DIFF
--- a/airflow/operators/python.py
+++ b/airflow/operators/python.py
@@ -248,7 +248,7 @@ class ShortCircuitOperator(PythonOperator, SkipMixin):
 
         if condition:
             self.log.info('Proceeding with downstream tasks...')
-            return
+            return condition
 
         self.log.info('Skipping downstream tasks...')
 


### PR DESCRIPTION
closes: #19922
related: #20044

Add return condition for `ShortCircuinOperator`.
If `python_callable` returns the object that casts as `True` then that object will be available as XCom with key `return_value`.

Possible use case:
If we need to run pipeline only when some files exist in a certain directory. Then callable in `ShortCircuitOperator` could return all files in the directory. If there are no files then downstream tasks will be skipped (`[] == False`) otherwise downstream tasks just will take the list of files and process it.



