### PR TITLE
Fix start date for following sensor reschedule

### DIFF
--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1204,10 +1204,12 @@ class TaskInstance(Base, LoggingMixin):
             # For reporting purposes, we report based on 1-indexed,
             # not 0-indexed lists (i.e. Attempt 1 instead of
             # Attempt 0 for the first attempt).
-            # Set the task start date. In case it was re-scheduled use the initial
-            # start date that is recorded in task_reschedule table
+            # Set the task start date.
             self.start_date = timezone.utcnow()
-            if self.state == State.UP_FOR_RESCHEDULE:
+
+            # In case it was re-scheduled use the initial
+            # start date that is recorded in task_reschedule table
+            if hasattr(self.task, 'reschedule') and self.task.reschedule:
                 task_reschedule: TR = TR.query_for_task_instance(self, session=session).first()
                 if task_reschedule:
                     self.start_date = task_reschedule.start_date

--- a/tests/sensors/test_base.py
+++ b/tests/sensors/test_base.py
@@ -158,6 +158,7 @@ class TestBaseSensor:
                 # verify task is re-scheduled, i.e. state set to NONE
                 assert ti.state == State.UP_FOR_RESCHEDULE
                 # verify task start date is the initial one
+                # task state realistically would be queued as defined by the task life cycle
                 assert ti.start_date == date1
                 # verify one row in task_reschedule table
                 task_reschedules = TaskReschedule.find_for_task_instance(ti)


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Fixes #15645 that was likely the result of PR #9087.

The original optimization was well intentioned. However, because of the [task lifecycle](https://airflow.apache.org/docs/apache-airflow/2.2.2/concepts/tasks.html#task-instances), the task state is never in `UP_FOR_RESCHEDULE` when task is executed at the next poke interval. 

The scheduler updates the state for schedule-able tasks, which includes tasks with state `UP_FOR_RESCHEDULE`, to `SCHEDULED`. (see [source](https://github.com/apache/airflow/blob/9ac742885ffb83c15f7e3dc910b0cf9df073407a/airflow/models/dagrun.py#L884-L905)). This means that the original condition is never satisfied.

Instead of checking task state, we can check if mode is reschedule with the reschedule attribute if present.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
