### PR TITLE
Add linter for values.schema.json

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -684,6 +684,13 @@ repos:
         files: airflow/config_templates/config\.yml$
         require_serial: true
         additional_dependencies: ['jsonschema==3.2.0', 'PyYAML==5.3.1', 'requests==2.25.0']
+      - id: chart-schema-lint
+        name: Lint chart/values.schema.json file
+        entry: ./scripts/ci/pre_commit/pre_commit_chart_schema.py
+        language: python
+        pass_filenames: false
+        files: ^chart/values\.schema\.json$
+        require_serial: true
       - id: ui-lint
         name: ESLint against airflow/ui
         language: node

--- a/BREEZE.rst
+++ b/BREEZE.rst
@@ -2194,21 +2194,22 @@ This is the current syntax for  `./breeze <./breeze>`_:
 
                  all airflow-config-yaml airflow-providers-available airflow-provider-yaml-files-ok
                  base-operator bats-tests bats-in-container-tests black blacken-docs boring-cyborg
-                 build build-providers-dependencies capitalized-breeze changelog-duplicates
-                 check-apache-license check-builtin-literals check-executables-have-shebangs
-                 check-extras-order check-hooks-apply check-integrations check-merge-conflict
-                 check-xml daysago-import-check debug-statements detect-private-key doctoc
-                 dont-use-safe-filter end-of-file-fixer fix-encoding-pragma flake8 flynt codespell
-                 forbid-tabs helm-lint identity incorrect-use-of-LoggingMixin insert-license isort
-                 json-schema language-matters lint-dockerfile lint-openapi markdownlint mermaid
-                 mixed-line-ending mypy mypy-helm no-providers-in-core-examples no-relative-imports
-                 pre-commit-descriptions pre-commit-hook-names pretty-format-json
-                 provide-create-sessions providers-changelogs providers-init-file
-                 providers-subpackages-init-file provider-yamls pydevd pydocstyle python-no-log-warn
-                 pyupgrade restrict-start_date rst-backticks setup-order setup-extra-packages
-                 shellcheck sort-in-the-wild sort-spelling-wordlist stylelint trailing-whitespace
-                 ui-lint update-breeze-file update-extras update-local-yml-file update-setup-cfg-file
-                 update-versions verify-db-migrations-documented version-sync www-lint yamllint yesqa
+                 build build-providers-dependencies chart-schema-lint capitalized-breeze
+                 changelog-duplicates check-apache-license check-builtin-literals
+                 check-executables-have-shebangs check-extras-order check-hooks-apply
+                 check-integrations check-merge-conflict check-xml daysago-import-check
+                 debug-statements detect-private-key doctoc dont-use-safe-filter end-of-file-fixer
+                 fix-encoding-pragma flake8 flynt codespell forbid-tabs helm-lint identity
+                 incorrect-use-of-LoggingMixin insert-license isort json-schema language-matters
+                 lint-dockerfile lint-openapi markdownlint mermaid mixed-line-ending mypy mypy-helm
+                 no-providers-in-core-examples no-relative-imports pre-commit-descriptions
+                 pre-commit-hook-names pretty-format-json provide-create-sessions
+                 providers-changelogs providers-init-file providers-subpackages-init-file
+                 provider-yamls pydevd pydocstyle python-no-log-warn pyupgrade restrict-start_date
+                 rst-backticks setup-order setup-extra-packages shellcheck sort-in-the-wild
+                 sort-spelling-wordlist stylelint trailing-whitespace ui-lint update-breeze-file
+                 update-extras update-local-yml-file update-setup-cfg-file update-versions
+                 verify-db-migrations-documented version-sync www-lint yamllint yesqa
 
         You can pass extra arguments including options to the pre-commit framework as
         <EXTRA_ARGS> passed after --. For example:

--- a/STATIC_CODE_CHECKS.rst
+++ b/STATIC_CODE_CHECKS.rst
@@ -148,6 +148,8 @@ require Breeze Docker images to be installed locally.
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``build-providers-dependencies``       Regenerates the JSON file with cross-provider dependencies
 ------------------------------------ ---------------------------------------------------------------- ------------
+``chart-schema-lint``                  Lint chart/values.schema.json file
+------------------------------------ ---------------------------------------------------------------- ------------
 ``capitalized-breeze``                 Breeze has to be Capitalized in Breeze2
 ------------------------------------ ---------------------------------------------------------------- ------------
 ``changelog-duplicates``               Checks for duplicate changelog entries

--- a/breeze-complete
+++ b/breeze-complete
@@ -85,6 +85,7 @@ blacken-docs
 boring-cyborg
 build
 build-providers-dependencies
+chart-schema-lint
 capitalized-breeze
 changelog-duplicates
 check-apache-license

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -2461,6 +2461,9 @@
                                 "ports": {
                                     "description": "Ports for flower NetworkPolicy ingress (if `from` is set).",
                                     "type": "array",
+                                    "items": {
+                                        "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.22.0-standalone-strict/networkpolicyport-networking-v1.json"
+                                    },
                                     "default": [
                                         {
                                             "port": "flower-ui"

--- a/scripts/ci/pre_commit/pre_commit_chart_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_chart_schema.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import json
+import sys
+from pathlib import Path
+
+if __name__ not in ("__main__", "__mp_main__"):
+    raise SystemExit(
+        "This file is intended to be executed as an executable program. You cannot use it as a module."
+        f"To run this script, run the ./{__file__} command"
+    )
+
+PROJECT_SOURCE_ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
+CHART_DIR = PROJECT_SOURCE_ROOT_DIR / "chart"
+
+
+KNOWN_INVALID_TYPES = {
+    # I don't know the data structure for this type with 100 certainty. We have no tests.
+    "$['properties']['ingress']['properties']['web']['properties']['precedingPaths']",
+    # I don't know the data structure for this type with 100 certainty. We have no tests.
+    "$['properties']['ingress']['properties']['web']['properties']['succeedingPaths']",
+    # The value of this parameter is passed to statsd_exporter, which does not have a strict type definition.
+    "$['properties']['statsd']['properties']['extraMappings']",
+}
+schema = json.loads((CHART_DIR / "values.schema.json").read_text())
+
+
+def display_definitions_list(definitions_list):
+    print("Invalid definitions: ")
+    for no_d, (schema_type, schema_path) in enumerate(definitions_list, start=1):
+        print(f"{no_d}: {schema_path}")
+        print(json.dumps(schema_type, indent=2))
+
+
+def walk(value, path='$'):
+    yield value, path
+    if isinstance(value, dict):
+        for k, v in value.items():
+            yield from walk(v, path + f"[{k!r}]")
+    elif isinstance(value, (list, set, tuple)):
+        for no, v in enumerate(value):
+            yield from walk(v, path + f"[{no}]")
+
+
+def validate_object_types():
+    all_object_types = ((d, p) for d, p in walk(schema) if type(d) == dict and d.get('type') == 'object')
+    all_object_types_with_a_loose_definition = [
+        (d, p)
+        for d, p in all_object_types
+        if 'properties' not in d
+        and "$ref" not in d
+        and type(d.get('additionalProperties')) != dict
+        and p not in KNOWN_INVALID_TYPES
+    ]
+    to_display_invalid_types = [
+        (d, p) for d, p in all_object_types_with_a_loose_definition if p not in KNOWN_INVALID_TYPES
+    ]
+    if to_display_invalid_types:
+        print(
+            "Found object type definitions with too loose a definition. "
+            "Make sure that the type meets one of the following conditions:"
+        )
+        print(" - has a `properties` key")
+        print(" - has a `$ref` key")
+        print(" - has a `additionalProperties` key, which content is an object")
+        display_definitions_list(to_display_invalid_types)
+    return all_object_types_with_a_loose_definition
+
+
+def validate_array_types():
+    all_array_types = ((d, p) for d, p in walk(schema) if type(d) == dict and d.get('type') == 'array')
+    all_array_types_with_a_loose_definition = [
+        (d, p) for (d, p) in all_array_types if type(d.get('items')) != dict
+    ]
+    to_display_invalid_types = [
+        (d, p) for d, p in all_array_types_with_a_loose_definition if p not in KNOWN_INVALID_TYPES
+    ]
+
+    if to_display_invalid_types:
+        print(
+            "Found array type definitions with too loose a definition. "
+            "Make sure the object has the items key."
+        )
+        display_definitions_list(to_display_invalid_types)
+    return all_array_types_with_a_loose_definition
+
+
+invalid_object_types_path = {p for _, p in validate_object_types()}
+invalid_array_types_path = {p for _, p in validate_array_types()}
+fixed_types = KNOWN_INVALID_TYPES - invalid_object_types_path - invalid_array_types_path
+invalid_paths = (invalid_object_types_path.union(invalid_array_types_path)) - KNOWN_INVALID_TYPES
+
+if fixed_types:
+    current_file = Path(__file__).resolve()
+    print(
+        f"Some types that were known to be invalid have been fixed. Can you update the variable "
+        f"`known_invalid_types` in file {current_file!r}? You just need to delete the following items:"
+    )
+    print("\n".join(KNOWN_INVALID_TYPES))
+
+if fixed_types or invalid_paths:
+    sys.exit(1)
+else:
+    print("No problems")

--- a/scripts/ci/pre_commit/pre_commit_chart_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_chart_schema.py
@@ -28,8 +28,6 @@ if __name__ not in ("__main__", "__mp_main__"):
 
 PROJECT_SOURCE_ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent
 CHART_DIR = PROJECT_SOURCE_ROOT_DIR / "chart"
-
-
 KNOWN_INVALID_TYPES = {
     # I don't know the data structure for this type with 100 certainty. We have no tests.
     "$['properties']['ingress']['properties']['web']['properties']['precedingPaths']",
@@ -38,7 +36,8 @@ KNOWN_INVALID_TYPES = {
     # The value of this parameter is passed to statsd_exporter, which does not have a strict type definition.
     "$['properties']['statsd']['properties']['extraMappings']",
 }
-schema = json.loads((CHART_DIR / "values.schema.json").read_text())
+
+SCHEMA = json.loads((CHART_DIR / "values.schema.json").read_text())
 
 
 def display_definitions_list(definitions_list):

--- a/scripts/ci/pre_commit/pre_commit_chart_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_chart_schema.py
@@ -58,7 +58,7 @@ def walk(value, path='$'):
 
 
 def validate_object_types():
-    all_object_types = ((d, p) for d, p in walk(schema) if type(d) == dict and d.get('type') == 'object')
+    all_object_types = ((d, p) for d, p in walk(SCHEMA) if type(d) == dict and d.get('type') == 'object')
     all_object_types_with_a_loose_definition = [
         (d, p)
         for d, p in all_object_types
@@ -83,7 +83,7 @@ def validate_object_types():
 
 
 def validate_array_types():
-    all_array_types = ((d, p) for d, p in walk(schema) if type(d) == dict and d.get('type') == 'array')
+    all_array_types = ((d, p) for d, p in walk(SCHEMA) if type(d) == dict and d.get('type') == 'array')
     all_array_types_with_a_loose_definition = [
         (d, p) for (d, p) in all_array_types if type(d.get('items')) != dict
     ]

--- a/scripts/ci/pre_commit/pre_commit_chart_schema.py
+++ b/scripts/ci/pre_commit/pre_commit_chart_schema.py
@@ -112,7 +112,7 @@ if fixed_types:
         f"Some types that were known to be invalid have been fixed. Can you update the variable "
         f"`known_invalid_types` in file {current_file!r}? You just need to delete the following items:"
     )
-    print("\n".join(KNOWN_INVALID_TYPES))
+    print("\n".join(fixed_types))
 
 if fixed_types or invalid_paths:
     sys.exit(1)


### PR DESCRIPTION
We have a strict schema for all most types. (PR: https://github.com/apache/airflow/pull/19181) To avoid regression, I am adding static checks.
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
