### PR TITLE
Fix deprecation messages after splitting redshift modules

### DIFF
--- a/airflow/providers/amazon/aws/hooks/redshift.py
+++ b/airflow/providers/amazon/aws/hooks/redshift.py
@@ -22,8 +22,8 @@ from airflow.providers.amazon.aws.hooks.redshift_cluster import RedshiftHook
 from airflow.providers.amazon.aws.hooks.redshift_sql import RedshiftSQLHook
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.hooks.redshift_sql` "
-    "or `airflow.hooks.redshift_cluster` as appropriate.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.hooks.redshift_cluster` "
+    "or `airflow.providers.amazon.aws.hooks.redshift_sql` as appropriate.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/amazon/aws/operators/redshift.py
+++ b/airflow/providers/amazon/aws/operators/redshift.py
@@ -24,8 +24,8 @@ from airflow.providers.amazon.aws.operators.redshift_cluster import (
 from airflow.providers.amazon.aws.operators.redshift_sql import RedshiftSQLOperator
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.operators.redshift_sql` "
-    "or `airflow.operators.redshift_cluster` as appropriate.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.redshift_sql` "
+    "or `airflow.providers.amazon.aws.operators.redshift_cluster` as appropriate.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/airflow/providers/amazon/aws/sensors/redshift.py
+++ b/airflow/providers/amazon/aws/sensors/redshift.py
@@ -20,7 +20,7 @@ import warnings
 from airflow.providers.amazon.aws.sensors.redshift_cluster import AwsRedshiftClusterSensor
 
 warnings.warn(
-    "This module is deprecated. Please use `airflow.sensors.redshift_cluster`.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.redshift_cluster`.",
     DeprecationWarning,
     stacklevel=2,
 )

--- a/dev/provider_packages/prepare_provider_packages.py
+++ b/dev/provider_packages/prepare_provider_packages.py
@@ -2154,11 +2154,11 @@ KNOWN_DEPRECATED_DIRECT_IMPORTS: Set[str] = {
     "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.dms`.",
     'This module is deprecated. Please use `airflow.providers.amazon.aws.operators.emr`.',
     'This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.emr`.',
-    'This module is deprecated. Please use `airflow.hooks.redshift_sql` '
-    'or `airflow.hooks.redshift_cluster` as appropriate.',
-    'This module is deprecated. Please use `airflow.operators.redshift_sql` or '
-    '`airflow.operators.redshift_cluster` as appropriate.',
-    'This module is deprecated. Please use `airflow.sensors.redshift_cluster`.',
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.hooks.redshift_cluster` "
+    "or `airflow.providers.amazon.aws.hooks.redshift_sql` as appropriate.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.operators.redshift_sql` "
+    "or `airflow.providers.amazon.aws.operators.redshift_cluster` as appropriate.",
+    "This module is deprecated. Please use `airflow.providers.amazon.aws.sensors.redshift_cluster`.",
 }
 
 


### PR DESCRIPTION
We split redshift into redshift_sql and redshift_cluster. Somehow I screwed up the module paths in the deprecation messages.
