### PR TITLE
Simplify helm install command in chart index

### DIFF
--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -86,9 +86,8 @@ To install this chart using Helm 3, run the following commands:
 
 .. code-block:: bash
 
-    kubectl create namespace airflow
     helm repo add apache-airflow https://airflow.apache.org
-    helm install airflow apache-airflow/airflow --namespace airflow
+    helm upgrade airflow apache-airflow/airflow --namespace airflow --create-namespace --install
 
 The command deploys Airflow on the Kubernetes cluster in the default configuration. The :doc:`parameters-ref`
 section lists the parameters that can be configured during installation.

--- a/docs/helm-chart/index.rst
+++ b/docs/helm-chart/index.rst
@@ -87,7 +87,7 @@ To install this chart using Helm 3, run the following commands:
 .. code-block:: bash
 
     helm repo add apache-airflow https://airflow.apache.org
-    helm upgrade airflow apache-airflow/airflow --namespace airflow --create-namespace --install
+    helm upgrade --install airflow apache-airflow/airflow --namespace airflow --create-namespace
 
 The command deploys Airflow on the Kubernetes cluster in the default configuration. The :doc:`parameters-ref`
 section lists the parameters that can be configured during installation.


### PR DESCRIPTION
Helm allows use to install (or upgrade) and create namespace (if not exists) in a single command.  Using this approach makes the doc just a tiny bit cleaner. And it's a more convenient command since the same  one can be used for installing _and_ upgrading.
