### PR TITLE
Log only when Zombies exists

### DIFF
--- a/airflow/dag_processing/manager.py
+++ b/airflow/dag_processing/manager.py
@@ -1066,7 +1066,6 @@ class DagFileProcessorManager(LoggingMixin):
             TI = airflow.models.TaskInstance
             DM = airflow.models.DagModel
             limit_dttm = timezone.utcnow() - timedelta(seconds=self._zombie_threshold_secs)
-            self.log.info("Failing jobs without heartbeat after %s", limit_dttm)
 
             zombies = (
                 session.query(TI, DM.fileloc)
@@ -1081,6 +1080,9 @@ class DagFileProcessorManager(LoggingMixin):
                 )
                 .all()
             )
+
+            if zombies:
+                self.log.info("Failing (%s) jobs without heartbeat after %s", len(zombies), limit_dttm)
 
             self._last_zombie_query_time = timezone.utcnow()
             for ti, file_loc in zombies:


### PR DESCRIPTION
The following feels like there were non-zero jobs that were zombies while there weren't
```
[2021-12-07 20:54:35,502] {manager.py:1051} INFO - Finding 'running' jobs without a recent heartbeat
[2021-12-07 20:54:35,502] {manager.py:1055} INFO - Failing jobs without heartbeat after 2021-12-07 20:49:35.502841+00:00
[2021-12-07 20:54:45,541] {manager.py:1051} INFO - Finding 'running' jobs without a recent heartbeat
[2021-12-07 20:54:45,542] {manager.py:1055} INFO - Failing jobs without heartbeat after 2021-12-07 20:49:45.542170+00:00
```

This changes so that logs only exists when we have more than 0 zombies

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
