### PR TITLE
Add specific warning when Task asks for more slots than pool defined with

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -330,7 +330,11 @@ class SchedulerJob(BaseJob):
             pool_total = pools[pool]["total"]
             if task_instance.pool_slots > pool_total:
                 self.log.warning(
-                    "Tasks requesting more slots than pool configured. pool '%s' will not be scheduled", pool
+                    "Not executing %s since requesting %s slots when total pool '%s' slots are %s.",
+                    task_instance,
+                    task_instance.pool_slots,
+                    pool,
+                    pool_total,
                 )
                 continue
 

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -327,6 +327,13 @@ class SchedulerJob(BaseJob):
                 self.log.warning("Tasks using non-existent pool '%s' will not be scheduled", pool)
                 continue
 
+            pool_total = pools[pool]["total"]
+            if task_instance.pool_slots > pool_total:
+                self.log.warning(
+                    "Tasks requesting more slots than pool configured. pool '%s' will not be scheduled", pool
+                )
+                continue
+
             open_slots = pools[pool]["open"]
 
             num_ready = len(task_instances)

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -330,11 +330,12 @@ class SchedulerJob(BaseJob):
             pool_total = pools[pool]["total"]
             if task_instance.pool_slots > pool_total:
                 self.log.warning(
-                    "Not executing %s since requesting %s slots when total pool '%s' slots are %s.",
+                    "Not executing %s. Requested pool slots (%s) are greater than "
+                    "total pool slots: '%s' for pool: %s.",
                     task_instance,
                     task_instance.pool_slots,
-                    pool,
                     pool_total,
+                    pool,
                 )
                 continue
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -657,8 +657,9 @@ class TestSchedulerJob:
             self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session)
             assert (
                 "Not executing <TaskInstance: "
-                "SchedulerJobTest.test_test_not_enough_pool_slots.dummy test [scheduled]> "
-                "since requesting 4 slots when total pool 'some_pool' slots are 2." in caplog.text
+                "SchedulerJobTest.test_test_not_enough_pool_slots.dummy test [scheduled]>. "
+                "Requested pool slots (4) are greater than total pool slots: '2' for pool: some_pool"
+                in caplog.text
             )
         session.flush()
         session.rollback()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -646,7 +646,6 @@ class TestSchedulerJob:
 
         self.scheduler_job = SchedulerJob(subdir=os.devnull)
         session = settings.Session()
-
         dr = dag_maker.create_dagrun()
         ti = dr.task_instances[0]
         ti.state = State.SCHEDULED
@@ -657,8 +656,9 @@ class TestSchedulerJob:
         with caplog.at_level(logging.WARNING):
             self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session)
             assert (
-                "Tasks requesting more slots than pool configured. pool 'some_pool' will not be scheduled"
-                in caplog.text
+                "Not executing <TaskInstance: "
+                "SchedulerJobTest.test_test_not_enough_pool_slots.dummy test [scheduled]> "
+                "since requesting 4 slots when total pool 'some_pool' slots are 2." in caplog.text
             )
         session.flush()
         session.rollback()


### PR DESCRIPTION
**Description:**
In cases where task asks for more pool slots than the total number it has the scheduler generates the following warning:
`[2021-12-09 19:37:51,949] {scheduler_job.py:407} INFO - Not executing <TaskInstance: a_pool.my_task scheduled__2021-12-09T19:08:00+00:0│172.18.0.10 [scheduled]> since it requires 4 slots but there are 2 open slots in the pool my_pool. ` 

https://github.com/apache/airflow/blob/985bb06ba57ab67bb218ca9ca7549a81bea88f87/airflow/jobs/scheduler_job.py#L401-L408

However this message is very confusing as the issue is not with open slots but with the total slots of the pool. Waiting for slots will not resolve the problem. To make the task run there must be an action from the user:

1.  User to increase the total number of slots in the Pool
2. User need to change the task code to requests less slots.

This PR add specific log notice for this case.

**Testing:**
Added test to cover this case where pool is configured with 2 slots when task ask for 4 slots.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
