### PR TITLE
Allow users to input reasons when manually mark states.

### DIFF
--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -38,6 +38,10 @@
     {% for name,val in request.values.items() if name != "csrf_token" %}
       <input type="hidden" name="{{ name }}" value="{{ val }}">
     {% endfor %}
+    <div class="form-group" style="max-width: 360px">
+      <label for="comment">(Optional) Add a comment explaining the reason for this action.</label>
+      <textarea class="form-control" name="comment">{{ comment }}</textarea>
+    </div>
     <button type="submit" class="btn btn-primary">OK</button>
     <button type="button" class="btn" onclick="window.history.back(); return false">Cancel</button>
   </form>

--- a/airflow/www/templates/airflow/confirm.html
+++ b/airflow/www/templates/airflow/confirm.html
@@ -39,8 +39,8 @@
       <input type="hidden" name="{{ name }}" value="{{ val }}">
     {% endfor %}
     <div class="form-group" style="max-width: 360px">
-      <label for="comment">(Optional) Add a comment explaining the reason for this action.</label>
-      <textarea class="form-control" name="comment">{{ comment }}</textarea>
+      <label for="note">(Optional) Add a not explaining the reason for this action.</label>
+      <textarea class="form-control" name="note">{{ note }}</textarea>
     </div>
     <button type="submit" class="btn btn-primary">OK</button>
     <button type="button" class="btn" onclick="window.history.back(); return false">Cancel</button>


### PR DESCRIPTION
This PR is a change that allows users to input reasons on the UI when they manually mark state (clear, success, failed) of a DAG run or task instances. Recording users' comments associated with such actions enriches the audit logs, and helps team that maintains the DAG or admins to understand the intention of particular manual operations.

Changes include adding an input box on the UI allowing users to add a comment explaining the reasons. 
Comment text is stored in the DB Log table, extra column.
