### PR TITLE
Add and use `exactly_one` helper

### DIFF
--- a/airflow/models/xcom.py
+++ b/airflow/models/xcom.py
@@ -30,7 +30,7 @@ from sqlalchemy.orm import Query, Session, reconstructor, relationship
 from airflow.configuration import conf
 from airflow.models.base import COLLATION_ARGS, ID_LEN, Base
 from airflow.utils import timezone
-from airflow.utils.helpers import is_container
+from airflow.utils.helpers import exactly_one, is_container
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime
@@ -134,7 +134,7 @@ class BaseXCom(Base, LoggingMixin):
         run_id: Optional[str] = None,
     ) -> None:
         """:sphinx-autoapi-skip:"""
-        if not (execution_date is None) ^ (run_id is None):
+        if not exactly_one(execution_date is not None, run_id is not None):
             raise ValueError("Exactly one of execution_date or run_id must be passed")
 
         if run_id:
@@ -225,7 +225,7 @@ class BaseXCom(Base, LoggingMixin):
         run_id: Optional[str] = None,
     ) -> Optional[Any]:
         """:sphinx-autoapi-skip:"""
-        if not (execution_date is None) ^ (run_id is None):
+        if not exactly_one(execution_date is not None, run_id is not None):
             raise ValueError("Exactly one of execution_date or run_id must be passed")
 
         if run_id is not None:
@@ -319,7 +319,7 @@ class BaseXCom(Base, LoggingMixin):
         run_id: Optional[str] = None,
     ) -> Query:
         """:sphinx-autoapi-skip:"""
-        if not (execution_date is None) ^ (run_id is None):
+        if not exactly_one(execution_date is not None, run_id is not None):
             raise ValueError("Exactly one of execution_date or run_id must be passed")
 
         filters = []
@@ -420,7 +420,7 @@ class BaseXCom(Base, LoggingMixin):
         if task_id is None:
             raise TypeError("clear() missing required argument: task_id")
 
-        if not (execution_date is None) ^ (run_id is None):
+        if not exactly_one(execution_date is not None, run_id is not None):
             raise ValueError("Exactly one of execution_date or run_id must be passed")
 
         query = session.query(cls).filter(

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -286,3 +286,13 @@ def render_template_to_string(template: jinja2.Template, context: Context) -> st
 def render_template_as_native(template: jinja2.Template, context: Context) -> Any:
     """Shorthand to ``render_template(native=True)`` with better typing support."""
     return render_template(template, context, native=True)
+
+
+def exactly_one(*args):
+    """
+    Returns True if exactly one of *args is "truthy", and False otherwise.
+
+    :param args:
+    :return:
+    """
+    return sum(map(bool, args)) == 1

--- a/airflow/utils/helpers.py
+++ b/airflow/utils/helpers.py
@@ -288,11 +288,14 @@ def render_template_as_native(template: jinja2.Template, context: Context) -> An
     return render_template(template, context, native=True)
 
 
-def exactly_one(*args):
+def exactly_one(*args) -> bool:
     """
     Returns True if exactly one of *args is "truthy", and False otherwise.
 
-    :param args:
-    :return:
+    If user supplies an iterable, we raise ValueError and force them to unpack.
     """
+    if is_container(args[0]):
+        raise ValueError(
+            "Not supported for iterable args. Use `*` to unpack your iterable in the function call."
+        )
     return sum(map(bool, args)) == 1

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 import re
-from itertools import combinations, product
+from itertools import product
 
 import pytest
 


### PR DESCRIPTION
Python's XOR operator `^` is not very readable, only works with True / False, and only works with two values.  E.g. if you need to test "exactly one of a, b, or c", you cannot do  a ^ b ^ c.  I add an "exactly_one" boolean helper to address all of these shortcomings.
