### PR TITLE
Forward decorated function type to provide_session reusult

### DIFF
--- a/airflow/mypy/plugin/decorators.py
+++ b/airflow/mypy/plugin/decorators.py
@@ -25,8 +25,9 @@ from mypy.plugin import FunctionContext, Plugin
 from mypy.types import CallableType, NoneType, UnionType
 
 TYPED_DECORATORS = {
-    "fallback_to_default_project_id of GoogleBaseHook": ["project_id"],
+    "airflow.utils.session.provide_session": [],
     "airflow.providers.google.cloud.hooks.dataflow._fallback_to_project_id_from_variables": ["project_id"],
+    "fallback_to_default_project_id of GoogleBaseHook": ["project_id"],
     "provide_gcp_credential_file of GoogleBaseHook": [],
 }
 


### PR DESCRIPTION
Now that we have `NEW_SESSION`, we don’t really need any more special hacks to make `provide_session`-decorated functions be type-checked. This is enough to type check the following:

```python
from sqlalchemy.orm import Session
from airflow.utils.session import NEW_SESSION, provide_session

@provide_session
def foo(x: int, *, session: Session = NEW_SESSION) -> str:
    return str(x)

foo(x="a")
foo(y=1)
```

and emit

```
Run mypy.................................................................Failed
- hook id: mypy
- exit code: 1

No need to rebuild the image: none of the important files changed

airflow/play.py:8: error: Argument "x" to "foo" has incompatible type "str";
expected "int"
    foo(x="a")
          ^
airflow/play.py:9: error: Unexpected keyword argument "y" for "foo"
    foo(y=1)
    ^
Found 2 errors in 1 file (checked 2 source files)

ERROR: The previous step completed with error. Please take a look at output above
```

For some reason, this does not type check `session`—I can pass literally anything to it (e.g. `session=object()`) and Mypy would let it pass. Not sure why, maybe because SQLAlchemy is not well-typed? But this is still very useful.