### PR TITLE
Adds missing mypy types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -521,6 +521,8 @@ zendesk = [
 # mypyd which does not support installing the types dynamically with --install-types
 mypy_dependencies = [
     'mypy==0.910',
+    'types-boto',
+    'types-certifi',
     'types-croniter',
     'types-docutils',
     'types-freezegun',
@@ -534,6 +536,7 @@ mypy_dependencies = [
     'types-setuptools',
     'types-termcolor',
     'types-tabulate',
+    'types-toml',
     'types-Markdown',
     'types-PyMySQL',
     'types-PyYAML',


### PR DESCRIPTION
This PR adds a few missing type stub packages that we have but so
far MyPy did not complain about lack of those.

Added by `mypy --install-types` command.

Part of #19891

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
