### PR TITLE
Update minimum sphinx versions after upgrading sphinx-autoapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -253,11 +253,10 @@ deprecated_api = [
 ]
 doc = [
     'click>=7.1,<9',
-    # Sphinx is limited to < 3.5.0 because of https://github.com/sphinx-doc/sphinx/issues/8880
-    'sphinx>=3.5.0, <5.0.0',
+    'sphinx>=4.0.0, <5.0.0',
     'sphinx-airflow-theme',
     'sphinx-argparse>=0.1.13',
-    'sphinx-autoapi==1.8.0',
+    'sphinx-autoapi~=1.8.0',
     'sphinx-copybutton',
     'sphinx-jinja~=1.1',
     'sphinx-rtd-theme>=0.1.6',


### PR DESCRIPTION
* Allow point releases of AutoAPI (I used with 1.8.4 in all my testing)
* Require at least Sphinx v4

  A few things got deprecated in Sphinx 4, and as this dep is only for
  us building docs we can pick and choose what we like without impacting
  users, so lets stay up-to-date.

As noticed by @mik-laj in https://github.com/apache/airflow/pull/20079#discussion_r765878693
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).