### PR TITLE
Fix MyPy Errors for Apache Beam (and Dataflow) provider.

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -212,7 +212,6 @@ class _DataflowJobsController(LoggingMixin):
         self._jobs: Optional[List[dict]] = None
         self.drain_pipeline = drain_pipeline
         self._wait_until_finished = wait_until_finished
-        self._jobs: Optional[List[dict]] = None
 
     def is_job_running(self) -> bool:
         """
@@ -1064,7 +1063,7 @@ class DataflowHook(GoogleBaseHook):
                 DeprecationWarning,
                 stacklevel=3,
             )
-            on_new_job_id_callback(job.get("id"))
+            on_new_job_id_callback(job["id"])
 
         if on_new_job_callback:
             on_new_job_callback(job)

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -140,7 +140,7 @@ class DataflowConfiguration:
     def __init__(
         self,
         *,
-        job_name: Optional[str] = "{{task.task_id}}",
+        job_name: str = "{{task.task_id}}",
         append_job_name: bool = True,
         project_id: Optional[str] = None,
         location: Optional[str] = DEFAULT_DATAFLOW_LOCATION,


### PR DESCRIPTION
Fixed mypy errors for Apache Beam and due to using some parts from Dataflow also checked it.

For fixing Beam I have to change the type in `DataflowConfiguration`.
Parameter `job_name` was `Optional[str]` and also had default value `"{{task.task_id}}"`.
I assumed that _optional_ mean _non-obligatory_ and not _might be None_.
That's why I also fixed two more errors in Dataflow.

related: #19891
