### PR TITLE
Remove unused code in SnowflakeHook

### DIFF
--- a/airflow/providers/snowflake/hooks/snowflake.py
+++ b/airflow/providers/snowflake/hooks/snowflake.py
@@ -18,7 +18,7 @@
 import os
 from contextlib import closing
 from io import StringIO
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Union
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -82,9 +82,9 @@ class SnowflakeHook(DbApiHook):
     @staticmethod
     def get_connection_form_widgets() -> Dict[str, Any]:
         """Returns connection widgets to add to connection form"""
-        from flask_appbuilder.fieldwidgets import BS3PasswordFieldWidget, BS3TextFieldWidget
+        from flask_appbuilder.fieldwidgets import BS3TextFieldWidget
         from flask_babel import lazy_gettext
-        from wtforms import PasswordField, StringField
+        from wtforms import StringField
 
         return {
             "extra__snowflake__account": StringField(lazy_gettext('Account'), widget=BS3TextFieldWidget()),
@@ -93,12 +93,6 @@ class SnowflakeHook(DbApiHook):
             ),
             "extra__snowflake__database": StringField(lazy_gettext('Database'), widget=BS3TextFieldWidget()),
             "extra__snowflake__region": StringField(lazy_gettext('Region'), widget=BS3TextFieldWidget()),
-            "extra__snowflake__aws_access_key_id": StringField(
-                lazy_gettext('AWS Access Key'), widget=BS3TextFieldWidget()
-            ),
-            "extra__snowflake__aws_secret_access_key": PasswordField(
-                lazy_gettext('AWS Secret Key'), widget=BS3PasswordFieldWidget()
-            ),
             "extra__snowflake__role": StringField(lazy_gettext('Role'), widget=BS3TextFieldWidget()),
         }
 
@@ -127,8 +121,6 @@ class SnowflakeHook(DbApiHook):
                 'extra__snowflake__warehouse': 'snowflake warehouse name',
                 'extra__snowflake__database': 'snowflake db name',
                 'extra__snowflake__region': 'snowflake hosted region',
-                'extra__snowflake__aws_access_key_id': 'aws access key id (S3ToSnowflakeOperator)',
-                'extra__snowflake__aws_secret_access_key': 'aws secret access key (S3ToSnowflakeOperator)',
                 'extra__snowflake__role': 'snowflake role',
             },
         }
@@ -222,24 +214,6 @@ class SnowflakeHook(DbApiHook):
         conn_config = self._get_conn_params()
         conn = connector.connect(**conn_config)
         return conn
-
-    def _get_aws_credentials(self) -> Tuple[Optional[Any], Optional[Any]]:
-        """
-        Returns aws_access_key_id, aws_secret_access_key
-        from extra
-
-        intended to be used by external import and export statements
-        """
-        if self.snowflake_conn_id:  # type: ignore[attr-defined]
-            connection_object = self.get_connection(self.snowflake_conn_id)  # type: ignore[attr-defined]
-            if 'aws_secret_access_key' in connection_object.extra_dejson:
-                aws_access_key_id = connection_object.extra_dejson.get(
-                    'aws_access_key_id'
-                ) or connection_object.extra_dejson.get('aws_access_key_id')
-                aws_secret_access_key = connection_object.extra_dejson.get(
-                    'aws_secret_access_key'
-                ) or connection_object.extra_dejson.get('aws_secret_access_key')
-        return aws_access_key_id, aws_secret_access_key
 
     def set_autocommit(self, conn, autocommit: Any) -> None:
         conn.autocommit(autocommit)

--- a/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
+++ b/docs/apache-airflow-providers-snowflake/connections/snowflake.rst
@@ -63,8 +63,6 @@ Extra (optional)
     * ``private_key_file``: Specify the path to the private key file.
     * ``session_parameters``: Specify `session level parameters
       <https://docs.snowflake.com/en/user-guide/python-connector-example.html#setting-session-parameters>`_
-    * ``aws_access_key_id``: Specify your aws S3 access key for use with the S3ToSnowflakeOperator.
-    * ``aws_secret_access_key``: Specify your aws S3 secret access key for use with the S3ToSnowflakeOperator.
 
 When specifying the connection in environment variable you should specify
 it using URI syntax.


### PR DESCRIPTION
Method `_get_aws_credentials` uses variables before they are defined, and in addition, I don't see any references to that method.  Fortunately, this method was marked private so we can safely remove it.
```
$ grep -R -i '_get_aws_credentials' airflow/ tests/
Binary file airflow//providers/snowflake/hooks/__pycache__/snowflake.cpython-38.pyc matches
airflow//providers/snowflake/hooks/snowflake.py:    def _get_aws_credentials(self) -> Tuple[Optional[Any], Optional[Any]]:
```
CC: @mattpolzin  @harishkrao @sfc-gh-turbaszek
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
