### PR TITLE
Fix arrow styling in DAG dependencies view

### DIFF
--- a/airflow/www/static/js/dag_dependencies.js
+++ b/airflow/www/static/js/dag_dependencies.js
@@ -200,7 +200,10 @@ const renderGraph = () => {
 
   // Set edges
   edges.forEach((edge) => {
-    g.setEdge(edge.u, edge.v);
+    g.setEdge(edge.u, edge.v, {
+      curve: d3.curveBasis,
+      arrowheadClass: 'arrowhead',
+    });
   });
 
   innerSvg.call(render, g);


### PR DESCRIPTION
closes: #19989

This PR updates the arrowhead styling in the DAG dependencies view to match that of the graph view. Both templates use the same css, but `dag_dependencies.js` was not assigning the `arrowhead` css class on the dag edges.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
