### PR TITLE
Add Google Cloud Tasks how-to documentation

### DIFF
--- a/airflow/providers/google/cloud/example_dags/example_tasks.py
+++ b/airflow/providers/google/cloud/example_dags/example_tasks.py
@@ -73,6 +73,7 @@ with models.DAG(
 ) as dag:
 
     # Queue operations
+    # [START create_queue]
     create_queue = CloudTasksQueueCreateOperator(
         location=LOCATION,
         task_queue=Queue(stackdriver_logging_config=dict(sampling_ratio=0.5)),
@@ -81,31 +82,41 @@ with models.DAG(
         timeout=5,
         task_id="create_queue",
     )
+    # [END create_queue]
 
+    # [START delete_queue]
     delete_queue = CloudTasksQueueDeleteOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
         task_id="delete_queue",
     )
+    # [END delete_queue]
 
+    # [START resume_queue]
     resume_queue = CloudTasksQueueResumeOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
         task_id="resume_queue",
     )
+    # [END resume_queue]
 
+    # [START pause_queue]
     pause_queue = CloudTasksQueuePauseOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
         task_id="pause_queue",
     )
+    # [END pause_queue]
 
+    # [START purge_queue]
     purge_queue = CloudTasksQueuePurgeOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
         task_id="purge_queue",
     )
+    # [END purge_queue]
 
+    # [START get_queue]
     get_queue = CloudTasksQueueGetOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
@@ -116,9 +127,11 @@ with models.DAG(
         task_id="get_queue_result",
         bash_command=f"echo {get_queue.output}",
     )
+    # [END get_queue]
 
     get_queue >> get_queue_result
 
+    # [START update_queue]
     update_queue = CloudTasksQueueUpdateOperator(
         task_queue=Queue(stackdriver_logging_config=dict(sampling_ratio=1)),
         location=LOCATION,
@@ -126,8 +139,11 @@ with models.DAG(
         update_mask={"paths": ["stackdriver_logging_config.sampling_ratio"]},
         task_id="update_queue",
     )
+    # [END update_queue]
 
+    # [START list_queue]
     list_queue = CloudTasksQueuesListOperator(location=LOCATION, task_id="list_queue")
+    # [END list_queue]
 
     chain(
         create_queue,
@@ -141,6 +157,7 @@ with models.DAG(
     )
 
     # Tasks operations
+    # [START create_task]
     create_task = CloudTasksTaskCreateOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
@@ -150,25 +167,34 @@ with models.DAG(
         timeout=5,
         task_id="create_task_to_run",
     )
+    # [END create_task]
 
+    # [START tasks_get]
     tasks_get = CloudTasksTaskGetOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
         task_name=TASK_NAME,
         task_id="tasks_get",
     )
+    # [END tasks_get]
 
+    # [START run_task]
     run_task = CloudTasksTaskRunOperator(
         location=LOCATION,
         queue_name=QUEUE_ID,
         task_name=TASK_NAME,
         task_id="run_task",
     )
+    # [END run_task]
 
+    # [START list_tasks]
     list_tasks = CloudTasksTasksListOperator(location=LOCATION, queue_name=QUEUE_ID, task_id="list_tasks")
+    # [END list_tasks]
 
+    # [START delete_task]
     delete_task = CloudTasksTaskDeleteOperator(
         location=LOCATION, queue_name=QUEUE_ID, task_name=TASK_NAME, task_id="delete_task"
     )
+    # [END delete_task]
 
     chain(purge_queue, create_task, tasks_get, list_tasks, run_task, delete_task, delete_queue)

--- a/airflow/providers/google/cloud/operators/tasks.py
+++ b/airflow/providers/google/cloud/operators/tasks.py
@@ -38,6 +38,10 @@ class CloudTasksQueueCreateOperator(BaseOperator):
     """
     Creates a queue in Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueueCreateOperator`
+
     :param location: The location name in which the queue will be created.
     :type location: str
     :param task_queue: The task queue to create.
@@ -140,6 +144,10 @@ class CloudTasksQueueUpdateOperator(BaseOperator):
     """
     Updates a queue in Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueueUpdateOperator`
+
     :param task_queue: The task queue to update.
         This method creates the queue if it does not exist and updates the queue if
         it does exist. The queue's name must be specified.
@@ -240,6 +248,10 @@ class CloudTasksQueueGetOperator(BaseOperator):
     """
     Gets a queue from Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueueGetOperator`
+
     :param location: The location name in which the queue was created.
     :type location: str
     :param queue_name: The queue's name.
@@ -321,6 +333,10 @@ class CloudTasksQueueGetOperator(BaseOperator):
 class CloudTasksQueuesListOperator(BaseOperator):
     """
     Lists queues from Cloud Tasks.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueuesListOperator`
 
     :param location: The location name in which the queues were created.
     :type location: str
@@ -409,6 +425,10 @@ class CloudTasksQueueDeleteOperator(BaseOperator):
     """
     Deletes a queue from Cloud Tasks, even if it has tasks in it.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueueDeleteOperator`
+
     :param location: The location name in which the queue will be deleted.
     :type location: str
     :param queue_name: The queue's name.
@@ -487,6 +507,10 @@ class CloudTasksQueueDeleteOperator(BaseOperator):
 class CloudTasksQueuePurgeOperator(BaseOperator):
     """
     Purges a queue by deleting all of its tasks from Cloud Tasks.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueuePurgeOperator`
 
     :param location: The location name in which the queue will be purged.
     :type location: str
@@ -570,6 +594,10 @@ class CloudTasksQueuePauseOperator(BaseOperator):
     """
     Pauses a queue in Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueuePauseOperator`
+
     :param location: The location name in which the queue will be paused.
     :type location: str
     :param queue_name: The queue's name.
@@ -652,6 +680,10 @@ class CloudTasksQueueResumeOperator(BaseOperator):
     """
     Resumes a queue in Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksQueueResumeOperator`
+
     :param location: The location name in which the queue will be resumed.
     :type location: str
     :param queue_name: The queue's name.
@@ -733,6 +765,10 @@ class CloudTasksQueueResumeOperator(BaseOperator):
 class CloudTasksTaskCreateOperator(BaseOperator):
     """
     Creates a task in Cloud Tasks.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksTaskCreateOperator`
 
     :param location: The location name in which the task will be created.
     :type location: str
@@ -836,6 +872,10 @@ class CloudTasksTaskGetOperator(BaseOperator):
     """
     Gets a task from Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksTaskGetOperator`
+
     :param location: The location name in which the task was created.
     :type location: str
     :param queue_name: The queue's name.
@@ -929,6 +969,10 @@ class CloudTasksTaskGetOperator(BaseOperator):
 class CloudTasksTasksListOperator(BaseOperator):
     """
     Lists the tasks in Cloud Tasks.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksTasksListOperator`
 
     :param location: The location name in which the tasks were created.
     :type location: str
@@ -1024,6 +1068,10 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
     """
     Deletes a task from Cloud Tasks.
 
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksTaskDeleteOperator`
+
     :param location: The location name in which the task will be deleted.
     :type location: str
     :param queue_name: The queue's name.
@@ -1108,6 +1156,10 @@ class CloudTasksTaskDeleteOperator(BaseOperator):
 class CloudTasksTaskRunOperator(BaseOperator):
     """
     Forces to run a task in Cloud Tasks.
+
+    .. seealso::
+        For more information on how to use this operator, take a look at the guide:
+        :ref:`howto/operator:CloudTasksTaskRunOperator`
 
     :param location: The location name in which the task was created.
     :type location: str

--- a/airflow/providers/google/provider.yaml
+++ b/airflow/providers/google/provider.yaml
@@ -169,6 +169,8 @@ integrations:
     tags: [gcp]
   - integration-name: Google Cloud Tasks
     external-doc-url: https://cloud.google.com/tasks/
+    how-to-guide:
+      - /docs/apache-airflow-providers-google/operators/cloud/tasks.rst
     logo: /integration-logos/gcp/Cloud-Tasks.png
     tags: [gcp]
   - integration-name: Google Cloud Text-to-Speech

--- a/docs/apache-airflow-providers-google/operators/cloud/tasks.rst
+++ b/docs/apache-airflow-providers-google/operators/cloud/tasks.rst
@@ -1,0 +1,229 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+Google Cloud Tasks
+==================
+
+Firestore in Datastore mode is a NoSQL document database built for automatic scaling,
+high performance, and ease of application development.
+
+For more information about the service visit
+`Cloud Tasks product documentation <https://cloud.google.com/tasks/docs>`__
+
+Prerequisite Tasks
+------------------
+
+.. include::/operators/_partials/prerequisite_tasks.rst
+
+
+Queue operations
+----------------
+
+.. _howto/operator:CloudTasksQueueCreateOperator:
+
+Create queue
+^^^^^^^^^^^^
+
+To create new Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueueCreateOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START create_queue]
+    :end-before: [END create_queue]
+
+.. _howto/operator:CloudTasksQueueDeleteOperator:
+
+Delete queue
+^^^^^^^^^^^^
+
+To delete Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueueDeleteOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START delete_queue]
+    :end-before: [END delete_queue]
+
+
+.. _howto/operator:CloudTasksQueueResumeOperator:
+
+Resume queue
+^^^^^^^^^^^^
+
+To resume Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueueResumeOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START resume_queue]
+    :end-before: [END resume_queue]
+
+.. _howto/operator:CloudTasksQueuePauseOperator:
+
+Pause queue
+^^^^^^^^^^^
+
+To pause Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueuePauseOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START pause_queue]
+    :end-before: [END pause_queue]
+
+.. _howto/operator:CloudTasksQueuePurgeOperator:
+
+Purge queue
+^^^^^^^^^^^
+
+To purge Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueuePurgeOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START purge_queue]
+    :end-before: [END purge_queue]
+
+.. _howto/operator:CloudTasksQueueGetOperator:
+
+Get queue
+^^^^^^^^^
+
+To get Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueueGetOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START get_queue]
+    :end-before: [END get_queue]
+
+.. _howto/operator:CloudTasksQueueUpdateOperator:
+
+Update queue
+^^^^^^^^^^^^
+
+To update Queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueueUpdateOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START update_queue]
+    :end-before: [END update_queue]
+
+.. _howto/operator:CloudTasksQueuesListOperator:
+
+List queues
+^^^^^^^^^^^
+
+To list all Queues use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksQueuesListOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START list_queue]
+    :end-before: [END list_queue]
+
+
+Tasks operations
+----------------
+
+.. _howto/operator:CloudTasksTaskCreateOperator:
+
+Create task
+^^^^^^^^^^^
+
+To create new Task in a particular queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksTaskCreateOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START create_task]
+    :end-before: [END create_task]
+
+.. _howto/operator:CloudTasksTaskGetOperator:
+
+Get task
+^^^^^^^^
+
+To get the Tasks in a particular queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksTaskGetOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START tasks_get]
+    :end-before: [END tasks_get]
+
+.. _howto/operator:CloudTasksTaskRunOperator:
+
+Run task
+^^^^^^^^
+
+To run the Task in a particular queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksTaskRunOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START run_task]
+    :end-before: [END run_task]
+
+.. _howto/operator:CloudTasksTasksListOperator:
+
+List tasks
+^^^^^^^^^^
+
+To list all Tasks in a particular queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksTasksListOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START list_tasks]
+    :end-before: [END list_tasks]
+
+.. _howto/operator:CloudTasksTaskDeleteOperator:
+
+Delete task
+^^^^^^^^^^^
+
+To delete the Task from particular queue use
+:class:`~airflow.providers.google.cloud.operators.tasks.CloudTasksTaskDeleteOperator`
+
+.. exampleinclude:: /../../airflow/providers/google/cloud/example_dags/example_tasks.py
+    :language: python
+    :dedent: 4
+    :start-after: [START create_task]
+    :end-before: [END create_task]
+
+
+References
+^^^^^^^^^^
+For further information, take a look at:
+
+* `Cloud Tasks API documentation <https://cloud.google.com/tasks/docs/reference/rest>`__
+* `Product documentation <https://cloud.google.com/tasks/docs>`__


### PR DESCRIPTION
closes: #8208
related: #8209

Add how-to documentation for Google Cloud Tasks.
I've built successfully in a local machine and made static checks.

This PR with the #20138 also closes: #8209