### PR TITLE
Fix MyPy errors in `docs/exts`

### DIFF
--- a/docs/exts/docs_build/lint_checks.py
+++ b/docs/exts/docs_build/lint_checks.py
@@ -136,11 +136,12 @@ def _check_missing_guide_references(operator_names, python_module_paths) -> List
                 continue
 
             docstring = ast.get_docstring(class_def)
-            if "This class is deprecated." in docstring:
-                continue
+            if docstring:
+                if "This class is deprecated." in docstring:
+                    continue
 
-            if f":ref:`howto/operator:{existing_operator}`" in ast.get_docstring(class_def):
-                continue
+                if f":ref:`howto/operator:{existing_operator}`" in docstring:
+                    continue
 
             build_errors.append(
                 _generate_missing_guide_error(py_module_path, class_def.lineno, existing_operator)

--- a/docs/exts/exampleinclude.py
+++ b/docs/exts/exampleinclude.py
@@ -24,7 +24,9 @@ import traceback
 from os import path
 
 from docutils import nodes
-from docutils.parsers.rst import directives
+
+# No stub exists for docutils.parsers.rst.directives. See https://github.com/python/typeshed/issues/5755.
+from docutils.parsers.rst import directives  # type: ignore[attr-defined]
 from sphinx.directives.code import LiteralIncludeReader
 from sphinx.ext.viewcode import viewcode_anchor
 from sphinx.locale import _

--- a/docs/exts/operators_and_hooks_ref.py
+++ b/docs/exts/operators_and_hooks_ref.py
@@ -23,7 +23,9 @@ import click
 import jinja2
 from docutils import nodes
 from docutils.nodes import Element
-from docutils.parsers.rst import Directive, directives
+
+# No stub exists for docutils.parsers.rst.directives. See https://github.com/python/typeshed/issues/5755.
+from docutils.parsers.rst import Directive, directives  # type: ignore[attr-defined]
 from docutils.statemachine import StringList
 from provider_yaml_utils import get_provider_yaml_paths, load_package_data
 from sphinx.util import nested_parse_with_titles

--- a/docs/exts/substitution_extensions.py
+++ b/docs/exts/substitution_extensions.py
@@ -22,7 +22,9 @@ from typing import Any, List, Tuple, Union
 
 from docutils import nodes
 from docutils.nodes import Node, system_message
-from docutils.parsers.rst import Directive, directives
+
+# No stub exists for docutils.parsers.rst.directives. See https://github.com/python/typeshed/issues/5755.
+from docutils.parsers.rst import Directive, directives  # type: ignore[attr-defined]
 from docutils.parsers.rst.roles import code_role
 from sphinx.application import Sphinx
 from sphinx.transforms import SphinxTransform


### PR DESCRIPTION
Related: #19891 

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
