### PR TITLE
Add context var hook to inject more env vars

### DIFF
--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -195,6 +195,21 @@ def pod_mutation_hook(pod):
     """
 
 
+def get_airflow_context_vars(context):
+    """
+    This setting allows getting the airflow context vars, which are key value pairs.
+    They are then injected to default airflow context vars, which in the end are
+    available as environment variables when running tasks
+    dag_id, task_id, execution_date, dag_run_id, try_number are reserved keys.
+    To define it, add a ``airflow_local_settings`` module
+    to your PYTHONPATH that defines this ``get_airflow_context_vars`` function.
+
+    :param context: The context for the task_instance of interest.
+    :type context: dict
+    """
+    return {}
+
+
 def configure_vars():
     """Configure Global Variables from airflow.cfg"""
     global SQL_ALCHEMY_CONN

--- a/docs/apache-airflow/howto/export-more-env-vars.rst
+++ b/docs/apache-airflow/howto/export-more-env-vars.rst
@@ -1,0 +1,53 @@
+ .. Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+ ..   http://www.apache.org/licenses/LICENSE-2.0
+
+ .. Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+
+
+Export dynamic environment variables available for operators to use
+===================================================================
+
+
+The key value pairs returned in ``get_airflow_context_vars`` defined in
+``airflow_local_settings.py`` are injected to default airflow context environment variables,
+which are available as environment variables when running tasks. Note, both key and
+value are must be string.
+
+``dag_id``, ``task_id``, ``execution_date``, ``dag_run_id``,
+``dag_owner``, ``dag_email`` are reserved keys.
+
+
+1.  Create ``airflow_local_settings.py`` file and put in on ``$PYTHONPATH`` or
+    to ``$AIRFLOW_HOME/config`` folder. (Airflow adds ``$AIRFLOW_HOME/config`` on ``PYTHONPATH`` when
+    Airflow is initialized)
+
+2.  Define ``get_airflow_context_vars`` in ``airflow_local_settings.py`` file.
+
+
+For example:
+
+In your ``airflow_local_settings.py`` file.
+
+.. code-block:: python
+
+  def get_airflow_context_vars(context) -> Dict[str, str]:
+      """
+      :param context: The context for the task_instance of interest.
+      :type context: dict
+      """
+      # more env vars
+      return {"airflow_cluster": "main"}

--- a/docs/apache-airflow/howto/index.rst
+++ b/docs/apache-airflow/howto/index.rst
@@ -37,6 +37,7 @@ configuring an Airflow environment.
     customize-ui
     custom-operator
     create-custom-decorator
+    export-more-env-vars
     connection
     variable
     run-behind-proxy

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -85,14 +85,14 @@ class TestOperatorHelpers(unittest.TestCase):
         with mock.patch('airflow.settings.get_airflow_context_vars') as mock_method:
             mock_method.return_value = {'airflow_cluster': [1, 2]}
             with pytest.raises(TypeError) as error:
-                assert "value of key <airflow_cluster> must be string, not <class 'list'>" == error.value
                 operator_helpers.context_to_airflow_vars(self.context)
+            assert "value of key <airflow_cluster> must be string, not <class 'list'>" == str(error.value)
 
         with mock.patch('airflow.settings.get_airflow_context_vars') as mock_method:
             mock_method.return_value = {1: "value"}
             with pytest.raises(TypeError) as error:
-                assert 'key <1> must be string' == error.value
                 operator_helpers.context_to_airflow_vars(self.context)
+            assert 'key <1> must be string' == str(error.value)
 
 
 def callable1(ds_nodash):

--- a/tests/utils/test_operator_helpers.py
+++ b/tests/utils/test_operator_helpers.py
@@ -71,6 +71,29 @@ class TestOperatorHelpers(unittest.TestCase):
             'AIRFLOW_CTX_DAG_EMAIL': 'email1@test.com',
         }
 
+    def test_context_to_airflow_vars_with_default_context_vars(self):
+        with mock.patch('airflow.settings.get_airflow_context_vars') as mock_method:
+            airflow_cluster = 'cluster-a'
+            mock_method.return_value = {'airflow_cluster': airflow_cluster}
+
+            context_vars = operator_helpers.context_to_airflow_vars(self.context)
+            assert context_vars['airflow.ctx.airflow_cluster'] == airflow_cluster
+
+            context_vars = operator_helpers.context_to_airflow_vars(self.context, in_env_var_format=True)
+            assert context_vars['AIRFLOW_CTX_AIRFLOW_CLUSTER'] == airflow_cluster
+
+        with mock.patch('airflow.settings.get_airflow_context_vars') as mock_method:
+            mock_method.return_value = {'airflow_cluster': [1, 2]}
+            with pytest.raises(TypeError) as error:
+                assert "value of key <airflow_cluster> must be string, not <class 'list'>" == error.value
+                operator_helpers.context_to_airflow_vars(self.context)
+
+        with mock.patch('airflow.settings.get_airflow_context_vars') as mock_method:
+            mock_method.return_value = {1: "value"}
+            with pytest.raises(TypeError) as error:
+                assert 'key <1> must be string' == error.value
+                operator_helpers.context_to_airflow_vars(self.context)
+
 
 def callable1(ds_nodash):
     return (ds_nodash,)


### PR DESCRIPTION
This is useful when customized env vars are needed, for e.g. airflow
cluster name.

cluster name env var is very helpful when you have many clusters.

We also use this hook to inject the cost tagging info so that the underlying compute engine process can get this information.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
