### PR TITLE
Add Python version check to cached_property imports in Azure

### DIFF
--- a/airflow/providers/microsoft/azure/log/wasb_task_handler.py
+++ b/airflow/providers/microsoft/azure/log/wasb_task_handler.py
@@ -17,13 +17,14 @@
 # under the License.
 import os
 import shutil
+import sys
 from typing import Dict, Optional, Tuple
 
 from azure.common import AzureHttpError
 
-try:
-    from functools import cached_property  # type: ignore[attr-defined]
-except ImportError:
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
     from cached_property import cached_property
 
 from airflow.configuration import conf

--- a/airflow/providers/microsoft/azure/secrets/key_vault.py
+++ b/airflow/providers/microsoft/azure/secrets/key_vault.py
@@ -14,15 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+import sys
 from typing import Optional
 
 from azure.core.exceptions import ResourceNotFoundError
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 
-try:
-    from functools import cached_property  # type: ignore[attr-defined]
-except ImportError:
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
     from cached_property import cached_property
 
 from airflow.secrets import BaseSecretsBackend


### PR DESCRIPTION
Related: #19891

Instead of adding the `# type: ignore[attr-defined]` comment to silence MyPy errors, we should add a Python version check to the `cached_property` module import (see [comment](https://github.com/apache/airflow/issues/19891#issuecomment-990728228)).

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
