### PR TITLE
Remove unnecssary logging in experimental API

### DIFF
--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -103,11 +103,11 @@ def trigger_dag(dag_id):
         try:
             execution_date = timezone.parse(execution_date)
         except ValueError:
+            log.error("Given execution date could not be identified as a date.")
             error_message = (
                 f'Given execution date, {execution_date}, could not be identified as a date. '
                 f'Example date format: 2015-11-16T14:34:15+00:00'
             )
-            log.error(error_message)
             response = jsonify({'error': error_message})
             response.status_code = 400
 
@@ -253,11 +253,11 @@ def task_instance_info(dag_id, execution_date, task_id):
     try:
         execution_date = timezone.parse(execution_date)
     except ValueError:
+        log.error("Given execution date could not be identified as a date.")
         error_message = (
             f'Given execution date, {execution_date}, could not be identified as a date. '
             f'Example date format: 2015-11-16T14:34:15+00:00'
         )
-        log.error(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
 
@@ -289,11 +289,11 @@ def dag_run_status(dag_id, execution_date):
     try:
         execution_date = timezone.parse(execution_date)
     except ValueError:
+        log.error("Given execution date could not be identified as a date.")
         error_message = (
             f'Given execution date, {execution_date}, could not be identified as a date. '
             f'Example date format: 2015-11-16T14:34:15+00:00'
         )
-        log.error(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
 
@@ -402,11 +402,11 @@ def get_lineage(dag_id: str, execution_date: str):
     try:
         execution_dt = timezone.parse(execution_date)
     except ValueError:
+        log.error("Given execution date could not be identified as a date.")
         error_message = (
             f'Given execution date, {execution_date}, could not be identified as a date. '
             f'Example date format: 2015-11-16T14:34:15+00:00'
         )
-        log.error(error_message)
         response = jsonify({'error': error_message})
         response.status_code = 400
 


### PR DESCRIPTION
The `execution_data` does not need to be passed to log. We send enough details to the API user in the response.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
