### PR TITLE
Add operator link to monitor Azure Data Factory pipeline runs

### DIFF
--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -17,12 +17,42 @@
 
 from typing import Any, Dict, Optional
 
-from airflow.models import BaseOperator
+from airflow.models import BaseOperator, BaseOperatorLink, TaskInstance
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,
     AzureDataFactoryPipelineRunStatus,
 )
+
+
+class AzureDataFactoryPipelineRunLink(BaseOperatorLink):
+    """Constructs a link to monitor a pipeline run in Azure Data Factory."""
+
+    name = "Monitor Pipeline Run"
+
+    def get_link(self, operator, dttm):
+        ti = TaskInstance(task=operator, execution_date=dttm)
+        run_id = ti.xcom_pull(task_ids=operator.task_id, key="run_id")
+
+        conn = AzureDataFactoryHook.get_connection(operator.azure_data_factory_conn_id)
+        subscription_id = conn.extra_dejson["extra__azure_data_factory__subscriptionId"]
+        # Both Resource Group Name and Factory Name can either be declared in the Azure Data Factory
+        # connection or passed directly to the operator.
+        resource_group_name = (
+            conn.extra_dejson.get("extra__azure_data_factory__resource_group_name")
+            or operator.resource_group_name
+        )
+        factory_name = (
+            conn.extra_dejson.get("extra__azure_data_factory__factory_name") or operator.factory_name
+        )
+        url = (
+            f"https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"
+            f"?factory=/subscriptions/{subscription_id}/"
+            f"resourceGroups/{resource_group_name}/providers/Microsoft.DataFactory/"
+            f"factories/{factory_name}"
+        )
+
+        return url
 
 
 class AzureDataFactoryRunPipelineOperator(BaseOperator):
@@ -84,6 +114,8 @@ class AzureDataFactoryRunPipelineOperator(BaseOperator):
     template_fields_renderers = {"parameters": "json"}
 
     ui_color = "#0678d4"
+
+    operator_extra_links = (AzureDataFactoryPipelineRunLink(),)
 
     def __init__(
         self,

--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -43,7 +43,7 @@ class AzureDataFactoryPipelineRunLink(BaseOperatorLink):
             "extra__azure_data_factory__resource_group_name"
         )
         factory_name = operator.factory_name or conn.extra_dejson.get(
-            "extra__azure_data_factory__factory_name")
+            "extra__azure_data_factory__factory_name"
         )
         url = (
             f"https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"

--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -39,12 +39,11 @@ class AzureDataFactoryPipelineRunLink(BaseOperatorLink):
         subscription_id = conn.extra_dejson["extra__azure_data_factory__subscriptionId"]
         # Both Resource Group Name and Factory Name can either be declared in the Azure Data Factory
         # connection or passed directly to the operator.
-        resource_group_name = (
-            conn.extra_dejson.get("extra__azure_data_factory__resource_group_name")
-            or operator.resource_group_name
+        resource_group_name = operator.resource_group_name or conn.extra_dejson.get(
+            "extra__azure_data_factory__resource_group_name"
         )
-        factory_name = (
-            conn.extra_dejson.get("extra__azure_data_factory__factory_name") or operator.factory_name
+        factory_name = operator.factory_name or conn.extra_dejson.get(
+            "extra__azure_data_factory__factory_name")
         )
         url = (
             f"https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"

--- a/airflow/providers/microsoft/azure/operators/data_factory.py
+++ b/airflow/providers/microsoft/azure/operators/data_factory.py
@@ -17,6 +17,7 @@
 
 from typing import Any, Dict, Optional
 
+from airflow.hooks.base import BaseHook
 from airflow.models import BaseOperator, BaseOperatorLink, TaskInstance
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
@@ -34,7 +35,7 @@ class AzureDataFactoryPipelineRunLink(BaseOperatorLink):
         ti = TaskInstance(task=operator, execution_date=dttm)
         run_id = ti.xcom_pull(task_ids=operator.task_id, key="run_id")
 
-        conn = AzureDataFactoryHook.get_connection(operator.azure_data_factory_conn_id)
+        conn = BaseHook.get_connection(operator.azure_data_factory_conn_id)
         subscription_id = conn.extra_dejson["extra__azure_data_factory__subscriptionId"]
         # Both Resource Group Name and Factory Name can either be declared in the Azure Data Factory
         # connection or passed directly to the operator.

--- a/airflow/providers/microsoft/azure/provider.yaml
+++ b/airflow/providers/microsoft/azure/provider.yaml
@@ -225,3 +225,6 @@ secrets-backends:
 
 logging:
   - airflow.providers.microsoft.azure.log.wasb_task_handler.WasbTaskHandler
+
+extra-links:
+  - airflow.providers.microsoft.azure.operators.data_factory.AzureDataFactoryPipelineRunLink

--- a/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
+++ b/tests/providers/microsoft/azure/operators/test_azure_data_factory.py
@@ -15,35 +15,63 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
-from parameterized import parameterized
 
+from airflow.models import Connection
 from airflow.providers.microsoft.azure.hooks.data_factory import (
     AzureDataFactoryHook,
     AzureDataFactoryPipelineRunException,
     AzureDataFactoryPipelineRunStatus,
 )
 from airflow.providers.microsoft.azure.operators.data_factory import AzureDataFactoryRunPipelineOperator
+from airflow.utils import db, timezone
 
+DEFAULT_DATE = timezone.datetime(2021, 1, 1)
+SUBSCRIPTION_ID = "my-subscription-id"
+TASK_ID = "run_pipeline_op"
+AZURE_DATA_FACTORY_CONN_ID = "azure_data_factory_test"
+PIPELINE_NAME = "pipeline1"
+CONN_EXTRAS = {
+    "extra__azure_data_factory__subscriptionId": SUBSCRIPTION_ID,
+    "extra__azure_data_factory__tenantId": "my-tenant-id",
+    "extra__azure_data_factory__resource_group_name": "my-resource-group-name-from-conn",
+    "extra__azure_data_factory__factory_name": "my-factory-name-from-conn",
+}
 PIPELINE_RUN_RESPONSE = {"additional_properties": {}, "run_id": "run_id"}
+EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK = (
+    "https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"
+    "?factory=/subscriptions/{subscription_id}/"
+    "resourceGroups/{resource_group_name}/providers/Microsoft.DataFactory/"
+    "factories/{factory_name}"
+)
 
 
-class TestAzureDataFactoryRunPipelineOperator(unittest.TestCase):
-    def setUp(self):
+class TestAzureDataFactoryRunPipelineOperator:
+    def setup_method(self):
         self.mock_ti = MagicMock()
         self.mock_context = {"ti": self.mock_ti}
         self.config = {
-            "task_id": "run_pipeline_op",
-            "azure_data_factory_conn_id": "azure_data_factory_test",
-            "pipeline_name": "pipeline1",
+            "task_id": TASK_ID,
+            "azure_data_factory_conn_id": AZURE_DATA_FACTORY_CONN_ID,
+            "pipeline_name": PIPELINE_NAME,
             "resource_group_name": "resource-group-name",
             "factory_name": "factory-name",
             "check_interval": 1,
             "timeout": 3,
         }
+
+        db.merge_conn(
+            Connection(
+                conn_id="azure_data_factory_test",
+                conn_type="azure_data_factory",
+                login="client-id",
+                password="client-secret",
+                extra=json.dumps(CONN_EXTRAS),
+            )
+        )
 
     @staticmethod
     def create_pipeline_run(status: str):
@@ -54,7 +82,9 @@ class TestAzureDataFactoryRunPipelineOperator(unittest.TestCase):
 
         return run
 
-    @parameterized.expand(
+    @patch.object(AzureDataFactoryHook, "run_pipeline", return_value=MagicMock(**PIPELINE_RUN_RESPONSE))
+    @pytest.mark.parametrize(
+        "pipeline_run_status,expected_output",
         [
             (AzureDataFactoryPipelineRunStatus.SUCCEEDED, None),
             (AzureDataFactoryPipelineRunStatus.FAILED, "exception"),
@@ -62,10 +92,9 @@ class TestAzureDataFactoryRunPipelineOperator(unittest.TestCase):
             (AzureDataFactoryPipelineRunStatus.IN_PROGRESS, "timeout"),
             (AzureDataFactoryPipelineRunStatus.QUEUED, "timeout"),
             (AzureDataFactoryPipelineRunStatus.CANCELING, "timeout"),
-        ]
+        ],
     )
-    @patch.object(AzureDataFactoryHook, "run_pipeline", return_value=MagicMock(**PIPELINE_RUN_RESPONSE))
-    def test_execute_wait_for_termination(self, pipeline_run_status, expected_output, mock_run_pipeline):
+    def test_execute_wait_for_termination(self, mock_run_pipeline, pipeline_run_status, expected_output):
         operator = AzureDataFactoryRunPipelineOperator(**self.config)
 
         assert operator.azure_data_factory_conn_id == self.config["azure_data_factory_conn_id"]
@@ -175,3 +204,50 @@ class TestAzureDataFactoryRunPipelineOperator(unittest.TestCase):
 
             # Checking the pipeline run status should _not_ be called when ``wait_for_termination`` is False.
             mock_get_pipeline_run.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "resource_group,factory",
+        [
+            # Both resource_group_name and factory_name are passed to the operator.
+            ("op-resource-group", "op-factory-name"),
+            # Only factory_name is passed to the operator; resource_group_name should fallback to Connection.
+            (None, "op-factory-name"),
+            # Only resource_group_name is passed to the operator; factory_nmae should fallback to Connection.
+            ("op-resource-group", None),
+            # Both resource_group_name and factory_name should fallback to Connection.
+            (None, None),
+        ],
+    )
+    def test_run_pipeline_operator_link(self, resource_group, factory, create_task_instance_of_operator):
+        ti = create_task_instance_of_operator(
+            AzureDataFactoryRunPipelineOperator,
+            dag_id="test_adf_run_pipeline_op_link",
+            execution_date=DEFAULT_DATE,
+            task_id=TASK_ID,
+            azure_data_factory_conn_id=AZURE_DATA_FACTORY_CONN_ID,
+            pipeline_name=PIPELINE_NAME,
+            resource_group_name=resource_group,
+            factory_name=factory,
+        )
+        ti.xcom_push(key="run_id", value=PIPELINE_RUN_RESPONSE["run_id"])
+
+        url = ti.task.get_extra_links(DEFAULT_DATE, "Monitor Pipeline Run")
+        EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK = (
+            "https://adf.azure.com/en-us/monitoring/pipelineruns/{run_id}"
+            "?factory=/subscriptions/{subscription_id}/"
+            "resourceGroups/{resource_group_name}/providers/Microsoft.DataFactory/"
+            "factories/{factory_name}"
+        )
+
+        conn = AzureDataFactoryHook.get_connection("azure_data_factory_test")
+        conn_resource_group_name = conn.extra_dejson["extra__azure_data_factory__resource_group_name"]
+        conn_factory_name = conn.extra_dejson["extra__azure_data_factory__factory_name"]
+
+        assert url == (
+            EXPECTED_PIPELINE_RUN_OP_EXTRA_LINK.format(
+                run_id=PIPELINE_RUN_RESPONSE["run_id"],
+                subscription_id=SUBSCRIPTION_ID,
+                resource_group_name=resource_group if resource_group else conn_resource_group_name,
+                factory_name=factory if factory else conn_factory_name,
+            )
+        )


### PR DESCRIPTION
This PR creates an operator link for the `AzureDataFactoryRunPipelineOperator` to directly monitor a pipeline run in Azure Data Factory after it has been executed.

TODO:
- [x] Add tests

**Operator Link "Monitor Pipeline Run"**
![image](https://user-images.githubusercontent.com/48934154/145641718-a4231ccf-7ced-44bd-8267-45e9f8b8511a.png)


**Pipeline run monitoring in Azure Data Factory**
![image](https://user-images.githubusercontent.com/48934154/145641782-c3e2fb09-8eb5-4992-b708-acc3a07a6204.png)



---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
