### PR TITLE
Fixed issue #18967 - Oracle check connection not working

### DIFF
--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -266,3 +266,16 @@ class OracleHook(DbApiHook):
         self.log.info('[%s] inserted %s rows', table, row_count)
         cursor.close()
         conn.close()  # type: ignore[attr-defined]
+
+    def test_connection(self):
+        """Tests the connection by executing a select 1 from dual query"""
+        status, message = False, ''
+        try:
+            if self.get_first("select 1 from dual"):
+                status = True
+                message = 'Connection successfully tested'
+        except Exception as e:
+            status = False
+            message = str(e)
+
+        return status, message        

--- a/airflow/providers/oracle/hooks/oracle.py
+++ b/airflow/providers/oracle/hooks/oracle.py
@@ -278,4 +278,4 @@ class OracleHook(DbApiHook):
             status = False
             message = str(e)
 
-        return status, message        
+        return status, message


### PR DESCRIPTION
Fix #18967

In order to check Oracle connection, the "select 1" statement is wrong.
It must be replaced by  "select 1 from dual".

The following images, shows that connection's test now works also for oracle databases.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/17742862/145395446-b98aa22b-21bf-4389-bb35-51f43d8c54d5.png">
