### PR TITLE
Limit httpx to <0.20.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,8 @@ install_requires =
     flask-wtf>=0.14.3, <0.15
     graphviz>=0.12
     gunicorn>=20.1.0
-    httpx
+    # We need to limit httpx until https://github.com/apache/airflow/issues/20088 is fixed
+    httpx<0.20.0
     importlib_metadata>=1.7;python_version<"3.9"
     importlib_resources~=5.2;python_version<"3.7"
     # Required by vendored-in connexion


### PR DESCRIPTION
This one limits httpx to <0.20.0 in order to handle breaaking
change for CloudSQL provider.

https://github.com/apache/airflow/issues/20088

We do not add it in main /2.3 because we will fix the problem
in main and release new provider then.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
