### PR TITLE
fixing #19028 by moving chown to use sudo

### DIFF
--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -70,7 +70,7 @@ class BaseTaskRunner(LoggingMixin):
             cfg_path = tmp_configuration_copy(chmod=0o600, include_env=True, include_cmds=True)
 
             # Give ownership of file to user; only they can read and write
-            subprocess.call(['sudo', 'chown', self.run_as_user, cfg_path, self._error_file.name], close_fds=True)
+            subprocess.check_call(['sudo', 'chown', self.run_as_user, cfg_path, self._error_file.name], close_fds=True)
 
             # propagate PYTHONPATH environment variable
             pythonpath_value = os.environ.get(PYTHONPATH_VAR, '')

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -87,11 +87,7 @@ class BaseTaskRunner(LoggingMixin):
 
         self._error_file = NamedTemporaryFile(delete=True)
         if self.run_as_user:
-            try:
-                os.chown(self._error_file.name, getpwnam(self.run_as_user).pw_uid, -1)
-            except KeyError:
-                # No user `run_as_user` found
-                pass
+            subprocess.call(['sudo', 'chown', self.run_as_user, self._error_file.name], close_fds=True)
 
         self._cfg_path = cfg_path
         self._command = (

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -19,7 +19,6 @@
 import os
 import subprocess
 import threading
-from pwd import getpwnam
 from tempfile import NamedTemporaryFile
 from typing import Optional, Union
 

--- a/airflow/task/task_runner/base_task_runner.py
+++ b/airflow/task/task_runner/base_task_runner.py
@@ -70,7 +70,9 @@ class BaseTaskRunner(LoggingMixin):
             cfg_path = tmp_configuration_copy(chmod=0o600, include_env=True, include_cmds=True)
 
             # Give ownership of file to user; only they can read and write
-            subprocess.check_call(['sudo', 'chown', self.run_as_user, cfg_path, self._error_file.name], close_fds=True)
+            subprocess.check_call(
+                ['sudo', 'chown', self.run_as_user, cfg_path, self._error_file.name], close_fds=True
+            )
 
             # propagate PYTHONPATH environment variable
             pythonpath_value = os.environ.get(PYTHONPATH_VAR, '')

--- a/tests/jobs/test_local_task_job.py
+++ b/tests/jobs/test_local_task_job.py
@@ -149,8 +149,9 @@ class TestLocalTaskJob:
         with pytest.raises(AirflowException):
             job1.heartbeat_callback()
 
+    @mock.patch('subprocess.check_call')
     @mock.patch('airflow.jobs.local_task_job.psutil')
-    def test_localtaskjob_heartbeat_with_run_as_user(self, psutil_mock, dag_maker):
+    def test_localtaskjob_heartbeat_with_run_as_user(self, psutil_mock, _, dag_maker):
         session = settings.Session()
         with dag_maker('test_localtaskjob_heartbeat'):
             op1 = DummyOperator(task_id='op1', run_as_user='myuser')
@@ -191,8 +192,9 @@ class TestLocalTaskJob:
             job1.heartbeat_callback()
 
     @conf_vars({('core', 'default_impersonation'): 'testuser'})
+    @mock.patch('subprocess.check_call')
     @mock.patch('airflow.jobs.local_task_job.psutil')
-    def test_localtaskjob_heartbeat_with_default_impersonation(self, psutil_mock, dag_maker):
+    def test_localtaskjob_heartbeat_with_default_impersonation(self, psutil_mock, _, dag_maker):
         session = settings.Session()
         with dag_maker('test_localtaskjob_heartbeat'):
             op1 = DummyOperator(task_id='op1')

--- a/tests/task/task_runner/test_base_task_runner.py
+++ b/tests/task/task_runner/test_base_task_runner.py
@@ -25,9 +25,11 @@ from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 
 
 @pytest.mark.parametrize(["impersonation"], (("nobody",), (None,)))
-@mock.patch('subprocess.call')
+@mock.patch('subprocess.check_call')
 @mock.patch('airflow.task.task_runner.base_task_runner.tmp_configuration_copy')
 def test_config_copy_mode(tmp_configuration_copy, subprocess_call, dag_maker, impersonation):
+    tmp_configuration_copy.return_value = "/tmp/some-string"
+
     with dag_maker("test"):
         BaseOperator(task_id="task_1", run_as_user=impersonation)
 
@@ -45,7 +47,7 @@ def test_config_copy_mode(tmp_configuration_copy, subprocess_call, dag_maker, im
 
     if impersonation:
         subprocess_call.assert_called_with(
-            ['sudo', 'chown', impersonation, tmp_configuration_copy.return_value, runner._error_file], close_fds=True
+            ['sudo', 'chown', impersonation, "/tmp/some-string", runner._error_file.name], close_fds=True
         )
     else:
         subprocess_call.not_assert_called()

--- a/tests/task/task_runner/test_base_task_runner.py
+++ b/tests/task/task_runner/test_base_task_runner.py
@@ -26,9 +26,8 @@ from airflow.task.task_runner.base_task_runner import BaseTaskRunner
 
 @pytest.mark.parametrize(["impersonation"], (("nobody",), (None,)))
 @mock.patch('subprocess.call')
-@mock.patch('os.chown')
 @mock.patch('airflow.task.task_runner.base_task_runner.tmp_configuration_copy')
-def test_config_copy_mode(tmp_configuration_copy, chown, subprocess_call, dag_maker, impersonation):
+def test_config_copy_mode(tmp_configuration_copy, subprocess_call, dag_maker, impersonation):
     with dag_maker("test"):
         BaseOperator(task_id="task_1", run_as_user=impersonation)
 
@@ -45,10 +44,8 @@ def test_config_copy_mode(tmp_configuration_copy, chown, subprocess_call, dag_ma
     tmp_configuration_copy.assert_called_with(chmod=0o600, include_env=includes, include_cmds=includes)
 
     if impersonation:
-        chown.assert_called()
         subprocess_call.assert_called_with(
             ['sudo', 'chown', impersonation, tmp_configuration_copy.return_value], close_fds=True
         )
     else:
-        chown.assert_not_called()
         subprocess_call.not_assert_called()

--- a/tests/task/task_runner/test_base_task_runner.py
+++ b/tests/task/task_runner/test_base_task_runner.py
@@ -45,7 +45,7 @@ def test_config_copy_mode(tmp_configuration_copy, subprocess_call, dag_maker, im
 
     if impersonation:
         subprocess_call.assert_called_with(
-            ['sudo', 'chown', impersonation, tmp_configuration_copy.return_value], close_fds=True
+            ['sudo', 'chown', impersonation, tmp_configuration_copy.return_value, runner._error_file], close_fds=True
         )
     else:
         subprocess_call.not_assert_called()


### PR DESCRIPTION
Without this change, using user impersonation requires that Airflow run as root or it won't work at all.

closes: #19028 
related: #15947 
