### PR TITLE
Applying the TI mutation hook to tasks run from UI

### DIFF
--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1618,6 +1618,7 @@ class Airflow(AirflowBaseView):
             return redirect(origin)
 
         ti.refresh_from_task(task)
+        settings.task_instance_mutation_hook(ti)
 
         # Make sure the task instance can be run
         dep_context = DepContext(


### PR DESCRIPTION
I discovered that `task_instance_mutation_hook` is only invoked in `dagrun.verify_integrity()`, which itself is not invoked often due to its cost. The goal of this change is to ensure tasks are mutated on every execution, regardless of the source of the run.

I am unsure how to formally test this change, though I did verify it behaved as expected locally by clicking the UI and checking webserver logs. 