### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/apache-airflow/howto/create-custom-decorator.rst
+++ b/docs/apache-airflow/howto/create-custom-decorator.rst
@@ -53,7 +53,7 @@ tasks. The steps to create and register ``@task.foo`` are:
 
 3. Register your new decorator in get_provider_info of your provider
 
-    Finally, add a key-value ``task-decortor`` to the dict returned from the provider entrypoint. This should be
+    Finally, add a key-value ``task-decorators`` to the dict returned from the provider entrypoint. This should be
     a list with each item containing ``name`` and ``class-name`` keys. When Airflow starts, the
     ``ProviderManager`` class will automatically import this value and ``task.foo`` will work as a new decorator!
 


### PR DESCRIPTION
Minor typo in the task decorator documentation