### PR TITLE
MyPy cant follow the logic for dynamic attribute existence in airflow/triggers

### DIFF
--- a/airflow/triggers/temporal.py
+++ b/airflow/triggers/temporal.py
@@ -38,7 +38,7 @@ class DateTimeTrigger(BaseTrigger):
         # Make sure it's in UTC
         elif moment.tzinfo is None:
             raise ValueError("You cannot pass naive datetimes")
-        elif not hasattr(moment.tzinfo, "offset") or moment.tzinfo.offset != 0:
+        elif not hasattr(moment.tzinfo, "offset") or moment.tzinfo.offset != 0:  # type: ignore
             raise ValueError(f"The passed datetime must be using Pendulum's UTC, not {moment.tzinfo!r}")
         else:
             self.moment = moment


### PR DESCRIPTION
Part of #19891

MyPy complaining that offset field does not exists. The first condition is ensuring the second check does not fail.
Hence ignoring

This should complete MyPy issues inside airflow/triggers

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
