### PR TITLE
Lazy Jinja2 context

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -92,6 +92,30 @@ TaskPostExecuteHook = Callable[[Context, Any], None]
 T = TypeVar('T', bound=FunctionType)
 
 
+# The 'template' argument is typed as Any because the jinja2.Template is too
+# dynamic to be effectively type-checked.
+def _render_jinja2(template: Any, context: Context) -> str:
+    """Render a Jinja2 template with given Airflow context.
+
+    The default implementation of ``jinja2.Template.render()`` converts the
+    input context into dict eagerly many times, which triggers deprecation
+    messages in our custom context class. This takes the implementation apart
+    and retain the context mapping without resolving instead.
+
+    :param template: A Jinja2 template to render.
+    :param context: The Airflow task context to render the template with.
+    :returns: The render result.
+    """
+    env = template.environment
+    if template.globals:
+        context.update((k, v) for k, v in template.globals.items() if k not in context)
+    try:
+        parts = template.root_render_func(env.context_class(env, context, template.name, template.blocks))
+    except Exception:
+        env.handle_exception()  # Rewrite traceback to point to the template.
+    return "".join(parts)
+
+
 class BaseOperatorMeta(abc.ABCMeta):
     """Metaclass of BaseOperator."""
 
@@ -1042,7 +1066,11 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         self.__dict__ = state
         self._log = logging.getLogger("airflow.task.operators")
 
-    def render_template_fields(self, context: Dict, jinja_env: Optional[jinja2.Environment] = None) -> None:
+    def render_template_fields(
+        self,
+        context: Context,
+        jinja_env: Optional[jinja2.Environment] = None,
+    ) -> None:
         """
         Template all attributes listed in template_fields. Note this operation is irreversible.
 
@@ -1060,7 +1088,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         self,
         parent: Any,
         template_fields: Iterable[str],
-        context: Dict,
+        context: Context,
         jinja_env: jinja2.Environment,
         seen_oids: Set,
     ) -> None:
@@ -1073,7 +1101,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
     def render_template(
         self,
         content: Any,
-        context: Dict,
+        context: Context,
         jinja_env: Optional[jinja2.Environment] = None,
         seen_oids: Optional[Set] = None,
     ) -> Any:
@@ -1100,11 +1128,12 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         from airflow.models.xcom_arg import XComArg
 
         if isinstance(content, str):
-            if any(content.endswith(ext) for ext in self.template_ext):
-                # Content contains a filepath
-                return jinja_env.get_template(content).render(**context)
+            if any(content.endswith(ext) for ext in self.template_ext):  # Content contains a filepath.
+                template = jinja_env.get_template(content)
             else:
-                return jinja_env.from_string(content).render(**context)
+                template = jinja_env.from_string(content)
+            return _render_jinja2(template, copy.copy(context))
+
         elif isinstance(content, (XComArg, DagParam)):
             return content.resolve(context)
 
@@ -1133,7 +1162,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
             return content
 
     def _render_nested_template_fields(
-        self, content: Any, context: Dict, jinja_env: jinja2.Environment, seen_oids: Set
+        self, content: Any, context: Context, jinja_env: jinja2.Environment, seen_oids: Set
     ) -> None:
         if id(content) not in seen_oids:
             seen_oids.add(id(content))

--- a/airflow/models/param.py
+++ b/airflow/models/param.py
@@ -22,6 +22,7 @@ from jsonschema import FormatChecker
 from jsonschema.exceptions import ValidationError
 
 from airflow.exceptions import AirflowException
+from airflow.utils.context import Context
 from airflow.utils.types import NOTSET, ArgNotSet
 
 
@@ -234,7 +235,7 @@ class DagParam:
         self._name = name
         self._default = default
 
-    def resolve(self, context: Dict) -> Any:
+    def resolve(self, context: Context) -> Any:
         """Pull DagParam value from DagRun context. This method is run during ``op.execute()``."""
         default = self._default
         if not self._default:

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -15,12 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.taskmixin import TaskMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
+from airflow.utils.context import Context
 from airflow.utils.edgemodifier import EdgeModifier
 
 
@@ -128,7 +129,7 @@ class XComArg(TaskMixin):
         """Proxy to underlying operator set_downstream method. Required by TaskMixin."""
         self.operator.set_downstream(task_or_task_list, edge_modifier)
 
-    def resolve(self, context: Dict) -> Any:
+    def resolve(self, context: Context) -> Any:
         """
         Pull XCom value for the existing arg. This method is run during ``op.execute()``
         in respectable context.

--- a/airflow/ti_deps/deps/trigger_rule_dep.py
+++ b/airflow/ti_deps/deps/trigger_rule_dep.py
@@ -18,8 +18,10 @@
 
 from collections import Counter
 
+from sqlalchemy.orm import Session
+
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
-from airflow.utils.session import provide_session
+from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule as TR
 
@@ -82,7 +84,16 @@ class TriggerRuleDep(BaseTIDep):
 
     @provide_session
     def _evaluate_trigger_rule(
-        self, ti, successes, skipped, failed, upstream_failed, done, flag_upstream_failed, session
+        self,
+        ti,
+        successes,
+        skipped,
+        failed,
+        upstream_failed,
+        done,
+        flag_upstream_failed,
+        *,
+        session: Session = NEW_SESSION,
     ):
         """
         Yields a dependency status that indicate whether the given task instance's trigger

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -149,7 +149,7 @@ class Context(MutableMapping[str, Any]):
 
     def __getitem__(self, key: str) -> Any:
         with contextlib.suppress(KeyError):
-            warnings.warn(_create_deprecation_warning(key, self._deprecation_replacements[key]), stacklevel=2)
+            warnings.warn(_create_deprecation_warning(key, self._deprecation_replacements[key]))
         with contextlib.suppress(KeyError):
             return self._context[key]
         raise KeyError(key)

--- a/airflow/utils/context.py
+++ b/airflow/utils/context.py
@@ -21,7 +21,18 @@
 import contextlib
 import copy
 import warnings
-from typing import AbstractSet, Any, Container, Dict, Iterator, List, MutableMapping, Tuple, ValuesView
+from typing import (
+    AbstractSet,
+    Any,
+    Container,
+    Dict,
+    Iterator,
+    List,
+    MutableMapping,
+    Optional,
+    Tuple,
+    ValuesView,
+)
 
 from airflow.utils.types import NOTSET
 
@@ -113,8 +124,10 @@ class Context(MutableMapping[str, Any]):
         "yesterday_ds_nodash": [],
     }
 
-    def __init__(self, context: MutableMapping[str, Any]) -> None:
-        self._context = context
+    def __init__(self, context: Optional[MutableMapping[str, Any]] = None, **kwargs: Any) -> None:
+        self._context = context or {}
+        if kwargs:
+            self._context.update(kwargs)
         self._deprecation_replacements = self._DEPRECATION_REPLACEMENTS.copy()
 
     def __repr__(self) -> str:

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,5 +32,6 @@ faulthandler_timeout = 480
 log_level = INFO
 filterwarnings =
     error::pytest.PytestCollectionWarning
+    error::airflow.utils.context.AirflowContextDeprecationWarning
 markers =
     need_serialized_dag

--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,5 @@ faulthandler_timeout = 480
 log_level = INFO
 filterwarnings =
     error::pytest.PytestCollectionWarning
-    error::airflow.utils.context.AirflowContextDeprecationWarning
 markers =
     need_serialized_dag

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,6 +231,7 @@ def breeze_test_helper(request):
 
 
 def pytest_configure(config):
+    config.addinivalue_line("filterwarnings", "error::airflow.utils.context.AirflowContextDeprecationWarning")
     config.addinivalue_line("markers", "integration(name): mark test to run with named integration")
     config.addinivalue_line("markers", "backend(name): mark test to run with named backend")
     config.addinivalue_line("markers", "system(name): mark test to run with named system")

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1516,7 +1516,6 @@ class TestTaskInstance:
         assert isinstance(template_context["data_interval_start"], pendulum.DateTime)
         assert isinstance(template_context["data_interval_end"], pendulum.DateTime)
 
-    @pytest.mark.filterwarnings("error::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_template_render(self, create_task_instance):
         ti = create_task_instance(
             dag_id="test_template_render",

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1516,6 +1516,28 @@ class TestTaskInstance:
         assert isinstance(template_context["data_interval_start"], pendulum.DateTime)
         assert isinstance(template_context["data_interval_end"], pendulum.DateTime)
 
+    @pytest.mark.filterwarnings("error::airflow.utils.context.AirflowTemplateDeprecationWarning")
+    def test_template_render(self, create_task_instance):
+        ti = create_task_instance(
+            dag_id="test_template_render",
+            task_id="test_template_render_task",
+            schedule_interval="0 12 * * *",
+        )
+        template_context = ti.get_template_context()
+        result = ti.task.render_template("Task: {{ dag.dag_id }} -> {{ task.task_id }}", template_context)
+        assert result == "Task: test_template_render -> test_template_render_task"
+
+    def test_template_render_deprecated(self, create_task_instance):
+        ti = create_task_instance(
+            dag_id="test_template_render",
+            task_id="test_template_render_task",
+            schedule_interval="0 12 * * *",
+        )
+        template_context = ti.get_template_context()
+        with pytest.deprecated_call():
+            result = ti.task.render_template("Execution date: {{ execution_date }}", template_context)
+        assert result.startswith("Execution date: ")
+
     @pytest.mark.parametrize(
         "content, expected_output",
         [

--- a/tests/models/test_taskinstance.py
+++ b/tests/models/test_taskinstance.py
@@ -1516,7 +1516,7 @@ class TestTaskInstance:
         assert isinstance(template_context["data_interval_start"], pendulum.DateTime)
         assert isinstance(template_context["data_interval_end"], pendulum.DateTime)
 
-    @pytest.mark.filterwarnings("error::airflow.utils.context.AirflowTemplateDeprecationWarning")
+    @pytest.mark.filterwarnings("error::airflow.utils.context.AirflowContextDeprecationWarning")
     def test_template_render(self, create_task_instance):
         ti = create_task_instance(
             dag_id="test_template_render",


### PR DESCRIPTION
Fix #20213. To work around Jinja2 eagerly resolving context into a new dict, we implement a custom copy interface, and use lower level Jinja2 functions to render templates (because the higher level `Template.render()` simply calls `dict(**data)` which is not overridable).

Tests are added to ensure that

1. Rendering a template with deprecated variable emits a deprecation warning.
2. Rendering a template _without_ deprecated variable does not emit a deprecation warning.