### PR TITLE
Rename TaskMixin to DependencyMixin

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -61,7 +61,7 @@ from airflow.models.base import Operator
 from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import Context, TaskInstance, clear_task_instances
-from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
+from airflow.models.taskmixin import DependencyMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
@@ -1411,7 +1411,7 @@ class BaseOperator(Operator, LoggingMixin, DependencyMixin, metaclass=BaseOperat
 
     def _set_relatives(
         self,
-        task_or_task_list: DependencyMixinOrList,
+        task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]],
         upstream: bool = False,
         edge_modifier: Optional[EdgeModifier] = None,
     ) -> None:
@@ -1473,7 +1473,7 @@ class BaseOperator(Operator, LoggingMixin, DependencyMixin, metaclass=BaseOperat
 
     def set_downstream(
         self,
-        task_or_task_list: DependencyMixinOrList,
+        task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]],
         edge_modifier: Optional[EdgeModifier] = None,
     ) -> None:
         """
@@ -1484,7 +1484,7 @@ class BaseOperator(Operator, LoggingMixin, DependencyMixin, metaclass=BaseOperat
 
     def set_upstream(
         self,
-        task_or_task_list: DependencyMixinOrList,
+        task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]],
         edge_modifier: Optional[EdgeModifier] = None,
     ) -> None:
         """
@@ -1661,10 +1661,10 @@ class BaseOperator(Operator, LoggingMixin, DependencyMixin, metaclass=BaseOperat
 
 
 # TODO: Deprecate for Airflow 3.0
-Chainable = DependencyMixinOrList
+Chainable = Union[DependencyMixin, Sequence[DependencyMixin]]
 
 
-def chain(*tasks: DependencyMixinOrList) -> None:
+def chain(*tasks: Union[DependencyMixin, Sequence[DependencyMixin]]) -> None:
     r"""
     Given a number of tasks, builds a dependency chain.
 
@@ -1798,7 +1798,7 @@ def chain(*tasks: DependencyMixinOrList) -> None:
 
 def cross_downstream(
     from_tasks: Sequence[DependencyMixin],
-    to_tasks: DependencyMixinOrList,
+    to_tasks: Union[DependencyMixin, Sequence[DependencyMixin]],
 ):
     r"""
     Set downstream dependencies for all tasks in from_tasks to all tasks in to_tasks.

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -61,7 +61,7 @@ from airflow.models.base import Operator
 from airflow.models.param import ParamsDict
 from airflow.models.pool import Pool
 from airflow.models.taskinstance import Context, TaskInstance, clear_task_instances
-from airflow.models.taskmixin import TaskMixin
+from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
@@ -80,7 +80,6 @@ from airflow.utils.weight_rule import WeightRule
 
 if TYPE_CHECKING:
     from airflow.models.dag import DAG
-    from airflow.models.xcom_arg import XComArg
     from airflow.utils.task_group import TaskGroup
 
 ScheduleInterval = Union[str, timedelta, relativedelta]
@@ -206,7 +205,7 @@ class BaseOperatorMeta(abc.ABCMeta):
 
 
 @functools.total_ordering
-class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta):
+class BaseOperator(Operator, LoggingMixin, DependencyMixin, metaclass=BaseOperatorMeta):
     """
     Abstract base class for all operators. Since operators create objects that
     become nodes in the dag, BaseOperator contains many recursive methods for
@@ -1412,7 +1411,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
     def _set_relatives(
         self,
-        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        task_or_task_list: DependencyMixinOrList,
         upstream: bool = False,
         edge_modifier: Optional[EdgeModifier] = None,
     ) -> None:
@@ -1424,13 +1423,12 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         for task_object in task_or_task_list:
             task_object.update_relative(self, not upstream)
             relatives = task_object.leaves if upstream else task_object.roots
-            task_list.extend(relatives)
-
-        for task in task_list:
-            if not isinstance(task, BaseOperator):
-                raise AirflowException(
-                    f"Relationships can only be set between Operators; received {task.__class__.__name__}"
-                )
+            for task in relatives:
+                if not isinstance(task, BaseOperator):
+                    raise AirflowException(
+                        f"Relationships can only be set between Operators; received {task.__class__.__name__}"
+                    )
+                task_list.append(task)
 
         # relationships can only be set if the tasks share a single DAG. Tasks
         # without a DAG are assigned to that DAG.
@@ -1475,7 +1473,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
     def set_downstream(
         self,
-        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        task_or_task_list: DependencyMixinOrList,
         edge_modifier: Optional[EdgeModifier] = None,
     ) -> None:
         """
@@ -1486,7 +1484,7 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
 
     def set_upstream(
         self,
-        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        task_or_task_list: DependencyMixinOrList,
         edge_modifier: Optional[EdgeModifier] = None,
     ) -> None:
         """
@@ -1662,10 +1660,11 @@ class BaseOperator(Operator, LoggingMixin, TaskMixin, metaclass=BaseOperatorMeta
         raise TaskDeferred(trigger=trigger, method_name=method_name, kwargs=kwargs, timeout=timeout)
 
 
-Chainable = Union[BaseOperator, "XComArg", EdgeModifier, "TaskGroup"]
+# TODO: Deprecate for Airflow 3.0
+Chainable = DependencyMixinOrList
 
 
-def chain(*tasks: Union[Chainable, Sequence[Chainable]]) -> None:
+def chain(*tasks: DependencyMixinOrList) -> None:
     r"""
     Given a number of tasks, builds a dependency chain.
 
@@ -1776,17 +1775,12 @@ def chain(*tasks: Union[Chainable, Sequence[Chainable]]) -> None:
         List[airflow.utils.EdgeModifier], airflow.utils.EdgeModifier, List[airflow.models.XComArg], XComArg,
         List[airflow.utils.TaskGroup], or airflow.utils.TaskGroup
     """
-    from airflow.models.xcom_arg import XComArg
-    from airflow.utils.task_group import TaskGroup
-
-    chainable_types = (BaseOperator, XComArg, EdgeModifier, TaskGroup)
-
     for index, up_task in enumerate(tasks[:-1]):
         down_task = tasks[index + 1]
-        if isinstance(up_task, chainable_types):
+        if isinstance(up_task, DependencyMixin):
             up_task.set_downstream(down_task)
             continue
-        if isinstance(down_task, chainable_types):
+        if isinstance(down_task, DependencyMixin):
             down_task.set_upstream(up_task)
             continue
         if not isinstance(up_task, Sequence) or not isinstance(down_task, Sequence):
@@ -1803,8 +1797,8 @@ def chain(*tasks: Union[Chainable, Sequence[Chainable]]) -> None:
 
 
 def cross_downstream(
-    from_tasks: Sequence[Union[BaseOperator, "XComArg"]],
-    to_tasks: Union[BaseOperator, "XComArg", Sequence[Union[BaseOperator, "XComArg"]]],
+    from_tasks: Sequence[DependencyMixin],
+    to_tasks: DependencyMixinOrList,
 ):
     r"""
     Set downstream dependencies for all tasks in from_tasks to all tasks in to_tasks.

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -15,61 +15,78 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import warnings
 from abc import abstractmethod
 from typing import Sequence, Union
 
+DependencyMixinOrList = Union["DependencyMixin", Sequence["DependencyMixin"]]
 
-class TaskMixin:
-    """
-    Mixing implementing common chain methods like >> and <<.
 
-    In the following functions we use:
-    Task = Union[BaseOperator, XComArg]
-    No type annotations due to cyclic imports.
-    """
+class DependencyMixin:
+    """Mixing implementing common dependency setting methods methods like >> and <<."""
 
     @property
-    def roots(self):
-        """Should return list of root operator List[BaseOperator]"""
+    def roots(self) -> Sequence["DependencyMixin"]:
+        """
+        List of root nodes -- ones with no upstream dependencies.
+
+        a.k.a. the "start" of this sub-graph
+        """
         raise NotImplementedError()
 
     @property
-    def leaves(self):
-        """Should return list of leaf operator List[BaseOperator]"""
+    def leaves(self) -> Sequence["DependencyMixin"]:
+        """
+        List of leaf nodes -- ones with only upstream dependencies.
+
+        a.k.a. the "end" of this sub-graph
+        """
         raise NotImplementedError()
 
     @abstractmethod
-    def set_upstream(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
+    def set_upstream(self, other: DependencyMixinOrList):
         """Set a task or a task list to be directly upstream from the current task."""
         raise NotImplementedError()
 
     @abstractmethod
-    def set_downstream(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
+    def set_downstream(self, other: DependencyMixinOrList):
         """Set a task or a task list to be directly downstream from the current task."""
         raise NotImplementedError()
 
-    def update_relative(self, other: "TaskMixin", upstream=True) -> None:
+    def update_relative(self, other: "DependencyMixin", upstream=True) -> None:
         """
         Update relationship information about another TaskMixin. Default is no-op.
         Override if necessary.
         """
 
-    def __lshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
+    def __lshift__(self, other: DependencyMixinOrList):
         """Implements Task << Task"""
         self.set_upstream(other)
         return other
 
-    def __rshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
+    def __rshift__(self, other: DependencyMixinOrList):
         """Implements Task >> Task"""
         self.set_downstream(other)
         return other
 
-    def __rrshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
+    def __rrshift__(self, other: DependencyMixinOrList):
         """Called for Task >> [Task] because list don't have __rshift__ operators."""
         self.__lshift__(other)
         return self
 
-    def __rlshift__(self, other: Union["TaskMixin", Sequence["TaskMixin"]]):
+    def __rlshift__(self, other: DependencyMixinOrList):
         """Called for Task << [Task] because list don't have __lshift__ operators."""
         self.__rshift__(other)
         return self
+
+
+class TaskMixin(DependencyMixin):
+    """:meta private:"""
+
+    def __init_subclass__(cls) -> None:
+        warnings.warn(
+            f"TaskMixin has been renamed to DependencyMixin, please update {cls.__name__}",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return super().__init_subclass__()

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -19,8 +19,6 @@ import warnings
 from abc import abstractmethod
 from typing import Sequence, Union
 
-DependencyMixinOrList = Union["DependencyMixin", Sequence["DependencyMixin"]]
-
 
 class DependencyMixin:
     """Mixing implementing common dependency setting methods methods like >> and <<."""
@@ -44,12 +42,12 @@ class DependencyMixin:
         raise NotImplementedError()
 
     @abstractmethod
-    def set_upstream(self, other: DependencyMixinOrList):
+    def set_upstream(self, other: Union["DependencyMixin", Sequence["DependencyMixin"]]):
         """Set a task or a task list to be directly upstream from the current task."""
         raise NotImplementedError()
 
     @abstractmethod
-    def set_downstream(self, other: DependencyMixinOrList):
+    def set_downstream(self, other: Union["DependencyMixin", Sequence["DependencyMixin"]]):
         """Set a task or a task list to be directly downstream from the current task."""
         raise NotImplementedError()
 
@@ -59,22 +57,22 @@ class DependencyMixin:
         Override if necessary.
         """
 
-    def __lshift__(self, other: DependencyMixinOrList):
+    def __lshift__(self, other: Union["DependencyMixin", Sequence["DependencyMixin"]]):
         """Implements Task << Task"""
         self.set_upstream(other)
         return other
 
-    def __rshift__(self, other: DependencyMixinOrList):
+    def __rshift__(self, other: Union["DependencyMixin", Sequence["DependencyMixin"]]):
         """Implements Task >> Task"""
         self.set_downstream(other)
         return other
 
-    def __rrshift__(self, other: DependencyMixinOrList):
+    def __rrshift__(self, other: Union["DependencyMixin", Sequence["DependencyMixin"]]):
         """Called for Task >> [Task] because list don't have __rshift__ operators."""
         self.__lshift__(other)
         return self
 
-    def __rlshift__(self, other: DependencyMixinOrList):
+    def __rlshift__(self, other: Union["DependencyMixin", Sequence["DependencyMixin"]]):
         """Called for Task << [Task] because list don't have __lshift__ operators."""
         self.__rshift__(other)
         return self

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
+from airflow.models.taskmixin import DependencyMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.utils.edgemodifier import EdgeModifier
 
@@ -116,7 +116,7 @@ class XComArg(DependencyMixin):
 
     def set_upstream(
         self,
-        task_or_task_list: DependencyMixinOrList,
+        task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]],
         edge_modifier: Optional[EdgeModifier] = None,
     ):
         """Proxy to underlying operator set_upstream method. Required by TaskMixin."""
@@ -124,7 +124,7 @@ class XComArg(DependencyMixin):
 
     def set_downstream(
         self,
-        task_or_task_list: DependencyMixinOrList,
+        task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]],
         edge_modifier: Optional[EdgeModifier] = None,
     ):
         """Proxy to underlying operator set_downstream method. Required by TaskMixin."""

--- a/airflow/models/xcom_arg.py
+++ b/airflow/models/xcom_arg.py
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, Any, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any, List, Optional
 
 from airflow.exceptions import AirflowException
 from airflow.models.baseoperator import BaseOperator
-from airflow.models.taskmixin import TaskMixin
+from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
 from airflow.models.xcom import XCOM_RETURN_KEY
 from airflow.utils.edgemodifier import EdgeModifier
 
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class XComArg(TaskMixin):
+class XComArg(DependencyMixin):
     """
     Class that represents a XCom push from a previous operator.
     Defaults to "return_value" as only key.
@@ -116,7 +116,7 @@ class XComArg(TaskMixin):
 
     def set_upstream(
         self,
-        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        task_or_task_list: DependencyMixinOrList,
         edge_modifier: Optional[EdgeModifier] = None,
     ):
         """Proxy to underlying operator set_upstream method. Required by TaskMixin."""
@@ -124,7 +124,7 @@ class XComArg(TaskMixin):
 
     def set_downstream(
         self,
-        task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]],
+        task_or_task_list: DependencyMixinOrList,
         edge_modifier: Optional[EdgeModifier] = None,
     ):
         """Proxy to underlying operator set_downstream method. Required by TaskMixin."""

--- a/airflow/utils/dot_renderer.py
+++ b/airflow/utils/dot_renderer.py
@@ -25,7 +25,7 @@ from airflow import AirflowException
 from airflow.models import TaskInstance
 from airflow.models.baseoperator import BaseOperator
 from airflow.models.dag import DAG
-from airflow.models.taskmixin import TaskMixin
+from airflow.models.taskmixin import DependencyMixin
 from airflow.serialization.serialized_objects import DagDependency
 from airflow.utils.state import State
 from airflow.utils.task_group import TaskGroup
@@ -111,7 +111,7 @@ def _draw_task_group(
 
 
 def _draw_nodes(
-    node: TaskMixin, parent_graph: graphviz.Digraph, states_by_task_id: Optional[Dict[Any, Any]]
+    node: DependencyMixin, parent_graph: graphviz.Digraph, states_by_task_id: Dict[str, str]
 ) -> None:
     """Draw the node and its children on the given parent_graph recursively."""
     if isinstance(node, BaseOperator):

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -14,13 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from typing import TYPE_CHECKING, List, Optional
 
-from typing import List, Optional, Sequence, Union
+from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
 
-from airflow.models.taskmixin import TaskMixin
+if TYPE_CHECKING:
+    from airflow.models.baseoperator import BaseOperator
 
 
-class EdgeModifier(TaskMixin):
+class EdgeModifier(DependencyMixin):
     """
     Class that represents edge information to be added between two
     tasks/operators. Has shorthand factory functions, like Label("hooray").
@@ -39,36 +41,37 @@ class EdgeModifier(TaskMixin):
     """
 
     def __init__(self, label: Optional[str] = None):
-        from airflow.models.baseoperator import BaseOperator
-
         self.label = label
-        self._upstream: List[BaseOperator] = []
-        self._downstream: List[BaseOperator] = []
+        self._upstream: List["BaseOperator"] = []
+        self._downstream: List["BaseOperator"] = []
 
     @property
     def roots(self):
-        """Should return list of root operator List["BaseOperator"]"""
         return self._downstream
 
     @property
     def leaves(self):
-        """Should return list of leaf operator List["BaseOperator"]"""
         return self._upstream
 
-    def set_upstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]], chain: bool = True):
+    def set_upstream(self, task_or_task_list: DependencyMixinOrList, chain: bool = True):
         """
         Sets the given task/list onto the upstream attribute, and then checks if
         we have both sides so we can resolve the relationship.
 
-        Providing this also provides << via TaskMixin.
+        Providing this also provides << via DependencyMixin.
         """
+        from airflow.models.baseoperator import BaseOperator
+
         # Ensure we have a list, even if it's just one item
-        if isinstance(task_or_task_list, TaskMixin):
+        if isinstance(task_or_task_list, DependencyMixin):
             task_or_task_list = [task_or_task_list]
         # Unfurl it into actual operators
-        operators = []
+        operators: List[BaseOperator] = []
         for task in task_or_task_list:
-            operators.extend(task.roots)
+            for root in task.roots:
+                if not isinstance(root, BaseOperator):
+                    raise TypeError(f"Cannot use edge labels with {type(root).__name__}, only operators")
+                operators.append(root)
         # For each already-declared downstream, pair off with each new upstream
         # item and store the edge info.
         for operator in operators:
@@ -79,20 +82,25 @@ class EdgeModifier(TaskMixin):
         # Add the new tasks to our list of ones we've seen
         self._upstream.extend(operators)
 
-    def set_downstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]], chain: bool = True):
+    def set_downstream(self, task_or_task_list: DependencyMixinOrList, chain: bool = True):
         """
         Sets the given task/list onto the downstream attribute, and then checks if
         we have both sides so we can resolve the relationship.
 
-        Providing this also provides >> via TaskMixin.
+        Providing this also provides >> via DependencyMixin.
         """
+        from airflow.models.baseoperator import BaseOperator
+
         # Ensure we have a list, even if it's just one item
-        if isinstance(task_or_task_list, TaskMixin):
+        if isinstance(task_or_task_list, DependencyMixin):
             task_or_task_list = [task_or_task_list]
         # Unfurl it into actual operators
-        operators = []
+        operators: List[BaseOperator] = []
         for task in task_or_task_list:
-            operators.extend(task.leaves)
+            for leaf in task.leaves:
+                if not isinstance(leaf, BaseOperator):
+                    raise TypeError(f"Cannot use edge labels with {type(leaf).__name__}, only operators")
+                operators.append(leaf)
         # Pair them off with existing
         for operator in operators:
             for upstream in self._upstream:
@@ -102,7 +110,7 @@ class EdgeModifier(TaskMixin):
         # Add the new tasks to our list of ones we've seen
         self._downstream.extend(operators)
 
-    def update_relative(self, other: "TaskMixin", upstream: bool = True) -> None:
+    def update_relative(self, other: DependencyMixin, upstream: bool = True) -> None:
         """
         Called if we're not the "main" side of a relationship; we still run the
         same logic, though.

--- a/airflow/utils/edgemodifier.py
+++ b/airflow/utils/edgemodifier.py
@@ -14,9 +14,9 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
-from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
+from airflow.models.taskmixin import DependencyMixin
 
 if TYPE_CHECKING:
     from airflow.models.baseoperator import BaseOperator
@@ -53,7 +53,9 @@ class EdgeModifier(DependencyMixin):
     def leaves(self):
         return self._upstream
 
-    def set_upstream(self, task_or_task_list: DependencyMixinOrList, chain: bool = True):
+    def set_upstream(
+        self, task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]], chain: bool = True
+    ):
         """
         Sets the given task/list onto the upstream attribute, and then checks if
         we have both sides so we can resolve the relationship.
@@ -82,7 +84,9 @@ class EdgeModifier(DependencyMixin):
         # Add the new tasks to our list of ones we've seen
         self._upstream.extend(operators)
 
-    def set_downstream(self, task_or_task_list: DependencyMixinOrList, chain: bool = True):
+    def set_downstream(
+        self, task_or_task_list: Union[DependencyMixin, Sequence[DependencyMixin]], chain: bool = True
+    ):
         """
         Sets the given task/list onto the downstream attribute, and then checks if
         we have both sides so we can resolve the relationship.

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -24,7 +24,7 @@ import re
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Sequence, Set, Union
 
 from airflow.exceptions import AirflowException, DuplicateTaskIdFound
-from airflow.models.taskmixin import TaskMixin
+from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
 from airflow.utils.helpers import validate_group_key
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from airflow.models.dag import DAG
 
 
-class TaskGroup(TaskMixin):
+class TaskGroup(DependencyMixin):
     """
     A collection of tasks. When set_downstream() or set_upstream() are called on the
     TaskGroup, it is applied across all tasks within the group if necessary.
@@ -200,7 +200,7 @@ class TaskGroup(TaskMixin):
         """group_id excluding parent's group_id used as the node label in UI."""
         return self._group_id
 
-    def update_relative(self, other: "TaskMixin", upstream=True) -> None:
+    def update_relative(self, other: DependencyMixin, upstream=True) -> None:
         """
         Overrides TaskMixin.update_relative.
 
@@ -232,9 +232,7 @@ class TaskGroup(TaskMixin):
                 else:
                     self.downstream_task_ids.add(task.task_id)
 
-    def _set_relative(
-        self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]], upstream: bool = False
-    ) -> None:
+    def _set_relative(self, task_or_task_list: DependencyMixinOrList, upstream: bool = False) -> None:
         """
         Call set_upstream/set_downstream for all root/leaf tasks within this TaskGroup.
         Update upstream_group_ids/downstream_group_ids/upstream_task_ids/downstream_task_ids.
@@ -252,11 +250,11 @@ class TaskGroup(TaskMixin):
         for task_like in task_or_task_list:
             self.update_relative(task_like, upstream)
 
-    def set_downstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]]) -> None:
+    def set_downstream(self, task_or_task_list: DependencyMixinOrList) -> None:
         """Set a TaskGroup/task/list of task downstream of this TaskGroup."""
         self._set_relative(task_or_task_list, upstream=False)
 
-    def set_upstream(self, task_or_task_list: Union[TaskMixin, Sequence[TaskMixin]]) -> None:
+    def set_upstream(self, task_or_task_list: DependencyMixinOrList) -> None:
         """Set a TaskGroup/task/list of task upstream of this TaskGroup."""
         self._set_relative(task_or_task_list, upstream=True)
 

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -24,7 +24,7 @@ import re
 from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Sequence, Set, Union
 
 from airflow.exceptions import AirflowException, DuplicateTaskIdFound
-from airflow.models.taskmixin import DependencyMixin, DependencyMixinOrList
+from airflow.models.taskmixin import DependencyMixin
 from airflow.utils.helpers import validate_group_key
 
 if TYPE_CHECKING:
@@ -232,7 +232,9 @@ class TaskGroup(DependencyMixin):
                 else:
                     self.downstream_task_ids.add(task.task_id)
 
-    def _set_relative(self, task_or_task_list: DependencyMixinOrList, upstream: bool = False) -> None:
+    def _set_relative(
+        self, task_or_task_list: Union["DependencyMixin", Sequence["DependencyMixin"]], upstream: bool = False
+    ) -> None:
         """
         Call set_upstream/set_downstream for all root/leaf tasks within this TaskGroup.
         Update upstream_group_ids/downstream_group_ids/upstream_task_ids/downstream_task_ids.
@@ -250,11 +252,13 @@ class TaskGroup(DependencyMixin):
         for task_like in task_or_task_list:
             self.update_relative(task_like, upstream)
 
-    def set_downstream(self, task_or_task_list: DependencyMixinOrList) -> None:
+    def set_downstream(
+        self, task_or_task_list: Union["DependencyMixin", Sequence["DependencyMixin"]]
+    ) -> None:
         """Set a TaskGroup/task/list of task downstream of this TaskGroup."""
         self._set_relative(task_or_task_list, upstream=False)
 
-    def set_upstream(self, task_or_task_list: DependencyMixinOrList) -> None:
+    def set_upstream(self, task_or_task_list: Union["DependencyMixin", Sequence["DependencyMixin"]]) -> None:
         """Set a TaskGroup/task/list of task upstream of this TaskGroup."""
         self._set_relative(task_or_task_list, upstream=True)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -105,6 +105,7 @@ Decrypt
 Decrypts
 DeidentifyContentResponse
 DeidentifyTemplate
+DependencyMixin
 Deprecations
 Deserialize
 Deserialized

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1347,6 +1347,7 @@ tagValue
 task_group
 taskflow
 taskinstance
+taskmixin
 tblproperties
 tcp
 templatable


### PR DESCRIPTION
It was used on things that weren't tasks (such as XComArg and
EdgeModifier) so the name was in-correct, and I want to disambiguate
this from a concept I need to add for AIP-42 (Dynamic task mapping) of
things that actually _are_ Tasks or Task-like objects.

~Since `Union[TaskMixin, Sequence[TaskMixin]]` was uses in so many places
I created a type alias for this of `DependencyMixinOrList`~


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).