### PR TITLE
Upload provider artifacts before install/test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,17 +663,17 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
         run: ./scripts/ci/build_airflow/ci_build_airflow_packages.sh
         env:
           PACKAGE_FORMAT: "sdist"
-      - name: "Install and test provider packages and airflow via sdist files"
-        run: ./scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
-        env:
-          USE_AIRFLOW_VERSION: "sdist"
-          PACKAGE_FORMAT: "sdist"
       - name: "Upload provider distribution artifacts"
         uses: actions/upload-artifact@v2
         with:
           name: airflow-provider-packages
           path: "./dist/apache-airflow-providers-*.tar.gz"
           retention-days: 1
+      - name: "Install and test provider packages and airflow via sdist files"
+        run: ./scripts/ci/provider_packages/ci_install_and_test_provider_packages.sh
+        env:
+          USE_AIRFLOW_VERSION: "sdist"
+          PACKAGE_FORMAT: "sdist"
 
   tests-helm:
     timeout-minutes: 40


### PR DESCRIPTION
The reasoning is that uploading is rather quick and sometimes you'll want to download the artifact regardless of whether tests pass or fail.
