### PR TITLE
Fix failing main.

### DIFF
--- a/tests/www/views/test_views_rendered.py
+++ b/tests/www/views/test_views_rendered.py
@@ -157,7 +157,7 @@ def test_user_defined_filter_and_macros_raise_error(admin_client, create_dag_run
     assert resp.status_code == 200
 
     resp_html: str = resp.data.decode("utf-8")
-    assert "echo Hello Apache Airflow" in resp_html
+    assert "echo Hello Apache Airflow" not in resp_html
     assert (
         "Webserver does not have access to User-defined Macros or Filters when "
         "Dag Serialization is enabled. Hence for the task that have not yet "


### PR DESCRIPTION
Previously, check_content_not_in_response was used but the current replacement is asserting that content is in resp.
This fixes it


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
