### PR TITLE
Fixing MyPy issues inside airflow/secrets and airflow/security

### DIFF
--- a/airflow/secrets/local_filesystem.py
+++ b/airflow/secrets/local_filesystem.py
@@ -114,7 +114,8 @@ def _parse_yaml_file(file_path: str) -> Tuple[Dict[str, List[str]], List[FileSyn
         secrets = yaml.safe_load(content)
 
     except yaml.MarkedYAMLError as e:
-        return {}, [FileSyntaxError(line_no=e.problem_mark.line, message=str(e))]
+        err_line_no = e.problem_mark.line if e.problem_mark else -1
+        return {}, [FileSyntaxError(line_no=err_line_no, message=str(e))]
     if not isinstance(secrets, dict):
         return {}, [FileSyntaxError(line_no=1, message="The file should contain the object.")]
 

--- a/airflow/security/kerberos.py
+++ b/airflow/security/kerberos.py
@@ -114,7 +114,7 @@ def renew_from_kt(principal: Optional[str], keytab: str, exit_on_fail: bool = Tr
         # (From: HUE-640). Kerberos clock have seconds level granularity. Make sure we
         # renew the ticket after the initial valid time.
         time.sleep(1.5)
-        ret = perform_krb181_workaround(principal)
+        ret = perform_krb181_workaround(cmd_principal)
         if exit_on_fail and ret != 0:
             sys.exit(ret)
         else:


### PR DESCRIPTION
Part of: #19891
- Since `yaml.MarkedYAMLError.problem_mark` attribute is optional and can be `None` this check will ensure it will not fail to access `line` attribute of `problem_mark`
- `principal` parameter of the renew_from_kt is Optional. Later code takes care of it by fetching the default principal from settings but this part is still referring to parameter value.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
