### PR TITLE
Fix missing get_backup method for Dataproc Metastore

### DIFF
--- a/airflow/providers/google/cloud/hooks/dataproc_metastore.py
+++ b/airflow/providers/google/cloud/hooks/dataproc_metastore.py
@@ -454,6 +454,53 @@ class DataprocMetastoreHook(GoogleBaseHook):
         return result
 
     @GoogleBaseHook.fallback_to_default_project_id
+    def get_backup(
+        self,
+        project_id: str,
+        region: str,
+        service_id: str,
+        backup_id: str,
+        retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
+        metadata: Sequence[Tuple[str, str]] = (),
+    ) -> Backup:
+        """
+        Get backup from a service.
+
+        :param project_id: Required. The ID of the Google Cloud project that the service belongs to.
+        :type project_id: str
+        :param region: Required. The ID of the Google Cloud region that the service belongs to.
+        :type region: str
+        :param service_id:  Required. The ID of the metastore service, which is used as the final component of
+            the metastore service's name. This value must be between 2 and 63 characters long inclusive, begin
+            with a letter, end with a letter or number, and consist of alphanumeric ASCII characters or
+            hyphens.
+
+            This corresponds to the ``service_id`` field on the ``request`` instance; if ``request`` is
+            provided, this should not be set.
+        :type service_id: str
+        :param backup_id:  Required. The ID of the metastore service backup to restore from
+        :type backup_id: str
+        :param retry: Designation of what errors, if any, should be retried.
+        :type retry: google.api_core.retry.Retry
+        :param timeout: The timeout for this request.
+        :type timeout: float
+        :param metadata: Strings which should be sent along with the request as metadata.
+        :type metadata: Sequence[Tuple[str, str]]
+        """
+        backup = f'projects/{project_id}/locations/{region}/services/{service_id}/backups/{backup_id}'
+        client = self.get_dataproc_metastore_client()
+        result = client.get_backup(
+            request={
+                'name': backup,
+            },
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        return result
+
+    @GoogleBaseHook.fallback_to_default_project_id
     def list_backups(
         self,
         project_id: str,

--- a/tests/providers/google/cloud/hooks/test_dataproc_metastore.py
+++ b/tests/providers/google/cloud/hooks/test_dataproc_metastore.py
@@ -130,6 +130,24 @@ class TestDataprocMetastoreWithDefaultProjectIdHook(TestCase):
         )
 
     @mock.patch(DATAPROC_METASTORE_STRING.format("DataprocMetastoreHook.get_dataproc_metastore_client"))
+    def test_get_backup(self, mock_client) -> None:
+        self.hook.get_backup(
+            project_id=TEST_PROJECT_ID,
+            region=TEST_REGION,
+            service_id=TEST_SERVICE_ID,
+            backup_id=TEST_BACKUP_ID,
+        )
+        mock_client.assert_called_once()
+        mock_client.return_value.get_backup.assert_called_once_with(
+            request=dict(
+                name=TEST_NAME_BACKUPS.format(TEST_PROJECT_ID, TEST_REGION, TEST_SERVICE_ID, TEST_BACKUP_ID),
+            ),
+            metadata=(),
+            retry=None,
+            timeout=None,
+        )
+
+    @mock.patch(DATAPROC_METASTORE_STRING.format("DataprocMetastoreHook.get_dataproc_metastore_client"))
     def test_delete_backup(self, mock_client) -> None:
         self.hook.delete_backup(
             project_id=TEST_PROJECT_ID,


### PR DESCRIPTION
Found during #19891 fixing (yay! MyPy actually found some real errors).

The `get_backup` method was missing in Dataproc Metastore
implementation.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
