### PR TITLE
Fix inconsitencies in checking edit permissions for a DAG

### DIFF
--- a/airflow/www/security.py
+++ b/airflow/www/security.py
@@ -322,8 +322,8 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
         if user.is_anonymous:
             roles = user.roles
         else:
-            if (permissions.ACTION_CAN_EDIT in user_actions and self.can_edit_all_dags()) or (
-                permissions.ACTION_CAN_READ in user_actions and self.can_read_all_dags()
+            if (permissions.ACTION_CAN_EDIT in user_actions and self.can_edit_all_dags(user)) or (
+                permissions.ACTION_CAN_READ in user_actions and self.can_read_all_dags(user)
             ):
                 return {dag.dag_id for dag in session.query(DagModel.dag_id)}
             user_query = (
@@ -441,17 +441,17 @@ class AirflowSecurityManager(SecurityManager, LoggingMixin):
             user = g.user
         return (
             self._has_role(["Admin", "Viewer", "Op", "User"], user)
-            or self.can_read_all_dags()
-            or self.can_edit_all_dags()
+            or self.can_read_all_dags(user)
+            or self.can_edit_all_dags(user)
         )
 
-    def can_edit_all_dags(self):
+    def can_edit_all_dags(self, user=None):
         """Has can_edit action on DAG resource"""
-        return self.has_access(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG)
+        return self.has_access(permissions.ACTION_CAN_EDIT, permissions.RESOURCE_DAG, user)
 
-    def can_read_all_dags(self):
+    def can_read_all_dags(self, user=None):
         """Has can_read action on DAG resource"""
-        return self.has_access(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG)
+        return self.has_access(permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG, user)
 
     def clean_perms(self):
         """FAB leaves faulty permissions that need to be cleaned up"""

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -109,6 +109,31 @@ def client_single_dag(app, user_single_dag):
     )
 
 
+@pytest.fixture(scope="module")
+def user_single_dag_edit(app):
+    """Create User that can edit DAG resource only a single DAG"""
+    return create_user(
+        app,
+        username="user_single_dag_edit",
+        role_name="role_single_dag",
+        permissions=[
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE),
+            (permissions.ACTION_CAN_READ, permissions.RESOURCE_DAG),
+            (permissions.ACTION_CAN_EDIT, permissions.resource_name_for_dag("filter_test_1")),
+        ],
+    )
+
+
+@pytest.fixture()
+def client_single_dag_edit(app, user_single_dag_edit):
+    """Client for User that can only edit the first DAG from TEST_FILTER_DAG_IDS"""
+    return client_with_login(
+        app,
+        username="user_single_dag_edit",
+        password="user_single_dag_edit",
+    )
+
+
 TEST_FILTER_DAG_IDS = ["filter_test_1", "filter_test_2", "a_first_dag_id_asc", "filter.test"]
 TEST_TAGS = ["example", "test", "team", "group"]
 
@@ -192,6 +217,17 @@ def test_home_dag_list_search(working_dags, user_client):
     check_content_in_response("dag_id=filter_test_2", resp)
     check_content_not_in_response("dag_id=filter.test", resp)
     check_content_not_in_response("dag_id=a_first_dag_id_asc", resp)
+
+
+def test_home_dag_edit_permissions(capture_templates, working_dags, client_single_dag_edit):
+    with capture_templates() as templates:
+        client_single_dag_edit.get('home', follow_redirects=True)
+
+    dags = templates[0].local_context['dags']
+    assert len(dags) > 0
+    dag_edit_perm_tuple = [(dag.dag_id, dag.can_edit) for dag in dags]
+    assert ("filter_test_1", True) in dag_edit_perm_tuple
+    assert ("filter_test_2", False) in dag_edit_perm_tuple
 
 
 def test_home_robots_header_in_response(user_client):

--- a/tests/www/views/test_views_home.py
+++ b/tests/www/views/test_views_home.py
@@ -221,9 +221,9 @@ def test_home_dag_list_search(working_dags, user_client):
 
 def test_home_dag_edit_permissions(capture_templates, working_dags, client_single_dag_edit):
     with capture_templates() as templates:
-        client_single_dag_edit.get('home', follow_redirects=True)
+        client_single_dag_edit.get("home", follow_redirects=True)
 
-    dags = templates[0].local_context['dags']
+    dags = templates[0].local_context["dags"]
     assert len(dags) > 0
     dag_edit_perm_tuple = [(dag.dag_id, dag.can_edit) for dag in dags]
     assert ("filter_test_1", True) in dag_edit_perm_tuple


### PR DESCRIPTION
We were short-circuting permission in the views instead of letting the security manager handle that. A user will find it inconsistent as the Graph and other views check "per-dag" permissions via https://github.com/apache/airflow/blob/174681911f96f17d41a4f560ca08d5e200944f7f/airflow/www/views.py#L579

so if someone uses Custom Security Manager that will end up with user not being able to "pause" DAG from individual dag page but would be able to do so from Homepage. This PR fixes this inconsistency and gives back this responsibility of permissions to security manager instead if Views.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
