### PR TITLE
Only list linked issues once in release issues

### DIFF
--- a/dev/prepare_release_issue.py
+++ b/dev/prepare_release_issue.py
@@ -273,8 +273,10 @@ def generate_issue_content(
             # Relate so we can find those from the body
             if pr.body:
                 body = pr.body.replace("\n", " ").replace("\r", " ")
-                for issue_match in ISSUE_MATCH_IN_BODY.finditer(body):
-                    linked_issue_number = int(issue_match.group(1))
+                linked_issue_numbers = {
+                    int(issue_match.group(1)) for issue_match in ISSUE_MATCH_IN_BODY.finditer(body)
+                }
+                for linked_issue_number in linked_issue_numbers:
                     progress.console.print(
                         f"Retrieving Linked issue PR#{linked_issue_number}: "
                         f"https://github.com/apache/airflow/issue/{linked_issue_number}"


### PR DESCRIPTION
I noticed we had duplicate linked issues sometimes, so toss them into a set first to dedup them.

This can happen when a given issue is mentioned more than once, e.g: https://github.com/apache/airflow/pull/19616.