### PR TITLE
Add optional location to bigquery data transfer service (#15088)

### DIFF
--- a/airflow/providers/google/cloud/hooks/bigquery_dts.py
+++ b/airflow/providers/google/cloud/hooks/bigquery_dts.py
@@ -51,6 +51,7 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         self,
         gcp_conn_id: str = "google_cloud_default",
         delegate_to: Optional[str] = None,
+        location: Optional[str] = None,
         impersonation_chain: Optional[Union[str, Sequence[str]]] = None,
     ) -> None:
         super().__init__(
@@ -58,6 +59,7 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
             delegate_to=delegate_to,
             impersonation_chain=impersonation_chain,
         )
+        self.location = location
 
     @staticmethod
     def _disable_auto_scheduling(config: Union[dict, TransferConfig]) -> TransferConfig:
@@ -133,6 +135,9 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         """
         client = self.get_conn()
         parent = f"projects/{project_id}"
+        if self.location:
+            parent = f"{parent}/locations/{self.location}"
+
         return client.create_transfer_config(
             request={
                 'parent': parent,
@@ -174,7 +179,11 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         :return: None
         """
         client = self.get_conn()
-        name = f"projects/{project_id}/transferConfigs/{transfer_config_id}"
+        project = f"projects/{project_id}"
+        if self.location:
+            project = f"/{project}/locations/{self.location}"
+
+        name = f"{project}/transferConfigs/{transfer_config_id}"        
         return client.delete_transfer_config(
             request={'name': name}, retry=retry, timeout=timeout, metadata=metadata or ()
         )
@@ -223,7 +232,11 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         :return: An ``google.cloud.bigquery_datatransfer_v1.types.StartManualTransferRunsResponse`` instance.
         """
         client = self.get_conn()
-        parent = f"projects/{project_id}/transferConfigs/{transfer_config_id}"
+        project = f"projects/{project_id}"
+        if self.location:
+            project = f"{project}/locations/{self.location}"
+
+        parent = f"{project}/transferConfigs/{transfer_config_id}"
         return client.start_manual_transfer_runs(
             request={
                 'parent': parent,
@@ -268,7 +281,11 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         :return: An ``google.cloud.bigquery_datatransfer_v1.types.TransferRun`` instance.
         """
         client = self.get_conn()
-        name = f"projects/{project_id}/transferConfigs/{transfer_config_id}/runs/{run_id}"
+        project = f"projects/{project_id}"
+        if self.location:
+            project = f"{project}/locations/{self.location}"
+
+        name = "f{project}/transferConfigs/{transfer_config_id}/runs/{run_id}"
         return client.get_transfer_run(
             request={'name': name}, retry=retry, timeout=timeout, metadata=metadata or ()
         )

--- a/airflow/providers/google/cloud/hooks/bigquery_dts.py
+++ b/airflow/providers/google/cloud/hooks/bigquery_dts.py
@@ -183,7 +183,7 @@ class BiqQueryDataTransferServiceHook(GoogleBaseHook):
         if self.location:
             project = f"/{project}/locations/{self.location}"
 
-        name = f"{project}/transferConfigs/{transfer_config_id}"        
+        name = f"{project}/transferConfigs/{transfer_config_id}"
         return client.delete_transfer_config(
             request={'name': name}, retry=retry, timeout=timeout, metadata=metadata or ()
         )

--- a/airflow/providers/google/cloud/operators/bigquery_dts.py
+++ b/airflow/providers/google/cloud/operators/bigquery_dts.py
@@ -101,7 +101,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
 
     def execute(self, context):
         hook = BiqQueryDataTransferServiceHook(
-            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location,
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location
         )
         self.log.info("Creating DTS transfer config")
         response = hook.create_transfer_config(
@@ -187,7 +187,7 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
 
     def execute(self, context) -> None:
         hook = BiqQueryDataTransferServiceHook(
-            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location,
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location
         )
         hook.delete_transfer_config(
             transfer_config_id=self.transfer_config_id,

--- a/airflow/providers/google/cloud/operators/bigquery_dts.py
+++ b/airflow/providers/google/cloud/operators/bigquery_dts.py
@@ -39,6 +39,8 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
             created. If set to None or missing, the default project_id from the Google Cloud connection
             is used.
     :type project_id: str
+    :param: location: BigQuery Transfer Service location for regional transfers.
+    :type location: Optional[str]
     :param authorization_code: authorization code to use with this transfer configuration.
         This is required if new credentials are needed.
     :type authorization_code: Optional[str]
@@ -77,6 +79,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
         *,
         transfer_config: dict,
         project_id: Optional[str] = None,
+        location: Optional[str] = None,
         authorization_code: Optional[str] = None,
         retry: Retry = None,
         timeout: Optional[float] = None,
@@ -89,6 +92,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
         self.transfer_config = transfer_config
         self.authorization_code = authorization_code
         self.project_id = project_id
+        self.location = location
         self.retry = retry
         self.timeout = timeout
         self.metadata = metadata
@@ -97,7 +101,7 @@ class BigQueryCreateDataTransferOperator(BaseOperator):
 
     def execute(self, context):
         hook = BiqQueryDataTransferServiceHook(
-            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location,
         )
         self.log.info("Creating DTS transfer config")
         response = hook.create_transfer_config(
@@ -127,6 +131,8 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
     :param project_id: The BigQuery project id where the transfer configuration should be
         created. If set to None or missing, the default project_id from the Google Cloud connection is used.
     :type project_id: str
+    :param: location: BigQuery Transfer Service location for regional transfers.
+    :type location: Optional[str]
     :param retry: A retry object used to retry requests. If `None` is
         specified, requests will not be retried.
     :type retry: Optional[google.api_core.retry.Retry]
@@ -161,6 +167,7 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
         *,
         transfer_config_id: str,
         project_id: Optional[str] = None,
+        location: Optional[str] = None,
         retry: Retry = None,
         timeout: Optional[float] = None,
         metadata: Optional[Sequence[Tuple[str, str]]] = None,
@@ -170,6 +177,7 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
+        self.location = location
         self.transfer_config_id = transfer_config_id
         self.retry = retry
         self.timeout = timeout
@@ -179,7 +187,7 @@ class BigQueryDeleteDataTransferConfigOperator(BaseOperator):
 
     def execute(self, context) -> None:
         hook = BiqQueryDataTransferServiceHook(
-            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location,
         )
         hook.delete_transfer_config(
             transfer_config_id=self.transfer_config_id,
@@ -215,6 +223,8 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
     :param project_id: The BigQuery project id where the transfer configuration should be
         created. If set to None or missing, the default project_id from the Google Cloud connection is used.
     :type project_id: str
+    :param: location: BigQuery Transfer Service location for regional transfers.
+    :type location: Optional[str]
     :param retry: A retry object used to retry requests. If `None` is
         specified, requests will not be retried.
     :type retry: Optional[google.api_core.retry.Retry]
@@ -251,6 +261,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
         *,
         transfer_config_id: str,
         project_id: Optional[str] = None,
+        location: Optional[str] = None,
         requested_time_range: Optional[dict] = None,
         requested_run_time: Optional[dict] = None,
         retry: Retry = None,
@@ -262,6 +273,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
     ) -> None:
         super().__init__(**kwargs)
         self.project_id = project_id
+        self.location = location
         self.transfer_config_id = transfer_config_id
         self.requested_time_range = requested_time_range
         self.requested_run_time = requested_run_time
@@ -273,7 +285,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(BaseOperator):
 
     def execute(self, context):
         hook = BiqQueryDataTransferServiceHook(
-            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain
+            gcp_conn_id=self.gcp_conn_id, impersonation_chain=self.impersonation_chain, location=self.location
         )
         self.log.info('Submitting manual transfer for %s', self.transfer_config_id)
         response = hook.start_manual_transfer_runs(


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #15088
relates: #15088 

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->
## Description
This pull request addresses the issue of using BigQuery Data Transfer Service (DTS) for cross-region transfers.
DTS has the option of sending the `location` `name` / `parent` parameter in the request URL, but is currently not supported in the current operators. [1]

## Main changes
* Add `location` as `Optional[str]` to the BQ DTS hook and operators
* Dynamically build `name` / `parent` resources based on `location` being not None in the instance of the DTS hook.

## Reference
1) https://cloud.google.com/bigquery-transfer/docs/reference/datatransfer/rpc/google.cloud.bigquery.datatransfer.v1#google.cloud.bigquery.datatransfer.v1.DataTransferService
---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
