### PR TITLE
DbApiHook class bug  （if elif Conditional Branching）

### DIFF
--- a/airflow/hooks/dbapi.py
+++ b/airflow/hooks/dbapi.py
@@ -71,14 +71,15 @@ class DbApiHook(BaseHook):
 
     def __init__(self, *args, schema: Optional[str] = None, **kwargs):
         super().__init__()
-        if not self.conn_name_attr:
-            raise AirflowException("conn_name_attr is not defined")
-        elif len(args) == 1:
+        if len(args) == 1:
             setattr(self, self.conn_name_attr, args[0])
         elif self.conn_name_attr not in kwargs:
             setattr(self, self.conn_name_attr, self.default_conn_name)
         else:
             setattr(self, self.conn_name_attr, kwargs[self.conn_name_attr])
+            
+        if not self.conn_name_attr:
+            raise AirflowException("conn_name_attr is not defined")
         # We should not make schema available in deriving hooks for backwards compatibility
         # If a hook deriving from DBApiHook has a need to access schema, then it should retrieve it
         # from kwargs and store it on its own. We do not run "pop" here as we want to give the


### PR DESCRIPTION
DbApiHook class instantiation method, using the if branch first use not to determine the bool of self.conn_name_attr inversion, and then elif branch to execute setattr so that the property is assigned to self, then the problem is that if the elif branch is not executed first, the if branch will always be executed first, because if the value of None is True, then the elif branch will not be executed, this is a logic error, I found it in the process of use, please adopt, thank you!

DbApiHook 类的实例化方法 ，使用if条件分支 先使用not  判断self.conn_name_attr 反转的bool，再elif分支执行setattr 使 属性 赋值给self，那么问题是 如果不先执行elif分支， if分支永远是先执行的，  因为if None 的值为True，那么elif分支将不执行，这是一个逻辑错误，我是在使用过程中发现的，请采纳，谢谢