### PR TITLE
Fix MyPy Errors for SFTP provider

### DIFF
--- a/airflow/providers/sftp/sensors/sftp.py
+++ b/airflow/providers/sftp/sensors/sftp.py
@@ -18,7 +18,7 @@
 """This module contains SFTP sensor."""
 from typing import Optional
 
-from paramiko import SFTP_NO_SUCH_FILE
+from paramiko.sftp import SFTP_NO_SUCH_FILE
 
 from airflow.providers.sftp.hooks.sftp import SFTPHook
 from airflow.sensors.base import BaseSensorOperator

--- a/tests/providers/sftp/sensors/test_sftp.py
+++ b/tests/providers/sftp/sensors/test_sftp.py
@@ -20,7 +20,7 @@ import unittest
 from unittest.mock import patch
 
 import pytest
-from paramiko import SFTP_FAILURE, SFTP_NO_SUCH_FILE
+from paramiko.sftp import SFTP_FAILURE, SFTP_NO_SUCH_FILE
 
 from airflow.providers.sftp.sensors.sftp import SFTPSensor
 


### PR DESCRIPTION
Actually, variables `SFTP_FAILURE` and `SFTP_NO_SUCH_FILE` are present in paramiko's `__init__.py` but in my local machine mypy still raises an error.
We could use direct import (as here) or use `# type: ignore[attr-defined]`
