### PR TITLE
Speed up Helm Upgrade tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1180,7 +1180,7 @@ ${{ hashFiles('.pre-commit-config.yaml') }}"
           retention-days: 7
 
   tests-helm-executor-upgrade:
-    timeout-minutes: 50
+    timeout-minutes: 80
     name: Helm Chart Executor Upgrade
     runs-on: ${{ fromJson(needs.build-info.outputs.runsOn) }}
     needs: [build-info, prod-images]

--- a/scripts/ci/kubernetes/ci_run_helm_upgrade.sh
+++ b/scripts/ci/kubernetes/ci_run_helm_upgrade.sh
@@ -18,11 +18,7 @@
 # shellcheck source=scripts/ci/libraries/_script_init.sh
 . "$( dirname "${BASH_SOURCE[0]}" )/../libraries/_script_init.sh"
 
-EXECUTOR=KubernetesExecutor
-export EXECUTOR
-
-# We started with KubernetesExecutor. Let's run tests first
-"$( dirname "${BASH_SOURCE[0]}" )/ci_run_kubernetes_tests.sh"
+# There is no need to run tests before upgrade (other tests do that). Let's test it after.
 for EXECUTOR in CeleryExecutor KubernetesExecutor
 do
     kind::upgrade_airflow_with_helm "${EXECUTOR}"


### PR DESCRIPTION
The Helm Upgrade tests took a long time on Public Runners. This
is in part because we were running tests before and after upgrade,
but we do not need to run them before the upgrade, simply because
those tests are already run elsewhere.

Also increased the timeout for the Upgrade Job - just in case
it will still not be enough

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
