### PR TITLE
Log filename template records

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -89,6 +89,12 @@ Smart sensors, an "early access" feature added in Airflow 2, are now deprecated 
 
 See [Migrating to Deferrable Operators](https://airflow.apache.org/docs/apache-airflow/2.3.0/concepts/smart-sensors.html#migrating-to-deferrable-operators) for details on how to migrate.
 
+### Task log filenames are not rendered from database entry instead of config value
+
+Previously, filename of a task’s log is dynamically rendered from the ``[core] log_filename_template`` config value at runtime. This resulted in unfortunate characteristics like it is inpractical to modify the config value after an Airflow instance is running for a while, since all existing task logs have be saved under the previous format and cannot be found with the new config value.
+
+A new `log_filename` table is introduced to solve this problem. This table is synchronised with the aforementioned config value every time Airflow starts, and a new field `log_filename_id` is added to every DAG run to point to the format used by tasks (`NULL` indicates the first ever entry for compatibility).
+
 ## Airflow 2.2.2
 
 No breaking changes.

--- a/airflow/migrations/versions/f9da662e7089_add_task_log_filename_template_model.py
+++ b/airflow/migrations/versions/f9da662e7089_add_task_log_filename_template_model.py
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Add model for task log filename template.
+
+Revision ID: f9da662e7089
+Revises: 786e3737b18f
+Create Date: 2021-12-09 06:11:21.044940
+"""
+
+from alembic import op
+from sqlalchemy import Column, ForeignKey, Integer, Text
+
+from airflow.utils.sqlalchemy import UtcDateTime
+
+# Revision identifiers, used by Alembic.
+revision = "f9da662e7089"
+down_revision = "786e3737b18f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add model for task log filename template and establish fk on task instance."""
+    op.create_table(
+        "log_filename",
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("template", Text, nullable=False),
+        Column("created_at", UtcDateTime, nullable=False),
+    )
+    dag_run_log_filename_id = Column(
+        "log_filename_id",
+        Integer,
+        ForeignKey("log_filename.id", name="task_instance_log_filename_id_fkey", ondelete="NO ACTION"),
+    )
+    with op.batch_alter_table("dag_run") as batch_op:
+        batch_op.add_column(dag_run_log_filename_id)
+
+
+def downgrade():
+    """Remove fk on task instance and model for task log filename template."""
+    with op.batch_alter_table("dag_run") as batch_op:
+        batch_op.drop_column("log_filename_id")
+    op.drop_table("log_filename")

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, NamedTuple, Optiona
 from sqlalchemy import (
     Boolean,
     Column,
+    ForeignKey,
     Index,
     Integer,
     PickleType,
@@ -37,13 +38,14 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import joinedload, relationship, synonym
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql import expression
+from sqlalchemy.sql.expression import false, select, true
 
 from airflow import settings
 from airflow.configuration import conf as airflow_conf
 from airflow.exceptions import AirflowException, TaskNotFound
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
 from airflow.models.taskinstance import TaskInstance as TI
+from airflow.models.tasklog import LogFilename
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
@@ -94,6 +96,14 @@ class DagRun(Base, LoggingMixin):
     # When a scheduler last attempted to schedule TIs for this DagRun
     last_scheduling_decision = Column(UtcDateTime)
     dag_hash = Column(String(32))
+    # Foreign key to LogFilename. DagRun rows created prior to this column's
+    # existence have this set to NULL. Later rows automatically populate this on
+    # insert to point to the latest LogFilename entry.
+    log_filename_id = Column(
+        Integer,
+        ForeignKey("log_filename.id", name="task_instance_log_filename_id_fkey", ondelete="NO ACTION"),
+        default=select([func.max(LogFilename.__table__.c.id)]),
+    )
 
     # Remove this `if` after upgrading Sphinx-AutoAPI
     if not TYPE_CHECKING and "BUILDING_AIRFLOW_DOCS" in os.environ:
@@ -258,14 +268,8 @@ class DagRun(Base, LoggingMixin):
         query = (
             session.query(cls)
             .filter(cls.state == state, cls.run_type != DagRunType.BACKFILL_JOB)
-            .join(
-                DagModel,
-                DagModel.dag_id == cls.dag_id,
-            )
-            .filter(
-                DagModel.is_paused == expression.false(),
-                DagModel.is_active == expression.true(),
-            )
+            .join(DagModel, DagModel.dag_id == cls.dag_id)
+            .filter(DagModel.is_paused == false(), DagModel.is_active == true())
         )
         if state == State.QUEUED:
             # For dag runs in the queued state, we check if they have reached the max_active_runs limit
@@ -933,3 +937,13 @@ class DagRun(Base, LoggingMixin):
             )
 
         return count
+
+    @provide_session
+    def get_log_filename_template(self, *, session: Session = NEW_SESSION) -> Optional[str]:
+        if self.log_filename_id is None:  # DagRun created before LogFilename introduction.
+            template = session.query(LogFilename.template).order_by(LogFilename.id).limit(1).scalar()
+        else:
+            template = session.query(LogFilename.template).filter_by(id=self.log_filename_id).one_or_none()
+        if template is not None:
+            return template
+        return airflow_conf.get("logging", "LOG_FILENAME_TEMPLATE")

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -943,7 +943,10 @@ class DagRun(Base, LoggingMixin):
         if self.log_filename_id is None:  # DagRun created before LogFilename introduction.
             template = session.query(LogFilename.template).order_by(LogFilename.id).limit(1).scalar()
         else:
-            template = session.query(LogFilename.template).filter_by(id=self.log_filename_id).one_or_none()
-        if template is not None:
-            return template
-        return airflow_conf.get("logging", "LOG_FILENAME_TEMPLATE")
+            template = session.query(LogFilename.template).filter_by(id=self.log_filename_id).scalar()
+        if template is None:
+            raise AirflowException(
+                f"No log_filename entry found for ID {self.log_filename_id!r}. "
+                f"Please make sure you set up the metadatabase correctly."
+            )
+        return template

--- a/airflow/models/tasklog.py
+++ b/airflow/models/tasklog.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy import Column, Integer, Text
+
+from airflow.models.base import Base
+from airflow.utils import timezone
+from airflow.utils.sqlalchemy import UtcDateTime
+
+
+class LogFilename(Base):
+    """Model to store ``[core] log_filename_template`` config changes.
+
+    This table is automatically populated when Airflow starts up, to store the
+    config's value if it does not match the last row in the table.
+    """
+
+    __tablename__ = "log_filename"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    template = Column(Text, nullable=False)
+    created_at = Column(UtcDateTime, nullable=False, default=timezone.utcnow)
+
+    def __repr__(self) -> str:
+        created_at = self.created_at.isoformat()
+        return f"LogFilename(id={self.id!r}, template={self.template!r}, created_at={created_at!r})"

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Callable, Optional, TypeVar, cast
 from airflow import settings
 from airflow.exceptions import AirflowException
 from airflow.utils import cli_action_loggers
-from airflow.utils.db import check_and_run_migrations
+from airflow.utils.db import check_and_run_migrations, synchronize_log_filename_template
 from airflow.utils.log.non_caching_file_handler import NonCachingFileHandler
 from airflow.utils.platform import getuser, is_terminal_support_colors
 from airflow.utils.session import provide_session
@@ -94,6 +94,7 @@ def action_cli(func=None, check_db=True):
                 # Check and run migrations if necessary
                 if check_db:
                     check_and_run_migrations()
+                    synchronize_log_filename_template()
                 return f(*args, **kwargs)
             except Exception as e:
                 metrics['error'] = e

--- a/airflow/utils/log/log_reader.py
+++ b/airflow/utils/log/log_reader.py
@@ -18,11 +18,14 @@
 import logging
 from typing import Dict, Iterator, List, Optional, Tuple
 
+from sqlalchemy.orm.session import Session
+
 from airflow.compat.functools import cached_property
 from airflow.configuration import conf
 from airflow.models import TaskInstance
 from airflow.utils.helpers import render_log_filename
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
+from airflow.utils.session import NEW_SESSION, provide_session
 
 
 class TaskLogReader:
@@ -105,7 +108,14 @@ class TaskLogReader:
 
         return self.log_handler.supports_external_link
 
-    def render_log_filename(self, ti: TaskInstance, try_number: Optional[int] = None):
+    @provide_session
+    def render_log_filename(
+        self,
+        ti: TaskInstance,
+        try_number: Optional[int] = None,
+        *,
+        session: Session = NEW_SESSION,
+    ):
         """
         Renders the log attachment filename
 
@@ -115,8 +125,10 @@ class TaskLogReader:
         :type try_number: Optional[int]
         :rtype: str
         """
-        filename_template = conf.get('logging', 'LOG_FILENAME_TEMPLATE')
+        dagrun = ti.get_dagrun(session=session)
         attachment_filename = render_log_filename(
-            ti=ti, try_number="all" if try_number is None else try_number, filename_template=filename_template
+            ti=ti,
+            try_number="all" if try_number is None else try_number,
+            filename_template=dagrun.get_log_filename_template(session=session),
         )
         return attachment_filename

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -1325,7 +1325,7 @@ class Airflow(AirflowBaseView):
                 return jsonify(message=message, metadata=metadata)
 
             metadata['download_logs'] = True
-            attachment_filename = task_log_reader.render_log_filename(ti, try_number)
+            attachment_filename = task_log_reader.render_log_filename(ti, try_number, session=session)
             log_stream = task_log_reader.read_log_stream(ti, try_number, metadata)
             return Response(
                 response=log_stream,

--- a/docs/apache-airflow/migrations-ref.rst
+++ b/docs/apache-airflow/migrations-ref.rst
@@ -23,7 +23,9 @@ Here's the list of all the Database Migrations that are executed via when you ru
 +--------------------------------+------------------+-----------------+---------------------------------------------------------------------------------------+
 | Revision ID                    | Revises ID       | Airflow Version | Description                                                                           |
 +--------------------------------+------------------+-----------------+---------------------------------------------------------------------------------------+
-| ``786e3737b18f`` (head)        | ``5e3ec427fdd3`` | ``2.3.0``       | Add ``timetable_description`` column to DagModel for UI.                              |
+| ``f9da662e7089`` (head)        | ``786e3737b18f`` | ``2.3.0``       | Add ``LogFilename`` table to track ``log_filename_template`` value changes.           |
++--------------------------------+------------------+-----------------+---------------------------------------------------------------------------------------+
+| ``786e3737b18f``               | ``5e3ec427fdd3`` | ``2.3.0``       | Add ``timetable_description`` column to DagModel for UI.                              |
 +--------------------------------+------------------+-----------------+---------------------------------------------------------------------------------------+
 | ``5e3ec427fdd3``               | ``be2bfac3da23`` | ``2.3.0``       | Increase length of email and username in ``ab_user`` and ``ab_register_user`` table   |
 |                                |                  |                 | to ``256`` characters                                                                 |

--- a/tests/www/views/test_views_log.py
+++ b/tests/www/views/test_views_log.py
@@ -27,7 +27,8 @@ import pytest
 
 from airflow import settings
 from airflow.config_templates.airflow_local_settings import DEFAULT_LOGGING_CONFIG
-from airflow.models import DagBag
+from airflow.models import DagBag, DagRun
+from airflow.models.tasklog import LogFilename
 from airflow.utils import timezone
 from airflow.utils.log.logging_mixin import ExternalLoggingMixin
 from airflow.utils.session import create_session
@@ -226,6 +227,70 @@ def test_get_logs_with_metadata_as_download_file(log_admin_client):
     assert f'{DAG_ID}/{TASK_ID}/{DEFAULT_DATE.isoformat()}/{try_number}.log' in content_disposition
     assert 200 == response.status_code
     assert 'Log for testing.' in response.data.decode('utf-8')
+
+
+DIFFERENT_LOG_FILENAME = "{{ ti.dag_id }}/{{ ti.run_id }}/{{ ti.task_id }}/{{ try_number }}.log"
+
+
+@conf_vars({("core", "log_filename_template"): DIFFERENT_LOG_FILENAME})
+def test_get_logs_for_changed_filename_format_config(log_admin_client):
+    url_template = (
+        "get_logs_with_metadata?dag_id={}&"
+        "task_id={}&execution_date={}&"
+        "try_number={}&metadata={}&format=file"
+    )
+    try_number = 1
+    url = url_template.format(
+        DAG_ID,
+        TASK_ID,
+        urllib.parse.quote_plus(DEFAULT_DATE.isoformat()),
+        try_number,
+        "{}",
+    )
+    response = log_admin_client.get(url)
+
+    # Should still find the log under previous filename, not the new config value.
+    content_disposition = response.headers['Content-Disposition']
+    assert content_disposition.startswith('attachment')
+    assert f'{DAG_ID}/{TASK_ID}/{DEFAULT_DATE.isoformat()}/{try_number}.log' in content_disposition
+    assert 200 == response.status_code
+    assert 'Log for testing.' in response.data.decode('utf-8')
+
+
+@pytest.fixture()
+def dag_run_with_log_filename():
+    run_filters = [DagRun.dag_id == DAG_ID, DagRun.execution_date == DEFAULT_DATE]
+    with create_session() as session:
+        log_filename = session.merge(LogFilename(template=DIFFERENT_LOG_FILENAME))
+        session.flush()  # To populate 'log_filename.id'.
+        run_query = session.query(DagRun).filter(*run_filters)
+        run_query.update({"log_filename_id": log_filename.id})
+        dag_run = run_query.one()
+    yield dag_run
+    with create_session() as session:
+        session.query(DagRun).filter(*run_filters).update({"log_filename_id": None})
+        session.query(LogFilename).filter(LogFilename.id == log_filename.id).delete()
+
+
+def test_get_logs_for_changed_filename_format_db(log_admin_client, dag_run_with_log_filename):
+    try_number = 1
+    url = (
+        f"get_logs_with_metadata?dag_id={dag_run_with_log_filename.dag_id}&"
+        f"task_id={TASK_ID}&"
+        f"execution_date={urllib.parse.quote_plus(dag_run_with_log_filename.logical_date.isoformat())}&"
+        f"try_number={try_number}&metadata={{}}&format=file"
+    )
+    response = log_admin_client.get(url)
+
+    # Should find the log under corresponding db entry.
+    assert 200 == response.status_code
+    assert "Log for testing." in response.data.decode("utf-8")
+    content_disposition = response.headers['Content-Disposition']
+    expected_filename = (
+        f"{dag_run_with_log_filename.dag_id}/{dag_run_with_log_filename.run_id}/{TASK_ID}/{try_number}.log"
+    )
+    assert content_disposition.startswith("attachment")
+    assert expected_filename in content_disposition
 
 
 @unittest.mock.patch(


### PR DESCRIPTION
See https://github.com/apache/airflow/issues/19058#issuecomment-947023469 and #19625 for context. This is the main prerequisite to make it possible for us to change the `log_filename_template` config’s default value.

This adds a new table `LogFilename`, and whenever an Airflow command is run (except those explicit set `check_db=False`), the user config value of `log_filename_template` is sync-ed into the table. Each `DagRun` gets a new `log_filename_id` foreign key (populated on creation) that can be used to look up what template they use to render task log filenames. All existing DagRun rows set this value to NULL (for performance reasons), and internally this makes them all use the first row in `LogFilename`, which should be the value in use when a user upgrades to 2.3.

~~The first commit is from #20163; that one needs to be merged first.~~ Merged.

Edit: Oh, and this still needs tests, and an entry in `UPDATING.md`.