### PR TITLE
The 'cx_Oracle' driver does support autocommit

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -39,7 +39,7 @@ class OracleHook(DbApiHook):
     conn_type = 'oracle'
     hook_name = 'Oracle'
 
-    supports_autocommit = False
+    supports_autocommit = True
 
     def get_conn(self) -> 'OracleHook':
         """
@@ -177,10 +177,9 @@ class OracleHook(DbApiHook):
         else:
             target_fields = ''
         conn = self.get_conn()
-        cur = conn.cursor()  # type: ignore[attr-defined]
         if self.supports_autocommit:
-            cur.execute('SET autocommit = 0')
-        conn.commit()  # type: ignore[attr-defined]
+            self.set_autocommit(conn, False)
+        cur = conn.cursor()  # type: ignore[attr-defined]
         i = 0
         for row in rows:
             i += 1
@@ -238,6 +237,8 @@ class OracleHook(DbApiHook):
         if not rows:
             raise ValueError("parameter rows could not be None or empty iterable")
         conn = self.get_conn()
+        if self.supports_autocommit:
+            self.set_autocommit(conn, False)
         cursor = conn.cursor()  # type: ignore[attr-defined]
         values_base = target_fields if target_fields else rows[0]
         prepared_stm = 'insert into {tablename} {columns} values ({values})'.format(


### PR DESCRIPTION
It's been [supported since version 4.3.2](https://cx-oracle.readthedocs.io/en/latest/release_notes.html#version-4-3-2-august-2007) – released in August, 2007.

The `insert_rows` and `bulk_insert_rows` methods have been updated to explicitly disable autocommit using the attribute interface (although that is presumably the default) – since in `insert_rows` this was previously already done (via the cursor).