### PR TITLE
Better confirmation prompts

### DIFF
--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1897,7 +1897,7 @@ class DAG(LoggingMixin):
         if confirm_prompt:
             ti_list = "\n".join(str(t) for t in tis)
             question = (
-                "You are about to delete these {count} tasks:\n{ti_list}\n\nAre you sure? (yes/no): "
+                "You are about to delete these {count} tasks:\n{ti_list}\n\nAre you sure? [y/n]"
             ).format(count=count, ti_list=ti_list)
             do_it = utils.helpers.ask_yesno(question)
 
@@ -1954,7 +1954,7 @@ class DAG(LoggingMixin):
             return 0
         if confirm_prompt:
             ti_list = "\n".join(str(t) for t in all_tis)
-            question = f"You are about to delete these {count} tasks:\n{ti_list}\n\nAre you sure? (yes/no): "
+            question = f"You are about to delete these {count} tasks:\n{ti_list}\n\nAre you sure? [y/n]"
             do_it = utils.helpers.ask_yesno(question)
 
         if do_it:

--- a/airflow/utils/db.py
+++ b/airflow/utils/db.py
@@ -692,9 +692,9 @@ def check_and_run_migrations():
 
     if sys.stdout.isatty() and verb:
         print()
-        question = f"Please confirm database {verb} (or wait 4 seconds to skip it). Are you sure?"
+        question = f"Please confirm database {verb} (or wait 4 seconds to skip it). Are you sure? [y/N]"
         try:
-            answer = helpers.prompt_with_timeout(question, timeout=4)
+            answer = helpers.prompt_with_timeout(question, timeout=4, default=False)
             if answer:
                 try:
                     db_command()

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -80,25 +80,25 @@ def alchemy_to_dict(obj: Any) -> Optional[Dict]:
     return output
 
 
-def ask_yesno(question: str) -> bool:
-    """Helper to get yes / no answer from user."""
+def ask_yesno(question: str, default: Optional[bool] = None) -> bool:
+    """Helper to get a yes or no answer from the user."""
     yes = {'yes', 'y'}
     no = {'no', 'n'}
 
-    done = False
     print(question)
-    while not done:
+    while True:
         choice = input().lower()
+        if choice == "" and default is not None:
+            return default
         if choice in yes:
             return True
-        elif choice in no:
+        if choice in no:
             return False
-        else:
-            print("Please respond by yes or no.")
+        print("Please respond with y/yes or n/no.")
 
 
-def prompt_with_timeout(question: str, timeout: int):
-    """Ask user a question and timeout after timeout"""
+def prompt_with_timeout(question: str, timeout: int, default: Optional[bool] = None) -> bool:
+    """Ask the user a question and timeout if they don't respond"""
 
     def handler(signum, frame):
         raise AirflowException(f"Timeout {timeout}s reached")
@@ -106,7 +106,7 @@ def prompt_with_timeout(question: str, timeout: int):
     signal.signal(signal.SIGALRM, handler)
     signal.alarm(timeout)
     try:
-        return ask_yesno(question)
+        return ask_yesno(question, default)
     finally:
         signal.alarm(0)
 


### PR DESCRIPTION
Make our confirmation prompts more consistent, and optionally support a default choice.

For example, by setting the default for the db migration confirmation to False, the user can simply hit Enter to skip them.