### PR TITLE
Fixing MyPy issues inside airflow/serialization

### DIFF
--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -109,7 +109,7 @@ class ExternalTaskSensor(BaseSensorOperator):
         self.allowed_states = list(allowed_states) if allowed_states else [State.SUCCESS]
         self.failed_states = list(failed_states) if failed_states else []
 
-        total_states: Iterable = self.allowed_states + self.failed_states
+        total_states: Iterable[str] = self.allowed_states + self.failed_states
         total_states = set(total_states)
 
         if set(self.failed_states).intersection(set(self.allowed_states)):

--- a/airflow/sensors/external_task.py
+++ b/airflow/sensors/external_task.py
@@ -259,17 +259,19 @@ class ExternalTaskSensor(BaseSensorOperator):
         implementation to pass all context variables as keyword arguments, to allow
         for more sophisticated returns of dates to return.
         """
-        if self.execution_date_fn and context:
-            from airflow.utils.operator_helpers import make_kwargs_callable
+        if self.execution_date_fn is None or context is None:
+            raise AirflowException("Execution date function or context is not provided")
 
-            # Remove "execution_date" because it is already a mandatory positional argument
-            execution_date = context["execution_date"]
-            kwargs = {k: v for k, v in context.items() if k != "execution_date"}
-            # Add "context" in the kwargs for backward compatibility (because context used to be
-            # an acceptable argument of execution_date_fn)
-            kwargs["context"] = context
-            kwargs_callable = make_kwargs_callable(self.execution_date_fn)
-            return kwargs_callable(execution_date, **kwargs)
+        from airflow.utils.operator_helpers import make_kwargs_callable
+
+        # Remove "execution_date" because it is already a mandatory positional argument
+        execution_date = context["execution_date"]
+        kwargs = {k: v for k, v in context.items() if k != "execution_date"}
+        # Add "context" in the kwargs for backward compatibility (because context used to be
+        # an acceptable argument of execution_date_fn)
+        kwargs["context"] = context
+        kwargs_callable = make_kwargs_callable(self.execution_date_fn)
+        return kwargs_callable(execution_date, **kwargs)
 
 
 class ExternalTaskMarker(DummyOperator):

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -118,7 +118,7 @@ def encode_timezone(var: Timezone) -> Union[str, int]:
 
 def decode_timezone(var: Union[str, int]) -> Timezone:
     """Decode a previously serialized Pendulum Timezone."""
-    return pendulum.timezone(var)
+    return pendulum.tz.timezone(var)
 
 
 def _get_registered_timetable(importable_string: str) -> Optional[Type[Timetable]]:
@@ -127,7 +127,10 @@ def _get_registered_timetable(importable_string: str) -> Optional[Type[Timetable
     if importable_string.startswith("airflow.timetables."):
         return import_string(importable_string)
     plugins_manager.initialize_timetables_plugins()
-    return plugins_manager.timetable_classes.get(importable_string)
+    if plugins_manager.timetable_classes:
+        return plugins_manager.timetable_classes.get(importable_string)
+    else:
+        return None
 
 
 class _TimetableNotRegistered(ValueError):
@@ -439,7 +442,7 @@ class BaseSerialization:
         return class_(**kwargs)
 
     @classmethod
-    def _serialize_params_dict(cls, params: ParamsDict):
+    def _serialize_params_dict(cls, params: Union[ParamsDict, dict]):
         """Serialize Params dict for a DAG/Task"""
         serialized_params = {}
         for k, v in params.items():
@@ -994,7 +997,7 @@ class SerializedTaskGroup(TaskGroup, BaseSerialization):
         }
         group = SerializedTaskGroup(group_id=group_id, parent_group=parent_group, **kwargs)
         group.children = {
-            label: task_dict[val]
+            label: task_dict[val]  # type: ignore
             if _type == DAT.OP  # type: ignore
             else SerializedTaskGroup.deserialize_task_group(val, group, task_dict)
             for label, (_type, val) in encoded_group["children"].items()


### PR DESCRIPTION
Part of: #19891

Fixing MyPy issues inside airflow/serialization:

- Change reference to timezone path using absolute path
- Handle None case for Optional type in return statement for _get_registered_timetable function
- Fix type signature for _serialize_params_dict inline with changes made https://github.com/apache/airflow/commit/7d8e3b828af0ac90261c341f5cb0e57da75e6a83#
	in https://github.com/apache/airflow/blob/7d8e3b828af0ac90261c341f5cb0e57da75e6a83/airflow/models/baseoperator.py#L649
- Ignore error when MyPy can't detect type correctly for task_dict[val] returned value

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
