### PR TITLE
Fix MyPy Errors for Apache Sqoop provider.

### DIFF
--- a/airflow/providers/apache/sqoop/hooks/sqoop.py
+++ b/airflow/providers/apache/sqoop/hooks/sqoop.py
@@ -81,6 +81,7 @@ class SqoopHook(BaseHook):
         self.verbose = verbose
         self.num_mappers = num_mappers
         self.properties = properties or {}
+        self.sub_process_pid: int
         self.log.info("Using connection to: %s:%s/%s", self.conn.host, self.conn.port, self.conn.schema)
 
     def get_conn(self) -> Any:
@@ -107,6 +108,7 @@ class SqoopHook(BaseHook):
         masked_cmd = ' '.join(self.cmd_mask_password(cmd))
         self.log.info("Executing command: %s", masked_cmd)
         with subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs) as sub_process:
+            self.sub_process_pid = sub_process.pid
             for line in iter(sub_process.stdout):  # type: ignore
                 self.log.info(line.strip())
             sub_process.wait()

--- a/airflow/providers/apache/sqoop/operators/sqoop.py
+++ b/airflow/providers/apache/sqoop/operators/sqoop.py
@@ -250,7 +250,7 @@ class SqoopOperator(BaseOperator):
         if self.hook is None:
             self.hook = self._get_hook()
         self.log.info('Sending SIGTERM signal to bash process group')
-        os.killpg(os.getpgid(self.hook.sub_process.pid), signal.SIGTERM)
+        os.killpg(os.getpgid(self.hook.sub_process_pid), signal.SIGTERM)
 
     def _get_hook(self) -> SqoopHook:
         return SqoopHook(


### PR DESCRIPTION
Sqoop's hook really had an attribute `sub_process`, but after this commit, it was removed.
https://github.com/apache/airflow/commit/4b031d39e12110f337151cda6693e2541bf71c2c#diff-c6f2edce79cb607d8de3508fb93f81bbd525d4bf00881e683b4b24db15e98667

Added attribute `sub_process_pid`.
I saw that this project was moved to Attic. So, I'm curious how long usually Airflow supports such project integrations?

related: #19891
