### PR TITLE
Standardize AWS Batch naming

### DIFF
--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -540,7 +540,7 @@ class BatchClientHook(AwsBaseHook):
         return uniform(delay / 3, delay)
 
 
-class AwsBatchProtocol(BatchProtocol, Protocol):
+class AwsBatchProtocol(BatchProtocol):
     """
     This class is deprecated.
     Please use :class:`airflow.providers.amazon.aws.hooks.batch.BatchProtocol`.

--- a/airflow/providers/amazon/aws/hooks/batch_client.py
+++ b/airflow/providers/amazon/aws/hooks/batch_client.py
@@ -540,7 +540,7 @@ class BatchClientHook(AwsBaseHook):
         return uniform(delay / 3, delay)
 
 
-class AwsBatchProtocol(BatchProtocol):
+class AwsBatchProtocol(BatchProtocol, Protocol):
     """
     This class is deprecated.
     Please use :class:`airflow.providers.amazon.aws.hooks.batch.BatchProtocol`.

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -27,7 +27,7 @@ An Airflow operator for AWS Batch services
     - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
 import warnings
-from typing import Any, Optional, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional, Sequence
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -26,17 +26,18 @@ An Airflow operator for AWS Batch services
     - http://boto3.readthedocs.io/en/latest/reference/services/batch.html
     - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
-from typing import TYPE_CHECKING, Any, Optional, Sequence
+import warnings
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator
-from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
 
 
-class AwsBatchOperator(BaseOperator):
+class BatchOperator(BaseOperator):
     """
     Execute a job on AWS Batch
 
@@ -62,9 +63,9 @@ class AwsBatchOperator(BaseOperator):
         submit_job operation gets the jobId defined by AWS Batch
     :type job_id: Optional[str]
 
-    :param waiters: an :py:class:`.AwsBatchWaiters` object (see note below);
+    :param waiters: an :py:class:`.BatchWaiters` object (see note below);
         if None, polling is used with max_retries and status_retries.
-    :type waiters: Optional[AwsBatchWaiters]
+    :type waiters: Optional[BatchWaiters]
 
     :param max_retries: exponential back-off retries, 4200 = 48 hours;
         polling is only used when waiters is None
@@ -133,7 +134,7 @@ class AwsBatchOperator(BaseOperator):
         self.parameters = parameters or {}
         self.waiters = waiters
         self.tags = tags or {}
-        self.hook = AwsBatchClientHook(
+        self.hook = BatchClientHook(
             max_retries=max_retries,
             status_retries=status_retries,
             aws_conn_id=aws_conn_id,
@@ -202,3 +203,19 @@ class AwsBatchOperator(BaseOperator):
 
         self.hook.check_job_success(self.job_id)
         self.log.info("AWS Batch job (%s) succeeded", self.job_id)
+
+
+class AwsBatchOperator(BatchOperator):
+    """
+    This operator is deprecated.
+    Please use :class:`airflow.providers.amazon.aws.operators.batch.BatchOperator`.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "This operator is deprecated. "
+            "Please use :class:`airflow.providers.amazon.aws.operators.batch.BatchOperator`.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)

--- a/airflow/providers/amazon/aws/operators/batch.py
+++ b/airflow/providers/amazon/aws/operators/batch.py
@@ -27,7 +27,7 @@ An Airflow operator for AWS Batch services
     - https://docs.aws.amazon.com/batch/latest/APIReference/Welcome.html
 """
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence
+from typing import Any, Optional, Sequence, TYPE_CHECKING
 
 from airflow.exceptions import AirflowException
 from airflow.models import BaseOperator

--- a/airflow/providers/amazon/aws/sensors/batch.py
+++ b/airflow/providers/amazon/aws/sensors/batch.py
@@ -18,7 +18,7 @@
 from typing import TYPE_CHECKING, Optional, Sequence
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.sensors.base import BaseSensorOperator
 
 if TYPE_CHECKING:
@@ -52,29 +52,29 @@ class BatchSensor(BaseSensorOperator):
         self.job_id = job_id
         self.aws_conn_id = aws_conn_id
         self.region_name = region_name
-        self.hook: Optional[AwsBatchClientHook] = None
+        self.hook: Optional[BatchClientHook] = None
 
     def poke(self, context: 'Context') -> bool:
         job_description = self.get_hook().get_job_description(self.job_id)
         state = job_description['status']
 
-        if state == AwsBatchClientHook.SUCCESS_STATE:
+        if state == BatchClientHook.SUCCESS_STATE:
             return True
 
-        if state in AwsBatchClientHook.INTERMEDIATE_STATES:
+        if state in BatchClientHook.INTERMEDIATE_STATES:
             return False
 
-        if state == AwsBatchClientHook.FAILURE_STATE:
+        if state == BatchClientHook.FAILURE_STATE:
             raise AirflowException(f'Batch sensor failed. AWS Batch job status: {state}')
 
         raise AirflowException(f'Batch sensor failed. Unknown AWS Batch job status: {state}')
 
-    def get_hook(self) -> AwsBatchClientHook:
-        """Create and return a AwsBatchClientHook"""
+    def get_hook(self) -> BatchClientHook:
+        """Create and return a BatchClientHook"""
         if self.hook:
             return self.hook
 
-        self.hook = AwsBatchClientHook(
+        self.hook = BatchClientHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region_name,
         )

--- a/tests/deprecated_classes.py
+++ b/tests/deprecated_classes.py
@@ -976,7 +976,7 @@ OPERATORS = [
         "airflow.contrib.operators.aws_athena_operator.AWSAthenaOperator",
     ),
     (
-        "airflow.providers.amazon.aws.operators.batch.AwsBatchOperator",
+        "airflow.providers.amazon.aws.operators.batch.BatchOperator",
         "airflow.contrib.operators.awsbatch_operator.AWSBatchOperator",
     ),
     (

--- a/tests/providers/amazon/aws/hooks/test_batch_client.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_client.py
@@ -25,7 +25,7 @@ import pytest
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 
 # Use dummy AWS credentials
 AWS_REGION = "eu-west-1"
@@ -35,7 +35,7 @@ AWS_SECRET_ACCESS_KEY = "airflow_dummy_secret"
 JOB_ID = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
 
 
-class TestAwsBatchClient(unittest.TestCase):
+class TestBatchClient(unittest.TestCase):
 
     MAX_RETRIES = 2
     STATUS_RETRIES = 3
@@ -46,7 +46,7 @@ class TestAwsBatchClient(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsBaseHook.get_client_type")
     def setUp(self, get_client_type_mock):
         self.get_client_type_mock = get_client_type_mock
-        self.batch_client = AwsBatchClientHook(
+        self.batch_client = BatchClientHook(
             max_retries=self.MAX_RETRIES,
             status_retries=self.STATUS_RETRIES,
             aws_conn_id='airflow_test',
@@ -230,12 +230,12 @@ class TestAwsBatchClient(unittest.TestCase):
         assert response == {}
 
 
-class TestAwsBatchClientDelays(unittest.TestCase):
+class TestBatchClientDelays(unittest.TestCase):
     @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
     @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
     @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
     def setUp(self):
-        self.batch_client = AwsBatchClientHook(aws_conn_id='airflow_test', region_name=AWS_REGION)
+        self.batch_client = BatchClientHook(aws_conn_id='airflow_test', region_name=AWS_REGION)
 
     def test_init(self):
         assert self.batch_client.max_retries == self.batch_client.MAX_RETRIES
@@ -253,12 +253,12 @@ class TestAwsBatchClientDelays(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.uniform")
     @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.sleep")
     def test_delay_defaults(self, mock_sleep, mock_uniform):
-        assert AwsBatchClientHook.DEFAULT_DELAY_MIN == 1
-        assert AwsBatchClientHook.DEFAULT_DELAY_MAX == 10
+        assert BatchClientHook.DEFAULT_DELAY_MIN == 1
+        assert BatchClientHook.DEFAULT_DELAY_MAX == 10
         mock_uniform.return_value = 0
         self.batch_client.delay()
         mock_uniform.assert_called_once_with(
-            AwsBatchClientHook.DEFAULT_DELAY_MIN, AwsBatchClientHook.DEFAULT_DELAY_MAX
+            BatchClientHook.DEFAULT_DELAY_MIN, BatchClientHook.DEFAULT_DELAY_MAX
         )
         mock_sleep.assert_called_once_with(0)
 

--- a/tests/providers/amazon/aws/hooks/test_batch_waiters.py
+++ b/tests/providers/amazon/aws/hooks/test_batch_waiters.py
@@ -18,11 +18,11 @@
 
 
 """
-Test AwsBatchWaiters
+Test BatchWaiters
 
 This test suite uses a large suite of moto mocks for the
-AWS batch infrastructure.  These infrastructure mocks are
-derived from the moto test suite for testing the batch client.
+AWS Batch infrastructure.  These infrastructure mocks are
+derived from the moto test suite for testing the Batch client.
 
 .. seealso::
 
@@ -43,7 +43,7 @@ import pytest
 from moto import mock_batch, mock_ec2, mock_ecs, mock_iam, mock_logs
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.batch_waiters import AwsBatchWaitersHook
+from airflow.providers.amazon.aws.hooks.batch_waiters import BatchWaitersHook
 
 # Use dummy AWS credentials
 AWS_REGION = "eu-west-1"
@@ -216,10 +216,10 @@ def batch_infrastructure(
 #
 
 
-def test_aws_batch_waiters(aws_region):
-    assert inspect.isclass(AwsBatchWaitersHook)
-    batch_waiters = AwsBatchWaitersHook(region_name=aws_region)
-    assert isinstance(batch_waiters, AwsBatchWaitersHook)
+def test_batch_waiters(aws_region):
+    assert inspect.isclass(BatchWaitersHook)
+    batch_waiters = BatchWaitersHook(region_name=aws_region)
+    assert isinstance(batch_waiters, BatchWaitersHook)
 
 
 @mock_batch
@@ -228,15 +228,15 @@ def test_aws_batch_waiters(aws_region):
 @mock_iam
 @mock_logs
 @pytest.mark.xfail(condition=True, reason="Inexplicable timeout issue when running this test. See PR 11020")
-def test_aws_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_definition_name):
+def test_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_definition_name):
     """
-    Submit batch jobs and wait for various job status indicators or errors.
-    These batch job waiter tests can be slow and might need to be marked
+    Submit Batch jobs and wait for various job status indicators or errors.
+    These Batch job waiter tests can be slow and might need to be marked
     for conditional skips if they take too long, although it seems to
     run in about 30 sec to a minute.
 
     .. note::
-        These tests have no control over how moto transitions the batch job status.
+        These tests have no control over how moto transitions the Batch job status.
 
     .. seealso::
         - https://github.com/boto/botocore/blob/develop/botocore/waiter.py
@@ -245,7 +245,7 @@ def test_aws_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_defi
     """
 
     aws_resources = batch_infrastructure(aws_clients, aws_region, job_queue_name, job_definition_name)
-    batch_waiters = AwsBatchWaitersHook(region_name=aws_resources.aws_region)
+    batch_waiters = BatchWaitersHook(region_name=aws_resources.aws_region)
 
     job_exists_waiter = batch_waiters.get_waiter("JobExists")
     assert job_exists_waiter
@@ -271,7 +271,7 @@ def test_aws_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_defi
     assert "Waiter JobExists failed" in str(ctx.value)
 
     # Submit a job and wait for various job status indicators;
-    # moto transitions the batch job status automatically.
+    # moto transitions the Batch job status automatically.
 
     job_name = "test-job"
     job_cmd = ['/bin/sh -c "for a in `seq 1 2`; do echo Hello World; sleep 0.25; done"']
@@ -318,7 +318,7 @@ def test_aws_batch_job_waiting(aws_clients, aws_region, job_queue_name, job_defi
     assert job_status == "SUCCEEDED"
 
 
-class TestAwsBatchWaiters(unittest.TestCase):
+class TestBatchWaiters(unittest.TestCase):
     @mock.patch.dict("os.environ", AWS_DEFAULT_REGION=AWS_REGION)
     @mock.patch.dict("os.environ", AWS_ACCESS_KEY_ID=AWS_ACCESS_KEY_ID)
     @mock.patch.dict("os.environ", AWS_SECRET_ACCESS_KEY=AWS_SECRET_ACCESS_KEY)
@@ -327,7 +327,7 @@ class TestAwsBatchWaiters(unittest.TestCase):
         self.job_id = "8ba9d676-4108-4474-9dca-8bbac1da9b19"
         self.region_name = AWS_REGION
 
-        self.batch_waiters = AwsBatchWaitersHook(region_name=self.region_name)
+        self.batch_waiters = BatchWaitersHook(region_name=self.region_name)
         assert self.batch_waiters.aws_conn_id == 'aws_default'
         assert self.batch_waiters.region_name == self.region_name
 

--- a/tests/providers/amazon/aws/operators/test_batch.py
+++ b/tests/providers/amazon/aws/operators/test_batch.py
@@ -24,8 +24,8 @@ from unittest import mock
 import pytest
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
-from airflow.providers.amazon.aws.operators.batch import AwsBatchOperator
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
+from airflow.providers.amazon.aws.operators.batch import BatchOperator
 
 # Use dummy AWS credentials
 AWS_REGION = "eu-west-1"
@@ -41,7 +41,7 @@ RESPONSE_WITHOUT_FAILURES = {
 }
 
 
-class TestAwsBatchOperator(unittest.TestCase):
+class TestBatchOperator(unittest.TestCase):
 
     MAX_RETRIES = 2
     STATUS_RETRIES = 3
@@ -52,7 +52,7 @@ class TestAwsBatchOperator(unittest.TestCase):
     @mock.patch("airflow.providers.amazon.aws.hooks.batch_client.AwsBaseHook.get_client_type")
     def setUp(self, get_client_type_mock):
         self.get_client_type_mock = get_client_type_mock
-        self.batch = AwsBatchOperator(
+        self.batch = BatchOperator(
             task_id="task",
             job_name=JOB_NAME,
             job_queue="queue",
@@ -104,15 +104,15 @@ class TestAwsBatchOperator(unittest.TestCase):
             "parameters",
         )
 
-    @mock.patch.object(AwsBatchClientHook, "wait_for_job")
-    @mock.patch.object(AwsBatchClientHook, "check_job_success")
+    @mock.patch.object(BatchClientHook, "wait_for_job")
+    @mock.patch.object(BatchClientHook, "check_job_success")
     def test_execute_without_failures(self, check_mock, wait_mock):
         # JOB_ID is in RESPONSE_WITHOUT_FAILURES
         self.client_mock.submit_job.return_value = RESPONSE_WITHOUT_FAILURES
         self.batch.job_id = None
         self.batch.waiters = None  # use default wait
 
-        self.batch.execute(None)
+        self.batch.execute({})
 
         self.client_mock.submit_job.assert_called_once_with(
             jobQueue="queue",
@@ -132,7 +132,7 @@ class TestAwsBatchOperator(unittest.TestCase):
         self.client_mock.submit_job.return_value = ""
 
         with pytest.raises(AirflowException):
-            self.batch.execute(None)
+            self.batch.execute({})
 
         self.client_mock.submit_job.assert_called_once_with(
             jobQueue="queue",
@@ -144,14 +144,14 @@ class TestAwsBatchOperator(unittest.TestCase):
             tags={},
         )
 
-    @mock.patch.object(AwsBatchClientHook, "check_job_success")
+    @mock.patch.object(BatchClientHook, "check_job_success")
     def test_wait_job_complete_using_waiters(self, check_mock):
         mock_waiters = mock.Mock()
         self.batch.waiters = mock_waiters
 
         self.client_mock.submit_job.return_value = RESPONSE_WITHOUT_FAILURES
         self.client_mock.describe_jobs.return_value = {"jobs": [{"jobId": JOB_ID, "status": "SUCCEEDED"}]}
-        self.batch.execute(None)
+        self.batch.execute({})
 
         mock_waiters.wait_for_job.assert_called_once_with(JOB_ID)
         check_mock.assert_called_once_with(JOB_ID)

--- a/tests/providers/amazon/aws/sensors/test_batch.py
+++ b/tests/providers/amazon/aws/sensors/test_batch.py
@@ -21,7 +21,7 @@ from unittest import mock
 from parameterized import parameterized
 
 from airflow.exceptions import AirflowException
-from airflow.providers.amazon.aws.hooks.batch_client import AwsBatchClientHook
+from airflow.providers.amazon.aws.hooks.batch_client import BatchClientHook
 from airflow.providers.amazon.aws.sensors.batch import BatchSensor
 
 TASK_ID = 'batch_job_sensor'
@@ -35,26 +35,26 @@ class TestBatchSensor(unittest.TestCase):
             job_id=JOB_ID,
         )
 
-    @mock.patch.object(AwsBatchClientHook, 'get_job_description')
+    @mock.patch.object(BatchClientHook, 'get_job_description')
     def test_poke_on_success_state(self, mock_get_job_description):
         mock_get_job_description.return_value = {'status': 'SUCCEEDED'}
-        self.assertTrue(self.batch_sensor.poke(None))
+        self.assertTrue(self.batch_sensor.poke({}))
         mock_get_job_description.assert_called_once_with(JOB_ID)
 
-    @mock.patch.object(AwsBatchClientHook, 'get_job_description')
+    @mock.patch.object(BatchClientHook, 'get_job_description')
     def test_poke_on_failure_state(self, mock_get_job_description):
         mock_get_job_description.return_value = {'status': 'FAILED'}
         with self.assertRaises(AirflowException) as e:
-            self.batch_sensor.poke(None)
+            self.batch_sensor.poke({})
 
         self.assertEqual('Batch sensor failed. AWS Batch job status: FAILED', str(e.exception))
         mock_get_job_description.assert_called_once_with(JOB_ID)
 
-    @mock.patch.object(AwsBatchClientHook, 'get_job_description')
+    @mock.patch.object(BatchClientHook, 'get_job_description')
     def test_poke_on_invalid_state(self, mock_get_job_description):
         mock_get_job_description.return_value = {'status': 'INVALID'}
         with self.assertRaises(AirflowException) as e:
-            self.batch_sensor.poke(None)
+            self.batch_sensor.poke({})
 
         self.assertEqual('Batch sensor failed. Unknown AWS Batch job status: INVALID', str(e.exception))
         mock_get_job_description.assert_called_once_with(JOB_ID)
@@ -68,8 +68,8 @@ class TestBatchSensor(unittest.TestCase):
             ('RUNNING',),
         ]
     )
-    @mock.patch.object(AwsBatchClientHook, 'get_job_description')
+    @mock.patch.object(BatchClientHook, 'get_job_description')
     def test_poke_on_intermediate_state(self, job_status, mock_get_job_description):
         mock_get_job_description.return_value = {'status': job_status}
-        self.assertFalse(self.batch_sensor.poke(None))
+        self.assertFalse(self.batch_sensor.poke({}))
         mock_get_job_description.assert_called_once_with(JOB_ID)


### PR DESCRIPTION
Part of https://github.com/apache/airflow/issues/20296

In addition:

- Fixed capitalization in some comments from `batch` to `Batch` where applicable.
- Changed `execute(None)` and `poke(None)` to `execute({})` and `poke({})` because my IDE was throwing a type error (expected a dict, got NoneType).

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/main/UPDATING.md).
