### PR TITLE
Update docs/tools for releasing core Airflow

### DIFF
--- a/dev/README_RELEASE_AIRFLOW.md
+++ b/dev/README_RELEASE_AIRFLOW.md
@@ -160,7 +160,7 @@ For now this is done manually, example run  `git log --oneline v2-2-test..HEAD -
 
     ```shell script
     git checkout origin/constraints-${VERSION_BRANCH}
-    git tag -s "constraints-${VERSION}"
+    git tag -s "constraints-${VERSION}" -m "Constraints for Apache Airflow ${VERSION}"
     git push origin "constraints-${VERSION}"
     ```
 
@@ -300,7 +300,7 @@ protected_branches:
 
 ## Prepare PyPI convenience "snapshot" packages
 
-At this point we have the artefact that we vote on, but as a convenience to developers we also want to
+At this point we have the artifact that we vote on, but as a convenience to developers we also want to
 publish "snapshots" of the RC builds to PyPI for installing via pip:
 
 To do this we need to

--- a/dev/airflow-github
+++ b/dev/airflow-github
@@ -72,6 +72,8 @@ def get_issue_type(issue):
         for label in issue.labels:
             if label.name.startswith(label_prefix):
                 return label.name.replace(label_prefix, "").strip()
+            if label.name == "changelog:skip":
+                return "(skip)"
     return issue_type
 
 
@@ -107,6 +109,8 @@ def is_pr(issue: Issue) -> bool:
 
 def print_changelog(sections):
     for section, lines in sections.items():
+        if section == "(skip)":
+            continue
         print(section)
         print('"' * len(section))
         for line in lines:
@@ -133,7 +137,7 @@ def cli():
     help="Specify the previous tag on the working branch to limit"
     " searching for few commits to find the cherry-picked commits",
 )
-@click.option('--unmerged', 'show_uncherrypicked_only', help="Show unmerged issues only", is_flag=True)
+@click.option('--unmerged', 'show_uncherrypicked_only', help="Show unmerged PRs only", is_flag=True)
 def compare(target_version, github_token, previous_version=None, show_uncherrypicked_only=False):
     repo = git.Repo(".", search_parent_directories=True)
 
@@ -174,6 +178,9 @@ def compare(target_version, github_token, previous_version=None, show_uncherrypi
             if show_uncherrypicked_only:
                 continue
             cherrypicked = click.style("Yes".ljust(6), "green")
+        elif not issue_is_pr and show_uncherrypicked_only:
+            # Don't show issues when looking for unmerged PRs
+            continue
         elif issue_is_pr:
             num_uncherrypicked[status] += 1
             cherrypicked = click.style("No".ljust(6), "red")

--- a/dev/prepare_release_issue.py
+++ b/dev/prepare_release_issue.py
@@ -258,6 +258,12 @@ def generate_issue_content(
                 except UnknownObjectException:
                     console.print(f"[red]The PR #{pr_number} could not be found[/]")
                 continue
+
+            # Ignore doc-only and skipped PRs
+            label_names = [label.name for label in pr.labels]
+            if "type:doc-only" in label_names or "changelog:skip" in label_names:
+                continue
+
             pull_requests[pr_number] = pr
             # GitHub does not have linked issues in PR - but we quite rigorously add Fixes/Closes
             # Relate so we can find those from the body


### PR DESCRIPTION
When building the "testing status" issue, don't include things skipped
on the changelog or doc-only changes.

Also, don't add skipped changelog entries in the changelog.