### PR TITLE
Remove Integration tests from MSSQL on Public Runners

### DIFF
--- a/scripts/ci/testing/ci_run_airflow_testing.sh
+++ b/scripts/ci/testing/ci_run_airflow_testing.sh
@@ -88,9 +88,18 @@ function run_all_test_types_in_parallel() {
         echo "${COLOR_YELLOW}Heavy tests will be run sequentially after parallel tests including cleaning up docker between tests${COLOR_RESET}"
         echo ""
         if [[ ${test_types_to_run} == *"Integration"* ]]; then
-            echo "${COLOR_YELLOW}Remove Integration from tests_types_to_run and add them to sequential tests due to low memory.${COLOR_RESET}"
             test_types_to_run="${test_types_to_run//Integration/}"
-            sequential_tests+=("Integration")
+            if [[ ${BACKEND} == "mssql" ]]; then
+                # Also for mssql we skip Integration tests altogether on Public Runners. Mssql uses far
+                # too much memory and often shuts down and similarly as in case of Providers tests,
+                # there is no need to run them also for MsSQL engine as those integration tests
+                # are not really using any metadata-specific behaviour.
+                # Those tests will run in `main` anyway.
+                echo "${COLOR_YELLOW}Do not run integration tests for mssql in small systems due to memory issues.${COLOR_RESET}"
+            else
+                echo "${COLOR_YELLOW}Remove Integration from tests_types_to_run and add them to sequential tests due to low memory.${COLOR_RESET}"
+                sequential_tests+=("Integration")
+            fi
         fi
         if [[ ${BACKEND} == "mssql" || ${BACKEND} == "mysql" ]]; then
             # For mssql/mysql - they take far more memory than postgres (or sqlite) - we skip the Provider


### PR DESCRIPTION
The Integration tests with MSSQL often fail on Public
Runners without a reason. The database becomes inaccessible and
no logs are explaining what's going on. Its very likely however
that this is a memory-related issue (Integration tests take a
lot of memory as they run a lot of extra containers.

Those tests will eventually run on Self-hosted runner after merge
and they are also run for Postgres/MySQL/SQlite so there is no
need to run them also for MSSQL if it causes random failures.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
