### PR TITLE
Remove db call from `DatabricksHook.__init__()`

### DIFF
--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -300,12 +300,13 @@ class DatabricksHook(BaseHook):
         """
         method, endpoint = endpoint_info
 
-        self.databricks_conn = self.get_connection(self.databricks_conn_id)
+        if self.databricks_conn is None:
+            self.databricks_conn = self.get_connection(self.databricks_conn_id)
 
-        if 'host' in self.databricks_conn.extra_dejson:
-            self.host = self._parse_host(self.databricks_conn.extra_dejson['host'])
-        else:
-            self.host = self._parse_host(self.databricks_conn.host)
+            if 'host' in self.databricks_conn.extra_dejson:
+                self.host = self._parse_host(self.databricks_conn.extra_dejson['host'])
+            else:
+                self.host = self._parse_host(self.databricks_conn.host)
 
         url = f'https://{self.host}/{endpoint}'
 

--- a/airflow/providers/databricks/hooks/databricks.py
+++ b/airflow/providers/databricks/hooks/databricks.py
@@ -135,11 +135,7 @@ class DatabricksHook(BaseHook):
     ) -> None:
         super().__init__()
         self.databricks_conn_id = databricks_conn_id
-        self.databricks_conn = self.get_connection(databricks_conn_id)
-        if 'host' in self.databricks_conn.extra_dejson:
-            self.host = self._parse_host(self.databricks_conn.extra_dejson['host'])
-        else:
-            self.host = self._parse_host(self.databricks_conn.host)
+        self.databricks_conn = None
         self.timeout_seconds = timeout_seconds
         if retry_limit < 1:
             raise ValueError('Retry limit must be greater than equal to 1')
@@ -303,6 +299,14 @@ class DatabricksHook(BaseHook):
         :rtype: dict
         """
         method, endpoint = endpoint_info
+
+        self.databricks_conn = self.get_connection(self.databricks_conn_id)
+
+        if 'host' in self.databricks_conn.extra_dejson:
+            self.host = self._parse_host(self.databricks_conn.extra_dejson['host'])
+        else:
+            self.host = self._parse_host(self.databricks_conn.host)
+
         url = f'https://{self.host}/{endpoint}'
 
         aad_headers = self._get_aad_headers()


### PR DESCRIPTION
This PR aligns both the original PR to move the db call to the metadata database out of the `DatabricksHook.__init__()` method (#18339) and a refactoring PR for the same hook (#19835).

> FYI @potiuk I did not add Mypy fixes to this file. The number of changes to handle the Mypy errors out-numbered the changes in scope here. I'll have those Mypy updates in a separate PR.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
