### PR TITLE
Standardize AWS Kinesis/Firehose naming

### DIFF
--- a/airflow/providers/amazon/aws/hooks/kinesis.py
+++ b/airflow/providers/amazon/aws/hooks/kinesis.py
@@ -17,12 +17,13 @@
 # under the License.
 
 """This module contains AWS Firehose hook"""
+import warnings
 from typing import Iterable
 
 from airflow.providers.amazon.aws.hooks.base_aws import AwsBaseHook
 
 
-class AwsFirehoseHook(AwsBaseHook):
+class FirehoseHook(AwsBaseHook):
     """
     Interact with AWS Kinesis Firehose.
 
@@ -46,3 +47,19 @@ class AwsFirehoseHook(AwsBaseHook):
         response = self.get_conn().put_record_batch(DeliveryStreamName=self.delivery_stream, Records=records)
 
         return response
+
+
+class AwsFirehoseHook(FirehoseHook):
+    """
+    This hook is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.hooks.kinesis.FirehoseHook`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This hook is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.hooks.kinesis.FirehoseHook`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/tests/providers/amazon/aws/hooks/test_kinesis.py
+++ b/tests/providers/amazon/aws/hooks/test_kinesis.py
@@ -21,7 +21,7 @@ import uuid
 import boto3
 import pytest
 
-from airflow.providers.amazon.aws.hooks.kinesis import AwsFirehoseHook
+from airflow.providers.amazon.aws.hooks.kinesis import FirehoseHook
 
 try:
     from moto import mock_firehose, mock_s3
@@ -30,10 +30,10 @@ except ImportError:
 
 
 @pytest.mark.skipif(mock_firehose is None, reason='moto package not present')
-class TestAwsFirehoseHook:
+class TestFirehoseHook:
     @mock_firehose
     def test_get_conn_returns_a_boto3_connection(self):
-        hook = AwsFirehoseHook(
+        hook = FirehoseHook(
             aws_conn_id='aws_default', delivery_stream="test_airflow", region_name="us-east-1"
         )
         assert hook.get_conn() is not None
@@ -42,7 +42,7 @@ class TestAwsFirehoseHook:
     @mock_s3
     def test_insert_batch_records_kinesis_firehose(self):
         boto3.client('s3').create_bucket(Bucket='kinesis-test')
-        hook = AwsFirehoseHook(
+        hook = FirehoseHook(
             aws_conn_id='aws_default', delivery_stream="test_airflow", region_name="us-east-1"
         )
 


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/20296

This hook doesn't appear to actually be used anywhere or particularly documented, but it's now standardized.

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
