### PR TITLE
Exclude snowflake-sqlalchemy v1.2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -470,7 +470,10 @@ slack = [
 ]
 snowflake = [
     'snowflake-connector-python>=2.4.1',
-    'snowflake-sqlalchemy>=1.1.0',
+    # The snowflake-alchemy 1.2.5 introduces a hard dependency on sqlalchemy>=1.4.0, but they didn't define
+    # this requirements in setup.py, so pip cannot figure out the correct set of dependencies.
+    # See: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/234
+    'snowflake-sqlalchemy>=1.1.0,!=1.2.5',
 ]
 spark = [
     'pyspark',


### PR DESCRIPTION
The snowflake-alchemy 1.2.5 introduces a hard dependency on `sqlalchemy>=1.4.0`, but they didn't define this requirement in setup.py, so pip cannot figure out the correct set of dependencies.
See: https://github.com/snowflakedb/snowflake-sqlalchemy/issues/234

This release should have been marked [yanked](https://www.python.org/dev/peps/pep-0592/), but Snowflake has not yet done so.

CC: @sfc-gh-abhatnagar @harishkrao  
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
