### PR TITLE
Fix typo in MySQL Database creation code (Set up DB docs) 

### DIFF
--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -238,7 +238,7 @@ In the example below, a database ``airflow_db`` and user  with username ``airflo
 
 .. code-block:: sql
 
-   CREATE DATABASE airflow_db CHARACTER SET utf8 COLLATE utf8mb3_unicode_ci;
+   CREATE DATABASE airflow_db CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
    CREATE USER 'airflow_user' IDENTIFIED BY 'airflow_pass';
    GRANT ALL PRIVILEGES ON airflow_db.* TO 'airflow_user';
 

--- a/docs/apache-airflow/howto/set-up-database.rst
+++ b/docs/apache-airflow/howto/set-up-database.rst
@@ -238,7 +238,7 @@ In the example below, a database ``airflow_db`` and user  with username ``airflo
 
 .. code-block:: sql
 
-   CREATE DATABASE airflow_db CHARACTER SET utf8 COLLATE utf8mb4_unicode_ci;
+   CREATE DATABASE airflow_db CHARACTER SET utf8 COLLATE utf8mb3_unicode_ci;
    CREATE USER 'airflow_user' IDENTIFIED BY 'airflow_pass';
    GRANT ALL PRIVILEGES ON airflow_db.* TO 'airflow_user';
 


### PR DESCRIPTION
Using `COLLATE utf8mb4_unicode_ci` (current code) throws the following error:
`ERROR 1253 (42000): COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'utf8'`

Character set `utf8` is an alias for `utf8mb3`, see MySQL docs linked below. This means collation should be set to `utf8mb3_unicode_ci`.

https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-sets.html

OS: macOS 11.3.1 (M1)
MySQL: 8.0.27-arm64
Airflow: 2.2.2