### PR TITLE
Move source_objects datatype check out of GCSToBigQueryOperator.__init__

### DIFF
--- a/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -216,7 +216,7 @@ class GCSToBigQueryOperator(BaseOperator):
         if time_partitioning is None:
             time_partitioning = {}
         self.bucket = bucket
-        self.source_objects = source_objects if isinstance(source_objects, list) else [source_objects]
+        self.source_objects = source_objects
         self.schema_object = schema_object
 
         # BQ config
@@ -279,6 +279,9 @@ class GCSToBigQueryOperator(BaseOperator):
         else:
             schema_fields = self.schema_fields
 
+        self.source_objects = (
+            self.source_objects if isinstance(self.source_objects, list) else [self.source_objects]
+        )
         source_uris = [f'gs://{self.bucket}/{source_object}' for source_object in self.source_objects]
         conn = bq_hook.get_conn()
         cursor = conn.cursor()


### PR DESCRIPTION
Closes: #20333

Currently there is a datatype check on `source_objects` within the `GCSToBigQueryOperator.__init__()` method. This is a template field for the operator. If a user tries to pass in an `XCom` value that will be rendered as a list (i.e. `render_template_as_native_obj=True` at the DAG level), the datatype check incorrectly assumes the value is a string and wraps the value in a list. When the `XCom` value is then rendered during `execute()` the value becomes a `List[List]` instead of the desired `List` type. 

Moving this datatype check into the `execute()` method of the operator will allow any template rendering to occur before the check is performed.

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
