### PR TITLE
Standardize AWS EKS naming

### DIFF
--- a/airflow/providers/amazon/aws/example_dags/example_eks_templated.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_templated.py
@@ -19,13 +19,13 @@ from datetime import datetime
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, NodegroupStates
 from airflow.providers.amazon.aws.operators.eks import (
-    EKSCreateClusterOperator,
-    EKSCreateNodegroupOperator,
-    EKSDeleteClusterOperator,
-    EKSDeleteNodegroupOperator,
-    EKSPodOperator,
+    EksCreateClusterOperator,
+    EksCreateNodegroupOperator,
+    EksDeleteClusterOperator,
+    EksDeleteNodegroupOperator,
+    EksPodOperator,
 )
-from airflow.providers.amazon.aws.sensors.eks import EKSClusterStateSensor, EKSNodegroupStateSensor
+from airflow.providers.amazon.aws.sensors.eks import EksClusterStateSensor, EksNodegroupStateSensor
 
 # Example Jinja Template format, substitute your values:
 """
@@ -56,32 +56,32 @@ with DAG(
 ) as dag:
 
     # Create an Amazon EKS Cluster control plane without attaching a compute service.
-    create_cluster = EKSCreateClusterOperator(
+    create_cluster = EksCreateClusterOperator(
         task_id='create_eks_cluster',
         compute=None,
         cluster_role_arn="{{ dag_run.conf['cluster_role_arn'] }}",
         resources_vpc_config="{{ dag_run.conf['resources_vpc_config'] }}",
     )
 
-    await_create_cluster = EKSClusterStateSensor(
+    await_create_cluster = EksClusterStateSensor(
         task_id='wait_for_create_cluster',
         target_state=ClusterStates.ACTIVE,
     )
 
-    create_nodegroup = EKSCreateNodegroupOperator(
+    create_nodegroup = EksCreateNodegroupOperator(
         task_id='create_eks_nodegroup',
         nodegroup_name="{{ dag_run.conf['nodegroup_name'] }}",
         nodegroup_subnets="{{ dag_run.conf['nodegroup_subnets'] }}",
         nodegroup_role_arn="{{ dag_run.conf['nodegroup_role_arn'] }}",
     )
 
-    await_create_nodegroup = EKSNodegroupStateSensor(
+    await_create_nodegroup = EksNodegroupStateSensor(
         task_id='wait_for_create_nodegroup',
         nodegroup_name="{{ dag_run.conf['nodegroup_name'] }}",
         target_state=NodegroupStates.ACTIVE,
     )
 
-    start_pod = EKSPodOperator(
+    start_pod = EksPodOperator(
         task_id="run_pod",
         pod_name="run_pod",
         image="amazon/aws-cli:latest",
@@ -92,22 +92,22 @@ with DAG(
         is_delete_operator_pod=True,
     )
 
-    delete_nodegroup = EKSDeleteNodegroupOperator(
+    delete_nodegroup = EksDeleteNodegroupOperator(
         task_id='delete_eks_nodegroup',
         nodegroup_name="{{ dag_run.conf['nodegroup_name'] }}",
     )
 
-    await_delete_nodegroup = EKSNodegroupStateSensor(
+    await_delete_nodegroup = EksNodegroupStateSensor(
         task_id='wait_for_delete_nodegroup',
         nodegroup_name="{{ dag_run.conf['nodegroup_name'] }}",
         target_state=NodegroupStates.NONEXISTENT,
     )
 
-    delete_cluster = EKSDeleteClusterOperator(
+    delete_cluster = EksDeleteClusterOperator(
         task_id='delete_eks_cluster',
     )
 
-    await_delete_cluster = EKSClusterStateSensor(
+    await_delete_cluster = EksClusterStateSensor(
         task_id='wait_for_delete_cluster',
         target_state=ClusterStates.NONEXISTENT,
     )

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroup_in_one_step.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroup_in_one_step.py
@@ -20,11 +20,11 @@ from os import environ
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, NodegroupStates
 from airflow.providers.amazon.aws.operators.eks import (
-    EKSCreateClusterOperator,
-    EKSDeleteClusterOperator,
-    EKSPodOperator,
+    EksCreateClusterOperator,
+    EksDeleteClusterOperator,
+    EksPodOperator,
 )
-from airflow.providers.amazon.aws.sensors.eks import EKSClusterStateSensor, EKSNodegroupStateSensor
+from airflow.providers.amazon.aws.sensors.eks import EksClusterStateSensor, EksNodegroupStateSensor
 
 CLUSTER_NAME = environ.get('EKS_CLUSTER_NAME', 'eks-demo')
 NODEGROUP_NAME = f'{CLUSTER_NAME}-nodegroup'
@@ -49,7 +49,7 @@ with DAG(
 
     # [START howto_operator_eks_create_cluster_with_nodegroup]
     # Create an Amazon EKS cluster control plane and an EKS nodegroup compute platform in one step.
-    create_cluster_and_nodegroup = EKSCreateClusterOperator(
+    create_cluster_and_nodegroup = EksCreateClusterOperator(
         task_id='create_eks_cluster_and_nodegroup',
         nodegroup_name=NODEGROUP_NAME,
         cluster_role_arn=ROLE_ARN,
@@ -62,13 +62,13 @@ with DAG(
     )
     # [END howto_operator_eks_create_cluster_with_nodegroup]
 
-    await_create_nodegroup = EKSNodegroupStateSensor(
+    await_create_nodegroup = EksNodegroupStateSensor(
         task_id='wait_for_create_nodegroup',
         nodegroup_name=NODEGROUP_NAME,
         target_state=NodegroupStates.ACTIVE,
     )
 
-    start_pod = EKSPodOperator(
+    start_pod = EksPodOperator(
         task_id="run_pod",
         pod_name="run_pod",
         image="amazon/aws-cli:latest",
@@ -82,10 +82,10 @@ with DAG(
     # [START howto_operator_eks_force_delete_cluster]
     # An Amazon EKS cluster can not be deleted with attached resources such as nodegroups or Fargate profiles.
     # Setting the `force` to `True` will delete any attached resources before deleting the cluster.
-    delete_all = EKSDeleteClusterOperator(task_id='delete_nodegroup_and_cluster', force_delete_compute=True)
+    delete_all = EksDeleteClusterOperator(task_id='delete_nodegroup_and_cluster', force_delete_compute=True)
     # [END howto_operator_eks_force_delete_cluster]
 
-    await_delete_cluster = EKSClusterStateSensor(
+    await_delete_cluster = EksClusterStateSensor(
         task_id='wait_for_delete_cluster',
         target_state=ClusterStates.NONEXISTENT,
     )

--- a/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
+++ b/airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
@@ -20,13 +20,13 @@ from os import environ
 from airflow.models.dag import DAG
 from airflow.providers.amazon.aws.hooks.eks import ClusterStates, NodegroupStates
 from airflow.providers.amazon.aws.operators.eks import (
-    EKSCreateClusterOperator,
-    EKSCreateNodegroupOperator,
-    EKSDeleteClusterOperator,
-    EKSDeleteNodegroupOperator,
-    EKSPodOperator,
+    EksCreateClusterOperator,
+    EksCreateNodegroupOperator,
+    EksDeleteClusterOperator,
+    EksDeleteNodegroupOperator,
+    EksPodOperator,
 )
-from airflow.providers.amazon.aws.sensors.eks import EKSClusterStateSensor, EKSNodegroupStateSensor
+from airflow.providers.amazon.aws.sensors.eks import EksClusterStateSensor, EksNodegroupStateSensor
 
 CLUSTER_NAME = 'eks-demo'
 NODEGROUP_SUFFIX = '-nodegroup'
@@ -52,7 +52,7 @@ with DAG(
 
     # [START howto_operator_eks_create_cluster]
     # Create an Amazon EKS Cluster control plane without attaching a compute service.
-    create_cluster = EKSCreateClusterOperator(
+    create_cluster = EksCreateClusterOperator(
         task_id='create_eks_cluster',
         cluster_role_arn=ROLE_ARN,
         resources_vpc_config=VPC_CONFIG,
@@ -60,13 +60,13 @@ with DAG(
     )
     # [END howto_operator_eks_create_cluster]
 
-    await_create_cluster = EKSClusterStateSensor(
+    await_create_cluster = EksClusterStateSensor(
         task_id='wait_for_create_cluster',
         target_state=ClusterStates.ACTIVE,
     )
 
     # [START howto_operator_eks_create_nodegroup]
-    create_nodegroup = EKSCreateNodegroupOperator(
+    create_nodegroup = EksCreateNodegroupOperator(
         task_id='create_eks_nodegroup',
         nodegroup_name=NODEGROUP_NAME,
         nodegroup_subnets=SUBNETS,
@@ -74,14 +74,14 @@ with DAG(
     )
     # [END howto_operator_eks_create_nodegroup]
 
-    await_create_nodegroup = EKSNodegroupStateSensor(
+    await_create_nodegroup = EksNodegroupStateSensor(
         task_id='wait_for_create_nodegroup',
         nodegroup_name=NODEGROUP_NAME,
         target_state=NodegroupStates.ACTIVE,
     )
 
     # [START howto_operator_eks_pod_operator]
-    start_pod = EKSPodOperator(
+    start_pod = EksPodOperator(
         task_id="run_pod",
         pod_name="run_pod",
         image="amazon/aws-cli:latest",
@@ -94,22 +94,22 @@ with DAG(
     # [END howto_operator_eks_pod_operator]
 
     # [START howto_operator_eks_delete_nodegroup]
-    delete_nodegroup = EKSDeleteNodegroupOperator(
+    delete_nodegroup = EksDeleteNodegroupOperator(
         task_id='delete_eks_nodegroup', nodegroup_name=NODEGROUP_NAME
     )
     # [END howto_operator_eks_delete_nodegroup]
 
-    await_delete_nodegroup = EKSNodegroupStateSensor(
+    await_delete_nodegroup = EksNodegroupStateSensor(
         task_id='wait_for_delete_nodegroup',
         nodegroup_name=NODEGROUP_NAME,
         target_state=NodegroupStates.NONEXISTENT,
     )
 
     # [START howto_operator_eks_delete_cluster]
-    delete_cluster = EKSDeleteClusterOperator(task_id='delete_eks_cluster')
+    delete_cluster = EksDeleteClusterOperator(task_id='delete_eks_cluster')
     # [END howto_operator_eks_delete_cluster]
 
-    await_delete_cluster = EKSClusterStateSensor(
+    await_delete_cluster = EksClusterStateSensor(
         task_id='wait_for_delete_cluster',
         target_state=ClusterStates.NONEXISTENT,
     )

--- a/airflow/providers/amazon/aws/hooks/eks.py
+++ b/airflow/providers/amazon/aws/hooks/eks.py
@@ -75,7 +75,7 @@ class NodegroupStates(Enum):
     NONEXISTENT = "NONEXISTENT"
 
 
-class EKSHook(AwsBaseHook):
+class EksHook(AwsBaseHook):
     """
     Interact with Amazon EKS, using the boto3 library.
 
@@ -644,3 +644,18 @@ class EKSHook(AwsBaseHook):
 
         # remove any base64 encoding padding:
         return 'k8s-aws-v1.' + base64_url.rstrip("=")
+
+
+class EKSHook(EksHook):
+    """
+    This hook is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.hooks.eks.EksHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This hook is deprecated. " "Please use `airflow.providers.amazon.aws.hooks.eks.EksHook`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -218,7 +218,7 @@ class EksCreateNodegroupOperator(BaseOperator):
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSCreateNodegroupOperator`
+        :ref:`howto/operator:EksCreateNodegroupOperator`
 
     :param cluster_name: The name of the Amazon EKS Cluster to create the managed nodegroup in. (templated)
     :type cluster_name: str

--- a/airflow/providers/amazon/aws/operators/eks.py
+++ b/airflow/providers/amazon/aws/operators/eks.py
@@ -22,7 +22,7 @@ from typing import Dict, Iterable, List, Optional
 
 from airflow import AirflowException
 from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EKSHook, FargateProfileStates
+from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EksHook, FargateProfileStates
 from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
 
 CHECK_INTERVAL_SECONDS = 15
@@ -44,7 +44,7 @@ NODEGROUP_FULL_NAME = 'Amazon EKS managed node groups'
 FARGATE_FULL_NAME = 'AWS Fargate profiles'
 
 
-class EKSCreateClusterOperator(BaseOperator):
+class EksCreateClusterOperator(BaseOperator):
     """
     Creates an Amazon EKS Cluster control plane.
 
@@ -52,18 +52,18 @@ class EKSCreateClusterOperator(BaseOperator):
 
      - If argument 'compute' is provided with a value of 'nodegroup', will also
          attempt to create an Amazon EKS Managed Nodegroup for the cluster.
-         See :class:`~airflow.providers.amazon.aws.operators.EKSCreateNodegroupOperator`
+         See :class:`~airflow.providers.amazon.aws.operators.EksCreateNodegroupOperator`
          documentation for requirements.
 
     -  If argument 'compute' is provided with a value of 'fargate', will also attempt to create an AWS
          Fargate profile for the cluster.
-         See :class:`~airflow.providers.amazon.aws.operators.EKSCreateFargateProfileOperator`
+         See :class:`~airflow.providers.amazon.aws.operators.EksCreateFargateProfileOperator`
          documentation for requirements.
 
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSCreateClusterOperator`
+        :ref:`howto/operator:EksCreateClusterOperator`
 
     :param cluster_name: The unique name to give to your Amazon EKS Cluster. (templated)
     :type cluster_name: str
@@ -162,7 +162,7 @@ class EKSCreateClusterOperator(BaseOperator):
         super().__init__(**kwargs)
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -212,7 +212,7 @@ class EKSCreateClusterOperator(BaseOperator):
             )
 
 
-class EKSCreateNodegroupOperator(BaseOperator):
+class EksCreateNodegroupOperator(BaseOperator):
     """
     Creates an Amazon EKS managed node group for an existing Amazon EKS Cluster.
 
@@ -270,7 +270,7 @@ class EKSCreateNodegroupOperator(BaseOperator):
         super().__init__(**kwargs)
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -283,13 +283,13 @@ class EKSCreateNodegroupOperator(BaseOperator):
         )
 
 
-class EKSCreateFargateProfileOperator(BaseOperator):
+class EksCreateFargateProfileOperator(BaseOperator):
     """
     Creates an AWS Fargate profile for an Amazon EKS cluster.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSCreateFargateProfileOperator`
+        :ref:`howto/operator:EksCreateFargateProfileOperator`
 
     :param cluster_name: The name of the Amazon EKS cluster to apply the AWS Fargate profile to. (templated)
     :type cluster_name: str
@@ -340,7 +340,7 @@ class EKSCreateFargateProfileOperator(BaseOperator):
         super().__init__(**kwargs)
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -353,13 +353,13 @@ class EKSCreateFargateProfileOperator(BaseOperator):
         )
 
 
-class EKSDeleteClusterOperator(BaseOperator):
+class EksDeleteClusterOperator(BaseOperator):
     """
     Deletes the Amazon EKS Cluster control plane and all nodegroups attached to it.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSDeleteClusterOperator`
+        :ref:`howto/operator:EksDeleteClusterOperator`
 
     :param cluster_name: The name of the Amazon EKS Cluster to delete. (templated)
     :type cluster_name: str
@@ -400,7 +400,7 @@ class EKSDeleteClusterOperator(BaseOperator):
         super().__init__(**kwargs)
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -478,13 +478,13 @@ class EKSDeleteClusterOperator(BaseOperator):
         self.log.info(SUCCESS_MSG.format(compute=FARGATE_FULL_NAME))
 
 
-class EKSDeleteNodegroupOperator(BaseOperator):
+class EksDeleteNodegroupOperator(BaseOperator):
     """
     Deletes an Amazon EKS managed node group from an Amazon EKS Cluster.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSDeleteNodegroupOperator`
+        :ref:`howto/operator:EksDeleteNodegroupOperator`
 
     :param cluster_name: The name of the Amazon EKS Cluster associated with your nodegroup. (templated)
     :type cluster_name: str
@@ -524,7 +524,7 @@ class EKSDeleteNodegroupOperator(BaseOperator):
         super().__init__(**kwargs)
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -532,13 +532,13 @@ class EKSDeleteNodegroupOperator(BaseOperator):
         eks_hook.delete_nodegroup(clusterName=self.cluster_name, nodegroupName=self.nodegroup_name)
 
 
-class EKSDeleteFargateProfileOperator(BaseOperator):
+class EksDeleteFargateProfileOperator(BaseOperator):
     """
     Deletes an AWS Fargate profile from an Amazon EKS Cluster.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSDeleteFargateProfileOperator`
+        :ref:`howto/operator:EksDeleteFargateProfileOperator`
 
     :param cluster_name: The name of the Amazon EKS cluster associated with your Fargate profile. (templated)
     :type cluster_name: str
@@ -577,7 +577,7 @@ class EKSDeleteFargateProfileOperator(BaseOperator):
         self.region = region
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -587,13 +587,13 @@ class EKSDeleteFargateProfileOperator(BaseOperator):
         )
 
 
-class EKSPodOperator(KubernetesPodOperator):
+class EksPodOperator(KubernetesPodOperator):
     """
     Executes a task in a Kubernetes pod on the specified Amazon EKS Cluster.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
-        :ref:`howto/operator:EKSPodOperator`
+        :ref:`howto/operator:EksPodOperator`
 
     :param cluster_name: The name of the Amazon EKS Cluster to execute the task on. (templated)
     :type cluster_name: str
@@ -678,12 +678,12 @@ class EKSPodOperator(KubernetesPodOperator):
                 stacklevel=2,
             )
         # There is no need to manage the kube_config file, as it will be generated automatically.
-        # All Kubernetes parameters (except config_file) are also valid for the EKSPodOperator.
+        # All Kubernetes parameters (except config_file) are also valid for the EksPodOperator.
         if self.config_file:
-            raise AirflowException("The config_file is not an allowed parameter for the EKSPodOperator.")
+            raise AirflowException("The config_file is not an allowed parameter for the EksPodOperator.")
 
     def execute(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -691,3 +691,115 @@ class EKSPodOperator(KubernetesPodOperator):
             eks_cluster_name=self.cluster_name, pod_namespace=self.namespace
         ) as self.config_file:
             return super().execute(context)
+
+
+class EKSCreateClusterOperator(EksCreateClusterOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksCreateClusterOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksCreateClusterOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSCreateNodegroupOperator(EksCreateNodegroupOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksCreateNodegroupOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksCreateNodegroupOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSCreateFargateProfileOperator(EksCreateFargateProfileOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksCreateFargateProfileOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksCreateFargateProfileOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSDeleteClusterOperator(EksDeleteClusterOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksDeleteClusterOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksDeleteClusterOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSDeleteNodegroupOperator(EksDeleteNodegroupOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksDeleteNodegroupOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksDeleteNodegroupOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSDeleteFargateProfileOperator(EksDeleteFargateProfileOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksDeleteFargateProfileOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksDeleteFargateProfileOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSPodOperator(EksPodOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.eks.EksPodOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use `airflow.providers.amazon.aws.operators.eks.EksPodOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/sensors/eks.py
+++ b/airflow/providers/amazon/aws/sensors/eks.py
@@ -16,12 +16,13 @@
 # under the License.
 #
 """Tracking the state of Amazon EKS Clusters, Amazon EKS managed node groups, and AWS Fargate profiles."""
+import warnings
 from typing import Optional
 
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.eks import (
     ClusterStates,
-    EKSHook,
+    EksHook,
     FargateProfileStates,
     NodegroupStates,
 )
@@ -51,7 +52,7 @@ UNEXPECTED_TERMINAL_STATE_MSG = (
 )
 
 
-class EKSClusterStateSensor(BaseSensorOperator):
+class EksClusterStateSensor(BaseSensorOperator):
     """
     Check the state of an Amazon EKS Cluster until it reaches the target state or another terminal state.
 
@@ -94,7 +95,7 @@ class EKSClusterStateSensor(BaseSensorOperator):
         super().__init__(**kwargs)
 
     def poke(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -111,7 +112,7 @@ class EKSClusterStateSensor(BaseSensorOperator):
         return cluster_state == self.target_state
 
 
-class EKSFargateProfileStateSensor(BaseSensorOperator):
+class EksFargateProfileStateSensor(BaseSensorOperator):
     """
     Check the state of an AWS Fargate profile until it reaches the target state or another terminal state.
 
@@ -158,7 +159,7 @@ class EKSFargateProfileStateSensor(BaseSensorOperator):
         super().__init__(**kwargs)
 
     def poke(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -177,7 +178,7 @@ class EKSFargateProfileStateSensor(BaseSensorOperator):
         return fargate_profile_state == self.target_state
 
 
-class EKSNodegroupStateSensor(BaseSensorOperator):
+class EksNodegroupStateSensor(BaseSensorOperator):
     """
     Check the state of an EKS managed node group until it reaches the target state or another terminal state.
 
@@ -224,7 +225,7 @@ class EKSNodegroupStateSensor(BaseSensorOperator):
         super().__init__(**kwargs)
 
     def poke(self, context):
-        eks_hook = EKSHook(
+        eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,
         )
@@ -241,3 +242,51 @@ class EKSNodegroupStateSensor(BaseSensorOperator):
                 )
             )
         return nodegroup_state == self.target_state
+
+
+class EKSClusterStateSensor(EksClusterStateSensor):
+    """
+    This sensor is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.sensors.eks.EksClusterStateSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. "
+            "Please use `airflow.providers.amazon.aws.sensors.eks.EksClusterStateSensor`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSFargateProfileStateSensor(EksFargateProfileStateSensor):
+    """
+    This sensor is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.sensors.eks.EksFargateProfileStateSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. "
+            "Please use `airflow.providers.amazon.aws.sensors.eks.EksFargateProfileStateSensor`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
+
+
+class EKSNodegroupStateSensor(EksNodegroupStateSensor):
+    """
+    This sensor is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.sensors.eks.EksNodegroupStateSensor`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This sensor is deprecated. "
+            "Please use `airflow.providers.amazon.aws.sensors.eks.EksNodegroupStateSensor`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/utils/eks_get_token.py
+++ b/airflow/providers/amazon/aws/utils/eks_get_token.py
@@ -19,7 +19,7 @@ import argparse
 import json
 from datetime import datetime, timedelta
 
-from airflow.providers.amazon.aws.hooks.eks import EKSHook
+from airflow.providers.amazon.aws.hooks.eks import EksHook
 
 # Presigned STS urls are valid for 15 minutes, set token expiration to 1 minute before it expires for
 # some cushion
@@ -53,7 +53,7 @@ def get_parser():
 def main():
     parser = get_parser()
     args = parser.parse_args()
-    eks_hook = EKSHook(aws_conn_id=args.aws_conn_id, region_name=args.region_name)
+    eks_hook = EksHook(aws_conn_id=args.aws_conn_id, region_name=args.region_name)
     access_token = eks_hook.fetch_access_token_for_cluster(args.cluster_name)
     access_token_expiration = get_expiration_time()
     exec_credential_object = {

--- a/docs/apache-airflow-providers-amazon/operators/eks.rst
+++ b/docs/apache-airflow-providers-amazon/operators/eks.rst
@@ -34,13 +34,13 @@ Prerequisite Tasks
 Manage Amazon EKS Clusters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _howto/operator:EKSCreateClusterOperator:
+.. _howto/operator:EksCreateClusterOperator:
 
 Create an Amazon EKS Cluster
 """"""""""""""""""""""""""""
 
 To create an Amazon EKS Cluster you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSCreateClusterOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksCreateClusterOperator`.
 
 Note: An AWS IAM role with the following permissions is required:
   ``eks.amazonaws.com`` must be added to the Trusted Relationships
@@ -51,13 +51,13 @@ Note: An AWS IAM role with the following permissions is required:
     :start-after: [START howto_operator_eks_create_cluster]
     :end-before: [END howto_operator_eks_create_cluster]
 
-.. _howto/operator:EKSDeleteClusterOperator:
+.. _howto/operator:EksDeleteClusterOperator:
 
 Delete an Amazon EKS Cluster
 """"""""""""""""""""""""""""
 
 To delete an existing Amazon EKS Cluster you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSDeleteClusterOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksDeleteClusterOperator`.
 
 .. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
     :language: python
@@ -77,13 +77,13 @@ Note: If the cluster has any attached resources, such as an Amazon EKS Nodegroup
 Manage Amazon EKS Managed Nodegroups
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _howto/operator:EKSCreateNodegroupOperator:
+.. _howto/operator:EksCreateNodegroupOperator:
 
 Create an Amazon EKS Managed NodeGroup
 """"""""""""""""""""""""""""""""""""""
 
 To create an Amazon EKS Managed Nodegroup you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSCreateNodegroupOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksCreateNodegroupOperator`.
 
 Note:  An AWS IAM role with the following permissions is required:
   ``ec2.amazon.aws.com`` must be in the Trusted Relationships
@@ -95,13 +95,13 @@ Note:  An AWS IAM role with the following permissions is required:
     :start-after: [START howto_operator_eks_create_nodegroup]
     :end-before: [END howto_operator_eks_create_nodegroup]
 
-.. _howto/operator:EKSDeleteNodegroupOperator:
+.. _howto/operator:EksDeleteNodegroupOperator:
 
 Delete an Amazon EKS Managed Nodegroup
 """"""""""""""""""""""""""""""""""""""
 
 To delete an existing Amazon EKS Managed Nodegroup you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSDeleteNodegroupOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksDeleteNodegroupOperator`.
 
 .. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_eks_with_nodegroups.py
     :language: python
@@ -113,7 +113,7 @@ Create an Amazon EKS Cluster and Nodegroup in one step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To create an Amazon EKS Cluster and an EKS Managed Nodegroup in one command, you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSCreateClusterOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksCreateClusterOperator`.
 
 Note: An AWS IAM role with the following permissions is required:
   ``ec2.amazon.aws.com`` must be in the Trusted Relationships
@@ -131,7 +131,7 @@ Create an Amazon EKS Cluster and AWS Fargate profile in one step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To create an Amazon EKS Cluster and an AWS Fargate profile in one command, you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSCreateClusterOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksCreateClusterOperator`.
 
 Note: An AWS IAM role with the following permissions is required:
   ``ec2.amazon.aws.com`` must be in the Trusted Relationships
@@ -148,13 +148,13 @@ Note: An AWS IAM role with the following permissions is required:
 Manage AWS Fargate Profiles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. _howto/operator:EKSCreateFargateProfileOperator:
+.. _howto/operator:EksCreateFargateProfileOperator:
 
 Create an AWS Fargate Profile
 """""""""""""""""""""""""""""
 
 To create an AWS Fargate Profile you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSCreateFargateProfileOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksCreateFargateProfileOperator`.
 
 Note:  An AWS IAM role with the following permissions is required:
   ``ec2.amazon.aws.com`` must be in the Trusted Relationships
@@ -166,26 +166,26 @@ Note:  An AWS IAM role with the following permissions is required:
     :start-after: [START howto_operator_eks_create_fargate_profile]
     :end-before: [END howto_operator_eks_create_fargate_profile]
 
-.. _howto/operator:EKSDeleteFargateProfileOperator:
+.. _howto/operator:EksDeleteFargateProfileOperator:
 
 Delete an AWS Fargate Profile
 """""""""""""""""""""""""""""
 
 To delete an existing AWS Fargate Profile you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSDeleteFargateProfileOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksDeleteFargateProfileOperator`.
 
 .. exampleinclude:: /../../airflow/providers/amazon/aws/example_dags/example_eks_with_fargate_profile.py
     :language: python
     :start-after: [START howto_operator_eks_delete_fargate_profile]
     :end-before: [END howto_operator_eks_delete_fargate_profile]
 
-.. _howto/operator:EKSPodOperator:
+.. _howto/operator:EksPodOperator:
 
 Perform a Task on an Amazon EKS Cluster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To run a pod on an existing Amazon EKS Cluster, you can use
-:class:`~airflow.providers.amazon.aws.operators.eks.EKSPodOperator`.
+:class:`~airflow.providers.amazon.aws.operators.eks.EksPodOperator`.
 
 Note: An Amazon EKS Cluster with underlying compute infrastructure is required.
 

--- a/tests/providers/amazon/aws/hooks/test_eks.py
+++ b/tests/providers/amazon/aws/hooks/test_eks.py
@@ -52,7 +52,7 @@ from moto.eks.models import (
     NODEGROUP_NOT_FOUND_MSG,
 )
 
-from airflow.providers.amazon.aws.hooks.eks import EKSHook
+from airflow.providers.amazon.aws.hooks.eks import EksHook
 
 from ..utils.eks_test_constants import (
     DEFAULT_CONN_ID,
@@ -126,11 +126,11 @@ def cluster_builder():
 
     def _execute(
         count: Optional[int] = 1, minimal: Optional[bool] = True
-    ) -> Tuple[EKSHook, ClusterTestDataFactory]:
+    ) -> Tuple[EksHook, ClusterTestDataFactory]:
         return eks_hook, ClusterTestDataFactory(count=count, minimal=minimal)
 
     mock_eks().start()
-    eks_hook = EKSHook(
+    eks_hook = EksHook(
         aws_conn_id=DEFAULT_CONN_ID,
         region_name=REGION,
     )
@@ -175,7 +175,7 @@ def fargate_profile_builder(cluster_builder):
 
     def _execute(
         count: Optional[int] = 1, minimal: Optional[bool] = True
-    ) -> Tuple[EKSHook, FargateProfileTestDataFactory]:
+    ) -> Tuple[EksHook, FargateProfileTestDataFactory]:
         return eks_hook, FargateProfileTestDataFactory(count=count, minimal=minimal)
 
     eks_hook, cluster = cluster_builder()
@@ -219,7 +219,7 @@ def nodegroup_builder(cluster_builder):
 
     def _execute(
         count: Optional[int] = 1, minimal: Optional[bool] = True
-    ) -> Tuple[EKSHook, NodegroupTestDataFactory]:
+    ) -> Tuple[EksHook, NodegroupTestDataFactory]:
         return eks_hook, NodegroupTestDataFactory(count=count, minimal=minimal)
 
     eks_hook, cluster = cluster_builder()
@@ -227,7 +227,7 @@ def nodegroup_builder(cluster_builder):
 
 
 @pytest.mark.skipif(mock_eks is None, reason=PACKAGE_NOT_PRESENT_MSG)
-class TestEKSHooks:
+class TestEksHooks:
     def test_hook(self, cluster_builder) -> None:
         eks_hook, _ = cluster_builder()
         assert eks_hook.get_conn() is not None
@@ -242,7 +242,7 @@ class TestEKSHooks:
     ###
     @mock_eks
     def test_list_clusters_returns_empty_by_default(self) -> None:
-        eks_hook: EKSHook = EKSHook(aws_conn_id=DEFAULT_CONN_ID, region_name=REGION)
+        eks_hook: EksHook = EksHook(aws_conn_id=DEFAULT_CONN_ID, region_name=REGION)
 
         result: List = eks_hook.list_clusters()
 
@@ -429,7 +429,7 @@ class TestEKSHooks:
 
     @mock_eks
     def test_create_nodegroup_throws_exception_when_cluster_not_found(self) -> None:
-        eks_hook: EKSHook = EKSHook(aws_conn_id=DEFAULT_CONN_ID, region_name=REGION)
+        eks_hook: EksHook = EksHook(aws_conn_id=DEFAULT_CONN_ID, region_name=REGION)
         non_existent_cluster_name: str = NON_EXISTING_CLUSTER_NAME
         non_existent_nodegroup_name: str = NON_EXISTING_NODEGROUP_NAME
         expected_exception: Type[AWSError] = ResourceNotFoundException
@@ -803,7 +803,7 @@ class TestEKSHooks:
 
     @mock_eks
     def test_create_fargate_profile_throws_exception_when_cluster_not_found(self) -> None:
-        eks_hook: EKSHook = EKSHook(aws_conn_id=DEFAULT_CONN_ID, region_name=REGION)
+        eks_hook: EksHook = EksHook(aws_conn_id=DEFAULT_CONN_ID, region_name=REGION)
         non_existent_cluster_name: str = NON_EXISTING_CLUSTER_NAME
         non_existent_fargate_profile_name: str = NON_EXISTING_FARGATE_PROFILE_NAME
         expected_exception: Type[AWSError] = ResourceNotFoundException
@@ -1167,7 +1167,7 @@ class TestEKSHooks:
             )
 
 
-class TestEKSHook:
+class TestEksHook:
     @mock.patch('airflow.providers.amazon.aws.hooks.base_aws.AwsBaseHook.conn')
     @pytest.mark.parametrize(
         "aws_conn_id, region_name, expected_args",
@@ -1209,7 +1209,7 @@ class TestEKSHook:
         mock_conn.describe_cluster.return_value = {
             'cluster': {'certificateAuthority': {'data': 'test-cert'}, 'endpoint': 'test-endpoint'}
         }
-        hook = EKSHook(aws_conn_id=aws_conn_id, region_name=region_name)
+        hook = EksHook(aws_conn_id=aws_conn_id, region_name=region_name)
         with hook.generate_config_file(
             eks_cluster_name='test-cluster', pod_namespace='k8s-namespace'
         ) as config_file:
@@ -1253,7 +1253,7 @@ class TestEKSHook:
     def test_fetch_access_token_for_cluster(self, mock_get_session, mock_conn, mock_signer):
         mock_signer.return_value.generate_presigned_url.return_value = 'http://example.com'
         mock_get_session.return_value.region_name = 'us-east-1'
-        hook = EKSHook()
+        hook = EksHook()
         token = hook.fetch_access_token_for_cluster(eks_cluster_name='test-cluster')
         mock_signer.assert_called_once_with(
             service_id=mock_conn.meta.service_model.service_id,

--- a/tests/providers/amazon/aws/operators/test_eks.py
+++ b/tests/providers/amazon/aws/operators/test_eks.py
@@ -18,15 +18,15 @@
 import unittest
 from unittest import mock
 
-from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EKSHook
+from airflow.providers.amazon.aws.hooks.eks import ClusterStates, EksHook
 from airflow.providers.amazon.aws.operators.eks import (
-    EKSCreateClusterOperator,
-    EKSCreateFargateProfileOperator,
-    EKSCreateNodegroupOperator,
-    EKSDeleteClusterOperator,
-    EKSDeleteFargateProfileOperator,
-    EKSDeleteNodegroupOperator,
-    EKSPodOperator,
+    EksCreateClusterOperator,
+    EksCreateFargateProfileOperator,
+    EksCreateNodegroupOperator,
+    EksDeleteClusterOperator,
+    EksDeleteFargateProfileOperator,
+    EksDeleteNodegroupOperator,
+    EksPodOperator,
 )
 from tests.providers.amazon.aws.utils.eks_test_constants import (
     NODEROLE_ARN,
@@ -49,7 +49,7 @@ EMPTY_NODEGROUP = '{"nodegroup": {}}'
 NAME_LIST = ["foo", "bar", "baz", "qux"]
 
 
-class TestEKSCreateClusterOperator(unittest.TestCase):
+class TestEksCreateClusterOperator(unittest.TestCase):
     def setUp(self) -> None:
         # Parameters which are needed to create a cluster.
         self.create_cluster_params = dict(
@@ -58,7 +58,7 @@ class TestEKSCreateClusterOperator(unittest.TestCase):
             resources_vpc_config=RESOURCES_VPC_CONFIG[1],
         )
 
-        self.create_cluster_operator = EKSCreateClusterOperator(
+        self.create_cluster_operator = EksCreateClusterOperator(
             task_id=TASK_ID, **self.create_cluster_params, compute=None
         )
 
@@ -80,7 +80,7 @@ class TestEKSCreateClusterOperator(unittest.TestCase):
             subnets=SUBNET_IDS,
         )
 
-        self.create_cluster_operator_with_nodegroup = EKSCreateClusterOperator(
+        self.create_cluster_operator_with_nodegroup = EksCreateClusterOperator(
             task_id=TASK_ID,
             **self.create_cluster_params,
             **self.base_nodegroup_params,
@@ -101,24 +101,24 @@ class TestEKSCreateClusterOperator(unittest.TestCase):
             cluster_name=CLUSTER_NAME,
         )
 
-        self.create_cluster_operator_with_fargate_profile = EKSCreateClusterOperator(
+        self.create_cluster_operator_with_fargate_profile = EksCreateClusterOperator(
             task_id=TASK_ID,
             **self.create_cluster_params,
             **self.base_fargate_profile_params,
             compute='fargate',
         )
 
-    @mock.patch.object(EKSHook, "create_cluster")
-    @mock.patch.object(EKSHook, "create_nodegroup")
+    @mock.patch.object(EksHook, "create_cluster")
+    @mock.patch.object(EksHook, "create_nodegroup")
     def test_execute_create_cluster(self, mock_create_nodegroup, mock_create_cluster):
         self.create_cluster_operator.execute({})
 
         mock_create_cluster.assert_called_once_with(**convert_keys(self.create_cluster_params))
         mock_create_nodegroup.assert_not_called()
 
-    @mock.patch.object(EKSHook, "get_cluster_state")
-    @mock.patch.object(EKSHook, "create_cluster")
-    @mock.patch.object(EKSHook, "create_nodegroup")
+    @mock.patch.object(EksHook, "get_cluster_state")
+    @mock.patch.object(EksHook, "create_cluster")
+    @mock.patch.object(EksHook, "create_nodegroup")
     def test_execute_when_called_with_nodegroup_creates_both(
         self, mock_create_nodegroup, mock_create_cluster, mock_cluster_state
     ):
@@ -129,9 +129,9 @@ class TestEKSCreateClusterOperator(unittest.TestCase):
         mock_create_cluster.assert_called_once_with(**convert_keys(self.create_cluster_params))
         mock_create_nodegroup.assert_called_once_with(**convert_keys(self.create_nodegroup_params))
 
-    @mock.patch.object(EKSHook, "get_cluster_state")
-    @mock.patch.object(EKSHook, "create_cluster")
-    @mock.patch.object(EKSHook, "create_fargate_profile")
+    @mock.patch.object(EksHook, "get_cluster_state")
+    @mock.patch.object(EksHook, "create_cluster")
+    @mock.patch.object(EksHook, "create_fargate_profile")
     def test_execute_when_called_with_fargate_creates_both(
         self, mock_create_fargate_profile, mock_create_cluster, mock_cluster_state
     ):
@@ -145,7 +145,7 @@ class TestEKSCreateClusterOperator(unittest.TestCase):
         )
 
 
-class TestEKSCreateFargateProfileOperator(unittest.TestCase):
+class TestEksCreateFargateProfileOperator(unittest.TestCase):
     def setUp(self) -> None:
         self.create_fargate_profile_params = dict(
             cluster_name=CLUSTER_NAME,
@@ -154,11 +154,11 @@ class TestEKSCreateFargateProfileOperator(unittest.TestCase):
             fargate_profile_name=FARGATE_PROFILE_NAME,
         )
 
-        self.create_fargate_profile_operator = EKSCreateFargateProfileOperator(
+        self.create_fargate_profile_operator = EksCreateFargateProfileOperator(
             task_id=TASK_ID, **self.create_fargate_profile_params
         )
 
-    @mock.patch.object(EKSHook, "create_fargate_profile")
+    @mock.patch.object(EksHook, "create_fargate_profile")
     def test_execute_when_fargate_profile_does_not_already_exist(self, mock_create_fargate_profile):
         self.create_fargate_profile_operator.execute({})
 
@@ -167,7 +167,7 @@ class TestEKSCreateFargateProfileOperator(unittest.TestCase):
         )
 
 
-class TestEKSCreateNodegroupOperator(unittest.TestCase):
+class TestEksCreateNodegroupOperator(unittest.TestCase):
     def setUp(self) -> None:
         self.create_nodegroup_params = dict(
             cluster_name=CLUSTER_NAME,
@@ -176,27 +176,27 @@ class TestEKSCreateNodegroupOperator(unittest.TestCase):
             nodegroup_role_arn=NODEROLE_ARN[1],
         )
 
-        self.create_nodegroup_operator = EKSCreateNodegroupOperator(
+        self.create_nodegroup_operator = EksCreateNodegroupOperator(
             task_id=TASK_ID, **self.create_nodegroup_params
         )
 
-    @mock.patch.object(EKSHook, "create_nodegroup")
+    @mock.patch.object(EksHook, "create_nodegroup")
     def test_execute_when_nodegroup_does_not_already_exist(self, mock_create_nodegroup):
         self.create_nodegroup_operator.execute({})
 
         mock_create_nodegroup.assert_called_once_with(**convert_keys(self.create_nodegroup_params))
 
 
-class TestEKSDeleteClusterOperator(unittest.TestCase):
+class TestEksDeleteClusterOperator(unittest.TestCase):
     def setUp(self) -> None:
         self.cluster_name: str = CLUSTER_NAME
 
-        self.delete_cluster_operator = EKSDeleteClusterOperator(
+        self.delete_cluster_operator = EksDeleteClusterOperator(
             task_id=TASK_ID, cluster_name=self.cluster_name
         )
 
-    @mock.patch.object(EKSHook, "list_nodegroups")
-    @mock.patch.object(EKSHook, "delete_cluster")
+    @mock.patch.object(EksHook, "list_nodegroups")
+    @mock.patch.object(EksHook, "delete_cluster")
     def test_existing_cluster_not_in_use(self, mock_delete_cluster, mock_list_nodegroups):
         mock_list_nodegroups.return_value = []
 
@@ -206,16 +206,16 @@ class TestEKSDeleteClusterOperator(unittest.TestCase):
         mock_delete_cluster.assert_called_once_with(name=self.cluster_name)
 
 
-class TestEKSDeleteNodegroupOperator(unittest.TestCase):
+class TestEksDeleteNodegroupOperator(unittest.TestCase):
     def setUp(self) -> None:
         self.cluster_name: str = CLUSTER_NAME
         self.nodegroup_name: str = NODEGROUP_NAME
 
-        self.delete_nodegroup_operator = EKSDeleteNodegroupOperator(
+        self.delete_nodegroup_operator = EksDeleteNodegroupOperator(
             task_id=TASK_ID, cluster_name=self.cluster_name, nodegroup_name=self.nodegroup_name
         )
 
-    @mock.patch.object(EKSHook, "delete_nodegroup")
+    @mock.patch.object(EksHook, "delete_nodegroup")
     def test_existing_nodegroup(self, mock_delete_nodegroup):
         self.delete_nodegroup_operator.execute({})
 
@@ -224,16 +224,16 @@ class TestEKSDeleteNodegroupOperator(unittest.TestCase):
         )
 
 
-class TestEKSDeleteFargateProfileOperator(unittest.TestCase):
+class TestEksDeleteFargateProfileOperator(unittest.TestCase):
     def setUp(self) -> None:
         self.cluster_name: str = CLUSTER_NAME
         self.fargate_profile_name: str = FARGATE_PROFILE_NAME
 
-        self.delete_fargate_profile_operator = EKSDeleteFargateProfileOperator(
+        self.delete_fargate_profile_operator = EksDeleteFargateProfileOperator(
             task_id=TASK_ID, cluster_name=self.cluster_name, fargate_profile_name=self.fargate_profile_name
         )
 
-    @mock.patch.object(EKSHook, "delete_fargate_profile")
+    @mock.patch.object(EksHook, "delete_fargate_profile")
     def test_existing_fargate_profile(self, mock_delete_fargate_profile):
         self.delete_fargate_profile_operator.execute({})
 
@@ -242,16 +242,16 @@ class TestEKSDeleteFargateProfileOperator(unittest.TestCase):
         )
 
 
-class TestEKSPodOperator(unittest.TestCase):
+class TestEksPodOperator(unittest.TestCase):
     @mock.patch('airflow.providers.cncf.kubernetes.operators.kubernetes_pod.KubernetesPodOperator.execute')
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.generate_config_file')
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.__init__', return_value=None)
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.generate_config_file')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.__init__', return_value=None)
     def test_existing_nodegroup(
         self, mock_eks_hook, mock_generate_config_file, mock_k8s_pod_operator_execute
     ):
         ti_context = mock.MagicMock(name="ti_context")
 
-        op = EKSPodOperator(
+        op = EksPodOperator(
             task_id="run_pod",
             pod_name="run_pod",
             cluster_name=CLUSTER_NAME,

--- a/tests/providers/amazon/aws/sensors/test_eks.py
+++ b/tests/providers/amazon/aws/sensors/test_eks.py
@@ -22,7 +22,7 @@ import pytest
 from airflow.exceptions import AirflowException
 from airflow.providers.amazon.aws.hooks.eks import (
     ClusterStates,
-    EKSHook,
+    EksHook,
     FargateProfileStates,
     NodegroupStates,
 )
@@ -31,9 +31,9 @@ from airflow.providers.amazon.aws.sensors.eks import (
     FARGATE_TERMINAL_STATES,
     NODEGROUP_TERMINAL_STATES,
     UNEXPECTED_TERMINAL_STATE_MSG,
-    EKSClusterStateSensor,
-    EKSFargateProfileStateSensor,
-    EKSNodegroupStateSensor,
+    EksClusterStateSensor,
+    EksFargateProfileStateSensor,
+    EksNodegroupStateSensor,
 )
 
 CLUSTER_NAME = 'test_cluster'
@@ -46,22 +46,22 @@ FARGATE_PENDING_STATES = frozenset({state.value for state in FargateProfileState
 NODEGROUP_PENDING_STATES = frozenset({state.value for state in NodegroupStates} - NODEGROUP_TERMINAL_STATES)
 
 
-class TestEKSClusterStateSensor:
+class TestEksClusterStateSensor:
     @pytest.fixture(scope="function")
     def setUp(self):
         self.target_state = ClusterStates.ACTIVE
-        self.sensor = EKSClusterStateSensor(
+        self.sensor = EksClusterStateSensor(
             task_id=TASK_ID,
             cluster_name=CLUSTER_NAME,
             target_state=self.target_state,
         )
 
-    @mock.patch.object(EKSHook, 'get_cluster_state', return_value=ClusterStates.ACTIVE)
+    @mock.patch.object(EksHook, 'get_cluster_state', return_value=ClusterStates.ACTIVE)
     def test_poke_reached_target_state(self, mock_get_cluster_state, setUp):
         assert self.sensor.poke({})
         mock_get_cluster_state.assert_called_once_with(clusterName=CLUSTER_NAME)
 
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.get_cluster_state')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.get_cluster_state')
     @pytest.mark.parametrize('pending_state', CLUSTER_PENDING_STATES)
     def test_poke_reached_pending_state(self, mock_get_cluster_state, setUp, pending_state):
         mock_get_cluster_state.return_value = pending_state
@@ -69,7 +69,7 @@ class TestEKSClusterStateSensor:
         assert not self.sensor.poke({})
         mock_get_cluster_state.assert_called_once_with(clusterName=CLUSTER_NAME)
 
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.get_cluster_state')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.get_cluster_state')
     @pytest.mark.parametrize('unexpected_terminal_state', CLUSTER_TERMINAL_STATES - {ClusterStates.ACTIVE})
     def test_poke_reached_unexpected_terminal_state(
         self, mock_get_cluster_state, setUp, unexpected_terminal_state
@@ -86,25 +86,25 @@ class TestEKSClusterStateSensor:
         mock_get_cluster_state.assert_called_once_with(clusterName=CLUSTER_NAME)
 
 
-class TestEKSFargateProfileStateSensor:
+class TestEksFargateProfileStateSensor:
     @pytest.fixture(scope="function")
     def setUp(self):
         self.target_state = FargateProfileStates.ACTIVE
-        self.sensor = EKSFargateProfileStateSensor(
+        self.sensor = EksFargateProfileStateSensor(
             task_id=TASK_ID,
             cluster_name=CLUSTER_NAME,
             fargate_profile_name=FARGATE_PROFILE_NAME,
             target_state=self.target_state,
         )
 
-    @mock.patch.object(EKSHook, 'get_fargate_profile_state', return_value=FargateProfileStates.ACTIVE)
+    @mock.patch.object(EksHook, 'get_fargate_profile_state', return_value=FargateProfileStates.ACTIVE)
     def test_poke_reached_target_state(self, mock_get_fargate_profile_state, setUp):
         assert self.sensor.poke({})
         mock_get_fargate_profile_state.assert_called_once_with(
             clusterName=CLUSTER_NAME, fargateProfileName=FARGATE_PROFILE_NAME
         )
 
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.get_fargate_profile_state')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.get_fargate_profile_state')
     @pytest.mark.parametrize('pending_state', FARGATE_PENDING_STATES)
     def test_poke_reached_pending_state(self, mock_get_fargate_profile_state, setUp, pending_state):
         mock_get_fargate_profile_state.return_value = pending_state
@@ -114,7 +114,7 @@ class TestEKSFargateProfileStateSensor:
             clusterName=CLUSTER_NAME, fargateProfileName=FARGATE_PROFILE_NAME
         )
 
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.get_fargate_profile_state')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.get_fargate_profile_state')
     @pytest.mark.parametrize(
         'unexpected_terminal_state', FARGATE_TERMINAL_STATES - {FargateProfileStates.ACTIVE}
     )
@@ -135,25 +135,25 @@ class TestEKSFargateProfileStateSensor:
         )
 
 
-class TestEKSNodegroupStateSensor:
+class TestEksNodegroupStateSensor:
     @pytest.fixture(scope="function")
     def setUp(self):
         self.target_state = NodegroupStates.ACTIVE
-        self.sensor = EKSNodegroupStateSensor(
+        self.sensor = EksNodegroupStateSensor(
             task_id=TASK_ID,
             cluster_name=CLUSTER_NAME,
             nodegroup_name=NODEGROUP_NAME,
             target_state=self.target_state,
         )
 
-    @mock.patch.object(EKSHook, 'get_nodegroup_state', return_value=NodegroupStates.ACTIVE)
+    @mock.patch.object(EksHook, 'get_nodegroup_state', return_value=NodegroupStates.ACTIVE)
     def test_poke_reached_target_state(self, mock_get_nodegroup_state, setUp):
         assert self.sensor.poke({})
         mock_get_nodegroup_state.assert_called_once_with(
             clusterName=CLUSTER_NAME, nodegroupName=NODEGROUP_NAME
         )
 
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.get_nodegroup_state')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.get_nodegroup_state')
     @pytest.mark.parametrize('pending_state', NODEGROUP_PENDING_STATES)
     def test_poke_reached_pending_state(self, mock_get_nodegroup_state, setUp, pending_state):
         mock_get_nodegroup_state.return_value = pending_state
@@ -163,7 +163,7 @@ class TestEKSNodegroupStateSensor:
             clusterName=CLUSTER_NAME, nodegroupName=NODEGROUP_NAME
         )
 
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook.get_nodegroup_state')
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook.get_nodegroup_state')
     @pytest.mark.parametrize(
         'unexpected_terminal_state', NODEGROUP_TERMINAL_STATES - {NodegroupStates.ACTIVE}
     )

--- a/tests/providers/amazon/aws/utils/eks_test_utils.py
+++ b/tests/providers/amazon/aws/utils/eks_test_utils.py
@@ -20,7 +20,7 @@ import re
 from copy import deepcopy
 from typing import Dict, List, Optional, Pattern, Tuple, Type, Union
 
-from airflow.providers.amazon.aws.hooks.eks import EKSHook
+from airflow.providers.amazon.aws.hooks.eks import EksHook
 
 from ..utils.eks_test_constants import (
     STATUS,
@@ -84,12 +84,12 @@ def attributes_to_test(
     return result
 
 
-def generate_clusters(eks_hook: EKSHook, num_clusters: int, minimal: bool) -> List[str]:
+def generate_clusters(eks_hook: EksHook, num_clusters: int, minimal: bool) -> List[str]:
     """
     Generates a number of EKS Clusters with data and adds them to the mocked backend.
 
-    :param eks_hook: An EKSHook object used to call the EKS API.
-    :type eks_hook: EKSHook
+    :param eks_hook: An EksHook object used to call the EKS API.
+    :type eks_hook: EksHook
     :param num_clusters: Number of clusters to generate.
     :type num_clusters: int
     :param minimal: If True, only the required values are generated; if False all values are generated.
@@ -107,13 +107,13 @@ def generate_clusters(eks_hook: EKSHook, num_clusters: int, minimal: bool) -> Li
 
 
 def generate_fargate_profiles(
-    eks_hook: EKSHook, cluster_name: str, num_profiles: int, minimal: bool
+    eks_hook: EksHook, cluster_name: str, num_profiles: int, minimal: bool
 ) -> List[str]:
     """
     Generates a number of EKS Fargate profiles with data and adds them to the mocked backend.
 
-    :param eks_hook: An EKSHook object used to call the EKS API.
-    :type eks_hook: EKSHook
+    :param eks_hook: An EksHook object used to call the EKS API.
+    :type eks_hook: EksHook
     :param cluster_name: The name of the EKS Cluster to attach the nodegroups to.
     :type cluster_name: str
     :param num_profiles: Number of Fargate profiles to generate.
@@ -135,13 +135,13 @@ def generate_fargate_profiles(
 
 
 def generate_nodegroups(
-    eks_hook: EKSHook, cluster_name: str, num_nodegroups: int, minimal: bool
+    eks_hook: EksHook, cluster_name: str, num_nodegroups: int, minimal: bool
 ) -> List[str]:
     """
     Generates a number of EKS Managed Nodegroups with data and adds them to the mocked backend.
 
-    :param eks_hook: An EKSHook object used to call the EKS API.
-    :type eks_hook: EKSHook
+    :param eks_hook: An EksHook object used to call the EKS API.
+    :type eks_hook: EksHook
     :param cluster_name: The name of the EKS Cluster to attach the nodegroups to.
     :type cluster_name: str
     :param num_nodegroups: Number of clusters to generate.

--- a/tests/providers/amazon/aws/utils/test_eks_get_token.py
+++ b/tests/providers/amazon/aws/utils/test_eks_get_token.py
@@ -25,8 +25,8 @@ import pytest
 from freezegun import freeze_time
 
 
-class TestGetEksTtoken:
-    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EKSHook')
+class TestGetEksToken:
+    @mock.patch('airflow.providers.amazon.aws.hooks.eks.EksHook')
     @freeze_time("1995-02-14")
     @pytest.mark.parametrize(
         "args, expected_aws_conn_id, expected_region_name",


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/20296

Also corrected a typo in a test class name from `TestGetEksTtoken` to `TestGetEksToken`.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
