### PR TITLE
Type (ignore) airflow.compat

### DIFF
--- a/airflow/compat/asyncio.py
+++ b/airflow/compat/asyncio.py
@@ -20,6 +20,9 @@ try:
 except ImportError:
     # create_task is not present in Python 3.6. Once Airflow is at 3.7+, we can
     # remove this helper.
-    def create_task(*args, **kwargs):
+    def create_task(*args, **kwargs):  # type: ignore
         """A version of create_task that always errors."""
         raise RuntimeError("Airflow's async functionality is only available on Python 3.7+")
+
+
+__all__ = ["create_task"]


### PR DESCRIPTION
We don't really care about the shim, and this module is going away pretty soon anyway, so let's not bother too much.

The `__all__` line silences a Flake8 error (not sure why it did not complain before).