### PR TITLE
Fix Scheduler crash when executing task instances of missing DAG

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -410,7 +410,9 @@ class SchedulerJob(BaseJob):
                             dag_id,
                             task_instance,
                         )
-                        task_instance.set_state(State.FAILED, session=session)
+                        session.query(TI).filter(TI.dag_id == dag_id, TI.state == State.SCHEDULED).update(
+                            {TI.state: State.NONE}, synchronize_session='fetch'
+                        )
                         continue
                     if serialized_dag.has_task(task_instance.task_id):
                         task_concurrency_limit = serialized_dag.get_task(

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -411,7 +411,7 @@ class SchedulerJob(BaseJob):
                             task_instance,
                         )
                         session.query(TI).filter(TI.dag_id == dag_id, TI.state == State.SCHEDULED).update(
-                            {TI.state: State.NONE}, synchronize_session='fetch'
+                            {TI.state: State.FAILED}, synchronize_session='fetch'
                         )
                         continue
                     if serialized_dag.has_task(task_instance.task_id):

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -316,6 +316,15 @@ class SchedulerJob(BaseJob):
 
         pool_to_task_instances: DefaultDict[str, List[models.Pool]] = defaultdict(list)
         for task_instance in task_instances_to_examine:
+            # If the dag is no longer in the dagbag, don't bother
+            if not self.dagbag.get_dag(task_instance.dag_id, session=session):
+                self.log.error(
+                    "DAG '%s' for taskinstance %s not found in serialized_dag table",
+                    task_instance.dag_id,
+                    task_instance,
+                )
+                continue
+
             pool_to_task_instances[task_instance.pool].append(task_instance)
 
         # dag_id to # of running tasks and (dag_id, task_id) to # of running tasks.
@@ -403,6 +412,15 @@ class SchedulerJob(BaseJob):
                     # Many dags don't have a task_concurrency, so where we can avoid loading the full
                     # serialized DAG the better.
                     serialized_dag = self.dagbag.get_dag(dag_id, session=session)
+                    # This check below may not be necessary because we have handled it before,
+                    # but it's better to be safe than sorry.
+                    if not serialized_dag:
+                        self.log.error(
+                            "DAG '%s' for taskinstance %s not found in serialized_dag table",
+                            dag_id,
+                            task_instance,
+                        )
+                        continue
                     if serialized_dag.has_task(task_instance.task_id):
                         task_concurrency_limit = serialized_dag.get_task(
                             task_instance.task_id

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -403,13 +403,14 @@ class SchedulerJob(BaseJob):
                     # Many dags don't have a task_concurrency, so where we can avoid loading the full
                     # serialized DAG the better.
                     serialized_dag = self.dagbag.get_dag(dag_id, session=session)
-                    # If the dag is missing, continue to the next task.
+                    # If the dag is missing, fail the task and continue to the next task.
                     if not serialized_dag:
                         self.log.error(
                             "DAG '%s' for task instance %s not found in serialized_dag table",
                             dag_id,
                             task_instance,
                         )
+                        task_instance.set_state(State.FAILED, session=session)
                         continue
                     if serialized_dag.has_task(task_instance.task_id):
                         task_concurrency_limit = serialized_dag.get_task(

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -406,7 +406,7 @@ class SchedulerJob(BaseJob):
                     # If the dag is missing, continue to the next task.
                     if not serialized_dag:
                         self.log.error(
-                            "DAG '%s' for taskinstance %s not found in serialized_dag table",
+                            "DAG '%s' for task instance %s not found in serialized_dag table",
                             dag_id,
                             task_instance,
                         )

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -648,7 +648,7 @@ class TestSchedulerJob:
     def test_executable_task_instances_to_queued_fails_task_for_missing_dag_in_dagbag(
         self, dag_maker, session
     ):
-        """Only check concurrency for dag in dagbag"""
+        """Check that task instances of missing DAGs are failed"""
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_in_dagbag'
         task_id_1 = 'dummy'
         task_id_2 = 'dummydummy'

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -671,7 +671,7 @@ class TestSchedulerJob:
         assert 0 == len(res)
         tis = dr.get_task_instances(session=session)
         assert len(tis) == 2
-        assert all(ti.state == State.NONE for ti in tis)
+        assert all(ti.state == State.FAILED for ti in tis)
 
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -645,6 +645,34 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
+    def test_executable_task_instances_to_queued_logs_for_missing_dag_in_dagbag(
+        self, dag_maker, caplog, session
+    ):
+        """If DAG is no longer in dagbag, do not execute"""
+        dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_in_dagbag'
+        task_id_1 = 'dummy'
+        task_id_2 = 'dummydummy'
+
+        with dag_maker(dag_id=dag_id, session=session):
+            DummyOperator(task_id=task_id_1)
+            DummyOperator(task_id=task_id_2)
+
+        self.scheduler_job = SchedulerJob(subdir=os.devnull)
+        self.scheduler_job.dagbag = mock.MagicMock()
+        self.scheduler_job.dagbag.get_dag.return_value = None
+
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+
+        tis = dr.task_instances
+        for ti in tis:
+            ti.state = State.SCHEDULED
+            session.merge(ti)
+        session.flush()
+        res = self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session)
+        session.flush()
+        assert 0 == len(res)
+        assert f"DAG '{dag_id}' for taskinstance {tis[0]} not found in serialized_dag table" in caplog.text
+
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'
         with dag_maker(dag_id=dag_id, max_active_tasks=16):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -645,8 +645,8 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_executable_task_instances_to_queued_logs_for_missing_dag_in_dagbag(
-        self, dag_maker, caplog, session
+    def test_executable_task_instances_to_queued_fails_task_for_missing_dag_in_dagbag(
+        self, dag_maker, session
     ):
         """Only check concurrency for dag in dagbag"""
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_in_dagbag'
@@ -671,7 +671,7 @@ class TestSchedulerJob:
         res = self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session)
         session.flush()
         assert 0 == len(res)
-        assert f"DAG '{dag_id}' for taskinstance {tis[0]} not found in serialized_dag table" in caplog.text
+        assert session.query(TaskInstance).filter(TaskInstance.state == State.FAILED).count() == 2
 
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -648,12 +648,12 @@ class TestSchedulerJob:
     def test_executable_task_instances_to_queued_logs_for_missing_dag_in_dagbag(
         self, dag_maker, caplog, session
     ):
-        """If DAG is no longer in dagbag, do not execute"""
+        """Only check concurrency for dag in dagbag"""
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_in_dagbag'
         task_id_1 = 'dummy'
         task_id_2 = 'dummydummy'
 
-        with dag_maker(dag_id=dag_id, session=session):
+        with dag_maker(dag_id=dag_id, session=session, default_args={"max_active_tis_per_dag": 1}):
             DummyOperator(task_id=task_id_1)
             DummyOperator(task_id=task_id_2)
 

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -645,9 +645,7 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_queued_task_instances_fails_with_missing_dag(
-        self, dag_maker, session
-    ):
+    def test_queued_task_instances_fails_with_missing_dag(self, dag_maker, session):
         """Check that task instances of missing DAGs are failed"""
         dag_id = 'SchedulerJobTest.test_find_executable_task_instances_not_in_dagbag'
         task_id_1 = 'dummy'
@@ -673,7 +671,7 @@ class TestSchedulerJob:
         assert 0 == len(res)
         tis = dr.get_task_instances(session=session)
         assert len(tis) == 2
-        assert all(ti.state == State.FAILED for ti in tis)
+        assert all(ti.state == State.NONE for ti in tis)
 
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -671,7 +671,9 @@ class TestSchedulerJob:
         res = self.scheduler_job._executable_task_instances_to_queued(max_tis=32, session=session)
         session.flush()
         assert 0 == len(res)
-        assert session.query(TaskInstance).filter(TaskInstance.state == State.FAILED).count() == 2
+        tis = dr.get_task_instances(session=session)
+        for ti in tis:
+            assert ti.state == State.FAILED
 
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -645,7 +645,7 @@ class TestSchedulerJob:
         session.rollback()
         session.close()
 
-    def test_executable_task_instances_to_queued_fails_task_for_missing_dag_in_dagbag(
+    def test_queued_task_instances_fails_with_missing_dag(
         self, dag_maker, session
     ):
         """Check that task instances of missing DAGs are failed"""
@@ -672,8 +672,8 @@ class TestSchedulerJob:
         session.flush()
         assert 0 == len(res)
         tis = dr.get_task_instances(session=session)
-        for ti in tis:
-            assert ti.state == State.FAILED
+        assert len(tis) == 2
+        assert all(ti.state == State.FAILED for ti in tis)
 
     def test_nonexistent_pool(self, dag_maker):
         dag_id = 'SchedulerJobTest.test_nonexistent_pool'


### PR DESCRIPTION
When executing task instances, we do not check if the dag is missing in
the dagbag. This PR fixes it by ignoring task instances if we can't find
the dag in serialized dag table

Closes: https://github.com/apache/airflow/issues/20099


---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
