### PR TITLE
Add deprecation warnining for non-json-serializable params

### DIFF
--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -68,7 +68,6 @@ class Param:
                 "The use of non-json-serializable params is deprecated and will be removed in "
                 " a future release",
                 DeprecationWarning,
-                stacklevel=2,
             )
         # If we have a value, validate it once. May raise ValueError.
         if not isinstance(value, ArgNotSet):

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -66,7 +66,7 @@ class Param:
         except Exception:
             warnings.warn(
                 "The use of non-json-serializable params is deprecated and will be removed in "
-                " a future release",
+                "a future release",
                 DeprecationWarning,
             )
         # If we have a value, validate it once. May raise ValueError.

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 import copy
+import json
+import warnings
 from typing import TYPE_CHECKING, Any, Dict, ItemsView, MutableMapping, Optional, ValuesView
 
 import jsonschema
@@ -49,10 +51,29 @@ class Param:
         self.description = description
         self.schema = kwargs.pop('schema') if 'schema' in kwargs else kwargs
 
+        if self.has_value:
+            self._validate(self.value, self.schema)
+
+    @staticmethod
+    def _validate(value, schema):
+        """
+        1. Check that value is json-serializable; if not, warn.  In future release we will require
+        the value to be json-serializable.
+        2. Validate ``value`` against ``schema``
+        """
+        try:
+            json.dumps(value)
+        except Exception:
+            warnings.warn(
+                "The use of non-json-serializable params is deprecated and will be removed in "
+                " a future release",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         # If we have a value, validate it once. May raise ValueError.
-        if not isinstance(default, ArgNotSet):
+        if not isinstance(value, ArgNotSet):
             try:
-                jsonschema.validate(self.value, self.schema, format_checker=FormatChecker())
+                jsonschema.validate(value, schema, format_checker=FormatChecker())
             except ValidationError as err:
                 raise ValueError(err)
 

--- a/tests/models/test_param.py
+++ b/tests/models/test_param.py
@@ -267,3 +267,7 @@ class TestDagParamRuntime:
 
         ti = dr.get_task_instances()[0]
         assert ti.xcom_pull() == 'test'
+
+    def test_param_non_json_serializable(self):
+        with pytest.warns(DeprecationWarning, match='The use of non-json-serializable params is deprecated'):
+            Param(default={0, 1, 2})


### PR DESCRIPTION
Following vote by lazy consensus (https://lists.apache.org/thread/whqbbo3gh84s7ggn7968mqlk4d41x7zl), we deprecate non-json-serializable params with removal planned for Airflow 3.0.
